### PR TITLE
fix(persistence): fail-fast at startup when active TenantIsolation strategy has no factory

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -172,7 +172,8 @@ public static class PersistenceTenantExtensions
         Action<TenantSchemaOptions>? configureTenantSchema = null)
         where TContext : DbContext
     {
-        // Isolation options — fail-fast on invalid appsettings value.
+        // Isolation options — fail-fast on invalid appsettings value AND on a missing
+        // factory delegate for the active strategy (see TenantIsolationFactoryRegistrationValidator).
         services.AddOptions<TenantIsolationOptions>()
             .BindConfiguration("TenantIsolation")
             .Validate(
@@ -181,12 +182,20 @@ public static class PersistenceTenantExtensions
                 "Valid values: SharedDatabase, DatabasePerTenant, SchemaPerTenant.")
             .ValidateOnStart();
 
+        // Idempotent — only one validator instance is needed; subsequent calls add
+        // duplicates which are harmless (every marker is still observed via IEnumerable<>).
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IValidateOptions<TenantIsolationOptions>,
+            TenantIsolationFactoryRegistrationValidator>());
+
         // HostDbSchema is set eagerly by GranitPersistenceEntityFrameworkCoreModule
         // via GranitDbDefaults.EnsureFromConfiguration(). No need to read config here —
         // the module runs before any downstream module registers DbContexts.
 
         services.TryAddSingleton<ITenantIsolationStrategyProvider,
             ConfigurationTenantIsolationStrategyProvider>();
+
+        HashSet<TenantIsolationStrategy> registeredStrategies = new();
 
         // SharedDatabase — always registered; the default fallback strategy.
         SharedDatabaseDbContextOptions<TContext> sharedOpts = new()
@@ -196,6 +205,7 @@ public static class PersistenceTenantExtensions
         services.AddKeyedScoped<IDbContextFactory<TContext>>(
             TenantIsolationStrategy.SharedDatabase,
             (sp, _) => new SharedDatabaseDbContextFactory<TContext>(sp, sharedOpts));
+        registeredStrategies.Add(TenantIsolationStrategy.SharedDatabase);
 
         // DatabasePerTenant — registered only when a configure delegate is provided.
         if (configureDatabasePerTenant is not null)
@@ -211,6 +221,7 @@ public static class PersistenceTenantExtensions
                     sp.GetRequiredService<ITenantConnectionStringProvider>(),
                     sp,
                     perDbOpts));
+            registeredStrategies.Add(TenantIsolationStrategy.DatabasePerTenant);
         }
 
         // SchemaPerTenant — registered only when a configure delegate is provided.
@@ -235,13 +246,17 @@ public static class PersistenceTenantExtensions
                     sp.GetRequiredService<ITenantSchemaActivator>(),
                     sp,
                     perSchemaOpts));
+            registeredStrategies.Add(TenantIsolationStrategy.SchemaPerTenant);
         }
 
         // Facade — dispatches to the keyed factory resolved at runtime.
         services.TryAddScoped<IDbContextFactory<TContext>, IsolatedDbContextFactory<TContext>>();
 
         // Marker for migration runner: this DbContext is tenant-isolated, skip on cold start.
-        services.AddSingleton(new IsolatedDbContextMarker(typeof(TContext)));
+        // Also carries the set of strategies for which a keyed factory was registered, so
+        // TenantIsolationFactoryRegistrationValidator can fail-fast at startup when the
+        // active strategy has no matching factory.
+        services.AddSingleton(new IsolatedDbContextMarker(typeof(TContext), registeredStrategies));
 
         // Scoped TContext: tries the isolated factory first, falls back to the
         // SharedDatabase keyed factory when no tenant is active. This fallback is

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/IsolatedDbContextMarker.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/IsolatedDbContextMarker.cs
@@ -5,7 +5,35 @@ namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 /// that require tenant isolation. Used by the migration runner to skip these contexts
 /// when no tenants exist (cold start) — they should only be migrated per-tenant.
 /// </summary>
