### PR TITLE
feat(persistence-postgres): add HasJsonbConversion helper

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33890,6 +33890,15 @@
       ]
     },
     {
+      "name": "JsonbPropertyBuilderExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Postgres.Extensions.JsonbPropertyBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore.Postgres",
+      "file": "src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/JsonbPropertyBuilderExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "NpgsqlDbContextOptionsExtensions",
       "fqn": "Granit.Persistence.EntityFrameworkCore.Postgres.Extensions.NpgsqlDbContextOptionsExtensions",
       "kind": "class",

--- a/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/JsonbPropertyBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/JsonbPropertyBuilderExtensions.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Persistence.EntityFrameworkCore.Postgres.Extensions;
+
+/// <summary>
+/// PostgreSQL-specific extensions for configuring JSON-serialized properties.
+/// </summary>
+public static class JsonbPropertyBuilderExtensions
+{
+    /// <summary>
+    /// Configures a property to be persisted as PostgreSQL <c>jsonb</c>, with the same
+    /// JSON serialization and deep-equality semantics as
+    /// <see cref="JsonPropertyBuilderExtensions.HasJsonConversion{T}(PropertyBuilder{T}, JsonSerializerOptions?)"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Storing as <c>jsonb</c> (rather than <c>text</c>) lets PostgreSQL validate the payload,
+    /// build GIN indexes on it, and query into the document via <c>@&gt;</c>, <c>jsonb_path_query</c>,
+    /// etc. The serialization is still string-based on the CLR side — this helper does not
+    /// enable EF Core's owned-type-to-JSON translation, only the column storage type.
+    /// </para>
+    /// <para>
+    /// Use this helper only when the consuming application targets PostgreSQL. Calling it
+    /// against a SQL Server provider will produce a migration referencing the <c>jsonb</c>
+    /// type, which SQL Server does not understand.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The property CLR type.</typeparam>
+    /// <param name="builder">The property builder to configure.</param>
+    /// <param name="options">Optional <see cref="JsonSerializerOptions"/>; defaults to STJ defaults.</param>
+    /// <returns>The same <see cref="PropertyBuilder{TProperty}"/> for chaining.</returns>
+    public static PropertyBuilder<T> HasJsonbConversion<T>(
+        this PropertyBuilder<T> builder,
+        JsonSerializerOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.HasJsonConversion(options).HasColumnType("jsonb");
+    }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/JsonbPropertyBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/JsonbPropertyBuilderExtensionsTests.cs
@@ -1,0 +1,71 @@
+// =============================================================================
+// Tests - JsonbPropertyBuilderExtensions
+// =============================================================================
+// Verifies that HasJsonbConversion:
+//   - Sets the EF Core column type to "jsonb"
+//   - Wires the same converter + comparer as HasJsonConversion (delegated)
+//   - Guards against null builder
+// =============================================================================
+
+using Granit.Persistence.EntityFrameworkCore.Postgres.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Postgres.Tests.Extensions;
+
+public sealed class JsonbPropertyBuilderExtensionsTests
+{
+    private sealed class JsonbEntity
+    {
+        public int Id { get; set; }
+        public List<string> Tags { get; set; } = [];
+    }
+
+    private sealed class TestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<JsonbEntity> Items => Set<JsonbEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<JsonbEntity>().Property(e => e.Tags).HasJsonbConversion();
+    }
+
+    // Connection string is never used: building the model and reading metadata does not
+    // open a connection, so the tests run fully offline.
+    private static IProperty TagsProperty()
+    {
+        TestDbContext ctx = new(new DbContextOptionsBuilder<TestDbContext>()
+            .UseNpgsql("Host=fake;Database=fake")
+            .Options);
+        return ctx.Model.FindEntityType(typeof(JsonbEntity))!.FindProperty(nameof(JsonbEntity.Tags))!;
+    }
+
+    [Fact]
+    public void HasJsonbConversion_throws_on_null_builder() =>
+        Should.Throw<ArgumentNullException>(
+            () => ((PropertyBuilder<int>)null!).HasJsonbConversion());
+
+    [Fact]
+    public void HasJsonbConversion_sets_column_type_to_jsonb() =>
+        TagsProperty().GetColumnType().ShouldBe("jsonb");
+
+    [Fact]
+    public void HasJsonbConversion_wires_value_converter()
+    {
+        IProperty property = TagsProperty();
+
+        property.GetValueConverter().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HasJsonbConversion_wires_deep_equality_comparer()
+    {
+        ValueComparer comparer = TagsProperty().GetValueComparer();
+
+        comparer.Equals(new List<string> { "a", "b" }, new List<string> { "a", "b" }).ShouldBeTrue();
+        comparer.Equals(new List<string> { "a", "b" }, new List<string> { "a", "b", "c" }).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`PropertyBuilder<T>.HasJsonbConversion()` in `Granit.Persistence.EntityFrameworkCore.Postgres`. Chains the base [HasJsonConversion](src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs) (from #2175) with `HasColumnType(\"jsonb\")`.

## Why

Apps targeting PostgreSQL get the wins of `jsonb` storage (validation, GIN indexability, `@>` queries, `jsonb_path_query`) in one declarative call — while framework module configurations stay provider-agnostic via the base helper.

Completes the symmetric pattern proposed during the .NET 11 JSON-mapping audit follow-up:
- `Granit.Persistence.EntityFrameworkCore` → `HasJsonConversion<T>()` (provider-agnostic, used by framework modules)
- `Granit.Persistence.EntityFrameworkCore.Postgres` → `HasJsonbConversion<T>()` (Postgres opt-in, used by apps)
- `Granit.Persistence.EntityFrameworkCore.SqlServer` → nothing needed (default `nvarchar(max)` is correct)

## Test plan

- [x] 4 unit tests in [JsonbPropertyBuilderExtensionsTests.cs](tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/JsonbPropertyBuilderExtensionsTests.cs) — column type, converter, comparer, null guard. Tests build the EF model with the Npgsql provider but never open a connection (model build is offline).
- [x] `Granit.Persistence.EntityFrameworkCore.Postgres.Tests` — 32 passed (4 new)
- [x] `dotnet format` clean on both csprojs
- [ ] CI green on relevant shards

## Follow-up

Not in scope here (separate PRs):
- Migrate remaining 11 JSON sites to `HasJsonConversion` / owned-types `.ToJson()` — esp. DataExchange (5 columns, deletes 2 stores).
- Optional convention helper `modelBuilder.UseGranitJsonbForJsonProperties()` that auto-upgrades any property already converted via `HasJsonConversion` to `jsonb` when the provider is Npgsql.