### PR TITLE
refactor(browsing): reduce cognitive complexity in PrivilegedFlagGuard + RequestRouter

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -11045,7 +11045,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs",
-      "line": 177,
+      "line": 199,
       "members": [
         {
           "name": "new",
@@ -11073,7 +11073,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs",
-      "line": 164,
+      "line": 186,
       "members": [
         {
           "name": "GetEnvironmentVariable",

--- a/src/Granit.Browsing/Pages/RequestRouter.cs
+++ b/src/Granit.Browsing/Pages/RequestRouter.cs
@@ -136,46 +136,74 @@ internal sealed class RequestRouter : IRequestRouter
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        // 1. Scheme.
-        if (!IsSchemeAllowed(request.Url.Scheme))
+        // 1-3. Sandbox shape checks (scheme, host allow/deny, URL pattern block) are all sync.
+        if (CheckSandboxRules(request) is { } sandboxReason)
         {
-            return await BlockAsync(request, "scheme_not_allowed", cancellationToken).ConfigureAwait(false);
+            return await BlockAsync(request, sandboxReason, cancellationToken).ConfigureAwait(false);
         }
 
-        // 2. Host allow-list.
+        // 4. Private-network re-resolution (anti-rebinding) — async because it goes through DNS.
+        if (await CheckPrivateNetworkBlockAsync(request, cancellationToken).ConfigureAwait(false) is { } pnReason)
+        {
+            return await BlockAsync(request, pnReason, cancellationToken).ConfigureAwait(false);
+        }
+
+        // 5. User handlers (registration order, copy-on-write snapshot).
+        return await RunUserHandlersAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Synchronous sandbox-shape checks: scheme allowlist, host allow/deny patterns,
+    /// blocked URL patterns. Returns a metric reason on block, or <see langword="null"/> on pass.
+    /// </summary>
+    private string? CheckSandboxRules(RouteRequest request)
+    {
+        if (!IsSchemeAllowed(request.Url.Scheme))
+        {
+            return "scheme_not_allowed";
+        }
+
         if (_sandbox.AllowedHostPatterns is { Count: > 0 } allowed
             && !MatchesAny(allowed, request.Url))
         {
-            return await BlockAsync(request, "host_not_allowed", cancellationToken).ConfigureAwait(false);
+            return "host_not_allowed";
         }
 
-        // 3. Host deny-list.
         if (_sandbox.DeniedHostPatterns is { Count: > 0 } denied
             && MatchesAny(denied, request.Url))
         {
-            return await BlockAsync(request, "host_denied", cancellationToken).ConfigureAwait(false);
+            return "host_denied";
         }
 
         if (_sandbox.BlockedUrlPatterns is { Count: > 0 } blocked
             && MatchesAny(blocked, request.Url))
         {
-            return await BlockAsync(request, "url_pattern_blocked", cancellationToken).ConfigureAwait(false);
+            return "url_pattern_blocked";
         }
 
-        // 4. Private-network re-resolution (anti-rebinding).
-        if (_sandbox.BlockPrivateNetworks)
+        return null;
+    }
+
+    private async ValueTask<string?> CheckPrivateNetworkBlockAsync(RouteRequest request, CancellationToken cancellationToken)
+    {
+        if (!_sandbox.BlockPrivateNetworks)
         {
-            UrlSafetyResult result = await _urlSafety
-                .ValidateAsync(request.Url, cancellationToken)
-                .ConfigureAwait(false);
-            if (!result.IsValid)
-            {
-                string reason = result.Violation is { Kind: var kind } ? kind.ToString() : "url_safety_violation";
-                return await BlockAsync(request, reason, cancellationToken).ConfigureAwait(false);
-            }
+            return null;
         }
 
-        // 5. User handlers (registration order, copy-on-write snapshot).
+        UrlSafetyResult result = await _urlSafety
+            .ValidateAsync(request.Url, cancellationToken)
+            .ConfigureAwait(false);
+        if (result.IsValid)
+        {
+            return null;
+        }
+
+        return result.Violation is { Kind: var kind } ? kind.ToString() : "url_safety_violation";
+    }
+
+    private async ValueTask<RouteDecision> RunUserHandlersAsync(RouteRequest request, CancellationToken cancellationToken)
+    {
         ImmutableList<Entry> snapshot = Volatile.Read(ref _handlers);
         foreach (Entry entry in snapshot)
         {
@@ -184,28 +212,38 @@ internal sealed class RequestRouter : IRequestRouter
                 continue;
             }
 
-            try
+            RouteDecision? terminal = await InvokeHandlerAsync(entry, request, cancellationToken).ConfigureAwait(false);
+            if (terminal is not null)
             {
-                RouteDecision decision = await entry.Handler(request, cancellationToken).ConfigureAwait(false);
-                if (decision.Kind != RouteDecisionKind.Continue)
-                {
-                    return decision;
-                }
-            }
-            catch (Exception ex)
-            {
-                _metrics.RecordRouterHandlerError(_engineName, CurrentTenantId);
-                _logger.LogWarning(ex, "User route handler threw for {Url}; applying RouterErrorPolicy={Policy}.", request.Url, _errorPolicy);
-
-                if (_errorPolicy == RouterErrorPolicy.AbortOnError)
-                {
-                    return RouteDecision.Abort(errorCode: "handler_error");
-                }
-                // ContinueOnError — fall through to the next handler.
+                return terminal;
             }
         }
 
         return RouteDecision.Continue;
+    }
+
+    /// <summary>
+    /// Runs one user handler. Returns the decision when terminal (non-Continue),
+    /// <see langword="null"/> when the loop should advance. Handler exceptions are mapped
+    /// to <see cref="RouterErrorPolicy"/>: <c>AbortOnError</c> returns an Abort decision,
+    /// <c>ContinueOnError</c> returns <see langword="null"/> to advance to the next handler.
+    /// </summary>
+    private async ValueTask<RouteDecision?> InvokeHandlerAsync(Entry entry, RouteRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            RouteDecision decision = await entry.Handler(request, cancellationToken).ConfigureAwait(false);
+            return decision.Kind == RouteDecisionKind.Continue ? null : decision;
+        }
+        catch (Exception ex)
+        {
+            _metrics.RecordRouterHandlerError(_engineName, CurrentTenantId);
+            _logger.LogWarning(ex, "User route handler threw for {Url}; applying RouterErrorPolicy={Policy}.", request.Url, _errorPolicy);
+
+            return _errorPolicy == RouterErrorPolicy.AbortOnError
+                ? RouteDecision.Abort(errorCode: "handler_error")
+                : null;
+        }
     }
 
     private bool IsSchemeAllowed(string scheme) =>

--- a/src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs
+++ b/src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs
@@ -78,62 +78,84 @@ public static class PrivilegedFlagGuard
     {
         ArgumentNullException.ThrowIfNull(logger);
 
-        // 1. Always-forbidden flags — no opt-in path exists, refuse immediately. Each
-        // entry is compared against the bare arg token first (everything before '='), and
-        // also against the full arg when the forbidden entry itself contains an '=' (so
-        // e.g. --disable-features=IsolateOrigins is matched precisely without rejecting
-        // every --disable-features=* value Chromium ships).
-        if (extraArgs is not null)
-        {
-            foreach (string arg in extraArgs)
-            {
-                string token = ExtractToken(arg);
-                foreach (string forbidden in AlwaysForbidden)
-                {
-                    bool match = forbidden.Contains('=', StringComparison.Ordinal)
-                        ? string.Equals(arg, forbidden, StringComparison.OrdinalIgnoreCase)
-                        : TokenMatches(token, forbidden);
-                    if (match)
-                    {
-                        throw new SandboxViolationException(
-                            SandboxViolationKind.PrivilegedFlagRefused,
-                            $"Privileged browser flag '{forbidden}' refused unconditionally — this flag widens the renderer attack surface and has no safe opt-in.");
-                    }
-                }
-            }
-        }
+        // 1. Always-forbidden flags — no opt-in path exists.
+        ThrowIfAlwaysForbidden(extraArgs);
 
         // 2. Container-opt-in flags (sandbox disablers).
-        string? offendingArg = null;
-        if (extraArgs is not null)
-        {
-            foreach (string arg in extraArgs)
-            {
-                string token = ExtractToken(arg);
-                offendingArg = RequiresContainerOptIn.FirstOrDefault(privileged => TokenMatches(token, privileged));
-                if (offendingArg is not null)
-                {
-                    break;
-                }
-            }
-        }
+        string? offendingArg = FindContainerOptInOffender(extraArgs);
 
         if (!disableSandbox && offendingArg is null)
         {
             return;
         }
 
-        IEnvironmentProbe p = probe ?? DefaultEnvironmentProbe.Instance;
+        // 3. Container/non-root/opt-in gating for sandbox disablers.
+        EnforceContainerOptIn(offendingArg, probe ?? DefaultEnvironmentProbe.Instance, logger);
+    }
 
-        bool optedIn = string.Equals(p.GetEnvironmentVariable(OptInEnvVar), "1", StringComparison.Ordinal);
-        bool inContainer = p.IsRunningInContainer();
-        bool nonRoot = !p.IsRunningAsRoot();
+    /// <summary>
+    /// Each entry is compared against the bare arg token (everything before <c>=</c>), and
+    /// also against the full arg when the forbidden entry itself contains an <c>=</c> (so
+    /// e.g. <c>--disable-features=IsolateOrigins</c> is matched precisely without rejecting
+    /// every <c>--disable-features=*</c> value Chromium ships).
+    /// </summary>
+    private static void ThrowIfAlwaysForbidden(IReadOnlyList<string>? extraArgs)
+    {
+        if (extraArgs is null)
+        {
+            return;
+        }
+
+        foreach (string arg in extraArgs)
+        {
+            string token = ExtractToken(arg);
+            string? hit = AlwaysForbidden.FirstOrDefault(forbidden => MatchesForbidden(arg, token, forbidden));
+            if (hit is not null)
+            {
+                throw new SandboxViolationException(
+                    SandboxViolationKind.PrivilegedFlagRefused,
+                    $"Privileged browser flag '{hit}' refused unconditionally — this flag widens the renderer attack surface and has no safe opt-in.");
+            }
+        }
+    }
+
+    private static bool MatchesForbidden(string arg, string token, string forbidden) =>
+        forbidden.Contains('=', StringComparison.Ordinal)
+            ? string.Equals(arg, forbidden, StringComparison.OrdinalIgnoreCase)
+            : TokenMatches(token, forbidden);
+
+    private static string? FindContainerOptInOffender(IReadOnlyList<string>? extraArgs)
+    {
+        if (extraArgs is null)
+        {
+            return null;
+        }
+
+        foreach (string arg in extraArgs)
+        {
+            string token = ExtractToken(arg);
+            string? hit = RequiresContainerOptIn.FirstOrDefault(privileged => TokenMatches(token, privileged));
+            if (hit is not null)
+            {
+                return hit;
+            }
+        }
+
+        return null;
+    }
+
+    private static void EnforceContainerOptIn(string? offendingArg, IEnvironmentProbe probe, ILogger logger)
+    {
+        bool optedIn = string.Equals(probe.GetEnvironmentVariable(OptInEnvVar), "1", StringComparison.Ordinal);
+        bool inContainer = probe.IsRunningInContainer();
+        bool nonRoot = !probe.IsRunningAsRoot();
+        string flag = offendingArg ?? "DisableSandbox";
 
         if (optedIn && inContainer && nonRoot)
         {
             logger.LogWarning(
                 "Privileged browser flag '{Flag}' permitted: container={Container}, nonRoot={NonRoot}, optIn={OptIn}.",
-                offendingArg ?? "DisableSandbox",
+                flag,
                 inContainer,
                 nonRoot,
                 optedIn);
@@ -142,7 +164,7 @@ public static class PrivilegedFlagGuard
 
         throw new SandboxViolationException(
             SandboxViolationKind.PrivilegedFlagRefused,
-            $"Privileged browser flag '{offendingArg ?? "DisableSandbox"}' refused (container={inContainer}, nonRoot={nonRoot}, optIn={optedIn}). Set {OptInEnvVar}=1 in a non-root container to allow.");
+            $"Privileged browser flag '{flag}' refused (container={inContainer}, nonRoot={nonRoot}, optIn={optedIn}). Set {OptInEnvVar}=1 in a non-root container to allow.");
     }
 
     /// <summary>
@@ -186,84 +208,82 @@ public sealed class DefaultEnvironmentProbe : IEnvironmentProbe
 #pragma warning restore RS0030
 
     /// <inheritdoc/>
-    public bool IsRunningInContainer()
-    {
-        // 1. Docker marker file.
-        if (File.Exists("/.dockerenv"))
-        {
-            return true;
-        }
+    public bool IsRunningInContainer() =>
+        File.Exists("/.dockerenv")                       // 1. Docker marker file.
+        || File.Exists("/run/.containerenv")             // 2. Podman marker file.
+        || HasContainerEnvVar()                          // 3. systemd "container" env var.
+        || HasCgroupV1ContainerMarker()                  // 4. cgroup v1 (Docker / kubepods / containerd / Podman).
+        || HasCgroupV2NonInitPid1();                     // 5. cgroup v2 heuristic — PID 1 is neither init nor systemd.
 
-        // 2. Podman marker file.
-        if (File.Exists("/run/.containerenv"))
-        {
-            return true;
-        }
-
-        // 3. systemd convention — every container manager sets the "container" env var.
 #pragma warning disable RS0030 // Process-environment access is intrinsic to container detection at boot.
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("container")))
-        {
-            return true;
-        }
+    private static bool HasContainerEnvVar() =>
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("container"));
 #pragma warning restore RS0030
 
