### PR TITLE
fix(blob-storage): apply framework convention audit findings

### DIFF
--- a/.github/shard-filters/api-data.slnf
+++ b/.github/shard-filters/api-data.slnf
@@ -29,6 +29,7 @@
       "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
       "src/Granit.DataLookup/Granit.DataLookup.csproj",
+      "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -460,7 +460,8 @@
     {
       "name": "Granit.BlobStorage.GoogleCloud",
       "deps": [
-        "Granit.BlobStorage"
+        "Granit.BlobStorage",
+        "Granit.Diagnostics"
       ],
       "framework": "net10.0"
     },
@@ -476,6 +477,7 @@
       "name": "Granit.BlobStorage.S3",
       "deps": [
         "Granit.BlobStorage",
+        "Granit.Diagnostics",
         "Granit.Observability"
       ],
       "framework": "net10.0"
@@ -8822,7 +8824,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.AI",
       "file": "src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitBlobStorageAI",
@@ -8894,7 +8896,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.AzureBlob",
       "file": "src/Granit.BlobStorage.AzureBlob/Extensions/BlobStorageAzureBlobHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitBlobStorageAzureBlob",
@@ -8919,7 +8921,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.AzureBlob",
       "file": "src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptions.cs",
-      "line": 25,
+      "line": 24,
       "members": [
         {
           "name": "ConnectionString",
@@ -9062,19 +9064,25 @@
       "kind": "class",
       "project": "Granit.BlobStorage.Database",
       "file": "src/Granit.BlobStorage.Database/Entities/DatabaseBlobContent.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
-          "name": "Id",
+          "name": "TenantId",
           "kind": "property",
-          "signature": "Guid Id",
-          "returnType": "Guid"
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
         },
         {
           "name": "Content",
           "kind": "property",
           "signature": "byte[] Content",
           "returnType": "byte[]"
+        },
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string objectKey, byte[] content)",
+          "returnType": "DatabaseBlobContent"
         }
       ]
     },
@@ -9084,7 +9092,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.Database",
       "file": "src/Granit.BlobStorage.Database/Extensions/BlobStorageDatabaseHostApplicationBuilderExtensions.cs",
-      "line": 21,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitBlobStorageDatabase",
@@ -9211,7 +9219,7 @@
           "name": "MarkAsUploading",
           "kind": "method",
           "signature": "MarkAsUploading()",
-          "returnType": "long MaxAllowedBytes { get; private set; } public string? VerifiedContentType { get; private set; } public long? SizeBytes { get; private set; } public BlobStatus Status { get; private set; } public DateTimeOffset CreatedAt { get; private set; } public DateTimeOffset? ValidatedAt { get; private set; } public DateTimeOffset? DeletedAt { get; private set; } public string? RejectionReason { get; private set; } public string? DeletionReason { get; private set; } public void"
+          "returnType": "long MaxAllowedBytes { get; private set; } public string? VerifiedContentType { get; private set; } public long? SizeBytes { get; private set; } public BlobStatus Status { get; private set; } public DateTimeOffset? ValidatedAt { get; private set; } public DateTimeOffset? DeletedAt { get; private set; } public string? RejectionReason { get; private set; } public string? DeletionReason { get; private set; } public void"
         }
       ]
     },
@@ -9311,13 +9319,29 @@
       "kind": "class",
       "project": "Granit.BlobStorage.Endpoints",
       "file": "src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "MapGranitBlobStorage",
           "kind": "method",
           "signature": "MapGranitBlobStorage(this IEndpointRouteBuilder endpoints, Action<BlobStorageEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageEndpointsHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.Endpoints.Extensions.BlobStorageEndpointsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointsHostApplicationBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageEndpoints",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageEndpoints(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
         }
       ]
     },
@@ -9401,7 +9425,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.EntityFrameworkCore",
       "file": "src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitBlobStorageEntityFrameworkCore",
@@ -9542,7 +9566,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.FileSystem",
       "file": "src/Granit.BlobStorage.FileSystem/Extensions/BlobStorageFileSystemHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitBlobStorageFileSystem",
@@ -9567,7 +9591,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.FileSystem",
       "file": "src/Granit.BlobStorage.FileSystem/Options/FileSystemBlobOptions.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
           "name": "BasePath",
@@ -9592,7 +9616,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.GoogleCloud",
       "file": "src/Granit.BlobStorage.GoogleCloud/Extensions/BlobStorageGoogleCloudHostApplicationBuilderExtensions.cs",
