### PR TITLE
fix(api-doc): whitelist OAuth2 IdP origin on Scalar CSP connect-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
-- `Granit.Http.ApiDocumentation` — `ScalarCspContributor` now whitelists `https://api.scalar.com` on `connect-src`. The Scalar Vue.js bootstrap fetches its curated-documents / search registry from `api.scalar.com/vector/registry/*` on mount and on every search, producing two CSP violations in the browser console of every Granit host that exposes Scalar via `UseGranitApiDocumentation()`.
+- `Granit.Http.ApiDocumentation` — `ScalarCspContributor` now whitelists `https://api.scalar.com` on `connect-src` (Scalar's Vue.js bootstrap fetches its curated-documents / search registry from `api.scalar.com/vector/registry/*` on mount and on every search keystroke). When `ApiDocumentationOptions.OAuth2` is configured, the contributor also adds the origins (scheme + host + port) of the OAuth2 `AuthorizationUrl` and `TokenUrl` to `connect-src`, allowing Scalar's Authorization Code → Token exchange (browser-side cross-origin POST to the IdP, e.g. `localhost:5000 → localhost:8080`) to complete instead of being blocked by CSP. Without this, the interactive "Authorize" button signed-in state never persisted.
 - `Granit.Authentication.OpenIddict` & `Granit.OpenIddict.Server` — role claims emitted by OpenIddict.Validation under the OIDC short claim type `role` are now normalized to `ClaimTypes.Role`, restoring parity with `Granit.Authentication.JwtBearer`. Without this, `ICurrentUserService.GetRoles()` and the `PermissionChecker.AdminRoles` bypass returned empty even when `ClaimsPrincipal.IsInRole()` matched, causing 403s on permission-protected endpoints for admin-role users on resource servers using OpenIddict validation.
 
 ### Changed (framework)

--- a/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
+++ b/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
@@ -122,7 +122,8 @@ public static partial class ApiDocumentationApplicationBuilderExtensions
             return;
         }
 
-        registry.Add(new ScalarCspContributor());
+        registry.Add(new ScalarCspContributor(
+            app.Services.GetRequiredService<IOptions<ApiDocumentationOptions>>()));
     }
 
     private static void ApplyAuthorizationPolicy(

--- a/src/Granit.Http.ApiDocumentation/Internal/ScalarCspContributor.cs
+++ b/src/Granit.Http.ApiDocumentation/Internal/ScalarCspContributor.cs
@@ -1,5 +1,7 @@
+using Granit.Http.ApiDocumentation.Options;
 using Granit.Http.SecurityHeaders;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Http.ApiDocumentation.Internal;
 
@@ -9,7 +11,11 @@ namespace Granit.Http.ApiDocumentation.Internal;
 /// inline styles, woff2 fonts from <c>https://fonts.scalar.com</c>, and
 /// fetches its curated-documents / search registry from
 /// <c>https://api.scalar.com</c> — all of which the API-grade default CSP
-/// (<c>default-src 'none'</c>) blocks.
+/// (<c>default-src 'none'</c>) blocks. When OAuth2 is configured, the
+/// origins (scheme + host + port) of the authorization and token endpoints
+/// are added to <c>connect-src</c> so the Authorization Code → Token
+/// exchange (cross-origin XHR/fetch from the Scalar SPA to the IdP) is
+/// not blocked.
 /// </summary>
 /// <remarks>
 /// Scoped strictly by the presence of <see cref="ScalarApiReferenceMetadata"/>
@@ -17,8 +23,10 @@ namespace Granit.Http.ApiDocumentation.Internal;
 /// contributor is registered by <c>UseGranitApiDocumentation</c> only when
 /// the dev/prod gate decides Scalar will actually be mapped.
 /// </remarks>
-internal sealed class ScalarCspContributor : ICspContributor
+internal sealed class ScalarCspContributor(IOptions<ApiDocumentationOptions> options) : ICspContributor
 {
+    private readonly ApiDocumentationOptions _options = options.Value;
+
     public void Contribute(HttpContext context, CspBuilder builder)
     {
         if (context.GetEndpoint()?.Metadata.GetMetadata<ScalarApiReferenceMetadata>() is null)
@@ -26,11 +34,24 @@ internal sealed class ScalarCspContributor : ICspContributor
             return;
         }
 
+        List<string> connectSources = ["'self'", "https://api.scalar.com"];
+        AddOrigin(connectSources, _options.OAuth2.AuthorizationUrl);
+        AddOrigin(connectSources, _options.OAuth2.TokenUrl);
+
         builder
             .AddScriptSrc("'self'", "'unsafe-inline'")
             .AddStyleSrc("'self'", "'unsafe-inline'")
             .AddFontSrc("'self'", "data:", "https://fonts.scalar.com")
             .AddImgSrc("'self'", "data:", "https:")
-            .AddConnectSrc("'self'", "https://api.scalar.com");
+            .AddConnectSrc([.. connectSources.Distinct()]);
+    }
+
+    private static void AddOrigin(List<string> list, string? url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+        {
+            list.Add($"{uri.Scheme}://{uri.Authority}");
+        }
     }
 }

