### PR TITLE
chore(ci): reduce Actions cost footprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,38 +293,6 @@ jobs:
           dotnet build -c $CONFIGURATION
           dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"
 
-  audit:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: NuGet cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
-          restore-keys: nuget-${{ runner.os }}-
-
-      - name: Check vulnerable packages
-        run: |
-          dotnet restore
-          dotnet list package --vulnerable --include-transitive 2>&1 | tee vulnerability-report.txt
-          ! grep -q "has the following vulnerable packages" vulnerability-report.txt
-
-      - name: Upload vulnerability report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: vulnerability-report
-          path: vulnerability-report.txt
-          retention-days: 7
-
   # ---------------------------------------------------------------------------
   # PACK
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Followup to the org-wide GitHub Actions cost audit (May 1–17 2026, ~$483 / 17 days; 96% from `granit-dotnet`). The audit asked for 7 mitigations; verifying current state shows most are already implemented:

| Audit recommendation | State |
|---|---|
| #1 Standard `runs-on: ubuntu-latest` (not larger runners) | ✅ already — all 18 jobs use 2-core standard |
| #2 `concurrency: cancel-in-progress` on workflows | ✅ already (ci.yml:25, codeql.yml:26) |
| #3 Disable CodeQL doublon (default OR advanced) | ✅ default setup is currently `not-configured` (verified via `gh api .../code-scanning/default-setup`); advanced `codeql.yml` is the active one. The 21k CodeQL minutes in the CSV came from default setup before it was switched off. |
| #4 Restrict CodeQL to protected branches + cron | ✅ already (`push: [develop, main]` + weekly cron) |
| #5 Reduce ci.yml matrix on PRs | n/a — matrix is already lean (7 test shards × 1 OS × 1 .NET) |
| #6 `retention-days: 7` on artifacts | ✅ already (except SBOM at 90, intentional for release attachments) |
| **Removable waste** | **this PR** ↓ |

## What this PR changes

Drops the legacy `audit` job from `.github/workflows/ci.yml`. It:

- ran an unsharded `dotnet restore` against the full solution (~295 projects, 5–10 min)
- then `dotnet list package --vulnerable --include-transitive` — exact same check as the sharded `dotnet-audit` job above it
- was `continue-on-error: true`, so it never blocked merges anyway

`dotnet-audit` already runs the same vulnerability scan in parallel across all 7 shards with `--locked-mode` restores, and blocks on High/Critical findings.

## Public-repo billing — open question

Repo visibility is `PUBLIC` (verified) and all runners are `ubuntu-latest` standard 2-core. These should be **free and unlimited** on public repos. Yet the org CSV billed ~$483 for `granit-dotnet` over the period.

Possible explanations to chase outside this PR:
- Visibility may have been `internal` for part of the period.
- An org-level policy may be forcing minute accounting on public repos.
- Some `uses:` reference may pull a composite action from a private repo and bill the caller.

A quick `gh api orgs/granit-fx/actions/permissions` and a re-check of the visibility audit log would settle it.

## Spam contributor check

The audit flagged `muhqasas14527` (27 min on 11 May). Worth a manual check (`gh api users/muhqasas14527`, `gh pr list --author muhqasas14527 --state all`). No code change in this PR — flagged here for visibility.

## Test plan

- [ ] CI runs on this PR — `dotnet-audit` shards still catch vulnerable packages (no regression in coverage).
- [ ] Verify no other workflow depends on the deleted `audit` job (it had no `needs:` consumers; nothing referenced its artifact `vulnerability-report` outside the job itself).