### PR TITLE
feat(ai): restore Granit.AI.Anthropic provider

### DIFF
--- a/.github/shard-filters/core-ai.slnf
+++ b/.github/shard-filters/core-ai.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "../../Granit.slnx",
     "projects": [
+      "src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj",
       "src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj",
       "src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj",
       "src/Granit.AI.EntityFrameworkCore/Granit.AI.EntityFrameworkCore.csproj",
@@ -92,6 +93,7 @@
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
       "src/bundles/Granit.Bundle.Essentials/Granit.Bundle.Essentials.csproj",
       "src/bundles/Granit.Bundle.Notifications/Granit.Bundle.Notifications.csproj",
+      "tests/Granit.AI.Anthropic.Tests/Granit.AI.Anthropic.Tests.csproj",
       "tests/Granit.AI.AzureOpenAI.Tests/Granit.AI.AzureOpenAI.Tests.csproj",
       "tests/Granit.AI.Endpoints.Tests/Granit.AI.Endpoints.Tests.csproj",
       "tests/Granit.AI.EntityFrameworkCore.Tests/Granit.AI.EntityFrameworkCore.Tests.csproj",

--- a/.github/shard-filters/src-only.slnf
+++ b/.github/shard-filters/src-only.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "../../Granit.slnx",
     "projects": [
+      "src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj",
       "src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj",
       "src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj",
       "src/Granit.AI.EntityFrameworkCore/Granit.AI.EntityFrameworkCore.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -4,6 +4,7 @@
       "name": "core-ai",
       "label": "Core + AI",
       "projects": [
+        "tests/Granit.AI.Anthropic.Tests",
         "tests/Granit.AI.AzureOpenAI.Tests",
         "tests/Granit.AI.Endpoints.Tests",
         "tests/Granit.AI.EntityFrameworkCore.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -17,6 +17,13 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.AI.Anthropic",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.AI.AzureOpenAI",
       "deps": [
         "Granit.AI"
@@ -2325,6 +2332,53 @@
       "file": "src/Granit.AI/AIUsageRecord.cs",
       "line": 6,
       "members": []
+    },
+    {
+      "name": "AIAnthropicHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.Anthropic.Extensions.AIAnthropicHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Anthropic",
+      "file": "src/Granit.AI.Anthropic/Extensions/AIAnthropicHostApplicationBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitAIAnthropic",
+          "kind": "method",
+          "signature": "AddGranitAIAnthropic(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIAnthropicModule",
+      "fqn": "Granit.AI.Anthropic.GranitAIAnthropicModule",
+      "kind": "class",
+      "project": "Granit.AI.Anthropic",
+      "file": "src/Granit.AI.Anthropic/GranitAIAnthropicModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AnthropicProviderOptions",
+      "fqn": "Granit.AI.Anthropic.Options.AnthropicProviderOptions",
+      "kind": "class",
+      "project": "Granit.AI.Anthropic",
+      "file": "src/Granit.AI.Anthropic/Options/AnthropicProviderOptions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultModel",
+          "kind": "property",
+          "signature": "string DefaultModel",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "AIAzureOpenAIHostApplicationBuilderExtensions",
@@ -24014,6 +24068,22 @@
       "file": "src/Granit.Identity.Local/Services/IExternalLoginService.cs",
       "line": 58,
       "members": []
+    },
+    {
+      "name": "TotpServiceBase",
+      "fqn": "Granit.Identity.Local.Services.TotpServiceBase",
+      "kind": "class",
+      "project": "Granit.Identity.Local",
+      "file": "src/Granit.Identity.Local/Services/TotpServiceBase.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "GetQrCodeUri",
+          "kind": "method",
+          "signature": "GetQrCodeUri(string email, string sharedKey)",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "TwoFactorStatus",

--- a/.slnf/ai.slnf
+++ b/.slnf/ai.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "Granit.slnx",
     "projects": [
+      "src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj",
       "src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj",
       "src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj",
       "src/Granit.AI.EntityFrameworkCore/Granit.AI.EntityFrameworkCore.csproj",
@@ -36,6 +37,7 @@
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
+      "tests/Granit.AI.Anthropic.Tests/Granit.AI.Anthropic.Tests.csproj",
       "tests/Granit.AI.AzureOpenAI.Tests/Granit.AI.AzureOpenAI.Tests.csproj",
       "tests/Granit.AI.Endpoints.Tests/Granit.AI.Endpoints.Tests.csproj",
       "tests/Granit.AI.EntityFrameworkCore.Tests/Granit.AI.EntityFrameworkCore.Tests.csproj",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "Granit.slnx",
     "projects": [
+      "src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj",
       "src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj",
       "src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj",
       "src/Granit.AI.EntityFrameworkCore/Granit.AI.EntityFrameworkCore.csproj",
@@ -157,6 +158,7 @@
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
       "src/bundles/Granit.Bundle.Essentials/Granit.Bundle.Essentials.csproj",
       "src/bundles/Granit.Bundle.Notifications/Granit.Bundle.Notifications.csproj",
+      "tests/Granit.AI.Anthropic.Tests/Granit.AI.Anthropic.Tests.csproj",
       "tests/Granit.AI.AzureOpenAI.Tests/Granit.AI.AzureOpenAI.Tests.csproj",
       "tests/Granit.AI.Endpoints.Tests/Granit.AI.Endpoints.Tests.csproj",
       "tests/Granit.AI.EntityFrameworkCore.Tests/Granit.AI.EntityFrameworkCore.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -258,6 +258,7 @@
     <Project Path="src/Granit.Notifications/Granit.Notifications.csproj" />
   </Folder>
   <Folder Name="/src/AI/">
+    <Project Path="src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj" />
     <Project Path="src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj" />
     <Project Path="src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj" />
     <Project Path="src/Granit.AI.EntityFrameworkCore/Granit.AI.EntityFrameworkCore.csproj" />
@@ -549,6 +550,7 @@
     <Project Path="tests/Granit.Notifications.Zulip.Tests/Granit.Notifications.Zulip.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/AI/">
+    <Project Path="tests/Granit.AI.Anthropic.Tests/Granit.AI.Anthropic.Tests.csproj" />
     <Project Path="tests/Granit.AI.AzureOpenAI.Tests/Granit.AI.AzureOpenAI.Tests.csproj" />
     <Project Path="tests/Granit.AI.Endpoints.Tests/Granit.AI.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.AI.EntityFrameworkCore.Tests/Granit.AI.EntityFrameworkCore.Tests.csproj" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-05-11
+Dernière mise à jour : 2026-05-19
 
 ---
 
@@ -12,7 +12,7 @@ Dernière mise à jour : 2026-05-11
 
 | Licence      | Nombre de packages |
 | ------------ | ------------------ |
-| MIT          | 90                 |
+| MIT          | 91                 |
 | Apache-2.0   | 36                 |
 | BSD-3-Clause | 2                  |
 | BSD-2-Clause | 1                  |
@@ -28,6 +28,7 @@ Dernière mise à jour : 2026-05-11
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
 | AngleSharp | 1.4.0 | Copyright (c) 2013-2025 AngleSharp Contributors |
+| Anthropic | 12.22.0 | Copyright 2026 Anthropic |
 | Asp.Versioning.Mvc | 10.0.0 | (c) .NET Foundation |
 | Asp.Versioning.Mvc.ApiExplorer | 10.0.0 | (c) .NET Foundation |
 | Azure.AI.OpenAI | 2.1.0 | (c) Microsoft Corporation |

--- a/src/Granit.AI.Anthropic/Diagnostics/AIAnthropicActivitySource.cs
+++ b/src/Granit.AI.Anthropic/Diagnostics/AIAnthropicActivitySource.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace Granit.AI.Anthropic.Diagnostics;
+
+/// <summary>OpenTelemetry activity source for the Anthropic AI provider.</summary>
+internal static class AIAnthropicActivitySource
+{
+    /// <summary>Activity source name.</summary>
+    public const string Name = "Granit.AI.Anthropic";
+
+    /// <summary>Shared activity source instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+}

--- a/src/Granit.AI.Anthropic/Extensions/AIAnthropicHostApplicationBuilderExtensions.cs
+++ b/src/Granit.AI.Anthropic/Extensions/AIAnthropicHostApplicationBuilderExtensions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+using Granit.AI.Anthropic.Diagnostics;
+using Granit.AI.Anthropic.Internal;
+using Granit.AI.Anthropic.Options;
+using Granit.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.Anthropic.Extensions;
+
+/// <summary>
+/// Extension methods for registering the Anthropic AI provider.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class AIAnthropicHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds the Anthropic (Claude) AI provider to the application.
+    /// </summary>
+    /// <remarks>
+    /// Binds <see cref="AnthropicProviderOptions"/> from the <c>AI:Anthropic</c> configuration section,
+    /// registers options validation, and registers <see cref="AnthropicProviderFactory"/>
+    /// as an <see cref="IAIProviderFactory"/> implementation.
+    /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHostApplicationBuilder AddGranitAIAnthropic(this IHostApplicationBuilder builder)
+    {
+        GranitActivitySourceRegistry.Register(AIAnthropicActivitySource.Name);
+
+        builder.Services
+            .AddOptions<AnthropicProviderOptions>()
+            .BindConfiguration(AnthropicProviderOptions.SectionName)
+            .ValidateOnStart();
+
+        builder.Services.AddSingleton<IValidateOptions<AnthropicProviderOptions>, AnthropicProviderOptionsValidator>();
+        builder.Services.AddSingleton<IAIProviderFactory, AnthropicProviderFactory>();
+
+        return builder;
+    }
+}

--- a/src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj
+++ b/src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.AI.Anthropic</PackageId>
+    <Description>Anthropic (Claude) provider for Granit.AI. Chat completion via Claude models (Opus, Sonnet, Haiku) with extended thinking support.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.AI.Anthropic.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Anthropic" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.AI.Anthropic/GranitAIAnthropicModule.cs
+++ b/src/Granit.AI.Anthropic/GranitAIAnthropicModule.cs
@@ -1,0 +1,15 @@
+using Granit.Modularity;
+
+namespace Granit.AI.Anthropic;
+
+/// <summary>
+/// Granit module for the Anthropic (Claude) AI provider.
+/// </summary>
+/// <remarks>
+/// Registers <c>AnthropicProviderFactory</c> as <see cref="IAIProviderFactory"/> when
+/// <see cref="Extensions.AIAnthropicHostApplicationBuilderExtensions.AddGranitAIAnthropic"/>
+/// is called. Claude models (Opus, Sonnet, Haiku) are exposed as chat completion providers;
+/// embedding generation is not supported.
+/// </remarks>
+[DependsOn(typeof(GranitAIModule))]
+public sealed class GranitAIAnthropicModule : GranitModule;

--- a/src/Granit.AI.Anthropic/Internal/AnthropicProviderFactory.cs
+++ b/src/Granit.AI.Anthropic/Internal/AnthropicProviderFactory.cs
@@ -1,0 +1,40 @@
+using Anthropic;
+using Granit.AI.Anthropic.Options;
+using Granit.AI.Workspaces;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.Anthropic.Internal;
+
+/// <summary>
+/// Anthropic implementation of <see cref="IAIProviderFactory"/>.
+/// </summary>
+/// <remarks>
+/// Creates <see cref="IChatClient"/> instances backed by the Anthropic SDK.
+/// Embedding generation is not supported by Anthropic and always returns <c>null</c>.
+/// The underlying <see cref="AnthropicClient"/> is created once and reused for the
+/// lifetime of the factory. It is disposed when the factory is disposed.
+/// </remarks>
+internal sealed class AnthropicProviderFactory(IOptions<AnthropicProviderOptions> options)
+    : IAIProviderFactory, IDisposable
+{
+    private readonly AnthropicClient _client = new() { ApiKey = options.Value.ApiKey };
+
+    /// <inheritdoc />
+    public string ProviderName => "Anthropic";
+
+    /// <inheritdoc />
+    public IChatClient CreateChatClient(AIWorkspace workspace)
+    {
+        string model = string.IsNullOrWhiteSpace(workspace.Model) ? options.Value.DefaultModel : workspace.Model;
+        return _client.AsIChatClient(model);
+    }
+
+    /// <inheritdoc />
+    /// <returns>Always <c>null</c>. Anthropic does not support embedding generation.</returns>
+    public IEmbeddingGenerator<string, Embedding<float>>? CreateEmbeddingGenerator(AIWorkspace workspace) =>
+        null;
+
+    /// <inheritdoc />
+    public void Dispose() => _client.Dispose();
+}

--- a/src/Granit.AI.Anthropic/Options/AnthropicProviderOptions.cs
+++ b/src/Granit.AI.Anthropic/Options/AnthropicProviderOptions.cs
@@ -1,0 +1,28 @@
+namespace Granit.AI.Anthropic.Options;
+
+/// <summary>
+/// Configuration for the Anthropic (Claude) AI provider.
+/// </summary>
+/// <remarks>
+/// Bound to the <c>AI:Anthropic</c> configuration section.
+/// The <see cref="ApiKey"/> should be injected from <c>Granit.Vault</c>; never hardcode it.
+/// </remarks>
+public sealed class AnthropicProviderOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "AI:Anthropic";
+
+    /// <summary>
+    /// Anthropic API key. Required. Inject from <c>Granit.Vault</c>; never hardcode.
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Default chat model to use when the workspace does not specify one.
+    /// </summary>
+    /// <remarks>
+    /// Supported models include <c>claude-opus-4-6</c>, <c>claude-sonnet-4-6</c>,
+    /// and <c>claude-haiku-4-5</c>.
+    /// </remarks>
+    public string DefaultModel { get; set; } = "claude-sonnet-4-6";
+}

--- a/src/Granit.AI.Anthropic/Options/AnthropicProviderOptionsValidator.cs
+++ b/src/Granit.AI.Anthropic/Options/AnthropicProviderOptionsValidator.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.Anthropic.Options;
+
+/// <summary>Validates <see cref="AnthropicProviderOptions"/>.</summary>
+internal sealed class AnthropicProviderOptionsValidator : IValidateOptions<AnthropicProviderOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, AnthropicProviderOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ApiKey))
+        {
+            return ValidateOptionsResult.Fail("AnthropicProviderOptions.ApiKey is required.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.AI.Anthropic/README.md
+++ b/src/Granit.AI.Anthropic/README.md
@@ -1,0 +1,19 @@
+# Granit.AI.Anthropic
+
+Anthropic (Claude) provider for Granit.AI. Chat completion via Claude Opus, Sonnet, and Haiku models.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI.Anthropic
+```
+
+## Dependencies
+
+- `Granit.AI`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.Anthropic/packages.lock.json
+++ b/src/Granit.AI.Anthropic/packages.lock.json
@@ -1,0 +1,179 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Anthropic": {
+        "type": "Direct",
+        "requested": "[12.*, )",
+        "resolved": "12.22.0",
+        "contentHash": "hSmNOcU2XbLChNULZHrN2MrJE9g+Em9VND5525czAJkfJDvCgo+cuHRKuezI+3abxZ3nZKu4VHMRj0wtzHnyEQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.5.1"
+        }
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "U+oquaPxFdY8lYeEIWO/AD7jDIl9sPW6aVWMQRHU/pZ/SWpLcOrAj2fcLe1HwXl4sYw1ONI56K/eELT3xr4RRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.6.0",
+        "contentHash": "JCkVoyqBqi9r3Vs5Qo5PfZobT0+CWeOx+9y9yggBxtW9s/X5CAoa7Iw/tP/rfUdz+nxRKMSBmrytYgwmu60lgA=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.AI.Anthropic.Tests/AnthropicProviderFactoryTests.cs
+++ b/tests/Granit.AI.Anthropic.Tests/AnthropicProviderFactoryTests.cs
@@ -1,0 +1,56 @@
+using Granit.AI.Anthropic.Internal;
+using Granit.AI.Anthropic.Options;
+using Granit.AI.Workspaces;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace Granit.AI.Anthropic.Tests;
+
+public sealed class AnthropicProviderFactoryTests
+{
+    private static readonly IOptions<AnthropicProviderOptions> DefaultOptions =
+        Microsoft.Extensions.Options.Options.Create(new AnthropicProviderOptions
+        {
+            ApiKey = "sk-ant-test-key",
+            DefaultModel = "claude-sonnet-4-6",
+        });
+
+    private static AIWorkspace CreateWorkspace(string? model = "claude-sonnet-4-6") =>
+        new()
+        {
+            Name = "test",
+            Provider = "Anthropic",
+            Model = model!,
+        };
+
+    [Fact]
+    public void ProviderName_IsAnthropic()
+    {
+        var factory = new AnthropicProviderFactory(DefaultOptions);
+
+        factory.ProviderName.ShouldBe("Anthropic");
+    }
+
+    [Fact]
+    public void CreateChatClient_WithValidOptions_ReturnsClient()
+    {
+        var factory = new AnthropicProviderFactory(DefaultOptions);
+        AIWorkspace workspace = CreateWorkspace();
+
+        IChatClient client = factory.CreateChatClient(workspace);
+
+        client.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CreateEmbeddingGenerator_ReturnsNull()
+    {
+        var factory = new AnthropicProviderFactory(DefaultOptions);
+        AIWorkspace workspace = CreateWorkspace();
+
+        IEmbeddingGenerator<string, Embedding<float>>? generator = factory.CreateEmbeddingGenerator(workspace);
+
+        generator.ShouldBeNull();
+    }
+}

--- a/tests/Granit.AI.Anthropic.Tests/AnthropicProviderOptionsValidatorTests.cs
+++ b/tests/Granit.AI.Anthropic.Tests/AnthropicProviderOptionsValidatorTests.cs
@@ -1,0 +1,40 @@
+using Granit.AI.Anthropic.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace Granit.AI.Anthropic.Tests;
+
+public sealed class AnthropicProviderOptionsValidatorTests
+{
+    private readonly AnthropicProviderOptionsValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidApiKey_Succeeds()
+    {
+        AnthropicProviderOptions options = new()
+        {
+            ApiKey = "sk-ant-valid-key",
+        };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_EmptyApiKey_Fails(string? apiKey)
+    {
+        AnthropicProviderOptions options = new()
+        {
+            ApiKey = apiKey!,
+        };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("ApiKey");
+    }
+}

--- a/tests/Granit.AI.Anthropic.Tests/GlobalUsings.cs
+++ b/tests/Granit.AI.Anthropic.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Granit.AI.Anthropic.Tests/Granit.AI.Anthropic.Tests.csproj
+++ b/tests/Granit.AI.Anthropic.Tests/Granit.AI.Anthropic.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.AI.Anthropic\Granit.AI.Anthropic.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.AI.Anthropic.Tests/packages.lock.json
+++ b/tests/Granit.AI.Anthropic.Tests/packages.lock.json
@@ -1,0 +1,421 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "U+oquaPxFdY8lYeEIWO/AD7jDIl9sPW6aVWMQRHU/pZ/SWpLcOrAj2fcLe1HwXl4sYw1ONI56K/eELT3xr4RRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.ai.anthropic": {
+        "type": "Project",
+        "dependencies": {
+          "Anthropic": "[12.*, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Anthropic": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.22.0",
+        "contentHash": "hSmNOcU2XbLChNULZHrN2MrJE9g+Em9VND5525czAJkfJDvCgo+cuHRKuezI+3abxZ3nZKu4VHMRj0wtzHnyEQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.5.1"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.6.0",
+        "contentHash": "JCkVoyqBqi9r3Vs5Qo5PfZobT0+CWeOx+9y9yggBxtW9s/X5CAoa7Iw/tP/rfUdz+nxRKMSBmrytYgwmu60lgA=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Restores the `Granit.AI.Anthropic` provider (chat completion via Claude Opus/Sonnet/Haiku) that was inadvertently deleted in #253 as collateral during the architecture-diagram refactor.
- Recovered from `6726b8a58^` and brought up to date with the current sibling pattern (`Granit.AI.OpenAI` / `Granit.AI.Ollama`).
- Wired into `Granit.slnx`, the `core-ai` shard, regenerated solution filters, and added `Anthropic 12.22.0` (MIT) to `THIRD-PARTY-NOTICES.md`.

## Adjustments vs. the old code

- Namespaces: `Granit.Core.Modularity` → `Granit.Modularity`, `Granit.Core.Diagnostics` → `Granit.Diagnostics`.
- `GranitAIAnthropicModule` is now a bodyless `sealed class` — consumer calls `AddGranitAIAnthropic` explicitly (matches OpenAI/Ollama).
- Dropped `[Required]` + `ValidateDataAnnotations()`; the custom `AnthropicProviderOptionsValidator` carries the ApiKey check.
- `AnthropicProviderFactory.CreateChatClient`: removed dead `??` fallback (`AIWorkspace.Model` is `required` non-nullable) — replaced with `string.IsNullOrWhiteSpace` pattern.

## Test plan

- [x] `dotnet restore Granit.slnx --force-evaluate`
- [x] `dotnet build src/Granit.AI.Anthropic -c Release` → 0 warning, 0 error
- [x] `dotnet build tests/Granit.AI.Anthropic.Tests -c Release`
- [x] `tests/Granit.AI.Anthropic.Tests/.../Granit.AI.Anthropic.Tests` → **7/7 pass**
- [x] `dotnet format whitespace + style --verify-no-changes` clean
- [x] `markdownlint-cli2 README.md THIRD-PARTY-NOTICES.md` → 0 error
- [ ] CI `core-ai` shard green