### PR TITLE
feat(workspaces): add IncludeWorkspacesMatching dynamic include

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -45076,6 +45076,15 @@
       "members": []
     },
     {
+      "name": "WorkspaceIncludeSpec",
+      "fqn": "Granit.Workspaces.WorkspaceIncludeSpec",
+      "kind": "record",
+      "project": "Granit.Workspaces.Abstractions",
+      "file": "src/Granit.Workspaces.Abstractions/WorkspaceSectionDescriptor.cs",
+      "line": 37,
+      "members": []
+    },
+    {
       "name": "WorkspaceItemBuilder",
       "fqn": "Granit.Workspaces.WorkspaceItemBuilder",
       "kind": "class",
@@ -45124,7 +45133,7 @@
       "kind": "record",
       "project": "Granit.Workspaces.Abstractions",
       "file": "src/Granit.Workspaces.Abstractions/WorkspaceSectionDescriptor.cs",
-      "line": 12,
+      "line": 20,
       "members": []
     }
   ]

--- a/src/Granit.Workspaces.Abstractions/WorkspaceSectionBuilder.cs
+++ b/src/Granit.Workspaces.Abstractions/WorkspaceSectionBuilder.cs
@@ -10,6 +10,7 @@ public sealed class WorkspaceSectionBuilder
     private int _order;
     private bool _collapsedByDefault;
     private readonly List<Func<WorkspaceItemDescriptor>> _itemFactories = [];
+    private WorkspaceIncludeSpec? _dynamicInclude;
 
     internal WorkspaceSectionBuilder(string key)
     {
@@ -113,6 +114,29 @@ public sealed class WorkspaceSectionBuilder
         return this;
     }
 
+    /// <summary>
+    /// Dynamically absorbs every registered workspace whose name satisfies
+    /// <paramref name="namePredicate"/> as a <see cref="WorkspaceItemKind.SubWorkspace"/>
+    /// item (per ADR-057 §3). The composer resolves the predicate at boot
+    /// against the workspace registry and synthesises one item per matching
+    /// workspace, lifting the target workspace's icon / display key / order —
+    /// no duplication between the including section and the included shell.
+    /// A workspace dropped as an empty shell produces no item; dangling
+    /// sub-workspace references are therefore impossible by construction.
+    /// </summary>
+    public WorkspaceSectionBuilder IncludeWorkspacesMatching(Predicate<string> namePredicate)
+    {
+        ArgumentNullException.ThrowIfNull(namePredicate);
+        if (_dynamicInclude is not null)
+        {
+            throw new InvalidOperationException(
+                $"Section '{_key}' already declared a dynamic include — only one " +
+                "IncludeWorkspacesMatching call per section is supported (per ADR-057 §3).");
+        }
+        _dynamicInclude = new WorkspaceIncludeSpec(namePredicate);
+        return this;
+    }
+
     internal WorkspaceSectionDescriptor Build()
     {
         IReadOnlyList<WorkspaceItemDescriptor> items =
@@ -123,6 +147,7 @@ public sealed class WorkspaceSectionBuilder
             _displayKey,
             _order,
             _collapsedByDefault,
-            items);
+            items,
+            _dynamicInclude);
     }
 }

--- a/src/Granit.Workspaces.Abstractions/WorkspaceSectionDescriptor.cs
+++ b/src/Granit.Workspaces.Abstractions/WorkspaceSectionDescriptor.cs
@@ -9,9 +9,29 @@ namespace Granit.Workspaces;
 /// <param name="Order">Display order within the workspace.</param>
 /// <param name="CollapsedByDefault">Whether the section starts collapsed.</param>
 /// <param name="Items">Items in declaration order.</param>
+/// <param name="DynamicInclude">
+/// Optional dynamic-inclusion spec (per ADR-057 §3) — when set, the composer
+/// synthesises one <see cref="WorkspaceItemKind.SubWorkspace"/> item per
+/// registered workspace whose name satisfies the spec's predicate, lifting
+/// the matched workspace's icon / display key / order. <see langword="null"/>
+/// after composition resolves the spec (the descriptor exposed at runtime
+/// never carries an unresolved spec).
+/// </param>
 public sealed record WorkspaceSectionDescriptor(
     string Key,
     string? DisplayKey,
     int Order,
     bool CollapsedByDefault,
-    IReadOnlyList<WorkspaceItemDescriptor> Items);
+    IReadOnlyList<WorkspaceItemDescriptor> Items,
+    WorkspaceIncludeSpec? DynamicInclude = null);
+
+/// <summary>
+/// Declarative spec used by
+/// <see cref="WorkspaceSectionBuilder.IncludeWorkspacesMatching(Predicate{string})"/>
+/// to ask the composer to absorb every registered workspace satisfying
+/// <see cref="NamePredicate"/> as a <see cref="WorkspaceItemKind.SubWorkspace"/>
+/// item (per ADR-057 §3). The matched workspaces contribute their own icon /
+/// display key / order — no duplication between the including section and the
+/// included shell.
+/// </summary>
+public sealed record WorkspaceIncludeSpec(Predicate<string> NamePredicate);


### PR DESCRIPTION
## Summary
- Adds `WorkspaceSectionBuilder.IncludeWorkspacesMatching(Predicate<string>)` and the matching `WorkspaceIncludeSpec` record on `WorkspaceSectionDescriptor` (ADR-057 §3).
- Aligns `Granit.Workspaces.Abstractions` with the divergent copy currently maintained in `granit-business`. Once this ships as a dev NuGet, that duplicated module will be removed and replaced with a `PackageReference` to this assembly.

## Why
`Granit.Workspaces.Abstractions` is the contract layer 22 framework `*.Endpoints` modules depend on to register `IFeatureProvider`s — it must stay in granit-dotnet. The runtime (`Granit.Workspaces`, `.Endpoints`, `.Framework`) moved to granit-business but the new `IncludeWorkspacesMatching` feature landed only in business's copy of `.Abstractions`, creating a publish-vs-source divergence.

## Test plan
- [x] `dotnet build src/Granit.Workspaces.Abstractions`
- [x] `dotnet format src/Granit.Workspaces.Abstractions --verify-no-changes`
- [ ] CI: full shard matrix
- [ ] Confirm dev NuGet publishes `Granit.Workspaces.Abstractions` with the new API before merging the granit-business follow-up