-      "line": 21,
+      "line": 24,
       "members": [
         {
           "name": "AddGranitBlobStorageGoogleCloud",
@@ -9617,7 +9641,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.GoogleCloud",
       "file": "src/Granit.BlobStorage.GoogleCloud/Options/GoogleCloudStorageOptions.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ProjectId",
@@ -9645,7 +9669,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage",
       "file": "src/Granit.BlobStorage/GranitBlobStorageModule.cs",
-      "line": 32,
+      "line": 31,
       "members": [
         {
           "name": "ConfigureServices",
@@ -9893,9 +9917,9 @@
       "line": 17,
       "members": [
         {
-          "name": "MapGranitBlobProxy",
+          "name": "MapGranitBlobStorageProxy",
           "kind": "method",
-          "signature": "MapGranitBlobProxy(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitBlobStorageProxy(this IEndpointRouteBuilder endpoints)",
           "returnType": "IEndpointRouteBuilder"
         }
       ]
@@ -9906,7 +9930,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.Proxy",
       "file": "src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyHostApplicationBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitBlobStorageProxy",
@@ -9996,7 +10020,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.S3",
       "file": "src/Granit.BlobStorage.S3/Extensions/BlobStorageS3HostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 23,
       "members": [
         {
           "name": "AddGranitBlobStorageS3",
@@ -10028,7 +10052,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.S3",
       "file": "src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs",
-      "line": 25,
+      "line": 24,
       "members": [
         {
           "name": "ServiceUrl",

--- a/.slnf/infrastructure.slnf
+++ b/.slnf/infrastructure.slnf
@@ -28,6 +28,7 @@
       "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
       "src/Granit.DataLookup/Granit.DataLookup.csproj",
+      "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj",

--- a/src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Granit.BlobStorage.AI.Internal;
 using Granit.BlobStorage.AI.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.AI.Extensions;
 
@@ -31,7 +32,10 @@ public static class BlobStorageAIHostApplicationBuilderExtensions
     {
         builder.Services
             .AddOptions<BlobStorageAIOptions>()
-            .BindConfiguration(BlobStorageAIOptions.SectionName);
+            .BindConfiguration(BlobStorageAIOptions.SectionName)
+            .ValidateOnStart();
+
+        builder.Services.AddSingleton<IValidateOptions<BlobStorageAIOptions>, BlobStorageAIOptionsValidator>();
 
         // Single instance serves both IAIBlobClassifier and IBlobValidator.
         builder.Services.AddSingleton<AIBlobClassifierService>();

--- a/src/Granit.BlobStorage.AI/Options/BlobStorageAIOptionsValidator.cs
+++ b/src/Granit.BlobStorage.AI/Options/BlobStorageAIOptionsValidator.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.BlobStorage.AI.Options;
+
+/// <summary>
+/// Validates <see cref="BlobStorageAIOptions"/> at startup (fail-fast on misconfiguration).
+/// </summary>
+internal sealed class BlobStorageAIOptionsValidator : IValidateOptions<BlobStorageAIOptions>
+{
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, BlobStorageAIOptions options)
+    {
+        if (options.TimeoutSeconds <= 0)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.TimeoutSeconds)} must be greater than zero.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.BlobStorage.AzureBlob/Extensions/BlobStorageAzureBlobHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Extensions/BlobStorageAzureBlobHostApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Granit.BlobStorage.Internal;
 using Granit.BlobStorage.Options;
 using Granit.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -43,12 +44,12 @@ public static class BlobStorageAzureBlobHostApplicationBuilderExtensions
 
         // AzureBlobClient implements IBlobStoreProvider + IPresignedUrlProvider.
         // Registered as Singleton: BlobServiceClient is thread-safe and intended for reuse.
-        builder.Services.AddSingleton<AzureBlobClient>();
-        builder.Services.AddSingleton<IBlobStoreProvider>(sp => sp.GetRequiredService<AzureBlobClient>());
-        builder.Services.AddSingleton<IPresignedUrlProvider>(sp => sp.GetRequiredService<AzureBlobClient>());
+        builder.Services.TryAddSingleton<AzureBlobClient>();
+        builder.Services.TryAddSingleton<IBlobStoreProvider>(sp => sp.GetRequiredService<AzureBlobClient>());
+        builder.Services.TryAddSingleton<IPresignedUrlProvider>(sp => sp.GetRequiredService<AzureBlobClient>());
 
-        builder.Services.AddScoped<IBlobKeyStrategy, AzureBlobKeyStrategy>();
-        builder.Services.AddScoped<IBlobStorage, DefaultBlobStorage>();
+        builder.Services.TryAddScoped<IBlobKeyStrategy, AzureBlobKeyStrategy>();
+        builder.Services.TryAddScoped<IBlobStorage, DefaultBlobStorage>();
 
         return builder;
     }

--- a/src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptions.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptions.cs
@@ -1,5 +1,4 @@
 using Granit.BlobStorage.Options;
-using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.AzureBlob.Options;
 
@@ -52,46 +51,4 @@ public sealed class AzureBlobOptions : BlobStorageOptions
     /// Multi-tenant isolation strategy. Defaults to <see cref="BlobTenantIsolation.Prefix"/>.
     /// </summary>
     public BlobTenantIsolation TenantIsolation { get; set; } = BlobTenantIsolation.Prefix;
-}
-
-/// <summary>
-/// Validates <see cref="AzureBlobOptions"/> at startup (fail-fast on misconfiguration).
-/// </summary>
-internal sealed class AzureBlobOptionsValidator : IValidateOptions<AzureBlobOptions>
-{
-    /// <inheritdoc/>
-    public ValidateOptionsResult Validate(string? name, AzureBlobOptions options)
-    {
-        if (options.UseManagedIdentity)
-        {
-            if (options.ServiceUri is null)
-            {
-                return ValidateOptionsResult.Fail(
-                    $"{nameof(options.ServiceUri)} must be set when {nameof(options.UseManagedIdentity)} is true.");
-            }
-
-            if (options.ServiceUri.Scheme != Uri.UriSchemeHttps)
-            {
-                return ValidateOptionsResult.Fail(
-                    $"{nameof(options.ServiceUri)} must use HTTPS.");
-            }
-        }
-        else
-        {
-            if (string.IsNullOrWhiteSpace(options.ConnectionString))
-            {
-                return ValidateOptionsResult.Fail(
-                    $"{nameof(options.ConnectionString)} must be non-empty when {nameof(options.UseManagedIdentity)} is false. " +
-                    "Inject from Granit.Vault.");
-            }
-        }
-
-        if (string.IsNullOrWhiteSpace(options.DefaultContainer))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.DefaultContainer)} must be non-empty.");
-        }
-
-        return ValidateOptionsResult.Success;
-    }
 }

--- a/src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptionsValidator.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptionsValidator.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.BlobStorage.AzureBlob.Options;
+
+/// <summary>
+/// Validates <see cref="AzureBlobOptions"/> at startup (fail-fast on misconfiguration).
+/// </summary>
+internal sealed class AzureBlobOptionsValidator : IValidateOptions<AzureBlobOptions>
+{
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, AzureBlobOptions options)
+    {
+        if (options.UseManagedIdentity)
+        {
+            if (options.ServiceUri is null)
+            {
+                return ValidateOptionsResult.Fail(
+                    $"{nameof(options.ServiceUri)} must be set when {nameof(options.UseManagedIdentity)} is true.");
+            }
+
+            if (options.ServiceUri.Scheme != Uri.UriSchemeHttps)
+            {
+                return ValidateOptionsResult.Fail(
+                    $"{nameof(options.ServiceUri)} must use HTTPS.");
+            }
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(options.ConnectionString))
+            {
+                return ValidateOptionsResult.Fail(
+                    $"{nameof(options.ConnectionString)} must be non-empty when {nameof(options.UseManagedIdentity)} is false. " +
+                    "Inject from Granit.Vault.");
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(options.DefaultContainer))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.DefaultContainer)} must be non-empty.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.BlobStorage.Database/Entities/DatabaseBlobContent.cs
+++ b/src/Granit.BlobStorage.Database/Entities/DatabaseBlobContent.cs
@@ -1,4 +1,5 @@
 using Granit.Domain;
+using Granit.MultiTenancy;
 
 namespace Granit.BlobStorage.Database.Entities;
 
@@ -9,23 +10,40 @@ namespace Granit.BlobStorage.Database.Entities;
 /// Each row represents one blob. The <see cref="ObjectKey"/> links this record
 /// to the <c>BlobDescriptor</c> managed by <c>Granit.BlobStorage.EntityFrameworkCore</c>.
 /// </remarks>
-public sealed class DatabaseBlobContent : IMultiTenant
+public sealed class DatabaseBlobContent : CreationAuditedEntity, IMultiTenant
 {
-    /// <summary>Primary key.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>Tenant identifier for multi-tenant isolation. Null when tenancy is not active.</summary>
-    public Guid? TenantId { get; set; }
+    public Guid? TenantId { get; private set; }
 
     /// <summary>
     /// The object key that identifies this blob in the storage abstraction.
     /// Format: <c>{tenantId}/{containerName}/{yyyy}/{MM}/{blobId}</c>.
     /// </summary>
-    public string ObjectKey { get; set; } = string.Empty;
+    public string ObjectKey { get; private set; } = string.Empty;
 
     /// <summary>Raw binary content of the blob.</summary>
-    public byte[] Content { get; set; } = [];
+    public byte[] Content { get; private set; } = [];
 
-    /// <summary>Timestamp when the blob was stored.</summary>
-    public DateTimeOffset CreatedAt { get; set; }
+    /// <summary>For EF Core materialization.</summary>
+    private DatabaseBlobContent() { }
+
+    /// <summary>
+    /// Creates a new database blob content row.
+    /// </summary>
+    /// <param name="id">Row identifier (typically from <c>IGuidGenerator</c>).</param>
+    /// <param name="objectKey">Object key linking this row to its descriptor.</param>
+    /// <param name="content">Raw blob bytes.</param>
+    public static DatabaseBlobContent Create(Guid id, string objectKey, byte[] content) =>
+        new()
+        {
+            Id = id,
+            ObjectKey = objectKey,
+            Content = content,
+        };
+
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
 }

--- a/src/Granit.BlobStorage.Database/EntityTypeConfiguration/DatabaseBlobContentConfiguration.cs
+++ b/src/Granit.BlobStorage.Database/EntityTypeConfiguration/DatabaseBlobContentConfiguration.cs
@@ -2,7 +2,7 @@ using Granit.BlobStorage.Database.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace Granit.BlobStorage.Database.Configurations;
+namespace Granit.BlobStorage.Database.EntityTypeConfiguration;
 
 /// <summary>
 /// EF Core configuration for <see cref="DatabaseBlobContent"/>.

--- a/src/Granit.BlobStorage.Database/Extensions/BlobStorageDatabaseHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Database/Extensions/BlobStorageDatabaseHostApplicationBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Granit.Diagnostics;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -49,11 +50,11 @@ public static class BlobStorageDatabaseHostApplicationBuilderExtensions
 
         builder.Services.AddSingleton<IValidateOptions<DatabaseBlobOptions>, DatabaseBlobOptionsValidator>();
 
-        builder.Services.AddGranitDbContext<BlobStorageDatabaseDbContext>(configure);
+        builder.Services.AddGranitIsolatedDbContext<BlobStorageDatabaseDbContext>(configure);
 
-        builder.Services.AddScoped<IBlobStoreProvider, DatabaseBlobClient>();
-        builder.Services.AddScoped<IBlobKeyStrategy, DatabaseBlobKeyStrategy>();
-        builder.Services.AddScoped<IBlobStorage, DefaultBlobStorage>();
+        builder.Services.TryAddScoped<IBlobStoreProvider, DatabaseBlobClient>();
+        builder.Services.TryAddScoped<IBlobKeyStrategy, DatabaseBlobKeyStrategy>();
+        builder.Services.TryAddScoped<IBlobStorage, DefaultBlobStorage>();
 
         return builder;
     }

--- a/src/Granit.BlobStorage.Database/Extensions/BlobStorageDatabaseModelBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Database/Extensions/BlobStorageDatabaseModelBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using Granit.BlobStorage.Database.Configurations;
+using Granit.BlobStorage.Database.EntityTypeConfiguration;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.BlobStorage.Database.Extensions;

--- a/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
+++ b/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
@@ -2,11 +2,9 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Granit.BlobStorage.Database.Diagnostics;
 using Granit.BlobStorage.Database.Entities;
-using Granit.BlobStorage.Database.Internal;
 using Granit.BlobStorage.Database.Options;
 using Granit.BlobStorage.Internal;
 using Granit.Guids;
-using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -25,7 +23,6 @@ namespace Granit.BlobStorage.Database.Internal;
 internal sealed class DatabaseBlobClient(
     IDbContextFactory<BlobStorageDatabaseDbContext> contextFactory,
     IOptions<DatabaseBlobOptions> options,
-    IClock clock,
     IGuidGenerator guidGenerator) : IBlobStoreProvider
 {
     /// <inheritdoc/>
@@ -40,26 +37,40 @@ internal sealed class DatabaseBlobClient(
         activity?.SetTag(BlobStorageDatabaseActivitySource.TagObjectKey, objectKey);
         activity?.SetTag(BlobStorageDatabaseActivitySource.TagContentType, contentType);
 
-        using MemoryStream ms = new();
-        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
-        byte[] bytes = ms.ToArray();
+        long maxBytes = options.Value.MaxBlobSizeBytes;
 
-        if (bytes.Length > options.Value.MaxBlobSizeBytes)
+        // Pre-flight size check when the stream is seekable; cheaper than buffering an oversized payload.
+        if (content.CanSeek && content.Length > maxBytes)
         {
             throw new InvalidOperationException(
-                $"Blob size ({bytes.Length} bytes) exceeds the maximum allowed size ({options.Value.MaxBlobSizeBytes} bytes).");
+                $"Blob size ({content.Length} bytes) exceeds the maximum allowed size ({maxBytes} bytes).");
+        }
+
+        // EF Core maps the column as `byte[]`, which requires full materialization before SaveChanges;
+        // we still cap the read at MaxBlobSizeBytes + 1 to fail fast on oversize unseekable streams.
+        using MemoryStream ms = new();
+        byte[] buffer = new byte[81920];
+        long totalRead = 0;
+        int read;
+        while ((read = await content.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            totalRead += read;
+            if (totalRead > maxBytes)
+            {
+                throw new InvalidOperationException(
+                    $"Blob size exceeds the maximum allowed size ({maxBytes} bytes).");
+            }
+
+            ms.Write(buffer, 0, read);
         }
 
         await using BlobStorageDatabaseDbContext context =
             await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        DatabaseBlobContent entity = new()
-        {
-            Id = guidGenerator.Create(),
-            ObjectKey = objectKey,
-            Content = bytes,
-            CreatedAt = clock.Now,
-        };
+        var entity = DatabaseBlobContent.Create(
+            guidGenerator.Create(),
+            objectKey,
+            ms.ToArray());
 
         context.BlobContents.Add(entity);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
@@ -7,6 +7,8 @@ using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.Endpoints.Extensions;
 
@@ -37,7 +39,9 @@ public static class BlobStorageEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         Action<BlobStorageEndpointsOptions>? configure = null)
     {
-        BlobStorageEndpointsOptions options = new();
+        BlobStorageEndpointsOptions options = endpoints.ServiceProvider
+            .GetService<IOptions<BlobStorageEndpointsOptions>>()?.Value
+            ?? new BlobStorageEndpointsOptions();
         configure?.Invoke(options);
 
         RouteGroupBuilder group = endpoints

--- a/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointsHostApplicationBuilderExtensions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+using Granit.BlobStorage.Endpoints.Internal;
+using Granit.BlobStorage.Endpoints.Options;
+using Granit.Http.ApiDocumentation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Granit.BlobStorage.Endpoints.Extensions;
+
+/// <summary>
+/// Extension methods for registering blob storage administration endpoint services.
+/// </summary>
+// DI wiring only — no logic to unit test.
+[ExcludeFromCodeCoverage]
+public static class BlobStorageEndpointsHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds <c>Granit.BlobStorage.Endpoints</c> services: binds
+    /// <see cref="BlobStorageEndpointsOptions"/> from the
+    /// <c>"BlobStorageEndpoints"</c> configuration section and registers the
+    /// OpenAPI schema example provider.
+    /// </summary>
+    /// <param name="builder">The host application builder.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHostApplicationBuilder AddGranitBlobStorageEndpoints(
+        this IHostApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services
+            .AddOptions<BlobStorageEndpointsOptions>()
+            .BindConfiguration(BlobStorageEndpointsOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ISchemaExampleProvider, BlobStorageSchemaExampleProvider>());
+
+        return builder;
+    }
+}

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Granit.BlobStorage.EntityFrameworkCore.Extensions;
@@ -54,12 +55,12 @@ public static class BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensio
             configureSchemaPerTenant,
             configureTenantSchema);
 
