### PR TITLE
feat(workspaces): migrate 16 remaining modules to FeatureProvider (ADR-057 phase 3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2631,6 +2631,15 @@
       "members": []
     },
     {
+      "name": "AIFeatures",
+      "fqn": "Granit.AI.Endpoints.Workspaces.AIFeatures",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Workspaces/AIFeatures.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "AIEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.AI.EntityFrameworkCore.Extensions.AIEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -4280,6 +4289,15 @@
       "project": "Granit.Auditing.Endpoints",
       "file": "src/Granit.Auditing.Endpoints/Permissions/AuditingPermissions.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "AuditingFeatures",
+      "fqn": "Granit.Auditing.Endpoints.Workspaces.AuditingFeatures",
+      "kind": "class",
+      "project": "Granit.Auditing.Endpoints",
+      "file": "src/Granit.Auditing.Endpoints/Workspaces/AuditingFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -7772,6 +7790,15 @@
       "members": []
     },
     {
+      "name": "BackgroundJobsFeatures",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Workspaces.BackgroundJobsFeatures",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Workspaces/BackgroundJobsFeatures.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.Extensions.BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -9331,6 +9358,15 @@
       "project": "Granit.BlobStorage.Endpoints",
       "file": "src/Granit.BlobStorage.Endpoints/Permissions/BlobStorageRateLimitPolicies.cs",
       "line": 18,
+      "members": []
+    },
+    {
+      "name": "BlobStorageFeatures",
+      "fqn": "Granit.BlobStorage.Endpoints.Workspaces.BlobStorageFeatures",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Workspaces/BlobStorageFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -11782,6 +11818,15 @@
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
       "line": 18,
+      "members": []
+    },
+    {
+      "name": "DataExchangeFeatures",
+      "fqn": "Granit.DataExchange.Endpoints.Workspaces.DataExchangeFeatures",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Workspaces/DataExchangeFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -16855,6 +16900,15 @@
       "project": "Granit.Features.Endpoints",
       "file": "src/Granit.Features.Endpoints/Permissions/FeaturesPermissions.cs",
       "line": 12,
+      "members": []
+    },
+    {
+      "name": "FeaturesFeatures",
+      "fqn": "Granit.Features.Endpoints.Workspaces.FeaturesFeatures",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Workspaces/FeaturesFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -24599,6 +24653,15 @@
       "members": []
     },
     {
+      "name": "LocalizationFeatures",
+      "fqn": "Granit.Localization.Endpoints.Workspaces.LocalizationFeatures",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Workspaces/LocalizationFeatures.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Localization.EntityFrameworkCore.Extensions.LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -26153,6 +26216,15 @@
       "project": "Granit.MultiTenancy.Endpoints",
       "file": "src/Granit.MultiTenancy.Endpoints/Permissions/MultiTenancyPermissions.cs",
       "line": 12,
+      "members": []
+    },
+    {
+      "name": "MultiTenancyFeatures",
+      "fqn": "Granit.MultiTenancy.Endpoints.Workspaces.MultiTenancyFeatures",
+      "kind": "class",
+      "project": "Granit.MultiTenancy.Endpoints",
+      "file": "src/Granit.MultiTenancy.Endpoints/Workspaces/MultiTenancyFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -28010,6 +28082,15 @@
       "project": "Granit.Notifications.Endpoints",
       "file": "src/Granit.Notifications.Endpoints/Permissions/NotificationPermissions.cs",
       "line": 14,
+      "members": []
+    },
+    {
+      "name": "NotificationsFeatures",
+      "fqn": "Granit.Notifications.Endpoints.Workspaces.NotificationsFeatures",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Workspaces/NotificationsFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -33879,6 +33960,15 @@
       "members": []
     },
     {
+      "name": "PrivacyFeatures",
+      "fqn": "Granit.Privacy.Endpoints.Workspaces.PrivacyFeatures",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Workspaces/PrivacyFeatures.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "LegalAgreementBaseConfiguration",
       "fqn": "Granit.Privacy.EntityFrameworkCore.Configurations.LegalAgreementBaseConfiguration",
       "kind": "class",
@@ -36636,6 +36726,15 @@
       "members": []
     },
     {
+      "name": "SchedulingFeatures",
+      "fqn": "Granit.Scheduling.Endpoints.Workspaces.SchedulingFeatures",
+      "kind": "class",
+      "project": "Granit.Scheduling.Endpoints",
+      "file": "src/Granit.Scheduling.Endpoints/Workspaces/SchedulingFeatures.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "SchedulingEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Scheduling.EntityFrameworkCore.Extensions.SchedulingEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -37340,6 +37439,15 @@
       "project": "Granit.Settings.Endpoints",
       "file": "src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs",
       "line": 24,
+      "members": []
+    },
+    {
+      "name": "SettingsFeatures",
+      "fqn": "Granit.Settings.Endpoints.Workspaces.SettingsFeatures",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Workspaces/SettingsFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -38148,6 +38256,15 @@
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Permissions/TemplatingPermissions.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "TemplatingFeatures",
+      "fqn": "Granit.Templating.Endpoints.Workspaces.TemplatingFeatures",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Workspaces/TemplatingFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -39698,6 +39815,15 @@
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineFeatures",
+      "fqn": "Granit.Timeline.Endpoints.Workspaces.TimelineFeatures",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Workspaces/TimelineFeatures.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -42588,6 +42714,15 @@
       ]
     },
     {
+      "name": "WebhooksFeatures",
+      "fqn": "Granit.Webhooks.Endpoints.Workspaces.WebhooksFeatures",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Workspaces/WebhooksFeatures.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Webhooks.EntityFrameworkCore.Extensions.WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -43886,6 +44021,15 @@
       "project": "Granit.Workflow.Endpoints",
       "file": "src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissions.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "WorkflowFeatures",
+      "fqn": "Granit.Workflow.Endpoints.Workspaces.WorkflowFeatures",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Workspaces/WorkflowFeatures.cs",
+      "line": 4,
       "members": []
     },
     {

--- a/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
+++ b/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
@@ -18,6 +18,9 @@ namespace Granit.AI.Endpoints;
 public sealed class GranitAIEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<AIWorkspaceContribution>();
+        context.Services.AddFeatureProvider<AIFeatureProvider>();
+    }
 }

