### PR TITLE
chore(ci): bump dotnet-audit timeout from 10m to 15m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,14 @@ jobs:
   # transitive dependencies disclosed AFTER lockfile generation).
   # Sharded the same way as build/test — restoring + auditing the full solution
   # (~295 projects) on a single runner exceeded the 5-minute budget.
+  # `dotnet list package --vulnerable --include-transitive` is bottlenecked by
+  # NuGet's vulnerability API: the architecture/security/infrastructure shards
+  # already trend toward 7–8 min as the framework grows, so a 10-min cap leaves
+  # no slack for NuGet latency spikes. 15 min keeps the job snappy on a green
+  # day while absorbing the worst observed runs.
   dotnet-audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- `dotnet-audit (architecture)` hit the 10-minute timeout on a recent run.
- The shard covers ~all of `src/` (259 projects), and `dotnet list package --vulnerable --include-transitive` is bottlenecked by NuGet's vulnerability API — durations on develop have crept from ~3 min to a peak of 7m26s (latest green run), well within a single NuGet latency spike of the cap.
- Bumping the audit job's `timeout-minutes` from 10 → 15 absorbs the variance without touching the audit semantics (no shard changes, no flag changes).

The deeper question (do we even need to audit each shard, since CVEs are package-scoped and the architecture shard already covers ~all unique packages?) is left for a follow-up — keeping this PR surgical.

## Test plan
- [ ] CI on this branch shows `dotnet-audit (architecture)` finishing under the new 15 min cap.
- [ ] No other audit shards regress — they were further from the cap (3–8 min) and won't change behavior.