### PR TITLE
test(coverage): cover MinimumResponseTimeGuard + ScheduledActionStatusMiddleware

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -24010,6 +24010,22 @@
       "members": []
     },
     {
+      "name": "TotpServiceBase",
+      "fqn": "Granit.Identity.Local.Services.TotpServiceBase",
+      "kind": "class",
+      "project": "Granit.Identity.Local",
+      "file": "src/Granit.Identity.Local/Services/TotpServiceBase.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "GetQrCodeUri",
+          "kind": "method",
+          "signature": "GetQrCodeUri(string email, string sharedKey)",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "TwoFactorStatus",
       "fqn": "Granit.Identity.Local.Services.TwoFactorStatus",
       "kind": "record",

--- a/tests/Granit.Http.Abstractions.Tests/MinimumResponseTimeGuardTests.cs
+++ b/tests/Granit.Http.Abstractions.Tests/MinimumResponseTimeGuardTests.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+using Granit.Http.Timing;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Abstractions.Tests;
+
+/// <summary>
+/// Validates <see cref="MinimumResponseTimeGuard"/> argument checks and timing-padding behavior.
+/// </summary>
+public sealed class MinimumResponseTimeGuardTests
+{
+    [Fact]
+    public void Begin_with_negative_minimum_throws()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => MinimumResponseTimeGuard.Begin(-1, 10));
+    }
+
+    [Fact]
+    public void Begin_with_maximum_less_than_minimum_throws()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => MinimumResponseTimeGuard.Begin(10, 5));
+    }
+
+    [Fact]
+    public void Begin_with_equal_minimum_and_maximum_is_allowed()
+    {
+        var guard = MinimumResponseTimeGuard.Begin(0, 0);
+
+        guard.ShouldBeOfType<MinimumResponseTimeGuard>();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_pads_to_floor_when_handler_is_fast()
+    {
+        const int floorMs = 200;
+
+        long start = Stopwatch.GetTimestamp();
+        await using (var guard = MinimumResponseTimeGuard.Begin(floorMs, floorMs))
+        {
+            // No work — should still take at least floorMs.
+        }
+        TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+
+        // Allow a small scheduler tolerance below the floor (Task.Delay can return ~15 ms early on busy CI).
+        elapsed.TotalMilliseconds.ShouldBeGreaterThanOrEqualTo(floorMs - 20);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_is_noop_when_handler_already_exceeds_floor()
+    {
+        const int floorMs = 20;
+        const int handlerWorkMs = 120;
+
+        long start = Stopwatch.GetTimestamp();
+        await using (var guard = MinimumResponseTimeGuard.Begin(floorMs, floorMs))
+        {
+            await Task.Delay(handlerWorkMs, TestContext.Current.CancellationToken);
+        }
+        TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+
+        // The guard must not add extra padding once the floor is already reached.
+        // Generous upper bound to keep the test robust on slow CI runners.
+        elapsed.TotalMilliseconds.ShouldBeLessThan(handlerWorkMs + 80);
+    }
+
+    [Fact]
+    public async Task Floor_picked_within_inclusive_range()
+    {
+        const int minMs = 30;
+        const int maxMs = 60;
+
+        // Run several iterations — each draws a fresh random floor in [minMs, maxMs].
+        for (int i = 0; i < 5; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            await using (var guard = MinimumResponseTimeGuard.Begin(minMs, maxMs))
+            {
+                // No work.
+            }
+            TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+
+            elapsed.TotalMilliseconds.ShouldBeGreaterThanOrEqualTo(minMs - 15);
+            // Upper bound: floor cannot exceed maxMs, plus generous scheduler slack.
+            elapsed.TotalMilliseconds.ShouldBeLessThan(maxMs + 150);
+        }
+    }
+}

--- a/tests/Granit.Scheduling.Wolverine.Tests/ScheduledActionStatusMiddlewareTests.cs
+++ b/tests/Granit.Scheduling.Wolverine.Tests/ScheduledActionStatusMiddlewareTests.cs
@@ -1,0 +1,294 @@
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using Granit.MultiTenancy;
+using Granit.Scheduling.Diagnostics;
+using Granit.Scheduling.Domain;
+using Granit.Scheduling.Domain.ValueObjects;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace Granit.Scheduling.Wolverine.Tests;
+
+/// <summary>
+/// Tests for <see cref="ScheduledActionStatusMiddleware"/> covering header parsing, claim gating
+/// (Before), executed/failed transitions (After/PostProcess), and metric emission.
+/// </summary>
+public sealed class ScheduledActionStatusMiddlewareTests : IDisposable
+{
+    private static readonly DateTimeOffset NowFixture = new(2026, 5, 19, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly ServiceProvider _sp;
+    private readonly IMeterFactory _meterFactory;
+    private readonly IScheduledActionReader _reader = Substitute.For<IScheduledActionReader>();
+    private readonly IScheduledActionWriter _writer = Substitute.For<IScheduledActionWriter>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly SchedulingMetrics _metrics;
+
+    public ScheduledActionStatusMiddlewareTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _meterFactory = _sp.GetRequiredService<IMeterFactory>();
+        _metrics = new SchedulingMetrics(_meterFactory);
+        _clock.Now.Returns(NowFixture);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private ScheduledActionStatusMiddleware CreateSut() =>
+        new(_reader, _writer, _clock, _metrics, _currentTenant);
+
+    private static Envelope CreateEnvelope(Guid? actionId = null)
+    {
+        Envelope envelope = new();
+        if (actionId is not null)
+        {
+            envelope.Headers[ScheduledActionStatusMiddleware.ActionIdHeader] = actionId.Value.ToString();
+        }
+        return envelope;
+    }
+
+    private static Envelope CreateEnvelopeWithRawHeader(string headerValue)
+    {
+        Envelope envelope = new();
+        envelope.Headers[ScheduledActionStatusMiddleware.ActionIdHeader] = headerValue;
+        return envelope;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="ScheduledAction"/> directly in the requested status. The status setter
+    /// is private and the Pending→Processing transition is performed by raw SQL in the EF store,
+    /// so reflection is the only way to materialize a "Processing" aggregate in an isolated unit
+    /// test of the middleware.
+    /// </summary>
+    private static ScheduledAction CreateActionInStatus(
+        ScheduledActionStatus status,
+        string payloadType = "Granit.Scheduling.Wolverine.Tests.FakePayload, Granit.Scheduling.Wolverine.Tests")
+    {
+        var action = ScheduledAction.Create(
+            Guid.NewGuid(),
+            payloadType,
+            "{}",
+            NowFixture.AddHours(1));
+
+        PropertyInfo statusProp = typeof(ScheduledAction).GetProperty(
+            nameof(ScheduledAction.Status),
+            BindingFlags.Public | BindingFlags.Instance)!;
+        statusProp.SetValue(action, status);
+
+        return action;
+    }
+
+    // -------------------------------------------------------------------------
+    // BeforeAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task BeforeAsync_ReturnsContinue_WhenHeaderMissing()
+    {
+        HandlerContinuation result = await CreateSut()
+            .BeforeAsync(CreateEnvelope(), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(HandlerContinuation.Continue);
+        await _writer.DidNotReceive().TryClaimForExecutionAsync(
+            Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BeforeAsync_ReturnsContinue_WhenHeaderIsNotAGuid()
+    {
+        HandlerContinuation result = await CreateSut()
+            .BeforeAsync(CreateEnvelopeWithRawHeader("not-a-guid"), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(HandlerContinuation.Continue);
+        await _writer.DidNotReceive().TryClaimForExecutionAsync(
+            Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BeforeAsync_ReturnsContinue_WhenWriterClaimsAction()
+    {
+        var actionId = Guid.NewGuid();
+        _writer.TryClaimForExecutionAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        HandlerContinuation result = await CreateSut()
+            .BeforeAsync(CreateEnvelope(actionId), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(HandlerContinuation.Continue);
+        await _writer.Received(1).TryClaimForExecutionAsync(
+            Arg.Is<ScheduledActionId>(id => id.Value == actionId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BeforeAsync_ReturnsStop_WhenWriterDoesNotClaim()
+    {
+        var actionId = Guid.NewGuid();
+        _writer.TryClaimForExecutionAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        HandlerContinuation result = await CreateSut()
+            .BeforeAsync(CreateEnvelope(actionId), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(HandlerContinuation.Stop);
+    }
+
+    // -------------------------------------------------------------------------
+    // AfterAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task AfterAsync_DoesNothing_WhenHeaderMissing()
+    {
+        await CreateSut().AfterAsync(CreateEnvelope(), TestContext.Current.CancellationToken);
+
+        await _reader.DidNotReceive().GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>());
+        await _writer.DidNotReceive().UpdateAsync(Arg.Any<ScheduledAction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AfterAsync_DoesNothing_WhenActionNotFound()
+    {
+        var actionId = Guid.NewGuid();
+        _reader.GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns((ScheduledAction?)null);
+
+        await CreateSut().AfterAsync(CreateEnvelope(actionId), TestContext.Current.CancellationToken);
+
+        await _writer.DidNotReceive().UpdateAsync(Arg.Any<ScheduledAction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AfterAsync_DoesNothing_WhenActionNotInProcessing()
+    {
+        var actionId = Guid.NewGuid();
+        ScheduledAction action = CreateActionInStatus(ScheduledActionStatus.Pending);
+        _reader.GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns(action);
+
+        await CreateSut().AfterAsync(CreateEnvelope(actionId), TestContext.Current.CancellationToken);
+
+        await _writer.DidNotReceive().UpdateAsync(Arg.Any<ScheduledAction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AfterAsync_MarksExecutedAndEmitsMetric_WhenActionIsProcessing()
+    {
+        var actionId = Guid.NewGuid();
+        ScheduledAction action = CreateActionInStatus(ScheduledActionStatus.Processing);
+        _reader.GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns(action);
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+
+        using MetricCollector<long> collector = new(
+            _meterFactory, SchedulingMetrics.MeterName, "granit.scheduling.action.executed");
+
+        await CreateSut().AfterAsync(CreateEnvelope(actionId), TestContext.Current.CancellationToken);
+
+        action.Status.ShouldBe(ScheduledActionStatus.Executed);
+        action.ExecutedAt.ShouldBe(NowFixture);
+        await _writer.Received(1).UpdateAsync(action, Arg.Any<CancellationToken>());
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.Count.ShouldBe(1);
+        snapshot[0].Value.ShouldBe(1);
+        snapshot[0].Tags["tenant_id"].ShouldBe("11111111-1111-1111-1111-111111111111");
+        // PayloadType "FullName, Assembly" → last segment of the FullName part.
+        snapshot[0].Tags["payload_type"].ShouldBe("FakePayload");
+    }
+
+    [Fact]
+    public async Task AfterAsync_TagsTenantAsGlobal_WhenNoCurrentTenant()
+    {
+        var actionId = Guid.NewGuid();
+        ScheduledAction action = CreateActionInStatus(ScheduledActionStatus.Processing);
+        _reader.GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns(action);
+        _currentTenant.IsAvailable.Returns(false);
+
+        using MetricCollector<long> collector = new(
+            _meterFactory, SchedulingMetrics.MeterName, "granit.scheduling.action.executed");
+
+        await CreateSut().AfterAsync(CreateEnvelope(actionId), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot[0].Tags["tenant_id"].ShouldBe("global");
+    }
+
+    // -------------------------------------------------------------------------
+    // PostProcessAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task PostProcessAsync_DoesNothing_WhenHeaderMissing()
+    {
+        await CreateSut().PostProcessAsync(
+            CreateEnvelope(), new InvalidOperationException("boom"), TestContext.Current.CancellationToken);
+
+        await _reader.DidNotReceive().GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>());
+        await _writer.DidNotReceive().UpdateAsync(Arg.Any<ScheduledAction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostProcessAsync_DoesNothing_WhenActionNotFound()
+    {
+        var actionId = Guid.NewGuid();
+        _reader.GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns((ScheduledAction?)null);
+
+        await CreateSut().PostProcessAsync(
+            CreateEnvelope(actionId), new InvalidOperationException("boom"), TestContext.Current.CancellationToken);
+
+        await _writer.DidNotReceive().UpdateAsync(Arg.Any<ScheduledAction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostProcessAsync_DoesNothing_WhenActionNotInProcessing()
+    {
+        var actionId = Guid.NewGuid();
+        ScheduledAction action = CreateActionInStatus(ScheduledActionStatus.Executed);
+        _reader.GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns(action);
+
+        await CreateSut().PostProcessAsync(
+            CreateEnvelope(actionId), new InvalidOperationException("boom"), TestContext.Current.CancellationToken);
+
+        await _writer.DidNotReceive().UpdateAsync(Arg.Any<ScheduledAction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostProcessAsync_MarksFailedAndEmitsMetric_WhenActionIsProcessing()
+    {
+        var actionId = Guid.NewGuid();
+        ScheduledAction action = CreateActionInStatus(ScheduledActionStatus.Processing);
+        _reader.GetByIdAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>())
+            .Returns(action);
+        _currentTenant.IsAvailable.Returns(false);
+
+        using MetricCollector<long> collector = new(
+            _meterFactory, SchedulingMetrics.MeterName, "granit.scheduling.action.failed");
+
+        var exception = new InvalidOperationException("payload handler exploded");
+        await CreateSut().PostProcessAsync(
+            CreateEnvelope(actionId), exception, TestContext.Current.CancellationToken);
+
+        action.Status.ShouldBe(ScheduledActionStatus.Failed);
+        action.FailureReason.ShouldBe("payload handler exploded");
+        action.ExecutedAt.ShouldBe(NowFixture);
+        await _writer.Received(1).UpdateAsync(action, Arg.Any<CancellationToken>());
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.Count.ShouldBe(1);
+        snapshot[0].Value.ShouldBe(1);
+        snapshot[0].Tags["payload_type"].ShouldBe("FakePayload");
+    }
+}


### PR DESCRIPTION
## Summary

Two low-coverage framework modules flipped to high coverage with focused unit tests — no churn, no premature abstractions.

- **`Granit.Http.Abstractions`** (~10% → ~95%): `MinimumResponseTimeGuard` had zero coverage. Adds tests for argument validation, the floor-padding path, the no-op path when the handler already exceeds the floor, and that the random floor stays in the inclusive `[min, max]` range.
- **`Granit.Scheduling.Wolverine`** (~22% → ~80%): `ScheduledActionStatusMiddleware` had zero coverage. Adds tests for header parsing (missing / non-Guid), `BeforeAsync` claim gating (Continue vs Stop), `AfterAsync`/`PostProcessAsync` no-op branches (header missing, action not found, action not in `Processing`), and the executed/failed transitions with metric tag assertions (`tenant_id`, `payload_type`) using `MetricCollector<long>`.

## Notes

- `ScheduledAction.MarkExecuted` / `MarkFailed` are `internal` and the `Pending → Processing` transition is performed by raw SQL in the EF store. The test helper uses reflection on the `Status` private setter to materialize a `Processing` aggregate in isolation — the only way to exercise the middleware's happy paths without spinning up EF + Wolverine. This is consistent with the framework's pre-1.0 stance on test pragmatism (no production reflection added).

## Test plan

- [x] `dotnet build tests/Granit.Http.Abstractions.Tests` — clean
- [x] `tests/Granit.Http.Abstractions.Tests` — 10/10 pass
- [x] `dotnet build tests/Granit.Scheduling.Wolverine.Tests` — clean
- [x] `tests/Granit.Scheduling.Wolverine.Tests` — 15/15 pass
- [x] `dotnet format --verify-no-changes` clean on both test projects