--- a/src/Granit.AI.Endpoints/Workspaces/AIFeatureProvider.cs
+++ b/src/Granit.AI.Endpoints/Workspaces/AIFeatureProvider.cs
@@ -1,0 +1,24 @@
+using Granit.AI.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.AI.Endpoints.Workspaces;
+
+/// <summary>Declares the AI module's features (per ADR-057).</summary>
+internal sealed class AIFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog)
+    {
+        catalog.Add(AIFeatures.Workspaces, f => f
+            .Permission(AIPermissions.Workspaces.Read)
+            .RouteName(AIFeatures.Workspaces)
+            .DefaultIcon("sparkles")
+            .DisplayKey("AIEndpoints:Workspace.Workspaces"));
+
+        catalog.Add(AIFeatures.Usage, f => f
+            .Permission(AIPermissions.Usage.Read)
+            .RouteName(AIFeatures.Usage)
+            .DefaultIcon("chart-bar")
+            .DisplayKey("AIEndpoints:Workspace.Usage"));
+    }
+}

--- a/src/Granit.AI.Endpoints/Workspaces/AIFeatures.cs
+++ b/src/Granit.AI.Endpoints/Workspaces/AIFeatures.cs
@@ -1,0 +1,11 @@
+namespace Granit.AI.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the AI module (per ADR-057).</summary>
+public static class AIFeatures
+{
+    /// <summary>AI workspaces dashboard — paired with <c>/ai/workspaces</c>.</summary>
+    public const string Workspaces = "ai.workspaces";
+
+    /// <summary>AI usage dashboard — paired with <c>/ai/usage</c>.</summary>
+    public const string Usage = "ai.usage";
+}

--- a/src/Granit.Auditing.Endpoints/GranitAuditingEndpointsModule.cs
+++ b/src/Granit.Auditing.Endpoints/GranitAuditingEndpointsModule.cs
@@ -25,6 +25,9 @@ namespace Granit.Auditing.Endpoints;
 public sealed class GranitAuditingEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<AuditingWorkspaceContribution>();
+        context.Services.AddFeatureProvider<AuditingFeatureProvider>();
+    }
 }

--- a/src/Granit.Auditing.Endpoints/Workspaces/AuditingFeatureProvider.cs
+++ b/src/Granit.Auditing.Endpoints/Workspaces/AuditingFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Auditing.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Auditing.Endpoints.Workspaces;
+
+/// <summary>Declares the auditing module's features (per ADR-057).</summary>
+internal sealed class AuditingFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(AuditingFeatures.Entries, f => f
+            .Permission(AuditingPermissions.AuditEntries.Read)
+            .RouteName(AuditingFeatures.Entries)
+            .DefaultIcon("clipboard-list")
+            .DisplayKey("AuditingEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Auditing.Endpoints/Workspaces/AuditingFeatures.cs
+++ b/src/Granit.Auditing.Endpoints/Workspaces/AuditingFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Auditing.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the auditing module (per ADR-057).</summary>
+public static class AuditingFeatures
+{
+    /// <summary>Audit log browser — paired with <c>/audit-log</c>.</summary>
+    public const string Entries = "auditing.entries";
+}

--- a/src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs
@@ -27,6 +27,9 @@ namespace Granit.BackgroundJobs.Endpoints;
 public sealed class GranitBackgroundJobsEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<BackgroundJobsWorkspaceContribution>();
+        context.Services.AddFeatureProvider<BackgroundJobsFeatureProvider>();
+    }
 }

--- a/src/Granit.BackgroundJobs.Endpoints/Workspaces/BackgroundJobsFeatureProvider.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Workspaces/BackgroundJobsFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.BackgroundJobs.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.BackgroundJobs.Endpoints.Workspaces;
+
+/// <summary>Declares the background-jobs module's features (per ADR-057).</summary>
+internal sealed class BackgroundJobsFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(BackgroundJobsFeatures.Jobs, f => f
+            .Permission(BackgroundJobsPermissions.Jobs.Read)
+            .RouteName(BackgroundJobsFeatures.Jobs)
+            .DefaultIcon("clock")
+            .DisplayKey("BackgroundJobsEndpoints:Workspace.Item"));
+}

--- a/src/Granit.BackgroundJobs.Endpoints/Workspaces/BackgroundJobsFeatures.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Workspaces/BackgroundJobsFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.BackgroundJobs.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the background-jobs module (per ADR-057).</summary>
+public static class BackgroundJobsFeatures
+{
+    /// <summary>Background jobs dashboard — paired with <c>/background-jobs</c>.</summary>
+    public const string Jobs = "background-jobs.jobs";
+}

--- a/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
+++ b/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
@@ -22,6 +22,9 @@ namespace Granit.BlobStorage.Endpoints;
 public sealed class GranitBlobStorageEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<BlobStorageWorkspaceContribution>();
+        context.Services.AddFeatureProvider<BlobStorageFeatureProvider>();
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Workspaces/BlobStorageFeatureProvider.cs
+++ b/src/Granit.BlobStorage.Endpoints/Workspaces/BlobStorageFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.BlobStorage.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.BlobStorage.Endpoints.Workspaces;
+
+/// <summary>Declares the blob-storage module's features (per ADR-057).</summary>
+internal sealed class BlobStorageFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(BlobStorageFeatures.Administration, f => f
+            .Permission(BlobStoragePermissions.Administration.Read)
+            .RouteName(BlobStorageFeatures.Administration)
+            .DefaultIcon("file")
+            .DisplayKey("BlobStorageEndpoints:Workspace.Item"));
+}

--- a/src/Granit.BlobStorage.Endpoints/Workspaces/BlobStorageFeatures.cs
+++ b/src/Granit.BlobStorage.Endpoints/Workspaces/BlobStorageFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.BlobStorage.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the blob-storage module (per ADR-057).</summary>
+public static class BlobStorageFeatures
+{
+    /// <summary>Blob storage admin dashboard — paired with <c>/blob-storage</c>.</summary>
+    public const string Administration = "blob-storage.administration";
+}

--- a/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
+++ b/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
@@ -25,6 +25,9 @@ namespace Granit.DataExchange.Endpoints;
 public sealed class GranitDataExchangeEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<DataExchangeWorkspaceContribution>();
+        context.Services.AddFeatureProvider<DataExchangeFeatureProvider>();
+    }
 }

