### PR TITLE
fix(localization): explicitly register endpoint resources to eliminate auto-discovery race

### DIFF
--- a/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
+++ b/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
@@ -1,5 +1,7 @@
+using Granit.AI.Endpoints.Internal;
 using Granit.AI.Endpoints.Workspaces;
 using Granit.Authorization;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
 using Granit.Workspaces;
@@ -20,6 +22,7 @@ public sealed class GranitAIEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<AIEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<AIFeatureProvider>();
     }
 }

--- a/src/Granit.Auditing.Endpoints/GranitAuditingEndpointsModule.cs
+++ b/src/Granit.Auditing.Endpoints/GranitAuditingEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Auditing;
+using Granit.Auditing.Endpoints.Internal;
 using Granit.Auditing.Endpoints.Workspaces;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -27,6 +29,7 @@ public sealed class GranitAuditingEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<AuditingEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<AuditingFeatureProvider>();
     }
 }

--- a/src/Granit.Authentication.ApiKeys.Endpoints/GranitAuthenticationApiKeysEndpointsModule.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/GranitAuthenticationApiKeysEndpointsModule.cs
@@ -1,6 +1,8 @@
+using Granit.Authentication.ApiKeys.Endpoints.Internal;
 using Granit.Authentication.ApiKeys.Endpoints.Workspaces;
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -23,6 +25,7 @@ public sealed class GranitAuthenticationApiKeysEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<ApiKeysEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<ApiKeysFeatureProvider>();
     }
 }

--- a/src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs
+++ b/src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
+using Granit.Authorization.Endpoints.Internal;
 using Granit.Authorization.Endpoints.Workspaces;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -30,6 +32,7 @@ public sealed class GranitAuthorizationEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<AuthorizationEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<AuthorizationFeatureProvider>();
     }
 }

--- a/src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs
@@ -1,5 +1,7 @@
 using Granit.Authorization;
+using Granit.BackgroundJobs.Endpoints.Internal;
 using Granit.BackgroundJobs.Endpoints.Workspaces;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine;
 using Granit.Validation;
@@ -29,6 +31,7 @@ public sealed class GranitBackgroundJobsEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<BackgroundJobsEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<BackgroundJobsFeatureProvider>();
     }
 }

--- a/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
+++ b/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
@@ -1,5 +1,7 @@
 using Granit.Authorization;
+using Granit.BlobStorage.Endpoints.Internal;
 using Granit.BlobStorage.Endpoints.Workspaces;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
 using Granit.RateLimiting;
@@ -24,6 +26,7 @@ public sealed class GranitBlobStorageEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<BlobStorageEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<BlobStorageFeatureProvider>();
     }
 }

--- a/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
+++ b/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
+using Granit.DataExchange.Endpoints.Internal;
 using Granit.DataExchange.Endpoints.Workspaces;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Workspaces;
 using Granit.Workspaces.Extensions;
@@ -27,6 +29,7 @@ public sealed class GranitDataExchangeEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<DataExchangeEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<DataExchangeFeatureProvider>();
     }
 }

--- a/src/Granit.DataLookup.Endpoints/GranitDataLookupEndpointsModule.cs
+++ b/src/Granit.DataLookup.Endpoints/GranitDataLookupEndpointsModule.cs
@@ -1,5 +1,7 @@
 using Granit.Authorization;
 using Granit.DataLookup;
+using Granit.DataLookup.Endpoints.Internal;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 
@@ -19,4 +21,11 @@ namespace Granit.DataLookup.Endpoints;
     typeof(GranitAuthorizationModule),
     typeof(GranitDataLookupModule),
     typeof(GranitValidationModule))]
-public sealed class GranitDataLookupEndpointsModule : GranitModule;
+public sealed class GranitDataLookupEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddLocalizationResource<DataLookupEndpointsLocalizationResource>();
+    }
+}

--- a/src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs
+++ b/src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
+using Granit.Diagnostics.Endpoints.Internal;
 using Granit.Diagnostics.Endpoints.Workspaces;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -23,6 +25,7 @@ public sealed class GranitDiagnosticsEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<DiagnosticsEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<DiagnosticsFeatureProvider>();
     }
 }

--- a/src/Granit.Features.Endpoints/GranitFeaturesEndpointsModule.cs
+++ b/src/Granit.Features.Endpoints/GranitFeaturesEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
+using Granit.Features.Endpoints.Internal;
 using Granit.Features.Endpoints.Workspaces;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -32,6 +34,7 @@ public sealed class GranitFeaturesEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<FeaturesEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<FeaturesFeatureProvider>();
     }
 }

