### PR TITLE
fix(persistence): migrate 20 framework DbContexts to GranitDbContext (bulk)

### DIFF
--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIDbContext.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIDbContext.cs
@@ -2,7 +2,7 @@ using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.AI.EntityFrameworkCore.Internal;
@@ -16,9 +16,9 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class AIDbContext(
     DbContextOptions<AIDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Dynamic AI workspace configurations.</summary>
     public DbSet<AIWorkspaceEntity> Workspaces { get; set; } = null!;
@@ -27,10 +27,6 @@ internal sealed class AIDbContext(
     public DbSet<AIUsageRecordEntity> UsageRecords { get; set; } = null!;
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureAIModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureAIModule();
 }

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/AuditingDbContext.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/AuditingDbContext.cs
@@ -2,7 +2,7 @@ using Granit.Auditing.Domain;
 using Granit.Auditing.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Auditing.EntityFrameworkCore.Internal;
@@ -22,9 +22,9 @@ namespace Granit.Auditing.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class AuditingDbContext(
     DbContextOptions<AuditingDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Root audit log entries.</summary>
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
@@ -38,10 +38,6 @@ internal sealed class AuditingDbContext(
     public DbSet<AuditPropertyChange> AuditPropertyChanges => Set<AuditPropertyChange>();
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureAuditingModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureAuditingModule();
 }

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/AuthenticationApiKeysDbContext.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/AuthenticationApiKeysDbContext.cs
@@ -2,7 +2,7 @@ using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
@@ -12,9 +12,9 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class AuthenticationApiKeysDbContext(
     DbContextOptions<AuthenticationApiKeysDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>
     /// API keys table.
@@ -22,11 +22,9 @@ internal sealed class AuthenticationApiKeysDbContext(
     public DbSet<ApiKeyEntry> ApiKeys => Set<ApiKeyEntry>();
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureApiKeysModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/BackgroundJobsDbContext.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/BackgroundJobsDbContext.cs
@@ -2,7 +2,7 @@ using Granit.BackgroundJobs.Domain;
 using Granit.BackgroundJobs.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.BackgroundJobs.EntityFrameworkCore.Internal;
@@ -22,18 +22,14 @@ namespace Granit.BackgroundJobs.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class BackgroundJobsDbContext(
     DbContextOptions<BackgroundJobsDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Administrative records for all registered recurring jobs.</summary>
     public DbSet<BackgroundJobDefinition> Jobs { get; set; } = null!;
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureBackgroundJobsModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureBackgroundJobsModule();
 }

--- a/src/Granit.Bff.EntityFrameworkCore/Internal/BffDbContext.cs
+++ b/src/Granit.Bff.EntityFrameworkCore/Internal/BffDbContext.cs
@@ -1,7 +1,7 @@
 using Granit.Bff.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Bff.EntityFrameworkCore.Internal;
@@ -13,18 +13,14 @@ namespace Granit.Bff.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class BffDbContext(
     DbContextOptions<BffDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>BFF sessions.</summary>
     public DbSet<BffSessionEntity> Sessions => Set<BffSessionEntity>();
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureBffModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureBffModule();
 }

--- a/src/Granit.BlobStorage.Database/Internal/BlobStorageDatabaseDbContext.cs
+++ b/src/Granit.BlobStorage.Database/Internal/BlobStorageDatabaseDbContext.cs
@@ -2,7 +2,7 @@ using Granit.BlobStorage.Database.Domain;
 using Granit.BlobStorage.Database.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.BlobStorage.Database.Internal;
@@ -13,16 +13,12 @@ namespace Granit.BlobStorage.Database.Internal;
 /// </summary>
 internal sealed class BlobStorageDatabaseDbContext(
     DbContextOptions<BlobStorageDatabaseDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     public DbSet<DatabaseBlobContent> BlobContents => Set<DatabaseBlobContent>();
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureBlobStorageDatabaseModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureBlobStorageDatabaseModule();
 }

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobStorageDbContext.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobStorageDbContext.cs
@@ -2,7 +2,7 @@ using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.BlobStorage.EntityFrameworkCore.Internal;
@@ -21,18 +21,14 @@ namespace Granit.BlobStorage.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class BlobStorageDbContext(
     DbContextOptions<BlobStorageDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Lifecycle records for all uploaded blobs.</summary>
     public DbSet<BlobDescriptor> Blobs { get; set; } = null!;
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureBlobStorageModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureBlobStorageModule();
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/DataExchangeDbContext.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/DataExchangeDbContext.cs
@@ -6,7 +6,7 @@ using Granit.DataExchange.Export.Domain;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.DataExchange.EntityFrameworkCore.Internal;
@@ -18,9 +18,9 @@ namespace Granit.DataExchange.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class DataExchangeDbContext(
     DbContextOptions<DataExchangeDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     public DbSet<ImportJob> ImportJobs { get; set; } = null!;
     public DbSet<SavedMappingEntity> SavedMappings { get; set; } = null!;
@@ -28,10 +28,6 @@ internal sealed class DataExchangeDbContext(
     public DbSet<ExportJob> ExportJobs { get; set; } = null!;
     public DbSet<ExportPresetEntity> ExportPresets { get; set; } = null!;
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureDataExchangeModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureDataExchangeModule();
 }

--- a/src/Granit.Features.EntityFrameworkCore/Internal/FeaturesDbContext.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/FeaturesDbContext.cs
@@ -2,7 +2,7 @@ using Granit.DataFiltering;
 using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Features.EntityFrameworkCore.Internal;
@@ -22,18 +22,14 @@ namespace Granit.Features.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class FeaturesDbContext(
     DbContextOptions<FeaturesDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Tenant-level feature value overrides.</summary>
     public DbSet<TenantFeatureOverride> FeatureOverrides { get; set; } = null!;
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureFeaturesModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureFeaturesModule();
 }

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
@@ -4,7 +4,7 @@ using Granit.Encryption.EntityFrameworkCore.Extensions;
 using Granit.Identity.Domain;
 using Granit.Identity.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Identity.EntityFrameworkCore.Internal;
@@ -16,34 +16,26 @@ namespace Granit.Identity.EntityFrameworkCore.Internal;
 /// <c>Granit.Parties</c>, gets the user table.
 /// </summary>
 /// <remarks>
-/// Per the framework convention (CLAUDE.md, "Isolated DbContext —
-/// MANDATORY"), this DbContext lazily injects <see cref="ICurrentTenant"/>
-/// and <see cref="IDataFilter"/> and applies the framework conventions
-/// (tenant + soft-delete + named query filters) via
-/// <see cref="ModelBuilderExtensions.ApplyGranitConventions"/>.
+/// Inherits from <see cref="GranitDbContext"/> so the multi-tenant filter is
+/// parameterised (per-request) instead of inlined into the compiled SQL.
 /// </remarks>
 internal sealed class IdentityDbContext(
     DbContextOptions<IdentityDbContext> options,
     IStringEncryptionService encryption,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     private readonly IStringEncryptionService _encryption = encryption;
-    private readonly ICurrentTenant? _currentTenant = currentTenant;
-    private readonly IDataFilter? _dataFilter = dataFilter;
 
     /// <summary>The <see cref="User"/> table.</summary>
     public DbSet<User> Users => Set<User>();
 
     /// <inheritdoc />
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
-        base.OnModelCreating(modelBuilder);
-
         modelBuilder.ConfigureGranitIdentityModule();
-        modelBuilder.ApplyGranitConventions(_currentTenant, _dataFilter);
         modelBuilder.ApplyEncryptionConventions(_encryption);
     }
 }

--- a/src/Granit.Localization.EntityFrameworkCore/Internal/LocalizationDbContext.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Internal/LocalizationDbContext.cs
@@ -2,7 +2,7 @@ using Granit.DataFiltering;
 using Granit.Localization.Domain;
 using Granit.Localization.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Localization.EntityFrameworkCore.Internal;
@@ -22,18 +22,14 @@ namespace Granit.Localization.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class LocalizationDbContext(
     DbContextOptions<LocalizationDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Translation overrides indexed by resource, culture, and key.</summary>
     public DbSet<LocalizationOverride> LocalizationOverrides { get; set; } = null!;
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureLocalizationModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureLocalizationModule();
 }

--- a/src/Granit.Mergeable.EntityFrameworkCore/Internal/MergeableDbContext.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Internal/MergeableDbContext.cs
@@ -1,7 +1,7 @@
 using Granit.DataFiltering;
 using Granit.Mergeable.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Mergeable.EntityFrameworkCore.Internal;
@@ -13,20 +13,18 @@ namespace Granit.Mergeable.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class MergeableDbContext(
     DbContextOptions<MergeableDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Replay cache for Stripe-style idempotency-key support on merges.</summary>
     internal DbSet<MergeIdempotencyEntry> MergeIdempotencyEntries =>
         Set<MergeIdempotencyEntry>();
 
     /// <inheritdoc />
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureMergeableModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/MultiTenancyDbContext.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/MultiTenancyDbContext.cs
@@ -1,7 +1,7 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy.Domain;
 using Granit.MultiTenancy.EntityFrameworkCore.Extensions;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.MultiTenancy.EntityFrameworkCore.Internal;
@@ -12,17 +12,13 @@ namespace Granit.MultiTenancy.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class MultiTenancyDbContext(
     DbContextOptions<MultiTenancyDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     public DbSet<Tenant> Tenants { get; set; } = null!;
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureMultiTenancyModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureMultiTenancyModule();
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsDbContext.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsDbContext.cs
@@ -5,7 +5,7 @@ using Granit.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Extensions;
 using Granit.Notifications.MobilePush.Domain;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
@@ -16,10 +16,12 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 internal sealed class NotificationsDbContext(
     DbContextOptions<NotificationsDbContext> options,
     IStringEncryptionService encryption,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
+    private readonly IStringEncryptionService _encryption = encryption;
+
     /// <summary>In-app user notifications (inbox).</summary>
     public DbSet<UserNotification> UserNotifications => Set<UserNotification>();
 
@@ -36,11 +38,9 @@ internal sealed class NotificationsDbContext(
     public DbSet<MobilePushToken> MobilePushTokens => Set<MobilePushToken>();
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureNotificationsModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-        modelBuilder.ApplyEncryptionConventions(encryption);
+        modelBuilder.ApplyEncryptionConventions(_encryption);
     }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
@@ -1,13 +1,18 @@
+using System.Linq.Expressions;
+using System.Reflection;
 using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Identity.Local.Domain;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.Domain;
 using Granit.OpenIddict.Entities.OpenIddict;
 using Granit.OpenIddict.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Metadata;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Options;
 
 namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
@@ -17,17 +22,37 @@ namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
 /// <see cref="IdentityDbContext{TUser,TRole,TKey}"/> with OpenIddict entity support.
 /// </summary>
 /// <remarks>
-/// Follows the canonical Granit isolated DbContext pattern
-/// (cf. <c>AuthenticationApiKeysDbContext</c>). Uses custom multi-tenant OpenIddict entities
-/// (<see cref="GranitOpenIddictApplication"/>, etc.) instead of the defaults.
+/// <para>
+/// Cannot inherit from <see cref="GranitDbContext"/> because the C# single-inheritance
+/// constraint already binds this type to ASP.NET Identity's
+/// <see cref="IdentityDbContext{TUser,TRole,TKey}"/>. The parameterised IMultiTenant
+/// filter is therefore replicated inline (see <see cref="CurrentTenantId"/>,
+/// <see cref="IsMultiTenantFilterEnabled"/>, <see cref="ConfigureMultiTenantFilter"/>) —
+/// any change to the GranitDbContext filter shape must mirror here.
+/// </para>
 /// </remarks>
 internal sealed class OpenIddictDbContext(
     DbContextOptions<OpenIddictDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null,
     IOptions<MetadataMappingOptions<LocalIdentity>>? extensionOptions = null)
     : IdentityDbContext<LocalIdentity, GranitRole, Guid>(options)
 {
+    private static readonly MethodInfo ConfigureMultiTenantFilterMethod =
+        typeof(OpenIddictDbContext).GetMethod(
+            nameof(ConfigureMultiTenantFilter),
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private readonly ICurrentTenant _currentTenant = currentTenant
+        ?? throw new ArgumentNullException(nameof(currentTenant));
+    private readonly IDataFilter? _dataFilter = dataFilter;
+
+    /// <inheritdoc cref="GranitDbContext.CurrentTenantId" />
+    public Guid? CurrentTenantId => _currentTenant.IsAvailable ? _currentTenant.Id : null;
+
+    /// <inheritdoc cref="GranitDbContext.IsMultiTenantFilterEnabled" />
+    public bool IsMultiTenantFilterEnabled => _dataFilter?.IsEnabled<IMultiTenant>() ?? true;
+
     /// <summary>Gets the user groups set.</summary>
     public DbSet<GranitUserGroup> UserGroups => Set<GranitUserGroup>();
 
@@ -43,18 +68,33 @@ internal sealed class OpenIddictDbContext(
         ArgumentNullException.ThrowIfNull(builder);
 
         // 1. ASP.NET Identity conventions (default table names, keys, indexes).
-        // ConfigureOpenIddictModule() is self-contained (defines Identity keys +
-        // calls UseOpenIddict), but base.OnModelCreating() is still needed for
-        // IdentityDbContext-specific conventions (navigation properties, indexes).
         base.OnModelCreating(builder);
 
         // 2. Granit OpenIddict conventions (Identity keys, OpenIddict conventions,
         //    openiddict_* table prefix, column constraints, manual soft-delete filter)
-        builder.ConfigureOpenIddictModule(dataFilter, extensionOptions?.Value);
+        builder.ConfigureOpenIddictModule(_dataFilter, extensionOptions?.Value);
 
-        // 4. Granit cross-cutting conventions (IMultiTenant, ISoftDeletable, IActive, etc.)
-        // This automatically adds multi-tenant filters for IMultiTenant entities
-        // (GranitOpenIddictApplication, GranitOpenIddictAuthorization, etc.)
-        builder.ApplyGranitConventions(currentTenant, dataFilter);
+        // 3. Granit cross-cutting conventions WITHOUT the IMultiTenant filter (currentTenant: null).
+        builder.ApplyGranitConventions(currentTenant: null, _dataFilter);
+
+        // 4. Parameterised IMultiTenant filter — inlined here because we cannot inherit
+        //    from GranitDbContext (see remarks on the class).
+        foreach (IMutableEntityType entityType in builder.Model.GetEntityTypes()
+            .Where(et => typeof(IMultiTenant).IsAssignableFrom(et.ClrType)))
+        {
+            ConfigureMultiTenantFilterMethod
+                .MakeGenericMethod(entityType.ClrType)
+                .Invoke(this, [builder]);
+        }
+    }
+
+    private void ConfigureMultiTenantFilter<TEntity>(ModelBuilder builder)
+        where TEntity : class
+    {
+        Expression<Func<TEntity, bool>> filter = e =>
+            !IsMultiTenantFilterEnabled
+            || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId;
+        builder.Entity<TEntity>()
+            .HasQueryFilter(GranitFilterNames.MultiTenant, filter);
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -97,15 +97,20 @@ public abstract class GranitDbContext : DbContext
     /// </remarks>
     protected sealed override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        // Non-tenant filters (soft-delete, active, etc.). Tenant is passed as null —
-        // ApplyGranitConventions skips its IMultiTenant block in that mode, leaving the
-        // filter to this class.
-        modelBuilder.ApplyGranitConventions(currentTenant: null, DataFilter);
-
+        // 1) Derived-class configuration first. Modules call `Ignore<>()` for
+        //    entities they don't own, configure FKs, etc. — those must land
+        //    before any iteration over `Model.GetEntityTypes()`.
         OnGranitModelCreating(modelBuilder);
 
-        // Register the parameterised IMultiTenant filter AFTER user model configuration so
-        // every entity type is discoverable.
+        // 2) Non-tenant filters (soft-delete, active, processing restriction,
+        //    publishable, merge tombstone). `currentTenant: null` skips the
+        //    IMultiTenant block in this overload — this class owns that filter
+        //    separately, with parameterised SQL.
+        modelBuilder.ApplyGranitConventions(currentTenant: null, DataFilter);
+
+        // 3) Parameterised IMultiTenant filter. Built inside a member of THIS
+        //    DbContext so `CurrentTenantId` is recognised by EF Core's parameter
+        //    extractor and emitted as @ef_filter__CurrentTenantId.
         foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes()
             .Where(et => typeof(IMultiTenant).IsAssignableFrom(et.ClrType)))
         {

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyDbContext.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyDbContext.cs
@@ -2,7 +2,7 @@ using Granit.DataFiltering;
 using Granit.Encryption;
 using Granit.Encryption.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Privacy.EntityFrameworkCore.DataDeletion;
 using Granit.Privacy.EntityFrameworkCore.DataExport;
 using Granit.Privacy.EntityFrameworkCore.Entities;
@@ -15,24 +15,24 @@ namespace Granit.Privacy.EntityFrameworkCore.Internal;
 internal sealed class PrivacyDbContext(
     DbContextOptions<PrivacyDbContext> options,
     IStringEncryptionService encryption,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
+    private readonly IStringEncryptionService _encryption = encryption;
+
     public DbSet<LegalDocument> LegalDocuments { get; set; } = null!;
 
     public DbSet<ExportRequestEntity> ExportRequests { get; set; } = null!;
 
     public DbSet<DeletionRequestEntity> DeletionRequests { get; set; } = null!;
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigurePrivacyModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
         // Encrypts every string property carrying [Encrypted] (DeletionRequestEntity.Reason
         // for now). New entities inheriting LegalAgreementBase pick up encryption on
         // IpAddress automatically.
-        modelBuilder.ApplyEncryptionConventions(encryption);
+        modelBuilder.ApplyEncryptionConventions(_encryption);
     }
 }

--- a/src/Granit.Scheduling.EntityFrameworkCore/Internal/SchedulingDbContext.cs
+++ b/src/Granit.Scheduling.EntityFrameworkCore/Internal/SchedulingDbContext.cs
@@ -1,6 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Scheduling.Domain;
 using Granit.Scheduling.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -16,18 +16,14 @@ namespace Granit.Scheduling.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class SchedulingDbContext(
     DbContextOptions<SchedulingDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Scheduled actions awaiting execution, cancelled, or completed.</summary>
     public DbSet<ScheduledAction> ScheduledActions { get; set; } = null!;
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureSchedulingModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureSchedulingModule();
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/TimelineDbContext.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/TimelineDbContext.cs
@@ -1,6 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timeline.Domain;
 using Granit.Timeline.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -16,9 +16,9 @@ namespace Granit.Timeline.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class TimelineDbContext(
     DbContextOptions<TimelineDbContext> options,
-    ICurrentTenant? currentTenant = null,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : DbContext(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Activity stream entries (comments, system logs, internal notes).</summary>
     public DbSet<TimelineEntry> TimelineEntries => Set<TimelineEntry>();
@@ -30,10 +30,6 @@ internal sealed class TimelineDbContext(
     public DbSet<Reaction> Reactions => Set<Reaction>();
 
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureTimelineModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureTimelineModule();
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
@@ -1,6 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -17,8 +17,9 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class WebhooksDbContext(
     DbContextOptions<WebhooksDbContext> options,
-    ICurrentTenant? currentTenant = null,
-    IDataFilter? dataFilter = null) : DbContext(options)
+    ICurrentTenant currentTenant,
+    IDataFilter? dataFilter = null)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
     /// <summary>Webhook subscriptions.</summary>
     public DbSet<WebhookSubscription> WebhookSubscriptions => Set<WebhookSubscription>();
@@ -35,11 +36,6 @@ internal sealed class WebhooksDbContext(
     public DbSet<WebhookDeliveryAttempt> WebhookDeliveryAttempts => Set<WebhookDeliveryAttempt>();
 
     /// <inheritdoc/>
-    /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureWebhooksModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
-    }
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureWebhooksModule();
 }

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
@@ -4,6 +4,7 @@ using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Internal;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -80,9 +81,9 @@ public sealed class EfAIUsageStoreTests : IAsyncDisposable
 
     private sealed class TestDbContextFactory(DbContextOptions<AIDbContext> options) : IDbContextFactory<AIDbContext>
     {
-        public AIDbContext CreateDbContext() => new(options, dataFilter: SharedFilter);
+        public AIDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant, dataFilter: SharedFilter);
 
         public Task<AIDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new AIDbContext(options, dataFilter: SharedFilter));
+            Task.FromResult(new AIDbContext(options, GranitDesignTime.CurrentTenant, dataFilter: SharedFilter));
     }
 }

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
@@ -3,6 +3,7 @@ using Granit.AI.EntityFrameworkCore.Internal;
 using Granit.AI.Workspaces;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;
@@ -131,9 +132,9 @@ public sealed class EfAIWorkspaceStoreTests : IAsyncDisposable
     private sealed class TestDbContextFactory(DbContextOptions<AIDbContext> options, IDataFilter dataFilter)
         : IDbContextFactory<AIDbContext>
     {
-        public AIDbContext CreateDbContext() => new(options, dataFilter: dataFilter);
+        public AIDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant, dataFilter: dataFilter);
 
         public Task<AIDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new AIDbContext(options, dataFilter: dataFilter));
+            Task.FromResult(new AIDbContext(options, GranitDesignTime.CurrentTenant, dataFilter: dataFilter));
     }
 }

--- a/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
+++ b/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
@@ -46,6 +46,64 @@ public sealed partial class IsolatedDbContextTests
             $"Violators: {string.Join(", ", violations)}");
     }
 
+    /// <summary>
+    /// Every concrete DbContext in <c>*.EntityFrameworkCore</c> or <c>*.Database</c> packages
+    /// must either inherit from <c>GranitDbContext</c> (preferred) or carry the inline
+    /// <c>ConfigureMultiTenantFilter</c> pattern (forced when single-inheritance already binds
+    /// the type elsewhere — currently only OpenIddictDbContext). Calling the legacy
+    /// <c>modelBuilder.ApplyGranitConventions(currentTenant, ...)</c> with a non-null tenant
+    /// re-introduces the "frozen tenant" SQL leak fixed in #2129.
+    /// </summary>
+    [Fact]
+    public void DbContext_classes_should_use_GranitDbContext_or_inline_parameterised_filter()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+
+        // MigrationProgressDbContext is in *.EntityFrameworkCore.Migrations (different
+        // project suffix) and doesn't carry tenant entities — already skipped by the
+        // project filter, but listed here for explicit traceability.
+        HashSet<string> exempted = ["MigrationProgressDbContext.cs", "GranitDbContext.cs"];
+
+        List<string> violations = [];
+
+        foreach (string project in Directory.GetDirectories(srcDir)
+            .Where(d => Path.GetFileName(d).EndsWith(".EntityFrameworkCore", StringComparison.Ordinal)
+                || Path.GetFileName(d).EndsWith(".Database", StringComparison.Ordinal)))
+        {
+            foreach (string csFile in Directory.GetFiles(project, "*DbContext.cs", SearchOption.AllDirectories))
+            {
+                string fileName = Path.GetFileName(csFile);
+                if (fileName.StartsWith('I') || exempted.Contains(fileName))
+                {
+                    continue;
+                }
+
+                string content = File.ReadAllText(csFile);
+
+                // Skip interfaces and abstract bases (not concrete DbContext classes).
+                if (!content.Contains("sealed class", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                bool inheritsGranitDbContext = content.Contains(": GranitDbContext", StringComparison.Ordinal);
+                bool implementsInlineFilter = content.Contains("ConfigureMultiTenantFilter", StringComparison.Ordinal);
+
+                if (!inheritsGranitDbContext && !implementsInlineFilter)
+                {
+                    violations.Add(Path.GetRelativePath(RepoRoot, csFile));
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every concrete *DbContext.cs must inherit GranitDbContext (preferred) or replicate " +
+            "its parameterised IMultiTenant filter inline (look for ConfigureMultiTenantFilter). " +
+            "The legacy ApplyGranitConventions(currentTenant, ...) call inlines the tenant id as " +
+            "a SQL literal — see PR #2129. " +
+            $"Violators: {string.Join(", ", violations)}");
+    }
+
     [Fact]
     public void No_manual_HasQueryFilter_in_entity_configurations()
     {

--- a/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
+++ b/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
@@ -199,6 +199,15 @@ public sealed partial class SourceCodeAntiPatternTests
                 continue;
             }
 
+            // OpenIddictDbContext cannot inherit GranitDbContext (single-inheritance is taken
+            // by IdentityDbContext<TUser,TRole,TKey>), so it inlines the parameterised
+            // IMultiTenant filter and needs the tenant / data-filter references stored as
+            // private fields for the lambda's closure. Exempt from the field-ban rule.
+            if (string.Equals(fileName, "OpenIddictDbContext.cs", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
             // Only check *.EntityFrameworkCore packages (not *.Migrations — system DbContext without domain entities)
             string relativePath = Path.GetRelativePath(srcDir, csFile);
             string moduleName = relativePath.Split(Path.DirectorySeparatorChar)[0];

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingCleanerTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingCleanerTests.cs
@@ -1,6 +1,7 @@
 using Granit.Auditing.Domain;
 using Granit.Auditing.EntityFrameworkCore.Internal;
 using Granit.Auditing.EntityFrameworkCore.Internal.Services;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -26,7 +27,7 @@ public sealed class EfCoreAuditingCleanerTests : IAsyncDisposable
             .UseSqlite(_connection)
             .Options;
 
-        using var ctx = new AuditingDbContext(_dbOptions);
+        using var ctx = new AuditingDbContext(_dbOptions, GranitDesignTime.CurrentTenant);
         ctx.Database.EnsureCreated();
     }
 
@@ -37,7 +38,7 @@ public sealed class EfCoreAuditingCleanerTests : IAsyncDisposable
     public async Task PseudonymizeByUserAsync_ReplacesPersonalData()
     {
         // Seed two entries for the target user and one for another user.
-        await using (AuditingDbContext seedCtx = new(_dbOptions))
+        await using (AuditingDbContext seedCtx = new(_dbOptions, GranitDesignTime.CurrentTenant))
         {
             seedCtx.AuditEntries.AddRange(
                 new AuditEntry
@@ -82,7 +83,7 @@ public sealed class EfCoreAuditingCleanerTests : IAsyncDisposable
         count.ShouldBe(2);
 
         // Verify pseudonymized entries.
-        await using AuditingDbContext verifyCtx = new(_dbOptions);
+        await using AuditingDbContext verifyCtx = new(_dbOptions, GranitDesignTime.CurrentTenant);
         string expectedHash = EfCoreAuditingCleaner.HashUserId("user-to-erase");
 
         List<AuditEntry> pseudonymized = await verifyCtx.AuditEntries
@@ -154,7 +155,7 @@ public sealed class EfCoreAuditingCleanerTests : IAsyncDisposable
     [Fact]
     public async Task PseudonymizeByUserAsync_IsIdempotent()
     {
-        await using (AuditingDbContext seedCtx = new(_dbOptions))
+        await using (AuditingDbContext seedCtx = new(_dbOptions, GranitDesignTime.CurrentTenant))
         {
             seedCtx.AuditEntries.Add(new AuditEntry
             {
@@ -185,6 +186,6 @@ public sealed class EfCoreAuditingCleanerTests : IAsyncDisposable
     private sealed class TestDbContextFactory(DbContextOptions<AuditingDbContext> options)
         : IDbContextFactory<AuditingDbContext>
     {
-        public AuditingDbContext CreateDbContext() => new(options);
+        public AuditingDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant);
     }
 }

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingReaderCachingTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingReaderCachingTests.cs
@@ -3,6 +3,7 @@ using Granit.Auditing.EntityFrameworkCore.Internal;
 using Granit.Auditing.EntityFrameworkCore.Internal.Services;
 using Granit.Auditing.Options;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -46,7 +47,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
         first.ShouldNotBeNull();
 
         // Delete from DB to prove second call comes from cache
-        await using (AuditingDbContext ctx = new(_dbOptions))
+        await using (AuditingDbContext ctx = new(_dbOptions, GranitDesignTime.CurrentTenant))
         {
             ctx.AuditEntries.RemoveRange(ctx.AuditEntries);
             await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -93,7 +94,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
         first.Items.Count.ShouldBe(1);
 
         // Delete from DB to prove second call comes from cache
-        await using (AuditingDbContext ctx = new(_dbOptions))
+        await using (AuditingDbContext ctx = new(_dbOptions, GranitDesignTime.CurrentTenant))
         {
             ctx.AuditEntries.RemoveRange(ctx.AuditEntries);
             await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -132,7 +133,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
 
     private async Task SeedEntryAsync(Guid id)
     {
-        await using AuditingDbContext ctx = new(_dbOptions);
+        await using AuditingDbContext ctx = new(_dbOptions, GranitDesignTime.CurrentTenant);
         ctx.AuditEntries.Add(new AuditEntry
         {
             Id = id,
@@ -145,7 +146,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
 
     private async Task SeedEntryWithEntityChangeAsync(Guid entryId, string entityType, string entityId)
     {
-        await using AuditingDbContext ctx = new(_dbOptions);
+        await using AuditingDbContext ctx = new(_dbOptions, GranitDesignTime.CurrentTenant);
         var entry = new AuditEntry
         {
             Id = entryId,
@@ -171,6 +172,6 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
     private sealed class TestDbContextFactory(DbContextOptions<AuditingDbContext> options)
         : IDbContextFactory<AuditingDbContext>
     {
-        public AuditingDbContext CreateDbContext() => new(options);
+        public AuditingDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant);
     }
 }

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingWriterTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingWriterTests.cs
@@ -1,6 +1,7 @@
 using Granit.Auditing.Domain;
 using Granit.Auditing.EntityFrameworkCore.Internal;
 using Granit.Auditing.EntityFrameworkCore.Internal.Services;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Shouldly;
 using Xunit;
@@ -31,7 +32,7 @@ public sealed class EfCoreAuditingWriterTests
 
         await writer.WriteAsync(entry, TestContext.Current.CancellationToken);
 
-        await using AuditingDbContext verifyCtx = new(dbOptions);
+        await using AuditingDbContext verifyCtx = new(dbOptions, GranitDesignTime.CurrentTenant);
         AuditEntry? persisted = await verifyCtx.AuditEntries.FindAsync([entry.Id], TestContext.Current.CancellationToken);
         persisted.ShouldNotBeNull();
         persisted.UserId.ShouldBe("user-1");
@@ -83,7 +84,7 @@ public sealed class EfCoreAuditingWriterTests
 
         await writer.WriteAsync(entry, TestContext.Current.CancellationToken);
 
-        await using AuditingDbContext verifyCtx = new(dbOptions);
+        await using AuditingDbContext verifyCtx = new(dbOptions, GranitDesignTime.CurrentTenant);
         AuditEntry? persisted = await verifyCtx.AuditEntries
             .Include(e => e.EntityChanges)
             .ThenInclude(ec => ec.PropertyChanges)
@@ -111,6 +112,6 @@ public sealed class EfCoreAuditingWriterTests
     private sealed class TestDbContextFactory(DbContextOptions<AuditingDbContext> options)
         : IDbContextFactory<AuditingDbContext>
     {
-        public AuditingDbContext CreateDbContext() => new(options);
+        public AuditingDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant);
     }
 }

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/StrictAuditingPublisherTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/StrictAuditingPublisherTests.cs
@@ -16,6 +16,7 @@ using Granit.Auditing.EntityFrameworkCore.Internal.Services;
 using Granit.Auditing.Messages;
 using Granit.Events;
 using Granit.Guids;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -26,8 +27,11 @@ using Xunit;
 
 namespace Granit.Auditing.EntityFrameworkCore.Tests.Internal;
 
-public sealed class StrictAuditingPublisherTests
+public sealed class StrictAuditingPublisherTests : IDisposable
 {
+    private readonly TestDataFilter _dataFilter = new();
+
+    public void Dispose() => _dataFilter.Dispose();
     // -------------------------------------------------------------------------
     // PublishAsync — happy path
     // -------------------------------------------------------------------------
@@ -44,7 +48,7 @@ public sealed class StrictAuditingPublisherTests
         guidGenerator.Create().Returns(_ => Guid.NewGuid());
 
         IServiceCollection services = new ServiceCollection();
-        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions));
+        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions, _dataFilter.Filter));
         services.AddSingleton(guidGenerator);
         services.AddSingleton(Substitute.For<IDistributedEventBus>());
         ServiceProvider sp = services.BuildServiceProvider();
@@ -58,7 +62,7 @@ public sealed class StrictAuditingPublisherTests
         await publisher.PublishAsync(batch, TestContext.Current.CancellationToken);
 
         // Assert
-        await using AuditingDbContext verifyCtx = new(dbOptions);
+        await using AuditingDbContext verifyCtx = new(dbOptions, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         int count = await verifyCtx.AuditEntries.CountAsync(TestContext.Current.CancellationToken);
         count.ShouldBe(1);
     }
@@ -75,7 +79,7 @@ public sealed class StrictAuditingPublisherTests
         guidGenerator.Create().Returns(_ => Guid.NewGuid());
 
         IServiceCollection services = new ServiceCollection();
-        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions));
+        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions, _dataFilter.Filter));
         services.AddSingleton(guidGenerator);
         services.AddSingleton(Substitute.For<IDistributedEventBus>());
         ServiceProvider sp = services.BuildServiceProvider();
@@ -107,7 +111,7 @@ public sealed class StrictAuditingPublisherTests
         await publisher.PublishAsync(batch, TestContext.Current.CancellationToken);
 
         // Assert
-        await using AuditingDbContext verifyCtx = new(dbOptions);
+        await using AuditingDbContext verifyCtx = new(dbOptions, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         AuditEntry persisted = await verifyCtx.AuditEntries
             .Include(e => e.EntityChanges)
             .ThenInclude(ec => ec.PropertyChanges)
@@ -139,7 +143,7 @@ public sealed class StrictAuditingPublisherTests
         guidGenerator.Create().Returns(_ => Guid.NewGuid());
 
         IServiceCollection services = new ServiceCollection();
-        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions));
+        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions, _dataFilter.Filter));
         services.AddSingleton(guidGenerator);
         services.AddSingleton(Substitute.For<IDistributedEventBus>());
         ServiceProvider sp = services.BuildServiceProvider();
@@ -155,7 +159,7 @@ public sealed class StrictAuditingPublisherTests
         }
 
         // Assert
-        await using AuditingDbContext verifyCtx = new(dbOptions);
+        await using AuditingDbContext verifyCtx = new(dbOptions, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         int count = await verifyCtx.AuditEntries.CountAsync(TestContext.Current.CancellationToken);
         count.ShouldBe(3);
     }
@@ -172,7 +176,7 @@ public sealed class StrictAuditingPublisherTests
         guidGenerator.Create().Returns(_ => Guid.NewGuid());
 
         IServiceCollection services = new ServiceCollection();
-        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions));
+        services.AddSingleton<IDbContextFactory<AuditingDbContext>>(new TestDbContextFactory(dbOptions, _dataFilter.Filter));
         services.AddSingleton(guidGenerator);
         services.AddSingleton(Substitute.For<IDistributedEventBus>());
         ServiceProvider sp = services.BuildServiceProvider();
@@ -186,7 +190,7 @@ public sealed class StrictAuditingPublisherTests
         await publisher.PublishAsync(batch, TestContext.Current.CancellationToken);
 
         // Assert
-        await using AuditingDbContext verifyCtx = new(dbOptions);
+        await using AuditingDbContext verifyCtx = new(dbOptions, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         AuditEntry entry = await verifyCtx.AuditEntries
             .Include(e => e.EntityChanges)
             .SingleAsync(TestContext.Current.CancellationToken);
@@ -218,10 +222,10 @@ public sealed class StrictAuditingPublisherTests
         return new AuditingMetrics(meterFactory, channel);
     }
 
-    private sealed class TestDbContextFactory(DbContextOptions<AuditingDbContext> options)
+    private sealed class TestDbContextFactory(DbContextOptions<AuditingDbContext> options, Granit.DataFiltering.DataFilter dataFilter)
         : IDbContextFactory<AuditingDbContext>
     {
-        public AuditingDbContext CreateDbContext() => new(options);
+        public AuditingDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant, dataFilter);
     }
 
     private sealed class TestMeterFactory : IMeterFactory

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/TestDataFilter.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/TestDataFilter.cs
@@ -1,0 +1,21 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+
+namespace Granit.Auditing.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Test-scoped helper that exposes a <see cref="DataFilter"/> with the
+/// <see cref="IMultiTenant"/> query filter disabled for the lifetime of the test
+/// instance. Tests insert and read rows under arbitrary tenant ids without
+/// setting up an ambient <c>ICurrentTenant</c>, so we bypass the parameterised
+/// tenant filter installed by <c>GranitDbContext</c>.
+/// </summary>
+internal sealed class TestDataFilter : IDisposable
+{
+    public DataFilter Filter { get; } = new();
+    private readonly IDisposable _scope;
+
+    public TestDataFilter() => _scope = Filter.Disable<IMultiTenant>();
+
+    public void Dispose() => _scope.Dispose();
+}

--- a/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -1,4 +1,5 @@
 using Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -37,7 +38,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<AuthenticationApi
         DbContextOptions<AuthenticationApiKeysDbContext> options = optionsBuilder.Options;
 
         // Create the schema
-        using (AuthenticationApiKeysDbContext db = new(options))
+        using (AuthenticationApiKeysDbContext db = new(options, GranitDesignTime.CurrentTenant))
         {
             db.Database.EnsureCreated();
         }
@@ -45,7 +46,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<AuthenticationApi
         return new TestDbContextFactory(connection, options);
     }
 
-    public AuthenticationApiKeysDbContext CreateDbContext() => new(_options);
+    public AuthenticationApiKeysDbContext CreateDbContext() => new(_options, GranitDesignTime.CurrentTenant);
 
     public void Dispose() => _connection.Dispose();
 }

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsDbContextTests.cs
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsDbContextTests.cs
@@ -1,5 +1,6 @@
 using Granit.BackgroundJobs.Domain;
 using Granit.BackgroundJobs.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;
