### PR TITLE
fix(auditing): wire ApplicationServiceProvider in UseGranitInterceptors

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextOptionsBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextOptionsBuilderExtensions.cs
@@ -58,6 +58,16 @@ public static class DbContextOptionsBuilderExtensions
         // since this is by design (modular architecture with isolated persistence).
         options.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
+        // Bridge the EF Core internal SP to the application SP so interceptors that
+        // resolve scoped services at SaveChanges time (e.g. AuditingChangeTrackingInterceptor
+        // → ChangeTrackingCaptureService) can reach them via
+        // ((IInfrastructure<IServiceProvider>)context).Instance.GetService<T>().
+        // EF Core's own AddDbContextFactory wires this automatically; the Granit
+        // custom factories (SharedDatabase / TenantPerSchema / TenantPerDatabase)
+        // build options manually, so without this call the lookup returns null and
+        // audit capture is silently skipped on every isolated DbContext.
+        options.UseApplicationServiceProvider(serviceProvider);
+
         // Order matters: Audit → Versioning → ConcurrencyStamp → DomainEvents → SoftDelete.
         // SoftDelete must be last because it converts Deleted → Modified,
         // which would prevent other interceptors from seeing the original state.


### PR DESCRIPTION
## Summary

`AuditingChangeTrackingInterceptor` is stateless and resolves the scoped `ChangeTrackingCaptureService` lazily at `SaveChanges` time via `((IInfrastructure<IServiceProvider>)context).Instance.GetService<T>()`. That lookup only delegates to the application SP when `UseApplicationServiceProvider` is set on the DbContext options.

EF Core's built-in `AddDbContextFactory` wires it automatically (so the `AddGranitDbContext` path is fine), but the three Granit custom factories — `SharedDatabaseDbContextFactory`, `TenantPerSchemaDbContextFactory`, `TenantPerDatabaseDbContextFactory` — build options manually and never call it. The capture service resolves to `null`, `Capture` is a no-op, and **every write through a tenant-isolated DbContext goes unaudited**.

Showcase repro: `host.audit_log_log_entries` / `host.audit_log_entity_changes` / `host.audit_log_property_changes` all at 0 rows despite normal admin activity.

Fix: set `UseApplicationServiceProvider` centrally in `UseGranitInterceptors` so both the EF-Core-native and Granit custom factory paths land on the same wiring. Idempotent with EF Core's own call on the `AddGranitDbContext` path.

## Test plan

- [ ] `dotnet build src/Granit.Persistence.EntityFrameworkCore` clean
- [ ] Republish dev NuGet, `--force-evaluate` restore in `granit-showcase-dotnet`, restart host
- [ ] Perform a tenant-scoped write (e.g. create a Party / upload a Document)
- [ ] `SELECT COUNT(*) FROM host.audit_log_log_entries` returns > 0
- [ ] Existing audit unit tests stay green
- [ ] Follow-up (out of scope here): add an integration test asserting an audit row lands after a write through `AddGranitIsolatedDbContext` — current tests use raw `UseInMemoryDatabase` with no DI and never exercise this path