### PR TITLE
test(testing): endpoint test harness + Validation.Endpoints HTTP coverage

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -39091,6 +39091,37 @@
       ]
     },
     {
+      "name": "GranitEndpointTestHost",
+      "fqn": "Granit.Testing.Endpoints.GranitEndpointTestHost",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "StartAsync",
+          "kind": "method",
+          "signature": "StartAsync(Action<IServiceCollection>? configureServices = null, Action<WebApplication>? configureEndpoints = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<GranitEndpointTestHost>"
+        },
+        {
+          "name": "CreateAuthenticatedClient",
+          "kind": "method",
+          "signature": "CreateAuthenticatedClient(params string[] roles)",
+          "returnType": "HttpClient"
+        }
+      ]
+    },
+    {
+      "name": "TestAuthHandler",
+      "fqn": "Granit.Testing.Endpoints.TestAuthHandler",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Endpoints/TestAuthHandler.cs",
+      "line": 20,
+      "members": []
+    },
+    {
       "name": "DbContextOptionsBuilderTestExtensions",
       "fqn": "Granit.Testing.EntityFrameworkCore.Extensions.DbContextOptionsBuilderTestExtensions",
       "kind": "class",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -80,6 +80,7 @@
       "src/Granit.Scheduling.Wolverine/Granit.Scheduling.Wolverine.csproj",
       "src/Granit.Scheduling/Granit.Scheduling.csproj",
       "src/Granit.Templating/Granit.Templating.csproj",
+      "src/Granit.Testing/Granit.Testing.csproj",
       "src/Granit.Timing/Granit.Timing.csproj",
       "src/Granit.Validation.AI/Granit.Validation.AI.csproj",
       "src/Granit.Validation.Endpoints/Granit.Validation.Endpoints.csproj",

--- a/src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs
+++ b/src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Testing.Endpoints;
+
+/// <summary>
+/// In-process ASP.NET Core host for testing a single Granit endpoint module
+/// without bootstrapping a full application. Wires <see cref="TestAuthHandler"/>
+/// so tests can drive authenticated vs anonymous flows via the
+/// <see cref="TestAuthHandler.RolesHeader"/> header.
+/// </summary>
+public sealed class GranitEndpointTestHost : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+
+    private GranitEndpointTestHost(WebApplication app)
+    {
+        _app = app;
+    }
+
+    /// <summary>The started application — exposed for advanced scenarios.</summary>
+    public WebApplication Application => _app;
+
+    /// <summary>
+    /// Builds and starts a host. <paramref name="configureServices"/> registers
+    /// the services the module under test depends on (mocks, authorization
+    /// policies, options). <paramref name="configureEndpoints"/> wires the
+    /// <c>Map*</c> extension method that registers the module's routes.
+    /// </summary>
+    public static async Task<GranitEndpointTestHost> StartAsync(
+        Action<IServiceCollection>? configureServices = null,
+        Action<WebApplication>? configureEndpoints = null,
+        CancellationToken cancellationToken = default)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddRouting();
+
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+
+        configureServices?.Invoke(builder.Services);
+
+        WebApplication app = builder.Build();
+        app.UseAuthentication();
+        app.UseAuthorization();
+
+        configureEndpoints?.Invoke(app);
+
+        await app.StartAsync(cancellationToken).ConfigureAwait(false);
+        return new GranitEndpointTestHost(app);
+    }
+
+    /// <summary>Returns an anonymous client (no auth header).</summary>
+    public HttpClient CreateAnonymousClient() => _app.GetTestClient();
+
+    /// <summary>
+    /// Returns a client carrying the <see cref="TestAuthHandler.RolesHeader"/>
+    /// header. <paramref name="roles"/> are joined with commas.
+    /// </summary>
+    public HttpClient CreateAuthenticatedClient(params string[] roles)
+    {
+        HttpClient client = _app.GetTestClient();
+        client.DefaultRequestHeaders.Add(
+            TestAuthHandler.RolesHeader,
+            roles.Length == 0 ? "user" : string.Join(',', roles));
+        return client;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _app.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Testing/Endpoints/TestAuthHandler.cs
+++ b/src/Granit.Testing/Endpoints/TestAuthHandler.cs
@@ -3,18 +3,25 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
-namespace Granit.Diagnostics.Endpoints.Tests;
+namespace Granit.Testing.Endpoints;
 
 /// <summary>
-/// Fake authentication handler that resolves authentication from the
-/// <c>X-Test-Roles</c> header. When the header is present, the user is
-/// considered authenticated with a fixed <c>sub</c> claim.
+/// Authentication handler for endpoint tests. Resolves identity from the
+/// <c>X-Test-Roles</c> header. When the header is absent, returns
+/// <see cref="AuthenticateResult.NoResult"/> (the user is anonymous).
 /// </summary>
-internal sealed class TestAuthHandler(
+/// <remarks>
+/// Roles are comma-separated. Each value becomes a <see cref="ClaimTypes.Role"/>
+/// claim. A fixed <c>sub</c> and <c>name</c> claim are also added so policies
+/// requiring an authenticated user pass.
+/// </remarks>
+public sealed class TestAuthHandler(
     IOptionsMonitor<AuthenticationSchemeOptions> options,
     ILoggerFactory logger,
-    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
 {
     public const string SchemeName = "Test";
     public const string RolesHeader = "X-Test-Roles";
@@ -22,7 +29,7 @@ internal sealed class TestAuthHandler(
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        if (!Request.Headers.TryGetValue(RolesHeader, out Microsoft.Extensions.Primitives.StringValues rolesHeader))
+        if (!Request.Headers.TryGetValue(RolesHeader, out StringValues rolesHeader))
         {
             return Task.FromResult(AuthenticateResult.NoResult());
         }

--- a/tests/Granit.Diagnostics.Endpoints.Tests/Granit.Diagnostics.Endpoints.Tests.csproj
+++ b/tests/Granit.Diagnostics.Endpoints.Tests/Granit.Diagnostics.Endpoints.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Diagnostics.Endpoints\Granit.Diagnostics.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Diagnostics.Endpoints.Tests/MonitoringEndpointsTests.cs
+++ b/tests/Granit.Diagnostics.Endpoints.Tests/MonitoringEndpointsTests.cs
@@ -3,9 +3,7 @@ using System.Net.Http.Json;
 using Granit.Diagnostics.Abstractions;
 using Granit.Diagnostics.Dtos;
 using Granit.Diagnostics.Endpoints.Extensions;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.TestHost;
+using Granit.Testing.Endpoints;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Shouldly;
@@ -13,15 +11,9 @@ using Xunit;
 
 namespace Granit.Diagnostics.Endpoints.Tests;
 
-public sealed class MonitoringEndpointsTests : IAsyncDisposable
+public sealed class MonitoringEndpointsTests
 {
-    private const string AuthRole = "authenticated";
     private const string Prefix = "/diagnostics";
-
-    private readonly IHealthCheckAggregator _aggregator = Substitute.For<IHealthCheckAggregator>();
-    private readonly WebApplication _app;
-    private readonly HttpClient _authClient;
-    private readonly HttpClient _anonClient;
 
     private static readonly MonitoringHealthResponse TestResponse = new(
         [
@@ -42,37 +34,35 @@ public sealed class MonitoringEndpointsTests : IAsyncDisposable
         ],
         CheckedAt: new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero));
 
-    public MonitoringEndpointsTests()
+    private static async Task<GranitEndpointTestHost> StartHostAsync(
+        IHealthCheckAggregator aggregator,
+        string? customPrefix = null)
     {
-        _aggregator.CheckAllAsync(Arg.Any<CancellationToken>())
-            .Returns(TestResponse);
-
-        WebApplicationBuilder builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseTestServer();
-
-        builder.Services
-            .AddAuthentication(TestAuthHandler.SchemeName)
-            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                TestAuthHandler.SchemeName, _ => { });
-
-        builder.Services.AddAuthorizationBuilder()
-            .AddPolicy("Diagnostics.Monitoring.Read", p => p.RequireAuthenticatedUser());
-
-        builder.Services.AddSingleton(_aggregator);
-
-        _app = builder.Build();
-        _app.MapGranitDiagnosticsMonitoring();
-        _app.StartAsync().GetAwaiter().GetResult();
-
-        _authClient = BuildClient(AuthRole);
-        _anonClient = _app.GetTestClient();
+        return await GranitEndpointTestHost.StartAsync(
+            configureServices: services =>
+            {
+                services.AddAuthorizationBuilder()
+                    .AddPolicy("Diagnostics.Monitoring.Read", p => p.RequireAuthenticatedUser());
+                services.AddSingleton(aggregator);
+            },
+            configureEndpoints: app =>
+            {
+                if (customPrefix is null)
+                {
+                    app.MapGranitDiagnosticsMonitoring();
+                }
+                else
+                {
+                    app.MapGranitDiagnosticsMonitoring(opts => opts.RoutePrefix = customPrefix);
+                }
+            });
     }
 
-    public async ValueTask DisposeAsync()
+    private static IHealthCheckAggregator BuildAggregator()
     {
-        _authClient.Dispose();
-        _anonClient.Dispose();
-        await _app.DisposeAsync();
+        IHealthCheckAggregator agg = Substitute.For<IHealthCheckAggregator>();
+        agg.CheckAllAsync(Arg.Any<CancellationToken>()).Returns(TestResponse);
+        return agg;
     }
 
     // =========================================================================
@@ -82,7 +72,10 @@ public sealed class MonitoringEndpointsTests : IAsyncDisposable
     [Fact]
     public async Task GetHealth_Authenticated_Returns_Ok_With_Services()
     {
-        HttpResponseMessage response = await _authClient.GetAsync(
+        await using GranitEndpointTestHost host = await StartHostAsync(BuildAggregator());
+        using HttpClient client = host.CreateAuthenticatedClient("authenticated");
+
+        HttpResponseMessage response = await client.GetAsync(
             $"{Prefix}/health", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -97,7 +90,10 @@ public sealed class MonitoringEndpointsTests : IAsyncDisposable
     [Fact]
     public async Task GetHealth_Anonymous_Returns_401()
     {
-        HttpResponseMessage response = await _anonClient.GetAsync(
+        await using GranitEndpointTestHost host = await StartHostAsync(BuildAggregator());
+        using HttpClient client = host.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.GetAsync(
             $"{Prefix}/health", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -106,7 +102,10 @@ public sealed class MonitoringEndpointsTests : IAsyncDisposable
     [Fact]
     public async Task GetHealth_Returns_Correct_Service_Statuses()
     {
-        HttpResponseMessage response = await _authClient.GetAsync(
+        await using GranitEndpointTestHost host = await StartHostAsync(BuildAggregator());
+        using HttpClient client = host.CreateAuthenticatedClient("authenticated");
+
+        HttpResponseMessage response = await client.GetAsync(
             $"{Prefix}/health", TestContext.Current.CancellationToken);
 
         MonitoringHealthResponse? result = await response.Content
@@ -125,7 +124,10 @@ public sealed class MonitoringEndpointsTests : IAsyncDisposable
     [Fact]
     public async Task GetHealth_Returns_CheckedAt_Timestamp()
     {
-        HttpResponseMessage response = await _authClient.GetAsync(
+        await using GranitEndpointTestHost host = await StartHostAsync(BuildAggregator());
+        using HttpClient client = host.CreateAuthenticatedClient("authenticated");
+
+        HttpResponseMessage response = await client.GetAsync(
             $"{Prefix}/health", TestContext.Current.CancellationToken);
 
         MonitoringHealthResponse? result = await response.Content
@@ -138,7 +140,10 @@ public sealed class MonitoringEndpointsTests : IAsyncDisposable
     [Fact]
     public async Task GetHealth_Returns_Tags()
     {
-        HttpResponseMessage response = await _authClient.GetAsync(
+        await using GranitEndpointTestHost host = await StartHostAsync(BuildAggregator());
+        using HttpClient client = host.CreateAuthenticatedClient("authenticated");
+
+        HttpResponseMessage response = await client.GetAsync(
             $"{Prefix}/health", TestContext.Current.CancellationToken);
 
         MonitoringHealthResponse? result = await response.Content
@@ -152,51 +157,14 @@ public sealed class MonitoringEndpointsTests : IAsyncDisposable
     [Fact]
     public async Task GetHealth_CustomPrefix_Works()
     {
-        await using WebApplication customApp = BuildAppWithPrefix("admin/monitoring");
-        await customApp.StartAsync(TestContext.Current.CancellationToken);
-        using HttpClient client = BuildClient(customApp, AuthRole);
+        await using GranitEndpointTestHost host = await StartHostAsync(
+            BuildAggregator(),
+            customPrefix: "admin/monitoring");
+        using HttpClient client = host.CreateAuthenticatedClient("authenticated");
 
         HttpResponseMessage response = await client.GetAsync(
             "/admin/monitoring/health", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-    }
-
-    // =========================================================================
-    // Helpers
-    // =========================================================================
-
-    private HttpClient BuildClient(string role)
-    {
-        HttpClient client = _app.GetTestClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, role);
-        return client;
-    }
-
-    private static HttpClient BuildClient(WebApplication app, string role)
-    {
-        HttpClient client = app.GetTestClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, role);
-        return client;
-    }
-
-    private WebApplication BuildAppWithPrefix(string prefix)
-    {
-        WebApplicationBuilder builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseTestServer();
-
-        builder.Services
-            .AddAuthentication(TestAuthHandler.SchemeName)
-            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                TestAuthHandler.SchemeName, _ => { });
-
-        builder.Services.AddAuthorizationBuilder()
-            .AddPolicy("Diagnostics.Monitoring.Read", p => p.RequireAuthenticatedUser());
-
-        builder.Services.AddSingleton(_aggregator);
-
-        WebApplication app = builder.Build();
-        app.MapGranitDiagnosticsMonitoring(opts => opts.RoutePrefix = prefix);
-        return app;
     }
 }

--- a/tests/Granit.Diagnostics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Diagnostics.Endpoints.Tests/packages.lock.json
@@ -5,8 +5,8 @@
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.0",
-        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
       },
       "JunitXml.TestLogger": {
         "type": "Direct",
@@ -572,6 +572,14 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.http.apidocumentation": {
         "type": "Project",
         "dependencies": {
@@ -611,6 +619,16 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
         }
       },
       "granit.timing": {
@@ -660,6 +678,12 @@
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0"
         }
+      },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
       },
       "FluentValidation": {
         "type": "CentralTransitive",

--- a/tests/Granit.Validation.Endpoints.Tests/Granit.Validation.Endpoints.Tests.csproj
+++ b/tests/Granit.Validation.Endpoints.Tests/Granit.Validation.Endpoints.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Validation.Endpoints\Granit.Validation.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointsHttpTests.cs
+++ b/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointsHttpTests.cs
@@ -1,0 +1,279 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentValidation;
+using Granit.Testing.Endpoints;
+using Granit.Validation.Endpoints.Dtos;
+using Granit.Validation.Endpoints.Extensions;
+using Granit.Validation.Endpoints.Validators;
+using Granit.Validation.ServerValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Validation.Endpoints.Tests;
+
+/// <summary>
+/// HTTP-level integration tests for <see cref="ValidationEndpointRouteBuilderExtensions"/>
+/// using <see cref="GranitEndpointTestHost"/>. Complements the unit tests in
+/// <see cref="ValidationEndpointTests"/> which call the handlers directly.
+/// </summary>
+public sealed class ValidationEndpointsHttpTests
+{
+    private const string Prefix = "/validation";
+
+    private static Task<GranitEndpointTestHost> StartAsync(params IServerValidator[] validators) =>
+        GranitEndpointTestHost.StartAsync(
+            configureServices: services =>
+            {
+                services.AddSingleton<IServerValidatorContributor>(
+                    new TestContributor(validators));
+                services.AddSingleton(sp =>
+                    new ServerValidatorRegistry(
+                        sp.GetRequiredService<IEnumerable<IServerValidatorContributor>>(),
+                        NullLogger<ServerValidatorRegistry>.Instance));
+                services.AddAuthorizationBuilder();
+                services.AddScoped<IValidator<ValidationFieldValidateRequest>, ValidationFieldValidateRequestValidator>();
+                services.AddScoped<IValidator<ValidationFieldValidateBatchRequest>, ValidationFieldValidateBatchRequestValidator>();
+            },
+            configureEndpoints: app => app.MapGranitValidation());
+
+    // =========================================================================
+    // POST /validation/validate
+    // =========================================================================
+
+    [Fact]
+    public async Task PostValidate_ValidValue_Returns200WithValidStatus()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(
+            new DelegatingServerValidator("Granit:Validation:InvalidIban", v => v == "BE68539007547034"));
+        using HttpClient client = host.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate",
+            new ValidationFieldValidateRequest("Granit:Validation:InvalidIban", "BE68539007547034"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        ValidationFieldValidateResponse? body = await response.Content
+            .ReadFromJsonAsync<ValidationFieldValidateResponse>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body.Status.ShouldBe(ValidationFieldStatus.Valid);
+        body.ErrorCode.ShouldBe("Granit:Validation:InvalidIban");
+    }
+
+    [Fact]
+    public async Task PostValidate_InvalidValue_Returns200WithInvalidStatus()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(
+            new DelegatingServerValidator("Granit:Validation:InvalidIban", _ => false));
+        using HttpClient client = host.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate",
+            new ValidationFieldValidateRequest("Granit:Validation:InvalidIban", "bad"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        ValidationFieldValidateResponse? body = await response.Content
+            .ReadFromJsonAsync<ValidationFieldValidateResponse>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body.Status.ShouldBe(ValidationFieldStatus.Invalid);
+    }
+
+    [Fact]
+    public async Task PostValidate_UnknownErrorCode_Returns404()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        using HttpClient client = host.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate",
+            new ValidationFieldValidateRequest("Granit:Validation:Unknown", "x"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PostValidate_SensitiveValidator_Anonymous_Returns404()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(
+            new DelegatingServerValidator("Granit:Validation:InvalidUsSsn", _ => true, isSensitive: true));
+        using HttpClient client = host.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate",
+            new ValidationFieldValidateRequest("Granit:Validation:InvalidUsSsn", "123-45-6789"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PostValidate_SensitiveValidator_Authenticated_Returns200()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(
+            new DelegatingServerValidator("Granit:Validation:InvalidUsSsn", _ => true, isSensitive: true));
+        using HttpClient client = host.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate",
+            new ValidationFieldValidateRequest("Granit:Validation:InvalidUsSsn", "123-45-6789"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task PostValidate_EmptyErrorCode_Returns422()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        using HttpClient client = host.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate",
+            new ValidationFieldValidateRequest("", "value"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // =========================================================================
+    // POST /validation/validate-batch
+    // =========================================================================
+
+    [Fact]
+    public async Task PostValidateBatch_MixedResults_Returns200WithEachStatus()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(
+            new DelegatingServerValidator("Granit:Validation:InvalidIban", v => v == "BE68539007547034"),
+            new DelegatingServerValidator("Granit:Validation:InvalidEmail", _ => false));
+        using HttpClient client = host.CreateAnonymousClient();
+
+        ValidationFieldValidateBatchRequest request = new(
+        [
+            new("Granit:Validation:InvalidIban", "BE68539007547034"),
+            new("Granit:Validation:InvalidEmail", "bad"),
+            new("Granit:Validation:Unknown", "x"),
+        ]);
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate-batch", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        ValidationFieldValidateBatchResponse? body = await response.Content
+            .ReadFromJsonAsync<ValidationFieldValidateBatchResponse>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body.Results.Count.ShouldBe(3);
+        body.Results[0].Status.ShouldBe(ValidationFieldStatus.Valid);
+        body.Results[1].Status.ShouldBe(ValidationFieldStatus.Invalid);
+        body.Results[2].Status.ShouldBe(ValidationFieldStatus.ValidatorNotFound);
+    }
+
+    [Fact]
+    public async Task PostValidateBatch_EmptyFields_Returns422()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        using HttpClient client = host.CreateAnonymousClient();
+
+        ValidationFieldValidateBatchRequest request = new([]);
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate-batch", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task PostValidateBatch_TooManyFields_Returns422()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        using HttpClient client = host.CreateAnonymousClient();
+
+        ValidationFieldValidateRequest[] fields =
+            [.. Enumerable.Range(0, 25)
+                .Select(i => new ValidationFieldValidateRequest($"Granit:Validation:X{i}", "v"))];
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"{Prefix}/validate-batch",
+            new ValidationFieldValidateBatchRequest(fields),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // =========================================================================
+    // GET /validation/validators
+    // =========================================================================
+
+    [Fact]
+    public async Task GetValidators_Anonymous_Returns200WithSortedCodes_HidesSensitive()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(
+            new DelegatingServerValidator("Granit:Validation:InvalidEmail", _ => true),
+            new DelegatingServerValidator("Granit:Validation:InvalidBicSwift", _ => true),
+            new DelegatingServerValidator("Granit:Validation:InvalidUsSsn", _ => true, isSensitive: true));
+        using HttpClient client = host.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            $"{Prefix}/validators", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        List<string>? codes = await response.Content
+            .ReadFromJsonAsync<List<string>>(TestContext.Current.CancellationToken);
+        codes.ShouldNotBeNull();
+        codes.ShouldBe(["Granit:Validation:InvalidBicSwift", "Granit:Validation:InvalidEmail"]);
+    }
+
+    [Fact]
+    public async Task GetValidators_Authenticated_IncludesSensitive()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(
+            new DelegatingServerValidator("Granit:Validation:InvalidIban", _ => true),
+            new DelegatingServerValidator("Granit:Validation:InvalidUsSsn", _ => true, isSensitive: true));
+        using HttpClient client = host.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            $"{Prefix}/validators", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        List<string>? codes = await response.Content
+            .ReadFromJsonAsync<List<string>>(TestContext.Current.CancellationToken);
+        codes.ShouldNotBeNull();
+        codes.Count.ShouldBe(2);
+    }
+
+    // =========================================================================
+    // Custom prefix
+    // =========================================================================
+
+    [Fact]
+    public async Task CustomPrefix_RoutesUnderProvidedPath()
+    {
+        await using GranitEndpointTestHost host = await GranitEndpointTestHost.StartAsync(
+            configureServices: services =>
+            {
+                services.AddSingleton<IServerValidatorContributor>(new TestContributor([]));
+                services.AddSingleton(sp =>
+                    new ServerValidatorRegistry(
+                        sp.GetRequiredService<IEnumerable<IServerValidatorContributor>>(),
+                        NullLogger<ServerValidatorRegistry>.Instance));
+                services.AddAuthorizationBuilder();
+                services.AddScoped<IValidator<ValidationFieldValidateRequest>, ValidationFieldValidateRequestValidator>();
+                services.AddScoped<IValidator<ValidationFieldValidateBatchRequest>, ValidationFieldValidateBatchRequestValidator>();
+            },
+            configureEndpoints: app => app.MapGranitValidation(opts => opts.RoutePrefix = "api/v1/validation"));
+
+        using HttpClient client = host.CreateAnonymousClient();
+        HttpResponseMessage response = await client.GetAsync(
+            "/api/v1/validation/validators", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private sealed class TestContributor(IServerValidator[] validators) : IServerValidatorContributor
+    {
+        public IEnumerable<IServerValidator> GetValidators() => validators;
+    }
+}

--- a/tests/Granit.Validation.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Validation.Endpoints.Tests/packages.lock.json
@@ -5,8 +5,8 @@
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.0",
-        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
       },
       "JunitXml.TestLogger": {
         "type": "Direct",
@@ -101,6 +101,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HRH/XAke90wkHv9ykCsrvpVqvKOUt53jQzvHHIXrPIPZWAjyPq6B5/InCmPYWvme+WKMXD10rplMAitzNMtC3w=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -110,6 +115,11 @@
         "type": "Transitive",
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
@@ -281,6 +291,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.apidocumentation": {
         "type": "Project",
         "dependencies": {
@@ -318,6 +334,16 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
         }
       },
       "granit.timing": {
@@ -361,6 +387,12 @@
           "Asp.Versioning.Mvc": "10.0.0"
         }
       },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
+      },
       "FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[12.*, )",
@@ -374,6 +406,16 @@
         "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
           "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "C9kMpUciPgx7ObqoO6W+eXEf3zHFWb7XpQgFJBzdO8GsmmVYrgcErTLMuki6e3EihycGpHbcJECYHDgM7XRMkg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.8",
+          "Microsoft.Extensions.DependencyModel": "10.0.8"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {


### PR DESCRIPTION
## Summary

- Extracts a reusable HTTP-test host (`GranitEndpointTestHost` + `TestAuthHandler`) into `Granit.Testing.Endpoints`, replacing ~60 lines of `WebApplicationBuilder` boilerplate per `*.Endpoints.Tests` project with a ~5-line call.
- Refactors `Granit.Diagnostics.Endpoints.Tests` onto the shared harness (regression check — 10/10 tests still pass).
- Adds HTTP-level tests for `Granit.Validation.Endpoints` via the new harness. Coverage on the 8 real source classes (route builder extension, both validators, all DTOs, options) reaches **100% line**.

The existing `GranitWebApplicationFactory<TProgram>` is unchanged — it still serves full-app integration tests that boot a `Program` entrypoint. This PR adds the module-scoped complement.

## Coverage context

`Granit.Validation.Endpoints` was at 16.9% line / 7.8% branch in Sonar before this PR. The local figure now reads ~25% because OpenCover includes the auto-generated `<OpenApiXmlCommentSupport_generated>__*` helpers Microsoft emits into every assembly that calls `AddOpenApi()`. Those classes can't be exercised from a unit-test project; the real Granit code is fully covered. A follow-up Sonar coverage exclusion would clean up the headline if desired.

## Test plan

- [x] `dotnet test tests/Granit.Diagnostics.Endpoints.Tests` — 10/10 pass
- [x] `dotnet test tests/Granit.Validation.Endpoints.Tests` — 56/56 pass (12 new + 44 existing)
- [x] `dotnet test tests/Granit.Testing.Tests` — 97/97 pass (host project not regressed)
- [x] `dotnet format` clean on touched files
- [x] No new dependencies introduced; `Granit.Testing` already had `Microsoft.AspNetCore.Mvc.Testing` + `FrameworkReference Microsoft.AspNetCore.App`

## Out of scope

This PR is the infrastructure. Each remaining `*.Endpoints` package below 30% (AI, Webhooks, Workflow, MultiTenancy, OpenIddict) can adopt the harness in a follow-up PR — each one needs its own dependency mocks so they're sized as separate units of work, not a bulk apply.

🤖 Generated with Claude Code