@@ -16,7 +17,7 @@ public sealed class BackgroundJobsDbContextTests
                 .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
                 .Options;
 
-        return new BackgroundJobsDbContext(options);
+        return new BackgroundJobsDbContext(options, GranitDesignTime.CurrentTenant);
     }
 
     // =========================================================================

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/EfBackgroundJobStoreTests.cs
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/EfBackgroundJobStoreTests.cs
@@ -3,6 +3,7 @@ using Granit.BackgroundJobs.Domain;
 using Granit.BackgroundJobs.EntityFrameworkCore.Internal;
 using Granit.BackgroundJobs.Internal;
 using Granit.Guids;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Shouldly;
@@ -34,7 +35,7 @@ public sealed class EfBackgroundJobStoreTests : IDisposable
                 new DbContextOptionsBuilder<BackgroundJobsDbContext>()
                     .UseSqlite(connection)
                     .Options;
-            return new BackgroundJobsDbContext(options);
+            return new BackgroundJobsDbContext(options, GranitDesignTime.CurrentTenant);
         }
 
         public Task<BackgroundJobsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>

--- a/tests/Granit.Bff.BackgroundJobs.Tests/Jobs/BffExpiredSessionCleanupHandlerTests.cs
+++ b/tests/Granit.Bff.BackgroundJobs.Tests/Jobs/BffExpiredSessionCleanupHandlerTests.cs
@@ -1,6 +1,7 @@
 using Granit.Bff.BackgroundJobs.Internal;
 using Granit.Bff.BackgroundJobs.Jobs;
 using Granit.Bff.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -56,7 +57,7 @@ public sealed class BffExpiredSessionCleanupHandlerTests
         public BffDbContext CreateDbContext()
         {
             CreateCount++;
-            return new BffDbContext(options);
+            return new BffDbContext(options, GranitDesignTime.CurrentTenant);
         }
     }
 }