-        builder.Services.AddScoped<EfBlobDescriptorStore>();
-        builder.Services.AddScoped<IBlobDescriptorStore>(sp => sp.GetRequiredService<EfBlobDescriptorStore>());
-        builder.Services.AddScoped<IBlobDescriptorReader>(sp => sp.GetRequiredService<EfBlobDescriptorStore>());
-        builder.Services.AddScoped<IBlobDescriptorWriter>(sp => sp.GetRequiredService<EfBlobDescriptorStore>());
+        builder.Services.TryAddScoped<EfBlobDescriptorStore>();
+        builder.Services.TryAddScoped<IBlobDescriptorStore>(sp => sp.GetRequiredService<EfBlobDescriptorStore>());
+        builder.Services.TryAddScoped<IBlobDescriptorReader>(sp => sp.GetRequiredService<EfBlobDescriptorStore>());
+        builder.Services.TryAddScoped<IBlobDescriptorWriter>(sp => sp.GetRequiredService<EfBlobDescriptorStore>());
 
-        builder.Services.AddScoped<IQueryableSource<BlobDescriptor>, EfBlobQueryableSource>();
+        builder.Services.TryAddScoped<IQueryableSource<BlobDescriptor>, EfBlobQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobQueryableSource.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobQueryableSource.cs
@@ -14,16 +14,30 @@ namespace Granit.BlobStorage.EntityFrameworkCore.Internal;
 internal sealed class EfBlobQueryableSource(
     IDbContextFactory<BlobStorageDbContext> contextFactory,
     ICurrentTenant currentTenant)
