### PR TITLE
chore(ci): publish dev packages to GitLab Package Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,45 @@ jobs:
           --api-key "$NUGET_AUTH_TOKEN"
           --skip-duplicate
 
+  # GitLab Package Registry (granit-business project, id 11) — fallback feed
+  # for downstream repos when GitHub Packages is rate-limited or unavailable.
+  # Uses a deploy token (write_package_registry scope) to avoid PAT churn.
+  publish-gitlab:
+    needs: [pack, sbom]
+    runs-on: ubuntu-latest
+    if: |
+      always()
+      && needs.pack.result == 'success'
+      && (needs.sbom.result == 'success' || needs.sbom.result == 'skipped')
+      && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Download packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nupkgs
+          path: nupkgs
+
+      - name: Push to GitLab Package Registry
+        # Credentials provided via NuGetPackageSourceCredentials_* env var rather
+        # than `dotnet nuget add source --store-password-in-clear-text`, which
+        # would write the deploy token to nuget.config on disk.
+        env:
+          NuGetPackageSourceCredentials_gitlab_granit_business: Username=${{ secrets.GITLAB_NUGET_USER }};Password=${{ secrets.GITLAB_NUGET_TOKEN }}
+          GITLAB_NUGET_TOKEN: ${{ secrets.GITLAB_NUGET_TOKEN }}
+        run: |
+          dotnet nuget add source \
+            "https://gitlab.digitaldynamics.be/api/v4/projects/11/packages/nuget/index.json" \
+            --name gitlab_granit_business
+          dotnet nuget push "nupkgs/*.nupkg" \
+            --source gitlab_granit_business \
+            --api-key "$GITLAB_NUGET_TOKEN" \
+            --skip-duplicate
+
   # nuget.org — release packages on version tags
   publish-nuget:
     needs: [pack, sbom]


### PR DESCRIPTION
## Why

GitHub Packages restores from `granit-business` started failing on May 17 with `twirp error permission_denied: Account has reached its billing limit` — direct fallout of the GitHub Actions billing audit (#2111 context). We need a feed that doesn't share the GitHub billing surface.

GitLab Package Registry on the self-hosted instance (`gitlab.digitaldynamics.be`) is unmetered. `granit-business` is already there (project id 11) and has the auth machinery in place.

## What this does

Adds a `publish-gitlab` job parallel to `publish-github`. Pushes `0.1.0-dev.*` nupkgs on every `develop`/`main` push. Does **not** touch nuget.org (release tags) and does **not** remove `publish-github` — both feeds publish until we're confident on the new one.

Credentials use `NuGetPackageSourceCredentials_*` env var (per [feedback_nuget_credential_in_ci](../../.claude/projects/-home-jf-dev-granit-fx-granit-dotnet/memory/feedback_nuget_credential_in_ci.md) — keeps the deploy token out of nuget.config on disk).

## Required before merge

Two GitHub repo secrets need to be created:

1. **GitLab side** — in `digital-dynamics/granit-fx/granit-business` settings → Repository → Deploy tokens:
   - Name: `granit-dotnet-publish`
   - Scope: `write_package_registry` (only — least privilege)
   - Copy username + token.

2. **GitHub side** — in `granit-fx/granit-dotnet` settings → Secrets and variables → Actions:
   - `GITLAB_NUGET_USER` = deploy token username
   - `GITLAB_NUGET_TOKEN` = deploy token value

The IDE shows two "Context access might be invalid" warnings on `secrets.GITLAB_NUGET_*` — those are expected until the secrets exist.

## Follow-up (separate PR in granit-business)

Update `nuget.config` to add the GitLab source with `<packageSourceMapping>` patterns `Granit` + `Granit.*` ([feedback_nuget_package_source_mapping](../../.claude/projects/-home-jf-dev-granit-fx-granit-dotnet/memory/feedback_nuget_package_source_mapping.md) — both patterns needed). Then granit-business CI can drop the `NuGetPackageSourceCredentials_GranitGitHub` block.

## Test plan

- [ ] Create the two GitHub secrets above.
- [ ] Merge → on the next `develop` push, watch `publish-gitlab` succeed.
- [ ] Verify packages land under <https://gitlab.digitaldynamics.be/digital-dynamics/granit-fx/granit-business/-/packages>.
- [ ] In a granit-business branch, swap nuget.config to the GitLab source and confirm restore works.