--- a/tests/Granit.Bff.EntityFrameworkCore.Tests/EfCoreBffTokenStoreTests.cs
+++ b/tests/Granit.Bff.EntityFrameworkCore.Tests/EfCoreBffTokenStoreTests.cs
@@ -3,6 +3,7 @@ using Granit.Bff.EntityFrameworkCore.Internal;
 using Granit.Bff.Options;
 using Granit.Encryption;
 using Granit.Guids;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -43,7 +44,7 @@ public sealed class EfCoreBffTokenStoreTests : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        await using BffDbContext db = new(_dbOptions);
+        await using BffDbContext db = new(_dbOptions, GranitDesignTime.CurrentTenant);
         await db.Database.EnsureDeletedAsync();
     }
 
@@ -70,7 +71,7 @@ public sealed class EfCoreBffTokenStoreTests : IAsyncLifetime
 
         await store.StoreAsync("admin", "session-1", _tokenSet, TestContext.Current.CancellationToken);
 
-        await using BffDbContext db = new(_dbOptions);
+        await using BffDbContext db = new(_dbOptions, GranitDesignTime.CurrentTenant);
         BffSessionEntity? entity = await db.Sessions.FirstOrDefaultAsync(TestContext.Current.CancellationToken);
 
         entity.ShouldNotBeNull();
