### PR TITLE
refactor(api-keys): rename table to {prefix}entries

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -30521,7 +30521,7 @@
       "kind": "class",
       "project": "Granit.Observability",
       "file": "src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitObservability",

--- a/src/Granit.Authentication.ApiKeys.BackgroundJobs/Services/ExpiringApiKeyScannerService.cs
+++ b/src/Granit.Authentication.ApiKeys.BackgroundJobs/Services/ExpiringApiKeyScannerService.cs
@@ -21,7 +21,7 @@ namespace Granit.Authentication.ApiKeys.BackgroundJobs.Services;
 /// request. Scheduling a "wake up at <c>ExpiresAt - 14 days</c>" timer per key would
 /// be possible but heavier than a daily query that scans only non-revoked keys with
 /// <c>ExpiresAt</c> set. The composite index
-/// <c>ix_*_api_keys_expiring_scan</c> keeps this O(matching keys).
+/// <c>ix_*_entries_expiring_scan</c> keeps this O(matching keys).
 /// </para>
 /// <para>
 /// <b>Order of operations.</b> The Eto is published <em>before</em> the timestamp

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
@@ -14,7 +14,7 @@ internal sealed class ApiKeyEntryConfiguration : IEntityTypeConfiguration<ApiKey
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.ToTable(
-            GranitApiKeysDbProperties.DbTablePrefix + "api_keys",
+            GranitApiKeysDbProperties.DbTablePrefix + "entries",
             GranitApiKeysDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
@@ -22,18 +22,18 @@ internal sealed class ApiKeyEntryConfiguration : IEntityTypeConfiguration<ApiKey
         // Unique index on HashedKey for O(1) lookups
         builder.HasIndex(e => e.HashedKey)
             .IsUnique()
-            .HasDatabaseName($"uq_{GranitApiKeysDbProperties.DbTablePrefix}api_keys_hashed_key");
+            .HasDatabaseName($"uq_{GranitApiKeysDbProperties.DbTablePrefix}entries_hashed_key");
 
         // Index on TenantId for multi-tenant queries
         builder.HasIndex(e => e.TenantId)
-            .HasDatabaseName($"ix_{GranitApiKeysDbProperties.DbTablePrefix}api_keys_tenant_id");
+            .HasDatabaseName($"ix_{GranitApiKeysDbProperties.DbTablePrefix}entries_tenant_id");
 
         // Composite index supporting the daily "expiring soon" scanner —
         // covers the (RevokedAt IS NULL, ExpiresAt within window, LastExpirationNotifiedAt < dedupeBefore)
         // predicate. Order: ExpiresAt first to enable range seek, then LastExpirationNotifiedAt
         // for dedupe filtering, finally RevokedAt as the cheapest equality filter.
         builder.HasIndex(e => new { e.ExpiresAt, e.LastExpirationNotifiedAt, e.RevokedAt })
-            .HasDatabaseName($"ix_{GranitApiKeysDbProperties.DbTablePrefix}api_keys_expiring_scan");
+            .HasDatabaseName($"ix_{GranitApiKeysDbProperties.DbTablePrefix}entries_expiring_scan");
 
         builder.Property(e => e.Name).HasMaxLength(200).IsRequired();
         builder.Property(e => e.HashedKey).HasMaxLength(64).IsRequired(); // SHA-256 hex = 64 chars


### PR DESCRIPTION
## Summary

- The `ApiKeyEntry` aggregate was mapped to `{DbTablePrefix}api_keys`, producing the awkward default `api_keys_api_keys`.
- Renaming the entity table segment to `entries` yields the canonical `api_keys_entries` while keeping the module's `api_keys_` prefix (in line with the snake_case lowercase convention shared by every other Granit module).
- Indexes renamed in cascade: `uq_*_entries_hashed_key`, `ix_*_entries_tenant_id`, `ix_*_entries_expiring_scan`.

## Why not change `DbTablePrefix` to `authentication_`?

- `Granit.Authentication.*` hosts 7+ sub-modules (`DPoP`, `JwtBearer.*`, `OpenIddict`). A shared `authentication_` prefix would force them all into the same naming space and risk collisions if any of them ever persists state.
- Granit's convention is one `DbTablePrefix` per persisted module, not per module family.

## Notes

- Pre-1.0: clean break, no migration shim. Consumers that customized `GranitApiKeysDbProperties.DbTablePrefix` are unaffected (only the suffix changes).
- `ExpiringApiKeyScannerService` XML doc updated to reference the new composite index name (no behavior change).

## Test plan

- [x] `dotnet build src/Granit.Authentication.ApiKeys.EntityFrameworkCore` — clean.
- [x] `dotnet build src/Granit.Authentication.ApiKeys.BackgroundJobs` — clean.
- [x] `dotnet build tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests` — clean.
- [x] EF Core tests pass (35/35).
- [ ] CI shards green.