### PR TITLE
feat(security): tenant trust boundaries hardening — sprint 1 (stories 1+3)

### DIFF
--- a/src/Granit.Bff.Endpoints/Endpoints/BffUserEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffUserEndpoints.cs
@@ -27,8 +27,10 @@ internal static class BffUserEndpoints
             .WithDescription(
                 "Reads the session cookie, loads the ID token from the token store, decodes "
                 + "the JWT payload, and returns a filtered set of claims: sub, name, email, roles, "
-                + "tenantId, and sessionExpiresAt. Returns { authenticated: false } if no valid "
-                + "session exists. Tokens are never exposed to the browser.")
+                + "tenantId, isHost, and sessionExpiresAt. isHost is server-emitted (true when "
+                + "the id_token carries no tenant_id claim) so the SPA never has to infer Host "
+                + "status from the absence of TenantId. Returns { authenticated: false } if no "
+                + "valid session exists. Tokens are never exposed to the browser.")
             .Produces<BffUserResponse>()
             .Produces<BffUnauthenticatedResponse>();
 
@@ -70,18 +72,31 @@ internal static class BffUserEndpoints
 
         httpContext.Response.Headers.CacheControl = "private, no-cache, no-store";
 
-        BffUserResponse response = new(
+        BffUserResponse response = BuildAuthenticatedResponse(claims, tokens.ExpiresAt);
+        return TypedResults.Ok<object>(response);
+    }
+#pragma warning restore GRAPI003
+
+    /// <summary>
+    /// Builds the authenticated user response from decoded id-token claims.
+    /// Server-emits <c>IsHost</c> from the presence/absence of the <c>tenant_id</c>
+    /// claim so the SPA never has to infer Host status from a missing field.
+    /// </summary>
+    internal static BffUserResponse BuildAuthenticatedResponse(
+        Dictionary<string, string> claims,
+        DateTimeOffset expiresAt)
+    {
+        string? tenantId = claims.GetValueOrDefault("tenant_id");
+        return new BffUserResponse(
             Authenticated: true,
             Sub: claims.GetValueOrDefault("sub"),
             Name: claims.GetValueOrDefault("name"),
             Email: claims.GetValueOrDefault("email"),
             Roles: ExtractStringArray(claims, "roles"),
-            TenantId: claims.GetValueOrDefault("tenant_id"),
-            SessionExpiresAt: tokens.ExpiresAt);
-
-        return TypedResults.Ok<object>(response);
+            TenantId: tenantId,
+            IsHost: string.IsNullOrEmpty(tenantId),
+            SessionExpiresAt: expiresAt);
     }
-#pragma warning restore GRAPI003
 
     /// <summary>
     /// Decodes the payload of a JWT without validation (the token was already validated
@@ -174,6 +189,7 @@ internal sealed record BffUserResponse(
     string? Email,
     string[] Roles,
     string? TenantId,
+    bool IsHost,
     DateTimeOffset SessionExpiresAt);
 
 /// <summary>Response for unauthenticated sessions.</summary>

--- a/tests/Granit.Bff.Endpoints.Tests/Endpoints/BffHelperMethodTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Endpoints/BffHelperMethodTests.cs
@@ -258,6 +258,69 @@ public sealed class BffHelperMethodTests
         result["active"].ShouldBe("true");
     }
 
+    // ──── BuildAuthenticatedResponse (IsHost invariant) ────
+
+    [Fact]
+    public void BuildAuthenticatedResponse_TenantIdClaimPresent_IsHostIsFalse()
+    {
+        Dictionary<string, string> claims = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["sub"] = "user-1",
+            ["tenant_id"] = "11111111-1111-1111-1111-111111111111",
+        };
+
+        BffUserResponse response = BffUserEndpoints.BuildAuthenticatedResponse(claims, DateTimeOffset.UtcNow);
+
+        response.IsHost.ShouldBeFalse();
+        response.TenantId.ShouldBe("11111111-1111-1111-1111-111111111111");
+    }
+
+    [Fact]
+    public void BuildAuthenticatedResponse_TenantIdClaimAbsent_IsHostIsTrue()
+    {
+        Dictionary<string, string> claims = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["sub"] = "host-user",
+        };
+
+        BffUserResponse response = BffUserEndpoints.BuildAuthenticatedResponse(claims, DateTimeOffset.UtcNow);
+
+        response.IsHost.ShouldBeTrue();
+        response.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildAuthenticatedResponse_TenantIdClaimEmpty_IsHostIsTrue()
+    {
+        Dictionary<string, string> claims = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["sub"] = "host-user",
+            ["tenant_id"] = string.Empty,
+        };
+
+        BffUserResponse response = BffUserEndpoints.BuildAuthenticatedResponse(claims, DateTimeOffset.UtcNow);
+
+        response.IsHost.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildAuthenticatedResponse_IsHostInvariant_HoldsForBothBranches()
+    {
+        Dictionary<string, string> host = new(StringComparer.OrdinalIgnoreCase) { ["sub"] = "h" };
+        Dictionary<string, string> tenant = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["sub"] = "t",
+            ["tenant_id"] = "22222222-2222-2222-2222-222222222222",
+        };
+
+        BffUserResponse hostResponse = BffUserEndpoints.BuildAuthenticatedResponse(host, DateTimeOffset.UtcNow);
+        BffUserResponse tenantResponse = BffUserEndpoints.BuildAuthenticatedResponse(tenant, DateTimeOffset.UtcNow);
+
+        // IsHost ⇔ TenantId is null/empty — pinned mechanically.
+        hostResponse.IsHost.ShouldBe(string.IsNullOrEmpty(hostResponse.TenantId));
+        tenantResponse.IsHost.ShouldBe(string.IsNullOrEmpty(tenantResponse.TenantId));
+    }
+
     // ──── ExtractStringArray ────
 
     [Fact]

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
@@ -215,6 +215,58 @@ public sealed class OidcPrincipalFactoryTests
         identity.FindFirst("tenant_id")?.Value.ShouldBe("abc-123");
     }
 