@@ -99,7 +100,7 @@ public sealed class EfCoreBffTokenStoreTests : IAsyncLifetime
 
         await store.StoreAsync("admin", "session-1", updatedTokens, TestContext.Current.CancellationToken);
 
-        await using BffDbContext db = new(_dbOptions);
+        await using BffDbContext db = new(_dbOptions, GranitDesignTime.CurrentTenant);
         List<BffSessionEntity> entities = await db.Sessions.ToListAsync(TestContext.Current.CancellationToken);
 
         entities.Count.ShouldBe(1);
@@ -114,7 +115,7 @@ public sealed class EfCoreBffTokenStoreTests : IAsyncLifetime
         await store.StoreAsync("admin", "session-1", _tokenSet, TestContext.Current.CancellationToken);
         await store.StoreAsync("patient", "session-1", _tokenSet, TestContext.Current.CancellationToken);
 
-        await using BffDbContext db = new(_dbOptions);
+        await using BffDbContext db = new(_dbOptions, GranitDesignTime.CurrentTenant);
         int count = await db.Sessions.CountAsync(TestContext.Current.CancellationToken);
 
         count.ShouldBe(2);
@@ -400,7 +401,7 @@ public sealed class EfCoreBffTokenStoreTests : IAsyncLifetime
         encryptionService.Received(1).Encrypt(Arg.Any<string>());
 
         // Verify stored value is encrypted
