### PR TITLE
feat(query-engine): add IncludeListEndpoint flag to QueryEndpointOptions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35650,6 +35650,12 @@
           "kind": "property",
           "signature": "string? TagName",
           "returnType": "string?"
+        },
+        {
+          "name": "IncludeListEndpoint",
+          "kind": "property",
+          "signature": "bool IncludeListEndpoint",
+          "returnType": "bool"
         }
       ]
     },

--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -59,8 +59,8 @@ public static class QueryEndpointRouteBuilderExtensions
     /// <remarks>
     /// <para>Registers the following endpoints:</para>
     /// <list type="bullet">
-    ///   <item><c>GET /</c> — paginated or grouped query</item>
-    ///   <item><c>GET /meta</c> — query metadata (columns, filters, sorts, etc.)</item>
+    ///   <item><c>GET /</c> — paginated or grouped query (skipped when <see cref="QueryEndpointOptions.IncludeListEndpoint"/> is <c>false</c>)</item>
+    ///   <item><c>GET /meta</c> — query metadata (skipped when <see cref="QueryEndpointOptions.IncludeMetaEndpoint"/> is <c>false</c>)</item>
     /// </list>
     /// <para>
     /// Saved-view persistence has moved to <c>Granit.Entities.Views.Endpoints</c> /
@@ -101,35 +101,38 @@ public static class QueryEndpointRouteBuilderExtensions
             group.RequireAuthorization();
         }
 
-        // Resolve the query definition once at setup time. When it declares a projection,
-        // dispatch to a generic helper that wires GET / to the typed ExecuteAsync<TDto>
-        // overload. Reflection is used exclusively here (setup) — never per request.
-        QueryDefinition<TEntity>? definitionForProjection = endpoints.ServiceProvider
-            .GetService<QueryDefinition<TEntity>>();
-
-        Type? projectionType = definitionForProjection?.GetProjectionType();
-        LambdaExpression? projectionExpression = definitionForProjection?.GetProjectionExpression();
-
-        IEndpointConventionBuilder listBuilder;
-        if (projectionType is not null && projectionExpression is not null)
+        if (options.IncludeListEndpoint)
         {
-            MethodInfo dispatch = typeof(QueryEndpointRouteBuilderExtensions)
-                .GetMethod(nameof(MapProjectedGetEndpoint), BindingFlags.NonPublic | BindingFlags.Static)!
-                .MakeGenericMethod(typeof(TEntity), projectionType);
+            // Resolve the query definition once at setup time. When it declares a projection,
+            // dispatch to a generic helper that wires GET / to the typed ExecuteAsync<TDto>
+            // overload. Reflection is used exclusively here (setup) — never per request.
+            QueryDefinition<TEntity>? definitionForProjection = endpoints.ServiceProvider
+                .GetService<QueryDefinition<TEntity>>();
 
-            listBuilder = (IEndpointConventionBuilder)dispatch.Invoke(
-                null, [group, sourceProvider, projectionExpression, entityName])!;
-        }
-        else
-        {
-            listBuilder = MapNonProjectedGetEndpoint<TEntity>(group, sourceProvider, entityName);
-        }
+            Type? projectionType = definitionForProjection?.GetProjectionType();
+            LambdaExpression? projectionExpression = definitionForProjection?.GetProjectionExpression();
 
