### PR TITLE
refactor: reduce cognitive complexity in Http.Security + Observability

### DIFF
--- a/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
+++ b/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
@@ -56,171 +56,220 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
 
         using Activity? activity = HttpSecurityActivitySource.Source.StartActivity(HttpSecurityActivitySource.ValidateUrl);
 
-        // (1) Absolute-URI gate.
-        if (!url.IsAbsoluteUri)
+        // (1)(2)(3) Cheap structural gates.
+        if (ValidateUrlShape(url, optionOverrides) is { } shapeViolation)
         {
-            return Block(activity, new UrlSafetyViolation(
-                UrlSafetyViolationKind.MalformedUrl,
-                "URL is not absolute.",
-                "UrlSafety:MalformedUrl",
-                []));
+            return Block(activity, shapeViolation);
         }
 
-        // (2) Length cap.
-        if (url.OriginalString.Length > optionOverrides.MaxUrlLength)
-        {
-            return Block(activity, new UrlSafetyViolation(
-                UrlSafetyViolationKind.UrlTooLong,
-                $"URL exceeds the maximum length of {optionOverrides.MaxUrlLength}.",
-                "UrlSafety:UrlTooLong",
-                [optionOverrides.MaxUrlLength]));
-        }
-
-        // (3) Scheme allowlist.
-        if (!IsSchemeAllowed(url.Scheme, optionOverrides.AllowedSchemes))
-        {
-            return Block(activity, new UrlSafetyViolation(
-                UrlSafetyViolationKind.SchemeNotAllowed,
-                $"URL scheme '{url.Scheme}' is not allowed.",
-                "UrlSafety:SchemeNotAllowed",
-                [url.Scheme]));
-        }
-
-        // (4) file:// — gated by AllowFileScheme AND empty authority (no UNC).
+        // (4) file:// — handled separately because it short-circuits host resolution.
         if (string.Equals(url.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
         {
-            if (!optionOverrides.AllowFileScheme)
-            {
-                return Block(activity, new UrlSafetyViolation(
-                    UrlSafetyViolationKind.SchemeNotAllowed,
-                    "The file scheme is disabled. Set UrlSafetyOptions.AllowFileScheme=true to opt in.",
-                    "UrlSafety:SchemeNotAllowed",
-                    [url.Scheme]));
-            }
-
-            if (!string.IsNullOrEmpty(url.Host))
-            {
-                // file://server/share — UNC path, triggers SMB egress and NTLM-relay on Windows.
-                return Block(activity, new UrlSafetyViolation(
-                    UrlSafetyViolationKind.SchemeNotAllowed,
-                    "UNC file:// paths are not allowed.",
-                    "UrlSafety:SchemeNotAllowed",
-                    [url.Scheme]));
-            }
-
-            RecordValid();
-            activity?.SetTag("url_safety.outcome", "valid");
-            return UrlSafetyResult.Valid([]);
+            return HandleFileScheme(activity, url, optionOverrides);
         }
 
-        string host = url.Host;
-        if (string.IsNullOrEmpty(host))
+        // (5)(6)(7)(8) Host normalization + reserved/deny/allow checks.
+        if (ValidateHost(url.Host, optionOverrides, out string asciiHost, out IPAddress? literalIp) is { } hostViolation)
         {
-            return Block(activity, new UrlSafetyViolation(
-                UrlSafetyViolationKind.MalformedUrl,
-                "URL has no host.",
-                "UrlSafety:MalformedUrl",
-                []));
+            return Block(activity, hostViolation);
         }
 
-        // (5) IDN normalization → punycode (skip when host is an IP literal or AllowIdn is off).
-        string asciiHost = optionOverrides.AllowIdn ? NormalizeHost(host) : host;
-
-        // (6) Reserved TLD check (skipped for IP literals).
-        if (!IPAddress.TryParse(StripBrackets(asciiHost), out IPAddress? literalIp)
-            && ReservedTldClassifier.IsReserved(asciiHost, out string? tld))
+        // (9) Resolve addresses (IP literal short-circuits DNS).
+        (IPAddress[]? addresses, UrlSafetyViolation? resolveViolation) =
+            await ResolveAddressesAsync(asciiHost, literalIp, optionOverrides, ct).ConfigureAwait(false);
+        if (resolveViolation is not null)
         {
-            return Block(activity, new UrlSafetyViolation(
-                UrlSafetyViolationKind.ReservedTld,
-                $"Host '{SanitizeForDisplay(asciiHost)}' uses the reserved TLD '{tld}'.",
-                "UrlSafety:ReservedTld",
-                [asciiHost, tld]));
+            return Block(activity, resolveViolation);
         }
 
-        // (7) Deny patterns.
-        if (optionOverrides.DeniedHostPatterns.Count > 0 && HostPatternMatcher.MatchesAny(asciiHost, optionOverrides.DeniedHostPatterns))
+        // (10) Classify each resolved address against the private-network policy.
+        if (ClassifyAddresses(addresses!, asciiHost, optionOverrides) is { } classifyViolation)
         {
-            return Block(activity, new UrlSafetyViolation(
-                UrlSafetyViolationKind.HostPatternDenied,
-                $"Host '{SanitizeForDisplay(asciiHost)}' matches a denied pattern.",
-                "UrlSafety:HostPatternDenied",
-                [asciiHost]));
-        }
-
-        // (8) Allow patterns (if non-empty, must match at least one).
-        if (optionOverrides.AllowedHostPatterns.Count > 0 && !HostPatternMatcher.MatchesAny(asciiHost, optionOverrides.AllowedHostPatterns))
-        {
-            return Block(activity, new UrlSafetyViolation(
-                UrlSafetyViolationKind.HostPatternNotAllowed,
-                $"Host '{SanitizeForDisplay(asciiHost)}' is not in the allowed pattern list.",
-                "UrlSafety:HostPatternNotAllowed",
-                [asciiHost]));
-        }
-
-        // (9 / 10) Resolve and classify. IP literal → classify directly.
-        IPAddress[] addresses;
-        if (literalIp is not null)
-        {
-            addresses = [literalIp];
-        }
-        else
-        {
-            try
-            {
-                using var cts = new CancellationTokenSource(optionOverrides.DnsResolveTimeout, _timeProvider);
-                using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, cts.Token);
-                addresses = await _resolver.GetHostAddressesAsync(asciiHost, linked.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-            {
-                HttpSecurityLog.DnsResolutionFailed(_logger, SanitizeForDisplay(asciiHost), "timeout");
-                return Block(activity, new UrlSafetyViolation(
-                    UrlSafetyViolationKind.DnsResolutionFailed,
-                    $"DNS resolution timed out for host '{SanitizeForDisplay(asciiHost)}'.",
-                    "UrlSafety:DnsResolutionFailed",
-                    [asciiHost]));
-            }
-            catch (SocketException)
-            {
-                HttpSecurityLog.DnsResolutionFailed(_logger, SanitizeForDisplay(asciiHost), "socket_error");
-                return Block(activity, new UrlSafetyViolation(
-                    UrlSafetyViolationKind.DnsResolutionFailed,
-                    $"DNS resolution failed for host '{SanitizeForDisplay(asciiHost)}'.",
-                    "UrlSafety:DnsResolutionFailed",
-                    [asciiHost]));
-            }
-
-            if (addresses.Length == 0)
-            {
-                HttpSecurityLog.DnsResolutionFailed(_logger, SanitizeForDisplay(asciiHost), "no_addresses");
-                return Block(activity, new UrlSafetyViolation(
-                    UrlSafetyViolationKind.DnsResolutionFailed,
-                    $"DNS resolution returned no addresses for host '{SanitizeForDisplay(asciiHost)}'.",
-                    "UrlSafety:DnsResolutionFailed",
-                    [asciiHost]));
-            }
-        }
-
-        foreach (IPAddress ip in addresses)
-        {
-            if (PrivateNetworkClassifier.Classify(ip, out UrlSafetyViolationKind kind))
-            {
-                if (IsAllowedByPolicy(kind, optionOverrides))
-                {
-                    continue;
-                }
-
-                return Block(activity, new UrlSafetyViolation(
-                    kind,
-                    BuildReason(kind, SanitizeForDisplay(asciiHost)),
-                    LocalizationKeyFor(kind),
-                    [asciiHost]));
-            }
+            return Block(activity, classifyViolation);
         }
 
         RecordValid();
         activity?.SetTag("url_safety.outcome", "valid");
-        return UrlSafetyResult.Valid(addresses);
+        return UrlSafetyResult.Valid(addresses!);
+    }
+
+    private static UrlSafetyViolation? ValidateUrlShape(Uri url, UrlSafetyOptions opts)
+    {
+        if (!url.IsAbsoluteUri)
+        {
+            return new UrlSafetyViolation(
+                UrlSafetyViolationKind.MalformedUrl,
+                "URL is not absolute.",
+                "UrlSafety:MalformedUrl",
+                []);
+        }
+
+        if (url.OriginalString.Length > opts.MaxUrlLength)
+        {
+            return new UrlSafetyViolation(
+                UrlSafetyViolationKind.UrlTooLong,
+                $"URL exceeds the maximum length of {opts.MaxUrlLength}.",
+                "UrlSafety:UrlTooLong",
+                [opts.MaxUrlLength]);
+        }
+
+        if (!IsSchemeAllowed(url.Scheme, opts.AllowedSchemes))
+        {
+            return new UrlSafetyViolation(
+                UrlSafetyViolationKind.SchemeNotAllowed,
+                $"URL scheme '{url.Scheme}' is not allowed.",
+                "UrlSafety:SchemeNotAllowed",
+                [url.Scheme]);
+        }
+
+        return null;
+    }
+
+    private UrlSafetyResult HandleFileScheme(Activity? activity, Uri url, UrlSafetyOptions opts)
+    {
+        if (!opts.AllowFileScheme)
+        {
+            return Block(activity, new UrlSafetyViolation(
+                UrlSafetyViolationKind.SchemeNotAllowed,
+                "The file scheme is disabled. Set UrlSafetyOptions.AllowFileScheme=true to opt in.",
+                "UrlSafety:SchemeNotAllowed",
+                [url.Scheme]));
+        }
+
+        if (!string.IsNullOrEmpty(url.Host))
+        {
+            // file://server/share — UNC path, triggers SMB egress and NTLM-relay on Windows.
+            return Block(activity, new UrlSafetyViolation(
+                UrlSafetyViolationKind.SchemeNotAllowed,
+                "UNC file:// paths are not allowed.",
+                "UrlSafety:SchemeNotAllowed",
+                [url.Scheme]));
+        }
+
+        RecordValid();
+        activity?.SetTag("url_safety.outcome", "valid");
+        return UrlSafetyResult.Valid([]);
+    }
+
+    private static UrlSafetyViolation? ValidateHost(
+        string host,
+        UrlSafetyOptions opts,
+        out string asciiHost,
+        out IPAddress? literalIp)
+    {
+        asciiHost = string.Empty;
+        literalIp = null;
+
+        if (string.IsNullOrEmpty(host))
+        {
+            return new UrlSafetyViolation(
+                UrlSafetyViolationKind.MalformedUrl,
+                "URL has no host.",
+                "UrlSafety:MalformedUrl",
+                []);
+        }
+
+        asciiHost = opts.AllowIdn ? NormalizeHost(host) : host;
+
+        bool isIpLiteral = IPAddress.TryParse(StripBrackets(asciiHost), out literalIp);
+
+        if (!isIpLiteral && ReservedTldClassifier.IsReserved(asciiHost, out string? tld))
+        {
+            return new UrlSafetyViolation(
+                UrlSafetyViolationKind.ReservedTld,
+                $"Host '{SanitizeForDisplay(asciiHost)}' uses the reserved TLD '{tld}'.",
+                "UrlSafety:ReservedTld",
+                [asciiHost, tld]);
+        }
+
+        if (opts.DeniedHostPatterns.Count > 0 && HostPatternMatcher.MatchesAny(asciiHost, opts.DeniedHostPatterns))
+        {
+            return new UrlSafetyViolation(
+                UrlSafetyViolationKind.HostPatternDenied,
+                $"Host '{SanitizeForDisplay(asciiHost)}' matches a denied pattern.",
+                "UrlSafety:HostPatternDenied",
+                [asciiHost]);
+        }
+
+        if (opts.AllowedHostPatterns.Count > 0 && !HostPatternMatcher.MatchesAny(asciiHost, opts.AllowedHostPatterns))
+        {
+            return new UrlSafetyViolation(
+                UrlSafetyViolationKind.HostPatternNotAllowed,
+                $"Host '{SanitizeForDisplay(asciiHost)}' is not in the allowed pattern list.",
+                "UrlSafety:HostPatternNotAllowed",
+                [asciiHost]);
+        }
+
+        return null;
+    }
+
+    private async ValueTask<(IPAddress[]? Addresses, UrlSafetyViolation? Violation)> ResolveAddressesAsync(
+        string asciiHost,
+        IPAddress? literalIp,
+        UrlSafetyOptions opts,
+        CancellationToken ct)
+    {
+        if (literalIp is not null)
+        {
+            return ([literalIp], null);
+        }
+
+        IPAddress[] addresses;
+        try
+        {
+            using var cts = new CancellationTokenSource(opts.DnsResolveTimeout, _timeProvider);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, cts.Token);
+            addresses = await _resolver.GetHostAddressesAsync(asciiHost, linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return (null, DnsFailure(asciiHost, "timeout", "DNS resolution timed out for host"));
+        }
+        catch (SocketException)
+        {
+            return (null, DnsFailure(asciiHost, "socket_error", "DNS resolution failed for host"));
+        }
+
+        if (addresses.Length == 0)
+        {
+            return (null, DnsFailure(asciiHost, "no_addresses", "DNS resolution returned no addresses for host"));
+        }
+
+        return (addresses, null);
+    }
+
+    private UrlSafetyViolation DnsFailure(string asciiHost, string failureTag, string reasonPrefix)
+    {
+        HttpSecurityLog.DnsResolutionFailed(_logger, SanitizeForDisplay(asciiHost), failureTag);
+        return new UrlSafetyViolation(
+            UrlSafetyViolationKind.DnsResolutionFailed,
+            $"{reasonPrefix} '{SanitizeForDisplay(asciiHost)}'.",
+            "UrlSafety:DnsResolutionFailed",
+            [asciiHost]);
+    }
+
+    private static UrlSafetyViolation? ClassifyAddresses(IPAddress[] addresses, string asciiHost, UrlSafetyOptions opts)
+    {
+        foreach (IPAddress ip in addresses)
+        {
+            if (!PrivateNetworkClassifier.Classify(ip, out UrlSafetyViolationKind kind))
+            {
+                continue;
+            }
+
+            if (IsAllowedByPolicy(kind, opts))
+            {
+                continue;
+            }
+
+            return new UrlSafetyViolation(
+                kind,
+                BuildReason(kind, SanitizeForDisplay(asciiHost)),
+                LocalizationKeyFor(kind),
+                [asciiHost]);
+        }
+
+        return null;
     }
 
     private string? CurrentTenantId() =>

--- a/src/Granit.Http.Security/PrivateNetworkClassifier.cs
+++ b/src/Granit.Http.Security/PrivateNetworkClassifier.cs
@@ -86,24 +86,7 @@ public static class PrivateNetworkClassifier
             return true;
         }
 
-        // 0.0.0.0/8 — "this network" / unspecified (RFC 1122).
-        // 10.0.0.0/8 — private (RFC 1918).
-        // 100.64.0.0/10 — CGNAT (RFC 6598).
-        // 172.16.0.0/12 — private (RFC 1918).
-        // 192.168.0.0/16 — private (RFC 1918).
-        // 192.0.0.0/24 — IETF protocol assignments (RFC 6890).
-        // 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 — TEST-NET-1/2/3 (RFC 5737).
-        // 198.18.0.0/15 — benchmarking (RFC 2544); often routed to internal taps.
-        if (b[0] == 0
-            || b[0] == 10
-            || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
-            || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
-            || (b[0] == 192 && b[1] == 168)
-            || (b[0] == 192 && b[1] == 0 && b[2] == 0)
-            || (b[0] == 192 && b[1] == 0 && b[2] == 2)
-            || (b[0] == 198 && b[1] == 51 && b[2] == 100)
-            || (b[0] == 203 && b[1] == 0 && b[2] == 113)
-            || (b[0] == 198 && (b[1] == 18 || b[1] == 19)))
+        if (IsPrivateOrReservedIPv4(b))
         {
             kind = UrlSafetyViolationKind.PrivateNetwork;
             return true;
@@ -120,61 +103,103 @@ public static class PrivateNetworkClassifier
         return Miss(out kind);
     }
 
+    /// <summary>
+    /// RFC 1918 private, RFC 6598 CGNAT, RFC 6890 IETF-reserved, RFC 5737 TEST-NETs,
+    /// RFC 2544 benchmarking, plus 0.0.0.0/8 unspecified. Grouped here so the per-range
+    /// table stays auditable against the RFC comments.
+    /// </summary>
+    private static bool IsPrivateOrReservedIPv4(byte[] b) =>
+        b[0] == 0
+        || b[0] == 10
+        || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
+        || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
+        || (b[0] == 192 && b[1] == 168)
+        || (b[0] == 192 && b[1] == 0 && (b[2] == 0 || b[2] == 2))
+        || (b[0] == 198 && b[1] == 51 && b[2] == 100)
+        || (b[0] == 203 && b[1] == 0 && b[2] == 113)
+        || (b[0] == 198 && (b[1] == 18 || b[1] == 19));
+
     private static readonly byte[] IPv6LoopbackBytes = IPAddress.IPv6Loopback.GetAddressBytes();
     private static readonly byte[] IPv6UnspecifiedBytes = IPAddress.IPv6Any.GetAddressBytes();
     private static readonly byte[] Ipv6DocumentationPrefix = [0x20, 0x01, 0x0d, 0xb8]; // 2001:db8::/32
 
     private static bool ClassifyIPv6(byte[] b, out UrlSafetyViolationKind kind)
     {
-        // ::1 — loopback.
-        if (b.AsSpan().SequenceEqual(IPv6LoopbackBytes))
+        if (TryClassifyIPv6Exact(b, out kind))
+        {
+            return true;
+        }
+
+        if (TryClassifyIPv6Range(b, out kind))
+        {
+            return true;
+        }
+
+        return TryClassifyIPv6Transition(b, out kind);
+    }
+
+    /// <summary>
+    /// Exact-bytes matches: ::1 loopback, :: unspecified, and the AWS / Azure / GCP
+    /// metadata addresses embedded in IPv6.
+    /// </summary>
+    private static bool TryClassifyIPv6Exact(byte[] b, out UrlSafetyViolationKind kind)
+    {
+        ReadOnlySpan<byte> span = b;
+
+        if (span.SequenceEqual(IPv6LoopbackBytes) || span.SequenceEqual(IPv6UnspecifiedBytes))
         {
             kind = UrlSafetyViolationKind.Loopback;
             return true;
         }
 
-        // :: — unspecified (equivalent of 0.0.0.0).
-        if (b.AsSpan().SequenceEqual(IPv6UnspecifiedBytes))
-        {
-            kind = UrlSafetyViolationKind.Loopback;
-            return true;
-        }
-
-        // fd00:ec2::254 (AWS IMDSv6) and fe80::a9fe:a9fe (Azure/GCP variant).
-        if (b.AsSpan().SequenceEqual(AwsIPv6Metadata) || b.AsSpan().SequenceEqual(LinkLocalIPv6Metadata))
+        if (span.SequenceEqual(AwsIPv6Metadata) || span.SequenceEqual(LinkLocalIPv6Metadata))
         {
             kind = UrlSafetyViolationKind.MetadataEndpoint;
             return true;
         }
 
-        // fe80::/10 — link-local (RFC 4291).
+        return Miss(out kind);
+    }
+
+    /// <summary>
+    /// Prefix-range matches: fe80::/10 link-local, fc00::/7 ULA, ff00::/8 multicast,
+    /// 2001:db8::/32 documentation.
+    /// </summary>
+    private static bool TryClassifyIPv6Range(byte[] b, out UrlSafetyViolationKind kind)
+    {
         if (b[0] == 0xfe && (b[1] & 0xc0) == 0x80)
         {
             kind = UrlSafetyViolationKind.LinkLocal;
             return true;
         }
 
-        // fc00::/7 — unique local (RFC 4193). Includes the fd00::/8 half.
         if ((b[0] & 0xfe) == 0xfc)
         {
             kind = UrlSafetyViolationKind.IPv6UniqueLocal;
             return true;
         }
 
-        // ff00::/8 — multicast (RFC 4291).
         if (b[0] == 0xff)
         {
             kind = UrlSafetyViolationKind.ReservedAddress;
             return true;
         }
 
-        // 2001:db8::/32 — documentation (RFC 3849) — must never resolve.
         if (b.AsSpan(0, 4).SequenceEqual(Ipv6DocumentationPrefix))
         {
             kind = UrlSafetyViolationKind.ReservedAddress;
             return true;
         }
 
+        return Miss(out kind);
+    }
+
+    /// <summary>
+    /// IPv6-to-IPv4 transition forms (NAT64, 6to4, Teredo, IPv4-compatible) — each
+    /// extracts the embedded IPv4 and re-classifies it through <see cref="ClassifyEmbeddedIPv4"/>.
+    /// </summary>
+    private static bool TryClassifyIPv6Transition(byte[] b, out UrlSafetyViolationKind kind)
+    {
         // NAT64 well-known prefix 64:ff9b::/96 (RFC 6052) — last 4 bytes are an embedded IPv4.
         if (b.AsSpan(0, 12).SequenceEqual(Nat64Prefix))
         {
@@ -199,8 +224,7 @@ public static class PrivateNetworkClassifier
         }
 
         // ::a.b.c.d — IPv4-compatible IPv6 (deprecated, RFC 4291 §2.5.5.1). First 12 bytes are zero,
-        // last 4 are the IPv4. We already matched ::1 and :: above, so any other ::/96 with a non-zero
-        // tail is treated as embedded IPv4.
+        // last 4 are the IPv4. ::1 and :: are already filtered by TryClassifyIPv6Exact above.
         if (IsZero(b.AsSpan(0, 12)) && !IsZero(b.AsSpan(12, 4)))
         {
             return ClassifyEmbeddedIPv4(b.AsSpan(12, 4), out kind);

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -112,71 +112,8 @@ public static class ObservabilityServiceCollectionExtensions
                 serviceName: options.ServiceName,
                 serviceVersion: options.ServiceVersion,
                 serviceNamespace: options.ServiceNamespace))
-            .WithTracing(tracing =>
-            {
-                if (!options.EnableTracing)
-                {
-                    return;
-                }
-
-                // Register all Granit module ActivitySources declared via
-                // GranitActivitySourceRegistry.Register() during host configuration.
-                foreach (string source in GranitActivitySourceRegistry.GetRegisteredSources())
-                {
-                    tracing.AddSource(source);
-                }
-
-                tracing
-                    .AddAspNetCoreInstrumentation(aspnet =>
-                    {
-                        aspnet.RecordException = true;
-                        aspnet.Filter = httpContext =>
-                        {
-                            Microsoft.AspNetCore.Http.PathString path = httpContext.Request.Path;
-                            // Exclude /health/* (liveness, readiness, startup) and /healthz (legacy).
-                            // StartsWithSegments is segment-safe: /healthcare/... is NOT excluded.
-                            return !path.StartsWithSegments("/health") && path != "/healthz";
-                        };
-                    })
-                    .AddHttpClientInstrumentation()
-                    .AddEntityFrameworkCoreInstrumentation();
-
-                // Apply tracing contributors declared by SDK-embedding modules
-                // (Redis, Npgsql, AWS, ...). See GranitOpenTelemetryRegistry.
-                foreach (Action<TracerProviderBuilder> contributor in
-                    GranitOpenTelemetryRegistry.GetTracingContributors())
-                {
-                    contributor(tracing);
-                }
-
-                if (!crossCuttingOtlpActive)
-                {
-                    tracing.AddOtlpExporter(otlp => otlp.Endpoint = new Uri(options.OtlpEndpoint));
-                }
-            })
-            .WithMetrics(metrics =>
-            {
-                if (!options.EnableMetrics)
-                {
-                    return;
-                }
-
-                metrics
-                    .AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation();
-
-                // Apply metrics contributors declared by SDK-embedding modules.
-                foreach (Action<MeterProviderBuilder> contributor in
-                    GranitOpenTelemetryRegistry.GetMetricsContributors())
-                {
-                    contributor(metrics);
-                }
-
-                if (!crossCuttingOtlpActive)
-                {
-                    metrics.AddOtlpExporter(otlp => otlp.Endpoint = new Uri(options.OtlpEndpoint));
-                }
-            });
+            .WithTracing(tracing => ConfigureTracing(tracing, options, crossCuttingOtlpActive))
+            .WithMetrics(metrics => ConfigureMetrics(metrics, options, crossCuttingOtlpActive));
 
         // When OTEL_EXPORTER_OTLP_ENDPOINT is set (e.g. by .NET Aspire), use the
         // cross-cutting UseOtlpExporter() which exports all signals (traces, metrics,
@@ -184,6 +121,73 @@ public static class ObservabilityServiceCollectionExtensions
         if (crossCuttingOtlpActive)
         {
             otelBuilder.UseOtlpExporter();
+        }
+    }
+
+    private static void ConfigureTracing(TracerProviderBuilder tracing, ObservabilityOptions options, bool crossCuttingOtlpActive)
+    {
+        if (!options.EnableTracing)
+        {
+            return;
+        }
+
+        // Register all Granit module ActivitySources declared via
+        // GranitActivitySourceRegistry.Register() during host configuration.
+        foreach (string source in GranitActivitySourceRegistry.GetRegisteredSources())
+        {
+            tracing.AddSource(source);
+        }
+
+        tracing
+            .AddAspNetCoreInstrumentation(aspnet =>
+            {
+                aspnet.RecordException = true;
+                aspnet.Filter = static httpContext =>
+                {
+                    Microsoft.AspNetCore.Http.PathString path = httpContext.Request.Path;
+                    // Exclude /health/* (liveness, readiness, startup) and /healthz (legacy).
+                    // StartsWithSegments is segment-safe: /healthcare/... is NOT excluded.
+                    return !path.StartsWithSegments("/health") && path != "/healthz";
+                };
+            })
+            .AddHttpClientInstrumentation()
+            .AddEntityFrameworkCoreInstrumentation();
+
+        // Apply tracing contributors declared by SDK-embedding modules
+        // (Redis, Npgsql, AWS, ...). See GranitOpenTelemetryRegistry.
+        foreach (Action<TracerProviderBuilder> contributor in
+            GranitOpenTelemetryRegistry.GetTracingContributors())
+        {
+            contributor(tracing);
+        }
+
+        if (!crossCuttingOtlpActive)
+        {
+            tracing.AddOtlpExporter(otlp => otlp.Endpoint = new Uri(options.OtlpEndpoint));
+        }
+    }
+
+    private static void ConfigureMetrics(MeterProviderBuilder metrics, ObservabilityOptions options, bool crossCuttingOtlpActive)
+    {
+        if (!options.EnableMetrics)
+        {
+            return;
+        }
+
+        metrics
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation();
+
+        // Apply metrics contributors declared by SDK-embedding modules.
+        foreach (Action<MeterProviderBuilder> contributor in
+            GranitOpenTelemetryRegistry.GetMetricsContributors())
+        {
+            contributor(metrics);
+        }
+
+        if (!crossCuttingOtlpActive)
+        {
+            metrics.AddOtlpExporter(otlp => otlp.Endpoint = new Uri(options.OtlpEndpoint));
         }
     }
 }


