### PR TITLE
fix(data-exchange): move ExportOrchestrator out of Internal/

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12125,6 +12125,28 @@
       ]
     },
     {
+      "name": "ExportOrchestrator",
+      "fqn": "Granit.DataExchange.Export.ExportOrchestrator",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportOrchestrator.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ExportAsync",
+          "kind": "method",
+          "signature": "ExportAsync(ExportRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportJobResult>"
+        },
+        {
+          "name": "GetDownloadAsync",
+          "kind": "method",
+          "signature": "GetDownloadAsync(Guid jobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportDownload?>"
+        }
+      ]
+    },
+    {
       "name": "ExportPreset",
       "fqn": "Granit.DataExchange.Export.ExportPreset",
       "kind": "record",
@@ -12397,28 +12419,6 @@
           "kind": "method",
           "signature": "GetExtraFields(Type entityType)",
           "returnType": "IReadOnlyList<ExportFieldDescriptor>"
-        }
-      ]
-    },
-    {
-      "name": "ExportOrchestrator",
-      "fqn": "Granit.DataExchange.Export.Internal.ExportOrchestrator",
-      "kind": "class",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Export/Internal/ExportOrchestrator.cs",
-      "line": 27,
-      "members": [
-        {
-          "name": "ExportAsync",
-          "kind": "method",
-          "signature": "ExportAsync(ExportRequest request, CancellationToken cancellationToken = default)",
-          "returnType": "Task<ExportJobResult>"
-        },
-        {
-          "name": "GetDownloadAsync",
-          "kind": "method",
-          "signature": "GetDownloadAsync(Guid jobId, CancellationToken cancellationToken = default)",
-          "returnType": "Task<ExportDownload?>"
         }
       ]
     },

--- a/src/Granit.DataExchange/Export/ExportOrchestrator.cs
+++ b/src/Granit.DataExchange/Export/ExportOrchestrator.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Granit.DataExchange.Export.Internal;
+namespace Granit.DataExchange.Export;
 
 /// <summary>
 /// Default <see cref="IExportOrchestrator"/> implementation.


### PR DESCRIPTION
## Summary

Resolves the `ClassDesignTests.Public_types_should_not_reside_in_Internal_namespaces` violation introduced by the recent `internal → public` visibility flip on `ExportOrchestrator`.

The file moves from `src/Granit.DataExchange/Export/Internal/` to `src/Granit.DataExchange/Export/`, and the namespace updates accordingly. All call sites already import `Granit.DataExchange.Export` so no `using` changes are needed.

## Test plan

- [x] `dotnet build src/Granit.DataExchange` clean
- [x] `dotnet build tests/Granit.DataExchange.Tests` clean
- [x] 179/179 `Granit.ArchitectureTests` pass (fresh build)