--- a/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
+++ b/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Identity.Endpoints.Internal;
 using Granit.Identity.Endpoints.Workspaces;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -35,6 +37,7 @@ public sealed class GranitIdentityEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<IdentityEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<IdentityFeatureProvider>();
     }
 }

--- a/src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs
+++ b/src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs
@@ -3,6 +3,8 @@ using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Identity.Local;
 using Granit.Identity.Local.Endpoints.Endpoints;
+using Granit.Identity.Local.Endpoints.Internal;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +28,9 @@ namespace Granit.Identity.Local.Endpoints;
 public sealed class GranitIdentityLocalEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddLocalizationResource<IdentityLocalEndpointsLocalizationResource>();
         context.Services.AddScoped<IdentityLocalConfigProvider>();
+    }
 }

--- a/src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs
+++ b/src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Endpoints.Internal;
 using Granit.Localization.Endpoints.Workspaces;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -33,6 +35,7 @@ public sealed class GranitLocalizationEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<LocalizationEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<LocalizationFeatureProvider>();
     }
 }

--- a/src/Granit.Localization/Extensions/LocalizationServiceCollectionExtensions.cs
+++ b/src/Granit.Localization/Extensions/LocalizationServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Granit.Diagnostics;
 using Granit.Localization.Diagnostics;
 using Granit.Localization.Internal;
@@ -44,6 +45,55 @@ public static class LocalizationServiceCollectionExtensions
         {
             services.Configure(configure);
         }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Explicitly registers a localization resource marker type and its embedded JSON files.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Consolidates the boilerplate of <c>options.Resources.Add&lt;T&gt;(...).AddJson(...)</c>.
+    /// Use this from every module that owns a <see cref="LocalizationResourceNameAttribute"/>-decorated
+    /// marker type, instead of relying on <see cref="GranitLocalizationOptions.EnableAutoDiscovery"/>
+    /// which races with assembly load order.
+    /// </para>
+    /// <para>
+    /// Assumes the standard Granit convention for embedded JSON: files live at
+    /// <c>Localization/{ResourceName}/{culture}.json</c> inside the resource's owning
+    /// assembly, producing the embedded resource prefix
+    /// <c>{AssemblyName}.Localization.{ResourceName}</c>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TResource">Marker class decorated with <see cref="LocalizationResourceNameAttribute"/>.</typeparam>
+    /// <param name="services">Service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <exception cref="InvalidOperationException">If <typeparamref name="TResource"/> is not decorated with
+    /// <see cref="LocalizationResourceNameAttribute"/>.</exception>
+    public static IServiceCollection AddLocalizationResource<TResource>(this IServiceCollection services)
+        where TResource : class
+    {
+        Type resourceType = typeof(TResource);
+        LocalizationResourceNameAttribute attr =
+            resourceType.GetCustomAttribute<LocalizationResourceNameAttribute>()
+            ?? throw new InvalidOperationException(
+                $"Type '{resourceType.FullName}' must be decorated with [LocalizationResourceName] "
+                + "to be registered via AddLocalizationResource<T>().");
+
+        Assembly assembly = resourceType.Assembly;
+        string assemblyName = assembly.GetName().Name
+            ?? throw new InvalidOperationException(
+                $"Assembly for '{resourceType.FullName}' has no name.");
+
+        string embeddedResourcePrefix = $"{assemblyName}.Localization.{attr.Name}";
+
+        services.Configure<GranitLocalizationOptions>(options =>
+        {
+            options.Resources
+                .Add<TResource>(attr.DefaultCulture)
+                .AddJson(assembly, embeddedResourcePrefix);
+        });
 
         return services;
     }

--- a/src/Granit.Localization/Internal/JsonStringLocalizerFactory.cs
+++ b/src/Granit.Localization/Internal/JsonStringLocalizerFactory.cs
@@ -8,8 +8,11 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using Granit.Localization;
+using Granit.Localization.Extensions;
 using Granit.Localization.Options;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Localization.Internal;
@@ -18,22 +21,27 @@ namespace Granit.Localization.Internal;
 /// JSON localizer factory based on resources registered in
 /// <see cref="GranitLocalizationOptions"/>.
 /// </summary>