### PR DESCRIPTION
## Summary

Three Sonar S3776 cognitive-complexity refactors, all pure structural splits — no rule-set or behavioral change.

### `DefaultUrlSafetyValidator.ValidateAsync` (30 → ≤ 10 per branch)

Extracts five guard helpers + a DNS-failure factory from the linear 10-step pipeline:

| Helper | Responsibility |
|---|---|
| \`ValidateUrlShape\` | absolute-URI, length cap, scheme allowlist |
| \`HandleFileScheme\` | \`file://\` enabled + non-UNC |
| \`ValidateHost\` | IDN → ASCII, IP-literal detection, reserved TLD, deny/allow patterns |
| \`ResolveAddressesAsync\` | IP-literal short-circuit, DNS with timeout/socket/empty handling |
| \`ClassifyAddresses\` | per-address private-network classification + policy override |
| \`DnsFailure\` | shared log + violation builder for the three DNS failure tags |

### `PrivateNetworkClassifier`

- **\`ClassifyIPv4\` (17 → ≤ 8):** extract \`IsPrivateOrReservedIPv4\` — the long RFC-1918 / 5737 / 2544 / 6598 OR-chain moves to a dedicated audit table, keeping the per-RFC inline comments.
- **\`ClassifyIPv6\` (16 → ≤ 6 per branch):** split into three orthogonal passes — \`TryClassifyIPv6Exact\` (loopback / unspecified / metadata), \`TryClassifyIPv6Range\` (link-local / ULA / multicast / documentation), \`TryClassifyIPv6Transition\` (NAT64 / 6to4 / Teredo / IPv4-compatible).

### `ObservabilityServiceCollectionExtensions.ConfigureOpenTelemetry` (16 → ≤ 8)

The two nested \`WithTracing(...)\` / \`WithMetrics(...)\` lambdas move to top-level \`ConfigureTracing\` / \`ConfigureMetrics\` static helpers. AspNetCore filter lambda promoted to \`static\` for clarity.

## Test plan

- [x] \`dotnet build\` clean on \`Granit.Http.Security\` and \`Granit.Observability\`
- [x] \`dotnet test\` — \`Granit.Http.Security.Tests\` 152/152, \`Granit.Observability.Tests\` 53/53
- [x] \`dotnet format --verify-no-changes\` clean on both projects
- [ ] CI \`api-data\` + \`core-ai\` shards pass

## Out of scope (deferred)

- \`PrivilegedFlagGuard:73, 196\` and \`RequestRouter:135\` — same files were touched by #2115 (now merged); a follow-up PR will land them once this one is in.
- \`PlaywrightHeadlessBrowser.AcquirePageAsync\` (20→15) — hot-path browser-context / cookie mapping, deserves its own PR with focused review.
- \`ODataExposureEndpointRouteBuilderExtensions\` ValidateAndResolveWhitelists / MapEntitySetRoute — OData v4 route-handler refactor, separate concern.