-public sealed class IsolatedDbContextMarker(Type dbContextType)
+/// <remarks>
+/// Also carries the set of <see cref="TenantIsolationStrategy"/> values for which a keyed
+/// <see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/> factory was registered.
+/// Consumed by <see cref="TenantIsolationFactoryRegistrationValidator"/> to fail-fast at
+/// startup when the active strategy has no matching factory.
+/// </remarks>
+public sealed class IsolatedDbContextMarker
 {
-    public Type DbContextType { get; } = dbContextType;
+    /// <summary>
+    /// Initializes a new <see cref="IsolatedDbContextMarker"/>.
+    /// </summary>
+    /// <param name="dbContextType">The isolated <see cref="Microsoft.EntityFrameworkCore.DbContext"/> type.</param>
+    /// <param name="registeredStrategies">
+    /// The set of isolation strategies for which a keyed factory was registered.
+    /// </param>
+    public IsolatedDbContextMarker(
+        Type dbContextType,
+        IReadOnlySet<TenantIsolationStrategy> registeredStrategies)
+    {
+        DbContextType = dbContextType;
+        RegisteredStrategies = registeredStrategies;
+    }
+
+    /// <summary>The isolated <see cref="Microsoft.EntityFrameworkCore.DbContext"/> type.</summary>
+    public Type DbContextType { get; }
+
+    /// <summary>
+    /// Set of <see cref="TenantIsolationStrategy"/> values for which a keyed factory was
+    /// registered in DI for <see cref="DbContextType"/>.
+    /// </summary>
+    public IReadOnlySet<TenantIsolationStrategy> RegisteredStrategies { get; }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantIsolationFactoryRegistrationValidator.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantIsolationFactoryRegistrationValidator.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+
+/// <summary>
+/// Fail-fast validator that ensures every <see cref="IsolatedDbContextMarker"/> has a
+/// registered keyed factory for the active <see cref="TenantIsolationOptions.Strategy"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Runs during <c>host.StartAsync()</c> via the <c>ValidateOnStartHostedService</c>
+/// registered by <c>ValidateOnStart()</c> on <see cref="TenantIsolationOptions"/> —
+/// before any request is served, before any Wolverine handler, before any seed
+/// contributor. Reads only the metadata of the registered
+/// <see cref="IsolatedDbContextMarker"/> singletons — it MUST NOT resolve any keyed
+/// <see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/> or trigger
+/// DbContext resolution. This guarantees the validator stays cheap and side-effect free.
+/// </para>
+/// <para>
+/// Without this validator a misconfigured host would only fail on the first
+/// <c>CreateDbContextAsync</c> call — typically deep inside a request handler — with a
+/// stack pointing at the consumer rather than the misconfigured registration.
+/// </para>
+/// </remarks>
+internal sealed class TenantIsolationFactoryRegistrationValidator(
+    IEnumerable<IsolatedDbContextMarker> markers)
+    : IValidateOptions<TenantIsolationOptions>
+{
+    private readonly IReadOnlyCollection<IsolatedDbContextMarker> _markers = markers.ToArray();
+
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, TenantIsolationOptions options)
+    {
+        TenantIsolationStrategy strategy = options.Strategy;
+
+        // SharedDatabase is always registered by AddGranitIsolatedDbContext — short-circuit.
+        if (strategy == TenantIsolationStrategy.SharedDatabase)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        var missing = _markers
+            .Where(m => !m.RegisteredStrategies.Contains(strategy))
+            .ToList();
+
+        if (missing.Count == 0)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        string delegateName = strategy switch
+        {
+            TenantIsolationStrategy.DatabasePerTenant => "configureDatabasePerTenant",
+            TenantIsolationStrategy.SchemaPerTenant => "configureSchemaPerTenant",
+            _ => "configure" + strategy,
+        };
+
+        StringBuilder sb = new();
+        sb.Append("TenantIsolation:Strategy='").Append(strategy)
+          .Append("' but no ").Append(delegateName)
+          .AppendLine(" delegate was passed for the following DbContexts:");
+
+        foreach (IsolatedDbContextMarker m in missing)
+        {
+            sb.Append("  - ").AppendLine(m.DbContextType.FullName ?? m.DbContextType.Name);
+        }
+
+        sb.Append("Either pass the delegate in AddGranit{X}EntityFrameworkCore(...) ")
+          .Append("or change TenantIsolation:Strategy in appsettings.");
+
+        return ValidateOptionsResult.Fail(sb.ToString());
+    }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/AutoTenantProvisionerTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/AutoTenantProvisionerTests.cs
@@ -175,7 +175,9 @@ public sealed class AutoTenantProvisionerTests : IDisposable
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
         // Register a test DbContext as isolated — uses SQLite in-memory so MigrateAsync works.
-        services.AddSingleton(new IsolatedDbContextMarker(typeof(TestTenantDbContext)));
+        services.AddSingleton(new IsolatedDbContextMarker(
+            typeof(TestTenantDbContext),
+            new HashSet<TenantIsolationStrategy> { TenantIsolationStrategy.SharedDatabase }));
         DbConnection connection = _connection;
         services.AddDbContext<TestTenantDbContext>(opts => opts.UseSqlite(connection));
 

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantIsolationFactoryRegistrationValidatorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantIsolationFactoryRegistrationValidatorTests.cs
@@ -1,0 +1,121 @@
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests.MultiTenancy;
+
+public sealed class TenantIsolationFactoryRegistrationValidatorTests
+{
+    private sealed class CtxA(DbContextOptions<CtxA> options) : DbContext(options);
+    private sealed class CtxB(DbContextOptions<CtxB> options) : DbContext(options);
+
+    private static HostApplicationBuilder NewBuilder(string strategy)
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TenantIsolation:Strategy"] = strategy,
+        });
+        return builder;
+    }
+
+    [Fact]
+    public async Task SchemaPerTenant_configured_but_no_configureSchemaPerTenant_delegate_fails_at_ValidateOnStart()
+    {
+        HostApplicationBuilder builder = NewBuilder("SchemaPerTenant");
+
+        builder.Services.AddGranitIsolatedDbContext<CtxA>(
+            configureShared: opts => opts.UseInMemoryDatabase("shared"));
+
+        using IHost host = builder.Build();
+
+        OptionsValidationException ex = await Should.ThrowAsync<OptionsValidationException>(
+            async () => await host.StartAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(nameof(CtxA));
+        ex.Message.ShouldContain("SchemaPerTenant");
+        ex.Message.ShouldContain("configureSchemaPerTenant");
+    }
+
+    [Fact]
+    public async Task SchemaPerTenant_configured_with_delegate_passes()
+    {
+        HostApplicationBuilder builder = NewBuilder("SchemaPerTenant");
+
+        builder.Services.AddGranitIsolatedDbContext<CtxA>(
+            configureShared: opts => opts.UseInMemoryDatabase("shared"),
+            configureSchemaPerTenant: opts => opts.UseInMemoryDatabase("schema"));
+
+        using IHost host = builder.Build();
+
+        // Triggers all ValidateOnStart validators including the registration validator.
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        await host.StopAsync(TestContext.Current.CancellationToken);
+
+        TenantIsolationOptions options = host.Services
+            .GetRequiredService<IOptions<TenantIsolationOptions>>().Value;
+        options.Strategy.ShouldBe(TenantIsolationStrategy.SchemaPerTenant);
+    }
+
+    [Fact]
+    public async Task Multiple_isolated_contexts_missing_factory_emits_single_aggregated_error()
+    {
+        HostApplicationBuilder builder = NewBuilder("SchemaPerTenant");
+
+        builder.Services.AddGranitIsolatedDbContext<CtxA>(
+            configureShared: opts => opts.UseInMemoryDatabase("a-shared"));
+        builder.Services.AddGranitIsolatedDbContext<CtxB>(
+            configureShared: opts => opts.UseInMemoryDatabase("b-shared"));
+
+        using IHost host = builder.Build();
+
+        OptionsValidationException ex = await Should.ThrowAsync<OptionsValidationException>(
+            async () => await host.StartAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(nameof(CtxA));
+        ex.Message.ShouldContain(nameof(CtxB));
+        // Aggregated: both context names appear in a single failure entry.
+        ex.Failures.Count(f => f.Contains(nameof(CtxA)) && f.Contains(nameof(CtxB))).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task SharedDatabase_always_registered_never_fails()
+    {
+        HostApplicationBuilder builder = NewBuilder("SharedDatabase");
+
+        builder.Services.AddGranitIsolatedDbContext<CtxA>(
+            configureShared: opts => opts.UseInMemoryDatabase("shared"));
+
+        using IHost host = builder.Build();
+
+        // Regression guard: validator must never fail when strategy is SharedDatabase.
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        await host.StopAsync(TestContext.Current.CancellationToken);
+
+        TenantIsolationOptions options = host.Services
+            .GetRequiredService<IOptions<TenantIsolationOptions>>().Value;
+        options.Strategy.ShouldBe(TenantIsolationStrategy.SharedDatabase);
+    }
+
+    [Fact]
+    public async Task DatabasePerTenant_without_delegate_fails_with_named_delegate_in_message()
+    {
+        HostApplicationBuilder builder = NewBuilder("DatabasePerTenant");
+
+        builder.Services.AddGranitIsolatedDbContext<CtxA>(
+            configureShared: opts => opts.UseInMemoryDatabase("shared"));
+
+        using IHost host = builder.Build();
+
+        OptionsValidationException ex = await Should.ThrowAsync<OptionsValidationException>(
+            async () => await host.StartAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("configureDatabasePerTenant");
+    }
+}


### PR DESCRIPTION
## Summary

`AddGranitIsolatedDbContext<TContext>` registers the keyed `IDbContextFactory<TContext>` for `DatabasePerTenant` / `SchemaPerTenant` **only** when the corresponding configure delegate is non-null. `TenantIsolationOptions` validates the enum value of `TenantIsolation:Strategy`, but never cross-checks that a factory exists for the active strategy. Result: misconfiguration surfaces at **first `CreateDbContextAsync` call** as `InvalidOperationException` — often deep inside a request, a Wolverine handler, or `DbContextAutoExportDefinitionSource.ScanDbContext`. Stack trace points at the *consumer*, not the misconfigured registration.

This PR moves the failure to startup via `IValidateOptions<TenantIsolationOptions>` + `ValidateOnStart()`. Runs during `host.StartAsync()` via the `ValidateOnStartHostedService` — before any request is served, before any Wolverine handler, before any seed contributor.

## Changes

- `IsolatedDbContextMarker` extended with `RegisteredStrategies` (set of strategies for which a keyed factory was registered). Single-arg ctor removed (clean pre-1.0 break; `AutoTenantProvisionerTests` updated to pass strategies explicitly).
- New `TenantIsolationFactoryRegistrationValidator` — enumerates `IsolatedDbContextMarker` singletons, aggregates missing-factory failures into a single error message naming every affected `TContext`. **Zero DI lookups, zero factory resolution** — pure metadata check.
- Validator registered via `TryAddEnumerable<IValidateOptions<TenantIsolationOptions>>` (dedupe-safe, future-proof for other validators).
- `PersistenceTenantExtensions.AddGranitIsolatedDbContext` tracks which strategies got a factory, hands the set to the marker.

## Downstream impact

- granit-showcase-dotnet: workaround in `InfrastructureModule.cs:265` becomes a no-op (already passes the delegate). To be removed after dev publish bump.
- **Hosts running `SchemaPerTenant` / `DatabasePerTenant` without the matching delegate will fail at `host.StartAsync()` instead of first request.** Desired regression — flag for reviewers.

## Test plan

- [x] `SchemaPerTenant` configured but no `configureSchemaPerTenant` → fails at `ValidateOnStart` with `TContext` named in message
- [x] `SchemaPerTenant` with delegate → passes
- [x] Multiple isolated contexts missing factory → single aggregated error
- [x] `SharedDatabase` always passes (regression guard for default fallback)
- [x] `DatabasePerTenant` without delegate → message names `configureDatabasePerTenant`
- [x] Shard `persistence` (333 tests) green
- [x] Hosting tests (22) green
- [x] `dotnet format --verify-no-changes` clean