### PR TITLE
test(workspaces): port abstractions test coverage from granit-business

### DIFF
--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceBuilderTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceBuilderTests.cs
@@ -45,10 +45,8 @@ public sealed class WorkspaceBuilderTests
     }
 
     [Fact]
-    public void View_can_only_be_called_on_entity_items()
-    {
+    public void View_can_only_be_called_on_entity_items() =>
         Should.Throw<InvalidOperationException>(() => new InvalidViewOnLink().Descriptor);
-    }
 
     [Fact]
     public void Feature_item_carries_feature_name_and_optional_route_override()
@@ -64,10 +62,8 @@ public sealed class WorkspaceBuilderTests
     }
 
     [Fact]
-    public void RouteName_can_only_be_called_on_feature_items()
-    {
+    public void RouteName_can_only_be_called_on_feature_items() =>
         Should.Throw<InvalidOperationException>(() => new InvalidRouteNameOnLink().Descriptor);
-    }
 
     private sealed class SampleDefinition : WorkspaceDefinition
     {

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceDefinitionTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceDefinitionTests.cs
@@ -1,0 +1,88 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workspaces.Abstractions.Tests;
+
+public sealed class WorkspaceDefinitionTests
+{
+    [Fact]
+    public void Descriptor_is_built_once_and_cached()
+    {
+        CountingDefinition def = new();
+
+        WorkspaceDescriptor first = def.Descriptor;
+        WorkspaceDescriptor second = def.Descriptor;
+
+        ReferenceEquals(first, second).ShouldBeTrue();
+        def.ConfigureCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Descriptor_exposes_the_name_set_by_the_subclass()
+    {
+        CountingDefinition def = new();
+        def.Descriptor.Name.ShouldBe(def.Name);
+    }
+
+    [Fact]
+    public void Builder_DisplayKey_blank_throws() =>
+        Should.Throw<ArgumentException>(() => new BlankDisplayKey().Descriptor);
+
+    [Fact]
+    public void Builder_Icon_blank_throws() =>
+        Should.Throw<ArgumentException>(() => new BlankIcon().Descriptor);
+
+    [Fact]
+    public void Builder_RequiresPermission_blank_throws() =>
+        Should.Throw<ArgumentException>(() => new BlankPermission().Descriptor);
+
+    [Fact]
+    public void Defaults_are_null_or_zero_when_unset()
+    {
+        BareDefinition def = new();
+        WorkspaceDescriptor d = def.Descriptor;
+
+        d.DisplayKey.ShouldBeNull();
+        d.Icon.ShouldBeNull();
+        d.Order.ShouldBe(0);
+        d.RequiresPermission.ShouldBeNull();
+        d.IsShell.ShouldBeFalse();
+        d.Sections.ShouldBeEmpty();
+    }
+
+    private sealed class CountingDefinition : WorkspaceDefinition
+    {
+        public int ConfigureCallCount { get; private set; }
+        public override string Name => "Counted";
+
+        protected override void Configure(WorkspaceBuilder b)
+        {
+            ConfigureCallCount++;
+            b.Order(3);
+        }
+    }
+
+    private sealed class BareDefinition : WorkspaceDefinition
+    {
+        public override string Name => "Bare";
+        protected override void Configure(WorkspaceBuilder b) { }
+    }
+
+    private sealed class BlankDisplayKey : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) => b.DisplayKey("  ");
+    }
+
+    private sealed class BlankIcon : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) => b.Icon(" ");
+    }
+
+    private sealed class BlankPermission : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) => b.RequiresPermission("");
+    }
+}

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceItemBuilderTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceItemBuilderTests.cs
@@ -1,0 +1,163 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workspaces.Abstractions.Tests;
+
+public sealed class WorkspaceItemBuilderTests
+{
+    [Fact]
+    public void Entity_item_carries_metadata_view_and_preset_overlay()
+    {
+        EntityItemDefinition def = new();
+        WorkspaceItemDescriptor item = def.Descriptor.Sections[0].Items.Single();
+
+        item.Kind.ShouldBe(WorkspaceItemKind.Entity);
+        item.EntityName.ShouldBe("Mod.Customer");
+        item.EntityViewName.ShouldBe("open");
+        item.DisplayKey.ShouldBe("Customer:Label");
+        item.Icon.ShouldBe("user");
+        item.Order.ShouldBe(5);
+        item.RequiresPermission.ShouldBe("Mod.Customers.Read");
+        item.EntityPresetOverlay.ShouldNotBeNull();
+        item.EntityPresetOverlay!["status"].ShouldBe("active");
+    }
+
+    [Fact]
+    public void Typed_entity_uses_type_full_name_as_wire_id()
+    {
+        TypedEntityDefinition def = new();
+        WorkspaceItemDescriptor item = def.Descriptor.Sections[0].Items.Single();
+
+        item.EntityName.ShouldBe(typeof(SampleEntityMarker).FullName);
+    }
+
+    [Fact]
+    public void Dashboard_item_keeps_dashboard_name()
+    {
+        DashboardItemDefinition def = new();
+        WorkspaceItemDescriptor item = def.Descriptor.Sections[0].Items.Single();
+
+        item.Kind.ShouldBe(WorkspaceItemKind.Dashboard);
+        item.DashboardName.ShouldBe("Mod.SalesDashboard");
+        item.EntityName.ShouldBeNull();
+        item.LinkUrl.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Link_item_keeps_link_url()
+    {
+        LinkItemDefinition def = new();
+        WorkspaceItemDescriptor item = def.Descriptor.Sections[0].Items.Single();
+
+        item.Kind.ShouldBe(WorkspaceItemKind.Link);
+        item.LinkUrl.ShouldBe("https://example.test");
+    }
+
+    [Fact]
+    public void SubWorkspace_item_keeps_sub_workspace_name()
+    {
+        SubWorkspaceItemDefinition def = new();
+        WorkspaceItemDescriptor item = def.Descriptor.Sections[0].Items.Single();
+
+        item.Kind.ShouldBe(WorkspaceItemKind.SubWorkspace);
+        item.SubWorkspaceName.ShouldBe("Mod.Child");
+    }
+
+    [Fact]
+    public void Preset_cannot_be_called_on_link() =>
+        Should.Throw<InvalidOperationException>(() => new InvalidPresetOnLink().Descriptor);
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void DisplayKey_rejects_blank(string value) =>
+        Should.Throw<ArgumentException>(() => new BlankDisplayKey(value).Descriptor);
+
+    [Fact]
+    public void Items_are_ordered_by_order_value()
+    {
+        OrderingDefinition def = new();
+        IReadOnlyList<WorkspaceItemDescriptor> items = def.Descriptor.Sections[0].Items;
+
+        items.Select(i => i.Order).ShouldBe([1, 5, 10]);
+    }
+
+    [Fact]
+    public void Preset_throws_when_dictionary_is_null() =>
+        Should.Throw<ArgumentNullException>(() => new NullPresetDefinition().Descriptor);
+
+    private sealed class SampleEntityMarker;
+
+    private sealed class EntityItemDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Entity("Mod.Customer", i => i
+                .View("open")
+                .DisplayKey("Customer:Label")
+                .Icon("user")
+                .Order(5)
+                .RequiresPermission("Mod.Customers.Read")
+                .Preset(new Dictionary<string, object?> { ["status"] = "active" })));
+    }
+
+    private sealed class TypedEntityDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Entity<SampleEntityMarker>());
+    }
+
+    private sealed class DashboardItemDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Dashboard("Mod.SalesDashboard"));
+    }
+
+    private sealed class LinkItemDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Link("https://example.test"));
+    }
+
+    private sealed class SubWorkspaceItemDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.SubWorkspace("Mod.Child"));
+    }
+
+    private sealed class InvalidPresetOnLink : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Link("/x", i =>
+                i.Preset(new Dictionary<string, object?> { ["k"] = 1 })));
+    }
+
+    private sealed class BlankDisplayKey(string key) : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Entity("E", i => i.DisplayKey(key)));
+    }
+
+    private sealed class OrderingDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s
+                .Entity("A", i => i.Order(10))
+                .Entity("B", i => i.Order(1))
+                .Entity("C", i => i.Order(5)));
+    }
+
+    private sealed class NullPresetDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Entity("E", i => i.Preset(null!)));
+    }
+}

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceSectionBuilderTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceSectionBuilderTests.cs
@@ -1,0 +1,91 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workspaces.Abstractions.Tests;
+
+public sealed class WorkspaceSectionBuilderTests
+{
+    [Fact]
+    public void Section_stores_display_key_order_and_collapsed_flag()
+    {
+        ConfiguredSectionDefinition def = new();
+        WorkspaceSectionDescriptor section = def.Descriptor.Sections.Single();
+
+        section.Key.ShouldBe("reports");
+        section.DisplayKey.ShouldBe("Section:Reports");
+        section.Order.ShouldBe(7);
+        section.CollapsedByDefault.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CollapsedByDefault_default_overload_collapses()
+    {
+        DefaultCollapsedDefinition def = new();
+        def.Descriptor.Sections.Single().CollapsedByDefault.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Empty_section_has_empty_items()
+    {
+        EmptySectionDefinition def = new();
+        def.Descriptor.Sections.Single().Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Section_key_rejects_blank(string key) =>
+        Should.Throw<ArgumentException>(() => new BlankSectionKey(key).Descriptor);
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Entity_name_rejects_blank(string name) =>
+        Should.Throw<ArgumentException>(() => new BlankEntityName(name).Descriptor);
+
+    [Fact]
+    public void Section_throws_when_configure_is_null() =>
+        Should.Throw<ArgumentNullException>(() => new NullConfigureDefinition().Descriptor);
+
+    private sealed class ConfiguredSectionDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("reports", s => s
+                .DisplayKey("Section:Reports")
+                .Order(7)
+                .CollapsedByDefault(true));
+    }
+
+    private sealed class DefaultCollapsedDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.CollapsedByDefault());
+    }
+
+    private sealed class EmptySectionDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) => b.Section("s", _ => { });
+    }
+
+    private sealed class BlankSectionKey(string key) : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) => b.Section(key, _ => { });
+    }
+
+    private sealed class BlankEntityName(string n) : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Entity(n));
+    }
+
+    private sealed class NullConfigureDefinition : WorkspaceDefinition
+    {
+        public override string Name => "X";
+        protected override void Configure(WorkspaceBuilder b) => b.Section("s", null!);
+    }
+}

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceServiceCollectionExtensionsTests.cs
@@ -1,0 +1,59 @@
+using Granit.Workspaces.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workspaces.Abstractions.Tests;
+
+public sealed class WorkspaceServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddWorkspaceDefinition_registers_concrete_base_and_descriptor()
+    {
+        ServiceCollection services = new();
+        services.AddWorkspaceDefinition<DummyWorkspace>();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DummyWorkspace concrete = sp.GetRequiredService<DummyWorkspace>();
+        WorkspaceDefinition asBase = sp.GetRequiredService<WorkspaceDefinition>();
+        IWorkspaceDescriptor asDescriptor = sp.GetRequiredService<IWorkspaceDescriptor>();
+
+        ReferenceEquals(concrete, asBase).ShouldBeTrue();
+        ReferenceEquals(concrete, asDescriptor).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddWorkspaceDefinition_throws_when_services_null() =>
+        Should.Throw<ArgumentNullException>(() =>
+            WorkspaceServiceCollectionExtensions.AddWorkspaceDefinition<DummyWorkspace>(null!));
+
+    [Fact]
+    public void AddFeatureProvider_registers_as_singleton()
+    {
+        ServiceCollection services = new();
+        services.AddFeatureProvider<DummyFeatureProvider>();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        IFeatureProvider a = sp.GetRequiredService<IFeatureProvider>();
+        IFeatureProvider b = sp.GetRequiredService<IFeatureProvider>();
+
+        ReferenceEquals(a, b).ShouldBeTrue();
+        a.ShouldBeOfType<DummyFeatureProvider>();
+    }
+
+    [Fact]
+    public void AddFeatureProvider_throws_when_services_null() =>
+        Should.Throw<ArgumentNullException>(() =>
+            WorkspaceServiceCollectionExtensions.AddFeatureProvider<DummyFeatureProvider>(null!));
+
+    private sealed class DummyWorkspace : WorkspaceDefinition
+    {
+        public override string Name => "Dummy";
+        protected override void Configure(WorkspaceBuilder b) { }
+    }
+
+    private sealed class DummyFeatureProvider : IFeatureProvider
+    {
+        public void DefineFeatures(IFeatureCatalogBuilder catalog) { }
+    }
+}


### PR DESCRIPTION
## Summary
- Ports 4 missing test files + style alignment of `WorkspaceBuilderTests` from granit-business's local copy of `Granit.Workspaces.Abstractions.Tests` to the canonical project here.
- Follow-up to #2124 — granit-business kept richer test coverage on the duplicated `.Abstractions` than we had here. Now that the API lives canonically in this repo, the tests do too.

## Why
granit-business's `Granit.Workspaces.Abstractions.Tests` (5 files, 579 LoC) will be removed in the follow-up cleanup PR. Porting first preserves coverage end-to-end.

## Test plan
- [x] `dotnet build tests/Granit.Workspaces.Abstractions.Tests`
- [x] `dotnet test tests/Granit.Workspaces.Abstractions.Tests --no-build` → **38 passing**
- [x] `dotnet format tests/Granit.Workspaces.Abstractions.Tests --verify-no-changes`
- [ ] CI: architecture + relevant shard