### PR TITLE
fix(multitenancy): run host impersonation gate regardless of HeaderTrustMode

### DIFF
--- a/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
@@ -55,15 +55,17 @@ public sealed partial class TenantResolutionMiddleware(
 
         if (result.Tenant is not null)
         {
-            if (_options.HeaderTrustMode == TenantHeaderTrustMode.CrossValidate
-                && context.User.Identity?.IsAuthenticated == true)
+            if (context.User.Identity?.IsAuthenticated == true)
             {
                 string? jwtClaim = context.User.FindFirstValue(_options.TenantIdClaimType);
 
                 if (!string.IsNullOrEmpty(jwtClaim))
                 {
-                    // Tenant user: header (or any non-JWT resolver) must match the JWT claim.
-                    if (Guid.TryParse(jwtClaim, out Guid jwtTenantId)
+                    // Tenant user: in CrossValidate mode the resolved tenant must match
+                    // the JWT claim. In Unrestricted mode the header is trusted by
+                    // configuration and the cross-check is skipped.
+                    if (_options.HeaderTrustMode == TenantHeaderTrustMode.CrossValidate
+                        && Guid.TryParse(jwtClaim, out Guid jwtTenantId)
                         && result.Tenant.Id is Guid resolvedTenantId
                         && jwtTenantId != resolvedTenantId)
                     {
@@ -78,9 +80,12 @@ public sealed partial class TenantResolutionMiddleware(
                 else if (!result.IsAuthoritative && result.Tenant.Id.HasValue)
                 {
                     // Host user (no tenant_id claim) attempting tenant impersonation via a
-                    // non-JWT resolver (header, query, domain). Gate it through
-                    // IHostImpersonationGate — secure-by-default refuses unless wired up
-                    // by Granit.MultiTenancy.Authorization.
+                    // non-JWT resolver (header, query, domain). The gate runs regardless of
+                    // HeaderTrustMode: header trust and impersonation authorization are
+                    // orthogonal — opting into Unrestricted trusts the proxy to scrub the
+                    // header for Tenant users, not to waive permission checks for Host
+                    // operators. Secure-by-default refuses unless wired up by
+                    // Granit.MultiTenancy.Authorization.
                     HostImpersonationDecision decision = await _hostImpersonationGate
                         .CanImpersonateAsync(context.User, result.Tenant.Id.Value, context.RequestAborted)
                         .ConfigureAwait(false);

--- a/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
@@ -427,6 +427,68 @@ public sealed class TenantResolutionMiddlewareTests
     }
 
     [Fact]
+    public async Task HostUser_HeaderResolution_UnrestrictedMode_GateStillInvoked()
+    {
+        // Header trust and impersonation authorization are orthogonal: opting into
+        // Unrestricted only waives the JWT cross-check for Tenant users; Host operators
+        // still need the gate's permission to impersonate via a non-authoritative resolver.
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        var targetTenantId = Guid.NewGuid();
+        TenantResolverPipeline pipeline = PipelineWithResolver(
+            nameof(HeaderTenantResolver), new TenantInfo(targetTenantId));
+
+        IHostImpersonationGate gate = Substitute.For<IHostImpersonationGate>();
+#pragma warning disable CA2012 // NSubstitute Returns(...) idiom for ValueTask-returning methods
+        gate.CanImpersonateAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(new HostImpersonationDecision(false, "test.denied")));
+#pragma warning restore CA2012
+
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline,
+            headerTrustMode: TenantHeaderTrustMode.Unrestricted,
+            hostImpersonationGate: gate);
+
+        DefaultHttpContext context = AuthenticatedContext(tenantIdClaim: null);
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+        await gate.Received(1).CanImpersonateAsync(
+            Arg.Any<ClaimsPrincipal>(), targetTenantId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TenantUser_HeaderMismatchesClaim_UnrestrictedMode_PassesThrough()
+    {
+        // In Unrestricted mode the header is trusted by configuration — the JWT
+        // cross-check is intentionally skipped for Tenant users.
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDisposable scope = Substitute.For<IDisposable>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        var headerTenantId = Guid.NewGuid();
+        var claimTenantId = Guid.NewGuid();
+        TenantResolverPipeline pipeline = PipelineWithResolver(
+            nameof(HeaderTenantResolver), new TenantInfo(headerTenantId));
+
+        IHostImpersonationGate gate = Substitute.For<IHostImpersonationGate>();
+
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline,
+            headerTrustMode: TenantHeaderTrustMode.Unrestricted,
+            hostImpersonationGate: gate);
+
+        DefaultHttpContext context = AuthenticatedContext(tenantIdClaim: claimTenantId.ToString());
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        context.Response.StatusCode.ShouldNotBe(StatusCodes.Status403Forbidden);
+        currentTenant.Received(1).Change(headerTenantId, Arg.Any<string?>());
+        await gate.DidNotReceive().CanImpersonateAsync(
+            Arg.Any<ClaimsPrincipal>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task UnauthenticatedRequest_HostGateNotInvoked()
     {
         // The gate is only consulted for authenticated principals with no tenant_id claim.


### PR DESCRIPTION
## Summary

- **VULN-200 (MEDIUM)** — host impersonation gate was silently skipped in `HeaderTrustMode.Unrestricted`. Header trust and impersonation authorization are orthogonal concerns: opting into Unrestricted waives the JWT cross-check for Tenant users but should NOT waive the permission gate on Host operators.
- Move the `CrossValidate` predicate from the outer condition down to the JWT-claim mismatch check (its only legitimate guard). The gate now runs whenever a Host principal (no `tenant_id` claim) lands on a non-authoritative tenant resolution, regardless of `HeaderTrustMode`.
- Secure-by-default (`DenyAllHostImpersonationGate`) still holds when no permission package is wired.

## Impact

Apps in `Unrestricted` mode where Host operators were silently pivoting via `X-Tenant-Id` will now require `MultiTenancy.Host.Impersonate` on those principals. Pre-1.0; the default (`CrossValidate`) is unaffected, and the opt-in `AddGranitHostImpersonationWithPermissions()` is explicit.

## Audit context

Identified by `/security audit les 5 dernieres PR` on the post-#2138 tenant trust boundary work. The follow-up findings (VULN-201 unscoped permission, VULN-300/301 claim parsing, VULN-400 audit category) are tracked separately as tactical work.

## Test plan

- [x] `tests/Granit.MultiTenancy.Tests` — 113/113 (2 new tests verrouillent le nouveau comportement)
- [x] `tests/Granit.MultiTenancy.Auditing.Tests` — 6/6
- [x] `tests/Granit.MultiTenancy.Authorization.Tests` — 5/5
- [x] `dotnet format --verify-no-changes` clean on touched projects
- [ ] CI infrastructure shard green