### PR TITLE
fix(ai): align with architecture conventions (exception folder + encrypt-at-rest)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2822,6 +2822,22 @@
       "members": []
     },
     {
+      "name": "AIProviderCredentialNotConfiguredException",
+      "fqn": "Granit.AI.Exceptions.AIProviderCredentialNotConfiguredException",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Exceptions/AIProviderCredentialNotConfiguredException.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AIProviderCredentialNotConfiguredException",
+          "kind": "method",
+          "signature": "AIProviderCredentialNotConfiguredException(string providerName, string workspaceName, Guid? tenantId)",
+          "returnType": "string ProviderName { get; } public string WorkspaceName { get; } public Guid? TenantId { get; } public"
+        }
+      ]
+    },
+    {
       "name": "AIProviderNotRegisteredException",
       "fqn": "Granit.AI.Exceptions.AIProviderNotRegisteredException",
       "kind": "class",
@@ -3572,22 +3588,6 @@
       "members": []
     },
     {
-      "name": "AIProviderCredentialNotConfiguredException",
-      "fqn": "Granit.AI.Tenancy.AIProviderCredentialNotConfiguredException",
-      "kind": "class",
-      "project": "Granit.AI",
-      "file": "src/Granit.AI/Tenancy/AIProviderCredentialNotConfiguredException.cs",
-      "line": 7,
-      "members": [
-        {
-          "name": "AIProviderCredentialNotConfiguredException",
-          "kind": "method",
-          "signature": "AIProviderCredentialNotConfiguredException(string providerName, string workspaceName, Guid? tenantId)",
-          "returnType": "string ProviderName { get; } public string WorkspaceName { get; } public Guid? TenantId { get; } public"
-        }
-      ]
-    },
-    {
       "name": "AIProviderCredentialScope",
       "fqn": "Granit.AI.Tenancy.AIProviderCredentialScope",
       "kind": "enum",
@@ -3654,7 +3654,7 @@
       "kind": "interface",
       "project": "Granit.AI",
       "file": "src/Granit.AI/Tenancy/IAIProviderCredentialResolver.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "ResolveAsync",

--- a/src/Granit.AI.Anthropic/Internal/AnthropicCredentialResolver.cs
+++ b/src/Granit.AI.Anthropic/Internal/AnthropicCredentialResolver.cs
@@ -1,4 +1,5 @@
 using Granit.AI.Anthropic.Options;
+using Granit.AI.Exceptions;
 using Granit.AI.Tenancy;
 using Granit.AI.Workspaces;
 using Granit.Settings.Definitions;

--- a/src/Granit.AI.Anthropic/Internal/AnthropicProviderFactory.cs
+++ b/src/Granit.AI.Anthropic/Internal/AnthropicProviderFactory.cs
@@ -1,5 +1,6 @@
 using Anthropic;
 using Granit.AI.Anthropic.Options;
+using Granit.AI.Exceptions;
 using Granit.AI.Tenancy;
 using Granit.AI.Workspaces;
 using Microsoft.Extensions.AI;

--- a/src/Granit.AI.AzureOpenAI/Internal/AzureOpenAICredentialResolver.cs
+++ b/src/Granit.AI.AzureOpenAI/Internal/AzureOpenAICredentialResolver.cs
@@ -1,4 +1,5 @@
 using Granit.AI.AzureOpenAI.Options;
+using Granit.AI.Exceptions;
 using Granit.AI.Tenancy;
 using Granit.AI.Workspaces;
 using Granit.Settings.Definitions;

--- a/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
@@ -41,9 +41,11 @@ internal sealed class AIWorkspaceEntity : AuditedEntity, IActive, IMultiTenant, 
     public string? ApiKey { get; set; }
 
     /// <summary>
-    /// Workspace-scoped endpoint override (URL). Not encrypted (URL, not a secret) but masked
-    /// in audit/log/MCP output. Mirrors <see cref="AIWorkspace.Endpoint"/>.
+    /// Workspace-scoped endpoint override (URL). Encrypted at rest because a tenant-managed URL
+    /// can leak topology or internal hostnames; masked in audit/log/MCP output. Mirrors
+    /// <see cref="AIWorkspace.Endpoint"/>.
     /// </summary>
+    [Encrypted]
     [SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
     public string? Endpoint { get; set; }
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
@@ -44,9 +44,9 @@ internal sealed class AIWorkspaceEntityConfiguration : IEntityTypeConfiguration<
             .IsRequired()
             .HasDefaultValue(true);
 
-        // Workspace-scoped credentials (see AIWorkspaceEntity). ApiKey is encrypted via the
-        // [Encrypted] convention applied by ApplyEncryptionConventions in the host's DbContext;
-        // we only set the max length here. Endpoint is a URL — not encrypted.
+        // Workspace-scoped credentials (see AIWorkspaceEntity). Both ApiKey and Endpoint carry
+        // [Encrypted] — the value converter is applied by ApplyEncryptionConventions in the host's
+        // DbContext; we only set the max length here.
         builder.Property(e => e.ApiKey)
             .HasMaxLength(2_000);
 

--- a/src/Granit.AI.Ollama/Internal/OllamaCredentialResolver.cs
+++ b/src/Granit.AI.Ollama/Internal/OllamaCredentialResolver.cs
@@ -1,3 +1,4 @@
+using Granit.AI.Exceptions;
 using Granit.AI.Ollama.Options;
 using Granit.AI.Tenancy;
 using Granit.AI.Workspaces;

--- a/src/Granit.AI.OpenAI/Internal/OpenAICredentialResolver.cs
+++ b/src/Granit.AI.OpenAI/Internal/OpenAICredentialResolver.cs
@@ -1,3 +1,4 @@
+using Granit.AI.Exceptions;
 using Granit.AI.OpenAI.Options;
 using Granit.AI.Tenancy;
 using Granit.AI.Workspaces;

--- a/src/Granit.AI/Exceptions/AIProviderCredentialNotConfiguredException.cs
+++ b/src/Granit.AI/Exceptions/AIProviderCredentialNotConfiguredException.cs
@@ -1,4 +1,6 @@
-namespace Granit.AI.Tenancy;
+using Granit.AI.Tenancy;
+
+namespace Granit.AI.Exceptions;
 
 /// <summary>
 /// Raised when <see cref="IAIProviderCredentialResolver.ResolveAsync"/> cannot find a credential

--- a/src/Granit.AI/Tenancy/IAIProviderCredentialResolver.cs
+++ b/src/Granit.AI/Tenancy/IAIProviderCredentialResolver.cs
@@ -1,3 +1,4 @@
+using Granit.AI.Exceptions;
 using Granit.AI.Workspaces;
 
 namespace Granit.AI.Tenancy;

--- a/tests/Granit.AI.Anthropic.Tests/AnthropicProviderFactoryTests.cs
+++ b/tests/Granit.AI.Anthropic.Tests/AnthropicProviderFactoryTests.cs
@@ -1,5 +1,6 @@
 using Granit.AI.Anthropic.Internal;
 using Granit.AI.Anthropic.Options;
+using Granit.AI.Exceptions;
 using Granit.AI.Tenancy;
 using Granit.AI.Workspaces;
 using Microsoft.Extensions.AI;

--- a/tests/Granit.AI.AzureOpenAI.Tests/AzureOpenAIProviderFactoryTests.cs
+++ b/tests/Granit.AI.AzureOpenAI.Tests/AzureOpenAIProviderFactoryTests.cs
@@ -1,5 +1,6 @@
 using Granit.AI.AzureOpenAI.Internal;
 using Granit.AI.AzureOpenAI.Options;
+using Granit.AI.Exceptions;
 using Granit.AI.Tenancy;
 using Granit.AI.Workspaces;
 using Microsoft.Extensions.AI;

--- a/tests/Granit.AI.Ollama.Tests/OllamaProviderFactoryTests.cs
+++ b/tests/Granit.AI.Ollama.Tests/OllamaProviderFactoryTests.cs
@@ -1,3 +1,4 @@
+using Granit.AI.Exceptions;
 using Granit.AI.Ollama.Internal;
 using Granit.AI.Ollama.Options;
 using Granit.AI.Tenancy;

--- a/tests/Granit.AI.OpenAI.Tests/OpenAIProviderFactoryTests.cs
+++ b/tests/Granit.AI.OpenAI.Tests/OpenAIProviderFactoryTests.cs
@@ -1,3 +1,4 @@
+using Granit.AI.Exceptions;
 using Granit.AI.OpenAI.Internal;
 using Granit.AI.OpenAI.Options;
 using Granit.AI.Tenancy;


### PR DESCRIPTION
## Summary

Fixes two architecture-test violations introduced by #2159 (per-tenant credential cascade + anti-SSRF) that surfaced on `develop` after merge.

- **`FileOrganizationTests.Exception_classes_should_reside_in_Exceptions_folder`** — `AIProviderCredentialNotConfiguredException.cs` was placed under `Granit.AI/Tenancy/` instead of the conventional `Granit.AI/Exceptions/` folder (where the 3 other AI exceptions already live). The file was moved and its namespace flipped from `Granit.AI.Tenancy` to `Granit.AI.Exceptions`. Every consumer (4 provider resolvers, 1 factory, the `IAIProviderCredentialResolver` interface that owns the `<exception cref>` xmldoc, and 4 provider test classes) now imports the new namespace.
- **`SensitiveDataEncryptionConventionTests.Confidential_string_properties_on_persisted_types_must_be_Encrypted`** — `AIWorkspaceEntity.Endpoint` carried `[SensitiveData(Confidential)]` without `[Encrypted]`. A tenant-managed URL can leak topology / internal hostnames, which is precisely why it was already classified Confidential — so storing it plaintext at rest contradicts the classification. Adding `[Encrypted]` aligns persistence with the convention. The earlier "URL, not a secret" comment on both `AIWorkspaceEntity` and `AIWorkspaceEntityConfiguration` has been updated to reflect the new behaviour.

## Test plan

- [x] `dotnet test .github/shard-filters/architecture.slnf --no-build` — **182/182 green** (was 180/2 on `develop`).
- [x] `dotnet test` on `Granit.AI.Anthropic.Tests`, `Granit.AI.AzureOpenAI.Tests`, `Granit.AI.OpenAI.Tests`, `Granit.AI.Ollama.Tests` — **122/122 green**.
- [x] `dotnet format style` on the affected projects — clean.
- [ ] CI architecture + AI shards green on PR.