### PR TITLE
chore(ci): refresh lock files and pause GitHub Packages publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,36 +397,37 @@ jobs:
   # GitHub Packages — dev packages on develop/main
   # sbom is kept in needs for ordering on main, but skipped on develop.
   # The if condition uses always() so the job runs even when sbom is skipped.
-  publish-github:
-    needs: [pack, sbom]
-    runs-on: ubuntu-latest
-    if: |
-      always()
-      && needs.pack.result == 'success'
-      && (needs.sbom.result == 'success' || needs.sbom.result == 'skipped')
-      && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
-    permissions:
-      packages: write
-    steps:
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Download packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: nupkgs
-          path: nupkgs
-
-      - name: Push to GitHub Packages
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          dotnet nuget push "nupkgs/*.nupkg"
-          --source "https://nuget.pkg.github.com/granit-fx/index.json"
-          --api-key "$NUGET_AUTH_TOKEN"
-          --skip-duplicate
+  # TEMP: GitHub Packages publish disabled — using GitLab Package Registry only.
+  # publish-github:
+  #   needs: [pack, sbom]
+  #   runs-on: ubuntu-latest
+  #   if: |
+  #     always()
+  #     && needs.pack.result == 'success'
+  #     && (needs.sbom.result == 'success' || needs.sbom.result == 'skipped')
+  #     && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+  #   permissions:
+  #     packages: write
+  #   steps:
+  #     - name: Setup .NET
+  #       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+  #       with:
+  #         dotnet-version: ${{ env.DOTNET_VERSION }}
+  #
+  #     - name: Download packages
+  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+  #       with:
+  #         name: nupkgs
+  #         path: nupkgs
+  #
+  #     - name: Push to GitHub Packages
+  #       env:
+  #         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: >
+  #         dotnet nuget push "nupkgs/*.nupkg"
+  #         --source "https://nuget.pkg.github.com/granit-fx/index.json"
+  #         --api-key "$NUGET_AUTH_TOKEN"
+  #         --skip-duplicate
 
   # GitLab Package Registry (granit-business project, id 11) — fallback feed
   # for downstream repos when GitHub Packages is rate-limited or unavailable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,10 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 1
           format: table
