### PR TITLE
fix(bff): bind GranitBffOptions once in GranitBffModule

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -9221,7 +9221,7 @@
       "kind": "class",
       "project": "Granit.Bff.Yarp",
       "file": "src/Granit.Bff.Yarp/Extensions/BffYarpHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitBffYarp",

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -32,11 +32,9 @@ public sealed class GranitBffEndpointsModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        // Auto-bind BFF options from the "Bff" configuration section so consumers
-        // don't need to call Configure<GranitBffOptions> manually. Idempotent if
-        // AddGranitBffYarp also binds from the same section.
-        context.Services.Configure<GranitBffOptions>(
-            context.Builder!.Configuration.GetSection(GranitBffOptions.SectionName));
+        // GranitBffOptions binding is owned by GranitBffModule (single source of truth).
+        // Re-binding here would duplicate List<T> properties (e.g. Frontends) since
+        // IConfiguration.Bind appends on every call.
 
         context.Services.TryAddScoped<IBffLogoutOrchestrator, DefaultBffLogoutOrchestrator>();
 

--- a/src/Granit.Bff.Yarp/Extensions/BffYarpHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Bff.Yarp/Extensions/BffYarpHostApplicationBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using Granit.Bff.Options;
 using Granit.Bff.Yarp.Internal;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -22,8 +21,9 @@ public static class BffYarpHostApplicationBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Services.Configure<GranitBffOptions>(
-            builder.Configuration.GetSection(GranitBffOptions.SectionName));
+        // GranitBffOptions binding lives in GranitBffModule (single source of truth).
+        // Binding here too would duplicate List<T> properties (e.g. Frontends) since
+        // IConfiguration.Bind appends on every call.
 
         builder.Services
             .AddReverseProxy()

--- a/src/Granit.Bff/GranitBffModule.cs
+++ b/src/Granit.Bff/GranitBffModule.cs
@@ -34,6 +34,14 @@ public sealed class GranitBffModule : GranitModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        // Single binding site for the "Bff" section. Companion packages
+        // (Granit.Bff.Yarp, Granit.Bff.Endpoints) depend on this module and must NOT
+        // re-bind: IConfiguration.Bind appends to List<T> properties on every call,
+        // so a second bind would duplicate Frontends entries and break endpoint
+        // name uniqueness (BffLogin_<name>).
+        context.Services.Configure<GranitBffOptions>(
+            context.Configuration.GetSection(GranitBffOptions.SectionName));
+
         context.Services.TryAddSingleton<IValidateOptions<GranitBffOptions>, GranitBffOptionsValidator>();
         context.Services.TryAddSingleton<BffMetrics>();
         context.Services.TryAddScoped<IBffTokenStore, DistributedCacheBffTokenStore>();

--- a/tests/Granit.Bff.Yarp.Tests/Extensions/BffYarpHostApplicationBuilderExtensionsTests.cs
+++ b/tests/Granit.Bff.Yarp.Tests/Extensions/BffYarpHostApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,55 @@
+using Granit.Bff.Options;
+using Granit.Bff.Yarp.Extensions;
+using Granit.Modularity;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Bff.Yarp.Tests.Extensions;
+
+public sealed class BffYarpHostApplicationBuilderExtensionsTests
+{
+    /// <summary>
+    /// Regression: when both <see cref="GranitBffModule.ConfigureServices"/> (which now owns
+    /// the canonical <c>Bff</c> section binding) and <see cref="BffYarpHostApplicationBuilderExtensions.AddGranitBffYarp"/>
+    /// run against the same host, the <see cref="GranitBffOptions.Frontends"/> list must contain
+    /// exactly one entry per configured frontend — not two.
+    /// </summary>
+    /// <remarks>
+    /// Before the fix, <c>AddGranitBffYarp</c> also called <c>Configure&lt;GranitBffOptions&gt;</c>
+    /// on the same section. <c>IConfiguration.Bind</c> appends to <c>List&lt;T&gt;</c> properties on
+    /// every invocation, so a configured frontend would surface twice — duplicating the routes
+    /// mapped by <c>MapGranitBff</c> and throwing
+    /// <c>InvalidOperationException: Duplicate endpoint name 'BffLogin_&lt;name&gt;'</c> at startup.
+    /// </remarks>
+    [Fact]
+    public void AddGranitBffYarp_CombinedWithBffModule_DoesNotDuplicateFrontends()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Bff:Authority"] = "https://auth.example.com",
+            ["Bff:Frontends:0:Name"] = "admin",
+            ["Bff:Frontends:0:ClientId"] = "admin-client",
+            ["Bff:Frontends:0:ClientSecret"] = "secret",
+            ["ReverseProxy:Routes:r1:ClusterId"] = "c1",
+            ["ReverseProxy:Routes:r1:Match:Path"] = "/{**catch-all}",
+            ["ReverseProxy:Clusters:c1:Destinations:d1:Address"] = "http://backend",
+        });
+
+        // Stand in for the modularity pipeline: GranitBffModule owns the canonical binding.
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        new GranitBffModule().ConfigureServices(context);
+
+        builder.AddGranitBffYarp();
+
+        ServiceProvider provider = builder.Services.BuildServiceProvider();
+        GranitBffOptions options = provider.GetRequiredService<IOptions<GranitBffOptions>>().Value;
+
+        options.Frontends.Count.ShouldBe(1);
+        options.Frontends[0].Name.ShouldBe("admin");
+    }
+}


### PR DESCRIPTION
## Summary

- Move the canonical `Bff` configuration section binding into `GranitBffModule` — the common parent of `GranitBffYarpModule` and `GranitBffEndpointsModule`.
- Drop the duplicate `Configure<GranitBffOptions>` from `AddGranitBffYarp()` and `GranitBffEndpointsModule.ConfigureServices`. Remove the misleading "idempotent" comment.
- Add a regression test in `Granit.Bff.Yarp.Tests` that loads a single `Frontends` entry through both paths and asserts the resolved `IOptions<GranitBffOptions>.Value.Frontends` count is `1`.

## Root cause

`GranitBffOptions` was bound from the `Bff` section in two places: the YARP host-builder extension and the endpoints module. `IConfiguration.Bind` **appends** to `List<T>` properties on every call, so any host using YARP + endpoints together (the standard BFF shape) ended up with each `Frontends` entry duplicated. `MapGranitBff` then tried to map two routes with the same `WithName($"BffLogin_{frontend.Name}")` and threw `InvalidOperationException: Duplicate endpoint name 'BffLogin_<name>'` on the first HTTP hit.

The companion comment in `GranitBffEndpointsModule` claimed the double-bind was idempotent — false for `List<T>` properties.

## Why this approach

`GranitBffModule` is the natural single source of truth: both `GranitBffYarpModule` and `GranitBffEndpointsModule` declare `[DependsOn(typeof(GranitBffModule))]`, so the modularity pipeline always loads it whenever either companion is active. No public signature changes, and both single-side scenarios (YARP-only, endpoints-only) still get the binding.

## Test plan

- [x] `dotnet build .github/shard-filters/api-data.slnf` — clean.
- [x] `dotnet test tests/Granit.Bff.Tests` (166), `tests/Granit.Bff.Yarp.Tests` (32, incl. new regression), `tests/Granit.Bff.Endpoints.Tests` (113) — all green.
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 182 passed.
- [x] `dotnet format --verify-no-changes` on the four modified projects — clean.

## Downstream cleanup

Once this ships on the NuGet feed, the host-side workaround (`PostConfigure<GranitBffOptions>` deduping by `Name`) can be removed.