### PR TITLE
chore(sonar): batch quick-win cleanups across modules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,8 @@ concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analyze:

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -11045,7 +11045,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs",
-      "line": 184,
+      "line": 177,
       "members": [
         {
           "name": "new",
@@ -11073,7 +11073,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs",
-      "line": 171,
+      "line": 164,
       "members": [
         {
           "name": "GetEnvironmentVariable",

--- a/src/Granit.Analyzers/EvaluateAsyncStringInterpolationAnalyzer.cs
+++ b/src/Granit.Analyzers/EvaluateAsyncStringInterpolationAnalyzer.cs
@@ -255,14 +255,6 @@ public sealed class EvaluateAsyncStringInterpolationAnalyzer : DiagnosticAnalyze
             return true;
         }
 
-        foreach (INamedTypeSymbol iface in type.AllInterfaces)
-        {
-            if (SymbolEqualityComparer.Default.Equals(iface, interfaceType))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return type.AllInterfaces.Any(iface => SymbolEqualityComparer.Default.Equals(iface, interfaceType));
     }
 }

--- a/src/Granit.Authentication/Claims/RoleClaimNormalizationTransformation.cs
+++ b/src/Granit.Authentication/Claims/RoleClaimNormalizationTransformation.cs
@@ -55,23 +55,14 @@ public sealed class RoleClaimNormalizationTransformation(
         // Materialize source claims before mutating: ClaimsIdentity.FindAll returns a
         // live enumerator over the underlying claims collection — calling AddClaim
         // mid-iteration throws InvalidOperationException.
-        List<Claim> sourceClaims = [];
-        foreach (string sourceType in _options.SourceClaimTypes)
-        {
-            if (string.Equals(sourceType, ClaimTypes.Role, StringComparison.Ordinal))
-            {
-                continue;
-            }
+        List<Claim> sourceClaims = [..
+            _options.SourceClaimTypes
+                .Where(t => !string.Equals(t, ClaimTypes.Role, StringComparison.Ordinal))
+                .SelectMany(identity.FindAll)];
 
-            sourceClaims.AddRange(identity.FindAll(sourceType));
-        }
-
-        foreach (Claim claim in sourceClaims)
+        foreach (Claim claim in sourceClaims.Where(c => existing.Add(c.Value)))
         {
-            if (existing.Add(claim.Value))
-            {
-                identity.AddClaim(new Claim(ClaimTypes.Role, claim.Value));
-            }
+            identity.AddClaim(new Claim(ClaimTypes.Role, claim.Value));
         }
 
         return Task.FromResult(principal);

--- a/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
+++ b/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
@@ -61,7 +61,7 @@ internal sealed class DatabaseBlobClient(
                     $"Blob size exceeds the maximum allowed size ({maxBytes} bytes).");
             }
 
-            ms.Write(buffer, 0, read);
+            await ms.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
         }
 
         await using BlobStorageDatabaseDbContext context =

--- a/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerPdfViewerCapability.cs
+++ b/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerPdfViewerCapability.cs
@@ -35,8 +35,6 @@ internal sealed partial class PuppeteerPdfViewerCapability(
     ICurrentTenant? currentTenant = null,
     IPermissionChecker? permissionChecker = null) : IPdfViewerCapability
 {
-    private const string Engine = "chromium-puppeteer";
-
     /// <inheritdoc/>
     public async Task<IPdfDocumentPage> OpenPdfAsync(IBrowserPage page, Stream pdf, CancellationToken cancellationToken = default)
     {

--- a/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerRequestRouter.cs
+++ b/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerRequestRouter.cs
@@ -51,7 +51,7 @@ internal sealed partial class PuppeteerRequestRouter : IAsyncDisposable
         _router = router;
         _logger = logger;
 
-        _handler = (_, e) => _ = HandleRequestAsync(e);
+        _handler = (sender, e) => _ = HandleRequestAsync(e);
     }
 
     /// <summary>Exposes the underlying router so the page can register user handlers.</summary>

--- a/src/Granit.Browsing/Pages/RequestRouter.cs
+++ b/src/Granit.Browsing/Pages/RequestRouter.cs
@@ -208,18 +208,8 @@ internal sealed class RequestRouter : IRequestRouter
         return RouteDecision.Continue;
     }
 
-    private bool IsSchemeAllowed(string scheme)
-    {
-        foreach (string allowed in _sandbox.AllowedSchemes)
-        {
-            if (string.Equals(allowed, scheme, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    private bool IsSchemeAllowed(string scheme) =>
+        _sandbox.AllowedSchemes.Any(allowed => string.Equals(allowed, scheme, StringComparison.OrdinalIgnoreCase));
 
     private static bool MatchesAny(IReadOnlyList<string> patterns, Uri url)
     {

--- a/src/Granit.Browsing/Pool/HeadlessBrowserDrainCoordinator.cs
+++ b/src/Granit.Browsing/Pool/HeadlessBrowserDrainCoordinator.cs
@@ -45,10 +45,11 @@ internal sealed class HeadlessBrowserDrainCoordinator
         {
             await pool.DrainAsync(cancellationToken).WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
         }
-        catch (TimeoutException)
+        catch (TimeoutException ex)
         {
             _metrics.RecordPoolDrainTimeout(browser.EngineName);
             _logger.LogWarning(
+                ex,
                 "Headless browser pool drain timed out after {Timeout}; forcing disposal of {Engine}.",
                 timeout,
                 browser.EngineName);

--- a/src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs
+++ b/src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs
@@ -110,14 +110,7 @@ public static class PrivilegedFlagGuard
             foreach (string arg in extraArgs)
             {
                 string token = ExtractToken(arg);
-                foreach (string privileged in RequiresContainerOptIn)
-                {
-                    if (TokenMatches(token, privileged))
-                    {
-                        offendingArg = privileged;
-                        break;
-                    }
-                }
+                offendingArg = RequiresContainerOptIn.FirstOrDefault(privileged => TokenMatches(token, privileged));
                 if (offendingArg is not null)
                 {
                     break;
@@ -230,8 +223,14 @@ public sealed class DefaultEnvironmentProbe : IEnvironmentProbe
                 }
             }
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException)
+        {
+            // /proc/1/cgroup unreadable — treat as no container signal and fall through.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // /proc/1/cgroup denied — treat as no container signal and fall through.
+        }
 
         // 5. cgroup v2 / hardened-namespace heuristic — when PID 1 is neither "init" nor
         // "systemd" (typical bare-metal hosts), this process was started by a container
@@ -255,8 +254,14 @@ public sealed class DefaultEnvironmentProbe : IEnvironmentProbe
                 }
             }
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException)
+        {
+            // /proc/1/sched unreadable — treat as no container signal and fall through.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // /proc/1/sched denied — treat as no container signal and fall through.
+        }
 
         return false;
     }

--- a/src/Granit.Entities.Abstractions/Details/DetailSectionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Details/DetailSectionBuilder.cs
@@ -11,8 +11,9 @@ public sealed class DetailSectionBuilder<TEntity>
 {
     private readonly string _key;
 
+    private readonly int _order;
+
     private string? _labelKey;
-    private int _order;
     private string? _inheritsFromFormVariant;
     private List<string>? _fields;
 

--- a/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
@@ -15,13 +15,13 @@ public sealed class FieldBuilder<TEntity, TProperty>
 {
     private readonly string _propertyName;
     private readonly Type _clrType;
+    private readonly int _order;
 
     private string _component;
     private Dictionary<string, object?>? _config;
     private string? _labelKey;
     private string? _helpKey;
     private string? _requiresPermission;
-    private int _order;
     private bool _readOnly;
     private VisibilityCondition? _visibleIf;
 

--- a/src/Granit.Entities.Abstractions/Forms/SectionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/SectionBuilder.cs
@@ -10,9 +10,9 @@ public sealed class SectionBuilder<TEntity>
 {
     private readonly string _key;
     private readonly List<Func<FieldDescriptor>> _fieldFactories = [];
+    private readonly int _order;
 
     private string? _labelKey;
-    private int _order;
     private bool _collapsedByDefault;
     private int _nextFieldOrder;
 

--- a/src/Granit.Http.Bulkhead/Diagnostics/BulkheadMetrics.cs
+++ b/src/Granit.Http.Bulkhead/Diagnostics/BulkheadMetrics.cs
@@ -12,6 +12,10 @@ public sealed class BulkheadMetrics
     /// <summary>Name of the OpenTelemetry meter emitted by this module.</summary>
     public const string MeterName = "Granit.Http.Bulkhead";
 
+    private const string PolicyTag = "policy";
+    private const string TenantIdTag = "tenant_id";
+    private const string GlobalTenantId = "global";
+
     private readonly UpDownCounter<long> _activeCounter;
     private readonly Counter<long> _rejectedCounter;
     private readonly Counter<long> _evictedCounter;
@@ -47,24 +51,24 @@ public sealed class BulkheadMetrics
     public void RecordAcquired(string policyName, string? tenantId) =>
         _activeCounter.Add(1, new TagList
         {
-            { "policy", policyName },
-            { "tenant_id", tenantId ?? "global" },
+            { PolicyTag, policyName },
+            { TenantIdTag, tenantId ?? GlobalTenantId },
         });
 
     /// <summary>Records that a permit was released for <paramref name="policyName"/> and <paramref name="tenantId"/>.</summary>
     public void RecordReleased(string policyName, string? tenantId) =>
         _activeCounter.Add(-1, new TagList
         {
-            { "policy", policyName },
-            { "tenant_id", tenantId ?? "global" },
+            { PolicyTag, policyName },
+            { TenantIdTag, tenantId ?? GlobalTenantId },
         });
 
     /// <summary>Records that an acquire attempt was rejected for <paramref name="policyName"/> and <paramref name="tenantId"/>.</summary>
     public void RecordRejected(string policyName, string? tenantId) =>
         _rejectedCounter.Add(1, new TagList
         {
-            { "policy", policyName },
-            { "tenant_id", tenantId ?? "global" },
+            { PolicyTag, policyName },
+            { TenantIdTag, tenantId ?? GlobalTenantId },
         });
 
     /// <summary>
@@ -85,19 +89,19 @@ public sealed class BulkheadMetrics
     public void RecordBypassed(string policyName, string reason) =>
         _bypassedCounter.Add(1, new TagList
         {
-            { "policy", policyName },
+            { PolicyTag, policyName },
             { "reason", reason },
         });
 
     /// <summary>Records a reference to a policy name not present in configuration.</summary>
     public void RecordUnknownPolicy(string policyName) =>
-        _unknownPolicyCounter.Add(1, new TagList { { "policy", policyName } });
+        _unknownPolicyCounter.Add(1, new TagList { { PolicyTag, policyName } });
 
     /// <summary>Records that an acquire call was abandoned by the caller (client cancel) before acquiring a permit.</summary>
     public void RecordAbandoned(string policyName, string? tenantId) =>
         _abandonedCounter.Add(1, new TagList
         {
-            { "policy", policyName },
-            { "tenant_id", tenantId ?? "global" },
+            { PolicyTag, policyName },
+            { TenantIdTag, tenantId ?? GlobalTenantId },
         });
 }

--- a/src/Granit.Http.Security/ReservedTldClassifier.cs
+++ b/src/Granit.Http.Security/ReservedTldClassifier.cs
@@ -35,13 +35,12 @@ public static class ReservedTldClassifier
         int lastDot = host.LastIndexOf('.');
         string label = lastDot < 0 ? host : host[(lastDot + 1)..];
 
-        foreach (string r in Reserved)
+        string? match = Reserved.FirstOrDefault(
+            r => string.Equals(label, r, StringComparison.OrdinalIgnoreCase));
+        if (match is not null)
         {
-            if (string.Equals(label, r, StringComparison.OrdinalIgnoreCase))
-            {
-                tld = r;
-                return true;
-            }
+            tld = match;
+            return true;
         }
 
         tld = string.Empty;

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantIsolationFactoryRegistrationValidator.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantIsolationFactoryRegistrationValidator.cs
@@ -61,9 +61,9 @@ internal sealed class TenantIsolationFactoryRegistrationValidator(
           .Append("' but no ").Append(delegateName)
           .AppendLine(" delegate was passed for the following DbContexts:");
 
-        foreach (IsolatedDbContextMarker m in missing)
+        foreach (Type dbContextType in missing.Select(m => m.DbContextType))
         {
-            sb.Append("  - ").AppendLine(m.DbContextType.FullName ?? m.DbContextType.Name);
+            sb.Append("  - ").AppendLine(dbContextType.FullName ?? dbContextType.Name);
         }
 
         sb.Append("Either pass the delegate in AddGranit{X}EntityFrameworkCore(...) ")

--- a/tests/Granit.IO.Tests/LimitedStreamTests.cs
+++ b/tests/Granit.IO.Tests/LimitedStreamTests.cs
@@ -172,7 +172,7 @@ public sealed class LimitedStreamTests
         using MemoryStream inner = new();
         using LimitedStream stream = new(inner, 100);
 
-        await stream.FlushAsync(CancellationToken.None);
+        await Should.NotThrowAsync(() => stream.FlushAsync(CancellationToken.None));
     }
 
     [Fact]

--- a/tests/Granit.Timeline.Tests/InMemoryReactionStoreTests.cs
+++ b/tests/Granit.Timeline.Tests/InMemoryReactionStoreTests.cs
@@ -60,8 +60,8 @@ public sealed class InMemoryReactionStoreTests
     public async Task Remove_non_existent_is_noop()
     {
         InMemoryReactionStore sut = new();
-        await sut.RemoveAsync(Guid.NewGuid(), Guid.NewGuid(), "heart", TestContext.Current.CancellationToken);
-        // No exception.
+        await Should.NotThrowAsync(() =>
+            sut.RemoveAsync(Guid.NewGuid(), Guid.NewGuid(), "heart", TestContext.Current.CancellationToken));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Addresses ~20 low-effort Sonar findings (5-min-each bucket) flagged by SonarQube. Companion to PR #2113 — same Sonar dashboard, no behavioral change.

### Rules fixed

- **S3267** loops → LINQ `Any` / `FirstOrDefault` / `Where` / `Select` in `EvaluateAsyncStringInterpolationAnalyzer`, `RoleClaimNormalizationTransformation`, `RequestRouter`, `ReservedTldClassifier`, `PrivilegedFlagGuard`, `TenantIsolationFactoryRegistrationValidator`.
- **S2933** `_order` fields marked `readonly` in `DetailSectionBuilder`, `FieldBuilder`, `SectionBuilder`.
- **S108** empty `catch` blocks documented with intent comments in `PrivilegedFlagGuard` (4 occurrences around `/proc` probes).
- **S1481** unused private const `Engine` removed from `PuppeteerPdfViewerCapability`.
- **S1854** discard-into-parameter `_ = HandleRequestAsync(e)` fixed by renaming the unused param in `PuppeteerRequestRouter`.
- **S1192** repeated `"policy"` / `"tenant_id"` / `"global"` extracted to `const` in `BulkheadMetrics`.
- **S2629** logger now receives the caught `TimeoutException` in `HeadlessBrowserDrainCoordinator`.
- **S2699** added `Should.NotThrowAsync(...)` assertions to `LimitedStreamTests.FlushAsync_PassesThrough` and `InMemoryReactionStoreTests.Remove_non_existent_is_noop`.
- Carryover from PR #2113 follow-up: `DatabaseBlobClient` now `WriteAsync`s into the memory buffer; `codeql.yml` replaces blanket `read-all` with `contents: read` at the workflow scope (`security-events: write` stays job-local).

### Sonar false-positives intentionally left for UI triage

- **S125** « Remove this commented out code » on `DatabaseBlobClient:49` and `ApiKeyServiceCollectionExtensions:31` — both are genuine prose comments, not commented-out code.
- **S3267** on side-effect throw-loops (`LookupRegistry`, `WorkspaceBuilder`, `EntityDefinitionBuilder.AssertUniqueVariantNames`, `RoutePattern`, `ReactionEndpoints` count loop, `JsonSchemaWriter`) — the suggested `Where` form would smuggle mutation into LINQ or degrade performance.
- **TAggregate unused** on `IReferenceRewriter<TAggregate>` — load-bearing for DI discrimination across aggregates.

## Test plan

- [x] `dotnet build` on each affected `src/` project — clean
- [x] `dotnet test` on `Granit.IO.Tests`, `Granit.Timeline.Tests`, `Granit.Browsing.Tests`, `Granit.Http.Security.Tests`, `Granit.Http.Bulkhead.Tests`, `Granit.Authentication.Tests` — all green
- [x] `dotnet format --verify-no-changes` clean on all modified projects
- [ ] CI shards `core-ai`, `security`, `api-data`, `application` pass