### PR TITLE
fix(tests): xUnit1051 — pass CT to direct GranitEndpointTestHost.StartAsync call

### DIFF
--- a/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointsHttpTests.cs
+++ b/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointsHttpTests.cs
@@ -263,7 +263,8 @@ public sealed class ValidationEndpointsHttpTests
                 services.AddScoped<IValidator<ValidationFieldValidateRequest>, ValidationFieldValidateRequestValidator>();
                 services.AddScoped<IValidator<ValidationFieldValidateBatchRequest>, ValidationFieldValidateBatchRequestValidator>();
             },
-            configureEndpoints: app => app.MapGranitValidation(opts => opts.RoutePrefix = "api/v1/validation"));
+            configureEndpoints: app => app.MapGranitValidation(opts => opts.RoutePrefix = "api/v1/validation"),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         using HttpClient client = host.CreateAnonymousClient();
         HttpResponseMessage response = await client.GetAsync(


### PR DESCRIPTION
## Summary

Develop CI `pack` job (Release config, `TreatWarningsAsErrors=true`) fails with `xUnit1051` on a single test that calls `GranitEndpointTestHost.StartAsync` directly instead of via the local `StartAsync` wrapper. Pass `TestContext.Current.CancellationToken` to align with the rest of the suite.

Reproduces locally with `dotnet build tests/Granit.Validation.Endpoints.Tests -c Release`. The Debug shard build passed because the analyzer severity differs by config.

Failure: <https://github.com/granit-fx/granit-dotnet/actions/runs/26083096900/job/76690759049>

## Test plan

- [x] `dotnet build tests/Granit.Validation.Endpoints.Tests -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Granit.Validation.Endpoints.Tests -c Release` — 56/56
- [ ] CI `pack` job green