### PR TITLE
chore(i18n): shorten Workspace menu labels

### DIFF
--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/cs.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/cs.json
@@ -1,7 +1,7 @@
 {
   "culture": "cs",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Oprávnění",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Zobrazit všechny registrované definice oprávnění a skupiny",
     "Permission:Authorization.Grants.Manage": "Zobrazit, udělit a odvolat oprávnění pro role",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/de.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/de.json
@@ -1,7 +1,7 @@
 {
   "culture": "de",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Berechtigungen",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Alle registrierten Berechtigungsdefinitionen und Gruppen anzeigen",
     "Permission:Authorization.Grants.Manage": "Berechtigungen für Rollen anzeigen, erteilen und widerrufen",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/en-GB.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Permissions",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "PermissionGroup:Authorization": "Authorisation Management"
   }

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/en.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/en.json
@@ -1,7 +1,7 @@
 {
   "culture": "en",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Permissions",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "View all registered permission definitions and groups",
     "Permission:Authorization.Grants.Manage": "View, grant, and revoke permissions for roles",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/es.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/es.json
@@ -1,7 +1,7 @@
 {
   "culture": "es",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Permisos",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Ver todas las definiciones y grupos de permisos registrados",
     "Permission:Authorization.Grants.Manage": "Ver, conceder y revocar permisos para roles",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/fr-CA.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Catalogue des permissions",
+    "AuthorizationEndpoints:Workspace.Definitions": "Permissions",
     "AuthorizationEndpoints:Workspace.Section": "Autorisations"
   }
 }

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/fr.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/fr.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Catalogue des permissions",
+    "AuthorizationEndpoints:Workspace.Definitions": "Permissions",
     "AuthorizationEndpoints:Workspace.Section": "Autorisations",
     "Permission:Authorization.Definitions.Read": "Consulter toutes les définitions et groupes de permissions",
     "Permission:Authorization.Grants.Manage": "Consulter, accorder et révoquer les permissions pour les rôles",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/hi.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/hi.json
@@ -1,7 +1,7 @@
 {
   "culture": "hi",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "अनुमतियाँ",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "सभी पंजीकृत अनुमति परिभाषाएँ और समूह देखें",
     "Permission:Authorization.Grants.Manage": "भूमिकाओं के लिए अनुमतियाँ देखें, प्रदान करें और निरस्त करें",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/it.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/it.json
@@ -1,7 +1,7 @@
 {
   "culture": "it",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Autorizzazioni",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Visualizzare tutte le definizioni e i gruppi di permessi registrati",
     "Permission:Authorization.Grants.Manage": "Visualizzare, concedere e revocare i permessi per i ruoli",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/ja.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/ja.json
@@ -1,7 +1,7 @@
 {
   "culture": "ja",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "権限",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "登録済みの権限定義とグループをすべて表示",
     "Permission:Authorization.Grants.Manage": "ロールの権限を表示、付与、取消",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/ko.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/ko.json
@@ -1,7 +1,7 @@
 {
   "culture": "ko",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "권한",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "등록된 모든 권한 정의 및 그룹 보기",
     "Permission:Authorization.Grants.Manage": "역할에 대한 권한 보기, 부여 및 해지",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/nl.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/nl.json
@@ -1,7 +1,7 @@
 {
   "culture": "nl",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Machtigingen",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Alle geregistreerde machtigingsdefinities en groepen bekijken",
     "Permission:Authorization.Grants.Manage": "Machtigingen voor rollen bekijken, toekennen en intrekken",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/pl.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/pl.json
@@ -1,7 +1,7 @@
 {
   "culture": "pl",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Uprawnienia",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Wyświetlanie wszystkich zarejestrowanych definicji uprawnień i grup",
     "Permission:Authorization.Grants.Manage": "Wyświetlanie, przyznawanie i odwoływanie uprawnień dla ról",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/pt-BR.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Permissões",
     "AuthorizationEndpoints:Workspace.Section": "Authorization"
   }
 }

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/pt.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/pt.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Permissões",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Ver todas as definições e grupos de permissões registados",
     "Permission:Authorization.Grants.Manage": "Ver, conceder e revogar permissões para funções",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/sv.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/sv.json
@@ -1,7 +1,7 @@
 {
   "culture": "sv",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "Behörigheter",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Visa alla registrerade behörighetsdefinitioner och grupper",
     "Permission:Authorization.Grants.Manage": "Visa, bevilja och återkalla behörigheter för roller",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/tr.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/tr.json
@@ -1,7 +1,7 @@
 {
   "culture": "tr",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "İzinler",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "Tüm kayıtlı izin tanımlarını ve grupları görüntüle",
     "Permission:Authorization.Grants.Manage": "Roller için izinleri görüntüle, ver ve iptal et",

--- a/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/zh.json
+++ b/src/Granit.Authorization.Endpoints/Localization/AuthorizationEndpoints/zh.json
@@ -1,7 +1,7 @@
 {
   "culture": "zh",
   "texts": {
-    "AuthorizationEndpoints:Workspace.Definitions": "Permissions catalogue",
+    "AuthorizationEndpoints:Workspace.Definitions": "权限",
     "AuthorizationEndpoints:Workspace.Section": "Authorization",
     "Permission:Authorization.Definitions.Read": "查看所有已注册的权限定义和组",
     "Permission:Authorization.Grants.Manage": "查看、授予和撤销角色权限",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/cs.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/cs.json
@@ -1,7 +1,7 @@
 {
   "culture": "cs",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Naplánované úlohy",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Správa úloh na pozadí (seznam, pozastavení, obnovení, ruční spuštění)",
     "Permission:BackgroundJobs.Jobs.Read": "Zobrazit úlohy na pozadí (seznam, detail)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/de.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/de.json
@@ -1,7 +1,7 @@
 {
   "culture": "de",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Geplante Aufgaben",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Hintergrundaufgaben verwalten (Liste, Pause, Fortsetzen, manuelles Auslösen)",
     "Permission:BackgroundJobs.Jobs.Read": "Hintergrundaufgaben anzeigen (Liste, Detail)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/en-GB.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Scheduled tasks",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs"
   }
 }

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/en.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/en.json
@@ -1,7 +1,7 @@
 {
   "culture": "en",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Scheduled tasks",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Manage background jobs (list, pause, resume, manual trigger)",
     "Permission:BackgroundJobs.Jobs.Read": "View background jobs (list, detail)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/es.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/es.json
@@ -1,7 +1,7 @@
 {
   "culture": "es",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Tareas programadas",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Administrar tareas en segundo plano (lista, pausa, reanudación, ejecución manual)",
     "Permission:BackgroundJobs.Jobs.Read": "Ver tareas en segundo plano (lista, detalle)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/fr-CA.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Exécutions de tâches",
+    "BackgroundJobsEndpoints:Workspace.Item": "Tâches planifiées",
     "BackgroundJobsEndpoints:Workspace.Section": "Tâches d'arrière-plan"
   }
 }

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/fr.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/fr.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Exécutions de tâches",
+    "BackgroundJobsEndpoints:Workspace.Item": "Tâches planifiées",
     "BackgroundJobsEndpoints:Workspace.Section": "Tâches d'arrière-plan",
     "Permission:BackgroundJobs.Jobs.Manage": "Administrer les tâches en arrière-plan (liste, pause, reprise, déclenchement manuel)",
     "Permission:BackgroundJobs.Jobs.Read": "Consulter les tâches en arrière-plan (liste, détail)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/hi.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/hi.json
@@ -1,7 +1,7 @@
 {
   "culture": "hi",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "अनुसूचित कार्य",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "पृष्ठभूमि कार्य प्रबंधित करें (सूची, रोकें, फिर से शुरू करें, मैन्युअल ट्रिगर)",
     "Permission:BackgroundJobs.Jobs.Read": "पृष्ठभूमि कार्य देखें (सूची, विवरण)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/it.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/it.json
@@ -1,7 +1,7 @@
 {
   "culture": "it",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Attività pianificate",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Gestire le attività in background (elenco, pausa, ripresa, avvio manuale)",
     "Permission:BackgroundJobs.Jobs.Read": "Visualizzare le attività in background (elenco, dettaglio)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/ja.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/ja.json
@@ -1,7 +1,7 @@
 {
   "culture": "ja",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "予定されたタスク",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "バックグラウンドジョブの管理（一覧、一時停止、再開、手動実行）",
     "Permission:BackgroundJobs.Jobs.Read": "バックグラウンドジョブの閲覧（一覧、詳細）",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/ko.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/ko.json
@@ -1,7 +1,7 @@
 {
   "culture": "ko",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "예약된 작업",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "백그라운드 작업 관리 (목록, 일시중지, 재개, 수동 실행)",
     "Permission:BackgroundJobs.Jobs.Read": "백그라운드 작업 조회 (목록, 상세)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/nl.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/nl.json
@@ -1,7 +1,7 @@
 {
   "culture": "nl",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Geplande taken",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Achtergrondtaken beheren (lijst, pauzeren, hervatten, handmatig starten)",
     "Permission:BackgroundJobs.Jobs.Read": "Achtergrondtaken bekijken (lijst, detail)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/pl.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/pl.json
@@ -1,7 +1,7 @@
 {
   "culture": "pl",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Zaplanowane zadania",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Zarządzanie zadaniami w tle (lista, wstrzymanie, wznowienie, ręczne uruchomienie)",
     "Permission:BackgroundJobs.Jobs.Read": "Przeglądanie zadań w tle (lista, szczegóły)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/pt-BR.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Tarefas agendadas",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs"
   }
 }

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/pt.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/pt.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Tarefas agendadas",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Gerir tarefas em segundo plano (lista, pausa, retoma, execução manual)",
     "Permission:BackgroundJobs.Jobs.Read": "Ver tarefas em segundo plano (lista, detalhe)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/sv.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/sv.json
@@ -1,7 +1,7 @@
 {
   "culture": "sv",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Schemalagda uppgifter",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Hantera bakgrundsjobb (lista, pausa, återuppta, manuell körning)",
     "Permission:BackgroundJobs.Jobs.Read": "Visa bakgrundsjobb (lista, detalj)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/tr.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/tr.json
@@ -1,7 +1,7 @@
 {
   "culture": "tr",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "Zamanlanmış görevler",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "Arka plan görevlerini yönet (liste, duraklat, devam ettir, manuel tetikle)",
     "Permission:BackgroundJobs.Jobs.Read": "Arka plan görevlerini görüntüle (liste, detay)",

--- a/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/zh.json
+++ b/src/Granit.BackgroundJobs.Endpoints/Localization/BackgroundJobsEndpoints/zh.json
@@ -1,7 +1,7 @@
 {
   "culture": "zh",
   "texts": {
-    "BackgroundJobsEndpoints:Workspace.Item": "Job runs",
+    "BackgroundJobsEndpoints:Workspace.Item": "已计划任务",
     "BackgroundJobsEndpoints:Workspace.Section": "Background jobs",
     "Permission:BackgroundJobs.Jobs.Manage": "管理后台任务（列表、暂停、恢复、手动触发）",
     "Permission:BackgroundJobs.Jobs.Read": "查看后台任务（列表、详情）",

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/cs.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/cs.json
@@ -1,10 +1,10 @@
 {
-  "culture": "cs",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Spravovat úložiště souborů (nahrát, stáhnout, smazat, potvrdit, vyčistit)",
-    "Permission:BlobStorage.Administration.Read": "Zobrazit správu úložiště souborů (seznam, popisovače, dotaz)",
-    "PermissionGroup:BlobStorage": "Úložiště souborů"
-  }
+    "culture": "cs",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Bloby",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Spravovat úložiště souborů (nahrát, stáhnout, smazat, potvrdit, vyčistit)",
+        "Permission:BlobStorage.Administration.Read": "Zobrazit správu úložiště souborů (seznam, popisovače, dotaz)",
+        "PermissionGroup:BlobStorage": "Úložiště souborů"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/de.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/de.json
@@ -1,10 +1,10 @@
 {
-  "culture": "de",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Dateispeicher verwalten (hochladen, herunterladen, löschen, bestätigen, bereinigen)",
-    "Permission:BlobStorage.Administration.Read": "Dateispeicherverwaltung anzeigen (Liste, Deskriptoren, Abfrage)",
-    "PermissionGroup:BlobStorage": "Dateispeicher"
-  }
+    "culture": "de",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Dateispeicher verwalten (hochladen, herunterladen, löschen, bestätigen, bereinigen)",
+        "Permission:BlobStorage.Administration.Read": "Dateispeicherverwaltung anzeigen (Liste, Deskriptoren, Abfrage)",
+        "PermissionGroup:BlobStorage": "Dateispeicher"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/en-GB.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
-  "culture": "en-GB",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage"
-  }
+    "culture": "en-GB",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/en.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/en.json
@@ -1,10 +1,10 @@
 {
-  "culture": "en",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Manage blob storage (upload, download, delete, confirm, cleanup)",
-    "Permission:BlobStorage.Administration.Read": "View blob storage administration (list, descriptors, query)",
-    "PermissionGroup:BlobStorage": "Blob Storage"
-  }
+    "culture": "en",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Manage blob storage (upload, download, delete, confirm, cleanup)",
+        "Permission:BlobStorage.Administration.Read": "View blob storage administration (list, descriptors, query)",
+        "PermissionGroup:BlobStorage": "Blob Storage"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/es.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/es.json
@@ -1,10 +1,10 @@
 {
-  "culture": "es",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Gestionar almacenamiento de archivos (subir, descargar, eliminar, confirmar, limpiar)",
-    "Permission:BlobStorage.Administration.Read": "Ver administración de almacenamiento de archivos (lista, descriptores, consulta)",
-    "PermissionGroup:BlobStorage": "Almacenamiento de archivos"
-  }
+    "culture": "es",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Gestionar almacenamiento de archivos (subir, descargar, eliminar, confirmar, limpiar)",
+        "Permission:BlobStorage.Administration.Read": "Ver administración de almacenamiento de archivos (lista, descriptores, consulta)",
+        "PermissionGroup:BlobStorage": "Almacenamiento de archivos"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/fr-CA.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
-  "culture": "fr-CA",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Administration des blobs",
-    "BlobStorageEndpoints:Workspace.Section": "Stockage de blobs"
-  }
+    "culture": "fr-CA",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Stockage de blobs"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/fr.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/fr.json
@@ -1,10 +1,10 @@
 {
-  "culture": "fr",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Administration des blobs",
-    "BlobStorageEndpoints:Workspace.Section": "Stockage de blobs",
-    "Permission:BlobStorage.Administration.Manage": "Gérer le stockage de fichiers (téléverser, télécharger, supprimer, confirmer, nettoyer)",
-    "Permission:BlobStorage.Administration.Read": "Consulter l'administration du stockage de fichiers (liste, descripteurs, requêtes)",
-    "PermissionGroup:BlobStorage": "Stockage de fichiers"
-  }
+    "culture": "fr",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Stockage de blobs",
+        "Permission:BlobStorage.Administration.Manage": "Gérer le stockage de fichiers (téléverser, télécharger, supprimer, confirmer, nettoyer)",
+        "Permission:BlobStorage.Administration.Read": "Consulter l'administration du stockage de fichiers (liste, descripteurs, requêtes)",
+        "PermissionGroup:BlobStorage": "Stockage de fichiers"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/hi.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/hi.json
@@ -1,10 +1,10 @@
 {
-  "culture": "hi",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "ब्लॉब स्टोरेज प्रबंधित करें (अपलोड, डाउनलोड, हटाएँ, पुष्टि करें, सफ़ाई)",
-    "Permission:BlobStorage.Administration.Read": "ब्लॉब स्टोरेज प्रशासन देखें (सूची, डिस्क्रिप्टर, क्वेरी)",
-    "PermissionGroup:BlobStorage": "ब्लॉब स्टोरेज"
-  }
+    "culture": "hi",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blob",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "ब्लॉब स्टोरेज प्रबंधित करें (अपलोड, डाउनलोड, हटाएँ, पुष्टि करें, सफ़ाई)",
+        "Permission:BlobStorage.Administration.Read": "ब्लॉब स्टोरेज प्रशासन देखें (सूची, डिस्क्रिप्टर, क्वेरी)",
+        "PermissionGroup:BlobStorage": "ब्लॉब स्टोरेज"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/it.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/it.json
@@ -1,10 +1,10 @@
 {
-  "culture": "it",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Gestire l'archiviazione file (caricare, scaricare, eliminare, confermare, pulire)",
-    "Permission:BlobStorage.Administration.Read": "Visualizzare l'amministrazione dell'archiviazione file (elenco, descrittori, query)",
-    "PermissionGroup:BlobStorage": "Archiviazione file"
-  }
+    "culture": "it",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blob",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Gestire l'archiviazione file (caricare, scaricare, eliminare, confermare, pulire)",
+        "Permission:BlobStorage.Administration.Read": "Visualizzare l'amministrazione dell'archiviazione file (elenco, descrittori, query)",
+        "PermissionGroup:BlobStorage": "Archiviazione file"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/ja.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/ja.json
@@ -1,10 +1,10 @@
 {
-  "culture": "ja",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "ファイルストレージを管理（アップロード、ダウンロード、削除、確認、クリーンアップ）",
-    "Permission:BlobStorage.Administration.Read": "ファイルストレージ管理を表示（一覧、記述子、クエリ）",
-    "PermissionGroup:BlobStorage": "ファイルストレージ"
-  }
+    "culture": "ja",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blob",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "ファイルストレージを管理（アップロード、ダウンロード、削除、確認、クリーンアップ）",
+        "Permission:BlobStorage.Administration.Read": "ファイルストレージ管理を表示（一覧、記述子、クエリ）",
+        "PermissionGroup:BlobStorage": "ファイルストレージ"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/ko.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/ko.json
@@ -1,10 +1,10 @@
 {
-  "culture": "ko",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "파일 저장소 관리 (업로드, 다운로드, 삭제, 확인, 정리)",
-    "Permission:BlobStorage.Administration.Read": "파일 저장소 관리 조회 (목록, 설명자, 쿼리)",
-    "PermissionGroup:BlobStorage": "파일 저장소"
-  }
+    "culture": "ko",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blob",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "파일 저장소 관리 (업로드, 다운로드, 삭제, 확인, 정리)",
+        "Permission:BlobStorage.Administration.Read": "파일 저장소 관리 조회 (목록, 설명자, 쿼리)",
+        "PermissionGroup:BlobStorage": "파일 저장소"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/nl.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/nl.json
@@ -1,10 +1,10 @@
 {
-  "culture": "nl",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Bestandsopslag beheren (uploaden, downloaden, verwijderen, bevestigen, opruimen)",
-    "Permission:BlobStorage.Administration.Read": "Bestandsopslagbeheer bekijken (lijst, descriptors, query)",
-    "PermissionGroup:BlobStorage": "Bestandsopslag"
-  }
+    "culture": "nl",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Bestandsopslag beheren (uploaden, downloaden, verwijderen, bevestigen, opruimen)",
+        "Permission:BlobStorage.Administration.Read": "Bestandsopslagbeheer bekijken (lijst, descriptors, query)",
+        "PermissionGroup:BlobStorage": "Bestandsopslag"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/pl.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/pl.json
@@ -1,10 +1,10 @@
 {
-  "culture": "pl",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Zarządzanie magazynem plików (przesyłanie, pobieranie, usuwanie, potwierdzanie, czyszczenie)",
-    "Permission:BlobStorage.Administration.Read": "Wyświetlanie administracji magazynu plików (lista, deskryptory, zapytania)",
-    "PermissionGroup:BlobStorage": "Magazyn plików"
-  }
+    "culture": "pl",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobi",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Zarządzanie magazynem plików (przesyłanie, pobieranie, usuwanie, potwierdzanie, czyszczenie)",
+        "Permission:BlobStorage.Administration.Read": "Wyświetlanie administracji magazynu plików (lista, deskryptory, zapytania)",
+        "PermissionGroup:BlobStorage": "Magazyn plików"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/pt-BR.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/pt-BR.json
@@ -1,10 +1,10 @@
 {
-  "culture": "pt-BR",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Gerenciar armazenamento de arquivos (enviar, baixar, excluir, confirmar, limpar)",
-    "Permission:BlobStorage.Administration.Read": "Ver administração do armazenamento de arquivos (lista, descritores, consulta)",
-    "PermissionGroup:BlobStorage": "Armazenamento de arquivos"
-  }
+    "culture": "pt-BR",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Gerenciar armazenamento de arquivos (enviar, baixar, excluir, confirmar, limpar)",
+        "Permission:BlobStorage.Administration.Read": "Ver administração do armazenamento de arquivos (lista, descritores, consulta)",
+        "PermissionGroup:BlobStorage": "Armazenamento de arquivos"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/pt.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/pt.json
@@ -1,10 +1,10 @@
 {
-  "culture": "pt",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Gerir armazenamento de ficheiros (carregar, descarregar, eliminar, confirmar, limpar)",
-    "Permission:BlobStorage.Administration.Read": "Ver administração do armazenamento de ficheiros (lista, descritores, consulta)",
-    "PermissionGroup:BlobStorage": "Armazenamento de ficheiros"
-  }
+    "culture": "pt",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobs",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Gerir armazenamento de ficheiros (carregar, descarregar, eliminar, confirmar, limpar)",
+        "Permission:BlobStorage.Administration.Read": "Ver administração do armazenamento de ficheiros (lista, descritores, consulta)",
+        "PermissionGroup:BlobStorage": "Armazenamento de ficheiros"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/sv.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/sv.json
@@ -1,10 +1,10 @@
 {
-  "culture": "sv",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Hantera fillagring (ladda upp, ladda ner, ta bort, bekräfta, rensa)",
-    "Permission:BlobStorage.Administration.Read": "Visa fillagringsadministration (lista, beskrivningar, fråga)",
-    "PermissionGroup:BlobStorage": "Fillagring"
-  }
+    "culture": "sv",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blobbar",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Hantera fillagring (ladda upp, ladda ner, ta bort, bekräfta, rensa)",
+        "Permission:BlobStorage.Administration.Read": "Visa fillagringsadministration (lista, beskrivningar, fråga)",
+        "PermissionGroup:BlobStorage": "Fillagring"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/tr.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/tr.json
@@ -1,10 +1,10 @@
 {
-  "culture": "tr",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "Dosya depolamayı yönet (yükle, indir, sil, onayla, temizle)",
-    "Permission:BlobStorage.Administration.Read": "Dosya depolama yönetimini görüntüle (liste, tanımlayıcılar, sorgu)",
-    "PermissionGroup:BlobStorage": "Dosya depolama"
-  }
+    "culture": "tr",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Bloblar",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "Dosya depolamayı yönet (yükle, indir, sil, onayla, temizle)",
+        "Permission:BlobStorage.Administration.Read": "Dosya depolama yönetimini görüntüle (liste, tanımlayıcılar, sorgu)",
+        "PermissionGroup:BlobStorage": "Dosya depolama"
+    }
 }

--- a/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/zh.json
+++ b/src/Granit.BlobStorage.Endpoints/Localization/BlobStorageEndpoints/zh.json
@@ -1,10 +1,10 @@
 {
-  "culture": "zh",
-  "texts": {
-    "BlobStorageEndpoints:Workspace.Item": "Blob administration",
-    "BlobStorageEndpoints:Workspace.Section": "Blob storage",
-    "Permission:BlobStorage.Administration.Manage": "管理文件存储（上传、下载、删除、确认、清理）",
-    "Permission:BlobStorage.Administration.Read": "查看文件存储管理（列表、描述符、查询）",
-    "PermissionGroup:BlobStorage": "文件存储"
-  }
+    "culture": "zh",
+    "texts": {
+        "BlobStorageEndpoints:Workspace.Item": "Blob",
+        "BlobStorageEndpoints:Workspace.Section": "Blob storage",
+        "Permission:BlobStorage.Administration.Manage": "管理文件存储（上传、下载、删除、确认、清理）",
+        "Permission:BlobStorage.Administration.Read": "查看文件存储管理（列表、描述符、查询）",
+        "PermissionGroup:BlobStorage": "文件存储"
+    }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/cs.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/cs.json
@@ -1,7 +1,7 @@
 {
   "culture": "cs",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funkce",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Spravovat přepsání funkcí (nastavit, smazat)",
     "Permission:Features.Flags.Read": "Číst definice funkcí",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/de.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/de.json
@@ -1,7 +1,7 @@
 {
   "culture": "de",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funktionen",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Funktionsüberschreibungen verwalten (setzen, löschen)",
     "Permission:Features.Flags.Read": "Funktionsdefinitionen lesen",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en-GB.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Features",
     "FeaturesEndpoints:Workspace.Section": "Feature flags"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en.json
@@ -1,7 +1,7 @@
 {
   "culture": "en",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Features",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Manage feature overrides (set, delete)",
     "Permission:Features.Flags.Read": "Read feature definitions",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/es.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/es.json
@@ -1,7 +1,7 @@
 {
   "culture": "es",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funcionalidades",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Gestionar anulaciones de funcionalidades (establecer, eliminar)",
     "Permission:Features.Flags.Read": "Leer definiciones de funcionalidades",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr-CA.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Indicateurs",
+    "FeaturesEndpoints:Workspace.Item": "Fonctionnalités",
     "FeaturesEndpoints:Workspace.Section": "Indicateurs de fonctionnalités"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Indicateurs",
+    "FeaturesEndpoints:Workspace.Item": "Fonctionnalités",
     "FeaturesEndpoints:Workspace.Section": "Indicateurs de fonctionnalités",
     "Permission:Features.Flags.Manage": "Gérer les substitutions de fonctionnalités (définir, supprimer)",
     "Permission:Features.Flags.Read": "Consulter les définitions de fonctionnalités",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/hi.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/hi.json
@@ -1,7 +1,7 @@
 {
   "culture": "hi",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "सुविधाएँ",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "सुविधा ओवरराइड प्रबंधित करें (सेट करें, हटाएँ)",
     "Permission:Features.Flags.Read": "सुविधा परिभाषाएँ पढ़ें",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/it.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/it.json
@@ -1,7 +1,7 @@
 {
   "culture": "it",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funzionalità",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Gestire le sostituzioni delle funzionalità (impostare, eliminare)",
     "Permission:Features.Flags.Read": "Leggere le definizioni delle funzionalità",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ja.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ja.json
@@ -1,7 +1,7 @@
 {
   "culture": "ja",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "機能",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "機能オーバーライドを管理する（設定、削除）",
     "Permission:Features.Flags.Read": "機能定義を読み取る",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ko.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ko.json
@@ -1,7 +1,7 @@
 {
   "culture": "ko",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "기능",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "기능 재정의 관리 (설정, 삭제)",
     "Permission:Features.Flags.Read": "기능 정의 읽기",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/nl.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/nl.json
@@ -1,7 +1,7 @@
 {
   "culture": "nl",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Functies",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Functie-overschrijvingen beheren (instellen, verwijderen)",
     "Permission:Features.Flags.Read": "Functiedefinities lezen",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pl.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pl.json
@@ -1,7 +1,7 @@
 {
   "culture": "pl",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funkcje",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Zarządzaj nadpisaniami funkcjonalności (ustawiaj, usuwaj)",
     "Permission:Features.Flags.Read": "Odczytaj definicje funkcjonalności",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt-BR.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funcionalidades",
     "FeaturesEndpoints:Workspace.Section": "Feature flags"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funcionalidades",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Gerir substituições de funcionalidades (definir, eliminar)",
     "Permission:Features.Flags.Read": "Consultar definições de funcionalidades",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/sv.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/sv.json
@@ -1,7 +1,7 @@
 {
   "culture": "sv",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Funktioner",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Hantera funktionsöverskrivningar (ange, ta bort)",
     "Permission:Features.Flags.Read": "Läsa funktionsdefinitioner",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/tr.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/tr.json
@@ -1,7 +1,7 @@
 {
   "culture": "tr",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "Özellikler",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "Özellik geçersiz kılmalarını yönet (ayarla, sil)",
     "Permission:Features.Flags.Read": "Özellik tanımlarını oku",

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/zh.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/zh.json
@@ -1,7 +1,7 @@
 {
   "culture": "zh",
   "texts": {
-    "FeaturesEndpoints:Workspace.Item": "Flags",
+    "FeaturesEndpoints:Workspace.Item": "功能",
     "FeaturesEndpoints:Workspace.Section": "Feature flags",
     "Permission:Features.Flags.Manage": "管理功能覆盖（设置、删除）",
     "Permission:Features.Flags.Read": "读取功能定义",

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/cs.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/cs.json
@@ -1,10 +1,10 @@
 {
-  "culture": "cs",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Správa přepisů překladů (zobrazení, vytvoření, úprava, smazání)",
-    "Permission:Localization.Overrides.Read": "Zobrazit přepisy překladů",
-    "PermissionGroup:Localization": "Lokalizace"
-  }
+    "culture": "cs",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Překlady",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Správa přepisů překladů (zobrazení, vytvoření, úprava, smazání)",
+        "Permission:Localization.Overrides.Read": "Zobrazit přepisy překladů",
+        "PermissionGroup:Localization": "Lokalizace"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/de.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/de.json
@@ -1,10 +1,10 @@
 {
-  "culture": "de",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Übersetzungsüberschreibungen verwalten (anzeigen, erstellen, bearbeiten, löschen)",
-    "Permission:Localization.Overrides.Read": "Übersetzungsüberschreibungen anzeigen",
-    "PermissionGroup:Localization": "Lokalisierung"
-  }
+    "culture": "de",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Übersetzungen",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Übersetzungsüberschreibungen verwalten (anzeigen, erstellen, bearbeiten, löschen)",
+        "Permission:Localization.Overrides.Read": "Übersetzungsüberschreibungen anzeigen",
+        "PermissionGroup:Localization": "Lokalisierung"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/en-GB.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/en-GB.json
@@ -1,8 +1,8 @@
 {
-  "culture": "en-GB",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "PermissionGroup:Localization": "Localisation"
-  }
+    "culture": "en-GB",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Translations",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "PermissionGroup:Localization": "Localisation"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/en.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/en.json
@@ -1,10 +1,10 @@
 {
-  "culture": "en",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Manage translation overrides (view, create, edit, delete)",
-    "Permission:Localization.Overrides.Read": "View translation overrides",
-    "PermissionGroup:Localization": "Localization"
-  }
+    "culture": "en",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Translations",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Manage translation overrides (view, create, edit, delete)",
+        "Permission:Localization.Overrides.Read": "View translation overrides",
+        "PermissionGroup:Localization": "Localization"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/es.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/es.json
@@ -1,10 +1,10 @@
 {
-  "culture": "es",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Gestionar las sobrecargas de traducción (ver, crear, editar, eliminar)",
-    "Permission:Localization.Overrides.Read": "Ver las sobrecargas de traducción",
-    "PermissionGroup:Localization": "Localización"
-  }
+    "culture": "es",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Traducciones",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Gestionar las sobrecargas de traducción (ver, crear, editar, eliminar)",
+        "Permission:Localization.Overrides.Read": "Ver las sobrecargas de traducción",
+        "PermissionGroup:Localization": "Localización"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/fr-CA.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
-  "culture": "fr-CA",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Surcharges de traduction",
-    "LocalizationEndpoints:Workspace.Section": "Localisation"
-  }
+    "culture": "fr-CA",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Traductions",
+        "LocalizationEndpoints:Workspace.Section": "Localisation"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/fr.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/fr.json
@@ -1,10 +1,10 @@
 {
-  "culture": "fr",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Surcharges de traduction",
-    "LocalizationEndpoints:Workspace.Section": "Localisation",
-    "Permission:Localization.Overrides.Manage": "Gérer les surcharges de traduction (consulter, créer, modifier, supprimer)",
-    "Permission:Localization.Overrides.Read": "Consulter les surcharges de traduction",
-    "PermissionGroup:Localization": "Localisation"
-  }
+    "culture": "fr",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Traductions",
+        "LocalizationEndpoints:Workspace.Section": "Localisation",
+        "Permission:Localization.Overrides.Manage": "Gérer les surcharges de traduction (consulter, créer, modifier, supprimer)",
+        "Permission:Localization.Overrides.Read": "Consulter les surcharges de traduction",
+        "PermissionGroup:Localization": "Localisation"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/hi.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/hi.json
@@ -1,10 +1,10 @@
 {
-  "culture": "hi",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "अनुवाद ओवरराइड प्रबंधित करें (देखें, बनाएँ, संपादित करें, हटाएँ)",
-    "Permission:Localization.Overrides.Read": "अनुवाद ओवरराइड देखें",
-    "PermissionGroup:Localization": "स्थानीयकरण"
-  }
+    "culture": "hi",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "अनुवाद",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "अनुवाद ओवरराइड प्रबंधित करें (देखें, बनाएँ, संपादित करें, हटाएँ)",
+        "Permission:Localization.Overrides.Read": "अनुवाद ओवरराइड देखें",
+        "PermissionGroup:Localization": "स्थानीयकरण"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/it.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/it.json
@@ -1,10 +1,10 @@
 {
-  "culture": "it",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Gestire le sovrascritture di traduzione (visualizzare, creare, modificare, eliminare)",
-    "Permission:Localization.Overrides.Read": "Visualizzare le sovrascritture di traduzione",
-    "PermissionGroup:Localization": "Localizzazione"
-  }
+    "culture": "it",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Traduzioni",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Gestire le sovrascritture di traduzione (visualizzare, creare, modificare, eliminare)",
+        "Permission:Localization.Overrides.Read": "Visualizzare le sovrascritture di traduzione",
+        "PermissionGroup:Localization": "Localizzazione"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/ja.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/ja.json
@@ -1,10 +1,10 @@
 {
-  "culture": "ja",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "翻訳オーバーライドの管理（表示、作成、編集、削除）",
-    "Permission:Localization.Overrides.Read": "翻訳オーバーライドの閲覧",
-    "PermissionGroup:Localization": "ローカライゼーション"
-  }
+    "culture": "ja",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "翻訳",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "翻訳オーバーライドの管理（表示、作成、編集、削除）",
+        "Permission:Localization.Overrides.Read": "翻訳オーバーライドの閲覧",
+        "PermissionGroup:Localization": "ローカライゼーション"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/ko.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/ko.json
@@ -1,10 +1,10 @@
 {
-  "culture": "ko",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "번역 재정의 관리 (보기, 생성, 편집, 삭제)",
-    "Permission:Localization.Overrides.Read": "번역 재정의 조회",
-    "PermissionGroup:Localization": "현지화"
-  }
+    "culture": "ko",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "번역",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "번역 재정의 관리 (보기, 생성, 편집, 삭제)",
+        "Permission:Localization.Overrides.Read": "번역 재정의 조회",
+        "PermissionGroup:Localization": "현지화"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/nl.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/nl.json
@@ -1,10 +1,10 @@
 {
-  "culture": "nl",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Vertaaloverschrijvingen beheren (bekijken, aanmaken, bewerken, verwijderen)",
-    "Permission:Localization.Overrides.Read": "Vertaaloverschrijvingen bekijken",
-    "PermissionGroup:Localization": "Lokalisatie"
-  }
+    "culture": "nl",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Vertalingen",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Vertaaloverschrijvingen beheren (bekijken, aanmaken, bewerken, verwijderen)",
+        "Permission:Localization.Overrides.Read": "Vertaaloverschrijvingen bekijken",
+        "PermissionGroup:Localization": "Lokalisatie"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/pl.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/pl.json
@@ -1,10 +1,10 @@
 {
-  "culture": "pl",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Zarządzanie nadpisaniami tłumaczeń (wyświetlanie, tworzenie, edycja, usuwanie)",
-    "Permission:Localization.Overrides.Read": "Przeglądanie nadpisań tłumaczeń",
-    "PermissionGroup:Localization": "Lokalizacja"
-  }
+    "culture": "pl",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Tłumaczenia",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Zarządzanie nadpisaniami tłumaczeń (wyświetlanie, tworzenie, edycja, usuwanie)",
+        "Permission:Localization.Overrides.Read": "Przeglądanie nadpisań tłumaczeń",
+        "PermissionGroup:Localization": "Lokalizacja"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/pt-BR.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
-  "culture": "pt-BR",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization"
-  }
+    "culture": "pt-BR",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Traduções",
+        "LocalizationEndpoints:Workspace.Section": "Localization"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/pt.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/pt.json
@@ -1,10 +1,10 @@
 {
-  "culture": "pt",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Gerir substituições de tradução (ver, criar, editar, eliminar)",
-    "Permission:Localization.Overrides.Read": "Ver as substituições de tradução",
-    "PermissionGroup:Localization": "Localização"
-  }
+    "culture": "pt",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Traduções",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Gerir substituições de tradução (ver, criar, editar, eliminar)",
+        "Permission:Localization.Overrides.Read": "Ver as substituições de tradução",
+        "PermissionGroup:Localization": "Localização"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/sv.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/sv.json
@@ -1,10 +1,10 @@
 {
-  "culture": "sv",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Hantera översättningsåsidosättningar (visa, skapa, redigera, radera)",
-    "Permission:Localization.Overrides.Read": "Visa översättningsöverskridanden",
-    "PermissionGroup:Localization": "Lokalisering"
-  }
+    "culture": "sv",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Översättningar",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Hantera översättningsåsidosättningar (visa, skapa, redigera, radera)",
+        "Permission:Localization.Overrides.Read": "Visa översättningsöverskridanden",
+        "PermissionGroup:Localization": "Lokalisering"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/tr.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/tr.json
@@ -1,10 +1,10 @@
 {
-  "culture": "tr",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "Çeviri geçersiz kılmalarını yönet (görüntüle, oluştur, düzenle, sil)",
-    "Permission:Localization.Overrides.Read": "Çeviri geçersiz kılmalarını görüntüle",
-    "PermissionGroup:Localization": "Yerelleştirme"
-  }
+    "culture": "tr",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "Çeviriler",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "Çeviri geçersiz kılmalarını yönet (görüntüle, oluştur, düzenle, sil)",
+        "Permission:Localization.Overrides.Read": "Çeviri geçersiz kılmalarını görüntüle",
+        "PermissionGroup:Localization": "Yerelleştirme"
+    }
 }

--- a/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/zh.json
+++ b/src/Granit.Localization.Endpoints/Localization/LocalizationEndpoints/zh.json
@@ -1,10 +1,10 @@
 {
-  "culture": "zh",
-  "texts": {
-    "LocalizationEndpoints:Workspace.Item": "Translation overrides",
-    "LocalizationEndpoints:Workspace.Section": "Localization",
-    "Permission:Localization.Overrides.Manage": "管理翻译覆盖（查看、创建、编辑、删除）",
-    "Permission:Localization.Overrides.Read": "查看翻译覆盖",
-    "PermissionGroup:Localization": "本地化"
-  }
+    "culture": "zh",
+    "texts": {
+        "LocalizationEndpoints:Workspace.Item": "翻译",
+        "LocalizationEndpoints:Workspace.Section": "Localization",
+        "Permission:Localization.Overrides.Manage": "管理翻译覆盖（查看、创建、编辑、删除）",
+        "Permission:Localization.Overrides.Read": "查看翻译覆盖",
+        "PermissionGroup:Localization": "本地化"
+    }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/cs.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/cs.json
@@ -2,7 +2,7 @@
   "culture": "cs",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Nájemci",
     "Permission:MultiTenancy.Tenants.Create": "Vytvořit nové nájemce",
     "Permission:MultiTenancy.Tenants.Manage": "Spravovat životní cyklus nájemců (aktivovat, deaktivovat)",
     "Permission:MultiTenancy.Tenants.Read": "Zobrazit informace o nájemcích",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/de.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/de.json
@@ -2,7 +2,7 @@
   "culture": "de",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Mandanten",
     "Permission:MultiTenancy.Tenants.Create": "Neue Mandanten erstellen",
     "Permission:MultiTenancy.Tenants.Manage": "Mandantenlebenszyklus verwalten (aktivieren, deaktivieren)",
     "Permission:MultiTenancy.Tenants.Read": "Mandanteninformationen anzeigen",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/es.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/es.json
@@ -2,7 +2,7 @@
   "culture": "es",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Inquilinos",
     "Permission:MultiTenancy.Tenants.Create": "Crear nuevos inquilinos",
     "Permission:MultiTenancy.Tenants.Manage": "Gestionar ciclo de vida de inquilinos (activar, desactivar)",
     "Permission:MultiTenancy.Tenants.Read": "Ver información de inquilinos",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr-CA.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr-CA.json
@@ -2,6 +2,6 @@
   "culture": "fr-CA",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenant",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants"
+    "MultiTenancyEndpoints:Workspace.Tenants": "Locataires"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr.json
@@ -2,7 +2,7 @@
   "culture": "fr",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenant",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Locataires",
     "Permission:MultiTenancy.Tenants.Create": "Créer de nouveaux locataires",
     "Permission:MultiTenancy.Tenants.Manage": "Gérer le cycle de vie des locataires (activer, désactiver)",
     "Permission:MultiTenancy.Tenants.Read": "Consulter les informations des locataires",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/hi.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/hi.json
@@ -2,7 +2,7 @@
   "culture": "hi",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "किरायेदार",
     "Permission:MultiTenancy.Tenants.Create": "नए किरायेदार बनाएँ",
     "Permission:MultiTenancy.Tenants.Manage": "किरायेदार जीवनचक्र प्रबंधित करें (सक्रिय, निष्क्रिय)",
     "Permission:MultiTenancy.Tenants.Read": "किरायेदार जानकारी देखें",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/it.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/it.json
@@ -2,7 +2,7 @@
   "culture": "it",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenant",
     "Permission:MultiTenancy.Tenants.Create": "Creare nuovi tenant",
     "Permission:MultiTenancy.Tenants.Manage": "Gestire il ciclo di vita dei tenant (attivare, disattivare)",
     "Permission:MultiTenancy.Tenants.Read": "Visualizzare le informazioni dei tenant",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ja.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ja.json
@@ -2,7 +2,7 @@
   "culture": "ja",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "テナント",
     "Permission:MultiTenancy.Tenants.Create": "新規テナントの作成",
     "Permission:MultiTenancy.Tenants.Manage": "テナントライフサイクルの管理（有効化、無効化）",
     "Permission:MultiTenancy.Tenants.Read": "テナント情報の表示",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ko.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ko.json
@@ -2,7 +2,7 @@
   "culture": "ko",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "테넌트",
     "Permission:MultiTenancy.Tenants.Create": "새 테넌트 생성",
     "Permission:MultiTenancy.Tenants.Manage": "테넌트 수명 주기 관리 (활성화, 비활성화)",
     "Permission:MultiTenancy.Tenants.Read": "테넌트 정보 조회",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pl.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pl.json
@@ -2,7 +2,7 @@
   "culture": "pl",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Najemcy",
     "Permission:MultiTenancy.Tenants.Create": "Tworzenie nowych najemców",
     "Permission:MultiTenancy.Tenants.Manage": "Zarządzanie cyklem życia najemców (aktywacja, dezaktywacja)",
     "Permission:MultiTenancy.Tenants.Read": "Przeglądanie informacji o najemcach",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt-BR.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt-BR.json
@@ -2,7 +2,7 @@
   "culture": "pt-BR",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Inquilinos",
     "Permission:MultiTenancy.Tenants.Create": "Criar novos inquilinos",
     "Permission:MultiTenancy.Tenants.Manage": "Gerenciar ciclo de vida de inquilinos (ativar, desativar)",
     "Permission:MultiTenancy.Tenants.Read": "Ver informações de inquilinos",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt.json
@@ -2,7 +2,7 @@
   "culture": "pt",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Inquilinos",
     "Permission:MultiTenancy.Tenants.Create": "Criar novos inquilinos",
     "Permission:MultiTenancy.Tenants.Manage": "Gerir ciclo de vida de inquilinos (ativar, desativar)",
     "Permission:MultiTenancy.Tenants.Read": "Ver informações de inquilinos",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/sv.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/sv.json
@@ -2,7 +2,7 @@
   "culture": "sv",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Hyresgäster",
     "Permission:MultiTenancy.Tenants.Create": "Skapa nya hyresgäster",
     "Permission:MultiTenancy.Tenants.Manage": "Hantera hyresgästlivscykel (aktivera, inaktivera)",
     "Permission:MultiTenancy.Tenants.Read": "Visa hyresgästinformation",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/tr.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/tr.json
@@ -2,7 +2,7 @@
   "culture": "tr",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Kiracılar",
     "Permission:MultiTenancy.Tenants.Create": "Yeni kiracılar oluşturma",
     "Permission:MultiTenancy.Tenants.Manage": "Kiracı yaşam döngüsünü yönetme (etkinleştirme, devre dışı bırakma)",
     "Permission:MultiTenancy.Tenants.Read": "Kiracı bilgilerini görüntüleme",

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/zh.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/zh.json
@@ -2,7 +2,7 @@
   "culture": "zh",
   "texts": {
     "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
-    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
+    "MultiTenancyEndpoints:Workspace.Tenants": "租户",
     "Permission:MultiTenancy.Tenants.Create": "创建新租户",
     "Permission:MultiTenancy.Tenants.Manage": "管理租户生命周期（激活、停用）",
     "Permission:MultiTenancy.Tenants.Read": "查看租户信息",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/cs.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/cs.json
@@ -1,10 +1,10 @@
 {
-  "culture": "cs",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Spravovat oznámení (předvolby, odběry, push tokeny)",
-    "Permission:Notifications.UserNotifications.Read": "Zobrazit oznámení (doručená pošta, přehled aktivit)",
-    "PermissionGroup:Notifications": "Oznámení"
-  }
+    "culture": "cs",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Doručená pošta",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Spravovat oznámení (předvolby, odběry, push tokeny)",
+        "Permission:Notifications.UserNotifications.Read": "Zobrazit oznámení (doručená pošta, přehled aktivit)",
+        "PermissionGroup:Notifications": "Oznámení"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/cs.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/cs.json
@@ -1,7 +1,7 @@
 {
     "culture": "cs",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Doručená pošta",
+        "NotificationsEndpoints:Workspace.Item": "Oznámení",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Spravovat oznámení (předvolby, odběry, push tokeny)",
         "Permission:Notifications.UserNotifications.Read": "Zobrazit oznámení (doručená pošta, přehled aktivit)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/de.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/de.json
@@ -1,7 +1,7 @@
 {
     "culture": "de",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Posteingang",
+        "NotificationsEndpoints:Workspace.Item": "Benachrichtigungen",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Benachrichtigungen verwalten (Einstellungen, Abonnements, Push-Token)",
         "Permission:Notifications.UserNotifications.Read": "Benachrichtigungen anzeigen (Posteingang, Aktivitätsfeed)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/de.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/de.json
@@ -1,10 +1,10 @@
 {
-  "culture": "de",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Benachrichtigungen verwalten (Einstellungen, Abonnements, Push-Token)",
-    "Permission:Notifications.UserNotifications.Read": "Benachrichtigungen anzeigen (Posteingang, Aktivitätsfeed)",
-    "PermissionGroup:Notifications": "Benachrichtigungen"
-  }
+    "culture": "de",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Posteingang",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Benachrichtigungen verwalten (Einstellungen, Abonnements, Push-Token)",
+        "Permission:Notifications.UserNotifications.Read": "Benachrichtigungen anzeigen (Posteingang, Aktivitätsfeed)",
+        "PermissionGroup:Notifications": "Benachrichtigungen"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en-GB.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
-  "culture": "en-GB",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications"
-  }
+    "culture": "en-GB",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Inbox",
+        "NotificationsEndpoints:Workspace.Section": "Notifications"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en-GB.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
     "culture": "en-GB",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Inbox",
+        "NotificationsEndpoints:Workspace.Item": "Notifications",
         "NotificationsEndpoints:Workspace.Section": "Notifications"
     }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en.json
@@ -1,7 +1,7 @@
 {
     "culture": "en",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Inbox",
+        "NotificationsEndpoints:Workspace.Item": "Notifications",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Manage notifications (preferences, subscriptions, push tokens)",
         "Permission:Notifications.UserNotifications.Read": "View notifications (inbox, activity feed)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/en.json
@@ -1,10 +1,10 @@
 {
-  "culture": "en",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Manage notifications (preferences, subscriptions, push tokens)",
-    "Permission:Notifications.UserNotifications.Read": "View notifications (inbox, activity feed)",
-    "PermissionGroup:Notifications": "Notifications"
-  }
+    "culture": "en",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Inbox",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Manage notifications (preferences, subscriptions, push tokens)",
+        "Permission:Notifications.UserNotifications.Read": "View notifications (inbox, activity feed)",
+        "PermissionGroup:Notifications": "Notifications"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/es.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/es.json
@@ -1,10 +1,10 @@
 {
-  "culture": "es",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Gestionar notificaciones (preferencias, suscripciones, tokens push)",
-    "Permission:Notifications.UserNotifications.Read": "Ver notificaciones (bandeja de entrada, actividad)",
-    "PermissionGroup:Notifications": "Notificaciones"
-  }
+    "culture": "es",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Bandeja de entrada",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Gestionar notificaciones (preferencias, suscripciones, tokens push)",
+        "Permission:Notifications.UserNotifications.Read": "Ver notificaciones (bandeja de entrada, actividad)",
+        "PermissionGroup:Notifications": "Notificaciones"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/es.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/es.json
@@ -1,7 +1,7 @@
 {
     "culture": "es",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Bandeja de entrada",
+        "NotificationsEndpoints:Workspace.Item": "Notificaciones",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Gestionar notificaciones (preferencias, suscripciones, tokens push)",
         "Permission:Notifications.UserNotifications.Read": "Ver notificaciones (bandeja de entrada, actividad)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr-CA.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
     "culture": "fr-CA",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Boîte de réception",
+        "NotificationsEndpoints:Workspace.Item": "Notifications",
         "NotificationsEndpoints:Workspace.Section": "Notifications"
     }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr-CA.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
-  "culture": "fr-CA",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Boîte de réception et abonnements",
-    "NotificationsEndpoints:Workspace.Section": "Notifications"
-  }
+    "culture": "fr-CA",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Boîte de réception",
+        "NotificationsEndpoints:Workspace.Section": "Notifications"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr.json
@@ -1,10 +1,10 @@
 {
-  "culture": "fr",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Boîte de réception et abonnements",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Gérer les notifications (préférences, abonnements, jetons push)",
-    "Permission:Notifications.UserNotifications.Read": "Consulter les notifications (boîte de réception, fil d'activité)",
-    "PermissionGroup:Notifications": "Notifications"
-  }
+    "culture": "fr",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Boîte de réception",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Gérer les notifications (préférences, abonnements, jetons push)",
+        "Permission:Notifications.UserNotifications.Read": "Consulter les notifications (boîte de réception, fil d'activité)",
+        "PermissionGroup:Notifications": "Notifications"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/fr.json
@@ -1,7 +1,7 @@
 {
     "culture": "fr",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Boîte de réception",
+        "NotificationsEndpoints:Workspace.Item": "Notifications",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Gérer les notifications (préférences, abonnements, jetons push)",
         "Permission:Notifications.UserNotifications.Read": "Consulter les notifications (boîte de réception, fil d'activité)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/hi.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/hi.json
@@ -1,7 +1,7 @@
 {
     "culture": "hi",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "इनबॉक्स",
+        "NotificationsEndpoints:Workspace.Item": "सूचनाएँ",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "सूचनाएँ प्रबंधित करें (प्राथमिकताएँ, सब्सक्रिप्शन, पुश टोकन)",
         "Permission:Notifications.UserNotifications.Read": "सूचनाएँ देखें (इनबॉक्स, गतिविधि फ़ीड)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/hi.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/hi.json
@@ -1,10 +1,10 @@
 {
-  "culture": "hi",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "सूचनाएँ प्रबंधित करें (प्राथमिकताएँ, सब्सक्रिप्शन, पुश टोकन)",
-    "Permission:Notifications.UserNotifications.Read": "सूचनाएँ देखें (इनबॉक्स, गतिविधि फ़ीड)",
-    "PermissionGroup:Notifications": "सूचनाएँ"
-  }
+    "culture": "hi",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "इनबॉक्स",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "सूचनाएँ प्रबंधित करें (प्राथमिकताएँ, सब्सक्रिप्शन, पुश टोकन)",
+        "Permission:Notifications.UserNotifications.Read": "सूचनाएँ देखें (इनबॉक्स, गतिविधि फ़ीड)",
+        "PermissionGroup:Notifications": "सूचनाएँ"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/it.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/it.json
@@ -1,7 +1,7 @@
 {
     "culture": "it",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Posta in arrivo",
+        "NotificationsEndpoints:Workspace.Item": "Notifiche",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Gestire le notifiche (preferenze, iscrizioni, token push)",
         "Permission:Notifications.UserNotifications.Read": "Visualizzare le notifiche (posta in arrivo, attività)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/it.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/it.json
@@ -1,10 +1,10 @@
 {
-  "culture": "it",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Gestire le notifiche (preferenze, iscrizioni, token push)",
-    "Permission:Notifications.UserNotifications.Read": "Visualizzare le notifiche (posta in arrivo, attività)",
-    "PermissionGroup:Notifications": "Notifiche"
-  }
+    "culture": "it",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Posta in arrivo",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Gestire le notifiche (preferenze, iscrizioni, token push)",
+        "Permission:Notifications.UserNotifications.Read": "Visualizzare le notifiche (posta in arrivo, attività)",
+        "PermissionGroup:Notifications": "Notifiche"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ja.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ja.json
@@ -1,7 +1,7 @@
 {
     "culture": "ja",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "受信トレイ",
+        "NotificationsEndpoints:Workspace.Item": "通知",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "通知の管理（設定、サブスクリプション、プッシュトークン）",
         "Permission:Notifications.UserNotifications.Read": "通知の閲覧（受信トレイ、アクティビティフィード）",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ja.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ja.json
@@ -1,10 +1,10 @@
 {
-  "culture": "ja",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "通知の管理（設定、サブスクリプション、プッシュトークン）",
-    "Permission:Notifications.UserNotifications.Read": "通知の閲覧（受信トレイ、アクティビティフィード）",
-    "PermissionGroup:Notifications": "通知"
-  }
+    "culture": "ja",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "受信トレイ",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "通知の管理（設定、サブスクリプション、プッシュトークン）",
+        "Permission:Notifications.UserNotifications.Read": "通知の閲覧（受信トレイ、アクティビティフィード）",
+        "PermissionGroup:Notifications": "通知"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ko.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ko.json
@@ -1,10 +1,10 @@
 {
-  "culture": "ko",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "알림 관리 (설정, 구독, 푸시 토큰)",
-    "Permission:Notifications.UserNotifications.Read": "알림 조회 (수신함, 활동 피드)",
-    "PermissionGroup:Notifications": "알림"
-  }
+    "culture": "ko",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "받은편지함",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "알림 관리 (설정, 구독, 푸시 토큰)",
+        "Permission:Notifications.UserNotifications.Read": "알림 조회 (수신함, 활동 피드)",
+        "PermissionGroup:Notifications": "알림"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ko.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/ko.json
@@ -1,7 +1,7 @@
 {
     "culture": "ko",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "받은편지함",
+        "NotificationsEndpoints:Workspace.Item": "알림",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "알림 관리 (설정, 구독, 푸시 토큰)",
         "Permission:Notifications.UserNotifications.Read": "알림 조회 (수신함, 활동 피드)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/nl.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/nl.json
@@ -1,10 +1,10 @@
 {
-  "culture": "nl",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Meldingen beheren (voorkeuren, abonnementen, pushtokens)",
-    "Permission:Notifications.UserNotifications.Read": "Meldingen bekijken (inbox, activiteitenoverzicht)",
-    "PermissionGroup:Notifications": "Meldingen"
-  }
+    "culture": "nl",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Postvak in",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Meldingen beheren (voorkeuren, abonnementen, pushtokens)",
+        "Permission:Notifications.UserNotifications.Read": "Meldingen bekijken (inbox, activiteitenoverzicht)",
+        "PermissionGroup:Notifications": "Meldingen"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/nl.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/nl.json
@@ -1,7 +1,7 @@
 {
     "culture": "nl",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Postvak in",
+        "NotificationsEndpoints:Workspace.Item": "Notificaties",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Meldingen beheren (voorkeuren, abonnementen, pushtokens)",
         "Permission:Notifications.UserNotifications.Read": "Meldingen bekijken (inbox, activiteitenoverzicht)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pl.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pl.json
@@ -1,10 +1,10 @@
 {
-  "culture": "pl",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Zarządzanie powiadomieniami (preferencje, subskrypcje, tokeny push)",
-    "Permission:Notifications.UserNotifications.Read": "Przeglądanie powiadomień (skrzynka odbiorcza, aktywność)",
-    "PermissionGroup:Notifications": "Powiadomienia"
-  }
+    "culture": "pl",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Skrzynka odbiorcza",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Zarządzanie powiadomieniami (preferencje, subskrypcje, tokeny push)",
+        "Permission:Notifications.UserNotifications.Read": "Przeglądanie powiadomień (skrzynka odbiorcza, aktywność)",
+        "PermissionGroup:Notifications": "Powiadomienia"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pl.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pl.json
@@ -1,7 +1,7 @@
 {
     "culture": "pl",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Skrzynka odbiorcza",
+        "NotificationsEndpoints:Workspace.Item": "Powiadomienia",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Zarządzanie powiadomieniami (preferencje, subskrypcje, tokeny push)",
         "Permission:Notifications.UserNotifications.Read": "Przeglądanie powiadomień (skrzynka odbiorcza, aktywność)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt-BR.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
     "culture": "pt-BR",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Caixa de entrada",
+        "NotificationsEndpoints:Workspace.Item": "Notificações",
         "NotificationsEndpoints:Workspace.Section": "Notifications"
     }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt-BR.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
-  "culture": "pt-BR",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications"
-  }
+    "culture": "pt-BR",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Caixa de entrada",
+        "NotificationsEndpoints:Workspace.Section": "Notifications"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt.json
@@ -1,7 +1,7 @@
 {
     "culture": "pt",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Caixa de entrada",
+        "NotificationsEndpoints:Workspace.Item": "Notificações",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Gerir notificações (preferências, subscrições, tokens push)",
         "Permission:Notifications.UserNotifications.Read": "Ver notificações (caixa de entrada, atividade)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/pt.json
@@ -1,10 +1,10 @@
 {
-  "culture": "pt",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Gerir notificações (preferências, subscrições, tokens push)",
-    "Permission:Notifications.UserNotifications.Read": "Ver notificações (caixa de entrada, atividade)",
-    "PermissionGroup:Notifications": "Notificações"
-  }
+    "culture": "pt",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Caixa de entrada",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Gerir notificações (preferências, subscrições, tokens push)",
+        "Permission:Notifications.UserNotifications.Read": "Ver notificações (caixa de entrada, atividade)",
+        "PermissionGroup:Notifications": "Notificações"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/sv.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/sv.json
@@ -1,10 +1,10 @@
 {
-  "culture": "sv",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Hantera aviseringar (inställningar, prenumerationer, pushtoken)",
-    "Permission:Notifications.UserNotifications.Read": "Visa aviseringar (inkorg, aktivitetsflöde)",
-    "PermissionGroup:Notifications": "Aviseringar"
-  }
+    "culture": "sv",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Inkorg",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Hantera aviseringar (inställningar, prenumerationer, pushtoken)",
+        "Permission:Notifications.UserNotifications.Read": "Visa aviseringar (inkorg, aktivitetsflöde)",
+        "PermissionGroup:Notifications": "Aviseringar"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/sv.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/sv.json
@@ -1,7 +1,7 @@
 {
     "culture": "sv",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Inkorg",
+        "NotificationsEndpoints:Workspace.Item": "Aviseringar",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Hantera aviseringar (inställningar, prenumerationer, pushtoken)",
         "Permission:Notifications.UserNotifications.Read": "Visa aviseringar (inkorg, aktivitetsflöde)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/tr.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/tr.json
@@ -1,7 +1,7 @@
 {
     "culture": "tr",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "Gelen kutusu",
+        "NotificationsEndpoints:Workspace.Item": "Bildirimler",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "Bildirimleri yönet (tercihler, abonelikler, push tokenları)",
         "Permission:Notifications.UserNotifications.Read": "Bildirimleri görüntüle (gelen kutusu, etkinlik akışı)",

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/tr.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/tr.json
@@ -1,10 +1,10 @@
 {
-  "culture": "tr",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "Bildirimleri yönet (tercihler, abonelikler, push tokenları)",
-    "Permission:Notifications.UserNotifications.Read": "Bildirimleri görüntüle (gelen kutusu, etkinlik akışı)",
-    "PermissionGroup:Notifications": "Bildirimler"
-  }
+    "culture": "tr",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "Gelen kutusu",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "Bildirimleri yönet (tercihler, abonelikler, push tokenları)",
+        "Permission:Notifications.UserNotifications.Read": "Bildirimleri görüntüle (gelen kutusu, etkinlik akışı)",
+        "PermissionGroup:Notifications": "Bildirimler"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/zh.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/zh.json
@@ -1,10 +1,10 @@
 {
-  "culture": "zh",
-  "texts": {
-    "NotificationsEndpoints:Workspace.Item": "Inbox & subscriptions",
-    "NotificationsEndpoints:Workspace.Section": "Notifications",
-    "Permission:Notifications.UserNotifications.Manage": "管理通知（偏好设置、订阅、推送令牌）",
-    "Permission:Notifications.UserNotifications.Read": "查看通知（收件箱、活动动态）",
-    "PermissionGroup:Notifications": "通知"
-  }
+    "culture": "zh",
+    "texts": {
+        "NotificationsEndpoints:Workspace.Item": "收件箱",
+        "NotificationsEndpoints:Workspace.Section": "Notifications",
+        "Permission:Notifications.UserNotifications.Manage": "管理通知（偏好设置、订阅、推送令牌）",
+        "Permission:Notifications.UserNotifications.Read": "查看通知（收件箱、活动动态）",
+        "PermissionGroup:Notifications": "通知"
+    }
 }

--- a/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/zh.json
+++ b/src/Granit.Notifications.Endpoints/Localization/NotificationsEndpoints/zh.json
@@ -1,7 +1,7 @@
 {
     "culture": "zh",
     "texts": {
-        "NotificationsEndpoints:Workspace.Item": "收件箱",
+        "NotificationsEndpoints:Workspace.Item": "通知",
         "NotificationsEndpoints:Workspace.Section": "Notifications",
         "Permission:Notifications.UserNotifications.Manage": "管理通知（偏好设置、订阅、推送令牌）",
         "Permission:Notifications.UserNotifications.Read": "查看通知（收件箱、活动动态）",

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/cs.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/cs.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Spravovat nastavení nájemce (zobrazit, vytvořit, upravit)",
     "Permission:Settings.Tenant.Read": "Zobrazit nastavení nájemce",
     "PermissionGroup:Settings": "Nastavení",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Nastavení",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/de.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/de.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Mandanteneinstellungen verwalten (anzeigen, erstellen, bearbeiten)",
     "Permission:Settings.Tenant.Read": "Mandanteneinstellungen anzeigen",
     "PermissionGroup:Settings": "Einstellungen",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Einstellungen",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/en-GB.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/en-GB.json
@@ -4,7 +4,7 @@
     "Granit:Settings:NotFound": "Setting is not declared.",
     "Granit:Settings:ProviderNotAllowed": "This scope is not allowed for this setting.",
     "Granit:Settings:ValidationFailed": "Value does not match the setting's expected format or allow-list.",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Settings",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/en.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/en.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Manage tenant settings (view, create, edit)",
     "Permission:Settings.Tenant.Read": "View tenant settings",
     "PermissionGroup:Settings": "Settings",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Settings",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/es.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/es.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Gestionar configuración del inquilino (ver, crear, editar)",
     "Permission:Settings.Tenant.Read": "Ver configuración del inquilino",
     "PermissionGroup:Settings": "Configuración",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Configuración",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/fr-CA.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/fr-CA.json
@@ -4,7 +4,7 @@
     "Granit:Settings:NotFound": "Paramètre non déclaré.",
     "Granit:Settings:ProviderNotAllowed": "Ce scope n'est pas autorisé pour ce paramètre.",
     "Granit:Settings:ValidationFailed": "La valeur ne correspond pas au format attendu ou à la liste autorisée.",
-    "SettingsEndpoints:Workspace.Global": "Paramètres globaux",
+    "SettingsEndpoints:Workspace.Global": "Paramètres",
     "SettingsEndpoints:Workspace.Section": "Paramètres",
     "SettingsEndpoints:Workspace.Tenant": "Paramètres de tenant"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/fr.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/fr.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Gérer les paramètres du tenant (consulter, créer, modifier)",
     "Permission:Settings.Tenant.Read": "Consulter les paramètres du tenant",
     "PermissionGroup:Settings": "Paramètres",
-    "SettingsEndpoints:Workspace.Global": "Paramètres globaux",
+    "SettingsEndpoints:Workspace.Global": "Paramètres",
     "SettingsEndpoints:Workspace.Section": "Paramètres",
     "SettingsEndpoints:Workspace.Tenant": "Paramètres de tenant"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/hi.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/hi.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "टेनेंट सेटिंग्स प्रबंधित करें (देखें, बनाएँ, संपादित करें)",
     "Permission:Settings.Tenant.Read": "टेनेंट सेटिंग्स देखें",
     "PermissionGroup:Settings": "सेटिंग्स",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "सेटिंग्स",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/it.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/it.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Gestire le impostazioni del tenant (visualizzare, creare, modificare)",
     "Permission:Settings.Tenant.Read": "Visualizzare le impostazioni del tenant",
     "PermissionGroup:Settings": "Impostazioni",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Impostazioni",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/ja.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/ja.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "テナント設定の管理（表示、作成、編集）",
     "Permission:Settings.Tenant.Read": "テナント設定の表示",
     "PermissionGroup:Settings": "設定",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "設定",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/ko.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/ko.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "테넌트 설정 관리 (보기, 생성, 편집)",
     "Permission:Settings.Tenant.Read": "테넌트 설정 보기",
     "PermissionGroup:Settings": "설정",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "설정",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/nl.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/nl.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Tenantinstellingen beheren (bekijken, aanmaken, bewerken)",
     "Permission:Settings.Tenant.Read": "Tenantinstellingen bekijken",
     "PermissionGroup:Settings": "Instellingen",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Instellingen",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/pl.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/pl.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Zarządzanie ustawieniami najemcy (wyświetlanie, tworzenie, edycja)",
     "Permission:Settings.Tenant.Read": "Wyświetlanie ustawień najemcy",
     "PermissionGroup:Settings": "Ustawienia",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Ustawienia",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/pt-BR.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/pt-BR.json
@@ -4,7 +4,7 @@
     "Granit:Settings:NotFound": "Configuração não declarada.",
     "Granit:Settings:ProviderNotAllowed": "Este escopo não é permitido para esta configuração.",
     "Granit:Settings:ValidationFailed": "O valor não corresponde ao formato esperado ou à lista permitida.",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Configurações",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/pt.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/pt.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Gerir definições do inquilino (ver, criar, editar)",
     "Permission:Settings.Tenant.Read": "Ver definições do inquilino",
     "PermissionGroup:Settings": "Definições",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Configurações",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/sv.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/sv.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Hantera klientinställningar (visa, skapa, redigera)",
     "Permission:Settings.Tenant.Read": "Visa klientinställningar",
     "PermissionGroup:Settings": "Inställningar",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Inställningar",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/tr.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/tr.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "Kiracı ayarlarını yönet (görüntüle, oluştur, düzenle)",
     "Permission:Settings.Tenant.Read": "Kiracı ayarlarını görüntüle",
     "PermissionGroup:Settings": "Ayarlar",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "Ayarlar",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/zh.json
+++ b/src/Granit.Settings.Endpoints/Localization/SettingsEndpoints/zh.json
@@ -9,7 +9,7 @@
     "Permission:Settings.Tenant.Manage": "管理租户设置（查看、创建、编辑）",
     "Permission:Settings.Tenant.Read": "查看租户设置",
     "PermissionGroup:Settings": "设置",
-    "SettingsEndpoints:Workspace.Global": "Global settings",
+    "SettingsEndpoints:Workspace.Global": "设置",
     "SettingsEndpoints:Workspace.Section": "Settings",
     "SettingsEndpoints:Workspace.Tenant": "Tenant settings"
   }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/cs.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/cs.json
@@ -1,11 +1,11 @@
 {
-  "culture": "cs",
-  "texts": {
-    "Permission:Workflow.History.Read": "Zobrazit historii přechodů pracovního postupu (auditní stopa)",
-    "Permission:Workflow.Transitions.Execute": "Provést přechody stavů workflow",
-    "Permission:Workflow.Transitions.Read": "Zobrazit dostupné přechody workflow",
-    "PermissionGroup:Workflow": "Pracovní postup",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "cs",
+    "texts": {
+        "Permission:Workflow.History.Read": "Zobrazit historii přechodů pracovního postupu (auditní stopa)",
+        "Permission:Workflow.Transitions.Execute": "Provést přechody stavů workflow",
+        "Permission:Workflow.Transitions.Read": "Zobrazit dostupné přechody workflow",
+        "PermissionGroup:Workflow": "Pracovní postup",
+        "WorkflowEndpoints:Workspace.History": "Historie",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/de.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/de.json
@@ -1,11 +1,11 @@
 {
-  "culture": "de",
-  "texts": {
-    "Permission:Workflow.History.Read": "Workflow-Übergangsverlauf anzeigen (Audit-Prüfpfad)",
-    "Permission:Workflow.Transitions.Execute": "Workflow-Statusübergänge ausführen",
-    "Permission:Workflow.Transitions.Read": "Verfügbare Workflow-Übergänge anzeigen",
-    "PermissionGroup:Workflow": "Workflow",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "de",
+    "texts": {
+        "Permission:Workflow.History.Read": "Workflow-Übergangsverlauf anzeigen (Audit-Prüfpfad)",
+        "Permission:Workflow.Transitions.Execute": "Workflow-Statusübergänge ausführen",
+        "Permission:Workflow.Transitions.Read": "Verfügbare Workflow-Übergänge anzeigen",
+        "PermissionGroup:Workflow": "Workflow",
+        "WorkflowEndpoints:Workspace.History": "Verlauf",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en-GB.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
-  "culture": "en-GB",
-  "texts": {
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "en-GB",
+    "texts": {
+        "WorkflowEndpoints:Workspace.History": "History",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en.json
@@ -1,11 +1,11 @@
 {
-  "culture": "en",
-  "texts": {
-    "Permission:Workflow.History.Read": "View workflow transition history (Audit trail)",
-    "Permission:Workflow.Transitions.Execute": "Execute workflow state transitions",
-    "Permission:Workflow.Transitions.Read": "View available workflow transitions",
-    "PermissionGroup:Workflow": "Workflow",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "en",
+    "texts": {
+        "Permission:Workflow.History.Read": "View workflow transition history (Audit trail)",
+        "Permission:Workflow.Transitions.Execute": "Execute workflow state transitions",
+        "Permission:Workflow.Transitions.Read": "View available workflow transitions",
+        "PermissionGroup:Workflow": "Workflow",
+        "WorkflowEndpoints:Workspace.History": "History",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/es.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/es.json
@@ -1,11 +1,11 @@
 {
-  "culture": "es",
-  "texts": {
-    "Permission:Workflow.History.Read": "Ver el historial de transiciones del flujo de trabajo (Pista de auditoría)",
-    "Permission:Workflow.Transitions.Execute": "Ejecutar transiciones de estado del flujo de trabajo",
-    "Permission:Workflow.Transitions.Read": "Ver transiciones de flujo de trabajo disponibles",
-    "PermissionGroup:Workflow": "Flujo de trabajo",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "es",
+    "texts": {
+        "Permission:Workflow.History.Read": "Ver el historial de transiciones del flujo de trabajo (Pista de auditoría)",
+        "Permission:Workflow.Transitions.Execute": "Ejecutar transiciones de estado del flujo de trabajo",
+        "Permission:Workflow.Transitions.Read": "Ver transiciones de flujo de trabajo disponibles",
+        "PermissionGroup:Workflow": "Flujo de trabajo",
+        "WorkflowEndpoints:Workspace.History": "Historial",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr-CA.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
-  "culture": "fr-CA",
-  "texts": {
-    "WorkflowEndpoints:Workspace.History": "Historique des transitions",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "fr-CA",
+    "texts": {
+        "WorkflowEndpoints:Workspace.History": "Historique",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr.json
@@ -1,11 +1,11 @@
 {
-  "culture": "fr",
-  "texts": {
-    "Permission:Workflow.History.Read": "Consulter l'historique des transitions workflow (Piste d'audit)",
-    "Permission:Workflow.Transitions.Execute": "Exécuter les transitions d'état workflow",
-    "Permission:Workflow.Transitions.Read": "Consulter les transitions workflow disponibles",
-    "PermissionGroup:Workflow": "Workflow",
-    "WorkflowEndpoints:Workspace.History": "Historique des transitions",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "fr",
+    "texts": {
+        "Permission:Workflow.History.Read": "Consulter l'historique des transitions workflow (Piste d'audit)",
+        "Permission:Workflow.Transitions.Execute": "Exécuter les transitions d'état workflow",
+        "Permission:Workflow.Transitions.Read": "Consulter les transitions workflow disponibles",
+        "PermissionGroup:Workflow": "Workflow",
+        "WorkflowEndpoints:Workspace.History": "Historique",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/hi.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/hi.json
@@ -1,11 +1,11 @@
 {
-  "culture": "hi",
-  "texts": {
-    "Permission:Workflow.History.Read": "वर्कफ़्लो संक्रमण इतिहास देखें (ऑडिट ट्रेल)",
-    "Permission:Workflow.Transitions.Execute": "वर्कफ़्लो स्थिति संक्रमण करें",
-    "Permission:Workflow.Transitions.Read": "उपलब्ध वर्कफ़्लो संक्रमण देखें",
-    "PermissionGroup:Workflow": "वर्कफ़्लो",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "hi",
+    "texts": {
+        "Permission:Workflow.History.Read": "वर्कफ़्लो संक्रमण इतिहास देखें (ऑडिट ट्रेल)",
+        "Permission:Workflow.Transitions.Execute": "वर्कफ़्लो स्थिति संक्रमण करें",
+        "Permission:Workflow.Transitions.Read": "उपलब्ध वर्कफ़्लो संक्रमण देखें",
+        "PermissionGroup:Workflow": "वर्कफ़्लो",
+        "WorkflowEndpoints:Workspace.History": "इतिहास",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/it.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/it.json
@@ -1,11 +1,11 @@
 {
-  "culture": "it",
-  "texts": {
-    "Permission:Workflow.History.Read": "Visualizzare la cronologia delle transizioni del flusso di lavoro (Pista di audit)",
-    "Permission:Workflow.Transitions.Execute": "Eseguire le transizioni di stato del workflow",
-    "Permission:Workflow.Transitions.Read": "Visualizzare le transizioni workflow disponibili",
-    "PermissionGroup:Workflow": "Flusso di lavoro",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "it",
+    "texts": {
+        "Permission:Workflow.History.Read": "Visualizzare la cronologia delle transizioni del flusso di lavoro (Pista di audit)",
+        "Permission:Workflow.Transitions.Execute": "Eseguire le transizioni di stato del workflow",
+        "Permission:Workflow.Transitions.Read": "Visualizzare le transizioni workflow disponibili",
+        "PermissionGroup:Workflow": "Flusso di lavoro",
+        "WorkflowEndpoints:Workspace.History": "Cronologia",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ja.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ja.json
@@ -1,11 +1,11 @@
 {
-  "culture": "ja",
-  "texts": {
-    "Permission:Workflow.History.Read": "ワークフロー遷移履歴を表示（監査証跡）",
-    "Permission:Workflow.Transitions.Execute": "ワークフロー状態遷移を実行",
-    "Permission:Workflow.Transitions.Read": "利用可能なワークフロー遷移を表示",
-    "PermissionGroup:Workflow": "ワークフロー",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "ja",
+    "texts": {
+        "Permission:Workflow.History.Read": "ワークフロー遷移履歴を表示（監査証跡）",
+        "Permission:Workflow.Transitions.Execute": "ワークフロー状態遷移を実行",
+        "Permission:Workflow.Transitions.Read": "利用可能なワークフロー遷移を表示",
+        "PermissionGroup:Workflow": "ワークフロー",
+        "WorkflowEndpoints:Workspace.History": "履歴",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ko.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ko.json
@@ -1,11 +1,11 @@
 {
-  "culture": "ko",
-  "texts": {
-    "Permission:Workflow.History.Read": "워크플로 전환 이력 보기 (감사 추적)",
-    "Permission:Workflow.Transitions.Execute": "워크플로 상태 전환 실행",
-    "Permission:Workflow.Transitions.Read": "사용 가능한 워크플로 전환 보기",
-    "PermissionGroup:Workflow": "워크플로",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "ko",
+    "texts": {
+        "Permission:Workflow.History.Read": "워크플로 전환 이력 보기 (감사 추적)",
+        "Permission:Workflow.Transitions.Execute": "워크플로 상태 전환 실행",
+        "Permission:Workflow.Transitions.Read": "사용 가능한 워크플로 전환 보기",
+        "PermissionGroup:Workflow": "워크플로",
+        "WorkflowEndpoints:Workspace.History": "기록",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/nl.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/nl.json
@@ -1,11 +1,11 @@
 {
-  "culture": "nl",
-  "texts": {
-    "Permission:Workflow.History.Read": "Workflow-transitiegeschiedenis bekijken (Auditspoor)",
-    "Permission:Workflow.Transitions.Execute": "Workflowstatustransities uitvoeren",
-    "Permission:Workflow.Transitions.Read": "Beschikbare workflowtransities bekijken",
-    "PermissionGroup:Workflow": "Workflow",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "nl",
+    "texts": {
+        "Permission:Workflow.History.Read": "Workflow-transitiegeschiedenis bekijken (Auditspoor)",
+        "Permission:Workflow.Transitions.Execute": "Workflowstatustransities uitvoeren",
+        "Permission:Workflow.Transitions.Read": "Beschikbare workflowtransities bekijken",
+        "PermissionGroup:Workflow": "Workflow",
+        "WorkflowEndpoints:Workspace.History": "Geschiedenis",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pl.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pl.json
@@ -1,11 +1,11 @@
 {
-  "culture": "pl",
-  "texts": {
-    "Permission:Workflow.History.Read": "Wyświetlanie historii przejść przepływu pracy (ścieżka audytu)",
-    "Permission:Workflow.Transitions.Execute": "Wykonaj przejścia stanów workflow",
-    "Permission:Workflow.Transitions.Read": "Wyświetl dostępne przejścia workflow",
-    "PermissionGroup:Workflow": "Przepływ pracy",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "pl",
+    "texts": {
+        "Permission:Workflow.History.Read": "Wyświetlanie historii przejść przepływu pracy (ścieżka audytu)",
+        "Permission:Workflow.Transitions.Execute": "Wykonaj przejścia stanów workflow",
+        "Permission:Workflow.Transitions.Read": "Wyświetl dostępne przejścia workflow",
+        "PermissionGroup:Workflow": "Przepływ pracy",
+        "WorkflowEndpoints:Workspace.History": "Historia",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt-BR.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
-  "culture": "pt-BR",
-  "texts": {
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "pt-BR",
+    "texts": {
+        "WorkflowEndpoints:Workspace.History": "Histórico",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt.json
@@ -1,11 +1,11 @@
 {
-  "culture": "pt",
-  "texts": {
-    "Permission:Workflow.History.Read": "Ver o histórico de transições do fluxo de trabalho (Trilha de auditoria)",
-    "Permission:Workflow.Transitions.Execute": "Executar transições de estado do workflow",
-    "Permission:Workflow.Transitions.Read": "Ver transições de workflow disponíveis",
-    "PermissionGroup:Workflow": "Fluxo de trabalho",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "pt",
+    "texts": {
+        "Permission:Workflow.History.Read": "Ver o histórico de transições do fluxo de trabalho (Trilha de auditoria)",
+        "Permission:Workflow.Transitions.Execute": "Executar transições de estado do workflow",
+        "Permission:Workflow.Transitions.Read": "Ver transições de workflow disponíveis",
+        "PermissionGroup:Workflow": "Fluxo de trabalho",
+        "WorkflowEndpoints:Workspace.History": "Histórico",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/sv.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/sv.json
@@ -1,11 +1,11 @@
 {
-  "culture": "sv",
-  "texts": {
-    "Permission:Workflow.History.Read": "Visa arbetsflödets övergångshistorik (revisionsspår)",
-    "Permission:Workflow.Transitions.Execute": "Utför arbetsflödesstatusövergångar",
-    "Permission:Workflow.Transitions.Read": "Visa tillgängliga arbetsflödesövergångar",
-    "PermissionGroup:Workflow": "Arbetsflöde",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "sv",
+    "texts": {
+        "Permission:Workflow.History.Read": "Visa arbetsflödets övergångshistorik (revisionsspår)",
+        "Permission:Workflow.Transitions.Execute": "Utför arbetsflödesstatusövergångar",
+        "Permission:Workflow.Transitions.Read": "Visa tillgängliga arbetsflödesövergångar",
+        "PermissionGroup:Workflow": "Arbetsflöde",
+        "WorkflowEndpoints:Workspace.History": "Historik",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/tr.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/tr.json
@@ -1,11 +1,11 @@
 {
-  "culture": "tr",
-  "texts": {
-    "Permission:Workflow.History.Read": "İş akışı geçiş geçmişini görüntüle (denetim izi)",
-    "Permission:Workflow.Transitions.Execute": "İş akışı durum geçişlerini yürüt",
-    "Permission:Workflow.Transitions.Read": "Mevcut iş akışı geçişlerini görüntüle",
-    "PermissionGroup:Workflow": "İş Akışı",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "tr",
+    "texts": {
+        "Permission:Workflow.History.Read": "İş akışı geçiş geçmişini görüntüle (denetim izi)",
+        "Permission:Workflow.Transitions.Execute": "İş akışı durum geçişlerini yürüt",
+        "Permission:Workflow.Transitions.Read": "Mevcut iş akışı geçişlerini görüntüle",
+        "PermissionGroup:Workflow": "İş Akışı",
+        "WorkflowEndpoints:Workspace.History": "Geçmiş",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/zh.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/zh.json
@@ -1,11 +1,11 @@
 {
-  "culture": "zh",
-  "texts": {
-    "Permission:Workflow.History.Read": "查看工作流转换历史（审计跟踪）",
-    "Permission:Workflow.Transitions.Execute": "执行工作流状态转换",
-    "Permission:Workflow.Transitions.Read": "查看可用的工作流转换",
-    "PermissionGroup:Workflow": "工作流",
-    "WorkflowEndpoints:Workspace.History": "Transition history",
-    "WorkflowEndpoints:Workspace.Section": "Workflow"
-  }
+    "culture": "zh",
+    "texts": {
+        "Permission:Workflow.History.Read": "查看工作流转换历史（审计跟踪）",
+        "Permission:Workflow.Transitions.Execute": "执行工作流状态转换",
+        "Permission:Workflow.Transitions.Read": "查看可用的工作流转换",
+        "PermissionGroup:Workflow": "工作流",
+        "WorkflowEndpoints:Workspace.History": "历史",
+        "WorkflowEndpoints:Workspace.Section": "Workflow"
+    }
 }


### PR DESCRIPTION
## Summary
- Workspace sidebar menu entries had verbose labels (`Catalogue de tableaux de bord`, `Boîte de réception et abonnements`, `Administration des blobs`, …) that wrapped awkwardly.
- Shortened each entry to the bare noun across the 18 supported cultures (15 base + fr-CA / en-GB / pt-BR).
- 5 keys touched in this repo:
  - `AuthorizationEndpoints:Workspace.Definitions` → `Permissions`
  - `BlobStorageEndpoints:Workspace.Item` → `Blobs`
  - `LocalizationEndpoints:Workspace.Item` → `Translations`
  - `NotificationsEndpoints:Workspace.Item` → `Inbox`
  - `WorkflowEndpoints:Workspace.History` → `History`
- Companion PR in `granit-business` covers Dashboards and EntitiesCustomization.

## Test plan
- [ ] Visual check of the Workspace sidebar at default width (no wrapping)
- [ ] FR + EN smoke test in the showcase app