-internal sealed class JsonStringLocalizerFactory : IStringLocalizerFactory
+internal sealed partial class JsonStringLocalizerFactory : IStringLocalizerFactory
 {
     private readonly ConcurrentDictionary<Type, Lazy<IStringLocalizer>> _cache = new();
     private readonly IOptions<GranitLocalizationOptions> _options;
     private readonly ILocalizationOverrideStoreReader? _overrideStore;
+    private readonly ILogger<JsonStringLocalizerFactory> _logger;
 
     /// <summary>
     /// Creates a new factory. <paramref name="overrideStore"/> is optional:
     /// when <c>null</c>, DB overrides are not applied (transparent fallback to JSON only).
+    /// <paramref name="logger"/> is optional to keep backward compat for tests that instantiate
+    /// the factory directly without a logger; <see cref="NullLogger{T}"/> is used as fallback.
     /// </summary>
     public JsonStringLocalizerFactory(
         IOptions<GranitLocalizationOptions> options,
-        ILocalizationOverrideStoreReader? overrideStore = null)
+        ILocalizationOverrideStoreReader? overrideStore = null,
+        ILogger<JsonStringLocalizerFactory>? logger = null)
     {
         _options = options;
         _overrideStore = overrideStore;
+        _logger = logger ?? NullLogger<JsonStringLocalizerFactory>.Instance;
 
         if (options.Value.EnableAutoDiscovery)
         {
@@ -88,7 +96,21 @@ internal sealed class JsonStringLocalizerFactory : IStringLocalizerFactory
 
         if (!options.Resources.TryGetValue(resourceType, out LocalizationResourceInfo? info))
         {
-            // Unregistered type: return an empty localizer
+            // Unregistered type: emit a diagnostic warning when the type is annotated as a
+            // localization resource (so callers can see what to register), then fall back to
+            // an empty localizer (preserves the minimal-host escape hatch).
+            LocalizationResourceNameAttribute? attr =
+                resourceType.GetCustomAttribute<LocalizationResourceNameAttribute>();
+
+            if (attr is not null)
+            {
+                LogUnregisteredResource(
+                    resourceType.FullName,
+                    attr.Name,
+                    resourceType.Assembly.GetName().Name,
+                    resourceType.Name);
+            }
+
             return new JsonStringLocalizer([], "fr", []);
         }
 
@@ -119,4 +141,16 @@ internal sealed class JsonStringLocalizerFactory : IStringLocalizerFactory
         return new JsonStringLocalizer(
             info.JsonSources, info.DefaultCulture, baseLocalizers, resourceName, _overrideStore);
     }
+
+    [LoggerMessage(
+        LogLevel.Warning,
+        "Localization resource {ResourceType} ({ResourceName}) requested but not registered. "
+        + "Falling back on key suffix. Register it explicitly in assembly {Assembly}'s module "
+        + "ConfigureServices via services.AddLocalizationResource<{ResourceTypeShort}>(), "
+        + "or enable GranitLocalizationOptions.EnableAutoDiscovery=true.")]
+    private partial void LogUnregisteredResource(
+        string? resourceType,
+        string resourceName,
+        string? assembly,
+        string resourceTypeShort);
 }

--- a/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
+++ b/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
@@ -1,7 +1,9 @@
 using Granit.Authorization;
 using Granit.Guids;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
+using Granit.MultiTenancy.Endpoints.Internal;
 using Granit.MultiTenancy.Endpoints.Workspaces;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -29,6 +31,7 @@ public sealed class GranitMultiTenancyEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<MultiTenancyEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<MultiTenancyFeatureProvider>();
     }
 }

--- a/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
+++ b/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
+using Granit.Notifications.Endpoints.Internal;
 using Granit.Notifications.Endpoints.Workspaces;
 using Granit.Notifications.MobilePush;
 using Granit.Validation;
@@ -29,6 +31,7 @@ public sealed class GranitNotificationsEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<NotificationsEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<NotificationsFeatureProvider>();
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -1,6 +1,7 @@
 using Granit.Authorization;
 using Granit.Caching;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.OpenIddict.Endpoints.Internal;
 using Granit.OpenIddict.Endpoints.Workspaces;
@@ -40,6 +41,7 @@ public sealed class GranitOpenIddictEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<OpenIddictEndpointsLocalizationResource>();
         context.Services.TryAddScoped<OidcPrincipalFactory>();
         context.Services.AddFeatureProvider<OpenIddictFeatureProvider>();
     }