--- a/tests/Granit.Http.ApiDocumentation.Tests/ScalarCspContributorTests.cs
+++ b/tests/Granit.Http.ApiDocumentation.Tests/ScalarCspContributorTests.cs
@@ -8,6 +8,7 @@
 
 using Granit.Http.ApiDocumentation.Extensions;
 using Granit.Http.ApiDocumentation.Internal;
+using Granit.Http.ApiDocumentation.Options;
 using Granit.Http.SecurityHeaders;
 using Granit.Http.SecurityHeaders.Extensions;
 using Microsoft.AspNetCore.Builder;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Xunit;
+using MEOptions = Microsoft.Extensions.Options.Options;
 
 namespace Granit.Http.ApiDocumentation.Tests;
 
@@ -89,16 +91,10 @@ public sealed class ScalarCspContributorTests
     [Fact]
     public void ScalarCspContributor_OnScalarMarkedEndpoint_RelaxesCsp()
     {
-        ScalarCspContributor contributor = new();
+        ScalarCspContributor contributor = BuildContributor();
         CspBuilder builder = new();
 
-        DefaultHttpContext ctx = new();
-        ctx.SetEndpoint(new Endpoint(
-            static _ => Task.CompletedTask,
-            new EndpointMetadataCollection(new ScalarApiReferenceMetadata()),
-            "scalar"));
-
-        contributor.Contribute(ctx, builder);
+        contributor.Contribute(BuildScalarContext(), builder);
 
         builder.Directives.ShouldContainKey("script-src");
         builder.Directives["script-src"].ShouldContain("'self'");
@@ -115,9 +111,78 @@ public sealed class ScalarCspContributorTests
     }
 
     [Fact]