-        await using BffDbContext db = new(_dbOptions);
+        await using BffDbContext db = new(_dbOptions, GranitDesignTime.CurrentTenant);
         BffSessionEntity? entity = await db.Sessions.FirstOrDefaultAsync(TestContext.Current.CancellationToken);
         entity.ShouldNotBeNull();
         entity.SerializedTokens.ShouldStartWith("ENC:");
@@ -435,7 +436,7 @@ public sealed class EfCoreBffTokenStoreTests : IAsyncLifetime
         EfCoreBffTokenStore store = CreateStore(encryptionService: null);
         await store.StoreAsync("admin", "session-1", _tokenSet, TestContext.Current.CancellationToken);
 
-        await using BffDbContext db = new(_dbOptions);
+        await using BffDbContext db = new(_dbOptions, GranitDesignTime.CurrentTenant);
         BffSessionEntity? entity = await db.Sessions.FirstOrDefaultAsync(TestContext.Current.CancellationToken);
         entity.ShouldNotBeNull();
 
@@ -470,6 +471,6 @@ public sealed class EfCoreBffTokenStoreTests : IAsyncLifetime
     private sealed class InMemoryBffDbContextFactory(DbContextOptions<BffDbContext> options)
         : IDbContextFactory<BffDbContext>
     {
-        public BffDbContext CreateDbContext() => new(options);
+        public BffDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant);
     }
 }

--- a/tests/Granit.BlobStorage.EntityFrameworkCore.Tests/EfBlobDescriptorStoreTests.cs
+++ b/tests/Granit.BlobStorage.EntityFrameworkCore.Tests/EfBlobDescriptorStoreTests.cs
@@ -1,6 +1,7 @@
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.EntityFrameworkCore.Internal;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;
@@ -23,7 +24,7 @@ public sealed class EfBlobDescriptorStoreTests
                 new DbContextOptionsBuilder<BlobStorageDbContext>()
                     .UseInMemoryDatabase(dbName)
                     .Options;
-            return new BlobStorageDbContext(options, currentTenant);
+            return new BlobStorageDbContext(options, currentTenant ?? GranitDesignTime.CurrentTenant);
         }
 
         public Task<BlobStorageDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Infrastructure/InMemoryDataExchangeContextFactory.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Infrastructure/InMemoryDataExchangeContextFactory.cs
@@ -1,4 +1,6 @@
 using Granit.DataExchange.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.DataExchange.EntityFrameworkCore.Tests.Infrastructure;
@@ -6,14 +8,20 @@ namespace Granit.DataExchange.EntityFrameworkCore.Tests.Infrastructure;
 /// <summary>
 /// InMemory factory for <see cref="DataExchangeDbContext"/>.
 /// Each instance uses the same named database for test isolation.
+/// Accepts an <see cref="ICurrentTenant"/> so the DbContext-side
+/// <see cref="Granit.Domain.IMultiTenant"/> query filter sees the same tenant
+/// as the store that consumes the factory.
 /// </summary>
-internal sealed class InMemoryDataExchangeContextFactory(string dbName)
+internal sealed class InMemoryDataExchangeContextFactory(string dbName, ICurrentTenant? tenant = null)
     : IDbContextFactory<DataExchangeDbContext>
 {
+    private readonly ICurrentTenant _tenant = tenant ?? GranitDesignTime.CurrentTenant;
+
     public DataExchangeDbContext CreateDbContext() =>
         new(new DbContextOptionsBuilder<DataExchangeDbContext>()
             .UseInMemoryDatabase(dbName)
-            .Options);
+            .Options,
+            _tenant);
 
     public Task<DataExchangeDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
         Task.FromResult(CreateDbContext());

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Stores/EfMappingStoreTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Stores/EfMappingStoreTests.cs
@@ -34,13 +34,16 @@ public sealed class EfMappingStoreTests
         return tenant;
     }
 
