### PR TITLE
chore(async): add CancellationToken to public async APIs missing it

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19972,6 +19972,15 @@
       ]
     },
     {
+      "name": "AllowsPopupAuthorizationMetadata",
+      "fqn": "Granit.Http.SecurityHeaders.AllowsPopupAuthorizationMetadata",
+      "kind": "class",
+      "project": "Granit.Http.SecurityHeaders.Abstractions",
+      "file": "src/Granit.Http.SecurityHeaders.Abstractions/AllowsPopupAuthorizationMetadata.cs",
+      "line": 29,
+      "members": []
+    },
+    {
       "name": "CspBuilder",
       "fqn": "Granit.Http.SecurityHeaders.CspBuilder",
       "kind": "class",
@@ -40413,7 +40422,7 @@
         {
           "name": "BuildAsync",
           "kind": "method",
-          "signature": "BuildAsync(Action<IServiceCollection>? configureServices = null)",
+          "signature": "BuildAsync(Action<IServiceCollection>? configureServices = null, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {

--- a/src/Granit.Testing/GranitTestFixture.cs
+++ b/src/Granit.Testing/GranitTestFixture.cs
@@ -63,8 +63,13 @@ public class GranitTestFixture<TModule> : IAsyncDisposable, IDisposable
     /// Optional callback to register additional test-specific services
     /// (e.g. test DbContext, additional mocks).
     /// </param>
-    public async Task BuildAsync(Action<IServiceCollection>? configureServices = null)
+    /// <param name="cancellationToken">Token to cancel module bootstrap.</param>
+    public async Task BuildAsync(
+        Action<IServiceCollection>? configureServices = null,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
         await builder.AddGranitAsync<TModule>().ConfigureAwait(false);
 
@@ -75,6 +80,7 @@ public class GranitTestFixture<TModule> : IAsyncDisposable, IDisposable
 
         configureServices?.Invoke(builder.Services);
 
+        cancellationToken.ThrowIfCancellationRequested();
         _host = builder.Build();
         await _host.UseGranitAsync().ConfigureAwait(false);
     }

--- a/src/Granit.Wolverine/WolverineScopedSender.cs
+++ b/src/Granit.Wolverine/WolverineScopedSender.cs
@@ -17,8 +17,11 @@ public sealed class WolverineScopedSender(IServiceScopeFactory scopeFactory)
     /// </summary>
     /// <typeparam name="TCommand">The command type.</typeparam>
     /// <param name="command">The command to send.</param>
-    public async Task SendAsync<TCommand>(TCommand command) where TCommand : class
+    /// <param name="cancellationToken">Token to cancel the scope creation and dispatch.</param>
+    public async Task SendAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
+        where TCommand : class
     {
+        cancellationToken.ThrowIfCancellationRequested();
         await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
         IMessageBus bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
         await bus.SendAsync(command).ConfigureAwait(false);

--- a/tests/Granit.Testing.Tests/GranitTestFixtureAdditionalTests.cs
+++ b/tests/Granit.Testing.Tests/GranitTestFixtureAdditionalTests.cs
@@ -20,7 +20,7 @@ public sealed class GranitTestFixtureAdditionalTests
     public async Task Dispose_Does_Not_Throw_After_Build()
     {
         GranitTestFixture<GranitTestingModule> fixture = new();
-        await fixture.BuildAsync();
+        await fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Should.NotThrow(() => fixture.Dispose());
     }
@@ -37,7 +37,7 @@ public sealed class GranitTestFixtureAdditionalTests
     public async Task DisposeAsync_Stops_And_Disposes_Host()
     {
         GranitTestFixture<GranitTestingModule> fixture = new();
-        await fixture.BuildAsync();
+        await fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await fixture.DisposeAsync();
 
@@ -48,7 +48,7 @@ public sealed class GranitTestFixtureAdditionalTests
     public async Task Multiple_Dispose_Is_Safe()
     {
         GranitTestFixture<GranitTestingModule> fixture = new();
-        await fixture.BuildAsync();
+        await fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         fixture.Dispose();
         Should.NotThrow(() => fixture.Dispose());
@@ -73,7 +73,7 @@ public sealed class GranitTestFixtureAdditionalTests
     public async Task GetService_Returns_Registered_Service()
     {
         GranitTestFixture<GranitTestingModule> fixture = new();
-        await fixture.BuildAsync();
+        await fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         IClock? clock = fixture.GetService<IClock>();
 
@@ -92,7 +92,7 @@ public sealed class GranitTestFixtureAdditionalTests
         fixture.User.UserId = "custom-user";
         fixture.Clock.Now = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
-        await fixture.BuildAsync();
+        await fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         ICurrentTenant resolvedTenant = fixture.GetRequiredService<ICurrentTenant>();
         resolvedTenant.Id.ShouldBe(tenantId);

--- a/tests/Granit.Testing.Tests/GranitTestFixtureTests.cs
+++ b/tests/Granit.Testing.Tests/GranitTestFixtureTests.cs
@@ -15,7 +15,7 @@ public sealed class GranitTestFixtureTests : IAsyncDisposable
     [Fact]
     public async Task BuildAsync_Bootstraps_Module_Graph()
     {
-        await _fixture.BuildAsync();
+        await _fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         GranitApplication app = _fixture.GetRequiredService<GranitApplication>();
         app.ShouldNotBeNull();
@@ -24,7 +24,7 @@ public sealed class GranitTestFixtureTests : IAsyncDisposable
     [Fact]
     public async Task Fakes_Are_Injected_Into_Container()
     {
-        await _fixture.BuildAsync();
+        await _fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         _fixture.GetRequiredService<ICurrentTenant>().ShouldBeSameAs(_fixture.Tenant);
         _fixture.GetRequiredService<ICurrentUserService>().ShouldBeSameAs(_fixture.User);
@@ -35,8 +35,9 @@ public sealed class GranitTestFixtureTests : IAsyncDisposable
     [Fact]
     public async Task ConfigureServices_Callback_Can_Add_Services()
     {
-        await _fixture.BuildAsync(services =>
-            services.AddSingleton<ICustomTestService, CustomTestService>());
+        await _fixture.BuildAsync(
+            services => services.AddSingleton<ICustomTestService, CustomTestService>(),
+            TestContext.Current.CancellationToken);
 
         _fixture.GetRequiredService<ICustomTestService>().ShouldNotBeNull();
     }
@@ -48,7 +49,7 @@ public sealed class GranitTestFixtureTests : IAsyncDisposable
     [Fact]
     public async Task GetService_Returns_Null_For_Unregistered()
     {
-        await _fixture.BuildAsync();
+        await _fixture.BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         _fixture.GetService<ICustomTestService>().ShouldBeNull();
     }


### PR DESCRIPTION
## Summary

- `WolverineScopedSender.SendAsync<TCommand>` — added optional `CancellationToken` last param.
- `GranitTestFixture<TModule>.BuildAsync` — added optional `CancellationToken` last param.
- Updated all test call sites to pass `TestContext.Current.CancellationToken` (xunit1051).

Surfaced by a .NET 11 runtime-async readiness audit. Both methods are public surface that breached the framework convention "`CancellationToken` last param on async APIs".

The token is consumed via `ThrowIfCancellationRequested()` at bootstrap points. Deeper propagation into `AddGranitAsync` / `UseGranitAsync` is intentionally **out of scope** here and tracked as a follow-up.

## Why now

Granit is pre-1.0 — clean breaks are cheap, and these are additive-with-default-value so consumers aren't broken anyway. Doing it now keeps the runtime-async opt-in clean when .NET 11 GA lands.

## Test plan

- [x] `dotnet build src/Granit.Wolverine src/Granit.Testing tests/Granit.Wolverine.Tests tests/Granit.Testing.Tests` clean
- [x] `dotnet test tests/Granit.Wolverine.Tests` — 158 passed
- [x] `dotnet test tests/Granit.Testing.Tests` — 97 passed
- [x] `dotnet format` clean on all 4 projects
- [ ] CI green on relevant shards

## Follow-up

Thread `CancellationToken` through `AddGranitAsync` / `UseGranitAsync` so module bootstrap honours co-operative cancellation end-to-end.