-    : IQueryableSource<BlobDescriptor>
+    : IQueryableSource<BlobDescriptor>, IAsyncDisposable, IDisposable
 {
-    private readonly BlobStorageDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private BlobStorageDbContext? _context;
 
     public IQueryable<BlobDescriptor> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<BlobDescriptor> query = _context.Blobs.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        BlobStorageDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.BlobStorage.FileSystem/Extensions/BlobStorageFileSystemHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.FileSystem/Extensions/BlobStorageFileSystemHostApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Granit.BlobStorage.Internal;
 using Granit.BlobStorage.Options;
 using Granit.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -45,9 +46,9 @@ public static class BlobStorageFileSystemHostApplicationBuilderExtensions
 
         builder.Services.AddSingleton<IValidateOptions<FileSystemBlobOptions>, FileSystemBlobOptionsValidator>();
 
-        builder.Services.AddSingleton<IBlobStoreProvider, FileSystemBlobClient>();
-        builder.Services.AddScoped<IBlobKeyStrategy, FileSystemBlobKeyStrategy>();
-        builder.Services.AddScoped<IBlobStorage, DefaultBlobStorage>();
+        builder.Services.TryAddSingleton<IBlobStoreProvider, FileSystemBlobClient>();
+        builder.Services.TryAddScoped<IBlobKeyStrategy, FileSystemBlobKeyStrategy>();
+        builder.Services.TryAddScoped<IBlobStorage, DefaultBlobStorage>();
 
         return builder;
     }

--- a/src/Granit.BlobStorage.FileSystem/Options/FileSystemBlobOptions.cs
+++ b/src/Granit.BlobStorage.FileSystem/Options/FileSystemBlobOptions.cs
@@ -1,5 +1,4 @@
 using Granit.BlobStorage.Options;
-using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.FileSystem.Options;
 
@@ -25,23 +24,4 @@ public sealed class FileSystemBlobOptions : BlobStorageOptions
     /// Examples: <c>./blobs</c> (dev), <c>/data/blobs</c> (production).
     /// </summary>
     public string BasePath { get; set; } = string.Empty;
-}
-
-/// <summary>
-/// Validates <see cref="FileSystemBlobOptions"/> at startup (fail-fast on misconfiguration).
-/// </summary>
-internal sealed class FileSystemBlobOptionsValidator : IValidateOptions<FileSystemBlobOptions>
-{
-    /// <inheritdoc/>
-    public ValidateOptionsResult Validate(string? name, FileSystemBlobOptions options)
-    {
-        if (string.IsNullOrWhiteSpace(options.BasePath))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.BasePath)} must be non-empty. " +
-                "Set it to the root directory for blob storage (e.g. ./blobs or /data/blobs).");
-        }
-
-        return ValidateOptionsResult.Success;
-    }
 }

--- a/src/Granit.BlobStorage.FileSystem/Options/FileSystemBlobOptionsValidator.cs
+++ b/src/Granit.BlobStorage.FileSystem/Options/FileSystemBlobOptionsValidator.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.BlobStorage.FileSystem.Options;
+
+/// <summary>
+/// Validates <see cref="FileSystemBlobOptions"/> at startup (fail-fast on misconfiguration).
+/// </summary>
+internal sealed class FileSystemBlobOptionsValidator : IValidateOptions<FileSystemBlobOptions>
+{
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, FileSystemBlobOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.BasePath))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.BasePath)} must be non-empty. " +
+                "Set it to the root directory for blob storage (e.g. ./blobs or /data/blobs).");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.BlobStorage.FileSystem/README.md
+++ b/src/Granit.BlobStorage.FileSystem/README.md
@@ -26,7 +26,7 @@ builder.AddGranitBlobStorageFileSystem();
 builder.AddGranitBlobStorageProxy();       // required for pre-signed URLs
 
 var app = builder.Build();
