### PR TITLE
ci: drop GenerateDocumentationFile=false override (re-enable IDE0005)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
         run: >
           dotnet build .github/shard-filters/src-only.slnf
           -c $CONFIGURATION -m:4
-          -p:GenerateDocumentationFile=false
 
       - name: Check formatting (src only)
         run: dotnet format .github/shard-filters/src-only.slnf --verify-no-changes --no-restore


### PR DESCRIPTION
## Summary

Follow-up to #2156. The `Build (src only)` CI step was passing `-p:GenerateDocumentationFile=false`, which silently disables `IDE0005`/`CS8019` enforcement at build time — the very thing #2156 turned on in `.editorconfig`.

CI now fails with:
```
error EnableGenerateDocumentationFile: Set MSBuild property 'GenerateDocumentationFile' to 'true'
in project file to enable IDE0005 (Remove unnecessary usings/imports) on build
```

The override is unnecessary: `Directory.Build.props` already sets `GenerateDocumentationFile=true`, and root `NoWarn` covers `CS1591` so missing XML doc comments stay quiet.

## Test plan

- [x] Local build of `src-only.slnf` without the override: `0 Warning(s), 0 Error(s)`
- [ ] CI green on PR