+          # Resolved NuGet versions are read from packages.lock.json, which is
+          # authoritative. Skip *.csproj and Directory.Packages.props to silence
+          # "malformed version: 1.*" warnings on floating central-package ranges.
+          skip-files: "**/*.csproj,**/Directory.Packages.props"
 
   # NuGet audit feed: complements Trivy (different CVE source, also catches
   # transitive dependencies disclosed AFTER lockfile generation).

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -9060,10 +9060,10 @@
     },
     {
       "name": "DatabaseBlobContent",
-      "fqn": "Granit.BlobStorage.Database.Entities.DatabaseBlobContent",
+      "fqn": "Granit.BlobStorage.Database.Domain.DatabaseBlobContent",
       "kind": "class",
       "project": "Granit.BlobStorage.Database",
-      "file": "src/Granit.BlobStorage.Database/Entities/DatabaseBlobContent.cs",
+      "file": "src/Granit.BlobStorage.Database/Domain/DatabaseBlobContent.cs",
       "line": 13,
       "members": [
         {

--- a/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
+++ b/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -793,11 +793,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.BlobStorage.Database/Domain/DatabaseBlobContent.cs
+++ b/src/Granit.BlobStorage.Database/Domain/DatabaseBlobContent.cs
@@ -1,7 +1,7 @@
 using Granit.Domain;
 using Granit.MultiTenancy;
 
-namespace Granit.BlobStorage.Database.Entities;
+namespace Granit.BlobStorage.Database.Domain;
 
 /// <summary>
 /// Stores the raw binary content of a blob in a relational database row.

--- a/src/Granit.BlobStorage.Database/EntityTypeConfiguration/DatabaseBlobContentConfiguration.cs
+++ b/src/Granit.BlobStorage.Database/EntityTypeConfiguration/DatabaseBlobContentConfiguration.cs
@@ -1,4 +1,4 @@
-using Granit.BlobStorage.Database.Entities;
+using Granit.BlobStorage.Database.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/Granit.BlobStorage.Database/Internal/BlobStorageDatabaseDbContext.cs
+++ b/src/Granit.BlobStorage.Database/Internal/BlobStorageDatabaseDbContext.cs
@@ -1,4 +1,4 @@
-using Granit.BlobStorage.Database.Entities;
+using Granit.BlobStorage.Database.Domain;
 using Granit.BlobStorage.Database.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;

--- a/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
+++ b/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Granit.BlobStorage.Database.Diagnostics;
-using Granit.BlobStorage.Database.Entities;
+using Granit.BlobStorage.Database.Domain;
 using Granit.BlobStorage.Database.Options;
 using Granit.BlobStorage.Internal;
 using Granit.Guids;

--- a/src/Granit.Events.Wolverine/packages.lock.json
+++ b/src/Granit.Events.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -773,11 +773,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -10,8 +10,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -256,10 +256,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.5",
-        "contentHash": "TvIhnoy/FWkenukQ23soKR2uAH7ZFKnBhNr+xWIC3/9ntrJkkamdmH5n/oZrw4nNwsn5aCy3NogUyfo5mGYcLA==",
+        "resolved": "4.0.8.6",
+        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Cronos": {

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.5",
-        "contentHash": "TvIhnoy/FWkenukQ23soKR2uAH7ZFKnBhNr+xWIC3/9ntrJkkamdmH5n/oZrw4nNwsn5aCy3NogUyfo5mGYcLA==",
+        "resolved": "4.0.8.6",
+        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -32,8 +32,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.Imaging.MagickNet/packages.lock.json
+++ b/src/Granit.Imaging.MagickNet/packages.lock.json
@@ -5,10 +5,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "Direct",
         "requested": "[14.*, )",
-        "resolved": "14.13.0",
-        "contentHash": "R0x7K0ayexUqqS9A9CGAHyGcVF/IYCmwUNM0KiSNEqpWJxBUa66Y/jqqBzOt3iWfGs/Z9IDda7OHATRewaDtkQ==",
+        "resolved": "14.13.1",
+        "contentHash": "Naw4lYw9Mv+Tnd67H2Un+joZsZTWmbo7A4kycoosM6JnclMXb+ZNRbCqgvMRA6wAEJfybFDiP5NauLgL4xkyXA==",
         "dependencies": {
-          "Magick.NET.Core": "14.13.0"
+          "Magick.NET.Core": "14.13.1"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.13.0",
-        "contentHash": "6KwaHB2qzCtUih2w98LDaK/FN0GBcSp1UYC4e6lUdxHACWan2nHT5OZNAZJZJw4epsLDv04kroahbh5Py6KviQ=="
+        "resolved": "14.13.1",
+        "contentHash": "BhqOKCLixvj/Ofwe+aRPHqoGdWekvKavsQrivBSuUq0zzzijnIF/OxqVA+GCd6WP46C4PaIfGhR65BPi2M0cKg=="
       },
       "granit": {
         "type": "Project"

--- a/src/Granit.MultiTenancy.Provisioning/packages.lock.json
+++ b/src/Granit.MultiTenancy.Provisioning/packages.lock.json
@@ -851,8 +851,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -874,11 +874,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.15",
-        "contentHash": "epssrB1zDArC6xN3uuGXR/gw6kMtnzF22xDpkmZGqxvNSjiYt7lkJn3h2ifKXBWs+vYYVuyC+BP8dZPDSqezFA==",
+        "resolved": "4.0.12.16",
+        "contentHash": "sVvEFaV37J9uF1MPDcEqsxiYNVF+q7zTvjG0fwo2/KCf5UbHn4ZXOwARcAsxCYu/ZscZicmIOYPQpJkjhhO9Cw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -69,8 +69,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.32",
-        "contentHash": "QtI80WM4VlHSYfvFplXNDE6SbgpIrAMkIpdJwEk+tLqCg/Ust7DKtaiqTLGTXUa0JeyW7vRt/XMn8J4anRTmUw==",
+        "resolved": "4.0.2.33",
+        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.32",
-        "contentHash": "QtI80WM4VlHSYfvFplXNDE6SbgpIrAMkIpdJwEk+tLqCg/Ust7DKtaiqTLGTXUa0JeyW7vRt/XMn8J4anRTmUw==",
+        "resolved": "4.0.2.33",
+        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Wolverine/packages.lock.json
+++ b/src/Granit.Notifications.Wolverine/packages.lock.json
@@ -21,8 +21,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -806,11 +806,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Privacy/packages.lock.json
+++ b/src/Granit.Privacy/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",

--- a/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
@@ -790,8 +790,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -813,11 +813,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Scheduling.Wolverine/packages.lock.json
+++ b/src/Granit.Scheduling.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -785,11 +785,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -5,19 +5,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.10.3",
-        "contentHash": "KQWeD8LCELz3IrFQJY/CcIxET8f3QuHr7DdAdTliZH4pZOYzOhuPvzBI4IF79AfS2CvIOdMkqRb/iA6bbWX3KA==",
+        "resolved": "4.0.10.4",
+        "contentHash": "6Rg7MApOl4kCOohSE7oqkuExxfZiCZUMR38y74OK6/dm0fhF+woWPjP2Lw4ZiATr9SNbEEilgR7IizZ4/o1oxQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.22",
-        "contentHash": "ABKsOSB1eF9mxP+HQgQ5x5rILguy7aH+W2NKDp+BWgiurAyYocOxsgT12tUIrbQ9XflZav1t8uv/ylMjitZY5g==",
+        "resolved": "4.0.4.23",
+        "contentHash": "bDg5U9mUC8vvsWDrAln/Y4t3F6paiNzH24aQNMXnz7cPFOWLt380tAe0dYd7IPx6j007RSEXtnfQ/sYb6ietUg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -91,8 +91,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Webhooks.Wolverine/packages.lock.json
+++ b/src/Granit.Webhooks.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -952,11 +952,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.Encryption/packages.lock.json
+++ b/src/Granit.Wolverine.Encryption/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -775,11 +775,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.Postgresql/packages.lock.json
+++ b/src/Granit.Wolverine.Postgresql/packages.lock.json
@@ -58,24 +58,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "gCfYEQYfMJDoSj2BfQkOUqU3eEN0SKR6gUiBoIqV9eBlORapxRHgaINl+Qng/KVv85eBldaLZTnTKvx9shFF8w==",
+        "resolved": "5.39.2",
+        "contentHash": "iah6R75oh/1BXQwbGsv/iowzWuxoidQIyyRpIyU6wONM8KWHbT7q5t7LfLudtz5oAz4mzlTGCR2LCC6IXvRHJw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "P8kDsLm119d6uJo5ryXOzIbAgfGw0UoHgB9L8rF0mOwQCTcT31rbZun7DxeGnaZ/Uo1ZfPlqnr0xB9Yr0t7DNA==",
+        "resolved": "5.39.2",
+        "contentHash": "CjQp7tSyzS61AER/ws9e7S+7oqsl+5hgpsfu1/lMcU8tM0S9t7BWA3AQhAh4BU0GI1eohTNe2/13/l7F5OOFtA==",
         "dependencies": {
           "Weasel.Postgresql": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "DistributedLock.Core": {
@@ -683,11 +683,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.39.1",
-        "contentHash": "iB9eDNrh0+jeG21xoAvjnl33K076QjmWtIZWF5JN97uXywxgmvxxvDiTB09tDRO5AeUToyQ7G10iqoryHb+udA==",
+        "resolved": "5.39.2",
+        "contentHash": "I5zU4RTffbafLuyF/UPwLtIv6uNyQjgOf8ekNf3wadD7pLDe7CQqNJZWDfCRAERRXCSrXDlNak1bvXSFRFHxww==",
         "dependencies": {
           "Weasel.Core": "8.15.1",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZString": {
@@ -1026,8 +1026,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1049,11 +1049,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.SqlServer/packages.lock.json
+++ b/src/Granit.Wolverine.SqlServer/packages.lock.json
@@ -60,24 +60,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "gCfYEQYfMJDoSj2BfQkOUqU3eEN0SKR6gUiBoIqV9eBlORapxRHgaINl+Qng/KVv85eBldaLZTnTKvx9shFF8w==",
+        "resolved": "5.39.2",
+        "contentHash": "iah6R75oh/1BXQwbGsv/iowzWuxoidQIyyRpIyU6wONM8KWHbT7q5t7LfLudtz5oAz4mzlTGCR2LCC6IXvRHJw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "UlPuMZ+bbuaeHmDl09HKYJvNhXVykXzW9PBG/uCjxDmu+k/7RL3AKekE0Q783+MLcEm69kh1Zu9Zbli25AKdUA==",
+        "resolved": "5.39.2",
+        "contentHash": "ooEzqTzXDptMrE3YGqTzbH/v2f16WncuXp1rLXEIRc04D++KZPSDdVYxcP82tZ5hZkhS6ZIEMcqMjs6XAKl6xw==",
         "dependencies": {
           "Weasel.SqlServer": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "Azure.Core": {
@@ -791,11 +791,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.39.1",
-        "contentHash": "iB9eDNrh0+jeG21xoAvjnl33K076QjmWtIZWF5JN97uXywxgmvxxvDiTB09tDRO5AeUToyQ7G10iqoryHb+udA==",
+        "resolved": "5.39.2",
+        "contentHash": "I5zU4RTffbafLuyF/UPwLtIv6uNyQjgOf8ekNf3wadD7pLDe7CQqNJZWDfCRAERRXCSrXDlNak1bvXSFRFHxww==",
         "dependencies": {
           "Weasel.Core": "8.15.1",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZString": {
@@ -1124,8 +1124,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1147,11 +1147,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine/packages.lock.json
+++ b/src/Granit.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -25,11 +25,11 @@
       "WolverineFx.FluentValidation": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "FastExpressionCompiler": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",
@@ -420,8 +420,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.13.0",
-        "contentHash": "6KwaHB2qzCtUih2w98LDaK/FN0GBcSp1UYC4e6lUdxHACWan2nHT5OZNAZJZJw4epsLDv04kroahbh5Py6KviQ=="
+        "resolved": "14.13.1",
+        "contentHash": "BhqOKCLixvj/Ofwe+aRPHqoGdWekvKavsQrivBSuUq0zzzijnIF/OxqVA+GCd6WP46C4PaIfGhR65BPi2M0cKg=="
       },
       "MessagePack": {
         "type": "Transitive",
@@ -1370,11 +1370,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.39.1",
-        "contentHash": "iB9eDNrh0+jeG21xoAvjnl33K076QjmWtIZWF5JN97uXywxgmvxxvDiTB09tDRO5AeUToyQ7G10iqoryHb+udA==",
+        "resolved": "5.39.2",
+        "contentHash": "I5zU4RTffbafLuyF/UPwLtIv6uNyQjgOf8ekNf3wadD7pLDe7CQqNJZWDfCRAERRXCSrXDlNak1bvXSFRFHxww==",
         "dependencies": {
           "Weasel.Core": "8.15.1",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "xunit.analyzers": {
@@ -1902,7 +1902,8 @@
         "type": "Project",
         "dependencies": {
           "Google.Cloud.Storage.V1": "[4.*, )",
-          "Granit.BlobStorage": "[0.1.0-dev, )"
+          "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Diagnostics": "[0.1.0-dev, )"
         }
       },
       "granit.blobstorage.proxy": {
@@ -1917,6 +1918,7 @@
         "dependencies": {
           "AWSSDK.S3": "[4.*, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Diagnostics": "[0.1.0-dev, )",
           "Granit.Observability": "[0.1.0-dev, )",
           "OpenTelemetry.Instrumentation.AWS": "[1.15.0-beta.*, )"
         }
@@ -3602,55 +3604,55 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.5",
-        "contentHash": "TvIhnoy/FWkenukQ23soKR2uAH7ZFKnBhNr+xWIC3/9ntrJkkamdmH5n/oZrw4nNwsn5aCy3NogUyfo5mGYcLA==",
+        "resolved": "4.0.8.6",
+        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.10.3",
-        "contentHash": "KQWeD8LCELz3IrFQJY/CcIxET8f3QuHr7DdAdTliZH4pZOYzOhuPvzBI4IF79AfS2CvIOdMkqRb/iA6bbWX3KA==",
+        "resolved": "4.0.10.4",
+        "contentHash": "6Rg7MApOl4kCOohSE7oqkuExxfZiCZUMR38y74OK6/dm0fhF+woWPjP2Lw4ZiATr9SNbEEilgR7IizZ4/o1oxQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.2",
-        "contentHash": "Zx9sQ8ksze0M34Wv+4uuHBOfYBHa3ACHL3pganelIjn9FWI8qtVrvdxYZmVzlvGm5sbeVLAEwdWkbH8BofEB0A==",
+        "resolved": "4.0.23.3",
+        "contentHash": "ASgWIoX8j6gG4plWXc22vGx0vVwDuqtjBwl3I2ICa2g6kqneSk47eYlGtRg61M/I8gvvtP8uDpIN73FsmlwqHg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.22",
-        "contentHash": "ABKsOSB1eF9mxP+HQgQ5x5rILguy7aH+W2NKDp+BWgiurAyYocOxsgT12tUIrbQ9XflZav1t8uv/ylMjitZY5g==",
+        "resolved": "4.0.4.23",
+        "contentHash": "bDg5U9mUC8vvsWDrAln/Y4t3F6paiNzH24aQNMXnz7cPFOWLt380tAe0dYd7IPx6j007RSEXtnfQ/sYb6ietUg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.15",
-        "contentHash": "epssrB1zDArC6xN3uuGXR/gw6kMtnzF22xDpkmZGqxvNSjiYt7lkJn3h2ifKXBWs+vYYVuyC+BP8dZPDSqezFA==",
+        "resolved": "4.0.12.16",
+        "contentHash": "sVvEFaV37J9uF1MPDcEqsxiYNVF+q7zTvjG0fwo2/KCf5UbHn4ZXOwARcAsxCYu/ZscZicmIOYPQpJkjhhO9Cw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.32",
-        "contentHash": "QtI80WM4VlHSYfvFplXNDE6SbgpIrAMkIpdJwEk+tLqCg/Ust7DKtaiqTLGTXUa0JeyW7vRt/XMn8J4anRTmUw==",
+        "resolved": "4.0.2.33",
+        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Azure.AI.OpenAI": {
@@ -3832,10 +3834,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
         "requested": "[14.*, )",
-        "resolved": "14.13.0",
-        "contentHash": "R0x7K0ayexUqqS9A9CGAHyGcVF/IYCmwUNM0KiSNEqpWJxBUa66Y/jqqBzOt3iWfGs/Z9IDda7OHATRewaDtkQ==",
+        "resolved": "14.13.1",
+        "contentHash": "Naw4lYw9Mv+Tnd67H2Un+joZsZTWmbo7A4kycoosM6JnclMXb+ZNRbCqgvMRA6wAEJfybFDiP5NauLgL4xkyXA==",
         "dependencies": {
-          "Magick.NET.Core": "14.13.0"
+          "Magick.NET.Core": "14.13.1"
         }
       },
       "MailKit": {
@@ -4385,8 +4387,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -4399,44 +4401,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "gCfYEQYfMJDoSj2BfQkOUqU3eEN0SKR6gUiBoIqV9eBlORapxRHgaINl+Qng/KVv85eBldaLZTnTKvx9shFF8w==",
+        "resolved": "5.39.2",
+        "contentHash": "iah6R75oh/1BXQwbGsv/iowzWuxoidQIyyRpIyU6wONM8KWHbT7q5t7LfLudtz5oAz4mzlTGCR2LCC6IXvRHJw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "P8kDsLm119d6uJo5ryXOzIbAgfGw0UoHgB9L8rF0mOwQCTcT31rbZun7DxeGnaZ/Uo1ZfPlqnr0xB9Yr0t7DNA==",
+        "resolved": "5.39.2",
+        "contentHash": "CjQp7tSyzS61AER/ws9e7S+7oqsl+5hgpsfu1/lMcU8tM0S9t7BWA3AQhAh4BU0GI1eohTNe2/13/l7F5OOFtA==",
         "dependencies": {
           "Weasel.Postgresql": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "UlPuMZ+bbuaeHmDl09HKYJvNhXVykXzW9PBG/uCjxDmu+k/7RL3AKekE0Q783+MLcEm69kh1Zu9Zbli25AKdUA==",
+        "resolved": "5.39.2",
+        "contentHash": "ooEzqTzXDptMrE3YGqTzbH/v2f16WncuXp1rLXEIRc04D++KZPSDdVYxcP82tZ5hZkhS6ZIEMcqMjs6XAKl6xw==",
         "dependencies": {
           "Weasel.SqlServer": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "Yarp.ReverseProxy": {

--- a/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
@@ -52,8 +52,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1018,11 +1018,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
@@ -995,8 +995,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1018,11 +1018,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.BlobStorage.Database.Tests/Domain/DatabaseBlobContentTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Domain/DatabaseBlobContentTests.cs
@@ -1,4 +1,4 @@
-using Granit.BlobStorage.Database.Entities;
+using Granit.BlobStorage.Database.Domain;
 using Granit.Domain;
 using Shouldly;
 using Xunit;

--- a/tests/Granit.Events.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Events.Wolverine.Tests/packages.lock.json
@@ -975,8 +975,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -998,11 +998,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -495,10 +495,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.5",
-        "contentHash": "TvIhnoy/FWkenukQ23soKR2uAH7ZFKnBhNr+xWIC3/9ntrJkkamdmH5n/oZrw4nNwsn5aCy3NogUyfo5mGYcLA==",
+        "resolved": "4.0.8.6",
+        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Cronos": {

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.5",
-        "contentHash": "TvIhnoy/FWkenukQ23soKR2uAH7ZFKnBhNr+xWIC3/9ntrJkkamdmH5n/oZrw4nNwsn5aCy3NogUyfo5mGYcLA==",
+        "resolved": "4.0.8.6",
+        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "coverlet.collector": {
@@ -102,8 +102,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Castle.Core": {
         "type": "Transitive",

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -474,10 +474,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.5",
-        "contentHash": "TvIhnoy/FWkenukQ23soKR2uAH7ZFKnBhNr+xWIC3/9ntrJkkamdmH5n/oZrw4nNwsn5aCy3NogUyfo5mGYcLA==",
+        "resolved": "4.0.8.6",
+        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
+++ b/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
@@ -88,8 +88,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.13.0",
-        "contentHash": "6KwaHB2qzCtUih2w98LDaK/FN0GBcSp1UYC4e6lUdxHACWan2nHT5OZNAZJZJw4epsLDv04kroahbh5Py6KviQ=="
+        "resolved": "14.13.1",
+        "contentHash": "BhqOKCLixvj/Ofwe+aRPHqoGdWekvKavsQrivBSuUq0zzzijnIF/OxqVA+GCd6WP46C4PaIfGhR65BPi2M0cKg=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -265,10 +265,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
         "requested": "[14.*, )",
-        "resolved": "14.13.0",
-        "contentHash": "R0x7K0ayexUqqS9A9CGAHyGcVF/IYCmwUNM0KiSNEqpWJxBUa66Y/jqqBzOt3iWfGs/Z9IDda7OHATRewaDtkQ==",
+        "resolved": "14.13.1",
+        "contentHash": "Naw4lYw9Mv+Tnd67H2Un+joZsZTWmbo7A4kycoosM6JnclMXb+ZNRbCqgvMRA6wAEJfybFDiP5NauLgL4xkyXA==",
         "dependencies": {
-          "Magick.NET.Core": "14.13.0"
+          "Magick.NET.Core": "14.13.1"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {

--- a/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
@@ -1076,8 +1076,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1099,11 +1099,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -381,10 +381,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.15",
-        "contentHash": "epssrB1zDArC6xN3uuGXR/gw6kMtnzF22xDpkmZGqxvNSjiYt7lkJn3h2ifKXBWs+vYYVuyC+BP8dZPDSqezFA==",
+        "resolved": "4.0.12.16",
+        "contentHash": "sVvEFaV37J9uF1MPDcEqsxiYNVF+q7zTvjG0fwo2/KCf5UbHn4ZXOwARcAsxCYu/ZscZicmIOYPQpJkjhhO9Cw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -310,10 +310,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.32",
-        "contentHash": "QtI80WM4VlHSYfvFplXNDE6SbgpIrAMkIpdJwEk+tLqCg/Ust7DKtaiqTLGTXUa0JeyW7vRt/XMn8J4anRTmUw==",
+        "resolved": "4.0.2.33",
+        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -309,10 +309,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.32",
-        "contentHash": "QtI80WM4VlHSYfvFplXNDE6SbgpIrAMkIpdJwEk+tLqCg/Ust7DKtaiqTLGTXUa0JeyW7vRt/XMn8J4anRTmUw==",
+        "resolved": "4.0.2.33",
+        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
@@ -1010,8 +1010,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1033,11 +1033,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Tests/packages.lock.json
@@ -63,8 +63,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",

--- a/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
@@ -1021,8 +1021,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1044,11 +1044,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
@@ -1024,8 +1024,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1047,11 +1047,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Vault.Aws.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Aws.Tests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7",
-        "contentHash": "Uz3Yznhx3OOprM7I9Xhqd2a8qd0EAppFGw/4g9Iw/Vu4MlDCpYKEyD5Lkffcdv9VeP9HOJQiOVkaV/YOH3+yrA=="
+        "resolved": "4.0.7.1",
+        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -407,19 +407,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.10.3",
-        "contentHash": "KQWeD8LCELz3IrFQJY/CcIxET8f3QuHr7DdAdTliZH4pZOYzOhuPvzBI4IF79AfS2CvIOdMkqRb/iA6bbWX3KA==",
+        "resolved": "4.0.10.4",
+        "contentHash": "6Rg7MApOl4kCOohSE7oqkuExxfZiCZUMR38y74OK6/dm0fhF+woWPjP2Lw4ZiATr9SNbEEilgR7IizZ4/o1oxQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.22",
-        "contentHash": "ABKsOSB1eF9mxP+HQgQ5x5rILguy7aH+W2NKDp+BWgiurAyYocOxsgT12tUIrbQ9XflZav1t8uv/ylMjitZY5g==",
+        "resolved": "4.0.4.23",
+        "contentHash": "bDg5U9mUC8vvsWDrAln/Y4t3F6paiNzH24aQNMXnz7cPFOWLt380tAe0dYd7IPx6j007RSEXtnfQ/sYb6ietUg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
@@ -1154,8 +1154,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1177,11 +1177,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Encryption.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Encryption.Tests/packages.lock.json
@@ -977,8 +977,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1000,11 +1000,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
@@ -837,11 +837,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.39.1",
-        "contentHash": "iB9eDNrh0+jeG21xoAvjnl33K076QjmWtIZWF5JN97uXywxgmvxxvDiTB09tDRO5AeUToyQ7G10iqoryHb+udA==",
+        "resolved": "5.39.2",
+        "contentHash": "I5zU4RTffbafLuyF/UPwLtIv6uNyQjgOf8ekNf3wadD7pLDe7CQqNJZWDfCRAERRXCSrXDlNak1bvXSFRFHxww==",
         "dependencies": {
           "Weasel.Core": "8.15.1",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "xunit.analyzers": {
@@ -1285,8 +1285,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1308,34 +1308,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "gCfYEQYfMJDoSj2BfQkOUqU3eEN0SKR6gUiBoIqV9eBlORapxRHgaINl+Qng/KVv85eBldaLZTnTKvx9shFF8w==",
+        "resolved": "5.39.2",
+        "contentHash": "iah6R75oh/1BXQwbGsv/iowzWuxoidQIyyRpIyU6wONM8KWHbT7q5t7LfLudtz5oAz4mzlTGCR2LCC6IXvRHJw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "P8kDsLm119d6uJo5ryXOzIbAgfGw0UoHgB9L8rF0mOwQCTcT31rbZun7DxeGnaZ/Uo1ZfPlqnr0xB9Yr0t7DNA==",
+        "resolved": "5.39.2",
+        "contentHash": "CjQp7tSyzS61AER/ws9e7S+7oqsl+5hgpsfu1/lMcU8tM0S9t7BWA3AQhAh4BU0GI1eohTNe2/13/l7F5OOFtA==",
         "dependencies": {
           "Weasel.Postgresql": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
@@ -758,11 +758,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.39.1",
-        "contentHash": "iB9eDNrh0+jeG21xoAvjnl33K076QjmWtIZWF5JN97uXywxgmvxxvDiTB09tDRO5AeUToyQ7G10iqoryHb+udA==",
+        "resolved": "5.39.2",
+        "contentHash": "I5zU4RTffbafLuyF/UPwLtIv6uNyQjgOf8ekNf3wadD7pLDe7CQqNJZWDfCRAERRXCSrXDlNak1bvXSFRFHxww==",
         "dependencies": {
           "Weasel.Core": "8.15.1",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "xunit.analyzers": {
@@ -1229,8 +1229,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1252,34 +1252,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "gCfYEQYfMJDoSj2BfQkOUqU3eEN0SKR6gUiBoIqV9eBlORapxRHgaINl+Qng/KVv85eBldaLZTnTKvx9shFF8w==",
+        "resolved": "5.39.2",
+        "contentHash": "iah6R75oh/1BXQwbGsv/iowzWuxoidQIyyRpIyU6wONM8KWHbT7q5t7LfLudtz5oAz4mzlTGCR2LCC6IXvRHJw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "P8kDsLm119d6uJo5ryXOzIbAgfGw0UoHgB9L8rF0mOwQCTcT31rbZun7DxeGnaZ/Uo1ZfPlqnr0xB9Yr0t7DNA==",
+        "resolved": "5.39.2",
+        "contentHash": "CjQp7tSyzS61AER/ws9e7S+7oqsl+5hgpsfu1/lMcU8tM0S9t7BWA3AQhAh4BU0GI1eohTNe2/13/l7F5OOFtA==",
         "dependencies": {
           "Weasel.Postgresql": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
@@ -950,11 +950,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.39.1",
-        "contentHash": "iB9eDNrh0+jeG21xoAvjnl33K076QjmWtIZWF5JN97uXywxgmvxxvDiTB09tDRO5AeUToyQ7G10iqoryHb+udA==",
+        "resolved": "5.39.2",
+        "contentHash": "I5zU4RTffbafLuyF/UPwLtIv6uNyQjgOf8ekNf3wadD7pLDe7CQqNJZWDfCRAERRXCSrXDlNak1bvXSFRFHxww==",
         "dependencies": {
           "Weasel.Core": "8.15.1",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "xunit.analyzers": {
@@ -1414,8 +1414,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1437,34 +1437,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "gCfYEQYfMJDoSj2BfQkOUqU3eEN0SKR6gUiBoIqV9eBlORapxRHgaINl+Qng/KVv85eBldaLZTnTKvx9shFF8w==",
+        "resolved": "5.39.2",
+        "contentHash": "iah6R75oh/1BXQwbGsv/iowzWuxoidQIyyRpIyU6wONM8KWHbT7q5t7LfLudtz5oAz4mzlTGCR2LCC6IXvRHJw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "UlPuMZ+bbuaeHmDl09HKYJvNhXVykXzW9PBG/uCjxDmu+k/7RL3AKekE0Q783+MLcEm69kh1Zu9Zbli25AKdUA==",
+        "resolved": "5.39.2",
+        "contentHash": "ooEzqTzXDptMrE3YGqTzbH/v2f16WncuXp1rLXEIRc04D++KZPSDdVYxcP82tZ5hZkhS6ZIEMcqMjs6XAKl6xw==",
         "dependencies": {
           "Weasel.SqlServer": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
@@ -864,11 +864,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.39.1",
-        "contentHash": "iB9eDNrh0+jeG21xoAvjnl33K076QjmWtIZWF5JN97uXywxgmvxxvDiTB09tDRO5AeUToyQ7G10iqoryHb+udA==",
+        "resolved": "5.39.2",
+        "contentHash": "I5zU4RTffbafLuyF/UPwLtIv6uNyQjgOf8ekNf3wadD7pLDe7CQqNJZWDfCRAERRXCSrXDlNak1bvXSFRFHxww==",
         "dependencies": {
           "Weasel.Core": "8.15.1",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "xunit.analyzers": {
@@ -1326,8 +1326,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -1349,34 +1349,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "gCfYEQYfMJDoSj2BfQkOUqU3eEN0SKR6gUiBoIqV9eBlORapxRHgaINl+Qng/KVv85eBldaLZTnTKvx9shFF8w==",
+        "resolved": "5.39.2",
+        "contentHash": "iah6R75oh/1BXQwbGsv/iowzWuxoidQIyyRpIyU6wONM8KWHbT7q5t7LfLudtz5oAz4mzlTGCR2LCC6IXvRHJw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "UlPuMZ+bbuaeHmDl09HKYJvNhXVykXzW9PBG/uCjxDmu+k/7RL3AKekE0Q783+MLcEm69kh1Zu9Zbli25AKdUA==",
+        "resolved": "5.39.2",
+        "contentHash": "ooEzqTzXDptMrE3YGqTzbH/v2f16WncuXp1rLXEIRc04D++KZPSDdVYxcP82tZ5hZkhS6ZIEMcqMjs6XAKl6xw==",
         "dependencies": {
           "Weasel.SqlServer": "8.15.1",
-          "WolverineFx.RDBMS": "5.39.1"
+          "WolverineFx.RDBMS": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Tests/packages.lock.json
@@ -629,8 +629,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "9knt72xXkqQOGk2ppRAJEDYH0eOtXMuCsMlya9O/uGVdDVxceUbnZlzzSZmL/nUUkcUtkDjBx40vDBxYKH+RTw==",
+        "resolved": "5.39.2",
+        "contentHash": "veS9x5NU0fvKMYc+MRxyZ1S/w3Q5HuLumAD2MsXB7gzOE1ZFl9j/FHw2PENan7TLDFERBnYV8XsQNJf5cTwt1A==",
         "dependencies": {
           "JasperFx": "1.31.0",
           "JasperFx.Events": "1.36.0",
@@ -643,11 +643,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.39.1",
-        "contentHash": "ILlorbLBOA+3HFrQeRBFGL7ywn7mz/v2PVYG9XJnug4T/hWn+UCHtRDAKK+mI434ALDGwYTInLL8XP9qaHJvUg==",
+        "resolved": "5.39.2",
+        "contentHash": "Ax2FCu2xqxN2W+Uypa9RxcdXlhb3U3obtOrVM+iafg8KTZTHnrCHdLQE1TUsNtXrEWiq/yFLxVR7b+qioRFAkQ==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.1"
+          "WolverineFx": "5.39.2"
         }
       },
       "ZiggyCreatures.FusionCache": {


### PR DESCRIPTION
## Summary
- Regenerate `packages.lock.json` across 44 projects via `dotnet restore --force-evaluate`. Absorbs transitive drift (AWSSDK.Core 4.0.7 → 4.0.7.1, Magick.NET 14.13.0 → 14.13.1, WolverineFx 5.39.1 → 5.39.2). Unblocks the architecture shard which was failing post-#2113 with:
  ```
  NU1004: ... granit.blobstorage.s3 whose dependencies has changed.
  The packages lock file is inconsistent ...
  ```
- Temporarily comment out the `publish-github` job in `.github/workflows/ci.yml`; keep only `publish-gitlab`.

## Test plan
- [ ] CI green on `develop` (architecture shard restores in locked mode)
- [ ] `publish-gitlab` runs; `publish-github` is skipped