### PR TITLE
chore(sonar): apply expression-body + collection-init suggestions

### DIFF
--- a/src/Granit.DataLookup.Endpoints/GranitDataLookupEndpointsModule.cs
+++ b/src/Granit.DataLookup.Endpoints/GranitDataLookupEndpointsModule.cs
@@ -25,7 +25,5 @@ public sealed class GranitDataLookupEndpointsModule : GranitModule
 {
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context)
-    {
-        context.Services.AddLocalizationResource<DataLookupEndpointsLocalizationResource>();
-    }
+        => context.Services.AddLocalizationResource<DataLookupEndpointsLocalizationResource>();
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -195,7 +195,7 @@ public static class PersistenceTenantExtensions
         services.TryAddSingleton<ITenantIsolationStrategyProvider,
             ConfigurationTenantIsolationStrategyProvider>();
 
-        HashSet<TenantIsolationStrategy> registeredStrategies = new();
+        HashSet<TenantIsolationStrategy> registeredStrategies = [];
 
         // SharedDatabase — always registered; the default fallback strategy.
         SharedDatabaseDbContextOptions<TContext> sharedOpts = new()

--- a/src/Granit.Validation/JsonSchema/JsonSchemaWriter.cs
+++ b/src/Granit.Validation/JsonSchema/JsonSchemaWriter.cs
@@ -36,14 +36,14 @@ internal sealed class JsonSchemaWriter(IServiceScopeFactory scopeFactory) : IJso
 
         IValidatorDescriptor descriptor = validator.CreateDescriptor();
 
