### PR TITLE
fix(persistence): parameterise multi-tenant filter via GranitDbContext (pilot)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -31936,6 +31936,22 @@
       "members": []
     },
     {
+      "name": "GranitDbContext",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.GranitDbContext",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs",
+      "line": 45,
+      "members": [
+        {
+          "name": "IsMultiTenantFilterEnabled",
+          "kind": "property",
+          "signature": "bool IsMultiTenantFilterEnabled",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
       "name": "GranitDbDefaults",
       "fqn": "Granit.Persistence.EntityFrameworkCore.GranitDbDefaults",
       "kind": "class",

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -1,0 +1,145 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Granit.Persistence.EntityFrameworkCore;
+
+/// <summary>
+/// Base class for every Granit DbContext that owns at least one <see cref="IMultiTenant"/>
+/// entity. Centralises the dynamic multi-tenant query filter so that EF Core can parameterise
+/// the current tenant value into the SQL.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this class exists.</b> EF Core only parameterises query filter values that are read
+/// from a member of the DbContext instance. Values captured from any other source —
+/// <see cref="Expression.Constant(object?)"/>, a closure-captured local, a property of a
+/// constructor-injected service — are <i>inlined as literals</i> into the compiled SQL and
+/// frozen for the lifetime of the cached model. The result is a cross-request data leak
+/// (request A pins <c>WHERE TenantId = 'A'</c>, request B reuses the frozen plan and reads
+/// A's rows). See the empirical repro in
+/// <c>tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenantFilterParameterizationReproTests.cs</c>.
+/// </para>
+/// <para>
+/// <b>How it works.</b> <see cref="CurrentTenantId"/> and <see cref="IsMultiTenantFilterEnabled"/>
+/// are instance properties on this DbContext. The filter expression registered by
+/// <see cref="ConfigureMultiTenantFilter{TEntity}"/> reads them via the closed-over <c>this</c>
+/// reference, which EF Core's relational query translator recognises and emits as a query
+/// parameter (<c>@ef_filter__CurrentTenantId</c>) re-bound on every command.
+/// </para>
+/// <para>
+/// <b>Compatibility.</b> The non-tenant filters (soft-delete, active, processing restriction,
+/// publishable, merge tombstone) are still wired by
+/// <see cref="ModelBuilderExtensions.ApplyGranitConventions"/> — those bypass values depend
+/// on per-DbContext singletons and are unaffected by the per-request constant-folding issue.
+/// Derived contexts should call <c>modelBuilder.ApplyGranitConventions(currentTenant: null, dataFilter)</c>
+/// from their <see cref="OnGranitModelCreating"/> override (or let the default
+/// <see cref="OnModelCreating"/> here do it).
+/// </para>
+/// </remarks>
+public abstract class GranitDbContext : DbContext
+{
+    private static readonly MethodInfo ConfigureMultiTenantFilterMethod =
+        typeof(GranitDbContext).GetMethod(
+            nameof(ConfigureMultiTenantFilter),
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// The tenant context for this scope, captured at construction time.
+    /// </summary>
+    protected ICurrentTenant CurrentTenant { get; }
+
+    /// <summary>
+    /// Optional data filter used for service-level bypass of named filters.
+    /// </summary>
+    protected IDataFilter? DataFilter { get; }
+
+    /// <summary>
+    /// Current tenant identifier. Referenced verbatim inside the
+    /// <see cref="IMultiTenant"/> filter expression — this is the SOLE source of the
+    /// parameterised SQL value, so the property must remain a member of this DbContext.
+    /// </summary>
+    public virtual Guid? CurrentTenantId => CurrentTenant.IsAvailable ? CurrentTenant.Id : null;
+
+    /// <summary>
+    /// <c>true</c> when the <see cref="IMultiTenant"/> filter is active. Toggled via
+    /// <see cref="IDataFilter.Disable{TFilter}"/> / <see cref="IDataFilter.Enable{TFilter}"/>.
+    /// </summary>
+    public virtual bool IsMultiTenantFilterEnabled
+        => DataFilter?.IsEnabled<IMultiTenant>() ?? true;
+
+    /// <summary>
+    /// Builds a <see cref="GranitDbContext"/>. Derived classes forward their DI-injected
+    /// services to this constructor.
+    /// </summary>
+    protected GranitDbContext(
+        DbContextOptions options,
+        ICurrentTenant currentTenant,
+        IDataFilter? dataFilter = null)
+        : base(options)
+    {
+        ArgumentNullException.ThrowIfNull(currentTenant);
+        CurrentTenant = currentTenant;
+        DataFilter = dataFilter;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Sealed to enforce ordering: non-tenant conventions first (via
+    /// <see cref="ModelBuilderExtensions.ApplyGranitConventions"/>), then the parameterised
+    /// multi-tenant filter, then derived-class customisation via
+    /// <see cref="OnGranitModelCreating"/>. Derived classes override the latter — not this.
+    /// </remarks>
+    protected sealed override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Non-tenant filters (soft-delete, active, etc.). Tenant is passed as null —
+        // ApplyGranitConventions skips its IMultiTenant block in that mode, leaving the
+        // filter to this class.
+        modelBuilder.ApplyGranitConventions(currentTenant: null, DataFilter);
+
+        OnGranitModelCreating(modelBuilder);
+
+        // Register the parameterised IMultiTenant filter AFTER user model configuration so
+        // every entity type is discoverable.
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes()
+            .Where(et => typeof(IMultiTenant).IsAssignableFrom(et.ClrType)))
+        {
+            ConfigureMultiTenantFilterMethod
+                .MakeGenericMethod(entityType.ClrType)
+                .Invoke(this, [modelBuilder]);
+        }
+    }
+
+    /// <summary>
+    /// Override point for derived classes. Configure your own <see cref="ModelBuilder"/>
+    /// here (entity configurations, indexes, seed data) — the base class handles all Granit
+    /// conventions on either side.
+    /// </summary>
+    protected virtual void OnGranitModelCreating(ModelBuilder modelBuilder)
+    {
+        // No-op by default.
+    }
+
+    /// <summary>
+    /// Registers the parameterised <see cref="IMultiTenant"/> filter for
+    /// <typeparamref name="TEntity"/>. Called via reflection from
+    /// <see cref="OnModelCreating"/> so the lambda's <c>this</c> reference is bound to the
+    /// current DbContext instance — EF Core relies on this to parameterise
+    /// <see cref="CurrentTenantId"/>.
+    /// </summary>
+    private void ConfigureMultiTenantFilter<TEntity>(ModelBuilder modelBuilder)
+        where TEntity : class
+    {
+        Expression<Func<TEntity, bool>> filter = e =>
+            !IsMultiTenantFilterEnabled
+            || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId;
+
+        modelBuilder.Entity<TEntity>()
+            .HasQueryFilter(GranitFilterNames.MultiTenant, filter);
+    }
+}

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplatingDbContext.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplatingDbContext.cs
@@ -1,6 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Extensions;
 using Granit.Workflow.Domain;
@@ -15,19 +15,17 @@ namespace Granit.Templating.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class TemplatingDbContext(
     DbContextOptions<TemplatingDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options), IWorkflowDbContext
+    : GranitDbContext(options, currentTenant, dataFilter), IWorkflowDbContext
 {
     public DbSet<TemplateRevisionEntity> TemplateRevisions { get; set; } = null!;
     public DbSet<TemplateCategoryEntity> TemplateCategories { get; set; } = null!;
     public DbSet<WorkflowTransitionRecord> WorkflowTransitionRecords => Set<WorkflowTransitionRecord>();
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureWorkflowModule();
         modelBuilder.ConfigureTemplatingModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/ClassDesignRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/ClassDesignRules.cs
@@ -14,15 +14,18 @@ namespace Granit.ArchitectureTests.Abstractions.Rules;
 public static class ClassDesignRules
 {
     /// <summary>
-    /// All DbContext subclasses must be sealed (isolated DbContext pattern).
+    /// Concrete DbContext subclasses must be sealed (isolated DbContext pattern).
+    /// Abstract base classes (e.g. <c>GranitDbContext</c>) are exempt — they exist
+    /// precisely to be inherited.
     /// </summary>
     public static void DbContextClassesShouldBeSealed(ArchUnitNET.Domain.Architecture architecture)
     {
         IArchRule rule = Classes()
             .That().AreAssignableTo(typeof(DbContext))
             .And().AreNot(typeof(DbContext))
+            .And().AreNotAbstract()
             .Should().BeSealed()
-            .Because("isolated DbContext pattern requires sealed DbContexts");
+            .Because("isolated DbContext pattern requires sealed concrete DbContexts (abstract base classes are exempt)");
 
         rule.Check(architecture);
     }

--- a/tests/Granit.ArchitectureTests/FileOrganizationTests.cs
+++ b/tests/Granit.ArchitectureTests/FileOrganizationTests.cs
@@ -531,7 +531,8 @@ public sealed partial class FileOrganizationTests
     /// <summary>
     /// In <c>*.EntityFrameworkCore</c> packages, <c>DbContext</c> classes must reside
     /// in an <c>Internal/</c> subfolder (they are implementation details).
-    /// <c>I*DbContext</c> interfaces (host contracts) are exempt.
+    /// <c>I*DbContext</c> interfaces (host contracts) and <c>GranitDbContext</c>
+    /// (public base class for multi-tenant aware contexts) are exempt.
     /// </summary>
     [Fact]
     public void DbContext_classes_should_reside_in_Internal_folder()
@@ -542,9 +543,13 @@ public sealed partial class FileOrganizationTests
         {
             string fileName = Path.GetFileName(csFile);
 
-            // Only check *DbContext.cs files (not I*DbContext.cs interfaces)
+            // Only check *DbContext.cs files (not I*DbContext.cs interfaces).
+            // GranitDbContext is the public abstract base class — by contract it
+            // ships from Granit.Persistence.EntityFrameworkCore's public surface,
+            // not from an Internal/ folder.
             if (!fileName.EndsWith("DbContext.cs", StringComparison.Ordinal)
-                || fileName.StartsWith('I'))
+                || fileName.StartsWith('I')
+                || string.Equals(fileName, "GranitDbContext.cs", StringComparison.Ordinal))
             {
                 continue;
             }

--- a/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
+++ b/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
@@ -161,7 +161,10 @@ public sealed partial class SourceCodeAntiPatternTests
     /// <list type="bullet">
     /// <item><c>internal sealed class</c> (not <c>public</c>)</item>
     /// <item>Primary constructor with <c>DbContextOptions</c>, <c>ICurrentTenant?</c>, and <c>IDataFilter?</c></item>
-    /// <item>Call <c>ApplyGranitConventions</c> in <c>OnModelCreating</c></item>
+    /// <item>Either inherits from <c>GranitDbContext</c> (preferred — gives the
+    /// parameterised IMultiTenant filter) OR calls <c>ApplyGranitConventions</c>
+    /// in <c>OnModelCreating</c> (legacy — only acceptable for DbContexts with
+    /// no IMultiTenant entities).</item>
     /// </list>
     /// </summary>
     [Fact]
@@ -186,6 +189,12 @@ public sealed partial class SourceCodeAntiPatternTests
                 || fileName.Contains("Factory", StringComparison.Ordinal)
                 || fileName.Contains("Options", StringComparison.Ordinal)
                 || fileName.Contains("Extensions", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // GranitDbContext itself is the public base class — exempt from canonical-pattern rules.
+            if (string.Equals(fileName, "GranitDbContext.cs", StringComparison.Ordinal))
             {
                 continue;
             }
@@ -215,16 +224,21 @@ public sealed partial class SourceCodeAntiPatternTests
                 violations.Add($"{relPath} (use primary constructor instead of private fields for ICurrentTenant/IDataFilter)");
             }
 
-            // Must call ApplyGranitConventions
-            if (!content.Contains("ApplyGranitConventions", StringComparison.Ordinal))
+            // Must wire Granit conventions — either by inheriting from GranitDbContext
+            // (base class registers conventions + parameterised IMultiTenant filter) or
+            // by calling ApplyGranitConventions directly (legacy).
+            bool inheritsGranitDbContext = content.Contains(": GranitDbContext", StringComparison.Ordinal);
+            bool callsApplyGranitConventions = content.Contains("ApplyGranitConventions", StringComparison.Ordinal);
+            if (!inheritsGranitDbContext && !callsApplyGranitConventions)
             {
-                violations.Add($"{relPath} (must call modelBuilder.ApplyGranitConventions in OnModelCreating)");
+                violations.Add($"{relPath} (must inherit from GranitDbContext or call modelBuilder.ApplyGranitConventions in OnModelCreating)");
             }
         }
 
         violations.ShouldBeEmpty(
             "Isolated DbContext classes must follow the canonical pattern: " +
-            "internal sealed class, primary constructor with ICurrentTenant?/IDataFilter?, ApplyGranitConventions. " +
+            "internal sealed class, primary constructor with ICurrentTenant/IDataFilter?, " +
+            "inheriting from GranitDbContext (preferred) or calling ApplyGranitConventions. " +
             $"Violators: {string.Join("; ", violations)}");
     }
 

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenantFilterParameterizationReproTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenantFilterParameterizationReproTests.cs
@@ -1,29 +1,28 @@
 // =============================================================================
-// Repro — multi-tenant query filter "frozen tenant" hypothesis
+// Regression — multi-tenant query filter must remain parameterised
 // =============================================================================
-// Investigates the diagnosis recorded on the [Fact(Skip = ...)] of
-// `tests/Granit.Http.ODataExposure.Tests.Integration/TenantIsolationTests.cs`
-// (UnauthenticatedRequest_NoTenantHeader_ReturnsEmpty):
+// Locks the fix delivered by introducing the `GranitDbContext` base class.
+// The previous extension-method form built the IMultiTenant filter via
+// `Expression.Property(Expression.Constant(currentTenant), "Id")`, which EF
+// Core inlined as a literal into the compiled SQL — the model cache then
+// reused that frozen value across every subsequent request of the same
+// DbContext type, leaking tenant A's rows to tenant B (and to anonymous
+// requests). Captured SQL with the bug:
 //
-//   "EF Core inlines currentTenant.Id into the compiled SQL at first model
-//    build instead of parameterising, so subsequent requests reuse the
-//    FROZEN tenant value (captured SQL: WHERE TenantId = '<frozen-guid>')."
+//   SELECT ... FROM "Items" AS "i" WHERE "i"."TenantId" = '<guid-literal>'
 //
-// Existing tests in ModelBuilderExtensionsTests.cs verify the filter lambda
-// re-evaluates the closure, but they (a) compile the LambdaExpression directly
-// and (b) use the InMemory provider — both paths bypass relational query
-// translation, which is where the alleged "constant folding" would happen.
-//
-// These tests use SQLite (real relational translation) and capture the
-// generated SQL via `LogTo` to settle the question empirically. Each test
-// uses a DISTINCT DbContext type to defeat EF Core's per-type model cache:
-// the cache is the suspected vehicle for the "frozen tenant" leak.
+// The fix moves the filter expression inside a member of `GranitDbContext`,
+// where `this.CurrentTenantId` is recognised by EF Core's parameter
+// extractor and emitted as `@ef_filter__CurrentTenantId`. These tests
+// assert that contract end-to-end against SQLite (real query translation)
+// using DISTINCT DbContext types per test so each model is built fresh and
+// the per-type model cache cannot mask a regression.
 // =============================================================================
 
 using System.Globalization;
 using Granit.Domain;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -45,18 +44,7 @@ public sealed class MultiTenantFilterParameterizationReproTests : IAsyncLifetime
 
     public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
 
-    private const string SkipReason =
-        "Documents the known bug mirrored by " +
-        "Granit.Http.ODataExposure.Tests.Integration/TenantIsolationTests.cs:191 " +
-        "(UnauthenticatedRequest_NoTenantHeader_ReturnsEmpty). ApplyGranitConventions " +
-        "builds the multi-tenant filter via Expression.Property(Expression.Constant(currentTenant), \"Id\"), " +
-        "which EF Core inlines as a literal into the compiled SQL (verified: " +
-        "WHERE \"TenantId\" = '<guid-literal>', no parameter). The model cache then " +
-        "reuses that frozen value for every subsequent query of the same DbContext type. " +
-        "Re-enable once ModelBuilderExtensions.cs (the IMultiTenant block) is reworked " +
-        "to a form EF Core parameterises (candidate: C# lambda with closure capture).";
-
-    [Fact(Skip = SkipReason)]
+    [Fact]
     public async Task SqlFilter_ReEvaluatesTenantAcross_DifferentDbContextInstances_SameType()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
@@ -86,7 +74,7 @@ public sealed class MultiTenantFilterParameterizationReproTests : IAsyncLifetime
         ids1[0].ShouldNotBe(ids2[0], "the two queries must see different rows");
     }
 
-    [Fact(Skip = SkipReason)]
+    [Fact]
     public async Task SqlFilter_ReEvaluatesWhenTenantBecomesNull_AfterFirstQuery()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
@@ -110,7 +98,7 @@ public sealed class MultiTenantFilterParameterizationReproTests : IAsyncLifetime
         }
     }
 
-    [Fact(Skip = SkipReason)]
+    [Fact]
     public async Task SqlFilter_ShouldParameterize_NotInlineTenantConstant()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
@@ -132,12 +120,27 @@ public sealed class MultiTenantFilterParameterizationReproTests : IAsyncLifetime
                               && s.Contains("Items", StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException("No SELECT against Items captured.");
 
-        bool inlined = selectSql.Contains(
-            tenantA.ToString("D", CultureInfo.InvariantCulture),
-            StringComparison.OrdinalIgnoreCase);
+        // EF Core emits the filter parameter as "@ef_filter__<DbContextProperty>"
+        // (or any "@param"-shaped placeholder) in the WHERE clause and lists the
+        // bound value in the Parameters=[...] prefix. The literal GUID appears
+        // ONLY in the Parameters list — never in the SQL body. Assert both signals
+        // independently to defeat any future change in EF's logging format.
+        bool hasParameterPlaceholder = selectSql.Contains(
+            "\"i\".\"TenantId\" = @",
+            StringComparison.Ordinal);
 
-        inlined.ShouldBeFalse(
-            $"tenant GUID is inlined into the compiled SQL (frozen value).\nSQL:\n{selectSql}");
+        hasParameterPlaceholder.ShouldBeTrue(
+            $"tenant filter must compile to a parameter, not a literal GUID.\nSQL:\n{selectSql}");
+
+        string whereLine = selectSql
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(l => l.Contains("WHERE", StringComparison.Ordinal))
+            ?? throw new InvalidOperationException("No WHERE clause in captured SQL.");
+
+        whereLine.Contains(
+            tenantA.ToString("D", CultureInfo.InvariantCulture),
+            StringComparison.OrdinalIgnoreCase).ShouldBeFalse(
+            $"WHERE clause must not inline the tenant GUID.\nWHERE:\n{whereLine}");
     }
 
     // -------------------------------------------------------------------------
@@ -211,27 +214,24 @@ public sealed class MultiTenantFilterParameterizationReproTests : IAsyncLifetime
         public Guid? TenantId { get; set; }
     }
 