-        // 4. cgroup v1 markers (Docker, kubepods, containerd, Podman) in /proc/1/cgroup.
+    private static readonly string[] CgroupContainerMarkers =
+        ["docker", "kubepods", "containerd", "podman"];
+
+    private static bool HasCgroupV1ContainerMarker()
+    {
         try
         {
-            if (File.Exists("/proc/1/cgroup"))
+            if (!File.Exists("/proc/1/cgroup"))
             {
-                string cgroup = File.ReadAllText("/proc/1/cgroup");
-                if (cgroup.Contains("docker", StringComparison.OrdinalIgnoreCase)
-                    || cgroup.Contains("kubepods", StringComparison.OrdinalIgnoreCase)
-                    || cgroup.Contains("containerd", StringComparison.OrdinalIgnoreCase)
-                    || cgroup.Contains("podman", StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
+                return false;
             }
+
+            string cgroup = File.ReadAllText("/proc/1/cgroup");
+            return CgroupContainerMarkers.Any(m => cgroup.Contains(m, StringComparison.OrdinalIgnoreCase));
         }
         catch (IOException)
         {
-            // /proc/1/cgroup unreadable — treat as no container signal and fall through.
+            // /proc/1/cgroup unreadable — treat as no container signal.
+            return false;
         }
         catch (UnauthorizedAccessException)
         {
-            // /proc/1/cgroup denied — treat as no container signal and fall through.
+            // /proc/1/cgroup denied — treat as no container signal.
+            return false;
         }
+    }
 
-        // 5. cgroup v2 / hardened-namespace heuristic — when PID 1 is neither "init" nor
-        // "systemd" (typical bare-metal hosts), this process was started by a container
-        // runtime (Docker/Podman/k8s typically exec the app as PID 1).
+    /// <summary>
+    /// Heuristic: when PID 1 is neither <c>init</c> nor <c>systemd</c> (typical bare-metal hosts),
+    /// this process was started by a container runtime (Docker / Podman / k8s typically exec the
+    /// app as PID 1).
+    /// </summary>
+    private static bool HasCgroupV2NonInitPid1()
+    {
         try
         {
-            if (File.Exists("/proc/1/sched"))
+            if (!File.Exists("/proc/1/sched"))
             {
-                using var reader = new StreamReader("/proc/1/sched");
-                string? firstLine = reader.ReadLine();
-                if (!string.IsNullOrEmpty(firstLine))
-                {
-                    // Format: "<comm> (<pid>, #threads: <n>)" — extract comm token.
-                    int space = firstLine.IndexOf(' ');
-                    string comm = space < 0 ? firstLine : firstLine[..space];
-                    if (!string.Equals(comm, "init", StringComparison.Ordinal)
-                        && !string.Equals(comm, "systemd", StringComparison.Ordinal))
-                    {
-                        return true;
-                    }
-                }
+                return false;
             }
+
+            using var reader = new StreamReader("/proc/1/sched");
+            string? firstLine = reader.ReadLine();
+            if (string.IsNullOrEmpty(firstLine))
+            {
+                return false;
+            }
+
+            // Format: "<comm> (<pid>, #threads: <n>)" — extract comm token.
+            int space = firstLine.IndexOf(' ');
+            string comm = space < 0 ? firstLine : firstLine[..space];
+            return !string.Equals(comm, "init", StringComparison.Ordinal)
+                && !string.Equals(comm, "systemd", StringComparison.Ordinal);
         }
         catch (IOException)
         {
-            // /proc/1/sched unreadable — treat as no container signal and fall through.
+            // /proc/1/sched unreadable — treat as no container signal.
+            return false;
         }
         catch (UnauthorizedAccessException)
         {
-            // /proc/1/sched denied — treat as no container signal and fall through.
+            // /proc/1/sched denied — treat as no container signal.
+            return false;
         }
-
-        return false;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary

Three Sonar S3776 cognitive-complexity refactors in \`Granit.Browsing\`. Pure structural splits, no rule-set changes.

### \`PrivilegedFlagGuard.EnsureSafe\` (31 → ≤ 7 per branch)

Split into three orthogonal helpers:

| Helper | Responsibility |
|---|---|
| \`ThrowIfAlwaysForbidden\` | scan \`AlwaysForbidden\`; refuse unconditionally |
| \`FindContainerOptInOffender\` | return the first \`RequiresContainerOptIn\` match, or null |
| \`EnforceContainerOptIn\` | probe container/non-root/opt-in gating; warn-and-allow or throw |

Bonus: extracted the \`forbidden.Contains('=')\` ternary into a static \`MatchesForbidden\`.

### \`DefaultEnvironmentProbe.IsRunningInContainer\` (21 → 5)

Five sequential markers become five named helpers (\`HasContainerEnvVar\`, \`HasCgroupV1ContainerMarker\`, \`HasCgroupV2NonInitPid1\`) chained with \`||\` in the orchestrator. The two \`try { ... } catch (IOException) { } catch (UnauthorizedAccessException) { }\` blocks now sit each inside its own helper, so the orchestrator is a flat read.

Cgroup v1 marker list (\`docker\`, \`kubepods\`, \`containerd\`, \`podman\`) extracted to a static readonly array — matching is now \`Any(m => cgroup.Contains(m, ...))\` against that list.

### \`RequestRouter.EvaluateAsync\` (23 → ≤ 6 per branch)

| Helper | Responsibility |
|---|---|
| \`CheckSandboxRules\` (sync) | scheme allowlist, host allow/deny patterns, blocked URL patterns → returns metric reason or null |
| \`CheckPrivateNetworkBlockAsync\` | DNS re-resolution via \`IUrlSafetyValidator\` → returns violation kind or null |
| \`RunUserHandlersAsync\` | walks the COW handler snapshot, returns first terminal decision |
| \`InvokeHandlerAsync\` | one handler invocation + \`RouterErrorPolicy\` mapping; returns null to advance, decision to terminate |

The async \`BlockAsync(request, reason, ct)\` call now happens at exactly one place per layer (sandbox / private-network) instead of being inlined four times.

## Test plan

- [x] \`dotnet build src/Granit.Browsing\` — clean
- [x] \`dotnet test tests/Granit.Browsing.Tests\` — 97/97 passing
- [x] \`dotnet format src/Granit.Browsing --verify-no-changes\` — clean
- [ ] CI \`api-data\` shard passes