-        // Tag the endpoint so entity-discovery surfaces (Granit.Entities.Endpoints)
-        // can read RoutePattern.RawText off EndpointDataSource and expose the real
-        // route on EntityDiscoveryLinks.List — same mechanism ASP.NET's own OpenAPI
-        // generator uses for operation/tag/produces lookups.
-        listBuilder.WithMetadata(new EntityEndpointMetadata(typeof(TEntity), EntityEndpointKind.List));
+            IEndpointConventionBuilder listBuilder;
+            if (projectionType is not null && projectionExpression is not null)
+            {
+                MethodInfo dispatch = typeof(QueryEndpointRouteBuilderExtensions)
+                    .GetMethod(nameof(MapProjectedGetEndpoint), BindingFlags.NonPublic | BindingFlags.Static)!
+                    .MakeGenericMethod(typeof(TEntity), projectionType);
+
+                listBuilder = (IEndpointConventionBuilder)dispatch.Invoke(
+                    null, [group, sourceProvider, projectionExpression, entityName])!;
+            }
+            else
+            {
+                listBuilder = MapNonProjectedGetEndpoint<TEntity>(group, sourceProvider, entityName);
+            }
+
+            // Tag the endpoint so entity-discovery surfaces (Granit.Entities.Endpoints)
+            // can read RoutePattern.RawText off EndpointDataSource and expose the real
+            // route on EntityDiscoveryLinks.List — same mechanism ASP.NET's own OpenAPI
+            // generator uses for operation/tag/produces lookups.
+            listBuilder.WithMetadata(new EntityEndpointMetadata(typeof(TEntity), EntityEndpointKind.List));
+        }
 
         // GET /meta — query metadata
         if (options.IncludeMetaEndpoint)

--- a/src/Granit.QueryEngine.AspNetCore/Options/QueryEndpointOptions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Options/QueryEndpointOptions.cs
@@ -30,4 +30,12 @@ public sealed class QueryEndpointOptions
     /// Defaults to <c>true</c>.
     /// </summary>
     public bool IncludeMetaEndpoint { get; set; } = true;
+
+    /// <summary>
+    /// Whether to register the list endpoint (<c>GET /</c>).
+    /// Defaults to <c>true</c>. Set to <c>false</c> when the host provides its own
+    /// bespoke list endpoint on the same route group and only wants <c>/meta</c> from
+    /// the query engine (avoids route collision on <c>GET /</c>).
+    /// </summary>
+    public bool IncludeListEndpoint { get; set; } = true;
 }

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointIntegrationTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointIntegrationTests.cs
@@ -5,6 +5,8 @@ using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.QueryEngine.Meta;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -152,6 +154,126 @@ public sealed class QueryEndpointIntegrationTests : IAsyncDisposable
         result.ShouldNotBeNull();
         result.Columns.Count.ShouldBe(1);
         result.DefaultSort.ShouldBe("-Price");
+    }
+
+    [Fact]
+    public async Task MapGranitQuery_without_list_registers_meta_only()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddSingleton(_engine);
+        builder.Services.AddSingleton<QueryDefinition<TestProduct>, TestProductQueryDefinition>();
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+
+        _engine.GetMetadata().Returns(new QueryMetadata
+        {
+            Columns = [],
+            FilterableFields = [],
+            SortableFields = [],
+            PresetFilterGroups = [],
+            QuickFilters = [],
+            DateFilters = [],
+            GroupByFields = [],
+            Pagination = new PaginationMeta(20, 100, QueryEngineDefaults.MaxStreamSize, false),
+            DefaultSort = null,
+        });
+
+        await using WebApplication customApp = builder.Build();
+        customApp.MapGranitQuery<TestProduct>(
+            _ => Array.Empty<TestProduct>().AsQueryable(),
+            "/api/items",
+            opts => opts.IncludeListEndpoint = false);
+        await customApp.StartAsync(TestContext.Current.CancellationToken);
+
+        using HttpClient client = customApp.GetTestClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, "user");
+
+        HttpResponseMessage listResponse = await client.GetAsync(
+            "/api/items", TestContext.Current.CancellationToken);
+        listResponse.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+
+        HttpResponseMessage metaResponse = await client.GetAsync(
+            "/api/items/meta", TestContext.Current.CancellationToken);
+        metaResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task MapGranitQuery_without_list_or_meta_registers_no_endpoints()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddSingleton(_engine);
+        builder.Services.AddSingleton<QueryDefinition<TestProduct>, TestProductQueryDefinition>();
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+
+        await using WebApplication customApp = builder.Build();
+        Should.NotThrow(() => customApp.MapGranitQuery<TestProduct>(
+            _ => Array.Empty<TestProduct>().AsQueryable(),
+            "/api/empty",
+            opts =>
+            {
+                opts.IncludeListEndpoint = false;
+                opts.IncludeMetaEndpoint = false;
+            }));
+        await customApp.StartAsync(TestContext.Current.CancellationToken);
+
+        using HttpClient client = customApp.GetTestClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, "user");
+
+        (await client.GetAsync("/api/empty", TestContext.Current.CancellationToken))
+            .StatusCode.ShouldBe(HttpStatusCode.NotFound);
+        (await client.GetAsync("/api/empty/meta", TestContext.Current.CancellationToken))
+            .StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task MapGranitQuery_without_list_allows_bespoke_GET_on_same_group()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddSingleton(_engine);
+        builder.Services.AddSingleton<QueryDefinition<TestProduct>, TestProductQueryDefinition>();
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+
+        await using WebApplication customApp = builder.Build();
+
+        RouteGroupBuilder group = customApp.MapGranitQuery<TestProduct>(
+            _ => Array.Empty<TestProduct>().AsQueryable(),
+            "/api/bespoke",
+            opts =>
+            {
+                opts.IncludeListEndpoint = false;
+                opts.IncludeMetaEndpoint = false;
+                opts.AllowAnonymous = true;
+            });
+        group.MapGet("/", () => TypedResults.Ok(new[] { "bespoke" }));
+
+        await customApp.StartAsync(TestContext.Current.CancellationToken);
+
+        using HttpClient client = customApp.GetTestClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/api/bespoke", TestContext.Current.CancellationToken);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string[]? body = await response.Content
+            .ReadFromJsonAsync<string[]>(TestContext.Current.CancellationToken);
+        body.ShouldBe(["bespoke"]);
     }
 
     [Fact]

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Options/QueryEndpointOptionsTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Options/QueryEndpointOptionsTests.cs
@@ -53,4 +53,20 @@ public sealed class QueryEndpointOptionsTests
 
         options.IncludeMetaEndpoint.ShouldBeFalse();
     }