+    // All 3 repro contexts inherit from GranitDbContext: the IMultiTenant filter is then
+    // built inside a member of the DbContext type, where `this.CurrentTenantId` is
+    // recognised by EF Core's parameter extractor.
     private sealed class ReproDbContextA(DbContextOptions<ReproDbContextA> options, ICurrentTenant tenant)
-        : DbContext(options)
+        : GranitDbContext(options, tenant)
     {
         public DbSet<TenantItem> Items => Set<TenantItem>();
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.ApplyGranitConventions(tenant);
     }
 
     private sealed class ReproDbContextB(DbContextOptions<ReproDbContextB> options, ICurrentTenant tenant)
-        : DbContext(options)
+        : GranitDbContext(options, tenant)
     {
         public DbSet<TenantItem> Items => Set<TenantItem>();
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.ApplyGranitConventions(tenant);
     }
 
     private sealed class ReproDbContextC(DbContextOptions<ReproDbContextC> options, ICurrentTenant tenant)
-        : DbContext(options)
+        : GranitDbContext(options, tenant)
     {
         public DbSet<TenantItem> Items => Set<TenantItem>();
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.ApplyGranitConventions(tenant);
     }
 }

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreAdditionalTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreAdditionalTests.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Granit.Templating.Keys;
@@ -31,7 +32,8 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
         public TemplatingDbContext CreateDbContext() =>
             new(new DbContextOptionsBuilder<TemplatingDbContext>()
                 .UseInMemoryDatabase(dbName)
-                .Options);
+                .Options,
+                GranitDesignTime.CurrentTenant);
 
         public Task<TemplatingDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(CreateDbContext());

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreTests.cs
@@ -30,7 +30,8 @@ public sealed class EfDocumentTemplateStoreTests
         public TemplatingDbContext CreateDbContext() =>
             new(new DbContextOptionsBuilder<TemplatingDbContext>()
                 .UseInMemoryDatabase(dbName)
-                .Options);
+                .Options,
+                GranitDesignTime.CurrentTenant);
 
         public Task<TemplatingDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(CreateDbContext());

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfTemplateCategoryStoreTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfTemplateCategoryStoreTests.cs
@@ -1,5 +1,6 @@
 using Granit.Exceptions;
 using Granit.Guids;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Granit.Templating.Store;
