### PR TITLE
feat(persistence): add HasJsonConversion helper + migrate hand-rolled JSON converters

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -32972,6 +32972,15 @@
       ]
     },
     {
+      "name": "JsonPropertyBuilderExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.JsonPropertyBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "ModelBuilderExtensions",
       "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.ModelBuilderExtensions",
       "kind": "class",

--- a/src/Granit.Notifications.EntityFrameworkCore/Configurations/UserNotificationConfiguration.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Configurations/UserNotificationConfiguration.cs
@@ -1,8 +1,7 @@
-using System.Text.Json;
 using Granit.Notifications.Domain;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Granit.Notifications.EntityFrameworkCore.Configurations;
 
@@ -18,10 +17,7 @@ internal sealed class UserNotificationConfiguration : IEntityTypeConfiguration<U
         builder.Property(x => x.NotificationTypeName).HasMaxLength(256).IsRequired();
         builder.Property(x => x.RecipientUserId).HasMaxLength(256).IsRequired();
 
-        builder.Property(x => x.Data)
-            .HasConversion(new ValueConverter<JsonElement, string>(
-                v => v.GetRawText(),
-                v => JsonDocument.Parse(v, default).RootElement));
+        builder.Property(x => x.Data).HasJsonConversion();
 
         builder.Property(x => x.RelatedEntityType).HasMaxLength(256);
         builder.Property(x => x.RelatedEntityId).HasMaxLength(256);

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Granit.Persistence.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Extensions for configuring JSON-serialized properties on EF Core entities.
+/// </summary>
+public static class JsonPropertyBuilderExtensions
+{
+    /// <summary>
+    /// Configures a property to be persisted as a JSON-serialized string, with a deep-equality
+    /// <see cref="ValueComparer{T}"/> wired so EF Core change detection works on mutable payloads.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Provider-agnostic: the column type is left to the database provider
+    /// (<c>nvarchar(max)</c> on SQL Server, <c>text</c> on Npgsql). Apps targeting PostgreSQL that
+    /// want a queryable <c>jsonb</c> column can chain <c>.HasColumnType("jsonb")</c> in their own
+    /// configuration, or rely on a provider-specific helper from
+    /// <c>Granit.Persistence.EntityFrameworkCore.Postgres</c>.
+    /// </para>
+    /// <para>
+    /// Equality and hash are computed by re-serializing both operands — correct for any
+    /// <see cref="JsonSerializer"/>-serializable type (collections, POCOs, <see cref="JsonElement"/>),
+    /// at the cost of one serialization per change-tracking check. For very hot paths consider a
+    /// hand-rolled comparer instead.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The property CLR type.</typeparam>
+    /// <param name="builder">The property builder to configure.</param>
+    /// <param name="options">
+    /// Optional <see cref="JsonSerializerOptions"/>. When <see langword="null"/> the STJ defaults
+    /// are used — matches the existing per-site pattern in the framework.
+    /// </param>
+    /// <returns>The same <see cref="PropertyBuilder{TProperty}"/> for chaining.</returns>
+    public static PropertyBuilder<T> HasJsonConversion<T>(
+        this PropertyBuilder<T> builder,
+        JsonSerializerOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        ValueConverter<T, string> converter = new(
+            v => JsonSerializer.Serialize(v, options),
+            v => JsonSerializer.Deserialize<T>(v, options)!);
+
+        // Lambdas are converted to Expression<> trees by EF's ValueComparer ctor, so any C#
+        // construct disallowed in expression trees (pattern matching, switch expressions, etc.)
+        // cannot appear here. JsonSerializer handles null inputs by emitting the "null" literal,
+        // so explicit null checks are unnecessary.
+        ValueComparer<T> comparer = new(
+            (a, b) => JsonSerializer.Serialize(a, options) == JsonSerializer.Serialize(b, options),
+            v => JsonSerializer.Serialize(v, options).GetHashCode(StringComparison.Ordinal),
+            v => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(v, options), options)!);
+
+        builder.HasConversion(converter, comparer);
+        return builder;
+    }
+}