--- a/src/Granit.DataExchange.Endpoints/Workspaces/DataExchangeFeatureProvider.cs
+++ b/src/Granit.DataExchange.Endpoints/Workspaces/DataExchangeFeatureProvider.cs
@@ -1,0 +1,24 @@
+using Granit.DataExchange.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.DataExchange.Endpoints.Workspaces;
+
+/// <summary>Declares the data-exchange module's features (per ADR-057).</summary>
+internal sealed class DataExchangeFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog)
+    {
+        catalog.Add(DataExchangeFeatures.Imports, f => f
+            .Permission(DataExchangePermissions.Imports.Read)
+            .RouteName(DataExchangeFeatures.Imports)
+            .DefaultIcon("download")
+            .DisplayKey("DataExchangeEndpoints:Workspace.Imports"));
+
+        catalog.Add(DataExchangeFeatures.Exports, f => f
+            .Permission(DataExchangePermissions.Exports.Read)
+            .RouteName(DataExchangeFeatures.Exports)
+            .DefaultIcon("upload")
+            .DisplayKey("DataExchangeEndpoints:Workspace.Exports"));
+    }
+}

--- a/src/Granit.DataExchange.Endpoints/Workspaces/DataExchangeFeatures.cs
+++ b/src/Granit.DataExchange.Endpoints/Workspaces/DataExchangeFeatures.cs
@@ -1,0 +1,11 @@
+namespace Granit.DataExchange.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the data-exchange module (per ADR-057).</summary>
+public static class DataExchangeFeatures
+{
+    /// <summary>Imports dashboard — paired with <c>/data-exchange/imports</c>.</summary>
+    public const string Imports = "data-exchange.imports";
+
+    /// <summary>Exports dashboard — paired with <c>/data-exchange/exports</c>.</summary>
+    public const string Exports = "data-exchange.exports";
+}

--- a/src/Granit.Features.Endpoints/GranitFeaturesEndpointsModule.cs
+++ b/src/Granit.Features.Endpoints/GranitFeaturesEndpointsModule.cs
@@ -30,6 +30,9 @@ namespace Granit.Features.Endpoints;
 public sealed class GranitFeaturesEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<FeaturesWorkspaceContribution>();
+        context.Services.AddFeatureProvider<FeaturesFeatureProvider>();
+    }
 }

--- a/src/Granit.Features.Endpoints/Workspaces/FeaturesFeatureProvider.cs
+++ b/src/Granit.Features.Endpoints/Workspaces/FeaturesFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Features.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Features.Endpoints.Workspaces;
+
+/// <summary>Declares the feature-flags module's features (per ADR-057).</summary>
+internal sealed class FeaturesFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(FeaturesFeatures.Flags, f => f
+            .Permission(FeaturesPermissions.Flags.Read)
+            .RouteName(FeaturesFeatures.Flags)
+            .DefaultIcon("flag")
+            .DisplayKey("FeaturesEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Features.Endpoints/Workspaces/FeaturesFeatures.cs
+++ b/src/Granit.Features.Endpoints/Workspaces/FeaturesFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Features.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the feature-flags module (per ADR-057).</summary>
+public static class FeaturesFeatures
+{
+    /// <summary>Feature-flag list — paired with <c>/features</c>.</summary>
+    public const string Flags = "features.flags";
+}

--- a/src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs
+++ b/src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs
@@ -31,6 +31,9 @@ namespace Granit.Localization.Endpoints;
 public sealed class GranitLocalizationEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<LocalizationWorkspaceContribution>();
+        context.Services.AddFeatureProvider<LocalizationFeatureProvider>();
+    }
 }

--- a/src/Granit.Localization.Endpoints/Workspaces/LocalizationFeatureProvider.cs
+++ b/src/Granit.Localization.Endpoints/Workspaces/LocalizationFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Localization.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Localization.Endpoints.Workspaces;
+
+/// <summary>Declares the localization-overrides module's features (per ADR-057).</summary>
+internal sealed class LocalizationFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(LocalizationFeatures.Overrides, f => f
+            .Permission(LocalizationOverridesPermissions.Overrides.Read)
+            .RouteName(LocalizationFeatures.Overrides)
+            .DefaultIcon("languages")
+            .DisplayKey("LocalizationEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Localization.Endpoints/Workspaces/LocalizationFeatures.cs
+++ b/src/Granit.Localization.Endpoints/Workspaces/LocalizationFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Localization.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the localization-overrides module (per ADR-057).</summary>
+public static class LocalizationFeatures
+{
+    /// <summary>Localization overrides editor — paired with <c>/localization/overrides</c>.</summary>
+    public const string Overrides = "localization.overrides";
+}

--- a/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
+++ b/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
@@ -27,6 +27,9 @@ namespace Granit.MultiTenancy.Endpoints;
 public sealed class GranitMultiTenancyEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<MultiTenancyWorkspaceContribution>();
+        context.Services.AddFeatureProvider<MultiTenancyFeatureProvider>();
+    }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Workspaces/MultiTenancyFeatureProvider.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Workspaces/MultiTenancyFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.MultiTenancy.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.MultiTenancy.Endpoints.Workspaces;
+
+/// <summary>Declares the multi-tenancy module's features (per ADR-057).</summary>
+internal sealed class MultiTenancyFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(MultiTenancyFeatures.Tenants, f => f
+            .Permission(MultiTenancyPermissions.Tenants.Read)
+            .RouteName(MultiTenancyFeatures.Tenants)
+            .DefaultIcon("building-2")
+            .DisplayKey("MultiTenancyEndpoints:Workspace.Tenants"));
+}

--- a/src/Granit.MultiTenancy.Endpoints/Workspaces/MultiTenancyFeatures.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Workspaces/MultiTenancyFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.MultiTenancy.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the multi-tenancy module (per ADR-057).</summary>
+public static class MultiTenancyFeatures
+{
+    /// <summary>Tenants list — paired with <c>/multi-tenancy/tenants</c>.</summary>
+    public const string Tenants = "multi-tenancy.tenants";
+}

--- a/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
+++ b/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
@@ -27,6 +27,9 @@ namespace Granit.Notifications.Endpoints;
 public sealed class GranitNotificationsEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<NotificationsWorkspaceContribution>();