+
+    [Fact]
+    public void IncludeListEndpoint_defaults_to_true()
+    {
+        QueryEndpointOptions options = new();
+
+        options.IncludeListEndpoint.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IncludeListEndpoint_can_be_disabled()
+    {
+        QueryEndpointOptions options = new() { IncludeListEndpoint = false };
+
+        options.IncludeListEndpoint.ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `QueryEndpointOptions.IncludeListEndpoint` (default `true`), symmetric to `IncludeMetaEndpoint`.
- Wraps the `GET /` registration (projected and non-projected branches) plus the `EntityEndpointMetadata` tagging in the new flag inside `MapGranitQuery<TEntity>`.
- Updates the XML doc to list both skip conditions.

## Why

`Granit.Parties.Endpoints.MapGranitParties` exposes a bespoke `GET /parties` (non-paginated, denormalized projection) and does not call `MapGranitQuery`. The front-end (`@granit/react-entities/EntityList` → `useQueryMeta` → `GET {basePath}/meta`) then 404s when displaying `Granit.Parties.Party` in a workspace.

With the new flag, a host can mount the bespoke list *and* ask the query engine for `/meta` only — no route collision on `GET /`:

\`\`\`csharp
api.MapGranitParties();
api.MapGranitQuery<Party>(\"parties\", o => o.IncludeListEndpoint = false);
\`\`\`

## Tests

- `QueryEndpointOptionsTests`: default `true` + setter.
- `QueryEndpointIntegrationTests`: three new integration tests
  - meta-only: list returns 404, meta returns 200.
  - both flags off: no endpoints mounted, `MapGranitQuery` returns a group without throwing.
  - bespoke `GET /` chained on the returned group does not collide.

## Scope

No consumer changes — `Granit.Parties.Endpoints` and the showcase adoption are deferred to a follow-up PR on `granit-showcase-dotnet`.

## Test plan

- [x] \`dotnet build src/Granit.QueryEngine.AspNetCore\` clean
- [x] \`dotnet build tests/Granit.QueryEngine.AspNetCore.Tests\` + \`.Integration\` clean
- [x] Unit tests (8/8 passing)
- [x] Integration tests (8/8 passing — 5 existing + 3 new)