+    // ── Multi-tenancy trust boundary: tenant_id claim contract ─────────
+    // Invariant pinned: `tenant_id` claim present in principal iff user has TenantId.
+    // Host users (TenantId == null) MUST NOT emit a tenant_id claim — the front-end
+    // and tenant-resolution middleware rely on this absence to identify the Host scope.
+
+    [Fact]
+    public async Task CreateUserPrincipal_TenantUser_EmitsTenantIdClaim()
+    {
+        var tenantId = Guid.NewGuid();
+        LocalIdentity user = CreateTestUser();
+        user.TenantId = tenantId;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        var tenantClaims = principal.FindAll("tenant_id").ToList();
+        tenantClaims.Count.ShouldBe(1);
+        tenantClaims[0].Value.ShouldBe(tenantId.ToString());
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_HostUser_DoesNotEmitTenantIdClaim()
+    {
+        LocalIdentity user = CreateTestUser();
+        user.TenantId = null;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        principal.FindAll("tenant_id").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_TenantUser_TenantIdClaimDestinationProviderInvoked()
+    {
+        // Asserts the tenant_id claim is fed to the destination provider so its
+        // access_token+id_token routing (see DefaultClaimsDestinationProvider) takes effect.
+        var tenantId = Guid.NewGuid();
+        LocalIdentity user = CreateTestUser();
+        user.TenantId = tenantId;
+        SetupUserManager(user);
+
+        await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        _destinationProvider.Received().GetDestinations(
+            Arg.Is<Claim>(c => c.Type == "tenant_id" && c.Value == tenantId.ToString()),
+            Arg.Any<ClaimsPrincipal>());
+    }
+
     [Fact]
     public async Task CreateUserPrincipal_SetsScopes()
     {


### PR DESCRIPTION
## Summary

Sprint 1 of EPIC #2133 — Multi-tenancy trust boundaries hardening. Ships stories 1 and 3 (small, contained, design-stable); story 2 is deferred pending an architectural call (see below).

## Stories shipped

### #2134 — Explicit IsHost flag in BFF user response

`BffUserResponse` gains a server-emitted `IsHost: bool`. Invariant: `IsHost ⇔ id-token has no/empty tenant_id claim`. The handler computes both `TenantId` and `IsHost` from the same decoded JWT, so the SPA cannot face a state where one is set without the other. The response-building logic is extracted into `BuildAuthenticatedResponse(...)` so the invariant has a mechanical assertion (4 unit tests covering both branches).

### #2136 — Pin tenant_id claim emission contract

`OidcPrincipalFactory` already emits `tenant_id` iff `user.TenantId is not null`, and `DefaultClaimsDestinationProvider` already destines it to both access_token and id_token. Three new tests in `OidcPrincipalFactoryTests` pin this contract so a future refactor cannot silently break it:

- `TenantUser_EmitsTenantIdClaim` — exactly one claim, value equals user.TenantId.
- `HostUser_DoesNotEmitTenantIdClaim` — zero claims.
- `TenantUser_TenantIdClaimDestinationProviderInvoked` — claim is fed to destination provider.

## Story 2 (#2135) — deferred, architectural call needed

The audit reframed the original proposal #2 (\"tenant user with header absent → 400\") into \"gate Host-side X-Tenant-Id with a Host.Impersonate permission\" — see the EPIC for the rationale (the original wording would regress non-BFF API consumers).

The implementation has two viable shapes:

**Option A — direct project ref.** Add `Granit.Authorization` to `Granit.MultiTenancy.csproj`. Middleware resolves `IPermissionChecker` directly. Simpler, but `Granit.MultiTenancy` becomes a hard consumer of the authorization stack.

**Option B — pluggable gate.** Introduce `IHostImpersonationGate` in `Granit.MultiTenancy` (default impl: deny). `Granit.MultiTenancy.Endpoints` (which already references `Granit.Authorization`) ships a `PermissionBasedHostImpersonationGate`. Keeps the base module dependency-light; one more abstraction.

Both options also need 18 locale files updated for `Permission:MultiTenancy.Host.Impersonate` + a new metric counter.

**Asking for the user's call on A vs B before continuing**, since the choice shapes the project graph and is not trivially reversible later.

## Test plan

- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests` — 113 passed (4 new).
- [x] `dotnet test tests/Granit.OpenIddict.Endpoints.Tests --filter OidcPrincipalFactoryTests` — 20 passed (3 new).
- [x] `dotnet format` clean on changed projects.
- [ ] Full CI shards `api-data` and `security` green.

## Out of scope (later)

- Story 2 — see decision above.
- Audit logging of Host impersonation events.
- Documentation on `granit-docs` — separate PR per CLAUDE.md convention.

Closes #2134, closes #2136 (once merged). Keeps #2135 open for sprint 1.5.