-    private static EfMappingStore CreateStore(string dbName, IClock? clock = null, ICurrentTenant? tenant = null) =>
-        new(
-            new InMemoryDataExchangeContextFactory(dbName),
+    private static EfMappingStore CreateStore(string dbName, IClock? clock = null, ICurrentTenant? tenant = null)
+    {
+        ICurrentTenant resolvedTenant = tenant ?? CreateTenant();
+        return new(
+            new InMemoryDataExchangeContextFactory(dbName, resolvedTenant),
             clock ?? CreateClock(),
             new SimpleGuidGenerator(),
-            tenant ?? CreateTenant(),
+            resolvedTenant,
             Substitute.For<ICurrentUserService>());
+    }
 
     // ---- LoadAsync --------------------------------------------------------
 

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreAdditionalTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreAdditionalTests.cs
@@ -2,6 +2,7 @@ using Granit.Events;
 using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Granit.Features.Events;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -10,28 +11,34 @@ using Xunit;
 
 namespace Granit.Features.EntityFrameworkCore.Tests;
 
-public sealed class EfCoreFeatureStoreAdditionalTests
+public sealed class EfCoreFeatureStoreAdditionalTests : IDisposable
 {
     // -------------------------------------------------------------------------
     // Test infrastructure
     // -------------------------------------------------------------------------
 
-    private sealed class InMemoryContextFactory(string dbName) : IDbContextFactory<FeaturesDbContext>
+    private readonly TestDataFilter _dataFilter = new();
+
+    public void Dispose() => _dataFilter.Dispose();
+
+    private sealed class InMemoryContextFactory(string dbName, Granit.DataFiltering.DataFilter dataFilter) : IDbContextFactory<FeaturesDbContext>
     {
         public FeaturesDbContext CreateDbContext() =>
             new(new DbContextOptionsBuilder<FeaturesDbContext>()
                 .UseInMemoryDatabase(dbName)
-                .Options);
+                .Options,
+                GranitDesignTime.CurrentTenant,
+                dataFilter);
 
         public Task<FeaturesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(CreateDbContext());
     }
 
-    private static EfCoreFeatureStore CreateStore(
+    private EfCoreFeatureStore CreateStore(
         string dbName,
         ILocalEventBus? eventBus = null,
         TimeProvider? timeProvider = null) =>
-        new(new InMemoryContextFactory(dbName),
+        new(new InMemoryContextFactory(dbName, _dataFilter.Filter),
             eventBus ?? Substitute.For<ILocalEventBus>(),
             timeProvider ?? TimeProvider.System,
             NullLogger<EfCoreFeatureStore>.Instance);

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreTests.cs
@@ -2,6 +2,7 @@ using Granit.Events;
 using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Granit.Features.Events;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -10,37 +11,43 @@ using Xunit;
 
 namespace Granit.Features.EntityFrameworkCore.Tests;
 
-public sealed class EfCoreFeatureStoreTests
+public sealed class EfCoreFeatureStoreTests : IDisposable
 {
     // -------------------------------------------------------------------------
     // Test infrastructure
     // -------------------------------------------------------------------------
 
-    private sealed class InMemoryContextFactory(string dbName) : IDbContextFactory<FeaturesDbContext>
+    private readonly TestDataFilter _dataFilter = new();
+
+    public void Dispose() => _dataFilter.Dispose();
+
+    private sealed class InMemoryContextFactory(string dbName, Granit.DataFiltering.DataFilter dataFilter) : IDbContextFactory<FeaturesDbContext>
     {
         public FeaturesDbContext CreateDbContext() =>
             new(new DbContextOptionsBuilder<FeaturesDbContext>()
                 .UseInMemoryDatabase(dbName)
-                .Options);
+                .Options,
+                GranitDesignTime.CurrentTenant,
+                dataFilter);
 
         public Task<FeaturesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(CreateDbContext());
     }
 
-    private static EfCoreFeatureStore CreateStore(string dbName, ILocalEventBus? eventBus = null) =>
-        new(new InMemoryContextFactory(dbName),
+    private EfCoreFeatureStore CreateStore(string dbName, ILocalEventBus? eventBus = null) =>
+        new(new InMemoryContextFactory(dbName, _dataFilter.Filter),
             eventBus ?? Substitute.For<ILocalEventBus>(),
             TimeProvider.System,
             NullLogger<EfCoreFeatureStore>.Instance);
 
-    private static async Task SeedAsync(
+    private async Task SeedAsync(
         string dbName,
         Guid tenantId,
         string featureName,
         string value,
         CancellationToken cancellationToken = default)
     {
-        InMemoryContextFactory factory = new(dbName);
+        InMemoryContextFactory factory = new(dbName, _dataFilter.Filter);
         await using FeaturesDbContext ctx = factory.CreateDbContext();
         ctx.FeatureOverrides.Add(new TenantFeatureOverride
         {
@@ -177,7 +184,7 @@ public sealed class EfCoreFeatureStoreTests
             "Acme.Feature", tenantId.ToString(), "true",
             TestContext.Current.CancellationToken);
 
-        InMemoryContextFactory factory = new(db);
+        InMemoryContextFactory factory = new(db, _dataFilter.Filter);
         await using FeaturesDbContext ctx = factory.CreateDbContext();
         int count = await ctx.FeatureOverrides.CountAsync(
             o => o.FeatureName == "Acme.Feature" && o.TenantId == tenantId,

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesDbContextTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesDbContextTests.cs
@@ -1,5 +1,6 @@
 using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;
@@ -7,12 +8,18 @@ using Xunit;
 
 namespace Granit.Features.EntityFrameworkCore.Tests;
 
-public sealed class FeaturesDbContextTests
+public sealed class FeaturesDbContextTests : IDisposable
 {
-    private static FeaturesDbContext CreateInMemory() =>
+    private readonly TestDataFilter _dataFilter = new();
+
+    public void Dispose() => _dataFilter.Dispose();
+
+    private FeaturesDbContext CreateInMemory() =>
         new(new DbContextOptionsBuilder<FeaturesDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options);
+            .Options,
+            GranitDesignTime.CurrentTenant,
+            _dataFilter.Filter);
 
     // -------------------------------------------------------------------------
     // Schema creation

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesModelBuilderExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Extensions;
 using Granit.Features.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;
@@ -15,7 +16,7 @@ public sealed class FeaturesModelBuilderExtensionsTests
         DbContextOptionsBuilder<FeaturesDbContext> optionsBuilder = new();
         optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
 
-        using FeaturesDbContext context = new(optionsBuilder.Options);
+        using FeaturesDbContext context = new(optionsBuilder.Options, GranitDesignTime.CurrentTenant);
         return context.Model;
     }
 

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideConfigurationTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideConfigurationTests.cs
@@ -1,5 +1,6 @@
 using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;
@@ -12,7 +13,8 @@ public sealed class TenantFeatureOverrideConfigurationTests
     private static FeaturesDbContext CreateInMemory() =>
         new(new DbContextOptionsBuilder<FeaturesDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options);
+            .Options,
+            GranitDesignTime.CurrentTenant);
 
     // -------------------------------------------------------------------------
     // Audit columns constraints

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/TestDataFilter.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/TestDataFilter.cs
@@ -1,0 +1,21 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+
+namespace Granit.Features.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Test-scoped helper that exposes a <see cref="DataFilter"/> with the
+/// <see cref="IMultiTenant"/> query filter disabled for the lifetime of the test
+/// instance. Tests insert and read rows under arbitrary tenant ids without
+/// setting up an ambient <c>ICurrentTenant</c>, so we bypass the parameterised
+/// tenant filter installed by <c>GranitDbContext</c>.
+/// </summary>
+internal sealed class TestDataFilter : IDisposable
+{
+    public DataFilter Filter { get; } = new();
+    private readonly IDisposable _scope;
+
+    public TestDataFilter() => _scope = Filter.Disable<IMultiTenant>();
+
+    public void Dispose() => _scope.Dispose();
+}

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -1,5 +1,6 @@
 using Granit.Encryption;
 using Granit.Identity.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -40,7 +41,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext
         DbContextOptions<IdentityDbContext> options = optionsBuilder.Options;
 
         // Create the schema once for the connection lifetime.
-        using (IdentityDbContext db = new(options, new PassthroughEncryption()))
+        using (IdentityDbContext db = new(options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant))
         {
             db.Database.EnsureCreated();
         }
@@ -48,7 +49,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext
         return new TestDbContextFactory(connection, options);
     }
 
-    public IdentityDbContext CreateDbContext() => new(_options, new PassthroughEncryption());
+    public IdentityDbContext CreateDbContext() => new(_options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant);
 
     public void Dispose() => _connection.Dispose();
 

--- a/tests/Granit.Localization.EntityFrameworkCore.Tests/EfCoreLocalizationOverrideStoreTests.cs
+++ b/tests/Granit.Localization.EntityFrameworkCore.Tests/EfCoreLocalizationOverrideStoreTests.cs
@@ -1,6 +1,7 @@
 using Granit.Localization.Domain;
 using Granit.Localization.EntityFrameworkCore.Internal;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;
@@ -20,7 +21,8 @@ public sealed class EfCoreLocalizationOverrideStoreTests
         public LocalizationDbContext CreateDbContext() =>
             new(new DbContextOptionsBuilder<LocalizationDbContext>()
                 .UseInMemoryDatabase(dbName)
-                .Options);
+                .Options,
+                GranitDesignTime.CurrentTenant);
 
         public Task<LocalizationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(CreateDbContext());

--- a/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
+++ b/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
@@ -7,6 +7,7 @@ using Granit.Mergeable.EntityFrameworkCore.Internal;
 using Granit.Mergeable.EntityFrameworkCore.Options;
 using Granit.Mergeable.Exceptions;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -493,8 +494,8 @@ public sealed class EfMergeServiceTests
                     w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
                 .Options;
 
-        public MergeableDbContext CreateDbContext() => new(_options);
+        public MergeableDbContext CreateDbContext() => new(_options, GranitDesignTime.CurrentTenant);
         public Task<MergeableDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new MergeableDbContext(_options));
+            Task.FromResult(new MergeableDbContext(_options, GranitDesignTime.CurrentTenant));
     }
 }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbContextTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbContextTests.cs
@@ -1,5 +1,6 @@
 using Granit.MultiTenancy.Domain;
 using Granit.MultiTenancy.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;
@@ -12,7 +13,8 @@ public sealed class MultiTenancyDbContextTests
     private static MultiTenancyDbContext CreateInMemory() =>
         new(new DbContextOptionsBuilder<MultiTenancyDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options);
+            .Options,
+            GranitDesignTime.CurrentTenant);
 
     [Fact]
     public void Model_HasTenantEntityType()

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
@@ -1,5 +1,6 @@
 using Granit.MultiTenancy.Domain;
 using Granit.MultiTenancy.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;
@@ -12,7 +13,8 @@ public sealed class TenantEntityTypeConfigurationTests
     private static MultiTenancyDbContext CreateInMemory() =>
         new(new DbContextOptionsBuilder<MultiTenancyDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options);
+            .Options,
+            GranitDesignTime.CurrentTenant);
 
     [Fact]
     public void Model_TableName_IsTenantsTenants()

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -1,6 +1,9 @@
 using System.Text.Json;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Encryption;
 using Granit.Notifications.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -14,15 +17,28 @@ namespace Granit.Notifications.EntityFrameworkCore.Tests;
 /// for fast, isolated integration tests that support all relational operations
 /// (including <c>ExecuteUpdateAsync</c> / <c>ExecuteDeleteAsync</c>).
 /// </summary>
+/// <remarks>
+/// The <see cref="IMultiTenant"/> query filter is disabled via a dedicated
+/// <see cref="DataFilter"/> instance so tests can insert/read rows under
+/// arbitrary tenant ids without setting up an ambient <c>ICurrentTenant</c>.
+/// </remarks>
 internal sealed class TestDbContextFactory : IDbContextFactory<NotificationsDbContext>, IDisposable
 {
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<NotificationsDbContext> _options;
+    private readonly IDataFilter _dataFilter;
+    private readonly IDisposable _multiTenantDisabled;
 
-    private TestDbContextFactory(SqliteConnection connection, DbContextOptions<NotificationsDbContext> options)
+    private TestDbContextFactory(
+        SqliteConnection connection,
+        DbContextOptions<NotificationsDbContext> options,
+        IDataFilter dataFilter,
+        IDisposable multiTenantDisabled)
     {
         _connection = connection;
         _options = options;
+        _dataFilter = dataFilter;
+        _multiTenantDisabled = multiTenantDisabled;
     }
 
     public static TestDbContextFactory Create()
@@ -36,18 +52,25 @@ internal sealed class TestDbContextFactory : IDbContextFactory<NotificationsDbCo
 
         DbContextOptions<NotificationsDbContext> options = optionsBuilder.Options;
 
+        DataFilter dataFilter = new();
+        IDisposable multiTenantDisabled = dataFilter.Disable<IMultiTenant>();
+
         // Create the schema
-        using (NotificationsDbContext db = new(options, new PassthroughEncryption()))
+        using (NotificationsDbContext db = new(options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant, dataFilter))
         {
             db.Database.EnsureCreated();
         }
 
-        return new TestDbContextFactory(connection, options);
+        return new TestDbContextFactory(connection, options, dataFilter, multiTenantDisabled);
     }
 