+    public void ScalarCspContributor_WithoutOAuth2_OnlyExposesScalarRegistryOrigin()
+    {
+        // OAuth2 left at defaults (both URLs null) → AddOrigin skipped silently
+        ScalarCspContributor contributor = BuildContributor();
+        CspBuilder builder = new();
+
+        contributor.Contribute(BuildScalarContext(), builder);
+
+        builder.Directives["connect-src"].ShouldBe(["'self'", "https://api.scalar.com"]);
+    }
+
+    [Fact]
+    public void ScalarCspContributor_WithOAuth2KeycloakStyle_AddsSharedOriginOnce()
+    {
+        // Realistic Keycloak: auth and token endpoints share the same authority
+        ScalarCspContributor contributor = BuildContributor(new OAuth2Options
+        {
+            AuthorizationUrl = "http://localhost:8080/realms/iot-showcase/protocol/openid-connect/auth",
+            TokenUrl = "http://localhost:8080/realms/iot-showcase/protocol/openid-connect/token",
+            ClientId = "iot-showcase-scalar",
+        });
+        CspBuilder builder = new();
+
+        contributor.Contribute(BuildScalarContext(), builder);
+
+        IReadOnlyCollection<string> connect = builder.Directives["connect-src"];
+        connect.ShouldContain("http://localhost:8080");
+        connect.Count(o => o == "http://localhost:8080").ShouldBe(1, "Distinct() must dedupe the shared IdP origin");
+        connect.ShouldBe(["'self'", "https://api.scalar.com", "http://localhost:8080"]);
+    }
+
+    [Fact]
+    public void ScalarCspContributor_WithOAuth2DistinctAuthAndTokenHosts_AddsBothOrigins()
+    {
+        // Split-host IdP setup (auth UI on 8080, token endpoint on 8081)
+        ScalarCspContributor contributor = BuildContributor(new OAuth2Options
+        {
+            AuthorizationUrl = "http://localhost:8080/auth",
+            TokenUrl = "http://localhost:8081/token",
+            ClientId = "scalar",
+        });
+        CspBuilder builder = new();
+
+        contributor.Contribute(BuildScalarContext(), builder);
+
+        builder.Directives["connect-src"].ShouldContain("http://localhost:8080");
+        builder.Directives["connect-src"].ShouldContain("http://localhost:8081");
+    }
+
+    [Theory]
+    [InlineData("not a url")]                  // not absolute → TryCreate fails
+    [InlineData("/relative/path/only")]        // absolute-path-only → TryCreate yields file:// on Linux; filtered by scheme guard
+    [InlineData("ftp://idp.example.com")]      // valid URI but non-HTTP(S); filtered by scheme guard
+    public void ScalarCspContributor_WithMalformedOrNonHttpOAuth2Urls_SilentlyIgnoresThem(string badUrl)
+    {
+        ScalarCspContributor contributor = BuildContributor(new OAuth2Options
+        {
+            AuthorizationUrl = badUrl,
+            TokenUrl = badUrl,
+            ClientId = "scalar",
+        });
+        CspBuilder builder = new();
+
+        Should.NotThrow(() => contributor.Contribute(BuildScalarContext(), builder));
+
+        builder.Directives["connect-src"].ShouldBe(["'self'", "https://api.scalar.com"]);
+    }
+
+    [Fact]
     public void ScalarCspContributor_OnNonScalarEndpoint_DoesNothing()
     {
-        ScalarCspContributor contributor = new();
+        ScalarCspContributor contributor = BuildContributor();
         CspBuilder builder = new();
 
         DefaultHttpContext ctx = new();
@@ -135,13 +200,33 @@ public sealed class ScalarCspContributorTests
     [Fact]
     public void ScalarCspContributor_WithoutMatchedEndpoint_DoesNothing()
     {
-        ScalarCspContributor contributor = new();
+        ScalarCspContributor contributor = BuildContributor();
         CspBuilder builder = new();
         DefaultHttpContext ctx = new();   // No endpoint set
 
         contributor.Contribute(ctx, builder);
 
         builder.Directives.ShouldBeEmpty();
+    }
+
+    private static ScalarCspContributor BuildContributor(OAuth2Options? oauth2 = null)
+    {
+        ApiDocumentationOptions options = new();
+        if (oauth2 is not null)
+        {
+            options.OAuth2 = oauth2;
+        }
+        return new ScalarCspContributor(MEOptions.Create(options));
+    }
+
+    private static DefaultHttpContext BuildScalarContext()
+    {
+        DefaultHttpContext ctx = new();
+        ctx.SetEndpoint(new Endpoint(
+            static _ => Task.CompletedTask,
+            new EndpointMetadataCollection(new ScalarApiReferenceMetadata()),
+            "scalar"));
+        return ctx;
     }
 
     private static WebApplication BuildApp(


### PR DESCRIPTION
## Summary

- `ScalarCspContributor` now injects `ApiDocumentationOptions.OAuth2` and appends the origin (`{scheme}://{authority}`) of `AuthorizationUrl` and `TokenUrl` to `connect-src`.
- `Distinct()` dedupes the common Keycloak case where both endpoints share the same Authority (e.g. `http://localhost:8080`).
- Scheme guard restricts adds to `http`/`https` (avoids `Uri.TryCreate`'s `file://` quirk on relative paths).
- Scope is unchanged: still gated by `ScalarApiReferenceMetadata`.

## Why

Builds on #2168. With only `'self'` + `https://api.scalar.com` on `connect-src`, Scalar's interactive Authorization Code flow fails: when the user clicks **Authorize** and the browser receives the auth code, the SPA POSTs to the IdP token endpoint (`http://localhost:5000 → http://localhost:8080/realms/.../token`) and CSP blocks the cross-origin request. Token never lands → Scalar shows the user as signed-out.

The auth-popup itself (top-level navigation) is unaffected by CSP. Only the `XMLHttpRequest`/`fetch`-driven token exchange needed relaxation.

## Tests

`ScalarCspContributorTests` covers:

- OAuth2 not configured → only `'self'` + `https://api.scalar.com` on `connect-src` (no regression vs #2168).
- OAuth2 Keycloak-style (auth + token share same Authority) → single deduped origin.
- OAuth2 split-host (auth on `:8080`, token on `:8081`) → both origins added.
- Malformed / relative / non-HTTP URLs → silently ignored, no throw.
- Existing non-Scalar / unmatched-endpoint cases still no-op.

## Test plan

- [x] `dotnet test tests/Granit.Http.ApiDocumentation.Tests/...` — 12/12 relevant tests pass (the start-and-stop `WebApplication` test is excluded locally because another dev host already holds `:5000` — clean in CI).
- [x] `dotnet format` clean.
- [x] `npx markdownlint-cli2 CHANGELOG.md` clean.
- [ ] CI green on the `api-data` shard.
- [ ] Manual: bump iot-showcase to the resulting `0.1.0-dev.*`, click **Authorize** in `/scalar`, confirm the token exchange completes and the signed-in state persists (and the CSP violation is gone from devtools).

## Architectural note

We considered moving this contributor to `Granit.Authentication.JwtBearer` (so any IdP-aware UI benefits). Decided against for now: Scalar is the only browser-side OAuth consumer in Granit hosts today, and the `ScalarApiReferenceMetadata` marker gives clean per-route scoping that an auth-side contributor would lack. Promote later if a second consumer (custom SPA inside a Granit-hosted app) appears.