### PR TITLE
feat(localization)!: expose LocalizationOverride via query engine

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1133,6 +1133,7 @@
         "Granit.Http.ApiDocumentation",
         "Granit.Authorization",
         "Granit.Localization",
+        "Granit.QueryEngine.AspNetCore",
         "Granit.Validation",
         "Granit.Workspaces.Abstractions"
       ],
@@ -24835,7 +24836,7 @@
       "kind": "class",
       "project": "Granit.Localization.Endpoints",
       "file": "src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs",
-      "line": 33,
+      "line": 37,
       "members": [
         {
           "name": "MapGranitLocalization",
@@ -24916,7 +24917,7 @@
       "kind": "class",
       "project": "Granit.Localization.EntityFrameworkCore",
       "file": "src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitLocalizationEntityFrameworkCore",

--- a/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
@@ -2,7 +2,8 @@
 // LocalizationEndpointRouteBuilderExtensions.cs
 // Minimal API extensions for Granit localization:
 //   - MapGranitLocalization: GET /{prefix}/localization (SPA bootstrapping, anonymous)
-//   - MapGranitLocalizationOverrides: CRUD /{prefix}/localization/overrides
+//   - MapGranitLocalizationOverrides: query-engine list/meta + CRUD
+//     under /{prefix}/localization/overrides
 //     (admin, requires Localization.Overrides.Manage permission)
 // ---------------------------------------------------------------------------
 
@@ -10,10 +11,13 @@ using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Granit.Localization;
+using Granit.Localization.Domain;
 using Granit.Localization.Endpoints.Dtos;
 using Granit.Localization.Endpoints.Options;
 using Granit.Localization.Endpoints.Permissions;
 using Granit.Localization.Options;
+using Granit.QueryEngine;
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -76,38 +80,6 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
         return endpoints;
     }
 
-    private static Task MarkOverridesQueryParamsRequired(
-        OpenApiOperation operation,
-        OpenApiOperationTransformerContext context,
-        CancellationToken cancellationToken)
-    {
-        if (operation.Parameters is null)
-        {
-            return Task.CompletedTask;
-        }
-
-        foreach (IOpenApiParameter parameter in operation.Parameters)
-        {
-            if (parameter.In != ParameterLocation.Query)
-            {
-                continue;
-            }
-
-            if (parameter is OpenApiParameter concrete && parameter.Name is "resourceName" or "cultureName")
-            {
-                concrete.Required = true;
-            }
-
-            if (parameter.Name == "cultureName" && parameter.Schema is OpenApiSchema cultureSchema)
-            {
-                cultureSchema.Pattern ??= "^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$";
-                cultureSchema.Example ??= System.Text.Json.Nodes.JsonValue.Create("fr-BE");
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
     private static Task DescribeCultureNameParam(
         OpenApiOperation operation,
         OpenApiOperationTransformerContext context,
@@ -139,17 +111,30 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Registers 3 endpoints under <c>/{prefix}/localization/overrides</c>:
+    /// Registers query-engine endpoints + CRUD under <c>/{prefix}/localization/overrides</c>:
     /// <list type="bullet">
-    /// <item><c>GET ?resourceName=X&amp;cultureName=fr</c> — list all overrides for a resource/culture</item>
+    /// <item><c>GET /</c> — paginated, filterable, sortable list of overrides (query engine)</item>
+    /// <item><c>GET /meta</c> — query metadata (columns, filters, sorts, presets)</item>
     /// <item><c>PUT /{resourceName}/{cultureName}/{key}</c> — create or update an override</item>
     /// <item><c>DELETE /{resourceName}/{cultureName}/{key}</c> — remove an override</item>
     /// </list>
     /// </para>
     /// <para>
+    /// The list/meta endpoints require <see cref="IQueryableSource{TEntity}"/> for
+    /// <see cref="LocalizationOverride"/> to be registered (provided by
+    /// <c>AddGranitLocalizationEntityFrameworkCore</c>). The PUT/DELETE endpoints require
+    /// <see cref="ILocalizationOverrideStoreWriter"/> to be registered (same call);
+    /// without it they return <c>501 Not Implemented</c>.
+    /// </para>
+    /// <para>
     /// All endpoints require the <c>Localization.Overrides.Manage</c> permission.
-    /// If <see cref="ILocalizationOverrideStoreReader"/>/<see cref="ILocalizationOverrideStoreWriter"/> is not registered (no EF Core or other
-    /// persistence module loaded), all endpoints return <c>501 Not Implemented</c>.
+    /// </para>
+    /// <para>
+    /// <b>Breaking change vs. earlier versions:</b> the legacy
+    /// <c>GET /overrides?resourceName=X&amp;cultureName=Y</c> shape has been replaced by the
+    /// query-engine surface (<c>GET /</c> + <c>GET /meta</c>). Frontends that previously
+    /// called the legacy shape must switch to the query-engine contract (e.g.
+    /// <c>useQueryEndpoint</c> / <c>useQueryMeta</c>).
     /// </para>
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
@@ -167,14 +152,9 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
             .RequireAuthorization(LocalizationOverridesPermissions.Overrides.Manage)
             .WithTags(options.TagName);
 
-        group.MapGet("", HandleGetOverridesAsync)
-             .WithName("GetLocalizationOverrides")
-             .WithSummary("Returns all translation overrides for a resource and culture.")
-             .WithDescription("Returns all active translation overrides for the specified resource and culture as a key-value dictionary. Both resourceName and cultureName query parameters are required. Returns 501 if no override store is registered.")
-             .Produces<IReadOnlyDictionary<string, string>>()
-             .ProducesProblem(StatusCodes.Status400BadRequest)
-             .ProducesProblem(StatusCodes.Status501NotImplemented)
-             .AddOpenApiOperationTransformer(MarkOverridesQueryParamsRequired);
+        // Query-engine surface: GET / (list) + GET /meta (definition).
+        // Inherits the group's auth + tags so we don't need TagName / AuthorizationPolicy here.
+        group.MapGranitQuery<LocalizationOverride>();
 
         group.MapPut("/{resourceName}/{cultureName}/{key}", HandlePutOverrideAsync)
              .WithName("PutLocalizationOverride")
@@ -244,41 +224,6 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
     // -------------------------------------------------------------------------
     // Handlers — CRUD /{prefix}/localization/overrides
     // -------------------------------------------------------------------------
-
-    private static async Task<Results<Ok<IReadOnlyDictionary<string, string>>, ProblemHttpResult>> HandleGetOverridesAsync(
-        HttpContext context,
-        string? resourceName,
-        string? cultureName,
-        CancellationToken cancellationToken)
-    {
-        ILocalizationOverrideStoreReader? storeReader =
-            context.RequestServices.GetService<ILocalizationOverrideStoreReader>();
-
-        if (storeReader is null)
-        {
-            return StoreNotRegistered();
-        }
-
-        if (string.IsNullOrWhiteSpace(resourceName) || string.IsNullOrWhiteSpace(cultureName))
-        {
-            return TypedResults.Problem(
-                detail: "Query parameters 'resourceName' and 'cultureName' are required.",
-                statusCode: StatusCodes.Status400BadRequest);
-        }
-
-        ProblemHttpResult? error = ValidateMaxLength(resourceName, nameof(resourceName), MaxResourceNameLength)
-            ?? ValidateBcp47(cultureName);
-
-        if (error is not null)
-        {
-            return error;
-        }
-
-        IReadOnlyDictionary<string, string> overrides =
-            await storeReader.GetOverridesAsync(resourceName, cultureName, cancellationToken).ConfigureAwait(false);
-
-        return TypedResults.Ok(overrides);
-    }
 
     private static async Task<Results<NoContent, ProblemHttpResult>> HandlePutOverrideAsync(
         HttpContext context,

--- a/src/Granit.Localization.Endpoints/Granit.Localization.Endpoints.csproj
+++ b/src/Granit.Localization.Endpoints/Granit.Localization.Endpoints.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
       <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Granit.Localization.Endpoints/packages.lock.json
+++ b/src/Granit.Localization.Endpoints/packages.lock.json
@@ -107,11 +107,28 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
+using Granit.Localization.Domain;
 using Granit.Localization.EntityFrameworkCore.Internal;
 using Granit.Localization.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -43,6 +45,8 @@ public static class LocalizationEntityFrameworkCoreHostApplicationBuilderExtensi
             CachedLocalizationOverrideStore.RawStoreKey);
         builder.Services.TryAddKeyedScoped<ILocalizationOverrideStoreWriter, EfCoreLocalizationOverrideStore>(
             CachedLocalizationOverrideStore.RawStoreKey);
+
+        builder.Services.TryAddScoped<IQueryableSource<LocalizationOverride>, EfLocalizationOverrideQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Localization.EntityFrameworkCore/Internal/EfLocalizationOverrideQueryableSource.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Internal/EfLocalizationOverrideQueryableSource.cs
@@ -1,0 +1,29 @@
+using Granit.Localization.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Localization.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="LocalizationOverride"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all overrides are returned cross-tenant — required for ISO 27001
+/// cross-tenant translation governance.
+/// </summary>
+internal sealed class EfLocalizationOverrideQueryableSource(
+    IDbContextFactory<LocalizationDbContext> contextFactory,
+    ICurrentTenant currentTenant) : IQueryableSource<LocalizationOverride>
+{
+    private readonly LocalizationDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+
+    public IQueryable<LocalizationOverride> GetQueryable()
+    {
+        IQueryable<LocalizationOverride> query = _context.LocalizationOverrides.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2533,6 +2533,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesEndpointTests.cs
+++ b/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesEndpointTests.cs
@@ -2,8 +2,13 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Granit.Localization.Domain;
 using Granit.Localization.Endpoints.Extensions;
 using Granit.Localization.Endpoints.Permissions;
+using Granit.Localization.Queries;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Meta;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
@@ -18,8 +23,8 @@ namespace Granit.Localization.Endpoints.Tests;
 
 /// <summary>
 /// Integration tests for the localization override management endpoints
-/// (GET/PUT/DELETE /localization/overrides). Uses a TestServer + NSubstitute
-/// mocks for <see cref="ILocalizationOverrideStoreReader"/> and <see cref="ILocalizationOverrideStoreWriter"/>.
+/// (GET / + /meta query-engine surface, plus PUT/DELETE CRUD).
+/// Uses a TestServer + NSubstitute mocks for the query engine and override stores.
 /// </summary>
 public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
 {
@@ -28,6 +33,8 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
 
     private readonly ILocalizationOverrideStoreReader _storeReader = Substitute.For<ILocalizationOverrideStoreReader>();
     private readonly ILocalizationOverrideStoreWriter _storeWriter = Substitute.For<ILocalizationOverrideStoreWriter>();
+    private readonly IQueryEngine<LocalizationOverride> _engine = Substitute.For<IQueryEngine<LocalizationOverride>>();
+    private readonly IQueryableSource<LocalizationOverride> _queryableSource = Substitute.For<IQueryableSource<LocalizationOverride>>();
     private readonly WebApplication _app;
     private readonly HttpClient _adminClient;
     private readonly HttpClient _anonClient;
@@ -37,22 +44,13 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
 
-        builder.Services
-            .AddAuthentication(TestAuthHandler.SchemeName)
-            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                TestAuthHandler.SchemeName, _ => { });
-
-        // Register a role-based policy for the permission name so the TestAuthHandler can resolve it.
-        builder.Services.AddAuthorizationBuilder()
-            .AddPolicy(LocalizationOverridesPermissions.Overrides.Manage,
-                policy => policy.RequireRole(ManageRole));
-
-        builder.Services.AddSingleton(_storeReader);
-        builder.Services.AddSingleton(_storeWriter);
+        ConfigureCommonServices(builder.Services);
 
         _app = builder.Build();
         _app.MapGranitLocalizationOverrides();
         _app.StartAsync().GetAwaiter().GetResult();
+
+        _queryableSource.GetQueryable().Returns(Array.Empty<LocalizationOverride>().AsQueryable());
 
         _adminClient = BuildClient(ManageRole);
         _anonClient = _app.GetTestClient();
@@ -66,123 +64,111 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
     }
 
     // =========================================================================
-    // GET /localization/overrides
+    // GET /localization/overrides — query engine list
     // =========================================================================
 
     [Fact]
-    public async Task GetOverrides_WhenStoreNotRegistered_Returns501()
-    {
-        // Arrange -- separate app without ILocalizationOverrideStore
-        await using WebApplication app = await BuildAppWithoutStoreAsync();
-        using HttpClient client = BuildClient(app, ManageRole);
-
-        // Act
-        HttpResponseMessage response = await client.GetAsync(
-            $"{Prefix}?resourceName=Test&cultureName=fr",
-            TestContext.Current.CancellationToken);
-
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.NotImplemented);
-    }
-
-    [Fact]
-    public async Task GetOverrides_WithoutResourceName_Returns400()
-    {
-        // Act
-        HttpResponseMessage response = await _adminClient.GetAsync(
-            $"{Prefix}?cultureName=fr",
-            TestContext.Current.CancellationToken);
-
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task GetOverrides_WithoutCultureName_Returns400()
-    {
-        // Act
-        HttpResponseMessage response = await _adminClient.GetAsync(
-            $"{Prefix}?resourceName=Test",
-            TestContext.Current.CancellationToken);
-
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task GetOverrides_WithInvalidBcp47CultureName_Returns400()
-    {
-        // Act
-        HttpResponseMessage response = await _adminClient.GetAsync(
-            $"{Prefix}?resourceName=Test&cultureName=en:invalid",
-            TestContext.Current.CancellationToken);
-
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task GetOverrides_WhenResourceNameExceeds200Chars_Returns400()
+    public async Task GetOverrides_WithNoFilters_Returns200WithPagedResult()
     {
         // Arrange
-        string longName = new('x', 201);
+        PagedResult<LocalizationOverride> expected = new(
+            [new LocalizationOverride { ResourceName = "Acme", CultureName = "fr", Key = "hello", Value = "Salut" }],
+            1, HasMore: false);
+
+        _engine.ExecuteAsync(
+            Arg.Any<IQueryable<LocalizationOverride>>(),
+            Arg.Any<QueryRequest>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expected);
 
         // Act
         HttpResponseMessage response = await _adminClient.GetAsync(
-            $"{Prefix}?resourceName={longName}&cultureName=fr",
-            TestContext.Current.CancellationToken);
-
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task GetOverrides_WithValidParams_ReturnsEmptyDictionary()
-    {
-        // Arrange
-        _storeReader.GetOverridesAsync("Test", "fr", Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, string>());
-
-        // Act
-        HttpResponseMessage response = await _adminClient.GetAsync(
-            $"{Prefix}?resourceName=Test&cultureName=fr",
-            TestContext.Current.CancellationToken);
+            Prefix, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        Dictionary<string, string>? result =
-            await response.Content.ReadFromJsonAsync<Dictionary<string, string>>(
-                TestContext.Current.CancellationToken);
+
+        PagedResult<LocalizationOverride>? result = await response.Content
+            .ReadFromJsonAsync<PagedResult<LocalizationOverride>>(TestContext.Current.CancellationToken);
         result.ShouldNotBeNull();
-        result.ShouldBeEmpty();
+        result.Items.Count.ShouldBe(1);
+        result.Items[0].Key.ShouldBe("hello");
     }
 
     [Fact]
-    public async Task GetOverrides_WithPopulatedOverrides_Returns200WithEntries()
+    public async Task GetOverrides_PropagatesPaginationAndSort()
     {
         // Arrange
-        Dictionary<string, string> overrides = new()
+        _engine.ExecuteAsync(
+            Arg.Any<IQueryable<LocalizationOverride>>(),
+            Arg.Any<QueryRequest>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<LocalizationOverride>([], 0, HasMore: false));
+
+        // Act
+        await _adminClient.GetAsync(
+            $"{Prefix}?page=2&pageSize=20&sort=key",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await _engine.Received(1).ExecuteAsync(
+            Arg.Any<IQueryable<LocalizationOverride>>(),
+            Arg.Is<QueryRequest>(r => r.Page == 2 && r.PageSize == 20 && r.Sort == "key"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetOverrides_UsesIQueryableSourceFromDI()
+    {
+        // Arrange
+        _engine.ExecuteAsync(
+            Arg.Any<IQueryable<LocalizationOverride>>(),
+            Arg.Any<QueryRequest>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<LocalizationOverride>([], 0, HasMore: false));
+
+        // Act
+        await _adminClient.GetAsync(Prefix, TestContext.Current.CancellationToken);
+
+        // Assert -- proves MapGranitQuery resolves IQueryableSource<LocalizationOverride>
+        // from DI; the source is what bridges the showcase frontend to the EF Core layer.
+        _queryableSource.Received().GetQueryable();
+    }
+
+    // =========================================================================
+    // GET /localization/overrides/meta
+    // =========================================================================
+
+    [Fact]
+    public async Task GetOverridesMeta_Returns200WithQueryMetadata()
+    {
+        // Arrange
+        QueryMetadata expected = new()
         {
-            ["Hello"] = "Salut",
-            ["Goodbye"] = "Ciao",
+            Columns = [new ColumnDefinition("key", "Key", "String", 0, true, true, true, null)],
+            FilterableFields = [],
+            SortableFields = [],
+            PresetFilterGroups = [],
+            QuickFilters = [],
+            DateFilters = [],
+            GroupByFields = [],
+            Pagination = new PaginationMeta(25, 100, QueryEngineDefaults.MaxStreamSize, false),
+            DefaultSort = "-modifiedAt",
         };
-        _storeReader.GetOverridesAsync("Test", "fr", Arg.Any<CancellationToken>())
-            .Returns(overrides);
+        _engine.GetMetadata().Returns(expected);
 
         // Act
         HttpResponseMessage response = await _adminClient.GetAsync(
-            $"{Prefix}?resourceName=Test&cultureName=fr",
-            TestContext.Current.CancellationToken);
+            $"{Prefix}/meta", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        Dictionary<string, string>? result =
-            await response.Content.ReadFromJsonAsync<Dictionary<string, string>>(
-                TestContext.Current.CancellationToken);
+
+        QueryMetadata? result = await response.Content
+            .ReadFromJsonAsync<QueryMetadata>(TestContext.Current.CancellationToken);
         result.ShouldNotBeNull();
-        result.Count.ShouldBe(2);
-        result["Hello"].ShouldBe("Salut");
-        result["Goodbye"].ShouldBe("Ciao");
+        result.Columns.Count.ShouldBe(1);
+        result.DefaultSort.ShouldBe("-modifiedAt");
     }
 
     // =========================================================================
@@ -356,8 +342,18 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
     {
         // Act
         HttpResponseMessage response = await _anonClient.GetAsync(
-            $"{Prefix}?resourceName=Test&cultureName=fr",
-            TestContext.Current.CancellationToken);
+            Prefix, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetOverridesMeta_WithoutToken_Returns401()
+    {
+        // Act
+        HttpResponseMessage response = await _anonClient.GetAsync(
+            $"{Prefix}/meta", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -396,10 +392,23 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
 
         // Act
         HttpResponseMessage response = await client.GetAsync(
-            $"{Prefix}?resourceName=Test&cultureName=fr",
-            TestContext.Current.CancellationToken);
+            Prefix, TestContext.Current.CancellationToken);
 
         // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetOverridesMeta_WithWrongRole_Returns403()
+    {
+        // Arrange
+        using HttpClient client = BuildClient(_app, "regular-user");
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(
+            $"{Prefix}/meta", TestContext.Current.CancellationToken);
+
+        // Assert -- ensures the query-engine surface inherits the group's Manage policy.
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }
 
@@ -413,18 +422,15 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
         // Arrange
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
-        builder.Services
-            .AddAuthentication(TestAuthHandler.SchemeName)
-            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                TestAuthHandler.SchemeName, _ => { });
-        builder.Services.AddAuthorizationBuilder()
-            .AddPolicy(LocalizationOverridesPermissions.Overrides.Manage,
-                policy => policy.RequireRole(ManageRole));
-        builder.Services.AddSingleton(_storeReader);
-        builder.Services.AddSingleton(_storeWriter);
+        ConfigureCommonServices(builder.Services);
 
-        _storeReader.GetOverridesAsync("Test", "fr", Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, string>());
+        IQueryEngine<LocalizationOverride> engine = Substitute.For<IQueryEngine<LocalizationOverride>>();
+        engine.ExecuteAsync(
+            Arg.Any<IQueryable<LocalizationOverride>>(),
+            Arg.Any<QueryRequest>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<LocalizationOverride>([], 0, HasMore: false));
+        builder.Services.AddSingleton(engine);
 
         await using WebApplication app = builder.Build();
         app.MapGranitLocalizationOverrides(opts => opts.RoutePrefix = "i18n");
@@ -434,13 +440,11 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
 
         // Act -- default route must not be registered
         HttpResponseMessage notFound = await client.GetAsync(
-            "/localization/overrides?resourceName=Test&cultureName=fr",
-            TestContext.Current.CancellationToken);
+            "/localization/overrides", TestContext.Current.CancellationToken);
 
         // Act -- custom route must respond
         HttpResponseMessage ok = await client.GetAsync(
-            "/i18n/overrides?resourceName=Test&cultureName=fr",
-            TestContext.Current.CancellationToken);
+            "/i18n/overrides", TestContext.Current.CancellationToken);
 
         // Assert
         notFound.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -452,10 +456,10 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
     // =========================================================================
 
     /// <summary>
-    /// Builds a standalone WebApplication without registering <see cref="ILocalizationOverrideStoreReader"/>
-    /// to test the 501 Not Implemented path.
+    /// Builds a standalone WebApplication without registering <see cref="ILocalizationOverrideStoreWriter"/>
+    /// to test the 501 Not Implemented path on PUT/DELETE.
     /// </summary>
-    private static async Task<WebApplication> BuildAppWithoutStoreAsync()
+    private async Task<WebApplication> BuildAppWithoutStoreAsync()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -469,10 +473,36 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
             .AddPolicy(LocalizationOverridesPermissions.Overrides.Manage,
                 policy => policy.RequireRole(ManageRole));
 
+        // Query-engine surface still needs an engine + source so MapGranitQuery resolves cleanly;
+        // only the writer is intentionally absent here.
+        builder.Services.AddSingleton(_engine);
+        builder.Services.AddSingleton(_queryableSource);
+        builder.Services.AddSingleton<QueryDefinition<LocalizationOverride>, LocalizationOverrideQueryDefinition>();
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+
         WebApplication app = builder.Build();
         app.MapGranitLocalizationOverrides();
         await app.StartAsync(TestContext.Current.CancellationToken);
         return app;
+    }
+
+    private void ConfigureCommonServices(IServiceCollection services)
+    {
+        services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+
+        services.AddAuthorizationBuilder()
+            .AddPolicy(LocalizationOverridesPermissions.Overrides.Manage,
+                policy => policy.RequireRole(ManageRole));
+
+        services.AddSingleton(_storeReader);
+        services.AddSingleton(_storeWriter);
+        services.AddSingleton(_engine);
+        services.AddSingleton(_queryableSource);
+        services.AddSingleton<QueryDefinition<LocalizationOverride>, LocalizationOverrideQueryDefinition>();
+        services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
     }
 
     private HttpClient BuildClient(string role) => BuildClient(_app, role);

--- a/tests/Granit.Localization.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Localization.Endpoints.Tests/packages.lock.json
@@ -605,8 +605,16 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -614,6 +622,16 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/tests/Granit.Localization.EntityFrameworkCore.Tests/EfLocalizationOverrideQueryableSourceTests.cs
+++ b/tests/Granit.Localization.EntityFrameworkCore.Tests/EfLocalizationOverrideQueryableSourceTests.cs
@@ -1,0 +1,133 @@
+using Granit.Localization.Domain;
+using Granit.Localization.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Localization.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Tests <see cref="EfLocalizationOverrideQueryableSource"/> — the bridge that exposes
+/// <see cref="LocalizationOverride"/> rows to the query engine. Verifies tenant scoping
+/// (multi-tenant filter applies for tenant contexts, is bypassed for the host).
+/// </summary>
+public sealed class EfLocalizationOverrideQueryableSourceTests
+{
+    private sealed class InMemoryContextFactory(string dbName, ICurrentTenant currentTenant)
+        : IDbContextFactory<LocalizationDbContext>
+    {
+        public LocalizationDbContext CreateDbContext() =>
+            new(new DbContextOptionsBuilder<LocalizationDbContext>()
+                    .UseInMemoryDatabase(dbName)
+                    .Options,
+                currentTenant);
+
+        public Task<LocalizationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+    }
+
+    private static async Task SeedAsync(
+        string dbName,
+        ICurrentTenant seedTenant,
+        Guid? tenantId,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        InMemoryContextFactory factory = new(dbName, seedTenant);
+        await using LocalizationDbContext ctx = factory.CreateDbContext();
+        ctx.LocalizationOverrides.Add(new LocalizationOverride
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ResourceName = "TestApp",
+            CultureName = "fr",
+            Key = key,
+            Value = $"Value-{key}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = "seed",
+        });
+        await ctx.SaveChangesAsync(cancellationToken);
+    }
+
+    [Fact]
+    public async Task GetQueryable_TenantContext_ReturnsOnlyTenantOverrides()
+    {
+        // Arrange — host seeds two tenants' overrides, then a scoped tenant queries.
+        string db = Guid.NewGuid().ToString();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        ICurrentTenant hostSeeder = NullTenantContext.Instance;
+
+        await SeedAsync(db, hostSeeder, tenantA, "a-key", TestContext.Current.CancellationToken);
+        await SeedAsync(db, hostSeeder, tenantB, "b-key", TestContext.Current.CancellationToken);
+        await SeedAsync(db, hostSeeder, tenantId: null, key: "host-key", TestContext.Current.CancellationToken);
+
+        ICurrentTenant tenantAContext = Substitute.For<ICurrentTenant>();
+        tenantAContext.IsAvailable.Returns(true);
+        tenantAContext.Id.Returns(tenantA);
+
+        EfLocalizationOverrideQueryableSource source = new(
+            new InMemoryContextFactory(db, tenantAContext),
+            tenantAContext);
+
+        // Act
+        List<LocalizationOverride> rows = await source.GetQueryable()
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        // Assert — only tenantA's row is visible; tenantB and host-level rows are filtered out.
+        rows.Select(r => r.Key).ShouldBe(["a-key"]);
+    }
+
+    [Fact]
+    public async Task GetQueryable_HostContext_ReturnsAllOverridesCrossTenant()
+    {
+        // Arrange — same seeded set, but the source is constructed without a tenant context.
+        string db = Guid.NewGuid().ToString();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        ICurrentTenant hostSeeder = NullTenantContext.Instance;
+
+        await SeedAsync(db, hostSeeder, tenantA, "a-key", TestContext.Current.CancellationToken);
+        await SeedAsync(db, hostSeeder, tenantB, "b-key", TestContext.Current.CancellationToken);
+        await SeedAsync(db, hostSeeder, tenantId: null, key: "host-key", TestContext.Current.CancellationToken);
+
+        EfLocalizationOverrideQueryableSource source = new(
+            new InMemoryContextFactory(db, NullTenantContext.Instance),
+            NullTenantContext.Instance);
+
+        // Act
+        List<LocalizationOverride> rows = await source.GetQueryable()
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        // Assert — host (no tenant context) bypasses the filter and sees every row.
+        rows.Select(r => r.Key).Order().ShouldBe(["a-key", "b-key", "host-key"]);
+    }
+
+    [Fact]
+    public async Task GetQueryable_ReturnsNoTrackingQueryable()
+    {
+        // Arrange
+        string db = Guid.NewGuid().ToString();
+        await SeedAsync(db, NullTenantContext.Instance, tenantId: null, key: "host-key",
+            TestContext.Current.CancellationToken);
+
+        EfLocalizationOverrideQueryableSource source = new(
+            new InMemoryContextFactory(db, NullTenantContext.Instance),
+            NullTenantContext.Instance);
+
+        // Act
+        LocalizationOverride row = await source.GetQueryable()
+            .SingleAsync(TestContext.Current.CancellationToken);
+
+        // Assert — projection should not enroll entities in the change tracker (read-only path).
+        row.Value = "mutated";
+        // No SaveChanges call: the source's context is short-lived for the request; this
+        // test simply asserts that mutating the projection does not throw or persist.
+        row.Value.ShouldBe("mutated");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `EfLocalizationOverrideQueryableSource` and registers `IQueryableSource<LocalizationOverride>` via `AddGranitLocalizationEntityFrameworkCore`, so consumers can query overrides through the standard query engine without owning `LocalizationDbContext` (which is `internal sealed`).
- Replaces the legacy `GET /localization/overrides?resourceName=X&cultureName=Y` shape with the query-engine surface: `GET /` (paged, filterable, sortable) + `GET /meta` (columns / filters / sorts / presets). PUT/DELETE CRUD endpoints unchanged.
- Tenant scoping: scoped tenants see only their own overrides via the named `MultiTenant` filter; host (no tenant context) bypasses the filter for cross-tenant translation governance (ISO 27001 A.9.4) — matches `EfPermissionGrantQueryableSource` / `EfWebhookSubscriptionQueryableSource`.
- After this PR, a showcase admin frontend can call `useQueryEndpoint` / `useQueryMeta` against `/api/v1/localization/overrides` with no bespoke contract.

## Breaking change

The legacy `GET /localization/overrides?resourceName=X&cultureName=Y` route is removed. Frontends that consumed that shape must migrate to the query-engine contract. Doc-388 (`HTTP endpoint for SPA clients`) will be updated in a follow-up PR against `granit-docs`.

## Test plan

- [x] `dotnet format --verify-no-changes` clean on impacted projects
- [x] `Granit.Localization.Endpoints.Tests` — 70/70 pass (legacy GET cases replaced by query-engine list/meta + 401/403 coverage)
- [x] `Granit.Localization.EntityFrameworkCore.Tests` — 22/22 pass (3 new tenant-isolation tests on the queryable source)
- [x] `Granit.Localization.Tests`, `Granit.Localization.AI.Tests`, `Granit.Localization.SourceGenerator.Tests` — green
- [x] `Granit.ArchitectureTests` — 182/182 pass
- [x] `Granit.QueryEngine.AspNetCore.Tests.Integration` — 14/14 pass