### PR TITLE
refactor(multitenancy/auditing): host-impersonation audit follow-ups

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4116,7 +4116,7 @@
       "kind": "enum",
       "project": "Granit.Auditing",
       "file": "src/Granit.Auditing/Domain/AuditCategory.cs",
-      "line": 14,
+      "line": 15,
       "members": []
     },
     {
@@ -4750,6 +4750,12 @@
           "kind": "method",
           "signature": "FromDays(2555)",
           "returnType": "TimeSpan AccessDeniedRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(2555)",
+          "returnType": "TimeSpan PrivilegedAccessRetention { get; set; } = TimeSpan."
         },
         {
           "name": "FromMinutes",
@@ -26126,7 +26132,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.Auditing",
       "file": "src/Granit.MultiTenancy.Auditing/AuditingHostImpersonationAuditWriter.cs",
-      "line": 20,
+      "line": 23,
       "members": [
         {
           "name": "WriteAsync",

--- a/src/Granit.Auditing/Domain/AuditCategory.cs
+++ b/src/Granit.Auditing/Domain/AuditCategory.cs
@@ -9,6 +9,7 @@ namespace Granit.Auditing.Domain;
 ///   <item><see cref="ConfigurationChange"/> — settings, feature flags (always logged, non-disableable).</item>
 ///   <item><see cref="DataAccess"/> — read operations (opt-in, disabled by default).</item>
 ///   <item><see cref="AccessDenied"/> — authorization failures (opt-in).</item>
+///   <item><see cref="PrivilegedAccess"/> — privileged-access operations that succeeded (e.g. host tenant impersonation). Counterpart of <see cref="AccessDenied"/>: ISO 27001 A.12.4.3 wants successful privileged ops in their own bucket.</item>
 /// </list>
 /// </remarks>
 public enum AuditCategory
@@ -24,4 +25,11 @@ public enum AuditCategory
 
     /// <summary>Authorization failures (opt-in).</summary>
     AccessDenied = 3,
+
+    /// <summary>
+    /// Privileged-access operations that were granted (e.g. host tenant impersonation, admin masquerading).
+    /// Recorded as a counterpart to <see cref="AccessDenied"/> so RSSI dashboards can answer
+    /// "what did privileged actors successfully do" without joining against logs/metrics.
+    /// </summary>
+    PrivilegedAccess = 4,
 }

--- a/src/Granit.Auditing/Options/AuditingOptions.cs
+++ b/src/Granit.Auditing/Options/AuditingOptions.cs
@@ -52,6 +52,12 @@ public sealed class AuditingOptions
     public TimeSpan AccessDeniedRetention { get; set; } = TimeSpan.FromDays(2555);
 
     /// <summary>
+    /// Retention period for <see cref="AuditCategory.PrivilegedAccess"/> entries.
+    /// Default: ~7 years (2555 days) — same regulatory weight as <see cref="AuditCategory.AccessDenied"/>.
+    /// </summary>
+    public TimeSpan PrivilegedAccessRetention { get; set; } = TimeSpan.FromDays(2555);
+
+    /// <summary>
     /// Cache duration for individual audit log entries retrieved by ID.
     /// Entries are immutable so a long TTL is safe. Default: 30 minutes.
     /// </summary>
@@ -93,6 +99,7 @@ public sealed class AuditingOptions
         AuditCategory.DataMutation => DataMutationRetention,
         AuditCategory.DataAccess => DataAccessRetention,
         AuditCategory.AccessDenied => AccessDeniedRetention,
+        AuditCategory.PrivilegedAccess => PrivilegedAccessRetention,
         _ => DataMutationRetention,
     };
 }

--- a/src/Granit.MultiTenancy.Auditing/AuditingHostImpersonationAuditWriter.cs
+++ b/src/Granit.MultiTenancy.Auditing/AuditingHostImpersonationAuditWriter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Claims;
 using Granit.Auditing;
 using Granit.Auditing.Domain;
@@ -8,18 +9,23 @@ namespace Granit.MultiTenancy.Auditing;
 
 /// <summary>
 /// <see cref="IHostImpersonationAuditWriter"/> implementation that persists every
-/// gate decision (allowed + denied) as a <see cref="AuditCategory.AccessDenied"/>
-/// audit entry via <see cref="IAuditingWriter"/>.
+/// gate decision via <see cref="IAuditingWriter"/>. Allowed decisions land in
+/// <see cref="AuditCategory.PrivilegedAccess"/> (ISO 27001 A.12.4.3) and denied
+/// decisions in <see cref="AuditCategory.AccessDenied"/> (A.12.4.1).
 /// </summary>
 /// <remarks>