-app.MapGranitBlobProxy();
+app.MapGranitBlobStorageProxy();
 ```
 
 ## Configuration

--- a/src/Granit.BlobStorage.GoogleCloud/Extensions/BlobStorageGoogleCloudHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.GoogleCloud/Extensions/BlobStorageGoogleCloudHostApplicationBuilderExtensions.cs
@@ -6,7 +6,10 @@ using Granit.BlobStorage.GoogleCloud.Options;
 using Granit.BlobStorage.Internal;
 using Granit.BlobStorage.Options;
 using Granit.Diagnostics;
+using Granit.Diagnostics.Caching;
+using Granit.Timing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -45,12 +48,12 @@ public static class BlobStorageGoogleCloudHostApplicationBuilderExtensions
 
         // GoogleCloudBlobClient implements IBlobStoreProvider + IPresignedUrlProvider.
         // Registered as Singleton: StorageClient is thread-safe and intended for reuse.
-        builder.Services.AddSingleton<GoogleCloudBlobClient>();
-        builder.Services.AddSingleton<IBlobStoreProvider>(sp => sp.GetRequiredService<GoogleCloudBlobClient>());
-        builder.Services.AddSingleton<IPresignedUrlProvider>(sp => sp.GetRequiredService<GoogleCloudBlobClient>());
+        builder.Services.TryAddSingleton<GoogleCloudBlobClient>();
+        builder.Services.TryAddSingleton<IBlobStoreProvider>(sp => sp.GetRequiredService<GoogleCloudBlobClient>());
+        builder.Services.TryAddSingleton<IPresignedUrlProvider>(sp => sp.GetRequiredService<GoogleCloudBlobClient>());
 
-        builder.Services.AddScoped<IBlobKeyStrategy, GoogleCloudBlobKeyStrategy>();
-        builder.Services.AddScoped<IBlobStorage, DefaultBlobStorage>();
+        builder.Services.TryAddScoped<IBlobKeyStrategy, GoogleCloudBlobKeyStrategy>();
+        builder.Services.TryAddScoped<IBlobStorage, DefaultBlobStorage>();
 
         return builder;
     }
@@ -73,7 +76,10 @@ public static class BlobStorageGoogleCloudHostApplicationBuilderExtensions
 
         return builder.Add(new HealthCheckRegistration(
             name,
-            sp => sp.GetRequiredService<GoogleCloudStorageHealthCheck>(),
+            sp => new CachedHealthCheck(
+                sp.GetRequiredService<GoogleCloudStorageHealthCheck>(),
+                TimeSpan.FromSeconds(30),
+                sp.GetRequiredService<IClock>()),
             failureStatus,
             ["readiness", "startup"],
             timeout ?? TimeSpan.FromSeconds(10)));

--- a/src/Granit.BlobStorage.GoogleCloud/Granit.BlobStorage.GoogleCloud.csproj
+++ b/src/Granit.BlobStorage.GoogleCloud/Granit.BlobStorage.GoogleCloud.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.BlobStorage\Granit.BlobStorage.csproj" />
+    <ProjectReference Include="..\Granit.Diagnostics\Granit.Diagnostics.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.BlobStorage.GoogleCloud/Options/GoogleCloudStorageOptions.cs
+++ b/src/Granit.BlobStorage.GoogleCloud/Options/GoogleCloudStorageOptions.cs
@@ -1,5 +1,4 @@
 using Granit.BlobStorage.Options;
-using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.GoogleCloud.Options;
 
@@ -41,29 +40,4 @@ public sealed class GoogleCloudStorageOptions : BlobStorageOptions
     /// Multi-tenant isolation strategy. Defaults to <see cref="BlobTenantIsolation.Prefix"/>.
     /// </summary>
     public BlobTenantIsolation TenantIsolation { get; set; } = BlobTenantIsolation.Prefix;
-}
-
-/// <summary>
-/// Validates <see cref="GoogleCloudStorageOptions"/> at startup (fail-fast on missing configuration).
-/// </summary>
-internal sealed class GoogleCloudStorageOptionsValidator : IValidateOptions<GoogleCloudStorageOptions>
-{
-    /// <inheritdoc/>
-    public ValidateOptionsResult Validate(string? name, GoogleCloudStorageOptions options)
-    {
-        if (string.IsNullOrWhiteSpace(options.ProjectId))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.ProjectId)} must be non-empty. " +
-                "Set it to your GCP project ID (e.g. my-project-123).");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.DefaultBucket))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.DefaultBucket)} must be non-empty.");
-        }
-
-        return ValidateOptionsResult.Success;
-    }
 }

--- a/src/Granit.BlobStorage.GoogleCloud/Options/GoogleCloudStorageOptionsValidator.cs
+++ b/src/Granit.BlobStorage.GoogleCloud/Options/GoogleCloudStorageOptionsValidator.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.BlobStorage.GoogleCloud.Options;
+
+/// <summary>
+/// Validates <see cref="GoogleCloudStorageOptions"/> at startup (fail-fast on missing configuration).
+/// </summary>
+internal sealed class GoogleCloudStorageOptionsValidator : IValidateOptions<GoogleCloudStorageOptions>
+{
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, GoogleCloudStorageOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ProjectId))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.ProjectId)} must be non-empty. " +
+                "Set it to your GCP project ID (e.g. my-project-123).");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.DefaultBucket))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.DefaultBucket)} must be non-empty.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.BlobStorage.GoogleCloud/packages.lock.json
+++ b/src/Granit.BlobStorage.GoogleCloud/packages.lock.json
@@ -214,6 +214,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.diagnostics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class BlobStorageProxyEndpointRouteBuilderExtensions
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <returns>The endpoint route builder for chaining.</returns>
-    public static IEndpointRouteBuilder MapGranitBlobProxy(
+    public static IEndpointRouteBuilder MapGranitBlobStorageProxy(
         this IEndpointRouteBuilder endpoints)
     {
         ProxyBlobOptions options = endpoints.ServiceProvider

--- a/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyHostApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Granit.BlobStorage.Proxy.Internal;
 using Granit.BlobStorage.Proxy.Options;
 using Granit.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -47,9 +48,9 @@ public static class BlobStorageProxyHostApplicationBuilderExtensions
 
         builder.Services.AddSingleton<IValidateOptions<ProxyBlobOptions>, ProxyBlobOptionsValidator>();
 
-        builder.Services.AddSingleton<IBlobProxyTokenStore, DistributedBlobProxyTokenStore>();
-        builder.Services.AddScoped<IPresignedUrlProvider, ProxyPresignedUrlProvider>();
-        builder.Services.AddScoped<IBlobStorage, DefaultBlobStorage>();
+        builder.Services.TryAddSingleton<IBlobProxyTokenStore, DistributedBlobProxyTokenStore>();
+        builder.Services.TryAddScoped<IPresignedUrlProvider, ProxyPresignedUrlProvider>();
+        builder.Services.TryAddScoped<IBlobStorage, DefaultBlobStorage>();
 
         return builder;
     }

--- a/src/Granit.BlobStorage.Proxy/Internal/ProxyTokenEntry.cs
+++ b/src/Granit.BlobStorage.Proxy/Internal/ProxyTokenEntry.cs
@@ -13,15 +13,3 @@ internal sealed record ProxyTokenEntry(
     string? ContentType,
     long? MaxBytes,
     string? DownloadFileName);
-
-/// <summary>
-/// Discriminator preventing cross-use of upload and download tokens.
-/// </summary>
-internal enum ProxyTokenType
-{
-    /// <summary>Token authorizes a single upload (PUT).</summary>
-    Upload,
-
-    /// <summary>Token authorizes a single download (GET).</summary>
-    Download
-}

--- a/src/Granit.BlobStorage.Proxy/Internal/ProxyTokenType.cs
+++ b/src/Granit.BlobStorage.Proxy/Internal/ProxyTokenType.cs
@@ -1,0 +1,13 @@
+namespace Granit.BlobStorage.Proxy.Internal;
+
+/// <summary>
+/// Discriminator preventing cross-use of upload and download tokens.
+/// </summary>
+internal enum ProxyTokenType
+{
+    /// <summary>Token authorizes a single upload (PUT).</summary>
+    Upload,
+
+    /// <summary>Token authorizes a single download (GET).</summary>
+    Download
+}

--- a/src/Granit.BlobStorage.S3/Extensions/BlobStorageS3HostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.S3/Extensions/BlobStorageS3HostApplicationBuilderExtensions.cs
@@ -5,7 +5,10 @@ using Granit.BlobStorage.S3.HealthChecks;
 using Granit.BlobStorage.S3.Internal;
 using Granit.BlobStorage.S3.Options;
 using Granit.Diagnostics;
+using Granit.Diagnostics.Caching;
+using Granit.Timing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -44,12 +47,12 @@ public static class BlobStorageS3HostApplicationBuilderExtensions
 
         // S3BlobClient implements IBlobStoreProvider + IPresignedUrlProvider.
         // Registered as Singleton: AmazonS3Client is thread-safe and intended for reuse.
-        builder.Services.AddSingleton<S3BlobClient>();
-        builder.Services.AddSingleton<IBlobStoreProvider>(sp => sp.GetRequiredService<S3BlobClient>());
-        builder.Services.AddSingleton<IPresignedUrlProvider>(sp => sp.GetRequiredService<S3BlobClient>());
+        builder.Services.TryAddSingleton<S3BlobClient>();
+        builder.Services.TryAddSingleton<IBlobStoreProvider>(sp => sp.GetRequiredService<S3BlobClient>());
+        builder.Services.TryAddSingleton<IPresignedUrlProvider>(sp => sp.GetRequiredService<S3BlobClient>());
 
-        builder.Services.AddScoped<IBlobKeyStrategy, PrefixBlobKeyStrategy>();
-        builder.Services.AddScoped<IBlobStorage, DefaultBlobStorage>();
+        builder.Services.TryAddScoped<IBlobKeyStrategy, PrefixBlobKeyStrategy>();
+        builder.Services.TryAddScoped<IBlobStorage, DefaultBlobStorage>();
 
         return builder;
     }
@@ -72,7 +75,10 @@ public static class BlobStorageS3HostApplicationBuilderExtensions
 
         return builder.Add(new HealthCheckRegistration(
             name,
-            sp => sp.GetRequiredService<S3HealthCheck>(),
+            sp => new CachedHealthCheck(
+                sp.GetRequiredService<S3HealthCheck>(),
+                TimeSpan.FromSeconds(30),
+                sp.GetRequiredService<IClock>()),
             failureStatus,
             ["readiness", "startup"],
             timeout ?? TimeSpan.FromSeconds(10)));

--- a/src/Granit.BlobStorage.S3/Granit.BlobStorage.S3.csproj
+++ b/src/Granit.BlobStorage.S3/Granit.BlobStorage.S3.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.BlobStorage\Granit.BlobStorage.csproj" />
+    <ProjectReference Include="..\Granit.Diagnostics\Granit.Diagnostics.csproj" />
     <ProjectReference Include="..\Granit.Observability\Granit.Observability.csproj" />
   </ItemGroup>
 

--- a/src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs
+++ b/src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs
@@ -1,5 +1,4 @@
 using Granit.BlobStorage.Options;
-using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.S3.Options;
 
@@ -63,56 +62,4 @@ public sealed class S3BlobOptions : BlobStorageOptions
     /// Multi-tenant isolation strategy. Defaults to <see cref="BlobTenantIsolation.Prefix"/>.
     /// </summary>
     public BlobTenantIsolation TenantIsolation { get; set; } = BlobTenantIsolation.Prefix;
-}
-
-/// <summary>
-/// Validates <see cref="S3BlobOptions"/> at startup (fail-fast on missing credentials).
-/// </summary>
-internal sealed class S3BlobOptionsValidator : IValidateOptions<S3BlobOptions>
-{
-    /// <inheritdoc/>
-    public ValidateOptionsResult Validate(string? name, S3BlobOptions options)
-    {
-        if (string.IsNullOrWhiteSpace(options.ServiceUrl))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.ServiceUrl)} must be non-empty. " +
-                "Set it to your S3-compatible endpoint (e.g. https://s3.eu-west-1.amazonaws.com or http://localhost:9000).");
-        }
-
-        if (!Uri.TryCreate(options.ServiceUrl, UriKind.Absolute, out Uri? serviceUri))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.ServiceUrl)} must be a valid absolute URI.");
-        }
-
-        // Allow HTTP only for localhost (MinIO development). Enforce HTTPS for all other hosts.
-        bool isLocalhost = serviceUri.Host is "localhost" or "127.0.0.1" or "::1";
-        if (serviceUri.Scheme != Uri.UriSchemeHttps && !isLocalhost)
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.ServiceUrl)} must use HTTPS for non-localhost endpoints. " +
-                "HTTP is only allowed for local development (localhost/127.0.0.1).");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.AccessKey))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.AccessKey)} must be non-empty. Inject from Granit.Vault.");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.SecretKey))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.SecretKey)} must be non-empty. Inject from Granit.Vault.");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.DefaultBucket))
-        {
-            return ValidateOptionsResult.Fail(
-                $"{nameof(options.DefaultBucket)} must be non-empty.");
-        }
-
-        return ValidateOptionsResult.Success;
-    }
 }

--- a/src/Granit.BlobStorage.S3/Options/S3BlobOptionsValidator.cs
+++ b/src/Granit.BlobStorage.S3/Options/S3BlobOptionsValidator.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.BlobStorage.S3.Options;
+
+/// <summary>
+/// Validates <see cref="S3BlobOptions"/> at startup (fail-fast on missing credentials).
+/// </summary>
+internal sealed class S3BlobOptionsValidator : IValidateOptions<S3BlobOptions>
+{
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, S3BlobOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ServiceUrl))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.ServiceUrl)} must be non-empty. " +
+                "Set it to your S3-compatible endpoint (e.g. https://s3.eu-west-1.amazonaws.com or http://localhost:9000).");
+        }
+
+        if (!Uri.TryCreate(options.ServiceUrl, UriKind.Absolute, out Uri? serviceUri))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.ServiceUrl)} must be a valid absolute URI.");
+        }
+
+        // Allow HTTP only for localhost (MinIO development). Enforce HTTPS for all other hosts.
+        bool isLocalhost = serviceUri.Host is "localhost" or "127.0.0.1" or "::1";
+        if (serviceUri.Scheme != Uri.UriSchemeHttps && !isLocalhost)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.ServiceUrl)} must use HTTPS for non-localhost endpoints. " +
+                "HTTP is only allowed for local development (localhost/127.0.0.1).");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.AccessKey))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.AccessKey)} must be non-empty. Inject from Granit.Vault.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.SecretKey))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.SecretKey)} must be non-empty. Inject from Granit.Vault.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.DefaultBucket))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.DefaultBucket)} must be non-empty.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.BlobStorage.S3/packages.lock.json
+++ b/src/Granit.BlobStorage.S3/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.2",
-        "contentHash": "Zx9sQ8ksze0M34Wv+4uuHBOfYBHa3ACHL3pganelIjn9FWI8qtVrvdxYZmVzlvGm5sbeVLAEwdWkbH8BofEB0A==",
+        "resolved": "4.0.23.3",
+        "contentHash": "ASgWIoX8j6gG4plWXc22vGx0vVwDuqtjBwl3I2ICa2g6kqneSk47eYlGtRg61M/I8gvvtP8uDpIN73FsmlwqHg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -79,8 +79,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",
@@ -309,6 +309,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.diagnostics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {

--- a/src/Granit.BlobStorage/BlobStorageLocalizationResource.cs
+++ b/src/Granit.BlobStorage/BlobStorageLocalizationResource.cs
@@ -7,5 +7,5 @@ namespace Granit.BlobStorage;
 /// JSON files: <c>Localization/BlobStorage/{culture}.json</c>, embedded in this assembly.
 /// Auto-discovered by <see cref="LocalizationResourceNameAttribute"/>.
 /// </summary>
-[LocalizationResourceName("BlobStorage", DefaultCulture = "fr")]
+[LocalizationResourceName("BlobStorage", DefaultCulture = "en")]
 public sealed class BlobStorageLocalizationResource;

--- a/src/Granit.BlobStorage/Diagnostics/BlobStorageActivitySource.cs
+++ b/src/Granit.BlobStorage/Diagnostics/BlobStorageActivitySource.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Granit.BlobStorage.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for <c>Granit.BlobStorage</c> distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// </remarks>
+internal static class BlobStorageActivitySource
+{
+    /// <summary>The name of the <c>Granit.BlobStorage</c> <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.BlobStorage";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+}

--- a/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
+++ b/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
@@ -21,7 +21,7 @@ namespace Granit.BlobStorage.Domain;
 /// <see cref="BlobStatus.Deleted"/> means the S3 bytes are gone; the audit row remains for 3 years.
 /// </para>
 /// </remarks>
-public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
+public sealed class BlobDescriptor : CreationAuditedAggregateRoot, IMultiTenant
 {
     // Parameterless constructor required by EF Core materializer.
     private BlobDescriptor() { }
@@ -86,9 +86,6 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
 
     /// <summary>Current lifecycle status.</summary>
     public BlobStatus Status { get; private set; }
-
-    /// <summary>UTC instant when the upload ticket was issued.</summary>
-    public DateTimeOffset CreatedAt { get; private set; }
 
     /// <summary>UTC instant when the blob passed all validators; null until <see cref="BlobStatus.Valid"/>.</summary>
     public DateTimeOffset? ValidatedAt { get; private set; }

--- a/src/Granit.BlobStorage/GranitBlobStorageModule.cs
+++ b/src/Granit.BlobStorage/GranitBlobStorageModule.cs
@@ -4,6 +4,7 @@ using Granit.BlobStorage.Exports;
 using Granit.BlobStorage.Queries;
 using Granit.BlobStorage.Validators;
 using Granit.DataExchange.Extensions;
+using Granit.Diagnostics;
 using Granit.Guids;
 using Granit.Modularity;
 using Granit.QueryEngine.Extensions;
@@ -20,8 +21,6 @@ namespace Granit.BlobStorage;
 /// <see cref="IBlobKeyStrategy"/>, and <see cref="IBlobValidator"/> abstractions.
 /// Register a concrete provider (e.g. <c>Granit.BlobStorage.S3</c>) and a
 /// persistence adapter (e.g. <c>Granit.BlobStorage.EntityFrameworkCore</c>) alongside this module.
-/// Add the optional <c>Granit.BlobStorage.Analytics</c> + <c>Granit.BlobStorage.Dashboards</c>
-/// satellites to surface storage metrics and the operations dashboard.
 /// <para>
 /// Localization resources (<c>Localization/BlobStorage/{culture}.json</c>) are embedded in this
 /// assembly and auto-discovered by <c>GranitLocalizationModule</c> via
@@ -33,6 +32,8 @@ public sealed class GranitBlobStorageModule : GranitModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        GranitActivitySourceRegistry.Register(BlobStorageActivitySource.Name);
+
         context.Services.TryAddSingleton<BlobStorageMetrics>();
 
         context.Services.AddSingleton<IBlobValidator, ContentTypeAllowlistValidator>();

--- a/tests/Granit.BlobStorage.Database.Tests/Entities/DatabaseBlobContentTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Entities/DatabaseBlobContentTests.cs
@@ -8,50 +8,47 @@ namespace Granit.BlobStorage.Database.Tests.Entities;
 public sealed class DatabaseBlobContentTests
 {
     [Fact]
-    public void Id_DefaultsToEmpty() =>
-        new DatabaseBlobContent().Id.ShouldBe(Guid.Empty);
+    public void Create_AssignsIdAndObjectKeyAndContent()
+    {
+        var id = Guid.NewGuid();
+        byte[] content = [1, 2, 3];
+
+        var entity = DatabaseBlobContent.Create(id, "tenant/container/2026/01/blob-id", content);
+
+        entity.Id.ShouldBe(id);
+        entity.ObjectKey.ShouldBe("tenant/container/2026/01/blob-id");
+        entity.Content.ShouldBe(content);
+    }
 
     [Fact]
-    public void TenantId_DefaultsToNull() =>
-        new DatabaseBlobContent().TenantId.ShouldBeNull();
+    public void Create_DefaultsTenantIdToNull()
+    {
+        var entity = DatabaseBlobContent.Create(Guid.NewGuid(), "key", []);
+
+        entity.TenantId.ShouldBeNull();
+    }
 
     [Fact]
-    public void ObjectKey_DefaultsToEmpty() =>
-        new DatabaseBlobContent().ObjectKey.ShouldBe(string.Empty);
+    public void Create_DefaultsCreatedAtToMinValue()
+    {
+        var entity = DatabaseBlobContent.Create(Guid.NewGuid(), "key", []);
 
-    [Fact]
-    public void Content_DefaultsToEmptyArray() =>
-        new DatabaseBlobContent().Content.ShouldBeEmpty();
-
-    [Fact]
-    public void CreatedAt_DefaultsToMinValue() =>
-        new DatabaseBlobContent().CreatedAt.ShouldBe(default);
+        // CreatedAt is populated by the AuditedEntityInterceptor at SaveChanges time.
+        entity.CreatedAt.ShouldBe(default);
+    }
 
     [Fact]
     public void Implements_IMultiTenant() =>
         typeof(DatabaseBlobContent).GetInterfaces().ShouldContain(typeof(IMultiTenant));
 
     [Fact]
-    public void AllProperties_CanBeSet()
+    public void IMultiTenantTenantId_SetterIsAccessible()
     {
-        var id = Guid.NewGuid();
+        var entity = DatabaseBlobContent.Create(Guid.NewGuid(), "key", []);
         var tenantId = Guid.NewGuid();
-        DateTimeOffset now = DateTimeOffset.UtcNow;
-        byte[] content = [1, 2, 3];
 
-        DatabaseBlobContent entity = new()
-        {
-            Id = id,
-            TenantId = tenantId,
-            ObjectKey = "tenant/container/2026/01/blob-id",
-            Content = content,
-            CreatedAt = now,
-        };
+        ((IMultiTenant)entity).TenantId = tenantId;
 
-        entity.Id.ShouldBe(id);
         entity.TenantId.ShouldBe(tenantId);
-        entity.ObjectKey.ShouldBe("tenant/container/2026/01/blob-id");
-        entity.Content.ShouldBe(content);
-        entity.CreatedAt.ShouldBe(now);
     }
 }

--- a/tests/Granit.BlobStorage.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.GoogleCloud.Tests/packages.lock.json
@@ -364,6 +364,7 @@
         "dependencies": {
           "Google.Cloud.Storage.V1": "[4.*, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Diagnostics": "[0.1.0-dev, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
@@ -380,6 +381,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.diagnostics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {

--- a/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
@@ -72,8 +72,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",
@@ -473,6 +473,7 @@
         "dependencies": {
           "AWSSDK.S3": "[4.*, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Diagnostics": "[0.1.0-dev, )",
           "Granit.Observability": "[0.1.0-dev, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
@@ -491,6 +492,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.diagnostics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {
@@ -534,10 +541,10 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.2",
-        "contentHash": "Zx9sQ8ksze0M34Wv+4uuHBOfYBHa3ACHL3pganelIjn9FWI8qtVrvdxYZmVzlvGm5sbeVLAEwdWkbH8BofEB0A==",
+        "resolved": "4.0.23.3",
+        "contentHash": "ASgWIoX8j6gG4plWXc22vGx0vVwDuqtjBwl3I2ICa2g6kqneSk47eYlGtRg61M/I8gvvtP8uDpIN73FsmlwqHg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {


### PR DESCRIPTION
## Summary

Applies 17 of 18 findings from `/audit Granit.BlobStorage.*` across the 11 projects of the module family. Two findings were intentionally not changed (justified below).

## Findings mapping

### Architecture
- **A1** — `EfBlobQueryableSource` was Scoped and held a `BlobStorageDbContext` created in the field initializer with no disposal path → DbContext leak per request. Now lazy + `IAsyncDisposable`.
- **A2** — `Granit.BlobStorage.Database` now registers its content DbContext via `AddGranitIsolatedDbContext<T>` (matching the EFCore sibling) — preserves multi-tenant isolation.

### Convention
- **C1** — `BlobStorageLocalizationResource.DefaultCulture` `"fr"` → `"en"` (framework default).
- **C2** — Split one-type-per-file: `S3BlobOptionsValidator`, `AzureBlobOptionsValidator`, `GoogleCloudStorageOptionsValidator`, `FileSystemBlobOptionsValidator`, `ProxyTokenType` extracted.
- **C4 / C5** — New `AddGranitBlobStorageEndpoints` host extension binds `BlobStorageEndpointsOptions` from configuration with `ValidateOnStart`, and registers `BlobStorageSchemaExampleProvider` (previously dead code).
- **C6** — `DatabaseBlobContent` now inherits `CreationAuditedEntity` with a `Create` factory + private setters; folder renamed `Configurations/` → `EntityTypeConfiguration/`.
- **C7** — Public extension renamed `MapGranitBlobProxy` → `MapGranitBlobStorageProxy` (pre-1.0, clean break).
- **C8** — `BlobStorageAIOptionsValidator` added + `ValidateOnStart()`.
- **C9** — `BlobStorageActivitySource` (`"Granit.BlobStorage"`) registered via `GranitActivitySourceRegistry`.
- **C10** — `S3HealthCheck` + `GoogleCloudStorageHealthCheck` wrapped in `CachedHealthCheck` (30 s) for stampede protection.
- **C11** — `Add*` → `TryAdd*` for overridable single-impl services (providers, clients, key strategy, descriptor store). Multi-impl `IBlobValidator` left as plain `Add*`.

### Cleanup / Improvement
- **L2** — Removed stale Analytics/Dashboards mention from `GranitBlobStorageModule` XML doc (those modules never shipped in framework).
- **L3** — `DatabaseBlobClient.SaveAsync` now pre-checks seekable `Stream.Length` and enforces `MaxBlobSizeBytes` during `CopyToAsync` instead of full-buffering first.
- **I1** — `BlobDescriptor` → `CreationAuditedAggregateRoot` (kept custom `DeletedAt` for crypto-shred semantics).

### Not changed (intentional)
- **C3** — `BlobNotFoundException : NotFoundException` is mapped to 404 by `DefaultExceptionStatusCodeMapper`; current pattern is correct.
- **L1** — Verified `RequireGranitRateLimiting` does not emit 429 OpenAPI metadata; manual `.ProducesProblem(429)` declarations stay.
- **I2** — No async equivalent for `File.Exists` / `File.Delete` in .NET 10.

## Cross-cutting follow-up (separate PR worth opening)

`ISchemaExampleProvider` auto-discovery in `Granit.Http.ApiDocumentation` uses `GetExportedTypes()` — all `internal sealed` providers across the framework are silently skipped. Worth a framework-wide pass.

## Test plan

- [x] `dotnet test` on all BlobStorage test projects — 425 tests pass
- [x] `dotnet format` clean across all 10 modified `src/` projects + test project
- [ ] CI green
- [ ] Smoke test in showcase consumer once dev packages publish