+        context.Services.AddFeatureProvider<NotificationsFeatureProvider>();
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Workspaces/NotificationsFeatureProvider.cs
+++ b/src/Granit.Notifications.Endpoints/Workspaces/NotificationsFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Notifications.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Notifications.Endpoints.Workspaces;
+
+/// <summary>Declares the notifications module's features (per ADR-057).</summary>
+internal sealed class NotificationsFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(NotificationsFeatures.User, f => f
+            .Permission(NotificationPermissions.UserNotifications.Read)
+            .RouteName(NotificationsFeatures.User)
+            .DefaultIcon("bell")
+            .DisplayKey("NotificationsEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Notifications.Endpoints/Workspaces/NotificationsFeatures.cs
+++ b/src/Granit.Notifications.Endpoints/Workspaces/NotificationsFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Notifications.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the notifications module (per ADR-057).</summary>
+public static class NotificationsFeatures
+{
+    /// <summary>User notifications inbox — paired with <c>/notifications</c>.</summary>
+    public const string User = "notifications.user";
+}

--- a/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
+++ b/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
@@ -47,6 +47,7 @@ public sealed class GranitPrivacyEndpointsModule : GranitModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddWorkspaceContribution<PrivacyWorkspaceContribution>();
+        context.Services.AddFeatureProvider<PrivacyFeatureProvider>();
 
         context.Services
             .AddOptions<GpcDiscoveryOptions>()

--- a/src/Granit.Privacy.Endpoints/Workspaces/PrivacyFeatureProvider.cs
+++ b/src/Granit.Privacy.Endpoints/Workspaces/PrivacyFeatureProvider.cs
@@ -1,0 +1,24 @@
+using Granit.Privacy.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Privacy.Endpoints.Workspaces;
+
+/// <summary>Declares the privacy module's features (per ADR-057).</summary>
+internal sealed class PrivacyFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog)
+    {
+        catalog.Add(PrivacyFeatures.Purposes, f => f
+            .Permission(PrivacyPermissions.Purposes.Read)
+            .RouteName(PrivacyFeatures.Purposes)
+            .DefaultIcon("shield-check")
+            .DisplayKey("PrivacyEndpoints:Workspace.Purposes"));
+
+        catalog.Add(PrivacyFeatures.Agreements, f => f
+            .Permission(PrivacyPermissions.Agreements.Read)
+            .RouteName(PrivacyFeatures.Agreements)
+            .DefaultIcon("file-signature")
+            .DisplayKey("PrivacyEndpoints:Workspace.Agreements"));
+    }
+}

--- a/src/Granit.Privacy.Endpoints/Workspaces/PrivacyFeatures.cs
+++ b/src/Granit.Privacy.Endpoints/Workspaces/PrivacyFeatures.cs
@@ -1,0 +1,11 @@
+namespace Granit.Privacy.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the privacy module (per ADR-057).</summary>
+public static class PrivacyFeatures
+{
+    /// <summary>Privacy purposes list — paired with <c>/privacy/purposes</c>.</summary>
+    public const string Purposes = "privacy.purposes";
+
+    /// <summary>Privacy agreements list — paired with <c>/privacy/agreements</c>.</summary>
+    public const string Agreements = "privacy.agreements";
+}

--- a/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
+++ b/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
@@ -26,6 +26,9 @@ namespace Granit.Scheduling.Endpoints;
 public sealed class GranitSchedulingEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<SchedulingWorkspaceContribution>();
+        context.Services.AddFeatureProvider<SchedulingFeatureProvider>();
+    }
 }

--- a/src/Granit.Scheduling.Endpoints/Workspaces/SchedulingFeatureProvider.cs
+++ b/src/Granit.Scheduling.Endpoints/Workspaces/SchedulingFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Scheduling.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Scheduling.Endpoints.Workspaces;
+
+/// <summary>Declares the scheduling module's features (per ADR-057).</summary>
+internal sealed class SchedulingFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(SchedulingFeatures.Actions, f => f
+            .Permission(SchedulingPermissions.Actions.Read)
+            .RouteName(SchedulingFeatures.Actions)
+            .DefaultIcon("calendar-clock")
+            .DisplayKey("SchedulingEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Scheduling.Endpoints/Workspaces/SchedulingFeatures.cs
+++ b/src/Granit.Scheduling.Endpoints/Workspaces/SchedulingFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Scheduling.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the scheduling module (per ADR-057).</summary>
+public static class SchedulingFeatures
+{
+    /// <summary>Scheduled actions dashboard — paired with <c>/scheduling</c>.</summary>
+    public const string Actions = "scheduling.actions";
+}

--- a/src/Granit.Settings.Endpoints/GranitSettingsEndpointsModule.cs
+++ b/src/Granit.Settings.Endpoints/GranitSettingsEndpointsModule.cs
@@ -36,6 +36,9 @@ namespace Granit.Settings.Endpoints;
 public sealed class GranitSettingsEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<SettingsWorkspaceContribution>();
+        context.Services.AddFeatureProvider<SettingsFeatureProvider>();
+    }
 }

--- a/src/Granit.Settings.Endpoints/Workspaces/SettingsFeatureProvider.cs
+++ b/src/Granit.Settings.Endpoints/Workspaces/SettingsFeatureProvider.cs
@@ -1,0 +1,24 @@
+using Granit.Settings.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Settings.Endpoints.Workspaces;
+
+/// <summary>Declares the settings module's features (per ADR-057).</summary>
+internal sealed class SettingsFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog)
+    {
+        catalog.Add(SettingsFeatures.Global, f => f
+            .Permission(SettingsPermissions.Global.Read)
+            .RouteName(SettingsFeatures.Global)
+            .DefaultIcon("settings-2")
+            .DisplayKey("SettingsEndpoints:Workspace.Global"));
+
+        catalog.Add(SettingsFeatures.Tenant, f => f
+            .Permission(SettingsPermissions.Tenant.Read)
+            .RouteName(SettingsFeatures.Tenant)
+            .DefaultIcon("building")
+            .DisplayKey("SettingsEndpoints:Workspace.Tenant"));
+    }
+}

--- a/src/Granit.Settings.Endpoints/Workspaces/SettingsFeatures.cs
+++ b/src/Granit.Settings.Endpoints/Workspaces/SettingsFeatures.cs
@@ -1,0 +1,11 @@
+namespace Granit.Settings.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the settings module (per ADR-057).</summary>
+public static class SettingsFeatures
+{
+    /// <summary>Global settings — paired with <c>/settings/global</c>.</summary>
+    public const string Global = "settings.global";
+
+    /// <summary>Tenant settings — paired with <c>/settings/tenant</c>.</summary>
+    public const string Tenant = "settings.tenant";
+}