-/// Even allowed impersonations are recorded under <c>AccessDenied</c>: from the
-/// RSSI's point of view they are privileged-access events worth keeping in the
-/// same retention bucket as denials. The <c>CorrelationId</c> carries the request's
-/// trace id so the audit row links back to OTEL traces.
+/// Decision details (allowed flag, deny reason, resolver) are persisted as a
+/// synthetic <see cref="AuditEntityChange"/> with <c>EntityType =
+/// "HostImpersonation"</c> so investigators get a self-contained audit row
+/// without needing to correlate with logs or metrics. The <c>CorrelationId</c>
+/// still carries the request's trace id for cross-store lookups.
 /// </remarks>
 public sealed class AuditingHostImpersonationAuditWriter(IAuditingWriter auditingWriter, IClock clock)
     : IHostImpersonationAuditWriter
 {
+    private const string SyntheticEntityType = "HostImpersonation";
+    private const string UnknownUserSentinel = "<unknown>";
+
     public async ValueTask WriteAsync(
         ClaimsPrincipal principal,
         Guid targetTenantId,
@@ -38,25 +44,56 @@ public sealed class AuditingHostImpersonationAuditWriter(IAuditingWriter auditin
             Timestamp = clock.Now,
             UserId = principal.FindFirst("sub")?.Value
                 ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                ?? "unknown",
+                ?? UnknownUserSentinel,
             UserName = principal.FindFirst("name")?.Value
                 ?? principal.Identity?.Name,
-            Category = AuditCategory.AccessDenied,
+            Category = decision.Allowed
+                ? AuditCategory.PrivilegedAccess
+                : AuditCategory.AccessDenied,
             IpAddress = ipAddress,
             UserAgent = userAgent,
             TenantId = targetTenantId,
             CorrelationId = correlationId,
+            EntityChanges = [BuildDecisionChange(targetTenantId, decision, resolverType)],
         };
 
-        // No EntityChanges — host impersonation is not an entity mutation event.
-        // The actor + tenant + decision is what the auditor cares about; further
-        // detail (allowed vs denied, reason, resolver) lives in structured logs
-        // and the OTEL counter, both keyed by the same CorrelationId.
-        // Trailing context emitted via logger:
-        // - decision.Allowed = {true|false}
-        // - decision.DenyReasonCode = {NotConfigured|PermissionDenied|...}
-        // - resolverType (which non-JWT resolver matched)
-
         await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static AuditEntityChange BuildDecisionChange(
+        Guid targetTenantId,
+        HostImpersonationDecision decision,
+        string resolverType)
+    {
+        List<AuditPropertyChange> properties =
+        [
+            new AuditPropertyChange
+            {
+                PropertyName = "Allowed",
+                NewValue = decision.Allowed ? "true" : "false",
+            },
+            new AuditPropertyChange
+            {
+                PropertyName = "ResolverType",
+                NewValue = resolverType,
+            },
+        ];
+
+        if (!string.IsNullOrEmpty(decision.DenyReasonCode))
+        {
+            properties.Add(new AuditPropertyChange
+            {
+                PropertyName = "DenyReasonCode",
+                NewValue = decision.DenyReasonCode,
+            });
+        }
+
+        return new AuditEntityChange
+        {
+            EntityType = SyntheticEntityType,
+            EntityId = targetTenantId.ToString("D", CultureInfo.InvariantCulture),
+            ChangeType = AuditChangeType.Created,
+            PropertyChanges = properties,
+        };
     }
 }

--- a/src/Granit.MultiTenancy.Auditing/Granit.MultiTenancy.Auditing.csproj
+++ b/src/Granit.MultiTenancy.Auditing/Granit.MultiTenancy.Auditing.csproj
@@ -2,13 +2,12 @@
 
   <PropertyGroup>
     <PackageId>Granit.MultiTenancy.Auditing</PackageId>
-    <Description>Glue package wiring Granit.MultiTenancy's IHostImpersonationAuditWriter to Granit.Auditing's IAuditingWriter. Persists host-impersonation attempts (allowed and denied) as ISO 27001 A.12.4 AccessDenied / DataMutation audit entries.</Description>
+    <Description>Glue package wiring Granit.MultiTenancy's IHostImpersonationAuditWriter to Granit.Auditing's IAuditingWriter. Persists host-impersonation attempts as ISO 27001 A.12.4 PrivilegedAccess (allowed) / AccessDenied (denied) audit entries.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.MultiTenancy.Auditing.Tests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.MultiTenancy/Diagnostics/MultiTenancyMetrics.cs
+++ b/src/Granit.MultiTenancy/Diagnostics/MultiTenancyMetrics.cs
@@ -11,6 +11,9 @@ public sealed class MultiTenancyMetrics
 {
     public const string MeterName = "Granit.MultiTenancy";
 
+    private const string TenantIdTag = "tenant_id";
+    private const string GlobalTenant = "global";
+
     private readonly Counter<long> _resolutionsSucceeded;
     private readonly Counter<long> _resolutionsFailed;
     private readonly Counter<long> _contextSwitches;
@@ -33,34 +36,34 @@ public sealed class MultiTenancyMetrics
             description: "Number of explicit tenant context switches.");
 
         _hostImpersonations = meter.CreateCounter<long>(
-            "granit.multi_tenancy.host_impersonation",
-            description: "Host user impersonating a tenant via a non-JWT resolver. Tagged outcome=allowed|denied with deny_reason.");
+            "granit.multi_tenancy.host_impersonation.attempted",
+            description: "Host user attempting to impersonate a tenant via a non-JWT resolver. Tagged outcome=allowed|denied with deny_reason.");
     }
 
     public void RecordResolutionSucceeded(string tenantId, string resolverType) =>
         _resolutionsSucceeded.Add(1, new TagList
         {
-            { "tenant_id", tenantId },
+            { TenantIdTag, tenantId },
             { "resolver_type", resolverType },
         });
 
     public void RecordResolutionFailed() =>
         _resolutionsFailed.Add(1, new TagList
         {
-            { "tenant_id", "global" },
+            { TenantIdTag, GlobalTenant },
         });
 
     public void RecordContextSwitched(string? tenantId) =>
         _contextSwitches.Add(1, new TagList
         {
-            { "tenant_id", tenantId ?? "global" },
+            { TenantIdTag, tenantId ?? GlobalTenant },
         });
 
     public void RecordHostImpersonationAllowed(string tenantId) =>
         _hostImpersonations.Add(1, new TagList
         {
             { "outcome", "allowed" },
-            { "tenant_id", tenantId },
+            { TenantIdTag, tenantId },
             { "deny_reason", "none" },
         });
 