-    public NotificationsDbContext CreateDbContext() => new(_options, new PassthroughEncryption());
+    public NotificationsDbContext CreateDbContext() => new(_options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant, _dataFilter);
 
-    public void Dispose() => _connection.Dispose();
+    public void Dispose()
+    {
+        _multiTenantDisabled.Dispose();
+        _connection.Dispose();
+    }
 
     private sealed class PassthroughEncryption : IStringEncryptionService
     {

--- a/tests/Granit.Timeline.EntityFrameworkCore.Tests/ReactionConfigurationTests.cs
+++ b/tests/Granit.Timeline.EntityFrameworkCore.Tests/ReactionConfigurationTests.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timeline.Domain;
 using Granit.Timeline.EntityFrameworkCore;
 using Granit.Timeline.EntityFrameworkCore.Internal;
@@ -18,7 +19,7 @@ public sealed class ReactionConfigurationTests
         DbContextOptions<TimelineDbContext> options = new DbContextOptionsBuilder<TimelineDbContext>()
             .UseSqlite(connection)
             .Options;
-        using TimelineDbContext ctx = new(options);
+        using TimelineDbContext ctx = new(options, GranitDesignTime.CurrentTenant);
         return ctx.Model.FindEntityType(typeof(Reaction))
             ?? throw new InvalidOperationException("Reaction entity type missing from model");
     }

--- a/tests/Granit.Timeline.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Timeline.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timeline.EntityFrameworkCore.Internal;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -35,7 +36,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<TimelineDbContext
         DbContextOptions<TimelineDbContext> options = optionsBuilder.Options;
 
         // Create the schema
-        using (TimelineDbContext db = new(options))
+        using (TimelineDbContext db = new(options, GranitDesignTime.CurrentTenant))
         {
             db.Database.EnsureCreated();
         }
@@ -43,7 +44,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<TimelineDbContext
         return new TestDbContextFactory(connection, options);
     }
 
-    public TimelineDbContext CreateDbContext() => new(_options);
+    public TimelineDbContext CreateDbContext() => new(_options, GranitDesignTime.CurrentTenant);
 
     public void Dispose() => _connection.Dispose();
 }

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookDeliveryStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookDeliveryStoreTests.cs
@@ -1,5 +1,6 @@
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
@@ -18,6 +19,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
     private readonly IDbContextFactory<WebhooksDbContext> _contextFactory;
     private readonly DbContextOptions<WebhooksDbContext> _options;
     private readonly EfWebhookDeliveryStore _sut;
+    private readonly TestDataFilter _dataFilter = new();
 
     public EfWebhookDeliveryStoreTests()
     {
@@ -28,14 +30,15 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
             .UseInMemoryDatabase(databaseName: $"webhooks-delivery-{Guid.NewGuid()}")
             .Options;
 
-        _contextFactory = new TestWebhooksDbContextFactory(_options);
+        _contextFactory = new TestWebhooksDbContextFactory(_options, _dataFilter.Filter);
         _sut = new EfWebhookDeliveryStore(_contextFactory, Substitute.For<ICurrentTenant>(), _clock, new SimpleGuidGenerator());
     }
 
     public async ValueTask DisposeAsync()
     {
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         await context.Database.EnsureDeletedAsync();
+        _dataFilter.Dispose();
     }
 
     [Fact]
