### PR TITLE
fix(observability): defer OTLP exporter when host owns UseOtlpExporter

### DIFF
--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using Granit.Observability.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -98,33 +97,42 @@ public static class ObservabilityServiceCollectionExtensions
         });
     }
 
+    // OpenTelemetry SDK 1.9+ enforces mutual exclusion at TracerProvider/MeterProvider
+    // build time: a service collection may carry either a single cross-cutting
+    // UseOtlpExporter() registration OR per-signal AddOtlpExporter() registrations,
+    // but not both (NotSupportedException is thrown otherwise). UseOtlpExporter()
+    // marks its presence by registering this singleton — we probe for it by full
+    // type name because the type itself is internal to the SDK.
+    private const string UseOtlpExporterMarkerTypeFullName =
+        "OpenTelemetry.Exporter.UseOtlpExporterRegistration";
+
     private static void ConfigureOpenTelemetry(IHostApplicationBuilder builder, ObservabilityOptions options)
     {
-        // When OTEL_EXPORTER_OTLP_ENDPOINT is set (injected by .NET Aspire, picked up by
-        // ServiceDefaults.UseOtlpExporter()), mixing signal-specific AddOtlpExporter() on the
-        // same IServiceCollection is forbidden by OpenTelemetry SDK 1.9+.
-        // Skip the Granit-specific OTLP exporters — the cross-cutting one covers all signals.
-        bool crossCuttingOtlpActive = !string.IsNullOrWhiteSpace(
-            builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+        // Detect whether the host (e.g. .NET Aspire's ServiceDefaults) has already wired
+        // OpenTelemetry's cross-cutting UseOtlpExporter(). If so, Granit must defer
+        // entirely: registering per-signal AddOtlpExporter() in addition would trip the
+        // SDK's mutual-exclusion guard at TracerProvider build time.
+        //
+        // This relies on call ordering: AddServiceDefaults() (or any host UseOtlpExporter())
+        // MUST run before AddGranitObservability(). The microservice-template enforces
+        // this in SharedHostingExtensions.AddSharedHostingAsync.
+        //
+        // When no host registration is present, Granit owns OTLP — covering vanilla
+        // k8s/Docker/shell setups that rely on OTEL_EXPORTER_OTLP_ENDPOINT (picked up
+        // by ApplyFallbacks → options.OtlpEndpoint) without an Aspire-style host call.
+        bool deferOtlpToHost = builder.Services.Any(d =>
+            d.ServiceType.FullName == UseOtlpExporterMarkerTypeFullName);
 
-        OpenTelemetry.IOpenTelemetryBuilder otelBuilder = builder.Services.AddOpenTelemetry()
+        builder.Services.AddOpenTelemetry()
             .ConfigureResource(r => r.AddService(
                 serviceName: options.ServiceName,
                 serviceVersion: options.ServiceVersion,
                 serviceNamespace: options.ServiceNamespace))
-            .WithTracing(tracing => ConfigureTracing(tracing, options, crossCuttingOtlpActive))
-            .WithMetrics(metrics => ConfigureMetrics(metrics, options, crossCuttingOtlpActive));
-
-        // When OTEL_EXPORTER_OTLP_ENDPOINT is set (e.g. by .NET Aspire), use the
-        // cross-cutting UseOtlpExporter() which exports all signals (traces, metrics,
-        // logs) in a single call — avoiding the SDK 1.9+ conflict with per-signal exporters.
-        if (crossCuttingOtlpActive)
-        {
-            otelBuilder.UseOtlpExporter();
-        }
+            .WithTracing(tracing => ConfigureTracing(tracing, options, deferOtlpToHost))
+            .WithMetrics(metrics => ConfigureMetrics(metrics, options, deferOtlpToHost));
     }
 
-    private static void ConfigureTracing(TracerProviderBuilder tracing, ObservabilityOptions options, bool crossCuttingOtlpActive)
+    private static void ConfigureTracing(TracerProviderBuilder tracing, ObservabilityOptions options, bool deferOtlpToHost)
     {
         if (!options.EnableTracing)
         {
@@ -161,13 +169,13 @@ public static class ObservabilityServiceCollectionExtensions
             contributor(tracing);
         }
 
-        if (!crossCuttingOtlpActive)
+        if (!deferOtlpToHost)
         {
             tracing.AddOtlpExporter(otlp => otlp.Endpoint = new Uri(options.OtlpEndpoint));
         }
     }
 
-    private static void ConfigureMetrics(MeterProviderBuilder metrics, ObservabilityOptions options, bool crossCuttingOtlpActive)
+    private static void ConfigureMetrics(MeterProviderBuilder metrics, ObservabilityOptions options, bool deferOtlpToHost)
     {
         if (!options.EnableMetrics)
         {
@@ -185,7 +193,7 @@ public static class ObservabilityServiceCollectionExtensions
             contributor(metrics);
         }
 
-        if (!crossCuttingOtlpActive)
+        if (!deferOtlpToHost)
         {
             metrics.AddOtlpExporter(otlp => otlp.Endpoint = new Uri(options.OtlpEndpoint));
         }

--- a/tests/Granit.Observability.Tests/ObservabilityServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Observability.Tests/ObservabilityServiceCollectionExtensionsTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Shouldly;
@@ -359,9 +360,9 @@ public sealed class ObservabilityServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddGranitObservability_CrossCuttingOtlpActive_DoesNotThrow()
+    public void AddGranitObservability_DeferOtlpToHost_DoesNotThrow()
     {
-        // Arrange — set the env var that triggers the cross-cutting OTLP path
+        // Arrange — OTEL_EXPORTER_OTLP_ENDPOINT signals the host owns OTLP exporter setup
         HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
         builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://aspire-otel:4317";
         builder.Configuration["Observability:EnableTracing"] = "true";
@@ -377,7 +378,7 @@ public sealed class ObservabilityServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddGranitObservability_CrossCuttingOtlpActive_StillRegistersOptions()
+    public void AddGranitObservability_DeferOtlpToHost_StillRegistersOptions()
     {
         // Arrange
         HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
@@ -392,6 +393,62 @@ public sealed class ObservabilityServiceCollectionExtensionsTests
         // Assert
         ObservabilityOptions options = sp.GetRequiredService<IOptions<ObservabilityOptions>>().Value;
         options.ServiceName.ShouldBe("aspire-service");
+    }
+
+    /// <summary>
+    /// Regression: when the host (e.g. .NET Aspire's ServiceDefaults) calls
+    /// <c>UseOtlpExporter()</c> on the OpenTelemetry builder before Granit, the
+    /// resulting <see cref="TracerProvider"/>/<see cref="MeterProvider"/> must
+    /// build without throwing. OpenTelemetry SDK 1.9+ throws
+    /// <see cref="NotSupportedException"/> at build time when either
+    /// <c>UseOtlpExporter()</c> is registered twice or it is mixed with
+    /// per-signal <c>AddOtlpExporter()</c>. Granit detects the host registration
+    /// and defers entirely.
+    /// </summary>
+    [Fact]
+    public void AddGranitObservability_HostAlreadyCalledUseOtlpExporter_BuildsProviders()
+    {
+        // Arrange — mimic .NET Aspire ServiceDefaults: host wires UseOtlpExporter()
+        // (typically called via AddServiceDefaults) BEFORE Granit is added.
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+        builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://aspire-otel:4317";
+
+        builder.Services.AddOpenTelemetry().UseOtlpExporter();
+
+        // Act — Granit must NOT register a second UseOtlpExporter() nor per-signal exporters
+        Should.NotThrow(() => builder.AddGranitObservability());
+
+        // Assert — provider construction must succeed (this is where the SDK
+        // mutual-exclusion guard fires if Granit got it wrong)
+        using ServiceProvider sp = builder.Services.BuildServiceProvider();
+        Should.NotThrow(() => sp.GetService<TracerProvider>().ShouldNotBeNull());
+        Should.NotThrow(() => sp.GetService<MeterProvider>().ShouldNotBeNull());
+    }
+
+    /// <summary>
+    /// k8s/Docker scenario: <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is injected by the
+    /// orchestrator but there is no Aspire-style host call to <c>UseOtlpExporter()</c>.
+    /// Granit must own the OTLP exporter registration so telemetry actually flows
+    /// to the configured endpoint.
+    /// </summary>
+    [Fact]
+    public void AddGranitObservability_EnvVarSetButNoHostUseOtlpExporter_BuildsProviders()
+    {
+        // Arrange — env var set, no host registration
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+        builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://otel-collector:4317";
+
+        // Act
+        Should.NotThrow(() => builder.AddGranitObservability());
+
+        // Assert — providers build (Granit's per-signal AddOtlpExporter() runs, no mutex error),
+        // and the env-var endpoint flowed through ApplyFallbacks into the resolved options.
+        using ServiceProvider sp = builder.Services.BuildServiceProvider();
+        Should.NotThrow(() => sp.GetService<TracerProvider>().ShouldNotBeNull());
+        Should.NotThrow(() => sp.GetService<MeterProvider>().ShouldNotBeNull());
+
+        ObservabilityOptions options = sp.GetRequiredService<IOptions<ObservabilityOptions>>().Value;
+        options.OtlpEndpoint.ShouldBe("http://otel-collector:4317");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Replace the env-var heuristic with a direct probe of the SDK marker `OpenTelemetry.Exporter.UseOtlpExporterRegistration` in `IServiceCollection`. When the host (e.g. .NET Aspire's `ServiceDefaults`) has already called `UseOtlpExporter()`, Granit defers entirely; otherwise Granit owns OTLP via per-signal `AddOtlpExporter()` with the resolved endpoint.
- Covers Aspire, vanilla k8s/Docker with `OTEL_EXPORTER_OTLP_ENDPOINT` injected (no host call), and local dev — without regression in any path.
- Adds two regression tests for the Aspire and k8s scenarios.

## The bug

OpenTelemetry SDK 1.9+ throws `NotSupportedException` at `TracerProvider`/`MeterProvider` build time when the service collection carries either:

- two `UseOtlpExporter()` registrations, or
- a `UseOtlpExporter()` mixed with per-signal `AddOtlpExporter()`.

`Granit.Observability.AddGranitObservability()` previously called `UseOtlpExporter()` whenever `OTEL_EXPORTER_OTLP_ENDPOINT` was set, which collides with `ServiceDefaults.ConfigureOpenTelemetry()` doing the same thing on the same env-var signal in Aspire-hosted microservices → startup crash.

## Why probe the SDK marker

The env-var-based heuristic was too coarse:

| Scenario | Env var | Host call | Before this PR | After this PR |
| --- | --- | --- | --- | --- |
| Aspire ServiceDefaults | ✅ | ✅ | 💥 crash | ✅ defers to host |
| k8s/Docker (raw OTel env var) | ✅ | ❌ | ✅ (via Granit `UseOtlpExporter()`) | ✅ per-signal `AddOtlpExporter()` |
| Local dev | ❌ | ❌ | ✅ | ✅ |

The SDK registers `OpenTelemetry.Exporter.UseOtlpExporterRegistration` as a singleton inside `IServiceCollection`. Probing for it by full type name (the type is `internal sealed`) gives an unambiguous answer at the moment `AddGranitObservability()` runs.

## Call-order convention

`AddServiceDefaults()` (or any host-side `UseOtlpExporter()`) MUST run before `AddGranitObservability()`. The microservice-template already respects this order in `SharedHostingExtensions.AddSharedHostingAsync` (l.20).

## Downstream impact

Consumed via floating NuGet `0.1.0-dev.*`. Once a `0.1.0-dev.*` shipping this fix is published, the `granit-microservice-template` workaround in [`GranitMicroservice.ServiceDefaults/Extensions.cs`](https://github.com/granit-fx/granit-microservice-template) (removal of `UseOtlpExporter()` from its ServiceDefaults) can be reverted — Granit now plays nicely with the Aspire-recommended pattern.

## Test plan

- [x] `dotnet build src/Granit.Observability/Granit.Observability.csproj` — clean
- [x] `dotnet build tests/Granit.Observability.Tests/Granit.Observability.Tests.csproj` — clean
- [x] `dotnet format` — no changes
- [x] `Granit.Observability.Tests` — 35/35 passing (2 new regression tests)
- [ ] CI green on `core-ai` shard