@@ -68,7 +71,7 @@ public sealed class MultiTenancyMetrics
         _hostImpersonations.Add(1, new TagList
         {
             { "outcome", "denied" },
-            { "tenant_id", tenantId },
+            { TenantIdTag, tenantId },
             { "deny_reason", denyReason },
         });
 }

--- a/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
+++ b/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
@@ -42,6 +42,11 @@ public static class MultiTenancyServiceCollectionExtensions
         // Direct callers of AddGranitMultiTenancy() (test fixtures) must add it themselves.
         services.AddLocalizationResource<MultiTenancyLocalizationResource>();
 
+        // IProblemDetailsService is used by TenantResolutionMiddleware to emit
+        // 403 problem+json bodies for tenant-mismatch and host-impersonation-denied
+        // short-circuits. AddProblemDetails() is idempotent (TryAdd-based).
+        services.AddProblemDetails();
+
         services.TryAddSingleton<IValidateOptions<MultiTenancyOptions>, MultiTenancyOptionsValidator>();
 
         // Replace the NullTenantContext registered by AddGranit<T>() with the real

--- a/src/Granit.MultiTenancy/Internal/ProblemDetailsWriter.cs
+++ b/src/Granit.MultiTenancy/Internal/ProblemDetailsWriter.cs
@@ -1,31 +1,33 @@
-using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 
 namespace Granit.MultiTenancy.Internal;
 
 /// <summary>
-/// Writes an RFC 7807 <c>application/problem+json</c> body to the response
-/// for short-circuited 403 responses emitted by <c>TenantResolutionMiddleware</c>.
+/// Builds RFC 7807 <c>application/problem+json</c> bodies for short-circuited 403
+/// responses emitted by <c>TenantResolutionMiddleware</c> and writes them through
+/// <see cref="IProblemDetailsService"/> for consistency with the rest of the API.
 /// </summary>
 /// <remarks>
-/// The middleware sets the status code and returns; ASP.NET Core does not
-/// auto-emit a ProblemDetails body for middleware-level short-circuits, so we
-/// write it explicitly here. The body shape follows RFC 7807 with two extension
-/// members: <c>denyReasonCode</c> (stable string from <c>HostImpersonationDecision</c>)
-/// and <c>tenantId</c> (target, when known).
+/// ASP.NET Core does not auto-emit a ProblemDetails body for middleware-level
+/// short-circuits, so we drive the emission explicitly. Going through
+/// <see cref="IProblemDetailsService"/> (instead of a hand-rolled
+/// <c>JsonSerializer.Serialize</c>) reuses the writers configured by the host
+/// and shares any custom <c>CustomizeProblemDetails</c> hooks with
+/// <c>Granit.Http.ExceptionHandling</c>.
 /// </remarks>
 internal static class ProblemDetailsWriter
 {
-    private const string ProblemContentType = "application/problem+json";
-
     public static Task WriteHostImpersonationDeniedAsync(
         HttpContext context,
+        IProblemDetailsService problemDetailsService,
         IStringLocalizer<MultiTenancyLocalizationResource> localizer,
         string denyReasonCode,
         Guid? tenantId)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(problemDetailsService);
         ArgumentNullException.ThrowIfNull(localizer);
 
         string detailKey = denyReasonCode switch
@@ -37,50 +39,59 @@ internal static class ProblemDetailsWriter
             _ => "Problem:HostImpersonation.PermissionDenied.Detail",
         };
 
-        Dictionary<string, object?> payload = new(StringComparer.Ordinal)
+        ProblemDetails problemDetails = new()
         {
-            ["type"] = "https://granit-fx.dev/errors/host-impersonation-denied",
-            ["title"] = localizer["Problem:HostImpersonation.Title"].Value,
-            ["status"] = StatusCodes.Status403Forbidden,
-            ["detail"] = localizer[detailKey].Value,
-            ["denyReasonCode"] = denyReasonCode,
+            Type = "https://granit-fx.dev/errors/host-impersonation-denied",
+            Title = localizer["Problem:HostImpersonation.Title"].Value,
+            Status = StatusCodes.Status403Forbidden,
+            Detail = localizer[detailKey].Value,
         };
+        problemDetails.Extensions["denyReasonCode"] = denyReasonCode;
         if (tenantId.HasValue)
         {
-            payload["tenantId"] = tenantId.Value;
+            problemDetails.Extensions["tenantId"] = tenantId.Value;
         }
 
-        return WriteAsync(context, payload);
+        return WriteAsync(context, problemDetailsService, problemDetails);
     }
 
     public static Task WriteTenantMismatchAsync(
         HttpContext context,
+        IProblemDetailsService problemDetailsService,
         IStringLocalizer<MultiTenancyLocalizationResource> localizer,
         Guid resolvedTenantId,
         Guid jwtClaimTenantId)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(problemDetailsService);
         ArgumentNullException.ThrowIfNull(localizer);
 
-        Dictionary<string, object?> payload = new(StringComparer.Ordinal)
+        ProblemDetails problemDetails = new()
         {
-            ["type"] = "https://granit-fx.dev/errors/tenant-context-mismatch",
-            ["title"] = localizer["Problem:TenantMismatch.Title"].Value,
-            ["status"] = StatusCodes.Status403Forbidden,
-            ["detail"] = localizer["Problem:TenantMismatch.Detail"].Value,
-            ["resolvedTenantId"] = resolvedTenantId,
-            ["claimTenantId"] = jwtClaimTenantId,
+            Type = "https://granit-fx.dev/errors/tenant-context-mismatch",
+            Title = localizer["Problem:TenantMismatch.Title"].Value,
+            Status = StatusCodes.Status403Forbidden,
+            Detail = localizer["Problem:TenantMismatch.Detail"].Value,
         };
