### PR TITLE
feat(auditing): record authentication events via IAuditingWriter

### DIFF
--- a/.github/shard-filters/api-data.slnf
+++ b/.github/shard-filters/api-data.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Auditing/Granit.Auditing.csproj",
       "src/Granit.Authorization/Granit.Authorization.csproj",
       "src/Granit.BackgroundJobs.EntityFrameworkCore/Granit.BackgroundJobs.EntityFrameworkCore.csproj",
       "src/Granit.BackgroundJobs/Granit.BackgroundJobs.csproj",

--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Auditing/Granit.Auditing.csproj",
       "src/Granit.Authentication.DPoP/Granit.Authentication.DPoP.csproj",
       "src/Granit.Authentication/Granit.Authentication.csproj",
       "src/Granit.Authorization.EntityFrameworkCore/Granit.Authorization.EntityFrameworkCore.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -368,6 +368,7 @@
     {
       "name": "Granit.Bff.Endpoints",
       "deps": [
+        "Granit.Auditing",
         "Granit.Bff",
         "Granit.Caching",
         "Granit.Http.ApiDocumentation",
@@ -1058,6 +1059,7 @@
     {
       "name": "Granit.Identity.Local.Endpoints",
       "deps": [
+        "Granit.Auditing",
         "Granit.Authorization",
         "Granit.Caching",
         "Granit.Http.Abstractions",
@@ -1548,6 +1550,7 @@
     {
       "name": "Granit.OpenIddict.Endpoints",
       "deps": [
+        "Granit.Auditing",
         "Granit.Authorization",
         "Granit.Caching",
         "Granit.Http.Abstractions",
@@ -2245,7 +2248,7 @@
       "kind": "record",
       "project": "Granit.AI",
       "file": "src/Granit.AI/IAIChatCompletionService.cs",
-      "line": 14,
+      "line": 12,
       "members": []
     },
     {
@@ -2254,7 +2257,7 @@
       "kind": "record",
       "project": "Granit.AI",
       "file": "src/Granit.AI/IAIChatCompletionService.cs",
-      "line": 27,
+      "line": 25,
       "members": []
     },
     {
@@ -2781,7 +2784,7 @@
       "kind": "class",
       "project": "Granit.AI.EntityFrameworkCore",
       "file": "src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "ConfigureAIModule",
@@ -2928,7 +2931,7 @@
       "kind": "class",
       "project": "Granit.AI.Extraction",
       "file": "src/Granit.AI.Extraction/GranitAIExtractionModule.cs",
-      "line": 15,
+      "line": 14,
       "members": []
     },
     {
@@ -2981,7 +2984,7 @@
       "kind": "class",
       "project": "Granit.AI",
       "file": "src/Granit.AI/GranitAIModule.cs",
-      "line": 28,
+      "line": 27,
       "members": [
         {
           "name": "ConfigureServices",
@@ -3013,7 +3016,7 @@
       "kind": "interface",
       "project": "Granit.AI",
       "file": "src/Granit.AI/IAIChatCompletionService.cs",
-      "line": 33,
+      "line": 31,
       "members": [
         {
           "name": "CompleteAsync",
@@ -3140,7 +3143,7 @@
       "kind": "class",
       "project": "Granit.AI.Mcp",
       "file": "src/Granit.AI.Mcp/GranitAIMcpModule.cs",
-      "line": 16,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -3443,7 +3446,7 @@
       "kind": "class",
       "project": "Granit.AI.VectorData",
       "file": "src/Granit.AI.VectorData/GranitAIVectorDataModule.cs",
-      "line": 15,
+      "line": 14,
       "members": []
     },
     {
@@ -3748,7 +3751,7 @@
       "kind": "class",
       "project": "Granit.Analyzers.CodeFixes",
       "file": "src/Granit.Analyzers.CodeFixes/CrossModuleReferenceCodeFixProvider.cs",
-      "line": 21,
+      "line": 18,
       "members": [
         {
           "name": "FixableDiagnosticIds",
@@ -3785,7 +3788,7 @@
       "kind": "class",
       "project": "Granit.Analyzers.CodeFixes",
       "file": "src/Granit.Analyzers.CodeFixes/DependencyInjectionCodeFixProviderBase.cs",
-      "line": 19,
+      "line": 15,
       "members": [
         {
           "name": "FixableDiagnosticIds",
@@ -3813,7 +3816,7 @@
       "kind": "class",
       "project": "Granit.Analyzers.CodeFixes",
       "file": "src/Granit.Analyzers.CodeFixes/DirectCookieAccessCodeFixProvider.cs",
-      "line": 16,
+      "line": 15,
       "members": []
     },
     {
@@ -3831,7 +3834,7 @@
       "kind": "class",
       "project": "Granit.Analyzers.CodeFixes",
       "file": "src/Granit.Analyzers.CodeFixes/MinimalApiServiceParameterCodeFixProvider.cs",
-      "line": 20,
+      "line": 17,
       "members": [
         {
           "name": "FixableDiagnosticIds",
@@ -3859,7 +3862,7 @@
       "kind": "class",
       "project": "Granit.Analyzers.CodeFixes",
       "file": "src/Granit.Analyzers.CodeFixes/SynchronousSaveChangesCodeFixProvider.cs",
-      "line": 25,
+      "line": 22,
       "members": [
         {
           "name": "FixableDiagnosticIds",
@@ -3887,7 +3890,7 @@
       "kind": "class",
       "project": "Granit.Analyzers.CodeFixes",
       "file": "src/Granit.Analyzers.CodeFixes/TypedResultsBadRequestCodeFixProvider.cs",
-      "line": 20,
+      "line": 17,
       "members": [
         {
           "name": "FixableDiagnosticIds",
@@ -3915,7 +3918,7 @@
       "kind": "class",
       "project": "Granit.Analyzers.CodeFixes",
       "file": "src/Granit.Analyzers.CodeFixes/UntypedResultsCodeFixProvider.cs",
-      "line": 23,
+      "line": 20,
       "members": [
         {
           "name": "FixableDiagnosticIds",
@@ -3943,7 +3946,7 @@
       "kind": "class",
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/CrossModuleReferenceAnalyzer.cs",
-      "line": 22,
+      "line": 21,
       "members": []
     },
     {
@@ -4028,7 +4031,7 @@
       "kind": "class",
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/HardcodedSecretAnalyzer.cs",
-      "line": 19,
+      "line": 18,
       "members": []
     },
     {
@@ -4037,7 +4040,7 @@
       "kind": "class",
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/LoggerMessagePiiAnalyzer.cs",
-      "line": 21,
+      "line": 20,
       "members": []
     },
     {
@@ -4055,7 +4058,7 @@
       "kind": "class",
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/MinimalApiServiceParameterAnalyzer.cs",
-      "line": 31,
+      "line": 28,
       "members": []
     },
     {
@@ -4107,7 +4110,7 @@
       "kind": "class",
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/TagListPiiAnalyzer.cs",
-      "line": 19,
+      "line": 18,
       "members": []
     },
     {
@@ -4136,6 +4139,22 @@
       "file": "src/Granit.Auditing/Attributes/AuditIgnoreAttribute.cs",
       "line": 11,
       "members": []
+    },
+    {
+      "name": "AuthenticationAuditEntry",
+      "fqn": "Granit.Auditing.AuthenticationAuditEntry",
+      "kind": "class",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/AuthenticationAuditEntry.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "CreateSuccess",
+          "kind": "method",
+          "signature": "CreateSuccess(DateTimeOffset timestamp, string userId, string? userName, string method, Guid? tenantId, string? ipAddress, string? userAgent, string? correlationId)",
+          "returnType": "AuditEntry"
+        }
+      ]
     },
     {
       "name": "GranitAuditingConfigurationChangesModule",
@@ -4391,7 +4410,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Endpoints",
       "file": "src/Granit.Auditing.Endpoints/GranitAuditingEndpointsModule.cs",
-      "line": 27,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -4520,7 +4539,7 @@
       "kind": "class",
       "project": "Granit.Auditing.EntityFrameworkCore",
       "file": "src/Granit.Auditing.EntityFrameworkCore/GranitAuditingEntityFrameworkCoreModule.cs",
-      "line": 25,
+      "line": 24,
       "members": []
     },
     {
@@ -4988,7 +5007,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Privacy",
       "file": "src/Granit.Auditing.Privacy/GranitAuditingPrivacyModule.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -5072,7 +5091,7 @@
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys.BackgroundJobs",
       "file": "src/Granit.Authentication.ApiKeys.BackgroundJobs/GranitAuthenticationApiKeysBackgroundJobsModule.cs",
-      "line": 18,
+      "line": 17,
       "members": [
         {
           "name": "ConfigureServices",
@@ -5182,7 +5201,7 @@
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "Create",
@@ -5475,7 +5494,7 @@
       "kind": "record",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyExpiringSoonEto.cs",
-      "line": 37,
+      "line": 36,
       "members": []
     },
     {
@@ -5520,7 +5539,7 @@
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/Extensions/ApiKeyServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitApiKeyAuthentication",
@@ -5536,7 +5555,7 @@
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/GranitAuthenticationApiKeysModule.cs",
-      "line": 18,
+      "line": 17,
       "members": [
         {
           "name": "ConfigureServices",
@@ -5812,7 +5831,7 @@
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys.Notifications",
       "file": "src/Granit.Authentication.ApiKeys.Notifications/GranitAuthenticationApiKeysNotificationsModule.cs",
-      "line": 27,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -5990,7 +6009,7 @@
       "kind": "class",
       "project": "Granit.Authentication.DPoP",
       "file": "src/Granit.Authentication.DPoP/GranitAuthenticationDPoPModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6224,7 +6243,7 @@
       "kind": "class",
       "project": "Granit.Authentication.JwtBearer.Cognito",
       "file": "src/Granit.Authentication.JwtBearer.Cognito/GranitAuthenticationJwtBearerCognitoModule.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6300,7 +6319,7 @@
       "kind": "class",
       "project": "Granit.Authentication.JwtBearer.EntraId",
       "file": "src/Granit.Authentication.JwtBearer.EntraId/GranitAuthenticationJwtBearerEntraIdModule.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6420,7 +6439,7 @@
       "kind": "class",
       "project": "Granit.Authentication.JwtBearer.GoogleCloud",
       "file": "src/Granit.Authentication.JwtBearer.GoogleCloud/GranitAuthenticationJwtBearerGoogleCloudModule.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6470,7 +6489,7 @@
       "kind": "class",
       "project": "Granit.Authentication.JwtBearer",
       "file": "src/Granit.Authentication.JwtBearer/GranitAuthenticationJwtBearerModule.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6518,7 +6537,7 @@
       "kind": "class",
       "project": "Granit.Authentication.JwtBearer.Keycloak",
       "file": "src/Granit.Authentication.JwtBearer.Keycloak/GranitAuthenticationJwtBearerKeycloakModule.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6724,7 +6743,7 @@
       "kind": "class",
       "project": "Granit.Authorization.AI",
       "file": "src/Granit.Authorization.AI/GranitAuthorizationAIModule.cs",
-      "line": 19,
+      "line": 18,
       "members": []
     },
     {
@@ -6958,7 +6977,7 @@
       "kind": "record",
       "project": "Granit.Authorization.Endpoints",
       "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionDefinitionResponse.cs",
-      "line": 16,
+      "line": 15,
       "members": []
     },
     {
@@ -6985,7 +7004,7 @@
       "kind": "class",
       "project": "Granit.Authorization.Endpoints",
       "file": "src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs",
-      "line": 17,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitAuthorization",
@@ -7001,7 +7020,7 @@
       "kind": "class",
       "project": "Granit.Authorization.Endpoints",
       "file": "src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs",
-      "line": 30,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -7155,7 +7174,7 @@
       "kind": "class",
       "project": "Granit.Authorization.EntityFrameworkCore",
       "file": "src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 15,
       "members": []
     },
     {
@@ -7180,7 +7199,7 @@
       "kind": "class",
       "project": "Granit.Authorization.EntityFrameworkCore",
       "file": "src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationEntityFrameworkCoreModule.cs",
-      "line": 20,
+      "line": 19,
       "members": []
     },
     {
@@ -7275,7 +7294,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitAuthorization",
@@ -7313,7 +7332,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/GranitAuthorizationModule.cs",
-      "line": 26,
+      "line": 25,
       "members": [
         {
           "name": "ConfigureServices",
@@ -7811,7 +7830,7 @@
       "kind": "class",
       "project": "Granit.BackgroundJobs",
       "file": "src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
           "name": "Create",
@@ -7978,7 +7997,7 @@
       "kind": "class",
       "project": "Granit.BackgroundJobs.EntityFrameworkCore",
       "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitBackgroundJobsEntityFrameworkCore",
@@ -8112,7 +8131,7 @@
       "kind": "class",
       "project": "Granit.BackgroundJobs",
       "file": "src/Granit.BackgroundJobs/GranitBackgroundJobsModule.cs",
-      "line": 29,
+      "line": 28,
       "members": [
         {
           "name": "ConfigureServices",
@@ -8261,7 +8280,7 @@
       "kind": "class",
       "project": "Granit.BackgroundJobs.Notifications",
       "file": "src/Granit.BackgroundJobs.Notifications/GranitBackgroundJobsNotificationsModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -8377,7 +8396,7 @@
       "kind": "class",
       "project": "Granit.BackgroundJobs.Wolverine",
       "file": "src/Granit.BackgroundJobs.Wolverine/GranitBackgroundJobsWolverineModule.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -8409,7 +8428,7 @@
       "kind": "class",
       "project": "Granit.Bff.BackgroundJobs",
       "file": "src/Granit.Bff.BackgroundJobs/GranitBffBackgroundJobsModule.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureServices",
@@ -8537,7 +8556,7 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "MapGranitBff",
@@ -8578,7 +8597,7 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs",
-      "line": 29,
+      "line": 30,
       "members": [
         {
           "name": "ConfigureServices",
@@ -8658,7 +8677,7 @@
       "kind": "class",
       "project": "Granit.Bff",
       "file": "src/Granit.Bff/GranitBffModule.cs",
-      "line": 34,
+      "line": 33,
       "members": [
         {
           "name": "ConfigureServices",
@@ -8936,7 +8955,7 @@
       "kind": "class",
       "project": "Granit.Bff.Yarp",
       "file": "src/Granit.Bff.Yarp/Extensions/BffYarpHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitBffYarp",
@@ -8986,7 +9005,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.AI",
       "file": "src/Granit.BlobStorage.AI/GranitBlobStorageAIModule.cs",
-      "line": 22,
+      "line": 21,
       "members": []
     },
     {
@@ -9095,7 +9114,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.BackgroundJobs",
       "file": "src/Granit.BlobStorage.BackgroundJobs/GranitBlobStorageBackgroundJobsModule.cs",
-      "line": 16,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -9210,7 +9229,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.Database",
       "file": "src/Granit.BlobStorage.Database/Domain/DatabaseBlobContent.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "TenantId",
@@ -10347,7 +10366,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/IAccessibilityCapability.cs",
-      "line": 24,
+      "line": 20,
       "members": []
     },
     {
@@ -10356,7 +10375,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/IAccessibilityCapability.cs",
-      "line": 12,
+      "line": 8,
       "members": [
         {
           "name": "SnapshotTreeAsync",
@@ -10372,7 +10391,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/IHarRecordingCapability.cs",
-      "line": 10,
+      "line": 7,
       "members": [
         {
           "name": "StartHarAsync",
@@ -10394,7 +10413,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/IPdfCapability.cs",
-      "line": 15,
+      "line": 12,
       "members": [
         {
           "name": "RenderToPdfAsync",
@@ -10410,7 +10429,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/IPdfViewerCapability.cs",
-      "line": 28,
+      "line": 23,
       "members": [
         {
           "name": "RenderPageToImageAsync",
@@ -10426,7 +10445,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/IPdfViewerCapability.cs",
-      "line": 14,
+      "line": 9,
       "members": [
         {
           "name": "OpenPdfAsync",
@@ -10442,7 +10461,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/ITracingCapability.cs",
-      "line": 10,
+      "line": 7,
       "members": [
         {
           "name": "StartTracingAsync",
@@ -10510,7 +10529,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/IPdfViewerCapability.cs",
-      "line": 49,
+      "line": 44,
       "members": []
     },
     {
@@ -10519,7 +10538,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Capabilities/ITracingCapability.cs",
-      "line": 20,
+      "line": 17,
       "members": [
         {
           "name": "Snapshots",
@@ -10541,7 +10560,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/IBrowserPage.cs",
-      "line": 114,
+      "line": 110,
       "members": []
     },
     {
@@ -10550,7 +10569,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Diagnostics/BrowserPageAcquiredEvent.cs",
-      "line": 16,
+      "line": 15,
       "members": []
     },
     {
@@ -10559,7 +10578,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Diagnostics/BrowserScriptInjectedEvent.cs",
-      "line": 17,
+      "line": 16,
       "members": []
     },
     {
@@ -10568,7 +10587,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Diagnostics/BrowserUrlNavigatedEvent.cs",
-      "line": 17,
+      "line": 16,
       "members": []
     },
     {
@@ -10639,7 +10658,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Exceptions/SandboxViolationException.cs",
-      "line": 8,
+      "line": 6,
       "members": [
         {
           "name": "SandboxViolationException",
@@ -10655,7 +10674,7 @@
       "kind": "enum",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Exceptions/SandboxViolationException.cs",
-      "line": 29,
+      "line": 27,
       "members": []
     },
     {
@@ -10680,7 +10699,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/IBrowserPage.cs",
-      "line": 23,
+      "line": 19,
       "members": [
         {
           "name": "NavigateAsync",
@@ -10750,7 +10769,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/IBrowserSandboxProfile.cs",
-      "line": 25,
+      "line": 22,
       "members": []
     },
     {
@@ -10781,7 +10800,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/IHeadlessBrowserPool.cs",
-      "line": 11,
+      "line": 8,
       "members": [
         {
           "name": "GetStatsAsync",
@@ -10803,7 +10822,7 @@
       "kind": "enum",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/IBrowserPage.cs",
-      "line": 99,
+      "line": 95,
       "members": []
     },
     {
@@ -10812,7 +10831,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Options/BrowserPageOptions.cs",
-      "line": 6,
+      "line": 4,
       "members": [
         {
           "name": "Viewport",
@@ -10840,7 +10859,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Options/BrowserPageOptions.cs",
-      "line": 61,
+      "line": 59,
       "members": []
     },
     {
@@ -10849,7 +10868,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Options/GranitBrowsingOptions.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "MaxBrowsers",
@@ -10901,7 +10920,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Options/NavigationOptions.cs",
-      "line": 6,
+      "line": 4,
       "members": [
         {
           "name": "Timeout",
@@ -10917,7 +10936,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Options/GranitBrowsingOptions.cs",
-      "line": 66,
+      "line": 65,
       "members": [
         {
           "name": "FromSeconds",
@@ -10967,7 +10986,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Options/BrowserPageOptions.cs",
-      "line": 49,
+      "line": 47,
       "members": []
     },
     {
@@ -10976,7 +10995,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/IBrowserPage.cs",
-      "line": 119,
+      "line": 115,
       "members": []
     },
     {
@@ -10985,7 +11004,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pages/DefaultHarScrubber.cs",
-      "line": 13,
+      "line": 11,
       "members": [
         {
           "name": "Scrub",
@@ -11017,7 +11036,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pages/RouteDecision.cs",
-      "line": 14,
+      "line": 12,
       "members": [
         {
           "name": "new",
@@ -11045,7 +11064,7 @@
       "kind": "enum",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pages/RouteDecision.cs",
-      "line": 50,
+      "line": 48,
       "members": []
     },
     {
@@ -11054,7 +11073,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pages/RoutePattern.cs",
-      "line": 37,
+      "line": 36,
       "members": [
         {
           "name": "Parse",
@@ -11070,7 +11089,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pages/RouteRequest.cs",
-      "line": 13,
+      "line": 10,
       "members": []
     },
     {
@@ -11088,7 +11107,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Permissions/BrowsingPermissionDefinitionProvider.cs",
-      "line": 18,
+      "line": 17,
       "members": [
         {
           "name": "DefinePermissions",
@@ -11122,7 +11141,7 @@
       "kind": "class",
       "project": "Granit.Browsing.Playwright",
       "file": "src/Granit.Browsing.Playwright/Extensions/ServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitBrowsingPlaywright",
@@ -11191,7 +11210,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs",
-      "line": 199,
+      "line": 195,
       "members": [
         {
           "name": "new",
@@ -11219,7 +11238,7 @@
       "kind": "interface",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs",
-      "line": 186,
+      "line": 182,
       "members": [
         {
           "name": "GetEnvironmentVariable",
@@ -11247,7 +11266,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs",
-      "line": 30,
+      "line": 26,
       "members": [
         {
           "name": "EnsureSafe",
@@ -11263,7 +11282,7 @@
       "kind": "class",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Pool/TenantAwareHeadlessBrowser.cs",
-      "line": 39,
+      "line": 36,
       "members": [
         {
           "name": "Capabilities",
@@ -11300,7 +11319,7 @@
       "kind": "class",
       "project": "Granit.Browsing.PuppeteerSharp",
       "file": "src/Granit.Browsing.PuppeteerSharp/Extensions/ServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitBrowsingPuppeteerSharp",
@@ -11348,7 +11367,7 @@
       "kind": "record",
       "project": "Granit.Browsing",
       "file": "src/Granit.Browsing/Sandbox/SandboxProfile.cs",
-      "line": 21,
+      "line": 18,
       "members": [
         {
           "name": "DisableJavaScript",
@@ -11622,7 +11641,7 @@
       "kind": "class",
       "project": "Granit.Caching.StackExchangeRedis",
       "file": "src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitCachingRedis",
@@ -11697,7 +11716,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.AI",
       "file": "src/Granit.DataExchange.AI/Extensions/DataExchangeAIHostApplicationBuilderExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitDataExchangeAI",
@@ -11713,7 +11732,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.AI",
       "file": "src/Granit.DataExchange.AI/GranitDataExchangeAIModule.cs",
-      "line": 21,
+      "line": 20,
       "members": []
     },
     {
@@ -11772,7 +11791,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.BlobStorage",
       "file": "src/Granit.DataExchange.BlobStorage/GranitDataExchangeBlobStorageModule.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -11826,7 +11845,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.Csv",
       "file": "src/Granit.DataExchange.Csv/GranitDataExchangeCsvModule.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "ConfigureServices",
@@ -11995,7 +12014,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
-      "line": 12,
+      "line": 11,
       "members": []
     },
     {
@@ -12004,7 +12023,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
-      "line": 31,
+      "line": 30,
       "members": []
     },
     {
@@ -12013,7 +12032,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
-      "line": 18,
+      "line": 17,
       "members": []
     },
     {
@@ -12113,7 +12132,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.Excel",
       "file": "src/Granit.DataExchange.Excel/GranitDataExchangeExcelModule.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "ConfigureServices",
@@ -12129,7 +12148,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Export/Domain/ExportJob.cs",
-      "line": 14,
+      "line": 13,
       "members": [
         {
           "name": "Create",
@@ -12682,7 +12701,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/GranitDataExchangeModule.cs",
-      "line": 37,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",
@@ -12758,7 +12777,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Import/Domain/ImportJob.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "Create",
@@ -13787,7 +13806,7 @@
       "kind": "class",
       "project": "Granit.DataLookup.Endpoints",
       "file": "src/Granit.DataLookup.Endpoints/GranitDataLookupEndpointsModule.cs",
-      "line": 24,
+      "line": 23,
       "members": [
         {
           "name": "ConfigureServices",
@@ -13852,7 +13871,7 @@
       "kind": "class",
       "project": "Granit.DataLookup.EntityFrameworkCore",
       "file": "src/Granit.DataLookup.EntityFrameworkCore/GranitDataLookupEntityFrameworkCoreModule.cs",
-      "line": 18,
+      "line": 17,
       "members": []
     },
     {
@@ -13902,7 +13921,7 @@
       "kind": "class",
       "project": "Granit.DataLookup",
       "file": "src/Granit.DataLookup/GranitDataLookupModule.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -13958,7 +13977,7 @@
       "kind": "class",
       "project": "Granit.DataLookup",
       "file": "src/Granit.DataLookup/Sources/EnumLookupSource.cs",
-      "line": 27,
+      "line": 26,
       "members": [
         {
           "name": "SearchAsync",
@@ -14395,7 +14414,7 @@
       "kind": "class",
       "project": "Granit.DocumentGeneration.Excel",
       "file": "src/Granit.DocumentGeneration.Excel/GranitDocumentGenerationExcelModule.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -14443,7 +14462,7 @@
       "kind": "class",
       "project": "Granit.DocumentGeneration",
       "file": "src/Granit.DocumentGeneration/GranitDocumentGenerationModule.cs",
-      "line": 25,
+      "line": 24,
       "members": [
         {
           "name": "ConfigureServices",
@@ -14459,7 +14478,7 @@
       "kind": "class",
       "project": "Granit.DocumentGeneration.Pdf",
       "file": "src/Granit.DocumentGeneration.Pdf/Extensions/ServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitDocumentGenerationPdf",
@@ -14475,7 +14494,7 @@
       "kind": "class",
       "project": "Granit.DocumentGeneration.Pdf",
       "file": "src/Granit.DocumentGeneration.Pdf/GranitDocumentGenerationPdfModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -15253,7 +15272,7 @@
       "kind": "class",
       "project": "Granit.Encryption.EntityFrameworkCore",
       "file": "src/Granit.Encryption.EntityFrameworkCore/GranitEncryptionEntityFrameworkCoreModule.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -15485,7 +15504,7 @@
       "kind": "class",
       "project": "Granit.Encryption",
       "file": "src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ProviderName",
@@ -15517,7 +15536,7 @@
       "kind": "class",
       "project": "Granit.Encryption",
       "file": "src/Granit.Encryption/Services/DefaultStringEncryptionService.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "Encrypt",
@@ -15557,7 +15576,7 @@
       "kind": "class",
       "project": "Granit",
       "file": "src/Granit/Endpoints/BatchResultHelper.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "statusCode",
@@ -16525,7 +16544,7 @@
       "kind": "class",
       "project": "Granit.Events",
       "file": "src/Granit.Events/Extensions/EventsServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitEvents",
@@ -16705,7 +16724,7 @@
       "kind": "class",
       "project": "Granit.Events.Wolverine",
       "file": "src/Granit.Events.Wolverine/GranitEventsWolverineModule.cs",
-      "line": 27,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -16855,7 +16874,7 @@
       "kind": "class",
       "project": "Granit",
       "file": "src/Granit/Extensions/GranitHostBuilderExtensions.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "AddGranit",
@@ -17142,7 +17161,7 @@
       "kind": "class",
       "project": "Granit.Features.EntityFrameworkCore",
       "file": "src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitFeaturesEntityFrameworkCore",
@@ -17549,7 +17568,7 @@
       "kind": "class",
       "project": "Granit.Guids",
       "file": "src/Granit.Guids/Extensions/GuidsServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitGuids",
@@ -17738,7 +17757,7 @@
       "kind": "class",
       "project": "Granit.Http.ApiDocumentation",
       "file": "src/Granit.Http.ApiDocumentation/GranitHttpApiDocumentationModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -18049,7 +18068,7 @@
       "kind": "class",
       "project": "Granit.Http.Bulkhead",
       "file": "src/Granit.Http.Bulkhead/GranitHttpBulkheadModule.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureServices",
@@ -18893,7 +18912,7 @@
       "kind": "class",
       "project": "Granit.Http.Idempotency",
       "file": "src/Granit.Http.Idempotency/GranitHttpIdempotencyModule.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -19060,7 +19079,7 @@
       "kind": "class",
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/GranitHttpODataExposureModule.cs",
-      "line": 23,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -19965,7 +19984,7 @@
       "kind": "class",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Domain/User.cs",
-      "line": 32,
+      "line": 31,
       "members": [
         {
           "name": "DisplayName",
@@ -20178,7 +20197,7 @@
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
       "file": "src/Granit.Identity.Endpoints/Extensions/IdentityProviderEndpointRouteBuilderExtensions.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "MapGranitIdentityProvider",
@@ -20561,7 +20580,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Cognito.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.Cognito.BackgroundJobs/GranitIdentityFederatedCognitoBackgroundJobsModule.cs",
-      "line": 15,
+      "line": 14,
       "members": []
     },
     {
@@ -20689,7 +20708,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Cognito",
       "file": "src/Granit.Identity.Federated.Cognito/Sync/CognitoClientRoleSyncService.cs",
-      "line": 45,
+      "line": 44,
       "members": [
         {
           "name": "SyncAsync",
@@ -20790,7 +20809,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntityFrameworkCore",
       "file": "src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/IdentityEfCoreServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 13,
       "members": []
     },
     {
@@ -20815,7 +20834,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntityFrameworkCore",
       "file": "src/Granit.Identity.Federated.EntityFrameworkCore/GranitIdentityFederatedEntityFrameworkCoreModule.cs",
-      "line": 20,
+      "line": 19,
       "members": []
     },
     {
@@ -20824,7 +20843,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntraId.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.EntraId.BackgroundJobs/GranitIdentityFederatedEntraIdBackgroundJobsModule.cs",
-      "line": 15,
+      "line": 14,
       "members": []
     },
     {
@@ -20995,7 +21014,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntraId",
       "file": "src/Granit.Identity.Federated.EntraId/Sync/EntraIdClientRoleSyncService.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "SyncAsync",
@@ -21150,7 +21169,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs",
-      "line": 24,
+      "line": 23,
       "members": [
         {
           "name": "ConfigureServices",
@@ -21182,7 +21201,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Keycloak.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.Keycloak.BackgroundJobs/GranitIdentityFederatedKeycloakBackgroundJobsModule.cs",
-      "line": 15,
+      "line": 14,
       "members": []
     },
     {
@@ -21340,7 +21359,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Keycloak",
       "file": "src/Granit.Identity.Federated.Keycloak/Sync/KeycloakClientRoleSyncService.cs",
-      "line": 36,
+      "line": 35,
       "members": [
         {
           "name": "SyncAsync",
@@ -21356,7 +21375,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Notifications",
       "file": "src/Granit.Identity.Federated.Notifications/GranitIdentityFederatedNotificationsModule.cs",
-      "line": 31,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -21657,7 +21676,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Privacy",
       "file": "src/Granit.Identity.Federated.Privacy/GranitIdentityFederatedPrivacyModule.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -22190,7 +22209,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.AspNetIdentity",
       "file": "src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs",
-      "line": 33,
+      "line": 31,
       "members": [
         {
           "name": "ConfigureServices",
@@ -22326,7 +22345,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Domain/LocalIdentity.cs",
-      "line": 29,
+      "line": 28,
       "members": [
         {
           "name": "UserId",
@@ -22625,7 +22644,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Extensions/RoleEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "MapGranitRoles",
@@ -22641,7 +22660,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs",
-      "line": 28,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -22967,7 +22986,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/GranitIdentityLocalModule.cs",
-      "line": 37,
+      "line": 35,
       "members": [
         {
           "name": "ConfigureServices",
@@ -23104,7 +23123,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Notifications",
       "file": "src/Granit.Identity.Local.Notifications/Handlers/UserImpersonatedHandler.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "HandleAsync",
@@ -23667,7 +23686,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Privacy",
       "file": "src/Granit.Identity.Local.Privacy/GranitIdentityLocalPrivacyModule.cs",
-      "line": 23,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -24299,7 +24318,7 @@
       "kind": "class",
       "project": "Granit.Imaging.AI",
       "file": "src/Granit.Imaging.AI/GranitImagingAIModule.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -24573,7 +24592,7 @@
       "kind": "class",
       "project": "Granit.Imaging.MagickNet",
       "file": "src/Granit.Imaging.MagickNet/GranitImagingMagickNetModule.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -24694,7 +24713,7 @@
       "kind": "class",
       "project": "Granit.Localization.AI",
       "file": "src/Granit.Localization.AI/GranitLocalizationAIModule.cs",
-      "line": 16,
+      "line": 15,
       "members": []
     },
     {
@@ -24820,7 +24839,7 @@
       "kind": "class",
       "project": "Granit.Localization.Endpoints",
       "file": "src/Granit.Localization.Endpoints/Extensions/LocalizationApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "UseGranitRequestLocalization",
@@ -24836,7 +24855,7 @@
       "kind": "class",
       "project": "Granit.Localization.Endpoints",
       "file": "src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs",
-      "line": 37,
+      "line": 36,
       "members": [
         {
           "name": "MapGranitLocalization",
@@ -24917,7 +24936,7 @@
       "kind": "class",
       "project": "Granit.Localization.EntityFrameworkCore",
       "file": "src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitLocalizationEntityFrameworkCore",
@@ -25022,7 +25041,7 @@
       "kind": "class",
       "project": "Granit.Localization",
       "file": "src/Granit.Localization/GranitLocalizationResource.cs",
-      "line": 16,
+      "line": 14,
       "members": []
     },
     {
@@ -25197,7 +25216,7 @@
       "kind": "class",
       "project": "Granit.Localization",
       "file": "src/Granit.Localization/LocalizationResourceStore.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "Add",
@@ -25285,7 +25304,7 @@
       "kind": "class",
       "project": "Granit.Localization.SourceGenerator",
       "file": "src/Granit.Localization.SourceGenerator/LocalizationKeysGenerator.cs",
-      "line": 27,
+      "line": 24,
       "members": [
         {
           "name": "Initialize",
@@ -25601,7 +25620,7 @@
       "kind": "record",
       "project": "Granit.Mcp.Server",
       "file": "src/Granit.Mcp.Server/Endpoints/McpDiagnosticsEndpoints.cs",
-      "line": 75,
+      "line": 74,
       "members": []
     },
     {
@@ -25610,7 +25629,7 @@
       "kind": "record",
       "project": "Granit.Mcp.Server",
       "file": "src/Granit.Mcp.Server/Endpoints/McpDiagnosticsEndpoints.cs",
-      "line": 70,
+      "line": 69,
       "members": []
     },
     {
@@ -25619,7 +25638,7 @@
       "kind": "class",
       "project": "Granit.Mcp.Server",
       "file": "src/Granit.Mcp.Server/Extensions/McpServerEndpointRouteBuilderExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "MapGranitMcpServer",
@@ -25760,7 +25779,7 @@
       "kind": "class",
       "project": "Granit.Mergeable.BackgroundJobs",
       "file": "src/Granit.Mergeable.BackgroundJobs/GranitMergeableBackgroundJobsModule.cs",
-      "line": 25,
+      "line": 23,
       "members": [
         {
           "name": "ConfigureServices",
@@ -25792,7 +25811,7 @@
       "kind": "record",
       "project": "Granit.Mergeable.BackgroundJobs",
       "file": "src/Granit.Mergeable.BackgroundJobs/Jobs/MergeIdempotencyCleanupJob.cs",
-      "line": 15,
+      "line": 13,
       "members": []
     },
     {
@@ -25801,7 +25820,7 @@
       "kind": "interface",
       "project": "Granit.Mergeable.BackgroundJobs",
       "file": "src/Granit.Mergeable.BackgroundJobs/Services/IMergeIdempotencySweeper.cs",
-      "line": 12,
+      "line": 10,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -25839,7 +25858,7 @@
       "kind": "class",
       "project": "Granit.Mergeable.EntityFrameworkCore",
       "file": "src/Granit.Mergeable.EntityFrameworkCore/Extensions/MergeableEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitMergeableEntityFrameworkCore",
@@ -26431,7 +26450,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/CurrentTenant.cs",
-      "line": 31,
+      "line": 30,
       "members": [
         {
           "name": "Id",
@@ -27361,7 +27380,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AI",
       "file": "src/Granit.Notifications.AI/GranitNotificationsAIModule.cs",
-      "line": 21,
+      "line": 20,
       "members": []
     },
     {
@@ -27575,7 +27594,7 @@
       "kind": "interface",
       "project": "Granit.Notifications.Abstractions",
       "file": "src/Granit.Notifications.Abstractions/Abstractions/INotificationPublisher.cs",
-      "line": 9,
+      "line": 8,
       "members": []
     },
     {
@@ -28085,7 +28104,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email",
       "file": "src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitNotificationsEmail",
@@ -28335,7 +28354,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email.Smtp",
       "file": "src/Granit.Notifications.Email.Smtp/GranitNotificationsEmailSmtpModule.cs",
-      "line": 14,
+      "line": 13,
       "members": []
     },
     {
@@ -28610,7 +28629,7 @@
       "kind": "record",
       "project": "Granit.Notifications.Abstractions",
       "file": "src/Granit.Notifications.Abstractions/Events/UserNotificationCreatedEvent.cs",
-      "line": 15,
+      "line": 14,
       "members": []
     },
     {
@@ -28969,7 +28988,7 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush.GoogleFcm",
       "file": "src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs",
-      "line": 17,
+      "line": 16,
       "members": []
     },
     {
@@ -29302,7 +29321,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Privacy",
       "file": "src/Granit.Notifications.Privacy/GranitNotificationsPrivacyModule.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -30163,7 +30182,7 @@
       "kind": "class",
       "project": "Granit.Observability.AI",
       "file": "src/Granit.Observability.AI/GranitObservabilityAIModule.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -30492,7 +30511,7 @@
       "kind": "class",
       "project": "Granit.Oidc",
       "file": "src/Granit.Oidc/GranitOidcModule.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -30779,7 +30798,7 @@
       "kind": "class",
       "project": "Granit.Oidc.TokenManagement",
       "file": "src/Granit.Oidc.TokenManagement/GranitOidcTokenManagementModule.cs",
-      "line": 18,
+      "line": 17,
       "members": [
         {
           "name": "ConfigureServices",
@@ -30962,7 +30981,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.BackgroundJobs",
       "file": "src/Granit.OpenIddict.BackgroundJobs/GranitOpenIddictBackgroundJobsModule.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -31053,7 +31072,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.BackgroundJobs",
       "file": "src/Granit.OpenIddict.BackgroundJobs/Services/IdleSessionEnforcementService.cs",
-      "line": 25,
+      "line": 24,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -31284,7 +31303,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs",
-      "line": 39,
+      "line": 40,
       "members": [
         {
           "name": "ConfigureServices",
@@ -31561,7 +31580,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
-      "line": 37,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",
@@ -32214,7 +32233,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextPurgeExtensions.cs",
-      "line": 16,
+      "line": 15,
       "members": [
         {
           "name": "PurgeSoftDeletedBeforeAsync",
@@ -32246,7 +32265,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceDbContextServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 11,
       "members": []
     },
     {
@@ -32271,7 +32290,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs",
-      "line": 14,
+      "line": 13,
       "members": []
     },
     {
@@ -32370,7 +32389,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -32386,7 +32405,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.Hosting",
       "file": "src/Granit.Persistence.EntityFrameworkCore.Hosting/Extensions/PersistenceHostingHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitMigrateSupport",
@@ -32788,7 +32807,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.Migrations",
       "file": "src/Granit.Persistence.EntityFrameworkCore.Migrations/GranitPersistenceEntityFrameworkCoreMigrationsModule.cs",
-      "line": 29,
+      "line": 28,
       "members": [
         {
           "name": "ConfigureServices",
@@ -33171,7 +33190,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.Postgres",
       "file": "src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/PersistencePostgresHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitPostgres",
@@ -33187,7 +33206,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.Postgres",
       "file": "src/Granit.Persistence.EntityFrameworkCore.Postgres/GranitPersistenceEntityFrameworkCorePostgresModule.cs",
-      "line": 26,
+      "line": 24,
       "members": [
         {
           "name": "ConfigureServices",
@@ -33244,7 +33263,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Specification/SpecificationEvaluator.cs",
-      "line": 11,
+      "line": 10,
       "members": []
     },
     {
@@ -33253,7 +33272,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.SqlServer",
       "file": "src/Granit.Persistence.EntityFrameworkCore.SqlServer/Extensions/PersistenceSqlServerHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitSqlServer",
@@ -33456,7 +33475,7 @@
       "kind": "class",
       "project": "Granit.Privacy.AI",
       "file": "src/Granit.Privacy.AI/GranitPrivacyAIModule.cs",
-      "line": 21,
+      "line": 20,
       "members": []
     },
     {
@@ -33536,7 +33555,7 @@
       "kind": "class",
       "project": "Granit.Privacy.BackgroundJobs",
       "file": "src/Granit.Privacy.BackgroundJobs/GranitPrivacyBackgroundJobsModule.cs",
-      "line": 16,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -33668,7 +33687,7 @@
       "kind": "class",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/GranitPrivacyBlobStorageModule.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureServices",
@@ -34320,7 +34339,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs",
-      "line": 37,
+      "line": 36,
       "members": [
         {
           "name": "MapGranitPrivacy",
@@ -34485,7 +34504,7 @@
       "kind": "class",
       "project": "Granit.Privacy.EntityFrameworkCore",
       "file": "src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyBuilderEntityFrameworkCoreExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "UseEntityFrameworkCoreTrackers",
@@ -34517,7 +34536,7 @@
       "kind": "class",
       "project": "Granit.Privacy.EntityFrameworkCore",
       "file": "src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyModelBuilderExtensions.cs",
-      "line": 10,
+      "line": 9,
       "members": [
         {
           "name": "ConfigurePrivacyModule",
@@ -34574,7 +34593,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/GranitPrivacyBuilder.cs",
-      "line": 17,
+      "line": 15,
       "members": [
         {
           "name": "Services",
@@ -34879,7 +34898,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Notifications",
       "file": "src/Granit.Privacy.Notifications/GranitPrivacyNotificationsModule.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -35560,7 +35579,7 @@
       "kind": "interface",
       "project": "Granit.Privacy.Regulations",
       "file": "src/Granit.Privacy.Regulations/IPrivacyRegulationResolver.cs",
-      "line": 9,
+      "line": 7,
       "members": [
         {
           "name": "ResolveAsync",
@@ -35960,7 +35979,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.AI",
       "file": "src/Granit.QueryEngine.AI/GranitQueryEngineAIModule.cs",
-      "line": 22,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36135,7 +36154,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.EntityFrameworkCore",
       "file": "src/Granit.QueryEngine.EntityFrameworkCore/GranitQueryEngineEntityFrameworkCoreModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36314,7 +36333,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine",
       "file": "src/Granit.QueryEngine/GranitQueryEngineModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36724,7 +36743,7 @@
       "kind": "class",
       "project": "Granit.RateLimiting",
       "file": "src/Granit.RateLimiting/AspNetCore/RateLimitEndpointExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": []
     },
     {
@@ -36806,7 +36825,7 @@
       "kind": "class",
       "project": "Granit.RateLimiting",
       "file": "src/Granit.RateLimiting/GranitRateLimitingModule.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36979,7 +36998,7 @@
       "kind": "class",
       "project": "Granit.Scheduling.BackgroundJobs",
       "file": "src/Granit.Scheduling.BackgroundJobs/GranitSchedulingBackgroundJobsModule.cs",
-      "line": 18,
+      "line": 17,
       "members": [
         {
           "name": "ConfigureServices",
@@ -37309,7 +37328,7 @@
       "kind": "class",
       "project": "Granit.Scheduling",
       "file": "src/Granit.Scheduling/Extensions/SchedulingHostApplicationBuilderExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitScheduling",
@@ -37434,7 +37453,7 @@
       "kind": "class",
       "project": "Granit.Scheduling.Notifications",
       "file": "src/Granit.Scheduling.Notifications/GranitSchedulingNotificationsModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -38025,7 +38044,7 @@
       "kind": "class",
       "project": "Granit.Settings",
       "file": "src/Granit.Settings/GranitSettingsModule.cs",
-      "line": 26,
+      "line": 25,
       "members": [
         {
           "name": "ConfigureServices",
@@ -38470,7 +38489,7 @@
       "kind": "class",
       "project": "Granit.Templating.AI",
       "file": "src/Granit.Templating.AI/GranitTemplatingAIModule.cs",
-      "line": 24,
+      "line": 23,
       "members": []
     },
     {
@@ -38652,7 +38671,7 @@
       "kind": "class",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs",
-      "line": 37,
+      "line": 36,
       "members": [
         {
           "name": "MapGranitTemplating",
@@ -38668,7 +38687,7 @@
       "kind": "class",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs",
-      "line": 33,
+      "line": 32,
       "members": [
         {
           "name": "ConfigureServices",
@@ -38774,7 +38793,7 @@
       "kind": "class",
       "project": "Granit.Templating.EntityFrameworkCore",
       "file": "src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "ConfigureTemplatingModule",
@@ -38885,7 +38904,7 @@
       "kind": "class",
       "project": "Granit.Templating",
       "file": "src/Granit.Templating/GranitTemplatingModule.cs",
-      "line": 14,
+      "line": 13,
       "members": [
         {
           "name": "ConfigureServices",
@@ -38997,7 +39016,7 @@
       "kind": "class",
       "project": "Granit.Templating.Mjml",
       "file": "src/Granit.Templating.Mjml/GranitTemplatingMjmlModule.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -39137,7 +39156,7 @@
       "kind": "class",
       "project": "Granit.Templating.Scriban",
       "file": "src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitTemplatingWithScriban",
@@ -39187,7 +39206,7 @@
       "kind": "class",
       "project": "Granit.Templating.Scriban",
       "file": "src/Granit.Templating.Scriban/GranitTemplatingScribanModule.cs",
-      "line": 23,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -39367,7 +39386,7 @@
       "kind": "record",
       "project": "Granit.Templating",
       "file": "src/Granit.Templating/Store/TemplateListFilter.cs",
-      "line": 9,
+      "line": 8,
       "members": []
     },
     {
@@ -39453,7 +39472,7 @@
       "kind": "class",
       "project": "Granit.Testing",
       "file": "src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs",
-      "line": 17,
+      "line": 15,
       "members": [
         {
           "name": "StartAsync",
@@ -39502,7 +39521,7 @@
       "kind": "class",
       "project": "Granit.Testing.EntityFrameworkCore",
       "file": "src/Granit.Testing.EntityFrameworkCore/GranitTestingEntityFrameworkCoreModule.cs",
-      "line": 19,
+      "line": 18,
       "members": []
     },
     {
@@ -39692,7 +39711,7 @@
       "kind": "class",
       "project": "Granit.Testing",
       "file": "src/Granit.Testing/GranitTestingModule.cs",
-      "line": 19,
+      "line": 18,
       "members": []
     },
     {
@@ -39812,7 +39831,7 @@
       "kind": "class",
       "project": "Granit.Timeline.AI",
       "file": "src/Granit.Timeline.AI/GranitTimelineAIModule.cs",
-      "line": 22,
+      "line": 21,
       "members": []
     },
     {
@@ -40328,7 +40347,7 @@
       "kind": "record",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs",
-      "line": 24,
+      "line": 22,
       "members": []
     },
     {
@@ -40337,7 +40356,7 @@
       "kind": "record",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs",
-      "line": 12,
+      "line": 10,
       "members": []
     },
     {
@@ -40631,7 +40650,7 @@
       "kind": "class",
       "project": "Granit.Timeline",
       "file": "src/Granit.Timeline/GranitTimelineModule.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -40672,7 +40691,7 @@
       "kind": "class",
       "project": "Granit.Timeline.Notifications",
       "file": "src/Granit.Timeline.Notifications/GranitTimelineNotificationsModule.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -40947,7 +40966,7 @@
       "kind": "class",
       "project": "Granit.Timing",
       "file": "src/Granit.Timing/Extensions/TimingServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitTiming",
@@ -41197,7 +41216,7 @@
       "kind": "class",
       "project": "Granit.Validation.AI",
       "file": "src/Granit.Validation.AI/GranitValidationAIModule.cs",
-      "line": 19,
+      "line": 18,
       "members": []
     },
     {
@@ -41363,7 +41382,7 @@
       "kind": "class",
       "project": "Granit.Validation.Endpoints",
       "file": "src/Granit.Validation.Endpoints/GranitValidationEndpointsModule.cs",
-      "line": 19,
+      "line": 18,
       "members": []
     },
     {
@@ -41502,7 +41521,7 @@
       "kind": "class",
       "project": "Granit.Validation.Europe",
       "file": "src/Granit.Validation.Europe/GranitValidationEuropeModule.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -41518,7 +41537,7 @@
       "kind": "class",
       "project": "Granit.Validation.Europe",
       "file": "src/Granit.Validation.Europe/ValidationEuropeLocalizationResource.cs",
-      "line": 17,
+      "line": 16,
       "members": []
     },
     {
@@ -41630,7 +41649,7 @@
       "kind": "class",
       "project": "Granit.Validation",
       "file": "src/Granit.Validation/Extensions/ValidationServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitValidation",
@@ -41646,7 +41665,7 @@
       "kind": "class",
       "project": "Granit.Validation",
       "file": "src/Granit.Validation/GranitValidationModule.cs",
-      "line": 35,
+      "line": 34,
       "members": [
         {
           "name": "ConfigureServices",
@@ -41723,7 +41742,7 @@
       "kind": "class",
       "project": "Granit.Validation.NorthAmerica",
       "file": "src/Granit.Validation.NorthAmerica/GranitValidationNorthAmericaModule.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -41739,7 +41758,7 @@
       "kind": "class",
       "project": "Granit.Validation.NorthAmerica",
       "file": "src/Granit.Validation.NorthAmerica/ValidationNorthAmericaLocalizationResource.cs",
-      "line": 17,
+      "line": 16,
       "members": []
     },
     {
@@ -41909,7 +41928,7 @@
       "kind": "class",
       "project": "Granit.Validation.UnitedKingdom",
       "file": "src/Granit.Validation.UnitedKingdom/GranitValidationUnitedKingdomModule.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -41925,7 +41944,7 @@
       "kind": "class",
       "project": "Granit.Validation.UnitedKingdom",
       "file": "src/Granit.Validation.UnitedKingdom/ValidationUnitedKingdomLocalizationResource.cs",
-      "line": 16,
+      "line": 15,
       "members": []
     },
     {
@@ -42946,7 +42965,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.BackgroundJobs",
       "file": "src/Granit.Webhooks.BackgroundJobs/GranitWebhooksBackgroundJobsModule.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureServices",
@@ -43369,7 +43388,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.Endpoints",
       "file": "src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -43768,7 +43787,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.Notifications",
       "file": "src/Granit.Webhooks.Notifications/GranitWebhooksNotificationsModule.cs",
-      "line": 19,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -44175,7 +44194,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs",
-      "line": 27,
+      "line": 25,
       "members": [
         {
           "name": "AddGranitWolverine",
@@ -44191,7 +44210,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Extensions/WolverineValidationServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitValidatorsFromWolverineHandlerModules",
@@ -44207,7 +44226,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/GranitWolverineModule.cs",
-      "line": 23,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -44309,7 +44328,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.Postgresql",
       "file": "src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
           "name": "TransportConnectionStringName",
@@ -44404,7 +44423,7 @@
       "kind": "class",
       "project": "Granit.Workflow.AI",
       "file": "src/Granit.Workflow.AI/GranitWorkflowAIModule.cs",
-      "line": 27,
+      "line": 26,
       "members": []
     },
     {
@@ -44695,7 +44714,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Endpoints",
       "file": "src/Granit.Workflow.Endpoints/Extensions/WorkflowEndpointsServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitWorkflowEndpoints",
@@ -45046,7 +45065,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Notifications",
       "file": "src/Granit.Workflow.Notifications/Extensions/WorkflowNotificationsServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitWorkflowNotifications",
@@ -45062,7 +45081,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Notifications",
       "file": "src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs",
-      "line": 36,
+      "line": 35,
       "members": [
         {
           "name": "ConfigureServices",
@@ -45078,7 +45097,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Notifications",
       "file": "src/Granit.Workflow.Notifications/Handlers/WorkflowApprovalRequestedHandler.cs",
-      "line": 29,
+      "line": 28,
       "members": [
         {
           "name": "HandleAsync",
@@ -45094,7 +45113,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Notifications",
       "file": "src/Granit.Workflow.Notifications/Handlers/WorkflowStateChangedHandler.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "HandleAsync",

--- a/.slnf/security.slnf
+++ b/.slnf/security.slnf
@@ -5,6 +5,7 @@
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Auditing/Granit.Auditing.csproj",
       "src/Granit.Authentication.ApiKeys.BackgroundJobs/Granit.Authentication.ApiKeys.BackgroundJobs.csproj",
       "src/Granit.Authentication.ApiKeys.Endpoints/Granit.Authentication.ApiKeys.Endpoints.csproj",
       "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Granit.Authentication.ApiKeys.EntityFrameworkCore.csproj",

--- a/src/Granit.Auditing/AuthenticationAuditEntry.cs
+++ b/src/Granit.Auditing/AuthenticationAuditEntry.cs
@@ -1,0 +1,182 @@
+using Granit.Auditing.Domain;
+
+namespace Granit.Auditing;
+
+/// <summary>
+/// Builds <see cref="AuditEntry"/> instances for authentication events
+/// (login attempts, token issuance, denials) — the events the EF Core change-tracking
+/// interceptor cannot observe because no entity is mutated.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Successful authentications land in <see cref="AuditCategory.PrivilegedAccess"/>
+/// (ISO 27001 A.12.4.3 — "what privileged actors successfully did") and failed
+/// attempts in <see cref="AuditCategory.AccessDenied"/> (A.12.4.1). Both default
+/// to ~7 year retention via <see cref="Options.AuditingOptions"/>.
+/// </para>
+/// <para>
+/// Authentication details are persisted as a synthetic
+/// <see cref="AuditEntityChange"/> with <c>EntityType = "Authentication"</c>
+/// so investigators get a self-contained row without correlating against logs.
+/// Method, outcome and (when available) failure reason are recorded as
+/// <see cref="AuditPropertyChange"/> rows under that change.
+/// </para>
+/// </remarks>
+public static class AuthenticationAuditEntry
+{
+    /// <summary>
+    /// Synthetic entity type recorded on the audit row's
+    /// <see cref="AuditEntityChange.EntityType"/>.
+    /// </summary>
+    public const string SyntheticEntityType = "Authentication";
+
+    /// <summary>
+    /// Sentinel <see cref="AuditEntry.UserId"/> for failed attempts where the
+    /// caller could not be identified (e.g. "user_not_found").
+    /// </summary>
+    public const string UnknownUserSentinel = "<unknown>";
+
+    /// <summary>
+    /// Builds a <see cref="AuditCategory.PrivilegedAccess"/> entry recording a
+    /// successful authentication or token issuance.
+    /// </summary>
+    /// <param name="timestamp">Event time (UTC).</param>
+    /// <param name="userId">
+    /// Authenticated subject identifier. Required — successful auth always
+    /// resolves a user.
+    /// </param>
+    /// <param name="userName">Display name (nullable for pseudonymization).</param>
+    /// <param name="method">
+    /// Authentication or grant type — e.g. <c>"password"</c>, <c>"totp"</c>,
+    /// <c>"recovery_code"</c>, <c>"oidc"</c>, <c>"authorization_code"</c>,
+    /// <c>"refresh_token"</c>.
+    /// </param>
+    /// <param name="tenantId">Tenant scope of the operation.</param>
+    /// <param name="ipAddress">Source IP address.</param>
+    /// <param name="userAgent">Client User-Agent header.</param>
+    /// <param name="correlationId">Distributed-tracing correlation id.</param>
+    public static AuditEntry CreateSuccess(
+        DateTimeOffset timestamp,
+        string userId,
+        string? userName,
+        string method,
+        Guid? tenantId,
+        string? ipAddress,
+        string? userAgent,
+        string? correlationId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(userId);
+        ArgumentException.ThrowIfNullOrEmpty(method);
+
+        return Build(
+            timestamp,
+            userId,
+            userName,
+            method,
+            reason: null,
+            AuditCategory.PrivilegedAccess,
+            tenantId,
+            ipAddress,
+            userAgent,
+            correlationId);
+    }
+
+    /// <summary>
+    /// Builds an <see cref="AuditCategory.AccessDenied"/> entry recording a
+    /// failed authentication or token issuance.
+    /// </summary>
+    /// <param name="timestamp">Event time (UTC).</param>
+    /// <param name="userId">
+    /// Resolved subject identifier, or <see langword="null"/> when the user
+    /// could not be identified. Falls back to <see cref="UnknownUserSentinel"/>.
+    /// </param>
+    /// <param name="userName">Display name (nullable).</param>
+    /// <param name="method">
+    /// Attempted authentication or grant type — see <see cref="CreateSuccess"/>.
+    /// </param>
+    /// <param name="reason">
+    /// Short failure code — e.g. <c>"invalid_credentials"</c>,
+    /// <c>"account_locked"</c>, <c>"token_exchange_failed"</c>. Mirrors the
+    /// failure label used by the matching metric so dashboards and audit rows
+    /// stay correlatable.
+    /// </param>
+    /// <param name="tenantId">Tenant scope (when known).</param>
+    /// <param name="ipAddress">Source IP address.</param>
+    /// <param name="userAgent">Client User-Agent header.</param>
+    /// <param name="correlationId">Distributed-tracing correlation id.</param>
+    public static AuditEntry CreateFailure(
+        DateTimeOffset timestamp,
+        string? userId,
+        string? userName,
+        string method,
+        string reason,
+        Guid? tenantId,
+        string? ipAddress,
+        string? userAgent,
+        string? correlationId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(method);
+        ArgumentException.ThrowIfNullOrEmpty(reason);
+
+        return Build(
+            timestamp,
+            string.IsNullOrEmpty(userId) ? UnknownUserSentinel : userId,
+            userName,
+            method,
+            reason,
+            AuditCategory.AccessDenied,
+            tenantId,
+            ipAddress,
+            userAgent,
+            correlationId);
+    }
+
+    private static AuditEntry Build(
+        DateTimeOffset timestamp,
+        string userId,
+        string? userName,
+        string method,
+        string? reason,
+        AuditCategory category,
+        Guid? tenantId,
+        string? ipAddress,
+        string? userAgent,
+        string? correlationId)
+    {
+        List<AuditPropertyChange> properties =
+        [
+            new AuditPropertyChange { PropertyName = "Method", NewValue = method },
+            new AuditPropertyChange
+            {
+                PropertyName = "Outcome",
+                NewValue = category == AuditCategory.PrivilegedAccess ? "success" : "failure",
+            },
+        ];
+
+        if (!string.IsNullOrEmpty(reason))
+        {
+            properties.Add(new AuditPropertyChange { PropertyName = "Reason", NewValue = reason });
+        }
+
+        AuditEntityChange change = new()
+        {
+            EntityType = SyntheticEntityType,
+            EntityId = userId,
+            ChangeType = AuditChangeType.Created,
+            PropertyChanges = properties,
+        };
+
+        return new AuditEntry
+        {
+            Timestamp = timestamp,
+            UserId = userId,
+            UserName = userName,
+            Category = category,
+            IpAddress = ipAddress,
+            UserAgent = userAgent,
+            TenantId = tenantId,
+            CorrelationId = correlationId,
+            EntityChanges = [change],
+        };
+    }
+}

--- a/src/Granit.Bff.Endpoints/Endpoints/BffBackChannelLogoutEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffBackChannelLogoutEndpoints.cs
@@ -1,9 +1,14 @@
+using System.Diagnostics;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Bff.Options;
+using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -76,6 +81,8 @@ internal static partial class BffBackChannelLogoutEndpoints
         if (claims is null)
         {
             LogInvalidLogoutToken(logger, frontend.Name);
+            await TryWriteAuditAsync(httpContext, logger, userId: null,
+                failureReason: "invalid_logout_token", cancellationToken).ConfigureAwait(false);
             return TypedResults.Problem(
                 detail: "Invalid logout token.",
                 statusCode: StatusCodes.Status400BadRequest);
@@ -91,6 +98,8 @@ internal static partial class BffBackChannelLogoutEndpoints
             if (existing.HasValue)
             {
                 LogReplayDetected(logger, claims.Jti, frontend.Name);
+                await TryWriteAuditAsync(httpContext, logger, userId: claims.Subject,
+                    failureReason: "replay_detected", cancellationToken).ConfigureAwait(false);
                 return TypedResults.Problem(
                     detail: "Logout token replay detected.",
                     statusCode: StatusCodes.Status400BadRequest);
@@ -119,9 +128,63 @@ internal static partial class BffBackChannelLogoutEndpoints
             }
 
             LogBackChannelLogout(logger, claims.Subject, revoked, frontend.Name);
+            await TryWriteAuditAsync(httpContext, logger, userId: claims.Subject,
+                failureReason: null, cancellationToken).ConfigureAwait(false);
         }
 
         return TypedResults.Ok();
+    }
+
+    /// <summary>
+    /// Records a back-channel logout audit row. No-op when
+    /// <see cref="IAuditingWriter"/> is not registered; audit failures are
+    /// swallowed so the back-channel logout response is never blocked.
+    /// </summary>
+    private static async Task TryWriteAuditAsync(
+        HttpContext httpContext,
+        ILogger logger,
+        string? userId,
+        string? failureReason,
+        CancellationToken cancellationToken)
+    {
+        IAuditingWriter? auditingWriter = httpContext.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = httpContext.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
+        string? ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = httpContext.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+        const string Method = "bff_backchannel_logout";
+
+        AuditEntry entry = failureReason is null
+            ? AuthenticationAuditEntry.CreateSuccess(
+                timeProvider.GetUtcNow(),
+                userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
+                userName: null, method: Method,
+                tenantId, ipAddress, userAgent, correlationId)
+            : AuthenticationAuditEntry.CreateFailure(
+                timeProvider.GetUtcNow(),
+                userId, userName: null, method: Method, reason: failureReason,
+                tenantId, ipAddress, userAgent, correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
     }
 #pragma warning restore GRAPI003
 
@@ -135,4 +198,7 @@ internal static partial class BffBackChannelLogoutEndpoints
 
     [LoggerMessage(Level = LogLevel.Information, Message = "BFF back-channel logout: revoked {Count} session(s) for subject '{Subject}' on frontend {FrontendName}")]
     private static partial void LogBackChannelLogout(ILogger logger, string subject, int count, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "BFF back-channel logout: failed to write authentication audit entry — logout flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 }

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -2,9 +2,12 @@ using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Bff.Diagnostics;
 using Granit.Bff.Options;
 using Granit.Http.Cookies;
+using Granit.MultiTenancy;
 using Granit.Oidc.ClientAuthentication;
 using Granit.Oidc.ClientAuthentication.Internal;
 using Granit.Oidc.DPoP;
@@ -192,11 +195,15 @@ internal static partial class BffLoginEndpoints
         {
             string safeError = KnownOidcErrors.Contains(error) ? error : "unknown_error";
             LogCallbackError(logger, safeError, frontend.Name);
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: safeError, cancellationToken).ConfigureAwait(false);
             return RedirectToError(frontend, safeError);
         }
 
         if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
         {
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: "missing_code_or_state", cancellationToken).ConfigureAwait(false);
             return RedirectToError(frontend, "missing_code_or_state");
         }
 
@@ -208,12 +215,16 @@ internal static partial class BffLoginEndpoints
             if (string.IsNullOrEmpty(iss))
             {
                 LogIssuerMissing(logger, frontend.Name);
+                await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                    failureReason: "issuer_missing", cancellationToken).ConfigureAwait(false);
                 return RedirectToError(frontend, "issuer_missing");
             }
 
             if (!string.Equals(iss.TrimEnd('/'), expectedIssuer, StringComparison.OrdinalIgnoreCase))
             {
                 LogIssuerMismatch(logger, iss, expectedIssuer, frontend.Name);
+                await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                    failureReason: "issuer_mismatch", cancellationToken).ConfigureAwait(false);
                 return RedirectToError(frontend, "issuer_mismatch");
             }
         }
@@ -225,6 +236,8 @@ internal static partial class BffLoginEndpoints
 
         if (!maybePkce.HasValue)
         {
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: "invalid_state", cancellationToken).ConfigureAwait(false);
             return RedirectToError(frontend, "invalid_state");
         }
 
@@ -243,6 +256,8 @@ internal static partial class BffLoginEndpoints
         if (tokens is null)
         {
             LogTokenExchangeFailed(logger, frontend.Name);
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: "token_exchange_failed", cancellationToken).ConfigureAwait(false);
             return RedirectToError(frontend, "token_exchange_failed");
         }
 
@@ -269,6 +284,11 @@ internal static partial class BffLoginEndpoints
 
         metrics.RecordLogin(null);
         LogLoginSuccess(logger, BffSessionEndpoints.MaskSessionId(sessionId), frontend.Name);
+        await TryWriteAuthAuditAsync(httpContext, logger,
+            userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
+            userName: ExtractClaimFromIdToken(tokens.IdToken, "name"),
+            failureReason: null,
+            cancellationToken).ConfigureAwait(false);
 
         // Redirect to the original URL the user requested, or fall back to the configured post-login path
         string redirectUrl = !string.IsNullOrEmpty(pkceState.ReturnUrl)
@@ -518,7 +538,16 @@ internal static partial class BffLoginEndpoints
     /// Extracts the <c>sub</c> claim from an ID token JWT payload without full validation
     /// (token was already validated by the authorization server during exchange).
     /// </summary>
-    internal static string? ExtractSubFromIdToken(string? idToken)
+    internal static string? ExtractSubFromIdToken(string? idToken) =>
+        ExtractClaimFromIdToken(idToken, "sub");
+
+    /// <summary>
+    /// Extracts a single string claim from an ID token JWT payload without full
+    /// validation (token was already validated by the authorization server during
+    /// exchange). Returns <see langword="null"/> when the token is malformed or
+    /// the claim is absent.
+    /// </summary>
+    internal static string? ExtractClaimFromIdToken(string? idToken, string claimName)
     {
         if (string.IsNullOrEmpty(idToken))
         {
@@ -542,8 +571,8 @@ internal static partial class BffLoginEndpoints
 
             byte[] bytes = Convert.FromBase64String(payload);
             using var doc = JsonDocument.Parse(bytes);
-            return doc.RootElement.TryGetProperty("sub", out JsonElement sub)
-                ? sub.GetString() : null;
+            return doc.RootElement.TryGetProperty(claimName, out JsonElement claim)
+                ? claim.GetString() : null;
         }
         catch (FormatException)
         {
@@ -596,6 +625,56 @@ internal static partial class BffLoginEndpoints
             ? new PrivateKeyJwtStrategy(frontend.ClientSigningKeyJwk!, clock)
             : new ClientSecretPostStrategy(frontend.ClientSecret);
 
+    /// <summary>
+    /// Records an authentication audit row for the BFF callback. No-op when
+    /// <see cref="IAuditingWriter"/> is not registered (apps that don't opt into
+    /// auditing persistence). Audit failures are swallowed so a transient
+    /// audit-store outage never breaks the login flow.
+    /// </summary>
+    private static async Task TryWriteAuthAuditAsync(
+        HttpContext httpContext,
+        ILogger logger,
+        string? userId,
+        string? userName,
+        string? failureReason,
+        CancellationToken cancellationToken)
+    {
+        IAuditingWriter? auditingWriter = httpContext.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = httpContext.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
+        string? ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = httpContext.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+
+        AuditEntry entry = failureReason is null
+            ? AuthenticationAuditEntry.CreateSuccess(
+                timeProvider.GetUtcNow(), userId!, userName, method: "bff_session",
+                tenantId, ipAddress, userAgent, correlationId)
+            : AuthenticationAuditEntry.CreateFailure(
+                timeProvider.GetUtcNow(), userId, userName, method: "bff_session", failureReason,
+                tenantId, ipAddress, userAgent, correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
+    }
+
     // ──── Source-generated log messages ────
 
     [LoggerMessage(Level = LogLevel.Information, Message = "BFF login: redirecting to authority {Authority} for frontend {FrontendName}")]
@@ -630,4 +709,7 @@ internal static partial class BffLoginEndpoints
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "BFF callback: issuer mismatch — received '{ReceivedIssuer}', expected '{ExpectedIssuer}' for frontend {FrontendName}")]
     private static partial void LogIssuerMismatch(ILogger logger, string receivedIssuer, string expectedIssuer, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "BFF callback: failed to write authentication audit entry — login flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 }

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLogoutEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLogoutEndpoints.cs
@@ -1,13 +1,17 @@
 using System.Diagnostics;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Bff.Diagnostics;
 using Granit.Bff.Options;
 using Granit.Http.Cookies;
+using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Granit.Bff.Endpoints.Endpoints;
 
@@ -15,7 +19,7 @@ namespace Granit.Bff.Endpoints.Endpoints;
 /// BFF logout endpoint. Clears the session and redirects to the OIDC end_session_endpoint.
 /// Registered per-frontend under <c>/{pathPrefix}/bff/logout</c>.
 /// </summary>
-internal static class BffLogoutEndpoints
+internal static partial class BffLogoutEndpoints
 {
     internal static RouteGroupBuilder MapLogoutEndpoints(this RouteGroupBuilder group, BffFrontendOptions frontend)
     {
@@ -42,21 +46,31 @@ internal static class BffLogoutEndpoints
         IBffLogoutOrchestrator orchestrator,
         CancellationToken cancellationToken)
     {
+        ILogger logger = httpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.Bff.Endpoints.BffLogoutEndpoints");
+
         Activity? activity = BffActivitySource.Source.StartActivity(BffActivitySource.Logout);
         using IDisposable? activityScope = activity;
 
         string? sessionId = httpContext.Request.Cookies[frontend.SessionCookieName];
         string? idTokenHint = null;
+        bool hadActiveSession = !string.IsNullOrEmpty(sessionId);
 
-        if (!string.IsNullOrEmpty(sessionId))
+        if (hadActiveSession)
         {
             idTokenHint = await orchestrator.RevokeSessionAsync(
-                frontend.Name, sessionId, cancellationToken).ConfigureAwait(false);
+                frontend.Name, sessionId!, cancellationToken).ConfigureAwait(false);
         }
 
         // Clear frontend-specific session cookie via managed cookie system (GRSEC004)
         IGranitCookieManager cookieManager = httpContext.RequestServices.GetRequiredService<IGranitCookieManager>();
         cookieManager.DeleteCookie(httpContext, frontend.SessionCookieName);
+
+        if (hadActiveSession)
+        {
+            await TryWriteLogoutAuditAsync(httpContext, logger,
+                userId: null, userName: null, cancellationToken).ConfigureAwait(false);
+        }
 
         // Build end_session URL — support absolute URLs (e.g. separate frontend origin)
         string effectivePath = frontend.EffectivePostLogoutRedirectPath;
@@ -68,4 +82,58 @@ internal static class BffLogoutEndpoints
         return TypedResults.Redirect(endSessionUrl);
     }
 #pragma warning restore GRAPI003
+
+    /// <summary>
+    /// Records a successful BFF session logout as an
+    /// <see cref="AuditCategory.PrivilegedAccess"/> audit row. No-op when
+    /// <see cref="IAuditingWriter"/> is not registered. Audit failures are
+    /// swallowed so logout always completes.
+    /// </summary>
+    private static async Task TryWriteLogoutAuditAsync(
+        HttpContext httpContext,
+        ILogger logger,
+        string? userId,
+        string? userName,
+        CancellationToken cancellationToken)
+    {
+        IAuditingWriter? auditingWriter = httpContext.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = httpContext.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
+        string? ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = httpContext.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+
+        AuditEntry entry = AuthenticationAuditEntry.CreateSuccess(
+            timeProvider.GetUtcNow(),
+            userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
+            userName,
+            method: "bff_logout",
+            tenantId,
+            ipAddress,
+            userAgent,
+            correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "BFF logout: failed to write authentication audit entry — logout flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 }

--- a/src/Granit.Bff.Endpoints/Granit.Bff.Endpoints.csproj
+++ b/src/Granit.Bff.Endpoints/Granit.Bff.Endpoints.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\Granit.Bff\Granit.Bff.csproj" />
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing;
 using Granit.Bff.Endpoints.Internal;
 using Granit.Bff.Options;
 using Granit.Caching;
@@ -20,6 +21,7 @@ namespace Granit.Bff.Endpoints;
 /// because their names are configuration-driven (one per frontend).
 /// </remarks>
 [DependsOn(
+    typeof(GranitAuditingModule),
     typeof(GranitBffModule),
     typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),

--- a/src/Granit.Bff.Endpoints/packages.lock.json
+++ b/src/Granit.Bff.Endpoints/packages.lock.json
@@ -112,6 +112,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.bff": {
         "type": "Project",
         "dependencies": {
@@ -143,6 +153,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.http.apidocumentation": {

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
@@ -1,18 +1,25 @@
+using System.Diagnostics;
+using System.Security.Claims;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Internal;
 using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using IdentityConstants = Microsoft.AspNetCore.Identity.IdentityConstants;
 
 namespace Granit.Identity.Local.Endpoints.Endpoints;
 
-internal static class AccountExternalLoginEndpoints
+internal static partial class AccountExternalLoginEndpoints
 {
     internal static RouteGroupBuilder MapAccountExternalLoginEndpoints(this RouteGroupBuilder group)
     {
@@ -113,6 +120,9 @@ internal static class AccountExternalLoginEndpoints
         // Identity stores the originating scheme in
         // AuthenticationProperties.Items["LoginProvider"] under the well-known
         // IdentityConstants.ExternalScheme cookie.
+        ILogger logger = httpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.Identity.Local.Endpoints.AccountExternalLoginEndpoints");
+
         AuthenticateResult authResult = await httpContext
             .AuthenticateAsync(IdentityConstants.ExternalScheme)
             .ConfigureAwait(false);
@@ -123,31 +133,101 @@ internal static class AccountExternalLoginEndpoints
             || !authResult.Properties.Items.TryGetValue("LoginProvider", out string? provider)
             || string.IsNullOrEmpty(provider))
         {
+            await TryWriteExternalLoginAuditAsync(httpContext, logger, provider: "unknown",
+                userId: null, userName: null, failureReason: "callback_missing_scheme",
+                cancellationToken).ConfigureAwait(false);
             return TypedResults.Problem(
                 detail: "External login callback did not carry an authentication scheme.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
+
+        string? externalUserId = authResult.Principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        string? externalUserName = authResult.Principal.Identity?.Name;
 
         try
         {
             ProcessCallbackResult result = await externalLoginService
                 .ProcessCallbackAsync(authResult.Principal, provider, cancellationToken)
                 .ConfigureAwait(false);
+            await TryWriteExternalLoginAuditAsync(httpContext, logger, provider,
+                userId: externalUserId, userName: externalUserName, failureReason: null,
+                cancellationToken).ConfigureAwait(false);
             return TypedResults.Ok(result);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
         {
+            await TryWriteExternalLoginAuditAsync(httpContext, logger, provider,
+                userId: externalUserId, userName: externalUserName,
+                failureReason: "account_not_found", cancellationToken).ConfigureAwait(false);
             return TypedResults.Problem(
                 detail: ex.Message,
                 statusCode: StatusCodes.Status403Forbidden);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("DuplicateEmail", StringComparison.OrdinalIgnoreCase))
         {
+            await TryWriteExternalLoginAuditAsync(httpContext, logger, provider,
+                userId: externalUserId, userName: externalUserName,
+                failureReason: "duplicate_email", cancellationToken).ConfigureAwait(false);
             return TypedResults.Problem(
                 detail: "An account with this email already exists.",
                 statusCode: StatusCodes.Status409Conflict);
         }
     }
+
+    /// <summary>
+    /// Records an external-login callback audit row. No-op when
+    /// <see cref="IAuditingWriter"/> is not registered; audit failures are
+    /// swallowed so the login flow is never blocked by audit issues.
+    /// </summary>
+    private static async Task TryWriteExternalLoginAuditAsync(
+        HttpContext httpContext,
+        ILogger logger,
+        string provider,
+        string? userId,
+        string? userName,
+        string? failureReason,
+        CancellationToken cancellationToken)
+    {
+        IAuditingWriter? auditingWriter = httpContext.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = httpContext.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
+        string? ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = httpContext.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+        string method = $"external:{provider.ToLowerInvariant()}";
+
+        AuditEntry entry = failureReason is null
+            ? AuthenticationAuditEntry.CreateSuccess(
+                timeProvider.GetUtcNow(),
+                userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
+                userName, method, tenantId, ipAddress, userAgent, correlationId)
+            : AuthenticationAuditEntry.CreateFailure(
+                timeProvider.GetUtcNow(), userId, userName, method, failureReason,
+                tenantId, ipAddress, userAgent, correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "External login: failed to write authentication audit entry — login flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 
     private static async Task<Results<NoContent, ProblemHttpResult>> UnlinkExternalLoginAsync(
         string provider,

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Events;
@@ -131,6 +133,9 @@ internal static partial class AccountLoginEndpoints
 
             LogLoginFailed(logger, request.Login, "user_not_found");
             metrics?.RecordAuthenticationFailure(null, "invalid_credentials");
+            await TryWriteAuthAuditAsync(httpContext, logger,
+                method: "password", userId: null, userName: null,
+                failureReason: "invalid_credentials", cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Problem(
                 detail: "Invalid credentials.",
@@ -152,6 +157,9 @@ internal static partial class AccountLoginEndpoints
         {
             LogLoginSuccess(logger, user.Id.ToString());
             metrics?.RecordAuthenticationSuccess(null, "password");
+            await TryWriteAuthAuditAsync(httpContext, logger,
+                method: "password", userId: user.Id.ToString(), userName: user.UserName,
+                failureReason: null, cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
         }
@@ -170,6 +178,9 @@ internal static partial class AccountLoginEndpoints
 
             await PublishAccountLockedAsync(httpContext, userManager, user, cancellationToken)
                 .ConfigureAwait(false);
+            await TryWriteAuthAuditAsync(httpContext, logger,
+                method: "password", userId: user.Id.ToString(), userName: user.UserName,
+                failureReason: "account_locked", cancellationToken).ConfigureAwait(false);
 
             // Return 401 (same as invalid credentials) to prevent account enumeration.
             // The user is notified of the lockout exclusively via email.
@@ -182,6 +193,9 @@ internal static partial class AccountLoginEndpoints
         {
             LogLoginNotAllowed(logger, user.Id.ToString());
             metrics?.RecordAuthenticationFailure(null, "email_not_confirmed");
+            await TryWriteAuthAuditAsync(httpContext, logger,
+                method: "password", userId: user.Id.ToString(), userName: user.UserName,
+                failureReason: "email_not_confirmed", cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Problem(
                 detail: "Sign-in is not allowed. Verify your email address.",
@@ -191,6 +205,9 @@ internal static partial class AccountLoginEndpoints
         // Generic failure (wrong password)
         LogLoginFailed(logger, request.Login, "invalid_password");
         metrics?.RecordAuthenticationFailure(null, "invalid_credentials");
+        await TryWriteAuthAuditAsync(httpContext, logger,
+            method: "password", userId: user.Id.ToString(), userName: user.UserName,
+            failureReason: "invalid_credentials", cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Problem(
             detail: "Invalid credentials.",
@@ -263,6 +280,14 @@ internal static partial class AccountLoginEndpoints
         {
             LogTwoFactorSuccess(logger, method);
             metrics?.RecordAuthenticationSuccess(null, method);
+            LocalIdentity? signedInUser = await signInManager.UserManager
+                .GetUserAsync(httpContext.User).ConfigureAwait(false);
+            await TryWriteAuthAuditAsync(httpContext, logger,
+                method: method,
+                userId: signedInUser?.Id.ToString(),
+                userName: signedInUser?.UserName,
+                failureReason: null,
+                cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
         }
@@ -282,6 +307,13 @@ internal static partial class AccountLoginEndpoints
                     .ConfigureAwait(false);
             }
 
+            await TryWriteAuthAuditAsync(httpContext, logger,
+                method: method,
+                userId: lockedUser?.Id.ToString(),
+                userName: lockedUser?.UserName,
+                failureReason: "account_locked",
+                cancellationToken).ConfigureAwait(false);
+
             // Return 401 (same as invalid code) to prevent account enumeration.
             // The user is notified of the lockout exclusively via email.
             return TypedResults.Problem(
@@ -291,6 +323,14 @@ internal static partial class AccountLoginEndpoints
 
         LogTwoFactorFailed(logger, failureReason);
         metrics?.RecordAuthenticationFailure(null, "invalid_token");
+        LocalIdentity? twoFactorUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
+            .ConfigureAwait(false);
+        await TryWriteAuthAuditAsync(httpContext, logger,
+            method: method,
+            userId: twoFactorUser?.Id.ToString(),
+            userName: twoFactorUser?.UserName,
+            failureReason: failureReason,
+            cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Problem(
             detail: "Invalid verification code.",
@@ -391,6 +431,59 @@ internal static partial class AccountLoginEndpoints
             cancellationToken).ConfigureAwait(false);
     }
 
+    // ──── Authentication audit ────
+
+    /// <summary>
+    /// Records an authentication audit row for the local-identity login flow.
+    /// No-op when <see cref="IAuditingWriter"/> is not registered. Audit
+    /// failures are swallowed so a transient audit-store outage never breaks
+    /// authentication.
+    /// </summary>
+    private static async Task TryWriteAuthAuditAsync(
+        HttpContext httpContext,
+        ILogger logger,
+        string method,
+        string? userId,
+        string? userName,
+        string? failureReason,
+        CancellationToken cancellationToken)
+    {
+        IAuditingWriter? auditingWriter = httpContext.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = httpContext.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
+        string? ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = httpContext.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+
+        AuditEntry entry = failureReason is null
+            ? AuthenticationAuditEntry.CreateSuccess(
+                timeProvider.GetUtcNow(), userId!, userName, method,
+                tenantId, ipAddress, userAgent, correlationId)
+            : AuthenticationAuditEntry.CreateFailure(
+                timeProvider.GetUtcNow(), userId, userName, method, failureReason,
+                tenantId, ipAddress, userAgent, correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
+    }
+
     // ──── Source-generated log messages ────
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Headless login: user {UserId} authenticated successfully")]
@@ -413,4 +506,7 @@ internal static partial class AccountLoginEndpoints
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Headless login: two-factor failed — {Reason}")]
     private static partial void LogTwoFactorFailed(ILogger logger, string reason);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Headless login: failed to write authentication audit entry — login flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Http.SecurityHeaders.Extensions;
 using Granit.Identity.Local.Diagnostics;
@@ -5,6 +8,7 @@ using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Internal;
 using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -12,10 +16,11 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Granit.Identity.Local.Endpoints.Endpoints;
 
-internal static class AccountPasskeyEndpoints
+internal static partial class AccountPasskeyEndpoints
 {
     internal static RouteGroupBuilder MapAccountPasskeyEndpoints(this RouteGroupBuilder group)
     {
@@ -160,6 +165,8 @@ internal static class AccountPasskeyEndpoints
         CancellationToken cancellationToken)
     {
         IdentityLocalMetrics? metrics = httpContext.RequestServices.GetService<IdentityLocalMetrics>();
+        ILogger logger = httpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.Identity.Local.Endpoints.AccountPasskeyEndpoints");
 
         GranitPasskeyAssertionResult assertion = await passkeyService
             .CompleteAssertionAsync(request.CredentialJson, cancellationToken)
@@ -168,6 +175,9 @@ internal static class AccountPasskeyEndpoints
         if (!assertion.Succeeded || assertion.UserId is null)
         {
             metrics?.RecordAuthenticationFailure(null, "invalid_token");
+            await TryWritePasskeyAuditAsync(httpContext, logger,
+                userId: assertion.UserId, userName: null,
+                failureReason: "invalid_token", cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Problem(
                 detail: "Passkey authentication failed.",
@@ -178,6 +188,9 @@ internal static class AccountPasskeyEndpoints
 
         if (user is null)
         {
+            await TryWritePasskeyAuditAsync(httpContext, logger,
+                userId: assertion.UserId, userName: null,
+                failureReason: "user_not_found", cancellationToken).ConfigureAwait(false);
             return TypedResults.Problem(
                 detail: "User not found.",
                 statusCode: StatusCodes.Status401Unauthorized);
@@ -185,9 +198,66 @@ internal static class AccountPasskeyEndpoints
 
         await signInManager.SignInAsync(user, isPersistent: false).ConfigureAwait(false);
         metrics?.RecordAuthenticationSuccess(null, "passkey");
+        await TryWritePasskeyAuditAsync(httpContext, logger,
+            userId: user.Id.ToString(), userName: user.UserName,
+            failureReason: null, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
     }
+
+    /// <summary>
+    /// Records a passkey assertion audit row. No-op when
+    /// <see cref="IAuditingWriter"/> is not registered; audit failures are
+    /// swallowed so the login flow is never blocked by audit issues.
+    /// </summary>
+    private static async Task TryWritePasskeyAuditAsync(
+        HttpContext httpContext,
+        ILogger logger,
+        string? userId,
+        string? userName,
+        string? failureReason,
+        CancellationToken cancellationToken)
+    {
+        IAuditingWriter? auditingWriter = httpContext.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = httpContext.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
+        string? ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = httpContext.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+
+        AuditEntry entry = failureReason is null
+            ? AuthenticationAuditEntry.CreateSuccess(
+                timeProvider.GetUtcNow(),
+                userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
+                userName, method: "passkey", tenantId, ipAddress, userAgent, correlationId)
+            : AuthenticationAuditEntry.CreateFailure(
+                timeProvider.GetUtcNow(), userId, userName,
+                method: "passkey", reason: failureReason,
+                tenantId, ipAddress, userAgent, correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Passkey login: failed to write authentication audit entry — login flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 
     private static async Task<Results<NoContent, ProblemHttpResult>> RenamePasskeyAsync(
         Guid id,

--- a/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
+++ b/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />

--- a/src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs
+++ b/src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing;
 using Granit.Authorization;
 using Granit.Caching;
 using Granit.Http.ApiDocumentation;
@@ -19,6 +20,7 @@ namespace Granit.Identity.Local.Endpoints;
 /// <para>Validators are auto-discovered by <c>GranitValidationModule</c>.</para>
 /// </remarks>
 [DependsOn(
+    typeof(GranitAuditingModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -34,6 +34,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectLogoutEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectLogoutEndpoints.cs
@@ -1,9 +1,16 @@
+using System.Diagnostics;
+using System.Security.Claims;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
+using Granit.MultiTenancy;
 using Granit.OpenIddict.Endpoints.Options;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenIddict.Server.AspNetCore;
 
 namespace Granit.OpenIddict.Endpoints.Endpoints;
@@ -13,7 +20,7 @@ namespace Granit.OpenIddict.Endpoints.Endpoints;
 /// Signs out the Identity cookie and lets OpenIddict handle the post-logout redirect.
 /// </summary>
 #pragma warning disable GRAPI001 // OpenIddict requires Results.SignOut with explicit auth scheme
-internal static class ConnectLogoutEndpoints
+internal static partial class ConnectLogoutEndpoints
 {
     internal static IEndpointRouteBuilder MapConnectLogoutEndpoints(
         this IEndpointRouteBuilder endpoints,
@@ -31,12 +38,78 @@ internal static class ConnectLogoutEndpoints
         HttpContext context,
         OpenIddictServerEndpointsOptions options)
     {
+        // Capture identity before sign-out so the audit row can carry the
+        // subject. Once SignOutAsync has run, context.User is anonymous.
+        string? userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? context.User.FindFirst("sub")?.Value;
+        string? userName = context.User.Identity?.Name;
+        bool wasAuthenticated = context.User.Identity?.IsAuthenticated == true;
+
         // Sign out the Identity application cookie.
         await context.SignOutAsync(IdentityConstants.ApplicationScheme).ConfigureAwait(false);
+
+        if (wasAuthenticated)
+        {
+            ILogger logger = context.RequestServices.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("Granit.OpenIddict.Endpoints.ConnectLogoutEndpoints");
+            await TryWriteLogoutAuditAsync(context, logger, userId, userName).ConfigureAwait(false);
+        }
 
         // Let OpenIddict handle post_logout_redirect_uri validation and redirect.
         return Results.SignOut(
             new AuthenticationProperties { RedirectUri = options.PostLogoutRedirectPath },
             [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
     }
+
+    /// <summary>
+    /// Records a successful OIDC end-session logout. No-op when
+    /// <see cref="IAuditingWriter"/> is not registered; audit failures are
+    /// swallowed so logout always completes.
+    /// </summary>
+    private static async Task TryWriteLogoutAuditAsync(
+        HttpContext context,
+        ILogger logger,
+        string? userId,
+        string? userName)
+    {
+        IAuditingWriter? auditingWriter = context.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = context.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
+        Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
+        string? ipAddress = context.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = context.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+
+        AuditEntry entry = AuthenticationAuditEntry.CreateSuccess(
+            timeProvider.GetUtcNow(),
+            userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
+            userName,
+            method: "oidc_logout",
+            tenantId,
+            ipAddress,
+            userAgent,
+            correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "OIDC logout: failed to write authentication audit entry — logout flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 }

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -1,5 +1,8 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Security.Claims;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Identity.Local.Domain;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.Diagnostics;
@@ -85,6 +88,9 @@ internal static partial class ConnectTokenEndpoints
         {
             LogAuthenticationFailed(logger, request.GrantType!);
             metrics.RecordAuthenticationFailure(tenantId, "invalid_token");
+            await TryWriteAuthAuditAsync(context, logger,
+                method: request.GrantType!, userId: null, userName: null,
+                failureReason: "invalid_token", tenantId).ConfigureAwait(false);
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
@@ -116,6 +122,9 @@ internal static partial class ConnectTokenEndpoints
             {
                 LogUserNotFound(logger, subject ?? "(null)");
                 metrics.RecordAuthenticationFailure(tenantId, "invalid_credentials");
+                await TryWriteAuthAuditAsync(context, logger,
+                    method: request.GrantType!, userId: subject, userName: null,
+                    failureReason: "invalid_credentials", tenantId).ConfigureAwait(false);
                 return Results.Forbid(
                     authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
             }
@@ -132,6 +141,13 @@ internal static partial class ConnectTokenEndpoints
             metrics.RecordTokenIssued(tenantId, grantType);
             metrics.RecordAuthenticationSuccess(tenantId, grantType);
             LogTokenIssued(logger, user.Id.ToString(), grantType);
+
+            await TryWriteAuthAuditAsync(context, logger,
+                method: grantType,
+                userId: user.Id.ToString(),
+                userName: user.UserName,
+                failureReason: null,
+                tenantId).ConfigureAwait(false);
 
             return Results.SignIn(principal,
                 authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
@@ -164,6 +180,56 @@ internal static partial class ConnectTokenEndpoints
             authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }
 
+    /// <summary>
+    /// Records an authentication audit row for the token endpoint. No-op when
+    /// <see cref="IAuditingWriter"/> is not registered. Audit failures are
+    /// swallowed so a transient audit-store outage never breaks token issuance.
+    /// </summary>
+    private static async Task TryWriteAuthAuditAsync(
+        HttpContext context,
+        ILogger logger,
+        string method,
+        string? userId,
+        string? userName,
+        string? failureReason,
+        string? tenantId)
+    {
+        IAuditingWriter? auditingWriter = context.RequestServices.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = context.RequestServices.GetService<TimeProvider>()
+            ?? TimeProvider.System;
+        Guid? tenantGuid = !string.IsNullOrEmpty(tenantId) && Guid.TryParse(tenantId, out Guid parsed)
+            ? parsed : null;
+        string? ipAddress = context.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = context.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+        string? correlationId = Activity.Current?.Id;
+
+        AuditEntry entry = failureReason is null
+            ? AuthenticationAuditEntry.CreateSuccess(
+                timeProvider.GetUtcNow(), userId!, userName, method,
+                tenantGuid, ipAddress, userAgent, correlationId)
+            : AuthenticationAuditEntry.CreateFailure(
+                timeProvider.GetUtcNow(), userId, userName, method, failureReason,
+                tenantGuid, ipAddress, userAgent, correlationId);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(logger, ex);
+        }
+    }
+
     // ──── Source-generated log messages ────
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Token issued for subject '{Subject}' using grant type '{GrantType}'")]
@@ -177,4 +243,7 @@ internal static partial class ConnectTokenEndpoints
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Unsupported grant type '{GrantType}'")]
     private static partial void LogUnsupportedGrantType(ILogger logger, string grantType);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Token endpoint: failed to write authentication audit entry — token flow continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 }

--- a/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
+++ b/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing;
 using Granit.Authorization;
 using Granit.Caching;
 using Granit.Http.ApiDocumentation;
@@ -27,6 +28,7 @@ namespace Granit.OpenIddict.Endpoints;
 /// </para>
 /// </remarks>
 [DependsOn(
+    typeof(GranitAuditingModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -285,6 +285,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication": {
         "type": "Project",
         "dependencies": {

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -508,6 +508,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authentication": {
         "type": "Project",
         "dependencies": {
@@ -695,6 +707,7 @@
       "granit.identity.local.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
@@ -753,6 +766,7 @@
       "granit.openiddict.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1806,6 +1806,7 @@
       "granit.bff.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Bff": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
@@ -2456,6 +2457,7 @@
       "granit.identity.local.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
@@ -2920,6 +2922,7 @@
       "granit.openiddict.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Auditing.Tests/AuthenticationAuditEntryTests.cs
+++ b/tests/Granit.Auditing.Tests/AuthenticationAuditEntryTests.cs
@@ -1,0 +1,143 @@
+using Granit.Auditing.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Auditing.Tests;
+
+public sealed class AuthenticationAuditEntryTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 19, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void CreateSuccess_PopulatesEntryAsPrivilegedAccess()
+    {
+        var tenantId = Guid.NewGuid();
+
+        AuditEntry entry = AuthenticationAuditEntry.CreateSuccess(
+            Now,
+            userId: "user-42",
+            userName: "Jane Doe",
+            method: "password",
+            tenantId: tenantId,
+            ipAddress: "10.0.0.1",
+            userAgent: "Mozilla/5.0",
+            correlationId: "trace-abc");
+
+        entry.Category.ShouldBe(AuditCategory.PrivilegedAccess);
+        entry.Timestamp.ShouldBe(Now);
+        entry.UserId.ShouldBe("user-42");
+        entry.UserName.ShouldBe("Jane Doe");
+        entry.TenantId.ShouldBe(tenantId);
+        entry.IpAddress.ShouldBe("10.0.0.1");
+        entry.UserAgent.ShouldBe("Mozilla/5.0");
+        entry.CorrelationId.ShouldBe("trace-abc");
+
+        entry.EntityChanges.ShouldHaveSingleItem();
+        AuditEntityChange change = entry.EntityChanges.Single();
+        change.EntityType.ShouldBe(AuthenticationAuditEntry.SyntheticEntityType);
+        change.EntityId.ShouldBe("user-42");
+        change.ChangeType.ShouldBe(AuditChangeType.Created);
+
+        change.PropertyChanges
+            .Select(p => p.PropertyName)
+            .ShouldBe(["Method", "Outcome"], ignoreOrder: true);
+        change.PropertyChanges.First(p => p.PropertyName == "Method").NewValue.ShouldBe("password");
+        change.PropertyChanges.First(p => p.PropertyName == "Outcome").NewValue.ShouldBe("success");
+    }
+
+    [Fact]
+    public void CreateFailure_PopulatesEntryAsAccessDenied_WithReason()
+    {
+        AuditEntry entry = AuthenticationAuditEntry.CreateFailure(
+            Now,
+            userId: "user-42",
+            userName: null,
+            method: "password",
+            reason: "invalid_credentials",
+            tenantId: null,
+            ipAddress: null,
+            userAgent: null,
+            correlationId: null);
+
+        entry.Category.ShouldBe(AuditCategory.AccessDenied);
+        entry.UserId.ShouldBe("user-42");
+        entry.UserName.ShouldBeNull();
+        entry.TenantId.ShouldBeNull();
+
+        AuditEntityChange change = entry.EntityChanges.ShouldHaveSingleItem();
+        change.EntityId.ShouldBe("user-42");
+
+        change.PropertyChanges
+            .Select(p => p.PropertyName)
+            .ShouldBe(["Method", "Outcome", "Reason"], ignoreOrder: true);
+        change.PropertyChanges.First(p => p.PropertyName == "Outcome").NewValue.ShouldBe("failure");
+        change.PropertyChanges.First(p => p.PropertyName == "Reason").NewValue.ShouldBe("invalid_credentials");
+    }
+
+    [Fact]
+    public void CreateFailure_WithNullUserId_FallsBackToUnknownSentinel()
+    {
+        AuditEntry entry = AuthenticationAuditEntry.CreateFailure(
+            Now,
+            userId: null,
+            userName: null,
+            method: "password",
+            reason: "user_not_found",
+            tenantId: null,
+            ipAddress: null,
+            userAgent: null,
+            correlationId: null);
+
+        entry.UserId.ShouldBe(AuthenticationAuditEntry.UnknownUserSentinel);
+        entry.EntityChanges.Single().EntityId.ShouldBe(AuthenticationAuditEntry.UnknownUserSentinel);
+    }
+
+    [Fact]
+    public void CreateFailure_WithEmptyUserId_FallsBackToUnknownSentinel()
+    {
+        AuditEntry entry = AuthenticationAuditEntry.CreateFailure(
+            Now,
+            userId: string.Empty,
+            userName: null,
+            method: "oidc",
+            reason: "issuer_mismatch",
+            tenantId: null,
+            ipAddress: null,
+            userAgent: null,
+            correlationId: null);
+
+        entry.UserId.ShouldBe(AuthenticationAuditEntry.UnknownUserSentinel);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CreateSuccess_RejectsMissingUserId(string? userId) =>
+        Should.Throw<ArgumentException>(() => AuthenticationAuditEntry.CreateSuccess(
+            Now, userId!, userName: null, method: "password",
+            tenantId: null, ipAddress: null, userAgent: null, correlationId: null));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CreateSuccess_RejectsMissingMethod(string? method) =>
+        Should.Throw<ArgumentException>(() => AuthenticationAuditEntry.CreateSuccess(
+            Now, userId: "u", userName: null, method: method!,
+            tenantId: null, ipAddress: null, userAgent: null, correlationId: null));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CreateFailure_RejectsMissingReason(string? reason) =>
+        Should.Throw<ArgumentException>(() => AuthenticationAuditEntry.CreateFailure(
+            Now, userId: "u", userName: null, method: "password", reason: reason!,
+            tenantId: null, ipAddress: null, userAgent: null, correlationId: null));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CreateFailure_RejectsMissingMethod(string? method) =>
+        Should.Throw<ArgumentException>(() => AuthenticationAuditEntry.CreateFailure(
+            Now, userId: "u", userName: null, method: method!, reason: "x",
+            tenantId: null, ipAddress: null, userAgent: null, correlationId: null));
+}

--- a/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
@@ -371,6 +371,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.bff": {
         "type": "Project",
         "dependencies": {
@@ -384,6 +394,7 @@
       "granit.bff.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Bff": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
@@ -413,6 +424,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.http.apidocumentation": {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -82,10 +82,10 @@
       "Testcontainers.PostgreSql": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.11.0",
-        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "resolved": "4.12.0",
+        "contentHash": "LZcQu4vfcYuzzy2ENOb7giFb6WNztEEJbufsm7kGiQxjallVuzkWxrBL8LwnjlXGW939pgEZFstL5cO0R2XrBQ==",
         "dependencies": {
-          "Testcontainers": "4.11.0"
+          "Testcontainers": "4.12.0"
         }
       },
       "xunit.runner.visualstudio": {
@@ -137,15 +137,59 @@
       },
       "Docker.DotNet.Enhanced": {
         "type": "Transitive",
-        "resolved": "3.131.1",
-        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg=="
+        "resolved": "4.2.0",
+        "contentHash": "tm2V/DpnaURbBhMQ7Z3orNR3u+H863KQuYfA/sgGjI5py07dEeV0I02f6pGrx2869KG9uNM/E96puf9i0gId2w==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.NPipe": "4.2.0",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.Unix": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Handler.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "cQNxpdadEPdNdfjFCl9vgoCQIK3aVHRn1Qlu36aZUFpp4xHfPrk4hRPNVLR/CpobIFJ+dAt8AceTKMlCfPSccw=="
+      },
+      "Docker.DotNet.Enhanced.LegacyHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "sfbMX1HBPUec3PEMoqlP5ak6skXclcTBmu4gG3aUJatP34J2DgvYMP13bvz/rfrjVkAhPqnIiDKiHAkBCokajg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NativeHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "/ll+2ePYm1qrsMdgMO5BzCQnbfTGmPJAc9SqXEManbliVBZvEpBKHXLugx/OeEca2oC/b4RV+UNPtue5u4jAuA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NPipe": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "8wyYOD6VkvqRkITwsvkt3UbW/1WDl6NFypNAsIIDaMiglNRzFrQcK0nK9VUEZa6Oja8Bso3UYySDoL8qatatAA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Unix": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "x0wNcbww1+p9nUfw8i+JvsSArBDGkoZ9GI2PZ1wPo85B2OiFrdzp89omounNhO2GKyaIRWAqAm5jYZyNg9EnxA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
       },
       "Docker.DotNet.Enhanced.X509": {
         "type": "Transitive",
-        "resolved": "3.131.1",
-        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "resolved": "4.2.0",
+        "contentHash": "nMw+FHGwGZieDi7kBgpIVl+E8MzjzXeXHvMQpidLADT06fts2Gw6G+K+p0hMGv7liZULxyYiZnQ1UbE2B9NNQg==",
         "dependencies": {
-          "Docker.DotNet.Enhanced": "3.131.1"
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
         }
       },
       "EmptyFiles": {
@@ -352,11 +396,11 @@
       },
       "Testcontainers": {
         "type": "Transitive",
-        "resolved": "4.11.0",
-        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "resolved": "4.12.0",
+        "contentHash": "PTZRdG1ZVkFMsFbc3cK/VUaOB5L3l4wYL+OkWAK33/cvgd/5FcmZlQ6NhMAl3PWBqYkpdWmeYmQW9U2OIXqtFA==",
         "dependencies": {
-          "Docker.DotNet.Enhanced": "3.131.1",
-          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Docker.DotNet.Enhanced": "4.2.0",
+          "Docker.DotNet.Enhanced.X509": "4.2.0",
           "SSH.NET": "2025.1.0",
           "SharpZipLib": "1.4.2"
         }
@@ -435,6 +479,16 @@
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
       },
       "granit.authorization": {
         "type": "Project",
@@ -576,6 +630,7 @@
       "granit.identity.local.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -509,6 +509,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -640,6 +652,7 @@
       "granit.identity.local.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -556,6 +556,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication": {
         "type": "Project",
         "dependencies": {
@@ -720,6 +730,7 @@
       "granit.openiddict.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -73,10 +73,10 @@
       "Testcontainers.PostgreSql": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.11.0",
-        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "resolved": "4.12.0",
+        "contentHash": "LZcQu4vfcYuzzy2ENOb7giFb6WNztEEJbufsm7kGiQxjallVuzkWxrBL8LwnjlXGW939pgEZFstL5cO0R2XrBQ==",
         "dependencies": {
-          "Testcontainers": "4.11.0"
+          "Testcontainers": "4.12.0"
         }
       },
       "xunit.runner.visualstudio": {
@@ -128,15 +128,59 @@
       },
       "Docker.DotNet.Enhanced": {
         "type": "Transitive",
-        "resolved": "3.131.1",
-        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg=="
+        "resolved": "4.2.0",
+        "contentHash": "tm2V/DpnaURbBhMQ7Z3orNR3u+H863KQuYfA/sgGjI5py07dEeV0I02f6pGrx2869KG9uNM/E96puf9i0gId2w==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.NPipe": "4.2.0",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.Unix": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Handler.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "cQNxpdadEPdNdfjFCl9vgoCQIK3aVHRn1Qlu36aZUFpp4xHfPrk4hRPNVLR/CpobIFJ+dAt8AceTKMlCfPSccw=="
+      },
+      "Docker.DotNet.Enhanced.LegacyHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "sfbMX1HBPUec3PEMoqlP5ak6skXclcTBmu4gG3aUJatP34J2DgvYMP13bvz/rfrjVkAhPqnIiDKiHAkBCokajg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NativeHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "/ll+2ePYm1qrsMdgMO5BzCQnbfTGmPJAc9SqXEManbliVBZvEpBKHXLugx/OeEca2oC/b4RV+UNPtue5u4jAuA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NPipe": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "8wyYOD6VkvqRkITwsvkt3UbW/1WDl6NFypNAsIIDaMiglNRzFrQcK0nK9VUEZa6Oja8Bso3UYySDoL8qatatAA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Unix": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "x0wNcbww1+p9nUfw8i+JvsSArBDGkoZ9GI2PZ1wPo85B2OiFrdzp89omounNhO2GKyaIRWAqAm5jYZyNg9EnxA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
       },
       "Docker.DotNet.Enhanced.X509": {
         "type": "Transitive",
-        "resolved": "3.131.1",
-        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "resolved": "4.2.0",
+        "contentHash": "nMw+FHGwGZieDi7kBgpIVl+E8MzjzXeXHvMQpidLADT06fts2Gw6G+K+p0hMGv7liZULxyYiZnQ1UbE2B9NNQg==",
         "dependencies": {
-          "Docker.DotNet.Enhanced": "3.131.1"
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
         }
       },
       "EmptyFiles": {
@@ -548,11 +592,11 @@
       },
       "Testcontainers": {
         "type": "Transitive",
-        "resolved": "4.11.0",
-        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "resolved": "4.12.0",
+        "contentHash": "PTZRdG1ZVkFMsFbc3cK/VUaOB5L3l4wYL+OkWAK33/cvgd/5FcmZlQ6NhMAl3PWBqYkpdWmeYmQW9U2OIXqtFA==",
         "dependencies": {
-          "Docker.DotNet.Enhanced": "3.131.1",
-          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Docker.DotNet.Enhanced": "4.2.0",
+          "Docker.DotNet.Enhanced.X509": "4.2.0",
           "SSH.NET": "2025.1.0",
           "SharpZipLib": "1.4.2"
         }
@@ -631,6 +675,16 @@
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
       },
       "granit.authentication": {
         "type": "Project",
@@ -782,6 +836,7 @@
       "granit.identity.local.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
@@ -828,6 +883,7 @@
       "granit.openiddict.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

- The EF Core change-tracking interceptor only audits entity mutations, so logins/logouts/token issuance left no trail — Showcase's "Journaux d'audit" stayed empty even after signing in.
- Adds `AuthenticationAuditEntry.Create{Success,Failure}` helper in `Granit.Auditing` and wires `IAuditingWriter` into every credential-verification and session-revocation site.
- Apps without auditing persistence are unaffected: writer is resolved via `GetService<IAuditingWriter>()` (nullable) and writes are wrapped in try/catch — audit-store outages never break authentication.

## Sites covered

| Layer | Method (audit `Method` field) | Sites |
| --- | --- | --- |
| BFF | `bff_session` / `bff_logout` / `bff_backchannel_logout` | callback success + 6 failure branches; logout success; back-channel logout success + 2 failures |
| OpenIddict | `authorization_code` / `refresh_token` / `oidc_logout` | token issuance success + 2 failures; end-session success |
| Identity.Local | `password` / `totp` / `recovery_code` | login success + 4 failures (user-not-found, locked-out, not-allowed, invalid-credentials); 2FA success + 2 failures |
| External login | `external:google` / `external:microsoft` / … | callback success + 3 failures |
| Passkey (WebAuthn) | `passkey` | assertion success + 2 failures (invalid token, user-not-found) |

## Design notes

- **No duplicate logs** but **3 entries** per BFF login chain (`password` → `authorization_code` → `bff_session`) — each captures a distinct event in the auth chain. `CorrelationId` (W3C trace id) lets the UI group them; `Method` differentiates query intent ("who entered a password" vs. "whose token was refreshed").
- Synthetic `EntityType = "Authentication"` matches the precedent set by `AuditingHostImpersonationAuditWriter` (`EntityType = "HostImpersonation"`).
- `AuditCategory.PrivilegedAccess` for success (ISO 27001 A.12.4.3), `AuditCategory.AccessDenied` for failure (A.12.4.1). Both default to ~7-year retention.
- `Granit.Auditing` is now a direct dep of the 3 endpoint packages with `[DependsOn(GranitAuditingModule)]` declared.

## Test plan

- [x] `dotnet test tests/Granit.Auditing.Tests` — 103 passed (12 new tests for `AuthenticationAuditEntry`)
- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests` — 113 passed
- [x] `dotnet test tests/Granit.OpenIddict.Endpoints.Tests` — 70 passed
- [x] `dotnet test tests/Granit.Identity.Local.Endpoints.Tests` — 145 passed
- [x] `dotnet test tests/Granit.ArchitectureTests` — 182 passed (validates new `[DependsOn]` declarations)
- [x] `dotnet format --verify-no-changes` clean on all 4 modified projects
- [x] `dotnet build .github/shard-filters/{security,api-data,architecture}.slnf` — 0 warnings, 0 errors
- [ ] Manual: log in on Showcase, verify a `PrivilegedAccess` row appears in `audit_log_log_entries` with `EntityType=Authentication` and `Method=password`.