--- a/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/ExportRequestEntityConfiguration.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/ExportRequestEntityConfiguration.cs
@@ -1,9 +1,7 @@
-using System.Text.Json;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Privacy.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
 
@@ -31,17 +29,8 @@ internal sealed class ExportRequestEntityConfiguration : IEntityTypeConfiguratio
         builder.Property(e => e.ArchiveBlobReferenceId)
             .HasMaxLength(200);
 
-        ValueConverter<List<string>, string> missingProvidersConverter = new(
-            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-            v => JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>());
-
-        ValueComparer<List<string>> missingProvidersComparer = new(
-            (l, r) => (l ?? new List<string>()).SequenceEqual(r ?? new List<string>()),
-            v => v.Aggregate(0, (h, s) => HashCode.Combine(h, s.GetHashCode(StringComparison.Ordinal))),
-            v => v.ToList());
-
         builder.Property(e => e.MissingProviders)
-            .HasConversion(missingProvidersConverter, missingProvidersComparer)
+            .HasJsonConversion()
             .IsRequired();
 
         // User timeline lookup (GET /privacy/exports → GetByUserAsync).

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/JsonPropertyBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/JsonPropertyBuilderExtensionsTests.cs
@@ -1,0 +1,118 @@
+// =============================================================================
+// Tests - JsonPropertyBuilderExtensions
+// =============================================================================
+// Verifies that HasJsonConversion:
+//   - Persists arbitrary CLR types as JSON strings (round-trip through EF Core).
+//   - Wires a deep-equality ValueComparer so change tracking detects mutations
+//     to JSON payloads (mutable collections, POCOs, JsonElement).
+//   - Snapshots produce independent copies (snapshot mutation does not bleed).
+// =============================================================================
+
+using System.Text.Json;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class JsonPropertyBuilderExtensionsTests
+{
+    private sealed class ListEntity
+    {
+        public int Id { get; set; }
+        public List<string> Tags { get; set; } = [];
+    }
+
+    private sealed class JsonElementEntity
+    {
+        public int Id { get; set; }
+        public JsonElement Payload { get; set; }
+    }
+
+    private sealed class TestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<ListEntity> Lists => Set<ListEntity>();
+        public DbSet<JsonElementEntity> JsonElements => Set<JsonElementEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ListEntity>().Property(e => e.Tags).HasJsonConversion();
+            modelBuilder.Entity<JsonElementEntity>().Property(e => e.Payload).HasJsonConversion();
+        }
+    }
+
+    private static TestDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options);
+
+    [Fact]
+    public void HasJsonConversion_throws_on_null_builder() =>
+        Should.Throw<ArgumentNullException>(
+            () => ((Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder<int>)null!).HasJsonConversion());
+
+    [Fact]
+    public async Task List_round_trips_through_json()
+    {
+        await using TestDbContext ctx = NewContext();
+        ListEntity entity = new() { Id = 1, Tags = ["a", "b", "c"] };
+        ctx.Lists.Add(entity);
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ctx.ChangeTracker.Clear();
+        ListEntity? reloaded = await ctx.Lists.FindAsync([1], TestContext.Current.CancellationToken);
+
+        reloaded.ShouldNotBeNull();
+        reloaded.Tags.ShouldBe(["a", "b", "c"]);
+    }
+
+    [Fact]
+    public async Task JsonElement_round_trips_through_json()
+    {
+        await using TestDbContext ctx = NewContext();
+        JsonElement payload = JsonDocument.Parse("""{"k":"v","n":42}""").RootElement;
+        ctx.JsonElements.Add(new JsonElementEntity { Id = 1, Payload = payload });
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ctx.ChangeTracker.Clear();
+        JsonElementEntity? reloaded = await ctx.JsonElements.FindAsync([1], TestContext.Current.CancellationToken);
+
+        reloaded.ShouldNotBeNull();
+        reloaded.Payload.GetProperty("k").GetString().ShouldBe("v");
+        reloaded.Payload.GetProperty("n").GetInt32().ShouldBe(42);
+    }
+
+    [Fact]
+    public void ValueComparer_detects_list_mutation()
+    {
+        using TestDbContext ctx = NewContext();
+        IProperty property = ctx.Model.FindEntityType(typeof(ListEntity))!
+            .FindProperty(nameof(ListEntity.Tags))!;
+        ValueComparer comparer = property.GetValueComparer();
+
+        List<string> original = ["a", "b"];
+        List<string> mutated = ["a", "b", "c"];
+
+        comparer.Equals(original, original).ShouldBeTrue();
+        comparer.Equals(original, mutated).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Snapshot_is_an_independent_copy()
+    {
+        using TestDbContext ctx = NewContext();
+        IProperty property = ctx.Model.FindEntityType(typeof(ListEntity))!
+            .FindProperty(nameof(ListEntity.Tags))!;
+        ValueComparer comparer = property.GetValueComparer();
+
+        List<string> original = ["a", "b"];
+        object snapshot = comparer.Snapshot(original)!;
+        original.Add("c");
+
+        ((List<string>)snapshot).ShouldBe(["a", "b"]);
+    }
+}