--- a/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
+++ b/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
@@ -31,6 +31,9 @@ namespace Granit.Templating.Endpoints;
 public sealed class GranitTemplatingEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<TemplatingWorkspaceContribution>();
+        context.Services.AddFeatureProvider<TemplatingFeatureProvider>();
+    }
 }

--- a/src/Granit.Templating.Endpoints/Workspaces/TemplatingFeatureProvider.cs
+++ b/src/Granit.Templating.Endpoints/Workspaces/TemplatingFeatureProvider.cs
@@ -1,0 +1,24 @@
+using Granit.Templating.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Templating.Endpoints.Workspaces;
+
+/// <summary>Declares the templating module's features (per ADR-057).</summary>
+internal sealed class TemplatingFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog)
+    {
+        catalog.Add(TemplatingFeatures.Templates, f => f
+            .Permission(TemplatingPermissions.Templates.Read)
+            .RouteName(TemplatingFeatures.Templates)
+            .DefaultIcon("layout-template")
+            .DisplayKey("TemplatingEndpoints:Workspace.Templates"));
+
+        catalog.Add(TemplatingFeatures.Categories, f => f
+            .Permission(TemplatingPermissions.Categories.Read)
+            .RouteName(TemplatingFeatures.Categories)
+            .DefaultIcon("folder-tree")
+            .DisplayKey("TemplatingEndpoints:Workspace.Categories"));
+    }
+}

--- a/src/Granit.Templating.Endpoints/Workspaces/TemplatingFeatures.cs
+++ b/src/Granit.Templating.Endpoints/Workspaces/TemplatingFeatures.cs
@@ -1,0 +1,11 @@
+namespace Granit.Templating.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the templating module (per ADR-057).</summary>
+public static class TemplatingFeatures
+{
+    /// <summary>Templates list — paired with <c>/templating/templates</c>.</summary>
+    public const string Templates = "templating.templates";
+
+    /// <summary>Template categories — paired with <c>/templating/categories</c>.</summary>
+    public const string Categories = "templating.categories";
+}

--- a/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
+++ b/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
@@ -28,6 +28,9 @@ namespace Granit.Timeline.Endpoints;
 public sealed class GranitTimelineEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<TimelineWorkspaceContribution>();
+        context.Services.AddFeatureProvider<TimelineFeatureProvider>();
+    }
 }

--- a/src/Granit.Timeline.Endpoints/Workspaces/TimelineFeatureProvider.cs
+++ b/src/Granit.Timeline.Endpoints/Workspaces/TimelineFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Timeline.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Timeline.Endpoints.Workspaces;
+
+/// <summary>Declares the timeline module's features (per ADR-057).</summary>
+internal sealed class TimelineFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(TimelineFeatures.Entries, f => f
+            .Permission(TimelinePermissions.Entries.Read)
+            .RouteName(TimelineFeatures.Entries)
+            .DefaultIcon("activity")
+            .DisplayKey("TimelineEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Timeline.Endpoints/Workspaces/TimelineFeatures.cs
+++ b/src/Granit.Timeline.Endpoints/Workspaces/TimelineFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Timeline.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the timeline module (per ADR-057).</summary>
+public static class TimelineFeatures
+{
+    /// <summary>Timeline browser — paired with <c>/timeline</c>.</summary>
+    public const string Entries = "timeline.entries";
+}

--- a/src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs
+++ b/src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs
@@ -19,6 +19,9 @@ namespace Granit.Webhooks.Endpoints;
 public sealed class GranitWebhooksEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<WebhooksWorkspaceContribution>();
+        context.Services.AddFeatureProvider<WebhooksFeatureProvider>();
+    }
 }

--- a/src/Granit.Webhooks.Endpoints/Workspaces/WebhooksFeatureProvider.cs
+++ b/src/Granit.Webhooks.Endpoints/Workspaces/WebhooksFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Webhooks.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Webhooks.Endpoints.Workspaces;
+
+/// <summary>Declares the webhooks module's features (per ADR-057).</summary>
+internal sealed class WebhooksFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(WebhooksFeatures.Subscriptions, f => f
+            .Permission(WebhooksPermissions.Subscriptions.Read)
+            .RouteName(WebhooksFeatures.Subscriptions)
+            .DefaultIcon("webhook")
+            .DisplayKey("WebhooksEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Webhooks.Endpoints/Workspaces/WebhooksFeatures.cs
+++ b/src/Granit.Webhooks.Endpoints/Workspaces/WebhooksFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Webhooks.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the webhooks module (per ADR-057).</summary>
+public static class WebhooksFeatures
+{
+    /// <summary>Webhook subscriptions dashboard — paired with <c>/webhooks</c>.</summary>
+    public const string Subscriptions = "webhooks.subscriptions";
+}

--- a/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
+++ b/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
@@ -41,5 +41,6 @@ public sealed class GranitWorkflowEndpointsModule : GranitModule
     {
         context.Services.AddGranitWorkflowEndpoints();
         context.Services.AddWorkspaceContribution<WorkflowWorkspaceContribution>();
+        context.Services.AddFeatureProvider<WorkflowFeatureProvider>();
     }
 }

--- a/src/Granit.Workflow.Endpoints/Workspaces/WorkflowFeatureProvider.cs
+++ b/src/Granit.Workflow.Endpoints/Workspaces/WorkflowFeatureProvider.cs
@@ -1,0 +1,16 @@
+using Granit.Workflow.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Workflow.Endpoints.Workspaces;
+
+/// <summary>Declares the workflow module's features (per ADR-057).</summary>
+internal sealed class WorkflowFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(WorkflowFeatures.History, f => f
+            .Permission(WorkflowPermissions.History.Read)
+            .RouteName(WorkflowFeatures.History)
+            .DefaultIcon("git-branch")
+            .DisplayKey("WorkflowEndpoints:Workspace.History"));
+}

--- a/src/Granit.Workflow.Endpoints/Workspaces/WorkflowFeatures.cs
+++ b/src/Granit.Workflow.Endpoints/Workspaces/WorkflowFeatures.cs
@@ -1,0 +1,8 @@
+namespace Granit.Workflow.Endpoints.Workspaces;
+
+/// <summary>Feature name constants for the workflow module (per ADR-057).</summary>
+public static class WorkflowFeatures
+{
+    /// <summary>Workflow history dashboard — paired with <c>/workflow/history</c>.</summary>
+    public const string History = "workflow.history";
+}