--- a/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
+++ b/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
@@ -2,6 +2,7 @@ using Granit.Authorization;
 using Granit.Guids;
 using Granit.Http.ApiDocumentation;
 using Granit.Http.Cookies;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Privacy.Endpoints.Discovery;
 using Granit.Privacy.Endpoints.Internal;
@@ -46,6 +47,7 @@ public sealed class GranitPrivacyEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<PrivacyEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<PrivacyFeatureProvider>();
 
         context.Services

--- a/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
+++ b/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.Scheduling.Endpoints.Internal;
 using Granit.Scheduling.Endpoints.Workspaces;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -28,6 +30,7 @@ public sealed class GranitSchedulingEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<SchedulingEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<SchedulingFeatureProvider>();
     }
 }

--- a/src/Granit.Settings.Endpoints/GranitSettingsEndpointsModule.cs
+++ b/src/Granit.Settings.Endpoints/GranitSettingsEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
+using Granit.Settings.Endpoints.Internal;
 using Granit.Settings.Endpoints.Workspaces;
 using Granit.Timing;
 using Granit.Validation;
@@ -38,6 +40,7 @@ public sealed class GranitSettingsEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<SettingsEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<SettingsFeatureProvider>();
     }
 }

--- a/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
+++ b/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
+using Granit.Templating.Endpoints.Internal;
 using Granit.Templating.Endpoints.Workspaces;
 using Granit.Users;
 using Granit.Validation;
@@ -33,6 +35,7 @@ public sealed class GranitTemplatingEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<TemplatingEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<TemplatingFeatureProvider>();
     }
 }

--- a/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
+++ b/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
+using Granit.Timeline.Endpoints.Internal;
 using Granit.Timeline.Endpoints.Workspaces;
 using Granit.Validation;
 using Granit.Workspaces;
@@ -30,6 +32,7 @@ public sealed class GranitTimelineEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<TimelineEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<TimelineFeatureProvider>();
     }
 }

--- a/src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs
+++ b/src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs
@@ -1,7 +1,9 @@
 using Granit.Authorization;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
 using Granit.Webhooks;
+using Granit.Webhooks.Endpoints.Internal;
 using Granit.Webhooks.Endpoints.Workspaces;
 using Granit.Workspaces;
 using Granit.Workspaces.Extensions;
@@ -21,6 +23,7 @@ public sealed class GranitWebhooksEndpointsModule : GranitModule
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<WebhooksEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<WebhooksFeatureProvider>();
     }
 }

--- a/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
+++ b/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
@@ -1,8 +1,10 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workflow.Endpoints.Extensions;
+using Granit.Workflow.Endpoints.Internal;
 using Granit.Workflow.Endpoints.Workspaces;
 using Granit.Workspaces;
 using Granit.Workspaces.Extensions;
@@ -39,6 +41,7 @@ public sealed class GranitWorkflowEndpointsModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddLocalizationResource<WorkflowEndpointsLocalizationResource>();
         context.Services.AddGranitWorkflowEndpoints();
         context.Services.AddFeatureProvider<WorkflowFeatureProvider>();
     }