-        JsonObject schema = new();
-        JsonObject properties = new();
+        JsonObject schema = [];
+        JsonObject properties = [];
         JsonArray? required = null;
 
         foreach (System.Reflection.PropertyInfo prop in type.GetProperties())
         {
             string camelName = ToCamelCase(prop.Name);
-            JsonObject propertySchema = new();
+            JsonObject propertySchema = [];
             string? patternHint = null;
 
             foreach ((IPropertyValidator propertyValidator, IRuleComponent component)

--- a/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyHasherTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyHasherTests.cs
@@ -81,7 +81,5 @@ public sealed class ApiKeyHasherTests
 
     [Fact]
     public void ComputeCurrentHash_ThrowsOnEmptyInput()
-    {
-        Should.Throw<ArgumentException>(() => Create().ComputeCurrentHash(string.Empty));
-    }
+        => Should.Throw<ArgumentException>(() => Create().ComputeCurrentHash(string.Empty));
 }

--- a/tests/Granit.Authorization.Tests/Caching/PermissionsCacheKeyHashTests.cs
+++ b/tests/Granit.Authorization.Tests/Caching/PermissionsCacheKeyHashTests.cs
@@ -20,9 +20,7 @@ public sealed class PermissionsCacheKeyHashTests
 
     [Fact]
     public void Compute_NullUser_Throws()
-    {
-        Should.Throw<ArgumentNullException>(() => PermissionsCacheKeyHash.Compute(null!));
-    }
+        => Should.Throw<ArgumentNullException>(() => PermissionsCacheKeyHash.Compute(null!));
 
     [Fact]
     public void Compute_ShapeIs16LowercaseHexChars()

--- a/tests/Granit.Browsing.Playwright.Tests/PlaywrightExecutablePathValidatorTests.cs
+++ b/tests/Granit.Browsing.Playwright.Tests/PlaywrightExecutablePathValidatorTests.cs
@@ -11,9 +11,7 @@ public sealed class PlaywrightExecutablePathValidatorTests
 {
     [Fact]
     public void Null_executable_returns_null()
-    {
-        PlaywrightExecutablePathValidator.Validate(null, "/usr/lib/chromium/").ShouldBeNull();
-    }
+        => PlaywrightExecutablePathValidator.Validate(null, "/usr/lib/chromium/").ShouldBeNull();
 
     [Fact]
     public void Null_prefix_returns_resolved_path()

--- a/tests/Granit.Browsing.Playwright.Tests/PlaywrightScopeValidationTests.cs
+++ b/tests/Granit.Browsing.Playwright.Tests/PlaywrightScopeValidationTests.cs
@@ -28,7 +28,7 @@ public sealed class PlaywrightScopeValidationTests
         // and previously captured the scoped ILocalEventBus directly — failing
         // ValidateScopes (default in Development). The fix routes events through a
         // singleton-safe wrapper backed by IServiceScopeFactory.
-        ServiceCollection services = new();
+        ServiceCollection services = [];
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddLogging();
         services.AddMetrics();

--- a/tests/Granit.Browsing.PuppeteerSharp.Tests/PuppeteerExecutablePathValidatorTests.cs
+++ b/tests/Granit.Browsing.PuppeteerSharp.Tests/PuppeteerExecutablePathValidatorTests.cs
@@ -11,9 +11,7 @@ public sealed class PuppeteerExecutablePathValidatorTests
 {
     [Fact]
     public void Null_executable_returns_null()
-    {
-        PuppeteerExecutablePathValidator.Validate(null, "/usr/lib/chromium/").ShouldBeNull();
-    }
+        => PuppeteerExecutablePathValidator.Validate(null, "/usr/lib/chromium/").ShouldBeNull();
 
     [Fact]
     public void Null_prefix_returns_resolved_path()

--- a/tests/Granit.Caching.Tests.Integration/ModuleInitializer.cs
+++ b/tests/Granit.Caching.Tests.Integration/ModuleInitializer.cs
@@ -19,7 +19,5 @@ internal static class ModuleInitializer
 {
     [ModuleInitializer]
     public static void Initialize()
-    {
-        AppContext.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", Timeout.InfiniteTimeSpan);
-    }
+        => AppContext.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", Timeout.InfiniteTimeSpan);
 }

--- a/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
@@ -139,15 +139,11 @@ public sealed class ODataEdmModelBuilderTests
 
     [Fact]
     public void Build_EmptyDescriptorList_Throws()
-    {
-        Should.Throw<ArgumentException>(() => ODataEdmModelBuilder.Build([], Whitelist(typeof(Invoice))));
-    }
+        => Should.Throw<ArgumentException>(() => ODataEdmModelBuilder.Build([], Whitelist(typeof(Invoice))));
 
     [Fact]
     public void Build_NullDescriptors_Throws()
-    {
-        Should.Throw<ArgumentNullException>(() => ODataEdmModelBuilder.Build(null!, Whitelist(typeof(Invoice))));
-    }
+        => Should.Throw<ArgumentNullException>(() => ODataEdmModelBuilder.Build(null!, Whitelist(typeof(Invoice))));
 
     [Fact]
     public void Build_DefaultContainerName_IsTenantContainer()

--- a/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
+++ b/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
@@ -344,9 +344,7 @@ public sealed class EfMergeServiceTests
         public new Guid Id { get; init; } = id;
 
         public IReadOnlyList<FieldConflict> GetConflicts(FakeAggregate loser)
-        {
-            return [new FieldConflict("Name", Name, loser.Name, WinnerSide.Survivor)];
-        }
+            => [new FieldConflict("Name", Name, loser.Name, WinnerSide.Survivor)];
 
         public void MergeFrom(FakeAggregate loser, MergeFieldChoices choices)
         {
@@ -401,9 +399,7 @@ public sealed class EfMergeServiceTests
             MergeRequest request,
             IReadOnlyDictionary<string, int> rewriteCounts,
             DateTimeOffset mergedAt)
-        {
-            RaiseMergedEventsCalls++;
-        }
+            => RaiseMergedEventsCalls++;
     }
 
     private sealed class TenantedAggregate(Guid id, string name, Guid? tenantId) : AggregateRoot, IMergeable<TenantedAggregate>, IMultiTenant

--- a/tests/Granit.Testing.EntityFrameworkCore.Tests/Extensions/DbContextOptionsBuilderTestExtensionsTests.cs
+++ b/tests/Granit.Testing.EntityFrameworkCore.Tests/Extensions/DbContextOptionsBuilderTestExtensionsTests.cs
@@ -39,9 +39,7 @@ public sealed class DbContextOptionsBuilderTestExtensionsTests : IAsyncLifetime
     }
 
     public async ValueTask DisposeAsync()
-    {
-        await _connection.DisposeAsync();
-    }
+        => await _connection.DisposeAsync();
 
     /// <summary>
     /// Two DbContexts built in the same test, with two different tenant mocks. Without

--- a/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
+++ b/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
@@ -229,11 +229,9 @@ public sealed class JsonSchemaWriterTests
 
     [Fact]
     public void JsonSchemaWriter_Implements_IJsonSchemaWriter()
-    {
         // Sanity check — Granit.Entities and other consumers depend on the
         // interface, not the concrete implementation.
-        typeof(IJsonSchemaWriter).IsAssignableFrom(typeof(JsonSchemaWriter)).ShouldBeTrue();
-    }
+        => typeof(IJsonSchemaWriter).IsAssignableFrom(typeof(JsonSchemaWriter)).ShouldBeTrue();
 
     // -------------------------------------------------------------------------
     // Helpers


### PR DESCRIPTION
## Summary
- Address 13 Sonar Code Smells (IDE0022 / IDE0028 / IDE0300) across `src` and tests — pure style, no behavior change.
- Skipped 6 `foreach`→`Where`/`Select` suggestions: they target side-effecting loops with `throw` (LookupRegistry, EntityDefinitionBuilder, WorkspaceBuilder, ReactionEndpoints, JsonSchemaWriter, RoutePattern). LINQ rewrites would obscure control flow.
- Also deferred: `IReferenceRewriter.cs` (unused `TAggregate` — breaking change to assess), `ODataExposureEndpointRouteBuilderExtensions.cs:186` (accessibility bypass — needs justification), `TenantIsolationTests.cs:191` (skipped test — needs root-cause investigation).

## Test plan
- [x] `dotnet build` on all 12 affected projects — clean, 0 warnings
- [ ] CI shards green