### PR TITLE
fix(persistence): detach SVO auto-FKs in ApplyGranitConventions

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -177,12 +177,61 @@ public static class ModelBuilderExtensions
     // the CLR type as a navigation target and adds it as an entity type — which then fails
     // validation because no primary key is defined. This step removes those phantom entities
     // so the subsequent converter step can safely map the property as a scalar column.
+    //
+    // Convention also detaches any auto-discovered foreign key whose principal is an SVO type
+    // (e.g. Party.AvatarTempId : BlobReference creates an auto-FK that EF refuses to release
+    // when we call RemoveEntityType). The underlying scalar column survives and is then wrapped
+    // by ApplySingleValueObjectConverters with the matching ValueConverter.
     private static void RemoveSingleValueObjectEntityTypes(ModelBuilder modelBuilder)
     {
         var svoEntityTypes = modelBuilder.Model.GetEntityTypes()
             .Where(et => GetSingleValueObjectBase(et.ClrType) is not null)
             .ToList();
 
+        if (svoEntityTypes.Count == 0)
+        {
+            return;
+        }
+
+        HashSet<Type> svoClrTypes = [.. svoEntityTypes.Select(et => et.ClrType)];
+
+        foreach (IMutableEntityType ownerEntityType in modelBuilder.Model.GetEntityTypes()
+            .Where(et => !svoClrTypes.Contains(et.ClrType))
+            .ToList())
+        {
+            // Capture the SVO-typed CLR properties EF auto-discovered as navigations
+            // on this owner (e.g. Party.AvatarTempId : BlobReference). We will
+            // re-attach them as scalar properties once the navigation is gone.
+            List<System.Reflection.PropertyInfo> svoClrProperties = [.. ownerEntityType
+                .GetNavigations()
+                .Where(nav => svoClrTypes.Contains(nav.TargetEntityType.ClrType))
+                .Select(nav => nav.PropertyInfo)
+                .OfType<System.Reflection.PropertyInfo>()];
+
+            if (svoClrProperties.Count == 0)
+            {
+                continue;
+            }
+
+            // Use the builder API for both steps: `Ignore(name)` strips the
+            // auto-discovered navigation (and its backing FK) cleanly, then
+            // `Property(name)` re-registers the same CLR member as a scalar.
+            // Doing this at builder level avoids the IMutable* surface's
+            // navigation/property name conflicts and lets EF Core re-validate
+            // the model after each step.
+            Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder ownerBuilder =
+                modelBuilder.Entity(ownerEntityType.ClrType);
+
+            foreach (System.Reflection.PropertyInfo clrProperty in svoClrProperties)
+            {
+                ownerBuilder.Ignore(clrProperty.Name);
+                ownerBuilder.Property(clrProperty.PropertyType, clrProperty.Name);
+            }
+        }
+
+        // Now that no FK or navigation references them, the SVO entity types can be
+        // removed. ApplySingleValueObjectConverters runs next and wraps each promoted
+        // scalar property with the matching ValueConverter.
         foreach (IMutableEntityType svoEntityType in svoEntityTypes)
         {
             modelBuilder.Model.RemoveEntityType(svoEntityType.ClrType);

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/SvoEntityAutoDiscoveryRemovalTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/SvoEntityAutoDiscoveryRemovalTests.cs
@@ -1,0 +1,83 @@
+// =============================================================================
+// Repro — SVO entity auto-discovery removal must detach orphan FKs
+// =============================================================================
+// When a domain entity has a property of an SVO type (e.g. `BlobReference`,
+// which is `SingleValueObject<string>`), EF Core's auto-discovery scanner
+// treats the reference type as a navigation and registers the SVO as an
+// entity type, then auto-creates a foreign key from the owner.
+//
+// `RemoveSingleValueObjectEntityTypes` in `ApplyGranitConventions` exists to
+// purge those phantom SVO entities so the matching converter can map the
+// property as a scalar column. But until this fix it called `RemoveEntityType`
+// directly and EF rejects that whenever a referencing FK still exists:
+//
+//   System.InvalidOperationException :
+//     The entity type 'BlobReference' cannot be removed because it is being
+//     referenced by foreign key {'AvatarTempId'} on 'Party'.
+//
+// Reported by granit-business during the GranitDbContext migration on Parties
+// (Party.AvatarTempId : BlobReference) without an explicit
+// modelBuilder.Ignore<BlobReference>().
+//
+// The fix detaches any FK whose principal entity is an SVO before removing
+// the SVO entity itself. The underlying scalar column survives —
+// ApplySingleValueObjectConverters wraps it with a converter to round-trip
+// through the primitive form.
+// =============================================================================
+
+using Granit.Domain.ValueObjects;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class SvoEntityAutoDiscoveryRemovalTests
+{
+    [Fact]
+    public void ApplyGranitConventions_EntityWithSvoProperty_RemovesSvoAndDetachesOrphanForeignKey()
+    {
+        // Arrange — model the granit-business "Party" scenario in miniature:
+        // an entity exposes a property whose CLR type is an SVO. EF Core's
+        // convention scanner discovers it as an entity AND wires a FK before
+        // OnModelCreating runs.
+        using SvoOwnerDbContext context = new(new DbContextOptionsBuilder<SvoOwnerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+        // Act — model build triggers ApplyGranitConventions on first access.
+        IReadOnlyList<string> entityNames = [.. context.Model.GetEntityTypes()
+            .Select(et => et.ClrType.Name)];
+
+        // Assert — the SVO must NOT appear as an entity (it is a value object).
+        entityNames.ShouldContain(nameof(SvoOwnerEntity), "the owner entity must remain");
+        entityNames.ShouldNotContain(nameof(BlobReference),
+            "the SVO type must NOT survive as an entity type");
+
+        // The scalar column survives via ApplySingleValueObjectConverters.
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType owner = context.Model
+            .FindEntityType(typeof(SvoOwnerEntity))!;
+        owner.FindProperty(nameof(SvoOwnerEntity.AvatarTempId)).ShouldNotBeNull(
+            "the SVO column must survive as a scalar property on the owner");
+    }
+
+    public sealed class SvoOwnerEntity
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        // BlobReference is a SingleValueObject<string> in Granit.Domain.
+        // No Ignore<BlobReference>() configuration — relies on the framework
+        // convention to do the right thing.
+        public BlobReference? AvatarTempId { get; set; }
+    }
+
+    private sealed class SvoOwnerDbContext(DbContextOptions<SvoOwnerDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<SvoOwnerEntity> Owners => Set<SvoOwnerEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ApplyGranitConventions();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug in `RemoveSingleValueObjectEntityTypes` ([ModelBuilderExtensions.cs:180](src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs#L180)) reported by granit-business while migrating Parties to `GranitDbContext` (#2130 follow-up).

When a domain entity has a property of an SVO type (e.g. `Party.AvatarTempId : BlobReference`) without an explicit `modelBuilder.Ignore<BlobReference>()`, EF Core's convention scanner discovers the SVO as an entity AND auto-creates a foreign key from the owner. The framework's existing call to `Model.RemoveEntityType(svoEntityType.ClrType)` then fails:

```
System.InvalidOperationException :
  The entity type 'BlobReference' cannot be removed because it is being
  referenced by foreign key {'AvatarTempIdTempId'} on 'Party'.
```

Independent of the multi-tenant filter work in #2129/#2130 — branched directly from `develop`.

## Fix

Use the `EntityTypeBuilder` API for both steps:
1. `Ignore(name)` strips each SVO-typed auto-navigation cleanly (drops the backing FK as a side effect).
2. `Property(name)` re-registers the same CLR member as a scalar so the column survives.

Then `Model.RemoveEntityType(svo)` is safe, and the existing `ApplySingleValueObjectConverters` attaches the matching `ValueConverter` on the next pass.

Why builder API not `IMutable*`: tried `IMutableEntityType.RemoveForeignKey` + `AddProperty` first — EF Core's convention scanner re-discovered the navigation under a fresh shadow name (`AvatarTempIdTempId1`) before `AddProperty` could land. The builder surface re-validates the model after each call, which avoids the race.

## Test plan

- [x] New isolated repro `SvoEntityAutoDiscoveryRemovalTests` — failing before the fix with the exact error reported by granit-business; passing after.
- [x] `Granit.Persistence.EntityFrameworkCore.Tests` — 337/337 pass (no regression).
- [x] `api-data` shard — 0 failing dlls.
- [ ] CI on PR.

## Downstream impact

Once merged + dev NuGet bumped, granit-business's Parties migration unblocks (no longer needs to add `Ignore<BlobReference>()` to PartiesDbContext). Same applies to any other repo with entities exposing SVO-typed properties without explicit configuration.