### PR DESCRIPTION
## Summary

Provider-agnostic `PropertyBuilder<T>.HasJsonConversion()` extension in `Granit.Persistence.EntityFrameworkCore` that wires:
- a `JsonSerializer`-backed `ValueConverter<T, string>`
- a deep-equality `ValueComparer<T>` (re-serialize for hash/equality, deserialize for snapshot — generic, correct for collections, POCOs, `JsonElement`)

Migrates the two framework sites that hand-rolled the same pattern:
- `UserNotification.Data` (`JsonElement`) — [UserNotificationConfiguration.cs](src/Granit.Notifications.EntityFrameworkCore/Configurations/UserNotificationConfiguration.cs)
- `ExportRequestEntity.MissingProviders` (`List<string>`) — [ExportRequestEntityConfiguration.cs](src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/ExportRequestEntityConfiguration.cs)

## Why now

Surfaced by the .NET 11 EF Core JSON-mapping readiness audit (13 hand-rolled JSON sites across 8 modules). A single helper gives us **one migration point** when EF 11's native JSON mapping ships, instead of edits scattered across every module config.

## Design notes

- **Provider-agnostic by design**: column type stays at provider defaults (`nvarchar(max)` SQL Server, `text` Npgsql). Apps that want `jsonb` queryability on Postgres can chain `.HasColumnType("jsonb")` themselves, or a future helper in `Granit.Persistence.EntityFrameworkCore.Postgres` can register that convention.
- **No expression-tree-incompatible C# constructs** in the comparer lambdas (`is null`, switch expressions, etc.). EF's `ValueComparer<T>` ctor converts them to `Expression<>` trees.
- **Semantic change for `MissingProviders`**: the old converter returned `new List<string>()` when deserializing JSON literal `"null"`. The new helper returns `default(T)` — fine because `MissingProviders` is initialized `= []` on the entity and never serialized as `null`.

## Test plan

- [x] 5 new unit tests in [JsonPropertyBuilderExtensionsTests.cs](tests/Granit.Persistence.EntityFrameworkCore.Tests/JsonPropertyBuilderExtensionsTests.cs) — round-trip, change detection, snapshot independence, null builder guard
- [x] `Granit.Persistence.EntityFrameworkCore.Tests` — 346 passed (5 new)
- [x] `Granit.Notifications.EntityFrameworkCore.Tests` — 46 passed
- [x] `Granit.Privacy.EntityFrameworkCore.Tests` — 17 passed
- [x] `Granit.ArchitectureTests` — 183 passed
- [x] `dotnet format` clean on all 4 modified csprojs
- [ ] CI green on affected shards

## Follow-up

Remaining 11 JSON sites from the audit (BFF tokens, DataExchange Import/Export, Scheduling, Mergeable idempotency, Persistence Metadata sync, Auditing change capture) are tracked separately — they involve deeper refactors (owned-types vs strings, encrypted-then-serialized BFF tokens, etc.) and don't all fit the simple "single property" helper shape.