### PR TITLE
fix(api-doc): whitelist api.scalar.com on CSP connect-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- `Granit.Http.ApiDocumentation` — `ScalarCspContributor` now whitelists `https://api.scalar.com` on `connect-src`. The Scalar Vue.js bootstrap fetches its curated-documents / search registry from `api.scalar.com/vector/registry/*` on mount and on every search, producing two CSP violations in the browser console of every Granit host that exposes Scalar via `UseGranitApiDocumentation()`.
 - `Granit.Authentication.OpenIddict` & `Granit.OpenIddict.Server` — role claims emitted by OpenIddict.Validation under the OIDC short claim type `role` are now normalized to `ClaimTypes.Role`, restoring parity with `Granit.Authentication.JwtBearer`. Without this, `ICurrentUserService.GetRoles()` and the `PermissionChecker.AdminRoles` bypass returned empty even when `ClaimsPrincipal.IsInRole()` matched, causing 403s on permission-protected endpoints for admin-role users on resource servers using OpenIddict validation.
 
 ### Changed (framework)

--- a/src/Granit.Http.ApiDocumentation/Internal/ScalarCspContributor.cs
+++ b/src/Granit.Http.ApiDocumentation/Internal/ScalarCspContributor.cs
@@ -6,8 +6,10 @@ namespace Granit.Http.ApiDocumentation.Internal;
 /// <summary>
 /// Relaxes the Content-Security-Policy on the Scalar interactive API
 /// reference endpoint. The Scalar HTML bootstrap loads its own inline script,
-/// inline styles, and woff2 fonts from <c>https://fonts.scalar.com</c> — all
-/// of which the API-grade default CSP (<c>default-src 'none'</c>) blocks.
+/// inline styles, woff2 fonts from <c>https://fonts.scalar.com</c>, and
+/// fetches its curated-documents / search registry from
+/// <c>https://api.scalar.com</c> — all of which the API-grade default CSP
+/// (<c>default-src 'none'</c>) blocks.
 /// </summary>
 /// <remarks>
 /// Scoped strictly by the presence of <see cref="ScalarApiReferenceMetadata"/>
@@ -29,6 +31,6 @@ internal sealed class ScalarCspContributor : ICspContributor
             .AddStyleSrc("'self'", "'unsafe-inline'")
             .AddFontSrc("'self'", "data:", "https://fonts.scalar.com")
             .AddImgSrc("'self'", "data:", "https:")
-            .AddConnectSrc("'self'");
+            .AddConnectSrc("'self'", "https://api.scalar.com");
     }
 }

--- a/tests/Granit.Http.ApiDocumentation.Tests/ScalarCspContributorTests.cs
+++ b/tests/Granit.Http.ApiDocumentation.Tests/ScalarCspContributorTests.cs
@@ -110,6 +110,8 @@ public sealed class ScalarCspContributorTests
         builder.Directives["font-src"].ShouldContain("data:");
         builder.Directives.ShouldContainKey("img-src");
         builder.Directives.ShouldContainKey("connect-src");
+        builder.Directives["connect-src"].ShouldContain("'self'");
+        builder.Directives["connect-src"].ShouldContain("https://api.scalar.com");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `ScalarCspContributor` now whitelists `https://api.scalar.com` on `connect-src` alongside the existing `'self'`.
- Adds a regression assertion to `ScalarCspContributorTests`.
- CHANGELOG entry under `[Unreleased] / Fixed`.

## Why

Scalar's Vue.js bootstrap calls `https://api.scalar.com/vector/registry/curated` on mount and `https://api.scalar.com/vector/registry/search?query=…` on every search keystroke (curated-documents / registry-search features). With the previous policy (`connect-src 'self'`) every Granit host exposing Scalar via `UseGranitApiDocumentation()` produced two CSP violations in the browser devtools each time `/scalar` rendered. Non-blocking for the OAuth2 / Authorize flow, but noisy for every consumer (showcase, microservice-template, iot-showcase).

Mirrors the pattern already in place for `font-src` + `https://fonts.scalar.com`.

## Test plan

- [x] `dotnet test tests/Granit.Http.ApiDocumentation.Tests/Granit.Http.ApiDocumentation.Tests.csproj --filter "FullyQualifiedName~ScalarCspContributorTests"` (6/6 relevant tests pass — the 7th depends on binding `localhost:5000` and is flaky locally when another dev host already listens there; CI runs in a clean container).
- [x] `dotnet format` clean on touched files.
- [x] `npx markdownlint-cli2 CHANGELOG.md` clean.
- [ ] CI green on the `api-data` shard.
- [ ] Manual: bump to a dev.* package in `iot-showcase-dotnet @ develop` (64bee39) → reload `/scalar` → both violations gone.