--- a/tests/Granit.AI.Endpoints.Tests/AIFeatureProviderTests.cs
+++ b/tests/Granit.AI.Endpoints.Tests/AIFeatureProviderTests.cs
@@ -1,0 +1,38 @@
+using Granit.AI.Endpoints.Permissions;
+using Granit.AI.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.AI.Endpoints.Tests;
+
+public sealed class AIFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new AIFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(AIFeatures.Workspaces).Permission.ShouldBe(AIPermissions.Workspaces.Read);
+        catalog.Get(AIFeatures.Workspaces).RouteName.ShouldBe(AIFeatures.Workspaces);
+        catalog.Get(AIFeatures.Workspaces).DefaultIcon.ShouldBe("sparkles");
+        catalog.Get(AIFeatures.Workspaces).DisplayKey.ShouldBe("AIEndpoints:Workspace.Workspaces");
+        catalog.Get(AIFeatures.Usage).Permission.ShouldBe(AIPermissions.Usage.Read);
+        catalog.Get(AIFeatures.Usage).RouteName.ShouldBe(AIFeatures.Usage);
+        catalog.Get(AIFeatures.Usage).DefaultIcon.ShouldBe("chart-bar");
+        catalog.Get(AIFeatures.Usage).DisplayKey.ShouldBe("AIEndpoints:Workspace.Usage");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Auditing.Endpoints.Tests/AuditingFeatureProviderTests.cs
+++ b/tests/Granit.Auditing.Endpoints.Tests/AuditingFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Auditing.Endpoints.Permissions;
+using Granit.Auditing.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Auditing.Endpoints.Tests;
+
+public sealed class AuditingFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new AuditingFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(AuditingFeatures.Entries).Permission.ShouldBe(AuditingPermissions.AuditEntries.Read);
+        catalog.Get(AuditingFeatures.Entries).RouteName.ShouldBe(AuditingFeatures.Entries);
+        catalog.Get(AuditingFeatures.Entries).DefaultIcon.ShouldBe("clipboard-list");
+        catalog.Get(AuditingFeatures.Entries).DisplayKey.ShouldBe("AuditingEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.BackgroundJobs.Endpoints.Tests/BackgroundJobsFeatureProviderTests.cs
+++ b/tests/Granit.BackgroundJobs.Endpoints.Tests/BackgroundJobsFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.BackgroundJobs.Endpoints.Permissions;
+using Granit.BackgroundJobs.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BackgroundJobs.Endpoints.Tests;
+
+public sealed class BackgroundJobsFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new BackgroundJobsFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(BackgroundJobsFeatures.Jobs).Permission.ShouldBe(BackgroundJobsPermissions.Jobs.Read);
+        catalog.Get(BackgroundJobsFeatures.Jobs).RouteName.ShouldBe(BackgroundJobsFeatures.Jobs);
+        catalog.Get(BackgroundJobsFeatures.Jobs).DefaultIcon.ShouldBe("clock");
+        catalog.Get(BackgroundJobsFeatures.Jobs).DisplayKey.ShouldBe("BackgroundJobsEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.BlobStorage.Endpoints.Tests/BlobStorageFeatureProviderTests.cs
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/BlobStorageFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.BlobStorage.Endpoints.Permissions;
+using Granit.BlobStorage.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Endpoints.Tests;
+
+public sealed class BlobStorageFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new BlobStorageFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(BlobStorageFeatures.Administration).Permission.ShouldBe(BlobStoragePermissions.Administration.Read);
+        catalog.Get(BlobStorageFeatures.Administration).RouteName.ShouldBe(BlobStorageFeatures.Administration);
+        catalog.Get(BlobStorageFeatures.Administration).DefaultIcon.ShouldBe("file");
+        catalog.Get(BlobStorageFeatures.Administration).DisplayKey.ShouldBe("BlobStorageEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.DataExchange.Endpoints.Tests/DataExchangeFeatureProviderTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/DataExchangeFeatureProviderTests.cs
@@ -1,0 +1,38 @@
+using Granit.DataExchange.Endpoints.Permissions;
+using Granit.DataExchange.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.DataExchange.Endpoints.Tests;
+
+public sealed class DataExchangeFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new DataExchangeFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(DataExchangeFeatures.Imports).Permission.ShouldBe(DataExchangePermissions.Imports.Read);
+        catalog.Get(DataExchangeFeatures.Imports).RouteName.ShouldBe(DataExchangeFeatures.Imports);
+        catalog.Get(DataExchangeFeatures.Imports).DefaultIcon.ShouldBe("download");
+        catalog.Get(DataExchangeFeatures.Imports).DisplayKey.ShouldBe("DataExchangeEndpoints:Workspace.Imports");
+        catalog.Get(DataExchangeFeatures.Exports).Permission.ShouldBe(DataExchangePermissions.Exports.Read);
+        catalog.Get(DataExchangeFeatures.Exports).RouteName.ShouldBe(DataExchangeFeatures.Exports);
+        catalog.Get(DataExchangeFeatures.Exports).DefaultIcon.ShouldBe("upload");
+        catalog.Get(DataExchangeFeatures.Exports).DisplayKey.ShouldBe("DataExchangeEndpoints:Workspace.Exports");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Features.Endpoints.Tests/FeaturesFeatureProviderTests.cs
+++ b/tests/Granit.Features.Endpoints.Tests/FeaturesFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Features.Endpoints.Permissions;
+using Granit.Features.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Features.Endpoints.Tests;
+
+public sealed class FeaturesFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new FeaturesFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(FeaturesFeatures.Flags).Permission.ShouldBe(FeaturesPermissions.Flags.Read);
+        catalog.Get(FeaturesFeatures.Flags).RouteName.ShouldBe(FeaturesFeatures.Flags);
+        catalog.Get(FeaturesFeatures.Flags).DefaultIcon.ShouldBe("flag");
+        catalog.Get(FeaturesFeatures.Flags).DisplayKey.ShouldBe("FeaturesEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Localization.Endpoints.Tests/LocalizationFeatureProviderTests.cs
+++ b/tests/Granit.Localization.Endpoints.Tests/LocalizationFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Localization.Endpoints.Permissions;
+using Granit.Localization.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Localization.Endpoints.Tests;
+
+public sealed class LocalizationFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new LocalizationFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(LocalizationFeatures.Overrides).Permission.ShouldBe(LocalizationOverridesPermissions.Overrides.Read);
+        catalog.Get(LocalizationFeatures.Overrides).RouteName.ShouldBe(LocalizationFeatures.Overrides);
+        catalog.Get(LocalizationFeatures.Overrides).DefaultIcon.ShouldBe("languages");
+        catalog.Get(LocalizationFeatures.Overrides).DisplayKey.ShouldBe("LocalizationEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/MultiTenancyFeatureProviderTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/MultiTenancyFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.MultiTenancy.Endpoints.Permissions;
+using Granit.MultiTenancy.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.MultiTenancy.Endpoints.Tests;
+
+public sealed class MultiTenancyFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new MultiTenancyFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(MultiTenancyFeatures.Tenants).Permission.ShouldBe(MultiTenancyPermissions.Tenants.Read);
+        catalog.Get(MultiTenancyFeatures.Tenants).RouteName.ShouldBe(MultiTenancyFeatures.Tenants);
+        catalog.Get(MultiTenancyFeatures.Tenants).DefaultIcon.ShouldBe("building-2");
+        catalog.Get(MultiTenancyFeatures.Tenants).DisplayKey.ShouldBe("MultiTenancyEndpoints:Workspace.Tenants");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Notifications.Endpoints.Tests/NotificationsFeatureProviderTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/NotificationsFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Notifications.Endpoints.Permissions;
+using Granit.Notifications.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.Endpoints.Tests;
+
+public sealed class NotificationsFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new NotificationsFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(NotificationsFeatures.User).Permission.ShouldBe(NotificationPermissions.UserNotifications.Read);
+        catalog.Get(NotificationsFeatures.User).RouteName.ShouldBe(NotificationsFeatures.User);
+        catalog.Get(NotificationsFeatures.User).DefaultIcon.ShouldBe("bell");
+        catalog.Get(NotificationsFeatures.User).DisplayKey.ShouldBe("NotificationsEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/PrivacyFeatureProviderTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/PrivacyFeatureProviderTests.cs
@@ -1,0 +1,38 @@
+using Granit.Privacy.Endpoints.Permissions;
+using Granit.Privacy.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests;
+
+public sealed class PrivacyFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new PrivacyFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(PrivacyFeatures.Purposes).Permission.ShouldBe(PrivacyPermissions.Purposes.Read);
+        catalog.Get(PrivacyFeatures.Purposes).RouteName.ShouldBe(PrivacyFeatures.Purposes);
+        catalog.Get(PrivacyFeatures.Purposes).DefaultIcon.ShouldBe("shield-check");
+        catalog.Get(PrivacyFeatures.Purposes).DisplayKey.ShouldBe("PrivacyEndpoints:Workspace.Purposes");
+        catalog.Get(PrivacyFeatures.Agreements).Permission.ShouldBe(PrivacyPermissions.Agreements.Read);
+        catalog.Get(PrivacyFeatures.Agreements).RouteName.ShouldBe(PrivacyFeatures.Agreements);
+        catalog.Get(PrivacyFeatures.Agreements).DefaultIcon.ShouldBe("file-signature");
+        catalog.Get(PrivacyFeatures.Agreements).DisplayKey.ShouldBe("PrivacyEndpoints:Workspace.Agreements");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Scheduling.Endpoints.Tests/SchedulingFeatureProviderTests.cs
+++ b/tests/Granit.Scheduling.Endpoints.Tests/SchedulingFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Scheduling.Endpoints.Permissions;
+using Granit.Scheduling.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Scheduling.Endpoints.Tests;
+
+public sealed class SchedulingFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new SchedulingFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(SchedulingFeatures.Actions).Permission.ShouldBe(SchedulingPermissions.Actions.Read);
+        catalog.Get(SchedulingFeatures.Actions).RouteName.ShouldBe(SchedulingFeatures.Actions);
+        catalog.Get(SchedulingFeatures.Actions).DefaultIcon.ShouldBe("calendar-clock");
+        catalog.Get(SchedulingFeatures.Actions).DisplayKey.ShouldBe("SchedulingEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Settings.Endpoints.Tests/SettingsFeatureProviderTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/SettingsFeatureProviderTests.cs
@@ -1,0 +1,38 @@
+using Granit.Settings.Endpoints.Permissions;
+using Granit.Settings.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Settings.Endpoints.Tests;
+
+public sealed class SettingsFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new SettingsFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(SettingsFeatures.Global).Permission.ShouldBe(SettingsPermissions.Global.Read);
+        catalog.Get(SettingsFeatures.Global).RouteName.ShouldBe(SettingsFeatures.Global);
+        catalog.Get(SettingsFeatures.Global).DefaultIcon.ShouldBe("settings-2");
+        catalog.Get(SettingsFeatures.Global).DisplayKey.ShouldBe("SettingsEndpoints:Workspace.Global");
+        catalog.Get(SettingsFeatures.Tenant).Permission.ShouldBe(SettingsPermissions.Tenant.Read);
+        catalog.Get(SettingsFeatures.Tenant).RouteName.ShouldBe(SettingsFeatures.Tenant);
+        catalog.Get(SettingsFeatures.Tenant).DefaultIcon.ShouldBe("building");
+        catalog.Get(SettingsFeatures.Tenant).DisplayKey.ShouldBe("SettingsEndpoints:Workspace.Tenant");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Templating.Endpoints.Tests/TemplatingFeatureProviderTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplatingFeatureProviderTests.cs
@@ -1,0 +1,38 @@
+using Granit.Templating.Endpoints.Permissions;
+using Granit.Templating.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Templating.Endpoints.Tests;
+
+public sealed class TemplatingFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new TemplatingFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(TemplatingFeatures.Templates).Permission.ShouldBe(TemplatingPermissions.Templates.Read);
+        catalog.Get(TemplatingFeatures.Templates).RouteName.ShouldBe(TemplatingFeatures.Templates);
+        catalog.Get(TemplatingFeatures.Templates).DefaultIcon.ShouldBe("layout-template");
+        catalog.Get(TemplatingFeatures.Templates).DisplayKey.ShouldBe("TemplatingEndpoints:Workspace.Templates");
+        catalog.Get(TemplatingFeatures.Categories).Permission.ShouldBe(TemplatingPermissions.Categories.Read);
+        catalog.Get(TemplatingFeatures.Categories).RouteName.ShouldBe(TemplatingFeatures.Categories);
+        catalog.Get(TemplatingFeatures.Categories).DefaultIcon.ShouldBe("folder-tree");
+        catalog.Get(TemplatingFeatures.Categories).DisplayKey.ShouldBe("TemplatingEndpoints:Workspace.Categories");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineFeatureProviderTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Timeline.Endpoints.Permissions;
+using Granit.Timeline.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.Endpoints.Tests;
+
+public sealed class TimelineFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new TimelineFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(TimelineFeatures.Entries).Permission.ShouldBe(TimelinePermissions.Entries.Read);
+        catalog.Get(TimelineFeatures.Entries).RouteName.ShouldBe(TimelineFeatures.Entries);
+        catalog.Get(TimelineFeatures.Entries).DefaultIcon.ShouldBe("activity");
+        catalog.Get(TimelineFeatures.Entries).DisplayKey.ShouldBe("TimelineEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Webhooks.Endpoints.Tests/WebhooksFeatureProviderTests.cs
+++ b/tests/Granit.Webhooks.Endpoints.Tests/WebhooksFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Webhooks.Endpoints.Permissions;
+using Granit.Webhooks.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Endpoints.Tests;
+
+public sealed class WebhooksFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new WebhooksFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(WebhooksFeatures.Subscriptions).Permission.ShouldBe(WebhooksPermissions.Subscriptions.Read);
+        catalog.Get(WebhooksFeatures.Subscriptions).RouteName.ShouldBe(WebhooksFeatures.Subscriptions);
+        catalog.Get(WebhooksFeatures.Subscriptions).DefaultIcon.ShouldBe("webhook");
+        catalog.Get(WebhooksFeatures.Subscriptions).DisplayKey.ShouldBe("WebhooksEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Workflow.Endpoints.Tests/WorkflowFeatureProviderTests.cs
+++ b/tests/Granit.Workflow.Endpoints.Tests/WorkflowFeatureProviderTests.cs
@@ -1,0 +1,34 @@
+using Granit.Workflow.Endpoints.Permissions;
+using Granit.Workflow.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workflow.Endpoints.Tests;
+
+public sealed class WorkflowFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_expected_features()
+    {
+        FakeCatalog catalog = new();
+        new WorkflowFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(WorkflowFeatures.History).Permission.ShouldBe(WorkflowPermissions.History.Read);
+        catalog.Get(WorkflowFeatures.History).RouteName.ShouldBe(WorkflowFeatures.History);
+        catalog.Get(WorkflowFeatures.History).DefaultIcon.ShouldBe("git-branch");
+        catalog.Get(WorkflowFeatures.History).DisplayKey.ShouldBe("WorkflowEndpoints:Workspace.History");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}


### PR DESCRIPTION
## Summary

**Completes per-module phase 3.** Every \`*.Endpoints\` module that ships a \`*WorkspaceContribution\` now also ships a sibling \`*FeatureProvider\` declaring the same items as catalog entries. Builds on the Diagnostics pilot (#2097) and the IdentityAccess batch (#2098).

## 22 features migrated across 16 modules

### Platform (5 features)
- \`settings.global\`, \`settings.tenant\` (\`Granit.Settings.Endpoints\`)
- \`features.flags\` (\`Granit.Features.Endpoints\`)
- \`localization.overrides\` (\`Granit.Localization.Endpoints\`)
- \`multi-tenancy.tenants\` (\`Granit.MultiTenancy.Endpoints\`)

### Storage (3 features)
- \`blob-storage.administration\` (\`Granit.BlobStorage.Endpoints\`)
- \`data-exchange.imports\`, \`data-exchange.exports\` (\`Granit.DataExchange.Endpoints\`)

### Communication (3 features)
- \`templating.templates\`, \`templating.categories\` (\`Granit.Templating.Endpoints\`)
- \`notifications.user\` (\`Granit.Notifications.Endpoints\`)

### Automation (3 features)
- \`background-jobs.jobs\` (\`Granit.BackgroundJobs.Endpoints\`)
- \`scheduling.actions\` (\`Granit.Scheduling.Endpoints\`)
- \`workflow.history\` (\`Granit.Workflow.Endpoints\`)

### Observability (2 features)
- \`auditing.entries\` (\`Granit.Auditing.Endpoints\`)
- \`timeline.entries\` (\`Granit.Timeline.Endpoints\`)

### Compliance (2 features)
- \`privacy.purposes\`, \`privacy.agreements\` (\`Granit.Privacy.Endpoints\`)

### Integrations (1 feature)
- \`webhooks.subscriptions\` (\`Granit.Webhooks.Endpoints\`)

### AI (2 features)
- \`ai.workspaces\`, \`ai.usage\` (\`Granit.AI.Endpoints\`)

## Per-module shape (unchanged from earlier batches)

- \`<Module>Features.cs\` — public string constants
- \`<Module>FeatureProvider.cs\` — internal \`IFeatureProvider\`
- Module class registers both legacy contribution **and** new provider
- One unit test per provider

Display keys reused verbatim from the legacy contributions — no localisation file changes needed. Route names follow the \`{module}.{entity-plural}.{view?}\` convention from ADR-057.

## Tests

All 16 impacted test projects green. 1000+ tests total. New tests follow the FakeCatalog template from the Diagnostics pilot.

## State after this MR

| Counter | Value |
|---|---|
| Modules with FeatureProvider | 21 / 21 (everything that contributes to a workspace) |
| Modules with legacy WorkspaceContribution | 21 / 21 (kept until phase 5) |
| Features in catalog | 32 (4 Diagnostics + 9 IdentityAccess + 22 here, minus IdentityLocal already removed) |

Once **#2097, #2098 and this MR** are merged the catalog is complete. **Phase 2 (Defaults bundles)** can then wire features into workspaces. Until then the catalog is populated but unused by the workspace tree — the legacy \`WorkspaceContribution\` still drives the menu, so no UI change yet.

## Refs

- ADR-057 §1 phase 3 — granit-docs #37
- Diagnostics pilot — #2097 (merged)
- IdentityAccess batch — #2098 (open / under review)