+        problemDetails.Extensions["resolvedTenantId"] = resolvedTenantId;
+        problemDetails.Extensions["claimTenantId"] = jwtClaimTenantId;
 
-        return WriteAsync(context, payload);
+        return WriteAsync(context, problemDetailsService, problemDetails);
     }
 
-    private static Task WriteAsync(HttpContext context, Dictionary<string, object?> payload)
+    private static async Task WriteAsync(
+        HttpContext context,
+        IProblemDetailsService problemDetailsService,
+        ProblemDetails problemDetails)
     {
-        context.Response.StatusCode = StatusCodes.Status403Forbidden;
-        context.Response.ContentType = ProblemContentType;
-        return context.Response.WriteAsync(
-            JsonSerializer.Serialize(payload),
-            context.RequestAborted);
+        // IProblemDetailsService relies on the response's status code to drive
+        // negotiation and writer selection — set it before calling.
+        context.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status403Forbidden;
+
+        await problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = context,
+            ProblemDetails = problemDetails,
+        }).ConfigureAwait(false);
     }
 }

--- a/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
@@ -27,6 +27,7 @@ public sealed partial class TenantResolutionMiddleware(
     ITenantReader tenantReader,
     IHostImpersonationGate hostImpersonationGate,
     IHostImpersonationAuditWriter hostImpersonationAuditWriter,
+    IProblemDetailsService problemDetailsService,
     MultiTenancyMetrics metrics,
     IStringLocalizer<MultiTenancyLocalizationResource> localizer,
     IOptions<MultiTenancyOptions> options,
@@ -37,10 +38,11 @@ public sealed partial class TenantResolutionMiddleware(
     private readonly ITenantReader _tenantReader = tenantReader;
     private readonly IHostImpersonationGate _hostImpersonationGate = hostImpersonationGate;
     private readonly IHostImpersonationAuditWriter _hostImpersonationAuditWriter = hostImpersonationAuditWriter;
+    private readonly IProblemDetailsService _problemDetailsService = problemDetailsService;
     private readonly MultiTenancyMetrics _metrics = metrics;
     private readonly IStringLocalizer<MultiTenancyLocalizationResource> _localizer = localizer;
     private readonly MultiTenancyOptions _options = options.Value;
-    private readonly ILogger _logger = logger;
+    private readonly ILogger<TenantResolutionMiddleware> _logger = logger;
 
     /// <inheritdoc/>
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
@@ -53,87 +55,122 @@ public sealed partial class TenantResolutionMiddleware(
 
         TenantResolutionResult result = await _pipeline.ResolveAsync(context, context.RequestAborted).ConfigureAwait(false);
 
-        if (result.Tenant is not null)
-        {
-            if (context.User.Identity?.IsAuthenticated == true)
-            {
-                string? jwtClaim = context.User.FindFirstValue(_options.TenantIdClaimType);
-
-                if (!string.IsNullOrEmpty(jwtClaim))
-                {
-                    // Tenant user: in CrossValidate mode the resolved tenant must match
-                    // the JWT claim. In Unrestricted mode the header is trusted by
-                    // configuration and the cross-check is skipped.
-                    if (_options.HeaderTrustMode == TenantHeaderTrustMode.CrossValidate
-                        && Guid.TryParse(jwtClaim, out Guid jwtTenantId)
-                        && result.Tenant.Id is Guid resolvedTenantId
-                        && jwtTenantId != resolvedTenantId)
-                    {
-                        _metrics.RecordResolutionFailed();
-                        LogTenantMismatch(resolvedTenantId, result.ResolverType, jwtTenantId);
-                        await ProblemDetailsWriter
-                            .WriteTenantMismatchAsync(context, _localizer, resolvedTenantId, jwtTenantId)
-                            .ConfigureAwait(false);
-                        return;
-                    }
-                }
-                else if (!result.IsAuthoritative && result.Tenant.Id.HasValue)
-                {
-                    // Host user (no tenant_id claim) attempting tenant impersonation via a
-                    // non-JWT resolver (header, query, domain). The gate runs regardless of
-                    // HeaderTrustMode: header trust and impersonation authorization are
-                    // orthogonal — opting into Unrestricted trusts the proxy to scrub the
-                    // header for Tenant users, not to waive permission checks for Host
-                    // operators. Secure-by-default refuses unless wired up by
-                    // Granit.MultiTenancy.Authorization.
-                    HostImpersonationDecision decision = await _hostImpersonationGate
-                        .CanImpersonateAsync(context.User, result.Tenant.Id.Value, context.RequestAborted)
-                        .ConfigureAwait(false);
-
-                    // Audit BEFORE short-circuiting so the trail captures attempts, not
-                    // just successes. Audit-write failures must not propagate — wrap.
-                    await SafeAuditAsync(context, result, decision).ConfigureAwait(false);
-
-                    if (!decision.Allowed)
-                    {
-                        string reason = decision.DenyReasonCode ?? "unspecified";
-                        _metrics.RecordHostImpersonationDenied(result.Tenant.Id.Value.ToString(), reason);
-                        LogHostImpersonationDenied(result.Tenant.Id.Value, result.ResolverType, reason);
-                        await ProblemDetailsWriter
-                            .WriteHostImpersonationDeniedAsync(context, _localizer, reason, result.Tenant.Id)
-                            .ConfigureAwait(false);
-                        return;
-                    }
-
-                    _metrics.RecordHostImpersonationAllowed(result.Tenant.Id.Value.ToString());
-                }
-            }
-
-            // Validate that the resolved tenant actually exists in the store.
-            // Prevents phantom tenants (arbitrary GUIDs) from creating orphaned data.
-            if (_options.ValidateTenantExistence
-                && result.Tenant.Id.HasValue
-                && !await _tenantReader.ExistsAsync(result.Tenant.Id.Value, context.RequestAborted).ConfigureAwait(false))
-            {
-                _metrics.RecordResolutionFailed();
-                LogPhantomTenant(result.Tenant.Id.Value, result.ResolverType);
-                // Bare 403 without response body: intentional information-minimal
-                // rejection. Don't reveal to an attacker why the tenant was rejected.
-                // Server-side observability is provided by LogPhantomTenant.
-                context.Response.StatusCode = StatusCodes.Status403Forbidden;
-                return;
-            }
-
-            _metrics.RecordResolutionSucceeded(result.Tenant.Id.ToString()!, result.ResolverType);
-
-            using IDisposable _ = _currentTenant.Change(result.Tenant.Id, result.Tenant.Name);
-            await next(context).ConfigureAwait(false);
-        }
-        else
+        if (result.Tenant is null)
         {
             _metrics.RecordResolutionFailed();
             await next(context).ConfigureAwait(false);
+            return;
         }
+
+        if (context.User.Identity?.IsAuthenticated == true
+            && !await TryAuthorizeAuthenticatedAsync(context, result).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        if (!await EnsureTenantExistsAsync(context, result).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        _metrics.RecordResolutionSucceeded(result.Tenant.Id.ToString()!, result.ResolverType);
+
+        using IDisposable _ = _currentTenant.Change(result.Tenant.Id, result.Tenant.Name);
+        await next(context).ConfigureAwait(false);
+    }
+
+    private async Task<bool> TryAuthorizeAuthenticatedAsync(HttpContext context, TenantResolutionResult result)
+    {
+        string? jwtClaim = context.User.FindFirstValue(_options.TenantIdClaimType);
+
+        if (!string.IsNullOrEmpty(jwtClaim))
+        {
+            return await TryValidateJwtMatchAsync(context, result, jwtClaim).ConfigureAwait(false);
+        }
+
+        if (!result.IsAuthoritative && result.Tenant!.Id.HasValue)
+        {
+            return await TryAuthorizeHostImpersonationAsync(context, result).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    // Tenant user: in CrossValidate mode the resolved tenant must match the JWT
+    // claim. In Unrestricted mode the header is trusted by configuration and the
+    // cross-check is skipped.
+    private async Task<bool> TryValidateJwtMatchAsync(HttpContext context, TenantResolutionResult result, string jwtClaim)
+    {
+        if (_options.HeaderTrustMode != TenantHeaderTrustMode.CrossValidate
+            || !Guid.TryParse(jwtClaim, out Guid jwtTenantId)
+            || result.Tenant!.Id is not Guid resolvedTenantId
+            || jwtTenantId == resolvedTenantId)
+        {
+            return true;
+        }
+
+        _metrics.RecordResolutionFailed();
+        LogTenantMismatch(resolvedTenantId, result.ResolverType, jwtTenantId);
+        await ProblemDetailsWriter
+            .WriteTenantMismatchAsync(context, _problemDetailsService, _localizer, resolvedTenantId, jwtTenantId)
+            .ConfigureAwait(false);
+        return false;
+    }
+
+    // Host user (no tenant_id claim) attempting tenant impersonation via a non-JWT
+    // resolver (header, query, domain). The gate runs regardless of HeaderTrustMode:
+    // header trust and impersonation authorization are orthogonal — opting into
+    // Unrestricted trusts the proxy to scrub the header for Tenant users, not to
+    // waive permission checks for Host operators. Secure-by-default refuses unless
+    // wired up by Granit.MultiTenancy.Authorization.
+    private async Task<bool> TryAuthorizeHostImpersonationAsync(HttpContext context, TenantResolutionResult result)
+    {
+        Guid tenantId = result.Tenant!.Id!.Value;
+
+        HostImpersonationDecision decision = await _hostImpersonationGate
+            .CanImpersonateAsync(context.User, tenantId, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        // Audit BEFORE short-circuiting so the trail captures attempts, not just
+        // successes. Audit-write failures must not propagate — wrap.
+        await SafeAuditAsync(context, result, decision).ConfigureAwait(false);
+
+        if (!decision.Allowed)
+        {
+            string reason = decision.DenyReasonCode ?? "unspecified";
+            _metrics.RecordHostImpersonationDenied(tenantId.ToString(), reason);
+            LogHostImpersonationDenied(tenantId, result.ResolverType, reason);
+            await ProblemDetailsWriter
+                .WriteHostImpersonationDeniedAsync(context, _problemDetailsService, _localizer, reason, tenantId)
+                .ConfigureAwait(false);
+            return false;
+        }
+
+        _metrics.RecordHostImpersonationAllowed(tenantId.ToString());
+        return true;
+    }
+
+    // Validate that the resolved tenant actually exists in the store. Prevents
+    // phantom tenants (arbitrary GUIDs) from creating orphaned data.
+    private async Task<bool> EnsureTenantExistsAsync(HttpContext context, TenantResolutionResult result)
+    {
+        if (!_options.ValidateTenantExistence || !result.Tenant!.Id.HasValue)
+        {
+            return true;
+        }
+
+        if (await _tenantReader.ExistsAsync(result.Tenant.Id.Value, context.RequestAborted).ConfigureAwait(false))
+        {
+            return true;
+        }
+
+        _metrics.RecordResolutionFailed();
+        LogPhantomTenant(result.Tenant.Id.Value, result.ResolverType);
+        // Bare 403 without response body: intentional information-minimal rejection.
+        // Don't reveal to an attacker why the tenant was rejected. Server-side
+        // observability is provided by LogPhantomTenant.
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+        return false;
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Tenant mismatch: resolved tenant {ResolvedTenantId} via {ResolverType} but JWT claim contains {JwtTenantId}. Request rejected.")]

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
@@ -41,7 +41,7 @@ internal sealed class OpenIddictDbContext(
     private static readonly MethodInfo ConfigureMultiTenantFilterMethod =
         typeof(OpenIddictDbContext).GetMethod(
             nameof(ConfigureMultiTenantFilter),
-            BindingFlags.Instance | BindingFlags.NonPublic)!;
+            BindingFlags.Instance | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: ConfigureMultiTenantFilter must stay private to keep its `this`-binding (load-bearing for EF Core parameter extraction); reflection is the only way to invoke a generic instance method per-entity-type.
 
     private readonly ICurrentTenant _currentTenant = currentTenant
         ?? throw new ArgumentNullException(nameof(currentTenant));

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -47,7 +47,7 @@ public abstract class GranitDbContext : DbContext
     private static readonly MethodInfo ConfigureMultiTenantFilterMethod =
         typeof(GranitDbContext).GetMethod(
             nameof(ConfigureMultiTenantFilter),
-            BindingFlags.Instance | BindingFlags.NonPublic)!;
+            BindingFlags.Instance | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: ConfigureMultiTenantFilter must stay private to keep its `this`-binding (load-bearing for EF Core parameter extraction); reflection is the only way to invoke a generic instance method per-entity-type.
 
     /// <summary>
     /// The tenant context for this scope, captured at construction time.

--- a/src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs
+++ b/src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs
@@ -75,8 +75,5 @@ public sealed class GranitEndpointTestHost : IAsyncDisposable
         return client;
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        await _app.DisposeAsync().ConfigureAwait(false);
-    }
+    public async ValueTask DisposeAsync() => await _app.DisposeAsync().ConfigureAwait(false);
 }

--- a/tests/Granit.Auditing.Tests/Domain/AuditCategoryTests.cs
+++ b/tests/Granit.Auditing.Tests/Domain/AuditCategoryTests.cs
@@ -11,13 +11,14 @@ public sealed class AuditCategoryTests
     [InlineData(AuditCategory.ConfigurationChange, 1)]
     [InlineData(AuditCategory.DataAccess, 2)]
     [InlineData(AuditCategory.AccessDenied, 3)]
+    [InlineData(AuditCategory.PrivilegedAccess, 4)]
     public void Values_HaveExpectedNumericValues(AuditCategory category, int expectedValue) => ((int)category).ShouldBe(expectedValue);
 
     [Fact]
-    public void HasFourValues()
+    public void HasFiveValues()
     {
         AuditCategory[] values = Enum.GetValues<AuditCategory>();
-        values.Length.ShouldBe(4);
+        values.Length.ShouldBe(5);
     }
 
     [Theory]
@@ -25,5 +26,6 @@ public sealed class AuditCategoryTests
     [InlineData(AuditCategory.ConfigurationChange, "ConfigurationChange")]
     [InlineData(AuditCategory.DataAccess, "DataAccess")]
     [InlineData(AuditCategory.AccessDenied, "AccessDenied")]
+    [InlineData(AuditCategory.PrivilegedAccess, "PrivilegedAccess")]
     public void ToString_ReturnsExpectedName(AuditCategory category, string expected) => category.ToString().ShouldBe(expected);
 }

--- a/tests/Granit.Auditing.Tests/Domain/AuditingOptionsTests.cs
+++ b/tests/Granit.Auditing.Tests/Domain/AuditingOptionsTests.cs
@@ -20,6 +20,7 @@ public sealed class AuditingOptionsTests
         options.DataMutationRetention.ShouldBe(TimeSpan.FromDays(365));
         options.DataAccessRetention.ShouldBe(TimeSpan.FromDays(90));
         options.AccessDeniedRetention.ShouldBe(TimeSpan.FromDays(2555));
+        options.PrivilegedAccessRetention.ShouldBe(TimeSpan.FromDays(2555));
     }
 
     [Theory]
@@ -27,6 +28,7 @@ public sealed class AuditingOptionsTests
     [InlineData(AuditCategory.DataMutation, 365)]
     [InlineData(AuditCategory.DataAccess, 90)]
     [InlineData(AuditCategory.AccessDenied, 2555)]
+    [InlineData(AuditCategory.PrivilegedAccess, 2555)]
     public void GetRetention_ReturnsCorrectDefault(AuditCategory category, int expectedDays)
     {
         AuditingOptions options = new();

--- a/tests/Granit.MultiTenancy.Auditing.Tests/AuditingHostImpersonationAuditWriterTests.cs
+++ b/tests/Granit.MultiTenancy.Auditing.Tests/AuditingHostImpersonationAuditWriterTests.cs
@@ -15,8 +15,8 @@ public sealed class AuditingHostImpersonationAuditWriterTests
     private static ClaimsPrincipal Principal(string sub = "host-1", string? name = "Host Operator") =>
         new(new ClaimsIdentity(
             name is null
-                ? new[] { new Claim("sub", sub) }
-                : new[] { new Claim("sub", sub), new Claim("name", name) },
+                ? [new Claim("sub", sub)]
+                : [new Claim("sub", sub), new Claim("name", name)],
             "test"));
 
     private static IClock FixedClock(DateTimeOffset at)
@@ -27,7 +27,7 @@ public sealed class AuditingHostImpersonationAuditWriterTests
     }
 
     [Fact]
-    public async Task WriteAsync_AllowedDecision_PersistsAuditEntry()
+    public async Task WriteAsync_AllowedDecision_PersistsAsPrivilegedAccess()
     {
         IAuditingWriter writer = Substitute.For<IAuditingWriter>();
         AuditEntry? captured = null;
@@ -45,16 +45,19 @@ public sealed class AuditingHostImpersonationAuditWriterTests
         captured.UserId.ShouldBe("host-1");
         captured.UserName.ShouldBe("Host Operator");
         captured.TenantId.ShouldBe(tenantId);
-        captured.Category.ShouldBe(AuditCategory.AccessDenied);
+        captured.Category.ShouldBe(AuditCategory.PrivilegedAccess);
         captured.IpAddress.ShouldBe("10.0.0.1");
         captured.UserAgent.ShouldBe("test-agent/1.0");
         captured.CorrelationId.ShouldBe("trace-abc");
     }
 
     [Fact]
-    public async Task WriteAsync_DeniedDecision_AlsoPersists()
+    public async Task WriteAsync_DeniedDecision_PersistsAsAccessDenied()
     {
         IAuditingWriter writer = Substitute.For<IAuditingWriter>();
+        AuditEntry? captured = null;
+        await writer.WriteAsync(Arg.Do<AuditEntry>(e => captured = e), Arg.Any<CancellationToken>());
+
         var sut = new AuditingHostImpersonationAuditWriter(writer, FixedClock(DateTimeOffset.UnixEpoch));
 
         await sut.WriteAsync(
@@ -63,9 +66,62 @@ public sealed class AuditingHostImpersonationAuditWriterTests
             "HeaderTenantResolver", null, null, null,
             TestContext.Current.CancellationToken);
 
-        await writer.Received(1).WriteAsync(
-            Arg.Is<AuditEntry>(e => e.Category == AuditCategory.AccessDenied),
-            Arg.Any<CancellationToken>());
+        captured.ShouldNotBeNull();
+        captured.Category.ShouldBe(AuditCategory.AccessDenied);
+    }
+
+    [Fact]
+    public async Task WriteAsync_PersistsDecisionDetailsAsEntityChange()
+    {
+        // The audit row must be self-contained — investigators read decision detail
+        // straight off the row rather than joining against OTEL / structured logs.
+        IAuditingWriter writer = Substitute.For<IAuditingWriter>();
+        AuditEntry? captured = null;
+        await writer.WriteAsync(Arg.Do<AuditEntry>(e => captured = e), Arg.Any<CancellationToken>());
+
+        var sut = new AuditingHostImpersonationAuditWriter(writer, FixedClock(DateTimeOffset.UnixEpoch));
+        var tenantId = Guid.NewGuid();
+
+        await sut.WriteAsync(
+            Principal(), tenantId,
+            new HostImpersonationDecision(false, "HostImpersonation.PermissionDenied"),
+            "HeaderTenantResolver", null, null, null,
+            TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.EntityChanges.Count.ShouldBe(1);
+        AuditEntityChange change = captured.EntityChanges.Single();
+        change.EntityType.ShouldBe("HostImpersonation");
+        change.EntityId.ShouldBe(tenantId.ToString("D"));
+        change.ChangeType.ShouldBe(AuditChangeType.Created);
+
+        change.PropertyChanges.ShouldContain(p =>
+            p.PropertyName == "Allowed" && p.NewValue == "false");
+        change.PropertyChanges.ShouldContain(p =>
+            p.PropertyName == "ResolverType" && p.NewValue == "HeaderTenantResolver");
+        change.PropertyChanges.ShouldContain(p =>
+            p.PropertyName == "DenyReasonCode" && p.NewValue == "HostImpersonation.PermissionDenied");
+    }
+
+    [Fact]
+    public async Task WriteAsync_AllowedDecision_OmitsDenyReasonCodeFromEntityChanges()
+    {
+        IAuditingWriter writer = Substitute.For<IAuditingWriter>();
+        AuditEntry? captured = null;
+        await writer.WriteAsync(Arg.Do<AuditEntry>(e => captured = e), Arg.Any<CancellationToken>());
+
+        var sut = new AuditingHostImpersonationAuditWriter(writer, FixedClock(DateTimeOffset.UnixEpoch));
+
+        await sut.WriteAsync(
+            Principal(), Guid.NewGuid(), HostImpersonationDecision.Allow,
+            "HeaderTenantResolver", null, null, null,
+            TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        AuditEntityChange change = captured.EntityChanges.Single();
+        change.PropertyChanges.ShouldContain(p =>
+            p.PropertyName == "Allowed" && p.NewValue == "true");
+        change.PropertyChanges.ShouldNotContain(p => p.PropertyName == "DenyReasonCode");
     }
 
     [Fact]
@@ -88,7 +144,7 @@ public sealed class AuditingHostImpersonationAuditWriterTests
     }
 
     [Fact]
-    public async Task WriteAsync_PrincipalWithNoIdentityClaims_FallsBackToUnknown()
+    public async Task WriteAsync_PrincipalWithNoIdentityClaims_FallsBackToSentinel()
     {
         IAuditingWriter writer = Substitute.For<IAuditingWriter>();
         AuditEntry? captured = null;
@@ -102,7 +158,9 @@ public sealed class AuditingHostImpersonationAuditWriterTests
             "HeaderTenantResolver", null, null, null,
             TestContext.Current.CancellationToken);
 
-        captured!.UserId.ShouldBe("unknown");
+        // `<unknown>` (with delimiters) is grep-friendly and unlikely to collide with
+        // any real OIDC `sub` claim, avoiding an indexed-column hotspot.
+        captured!.UserId.ShouldBe("<unknown>");
     }
 
     [Fact]

--- a/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
@@ -15,6 +15,7 @@ using Granit.MultiTenancy.Pipeline;
 using Granit.MultiTenancy.Resolvers;
 using Granit.MultiTenancy.Stores;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -31,6 +32,17 @@ public sealed class TenantResolutionMiddlewareTests
         IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
         meterFactory.Create(Arg.Any<MeterOptions>()).Returns(callInfo => new Meter(callInfo.Arg<MeterOptions>().Name));
         return new MultiTenancyMetrics(meterFactory);
+    }
+
+    private static IProblemDetailsService CreateProblemDetailsService()
+    {
+        // The middleware emits 403 bodies through IProblemDetailsService — tests use
+        // the real default implementation so they can still assert the serialized body
+        // shape end-to-end.
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddProblemDetails();
+        return services.BuildServiceProvider().GetRequiredService<IProblemDetailsService>();
     }
 
     private static TenantResolutionMiddleware CreateMiddleware(
@@ -61,6 +73,7 @@ public sealed class TenantResolutionMiddlewareTests
             tenantReader,
             gate,
             Substitute.For<IHostImpersonationAuditWriter>(),
+            CreateProblemDetailsService(),
             CreateMetrics(),
             new TestLocalizer(),
             options,
@@ -234,6 +247,7 @@ public sealed class TenantResolutionMiddlewareTests
             tenantReader,
             AllowAllGate(),
             Substitute.For<IHostImpersonationAuditWriter>(),
+            CreateProblemDetailsService(),
             CreateMetrics(),
             new TestLocalizer(),
             options,
@@ -716,6 +730,7 @@ public sealed class TenantResolutionMiddlewareTests
             tenantReader,
             gate,
             audit,
+            CreateProblemDetailsService(),
             CreateMetrics(),
             new TestLocalizer(),
             options,


### PR DESCRIPTION
## Summary

Convention/cleanup pass on the host-impersonation slice landed by #2140–#2143, surfaced by `/audit`.

### Auditing
- **`AuditCategory.PrivilegedAccess`** (new, ISO 27001 A.12.4.3) + `PrivilegedAccessRetention` (default 7 years). Allowed impersonations no longer share the `AccessDenied` retention bucket with denials.
- **`AuditingHostImpersonationAuditWriter`** persists decision detail (`Allowed`, `ResolverType`, `DenyReasonCode`) as a synthetic `HostImpersonation` `AuditEntityChange` — audit rows are now self-contained, investigators don't have to join against OTEL / structured logs.
- `UserId` fallback `"unknown"` → `"<unknown>"` (grep-friendly sentinel, avoids indexed-column hotspot).

### MultiTenancy
- **`TenantResolutionMiddleware` + `ProblemDetailsWriter`** route 403 `problem+json` bodies through `IProblemDetailsService`, sharing the writer pipeline with `Granit.Http.ExceptionHandling`. `AddProblemDetails()` is wired in `AddGranitMultiTenancy()` (idempotent `TryAdd`).
- **Metric** renamed `granit.multi_tenancy.host_impersonation` → `.attempted` (matches `granit.{module}.{entity}.{action}` shape).
- Drop stray `DynamicProxyGenAssembly2` `InternalsVisibleTo`; restore generic `ILogger<T>` field type.

### Misc (commit 2)
- `OpenIddictDbContext` / `GranitDbContext`: NOSONAR S3011 marker on the reflective `ConfigureMultiTenantFilter` lookup with the rationale (private method is load-bearing for EF Core parameter extraction).
- `GranitEndpointTestHost.DisposeAsync`: expression-bodied for consistency.

## Test plan

- [x] `Granit.MultiTenancy.Tests` — 21/21
- [x] `Granit.MultiTenancy.Auditing.Tests` — 8/8 (2 new tests on `EntityChanges` shape + sentinel)
- [x] `Granit.MultiTenancy.Authorization/Endpoints/EFCore/Provisioning.Tests` — 83/83
- [x] `Granit.Auditing.Tests` — 91/91 (`AuditCategoryTests` + `AuditingOptionsTests` extended)
- [x] `Granit.Auditing.Notifications.Tests` — 7/7 (defaults unchanged, `PrivilegedAccess` not auto-added to `AlertableCategories`)
- [x] `Granit.ArchitectureTests` — 182/182
- [x] `dotnet format --verify-no-changes` clean on all touched projects

## Notes

- Granit is pre-1.0 → `AuditCategory.PrivilegedAccess = 4` is a non-breaking enum addition. `AuditNotificationOptions.AlertableCategories` keeps its conservative default `[AccessDenied, ConfigurationChange]` — no new notification flood.
- Body-shape assertions in middleware tests now go through the real `DefaultProblemDetailsService` (wired via a minimal `ServiceCollection.AddProblemDetails()` helper).