### PR TITLE
chore(diagnostics): localize Workspace.Item label across 18 cultures

### DIFF
--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/cs.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/cs.json
@@ -1,7 +1,7 @@
 {
   "culture": "cs",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Stav služeb",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Zobrazit panel monitorování stavu systému",
     "PermissionGroup:Diagnostics": "Diagnostika"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/de.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/de.json
@@ -1,7 +1,7 @@
 {
   "culture": "de",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Servicezustand",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Systemzustands-Dashboard anzeigen",
     "PermissionGroup:Diagnostics": "Diagnose"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en-GB.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Service health",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en.json
@@ -1,7 +1,7 @@
 {
   "culture": "en",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Service health",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "View system health monitoring dashboard",
     "PermissionGroup:Diagnostics": "Diagnostics"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/es.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/es.json
@@ -1,7 +1,7 @@
 {
   "culture": "es",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Estado de los servicios",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Ver panel de monitorización del sistema",
     "PermissionGroup:Diagnostics": "Diagnósticos"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr-CA.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Surveillance santé",
+    "DiagnosticsEndpoints:Workspace.Item": "Santé des services",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Surveillance santé",
+    "DiagnosticsEndpoints:Workspace.Item": "Santé des services",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Consulter le tableau de bord de surveillance",
     "PermissionGroup:Diagnostics": "Diagnostics"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/hi.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/hi.json
@@ -1,7 +1,7 @@
 {
   "culture": "hi",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "सेवा स्वास्थ्य",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "सिस्टम स्वास्थ्य मॉनिटरिंग डैशबोर्ड देखें",
     "PermissionGroup:Diagnostics": "डायग्नोस्टिक्स"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/it.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/it.json
@@ -1,7 +1,7 @@
 {
   "culture": "it",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Stato dei servizi",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Visualizzare la dashboard di monitoraggio del sistema",
     "PermissionGroup:Diagnostics": "Diagnostica"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ja.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ja.json
@@ -1,7 +1,7 @@
 {
   "culture": "ja",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "サービスの稼働状況",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "システムヘルスモニタリングダッシュボードを表示",
     "PermissionGroup:Diagnostics": "診断"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ko.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ko.json
@@ -1,7 +1,7 @@
 {
   "culture": "ko",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "서비스 상태",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "시스템 상태 모니터링 대시보드 보기",
     "PermissionGroup:Diagnostics": "진단"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/nl.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/nl.json
@@ -1,7 +1,7 @@
 {
   "culture": "nl",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Servicegezondheid",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Systeemgezondheidsmonitoring bekijken",
     "PermissionGroup:Diagnostics": "Diagnostiek"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pl.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pl.json
@@ -1,7 +1,7 @@
 {
   "culture": "pl",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Stan usług",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Przeglądanie panelu monitorowania systemu",
     "PermissionGroup:Diagnostics": "Diagnostyka"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt-BR.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Saúde dos serviços",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Estado dos serviços",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Ver painel de monitorização do sistema",
     "PermissionGroup:Diagnostics": "Diagnósticos"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/sv.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/sv.json
@@ -1,7 +1,7 @@
 {
   "culture": "sv",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Tjänsternas hälsa",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Visa systemhälsoövervakningens instrumentpanel",
     "PermissionGroup:Diagnostics": "Diagnostik"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/tr.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/tr.json
@@ -1,7 +1,7 @@
 {
   "culture": "tr",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "Hizmet durumu",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "Sistem sağlık izleme panosunu görüntüle",
     "PermissionGroup:Diagnostics": "Tanılama"

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/zh.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/zh.json
@@ -1,7 +1,7 @@
 {
   "culture": "zh",
   "texts": {
-    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Item": "服务健康状况",
     "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
     "Permission:Diagnostics.Monitoring.Read": "查看系统健康监控仪表板",
     "PermissionGroup:Diagnostics": "诊断"


### PR DESCRIPTION
## Summary
- Replaces the English fallback `"Health monitoring"` for `DiagnosticsEndpoints:Workspace.Item` with proper localized strings in cs, de, en-GB, en, es, fr-CA, fr, hi, it, ja, ko, nl, pl, pt-BR, pt, sv, tr, zh.
- Recovered from a stash left behind on the (now-deleted) `fix/auditing-application-service-provider` branch — the translation work never landed.

## Test plan
- [ ] CI green (localization archi tests cover key parity)
- [ ] Spot-check labels render in the diagnostics workspace menu in fr / en / de