@@ -48,7 +51,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await _sut.RecordSuccessAsync(command, 200, 42, "abc123", null, TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookDeliveryAttempt attempt = await context.WebhookDeliveryAttempts.SingleAsync(TestContext.Current.CancellationToken);
         attempt.DeliveryId.ShouldBe(command.DeliveryId);
         attempt.SubscriptionId.ShouldBe(command.SubscriptionId);
@@ -72,7 +75,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await _sut.RecordSuccessAsync(command, 200, 10, "hash", null, TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookSubscription? subscription = await context.WebhookSubscriptions.FindAsync([subscriptionId], TestContext.Current.CancellationToken);
         subscription.ShouldNotBeNull();
         subscription!.ConsecutiveFailureCount.ShouldBe(0);
@@ -89,7 +92,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await Should.NotThrowAsync(async () =>
             await _sut.RecordSuccessAsync(command, 200, 10, "hash", null, TestContext.Current.CancellationToken));
 
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         (await context.WebhookDeliveryAttempts.CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
     }
 
@@ -103,7 +106,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await _sut.RecordFailureAsync(command, 500, 100, "Server Error", null, TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookDeliveryAttempt attempt = await context.WebhookDeliveryAttempts.SingleAsync(TestContext.Current.CancellationToken);
         attempt.IsSuccess.ShouldBeFalse();
         attempt.HttpStatusCode.ShouldBe(500);
@@ -123,7 +126,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await _sut.RecordFailureAsync(command, 500, 50, "Error", null, TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookSubscription? subscription = await context.WebhookSubscriptions.FindAsync([subscriptionId], TestContext.Current.CancellationToken);
         subscription!.ConsecutiveFailureCount.ShouldBe(3);
     }
@@ -139,7 +142,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await _sut.RecordFailureAsync(command, null, 50, longError, null, TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookDeliveryAttempt attempt = await context.WebhookDeliveryAttempts.SingleAsync(TestContext.Current.CancellationToken);
         attempt.ErrorMessage!.Length.ShouldBe(2000);
     }
@@ -154,7 +157,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await _sut.RecordFailureAsync(command, null, 10000, "Timeout", null, TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookDeliveryAttempt attempt = await context.WebhookDeliveryAttempts.SingleAsync(TestContext.Current.CancellationToken);
         attempt.HttpStatusCode.ShouldBeNull();
     }
@@ -170,7 +173,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
         await _sut.SuspendSubscriptionAsync(subscriptionId, "Too many failures", TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookSubscription? subscription = await context.WebhookSubscriptions.FindAsync([subscriptionId], TestContext.Current.CancellationToken);
         subscription!.Status.ShouldBe(WebhookSubscriptionStatus.Suspended);
         subscription.DeactivationReason.ShouldBe("Too many failures");
@@ -231,14 +234,14 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
 
         sub.ClearDomainEvents();
 
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         context.WebhookSubscriptions.Add(sub);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
 
     private async Task SeedDeliveryAttemptAsync(DateTimeOffset occurredAt)
     {
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         context.WebhookDeliveryAttempts.Add(new WebhookDeliveryAttempt
         {
             Id = Guid.NewGuid(),
@@ -273,13 +276,15 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
     };
 }
 
-internal sealed class TestWebhooksDbContextFactory(DbContextOptions<WebhooksDbContext> options)
+internal sealed class TestWebhooksDbContextFactory(
+    DbContextOptions<WebhooksDbContext> options,
+    Granit.DataFiltering.DataFilter dataFilter)
     : IDbContextFactory<WebhooksDbContext>
 {
-    public WebhooksDbContext CreateDbContext() => new(options);
+    public WebhooksDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant, dataFilter);
 
     public Task<WebhooksDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult(new WebhooksDbContext(options));
+        Task.FromResult(new WebhooksDbContext(options, GranitDesignTime.CurrentTenant, dataFilter));
 }
 
 // =============================================================================
@@ -389,11 +394,16 @@ internal sealed class TestWebhooksSqliteFactory : IDbContextFactory<WebhooksDbCo
 {
     private readonly Microsoft.Data.Sqlite.SqliteConnection _connection;
     private readonly DbContextOptions<WebhooksDbContext> _options;
+    private readonly TestDataFilter _dataFilter;
 
-    private TestWebhooksSqliteFactory(Microsoft.Data.Sqlite.SqliteConnection connection, DbContextOptions<WebhooksDbContext> options)
+    private TestWebhooksSqliteFactory(
+        Microsoft.Data.Sqlite.SqliteConnection connection,
+        DbContextOptions<WebhooksDbContext> options,
+        TestDataFilter dataFilter)
     {
         _connection = connection;
         _options = options;
+        _dataFilter = dataFilter;
     }
 
     public static TestWebhooksSqliteFactory Create()
@@ -407,20 +417,26 @@ internal sealed class TestWebhooksSqliteFactory : IDbContextFactory<WebhooksDbCo
 
         DbContextOptions<WebhooksDbContext> options = optionsBuilder.Options;
 
-        using (WebhooksDbContext db = new(options))
+        TestDataFilter dataFilter = new();
+
+        using (WebhooksDbContext db = new(options, GranitDesignTime.CurrentTenant, dataFilter.Filter))
         {
             db.Database.EnsureCreated();
         }
 
-        return new TestWebhooksSqliteFactory(connection, options);
+        return new TestWebhooksSqliteFactory(connection, options, dataFilter);
     }
 
-    public WebhooksDbContext CreateDbContext() => new(_options);
+    public WebhooksDbContext CreateDbContext() => new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
 
     public Task<WebhooksDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
         Task.FromResult(CreateDbContext());
 
-    public void Dispose() => _connection.Dispose();
+    public void Dispose()
+    {
+        _dataFilter.Dispose();
+        _connection.Dispose();
+    }
 }
 
 internal sealed class WebhooksSqliteModelCustomizer(

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
@@ -1,5 +1,6 @@
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
@@ -20,6 +21,7 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
     private readonly DbContextOptions<WebhooksDbContext> _options;
     private readonly IDbContextFactory<WebhooksDbContext> _contextFactory;
     private readonly EfWebhookSubscriptionStore _sut;
+    private readonly TestDataFilter _dataFilter = new();
 
     public EfWebhookSubscriptionStoreTests()
     {
@@ -37,7 +39,7 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
         IClock clock = Substitute.For<IClock>();
         clock.Now.Returns(Now);
 
-        _contextFactory = new TestWebhooksDbContextFactory(_options);
+        _contextFactory = new TestWebhooksDbContextFactory(_options, _dataFilter.Filter);
         IOptions<WebhooksOptions> webhooksOptions =
             Microsoft.Extensions.Options.Options.Create(new WebhooksOptions());
         _sut = new EfWebhookSubscriptionStore(_contextFactory, Substitute.For<ICurrentTenant>(), guidGenerator, secretProtector, clock, webhooksOptions);
@@ -45,8 +47,11 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await using WebhooksDbContext context = new(_options);
-        await context.Database.EnsureDeletedAsync();
+        await using (WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter))
+        {
+            await context.Database.EnsureDeletedAsync();
+        }
+        _dataFilter.Dispose();
     }
 
     [Fact]
@@ -153,7 +158,7 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
         await _sut.DeactivateAsync(subscription.Id, "User requested", TestContext.Current.CancellationToken);
 
         // Assert
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         WebhookSubscription? updated = await context.WebhookSubscriptions.FindAsync([subscription.Id], TestContext.Current.CancellationToken);
         updated!.Status.ShouldBe(WebhookSubscriptionStatus.Deactivated);
         updated.DeactivationReason.ShouldBe("User requested");
@@ -173,7 +178,7 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
 
     private async Task SeedSubscriptions(params WebhookSubscription[] subscriptions)
     {
-        await using WebhooksDbContext context = new(_options);
+        await using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         context.WebhookSubscriptions.AddRange(subscriptions);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
     }

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/TestDataFilter.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/TestDataFilter.cs
@@ -1,0 +1,27 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Test-scoped helper that exposes a <see cref="DataFilter"/> with the
+/// <see cref="IMultiTenant"/> query filter disabled for the lifetime of the test
+/// instance. Tests insert and read rows under arbitrary tenant ids without
+/// setting up an ambient <c>ICurrentTenant</c>, so we bypass the parameterised
+/// tenant filter installed by <c>GranitDbContext</c>.
+/// </summary>
+/// <remarks>
+/// The disable scope is captured in the test's async flow (xunit creates a fresh
+/// instance per test, so the ctor and the test method share one
+/// <see cref="System.Threading.ExecutionContext"/>). Dispose in the test's
+/// dispose method to release the scope.
+/// </remarks>
+internal sealed class TestDataFilter : IDisposable
+{
+    public DataFilter Filter { get; } = new();
+    private readonly IDisposable _scope;
+
+    public TestDataFilter() => _scope = Filter.Disable<IMultiTenant>();
+
+    public void Dispose() => _scope.Dispose();
+}

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDbContextTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDbContextTests.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
@@ -9,6 +10,7 @@ namespace Granit.Webhooks.EntityFrameworkCore.Tests;
 public sealed class WebhooksDbContextTests : IAsyncDisposable
 {
     private readonly DbContextOptions<WebhooksDbContext> _options;
+    private readonly TestDataFilter _dataFilter = new();
 
     public WebhooksDbContextTests()
     {
@@ -19,8 +21,11 @@ public sealed class WebhooksDbContextTests : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await using WebhooksDbContext context = new(_options);
-        await context.Database.EnsureDeletedAsync();
+        await using (WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter))
+        {
+            await context.Database.EnsureDeletedAsync();
+        }
+        _dataFilter.Dispose();
     }
 
     [Fact]
@@ -28,7 +33,7 @@ public sealed class WebhooksDbContextTests : IAsyncDisposable
     {
         // Arrange
         var id = Guid.NewGuid();
-        await using (WebhooksDbContext context = new(_options))
+        await using (WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter))
         {
             context.WebhookSubscriptions.Add(
                 WebhookSubscription.Create(
@@ -38,7 +43,7 @@ public sealed class WebhooksDbContextTests : IAsyncDisposable
         }
 
         // Act
-        await using (WebhooksDbContext context = new(_options))
+        await using (WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter))
         {
             WebhookSubscription? subscription = await context.WebhookSubscriptions.FindAsync([id], TestContext.Current.CancellationToken);
 
@@ -53,7 +58,7 @@ public sealed class WebhooksDbContextTests : IAsyncDisposable
     {
         // Arrange
         var id = Guid.NewGuid();
-        await using (WebhooksDbContext context = new(_options))
+        await using (WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter))
         {
             context.WebhookDeliveryAttempts.Add(new WebhookDeliveryAttempt
             {
@@ -71,7 +76,7 @@ public sealed class WebhooksDbContextTests : IAsyncDisposable
         }
 
         // Act
-        await using (WebhooksDbContext context = new(_options))
+        await using (WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter))
         {
             WebhookDeliveryAttempt? attempt = await context.WebhookDeliveryAttempts.FindAsync([id], TestContext.Current.CancellationToken);
 
@@ -84,7 +89,7 @@ public sealed class WebhooksDbContextTests : IAsyncDisposable
     [Fact]
     public void DbSets_are_accessible()
     {
-        using WebhooksDbContext context = new(_options);
+        using WebhooksDbContext context = new(_options, GranitDesignTime.CurrentTenant, _dataFilter.Filter);
         context.WebhookSubscriptions.ShouldNotBeNull();
         context.WebhookDeliveryAttempts.ShouldNotBeNull();
     }


### PR DESCRIPTION
## Summary

Bulk follow-up to #2129 (pilot). Migrates every framework `IMultiTenant` DbContext to inherit from `GranitDbContext` so the multi-tenant filter is **parameterised per-request** instead of inlined into the cached compiled model. Closes the "frozen tenant" SQL leak class-wide.

## Migrated DbContexts (20)

**Standard inheritance (19)** — `: GranitDbContext(options, currentTenant, dataFilter?)` + `OnGranitModelCreating` override:

`AIDbContext`, `AuditingDbContext`, `AuthenticationApiKeysDbContext`, `BackgroundJobsDbContext`, `BffDbContext`, `BlobStorageDatabaseDbContext`, `BlobStorageDbContext`, `DataExchangeDbContext`, `FeaturesDbContext`, `IdentityDbContext`, `LocalizationDbContext`, `MergeableDbContext`, `MultiTenancyDbContext`, `NotificationsDbContext`, `PrivacyDbContext`, `SchedulingDbContext`, `TimelineDbContext`, `WebhooksDbContext`

**Inline pattern (1)** — `OpenIddictDbContext` cannot inherit from `GranitDbContext` because single-inheritance is taken by `IdentityDbContext<TUser,TRole,TKey>` from `Microsoft.AspNetCore.Identity.EntityFrameworkCore`. The parameterised filter is replicated inline (`ConfigureMultiTenantFilter<TEntity>` + `CurrentTenantId` / `IsMultiTenantFilterEnabled` properties). Documented in the class remarks; the new archi test exempts it explicitly.

**Excluded (1)** — `MigrationProgressDbContext` is a system context that bootstraps the migration runner before tenant interceptors exist; no `IMultiTenant` entities. Lives in `*.EntityFrameworkCore.Migrations`, already outside the archi test scope.

## Critical order fix in `GranitDbContext`

The pilot called `ApplyGranitConventions` BEFORE the derived class's configuration, which broke modules that `Ignore<>()` shared entities (DataExchange's `BlobReference`: `entity type cannot be removed because it is being referenced by foreign key`).

Swapped to:
1. `OnGranitModelCreating` (derived config — `Ignore<>`, FKs, indexes)
2. `ApplyGranitConventions` (non-tenant filters)
3. `IMultiTenant` filter loop (parameterised via `this.CurrentTenantId`)

## New archi rule

`DbContext_classes_should_use_GranitDbContext_or_inline_parameterised_filter` scans every concrete `*DbContext.cs` in `*.EntityFrameworkCore` or `*.Database` packages and asserts it either inherits `GranitDbContext` OR carries the `ConfigureMultiTenantFilter` marker (OpenIddict). Prevents any future module from re-introducing the buggy legacy form.

## Test infrastructure (29+ files)

Two patterns, picked per test intent:

- **`TestDataFilter` helper** (new in Webhooks/Features/Auditing) — `Disable<IMultiTenant>()` for tests that need cross-tenant visibility regardless of context state.
- **Explicit `ICurrentTenant`** plumbed through both factory and store (DataExchange) — for tests that genuinely verify per-tenant isolation, e.g. `EfMappingStoreTests.SaveAsync_and_LoadAsync_respect_tenant_isolation`.

29+ test files updated to pass `GranitDesignTime.CurrentTenant` (or a per-test tenant) at the right ctor slot. Constructor signature is now `(options, [encryption,] currentTenant, dataFilter?)` — `ICurrentTenant` non-nullable, after options/encryption and before the optional data filter.

## Test plan

- [x] `core-ai`, `application`, `api-data`, `infrastructure`, `security`, `architecture` shards — **all green**
- [x] `MultiTenantFilterParameterizationReproTests` (3 SQLite repro tests) — green via the migrated DbContexts
- [x] No production-code regressions (only signature change is `ICurrentTenant?` → `ICurrentTenant`; runtime DI always provides one)
- [ ] CI on PR
- [ ] `integration` shard (Testcontainers — locally skipped)

## Out of scope (downstream repos)

Self-contained handoff prompt was prepared (see #2129 conversation). Repos to migrate after this PR + dev NuGet bump:
- `granit-business` (17 DbContexts, GitLab)
- `granit-showcase-dotnet` (5)
- `granit-iot-showcase-dotnet` (4)
- `granit-microservice-template` (3)
- `granit-iot` (2)

## Out of scope (follow-ups)

- Re-enable `TenantIsolationTests.UnauthenticatedRequest_NoTenantHeader_ReturnsEmpty` once downstream migrations propagate.
- Tighten the 3 showcase defensive bypasses (#1180, #1182, #1185) once the framework-side leak is confirmed eliminated end-to-end.