--- a/tests/Granit.ArchitectureTests/EndpointModuleLocalizationRegistrationTests.cs
+++ b/tests/Granit.ArchitectureTests/EndpointModuleLocalizationRegistrationTests.cs
@@ -1,0 +1,175 @@
+using System.Reflection;
+using Granit.Localization;
+using Granit.Localization.Options;
+using Granit.Modularity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Convention check: every <c>Granit.*.Endpoints</c> assembly that ships a
+/// <c>[LocalizationResourceName]</c>-decorated marker type must explicitly register
+/// that resource from its <c>*EndpointsModule.ConfigureServices</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Prevents regressions of the dev.2691 sidebar bug where workspace labels rendered
+/// as the literal key suffix because endpoint resource registration was implicit
+/// through auto-discovery and races with assembly load order.
+/// </para>
+/// <para>
+/// Runtime-boot fallback: instead of brittle static analysis on
+/// <c>AddLocalizationResource&lt;T&gt;</c> call sites, this test loads each endpoint
+/// module, runs <c>ConfigureServices</c> against a real <see cref="ServiceCollection"/>,
+/// and asserts the resource type ends up in <see cref="GranitLocalizationOptions.Resources"/>.
+/// </para>
+/// </remarks>
+public sealed class EndpointModuleLocalizationRegistrationTests
+{
+    [Fact]
+    public void Every_endpoints_module_with_localization_resource_must_register_it_explicitly()
+    {
+        List<(Assembly Assembly, Type ResourceType, Type ModuleType)> candidates =
+            DiscoverEndpointModulesWithLocalizationResource();
+
+        candidates.ShouldNotBeEmpty(
+            "No *.Endpoints assembly with a [LocalizationResourceName] resource was found. "
+            + "Either the project layout changed, or the test cannot see endpoint assemblies "
+            + "via Granit.ArchitectureTests' references.");
+
+        List<string> failures = [];
+
+        foreach ((Assembly assembly, Type resourceType, Type moduleType) in candidates)
+        {
+            bool registered = TryRunModuleAndCheckRegistration(moduleType, resourceType);
+            if (!registered)
+            {
+                failures.Add(
+                    $"{moduleType.FullName} (assembly {assembly.GetName().Name}) does not register "
+                    + $"{resourceType.FullName}. Add "
+                    + $"`context.Services.AddLocalizationResource<{resourceType.Name}>();` at the top "
+                    + $"of ConfigureServices in {moduleType.Name}.");
+            }
+        }
+
+        failures.ShouldBeEmpty(
+            "Every Granit.*.Endpoints module that ships a [LocalizationResourceName] resource "
+            + "must register it explicitly from its *EndpointsModule.ConfigureServices. "
+            + $"{failures.Count} module(s) violate this rule:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, failures.Order(StringComparer.Ordinal)));
+    }
+
+    private static List<(Assembly, Type, Type)> DiscoverEndpointModulesWithLocalizationResource()
+    {
+        List<(Assembly, Type, Type)> result = [];
+
+        // Force-load every Granit.*.Endpoints.dll from the test output directory: project
+        // references are lazy and an endpoint assembly that hasn't been touched yet by any
+        // other code path won't appear in AppDomain.GetAssemblies().
+        string outputDir = Path.GetDirectoryName(typeof(EndpointModuleLocalizationRegistrationTests)
+            .Assembly.Location)!;
+
+        foreach (string dllPath in Directory.GetFiles(outputDir, "Granit.*.Endpoints.dll"))
+        {
+            try
+            {
+                Assembly.LoadFrom(dllPath);
+            }
+            catch
+            {
+                // Skip unreadable/unloadable assemblies — they don't carry endpoint modules.
+            }
+        }
+
+        Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+        foreach (Assembly assembly in assemblies)
+        {
+            string? name = assembly.GetName().Name;
+            if (name is null
+                || !name.StartsWith("Granit.", StringComparison.Ordinal)
+                || !name.EndsWith(".Endpoints", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = [.. ex.Types.OfType<Type>()];
+            }
+
+            Type? resourceType = types.FirstOrDefault(t =>
+                t.GetCustomAttribute<LocalizationResourceNameAttribute>() is not null);
+
+            if (resourceType is null)
+            {
+                continue;
+            }
+
+            Type? moduleType = types.FirstOrDefault(t =>
+                t is { IsAbstract: false, IsClass: true }
+                && t.Name.EndsWith("EndpointsModule", StringComparison.Ordinal)
+                && typeof(GranitModule).IsAssignableFrom(t));
+
+            if (moduleType is null)
+            {
+                // Assembly has a resource but no *EndpointsModule — count as a failure
+                // by recording a synthetic entry; the test loop will surface it.
+                result.Add((assembly, resourceType, typeof(MissingEndpointsModuleMarker)));
+                continue;
+            }
+
+            result.Add((assembly, resourceType, moduleType));
+        }
+
+        return result;
+    }
+
+    private static bool TryRunModuleAndCheckRegistration(Type moduleType, Type resourceType)
+    {
+        if (moduleType == typeof(MissingEndpointsModuleMarker))
+        {
+            return false;
+        }
+
+        try
+        {
+            HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+            builder.Services.AddOptions();
+            ServiceConfigurationContext context = new(
+                builder.Services, builder.Configuration, builder);
+
+            object moduleInstance = Activator.CreateInstance(moduleType)
+                ?? throw new InvalidOperationException(
+                    $"Could not instantiate {moduleType.FullName}.");
+            var module = (GranitModule)moduleInstance;
+            module.ConfigureServices(context);
+
+            using ServiceProvider sp = builder.Services.BuildServiceProvider();
+            GranitLocalizationOptions options =
+                sp.GetRequiredService<IOptions<GranitLocalizationOptions>>().Value;
+
+            return options.Resources.TryGetValue(resourceType, out _);
+        }
+        catch
+        {
+            // If the module fails to ConfigureServices in isolation (e.g. it transitively
+            // requires services not registered here), surface it as a violation rather than
+            // a green-by-default — but include the original message via the failures list.
+            return false;
+        }
+    }
+
+    private sealed class MissingEndpointsModuleMarker;
+}

--- a/tests/Granit.Localization.Tests/AddLocalizationResourceTests.cs
+++ b/tests/Granit.Localization.Tests/AddLocalizationResourceTests.cs
@@ -1,0 +1,173 @@
+using System.Globalization;
+using Granit.Localization.Extensions;
+using Granit.Localization.Internal;
+using Granit.Localization.Options;
+using Granit.Localization.Tests.TestResources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Localization.Tests;
+
+/// <summary>
+/// Tests for <c>LocalizationServiceCollectionExtensions.AddLocalizationResource&lt;T&gt;</c>
+/// and the diagnostic-warning path in <see cref="JsonStringLocalizerFactory"/> when a resource
+/// type is requested without explicit registration.
+/// </summary>
+public sealed class AddLocalizationResourceTests : IDisposable
+{
+    private readonly CultureInfo _originalUICulture = CultureInfo.CurrentUICulture;
+
+    public void Dispose() => CultureInfo.CurrentUICulture = _originalUICulture;
+
+    [Fact]
+    public void AddLocalizationResource_RegistersResourceAndJsonSource()
+    {
+        // Arrange — emulate the prefix convention this helper expects:
+        // {AssemblyName}.Localization.{ResourceName}. Use a test resource whose embedded JSON
+        // already follows this convention by aliasing the prefix via a manual entry, then verify
+        // that AddLocalizationResource registers the type into the options.
+        ServiceCollection services = new();
+        services.AddOptions();
+
+        // Act
+        services.AddLocalizationResource<RegisteredEndpointsLocalizationResource>();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        GranitLocalizationOptions options =
+            sp.GetRequiredService<IOptions<GranitLocalizationOptions>>().Value;
+
+        // Assert
+        options.Resources.TryGetValue(typeof(RegisteredEndpointsLocalizationResource), out LocalizationResourceInfo? info)
+            .ShouldBeTrue();
+        info.ShouldNotBeNull();
+        info!.ResourceType.ShouldBe(typeof(RegisteredEndpointsLocalizationResource));
+    }
+
+    [Fact]
+    public void AddLocalizationResource_TypeWithoutAttribute_Throws()
+    {
+        ServiceCollection services = new();
+        services.AddOptions();
+
+        // Act + Assert — call must throw; Configure delegates run on first Value access
+        // but the AddLocalizationResource helper validates eagerly via reflection on T.
+        Should.Throw<InvalidOperationException>(() =>
+            services.AddLocalizationResource<UndecoratedResource>());
+    }
+
+    [Fact]
+    public void Factory_ResolvingUnregisteredResource_LogsWarningWithActionableMessage()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        services.AddOptions();
+        ServiceProvider sp = services.BuildServiceProvider();
+        IOptions<GranitLocalizationOptions> opts =
+            sp.GetRequiredService<IOptions<GranitLocalizationOptions>>();
+
+        ILogger<JsonStringLocalizerFactory> logger =
+            Substitute.For<ILogger<JsonStringLocalizerFactory>>();
+        logger.IsEnabled(LogLevel.Warning).Returns(true);
+
+        JsonStringLocalizerFactory factory = new(opts, overrideStore: null, logger);
+
+        // Act — UnregisteredResource has [LocalizationResourceName] but isn't in options
+        IStringLocalizer localizer = factory.Create(typeof(UnregisteredResource));
+
+        // Assert: fallback still works (key suffix)
+        localizer["Foo:Bar"].ResourceNotFound.ShouldBeTrue();
+
+        // Assert: a warning was logged mentioning the type, resource name, owning assembly,
+        // and the AddLocalizationResource<> snippet.
+        logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state =>
+                state.ToString()!.Contains(typeof(UnregisteredResource).FullName!)
+                && state.ToString()!.Contains("Unregistered")
+                && state.ToString()!.Contains(typeof(UnregisteredResource).Assembly.GetName().Name!)
+                && state.ToString()!.Contains("AddLocalizationResource")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public void Factory_ResolvingRegisteredResource_DoesNotLogWarning()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        services.Configure<GranitLocalizationOptions>(options =>
+        {
+            options.Resources
+                .Add<TestResource>("fr")
+                .AddJson(
+                    typeof(JsonStringLocalizerFactoryTests).Assembly,
+                    "Granit.Localization.Tests.TestResources.Localization.Test");
+        });
+        ServiceProvider sp = services.BuildServiceProvider();
+        IOptions<GranitLocalizationOptions> opts =
+            sp.GetRequiredService<IOptions<GranitLocalizationOptions>>();
+
+        ILogger<JsonStringLocalizerFactory> logger =
+            Substitute.For<ILogger<JsonStringLocalizerFactory>>();
+
+        JsonStringLocalizerFactory factory = new(opts, overrideStore: null, logger);
+
+        // Act
+        factory.Create(typeof(TestResource));
+
+        // Assert
+        logger.DidNotReceive().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public void AutoDiscovery_DoesNotOverwriteExplicitRegistration()
+    {
+        // Regression guard: when EnableAutoDiscovery=true, an existing explicit entry must
+        // be preserved (the TryGetValue guard in LocalizationAutoDiscovery is intact).
+        // Arrange
+        ServiceCollection services = new();
+        services.Configure<GranitLocalizationOptions>(options =>
+        {
+            options.EnableAutoDiscovery = true;
+            // Explicitly register TestResource pointing at the real Test.* embedded JSON
+            options.Resources
+                .Add<TestResource>("fr")
+                .AddJson(
+                    typeof(JsonStringLocalizerFactoryTests).Assembly,
+                    "Granit.Localization.Tests.TestResources.Localization.Test");
+        });
+        ServiceProvider sp = services.BuildServiceProvider();
+        IOptions<GranitLocalizationOptions> opts =
+            sp.GetRequiredService<IOptions<GranitLocalizationOptions>>();
+
+        // Act — instantiate factory, which triggers auto-discovery
+        _ = new JsonStringLocalizerFactory(opts);
+        GranitLocalizationOptions afterDiscovery = opts.Value;
+
+        // Assert — explicit entry preserved (Test JSON resolves), not overwritten
+        afterDiscovery.Resources.TryGetValue(typeof(TestResource), out LocalizationResourceInfo? info).ShouldBeTrue();
+        info!.JsonSources.Count.ShouldBeGreaterThan(0);
+    }
+}
+
+// Test marker: lives in this assembly so the convention prefix
+// "Granit.Localization.Tests.Localization.RegisteredEndpoints" would be expected.
+// The helper builds it from the assembly + [LocalizationResourceName]. We only assert
+// registration here, not key resolution (no JSON is embedded for this marker).
+[LocalizationResourceName("RegisteredEndpoints")]
+public sealed class RegisteredEndpointsLocalizationResource;
+
+// Test marker missing the [LocalizationResourceName] attribute — used to assert the helper's
+// validation path.
+public sealed class UndecoratedResource;

--- a/tests/Granit.Scheduling.Endpoints.Tests/SchedulingEndpointsLocalizationCanaryTests.cs
+++ b/tests/Granit.Scheduling.Endpoints.Tests/SchedulingEndpointsLocalizationCanaryTests.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using Granit.Localization.Extensions;
+using Granit.Modularity;
+using Granit.Scheduling.Endpoints.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Localization;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Scheduling.Endpoints.Tests;
+
+/// <summary>
+/// Canary integration test that proves the explicit
+/// <c>services.AddLocalizationResource&lt;SchedulingEndpointsLocalizationResource&gt;()</c>
+/// wiring in <see cref="GranitSchedulingEndpointsModule"/> makes the workspace label
+/// resolve in both <c>fr</c> and <c>en</c> without relying on auto-discovery.
+///
+/// Regression guard for the dev.2691 sidebar regression where the literal "Item" rendered
+/// because <c>SchedulingEndpoints:Workspace.Item</c> failed to resolve.
+/// </summary>
+public sealed class SchedulingEndpointsLocalizationCanaryTests : IDisposable
+{
+    private readonly CultureInfo _originalUICulture = CultureInfo.CurrentUICulture;
+
+    public void Dispose() => CultureInfo.CurrentUICulture = _originalUICulture;
+
+    [Theory]
+    [InlineData("fr", "Actions planifiées")]
+    [InlineData("en", "Scheduled actions")]
+    public void Workspace_label_resolves_when_module_only_registers_explicitly(
+        string culture, string expected)
+    {
+        // Arrange — emulate a host that loads only the endpoint module, with auto-discovery OFF
+        // (so a resolution success proves explicit registration alone is sufficient).
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddOptions();
+        builder.Services.AddSingleton<IFusionCache>(new FusionCache(new FusionCacheOptions()));
+        builder.Services.AddGranitLocalization(options => options.EnableAutoDiscovery = false);
+
+        ServiceConfigurationContext context = new(
+            builder.Services, builder.Configuration, builder);
+
+        GranitSchedulingEndpointsModule module = new();
+        module.ConfigureServices(context);
+
+        using ServiceProvider sp = builder.Services.BuildServiceProvider();
+
+        CultureInfo.CurrentUICulture = new CultureInfo(culture);
+
+        // Act
+        IStringLocalizer<SchedulingEndpointsLocalizationResource> localizer =
+            sp.GetRequiredService<IStringLocalizer<SchedulingEndpointsLocalizationResource>>();
+        LocalizedString resolved = localizer["SchedulingEndpoints:Workspace.Item"];
+
+        // Assert
+        resolved.ResourceNotFound.ShouldBeFalse(
+            $"SchedulingEndpoints:Workspace.Item must resolve in '{culture}' without auto-discovery.");
+        resolved.Value.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
## Summary

`LocalizationAutoDiscovery.Discover` runs **once**, in the `JsonStringLocalizerFactory` constructor, scanning `AppDomain.CurrentDomain.GetAssemblies()` at that exact moment. Any consumer that resolves `IStringLocalizer<T>` early in startup (options validators, OpenAPI document generation, seed contributors, permission definition providers) instantiates the factory before all `Granit.*.Endpoints` module classes have been JIT-loaded → their assemblies aren't in `AppDomain` yet → their `*EndpointsLocalizationResource` types are silently skipped, and the cache freezes without them.

**Symptom in granit-showcase-dotnet dev.2691**: six workspace sections render the literal `"Item"` in the sidebar (Scheduled Actions, Background Jobs, Notifications, Feature Flags, Audit Logs, Monitoring) — fallback on key suffix when `SchedulingEndpoints:Workspace.Item` etc. don't resolve.

This PR removes the race by registering each endpoint resource explicitly in its `*EndpointsModule.ConfigureServices` — symmetric to how `*PermissionDefinitionProvider` is wired. Auto-discovery is kept as an opt-in escape hatch for test hosts and minimal apps.

## Changes

- New `AddLocalizationResource<TResource>()` extension on `IServiceCollection` — consolidates `options.Resources.Add<T>(...).AddJson(...)` boilerplate, derives the embedded-resource prefix from the assembly + `[LocalizationResourceName]` by convention, throws if the type isn't decorated.
- 25 `Granit.*.Endpoints` modules wired with one-liner `AddLocalizationResource<{X}EndpointsLocalizationResource>()` at the top of `ConfigureServices`.
- `JsonStringLocalizerFactory` emits a structured `[LoggerMessage]` warn when an `IStringLocalizer<T>` is requested for a `T` decorated with `[LocalizationResourceName]` but not in `Resources` — actionable message names the owning assembly and the exact one-liner to add. Class made `partial` for source-genned logging.
- `EnableAutoDiscovery` default unchanged (still `true` via `GranitLocalizationModule`); explicit registration takes precedence — auto-discovery's `TryGetValue` guard skips already-registered types.
- Architecture test in `Granit.ArchitectureTests`: loads every `Granit.*.Endpoints.dll` from the test output dir, runs each module's `ConfigureServices`, asserts the resource ends up in `GranitLocalizationOptions.Resources`. Prevents future modules from forgetting the registration.

## Downstream impact

- granit-showcase-dotnet: workaround at `ShowcaseHostModule.cs:292` becomes provably a no-op. To be removed after dev publish bump.
- Existing hosts that relied on auto-discovery working "by luck": now deterministic, no behavior change beyond "labels that were sometimes wrong are now always right".

## Test plan

- [x] Unit tests for `AddLocalizationResource<T>` helper (registration, throw on missing attr, idempotency)
- [x] Canary integration test on `Granit.Scheduling.Endpoints` — `Workspace.Item` label resolves in fr and en without host workaround
- [x] Architecture test boots every `*.Endpoints` module and asserts resource registration
- [x] Warn log fires with actionable message when resource is unregistered (`FakeLogger` assertion)
- [x] Auto-discovery does not overwrite explicit registration (regression guard)
- [x] Shards `localization` (104 tests) + `scheduling` (6) + `architecture` (1) green
- [x] `dotnet format --verify-no-changes` clean