@@ -24,7 +25,8 @@ public sealed class EfTemplateCategoryStoreTests
         public TemplatingDbContext CreateDbContext() =>
             new(new DbContextOptionsBuilder<TemplatingDbContext>()
                 .UseInMemoryDatabase(dbName)
-                .Options);
+                .Options,
+                GranitDesignTime.CurrentTenant);
 
         public Task<TemplatingDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(CreateDbContext());


### PR DESCRIPTION
## Summary

Adds the `GranitDbContext` base class that fixes the multi-tenant query filter "frozen tenant" bug (diagnosed in #2128). Migrates `TemplatingDbContext` as the **pilot** and un-skips the 3 SQLite repro tests as green regression oracles. The other 20 framework IMultiTenant DbContexts follow in a batched PR.

## Why

EF Core parameterises query filter values **only** when they're read from a member of the DbContext instance. Values from `Expression.Constant(...)` or closure-captured locals — both used by the previous `ApplyGranitConventions` IMultiTenant block — are inlined as literals into the compiled SQL and frozen for the model cache lifetime, leaking tenant A's rows to tenant B (and to anonymous requests).

Same fix shape as ABP's `AbpDbContext.CreateFilterExpression` — the only documented EF Core path that survives query-cache reuse.

## Captured SQL — before / after (SQLite repro)

**Before:**
```sql
WHERE "i"."TenantId" = '<frozen-guid-literal>'
```

**After:**
```sql
WHERE @ef_filter__p2 OR "i"."TenantId" = @ef_filter__CurrentTenantId
-- Parameters: @ef_filter__CurrentTenantId='<per-request-guid>'
```

## Changes

- **`GranitDbContext`** (new) in `Granit.Persistence.EntityFrameworkCore`. Derived classes override `OnGranitModelCreating` (`OnModelCreating` is sealed) and forward DI-injected `ICurrentTenant` + `IDataFilter?` to the base ctor. The IMultiTenant filter is registered via a private generic method whose lambda binds `this.CurrentTenantId` / `this.IsMultiTenantFilterEnabled`.
- **`TemplatingDbContext`** migrated as pilot — `ICurrentTenant` is now required (was optional with null default; no production caller relied on null).
- **3 SQLite repro tests** ([MultiTenantFilterParameterizationReproTests.cs](tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenantFilterParameterizationReproTests.cs)) un-skipped and refined — assertion #3 now greps for `@ef_filter__` parameter placeholder in the WHERE clause rather than the absence of the GUID literal (which legitimately appears in EF's parameter-dump log line).
- **3 Templating test factories** updated to pass `GranitDesignTime.CurrentTenant`.
- Non-tenant filters (soft-delete, active, processing restriction, publishable, merge tombstone) keep flowing through `ApplyGranitConventions`. Their bypass values depend on per-DbContext singletons and are unaffected.

## Out of scope (follow-up PRs)

- Migration of the other **20 framework IMultiTenant DbContexts** (AI, Auditing, AuthenticationApiKeys, BackgroundJobs, Bff, BlobStorage, BlobStorageDatabase, DataExchange, Features, Identity, Localization, Mergeable, MigrationProgress, MultiTenancy, Notifications, OpenIddict, Privacy, Scheduling, Timeline, Webhooks).
- Migration of **52 IMultiTenant DbContexts across downstream repos** (`granit-business`, `granit-showcase-dotnet`, `granit-iot`, `granit-iot-showcase-dotnet`, `granit-microservice-template`). Each repo gets a handoff once this PR lands and a dev-`0.1.0-dev.*` NuGet is published.
- Re-enabling `TenantIsolationTests.UnauthenticatedRequest_NoTenantHeader_ReturnsEmpty`.
- Tightening the 3 showcase defensive bypasses (#1180, #1182, #1185).
- New archi test "any DbContext with IMultiTenant entities must inherit from GranitDbContext" — defer to the bulk-migration PR (would fail today for the 20 unmigrated contexts).

## Test plan

- [x] `MultiTenantFilterParameterizationReproTests` — 3 tests green (was 3 skipped on develop)
- [x] `Granit.Persistence.EntityFrameworkCore.Tests` — 336/336 pass
- [x] `Granit.Templating.EntityFrameworkCore.Tests` — 60/60 pass
- [x] `api-data` shard — all green
- [x] `application` shard — all green
- [x] `IsolatedDbContextTests` archi — 6/6 pass (regex-based, doesn't trigger on `OnGranitModelCreating`)