### PR TITLE
fix(keycloak)!: Configure before framework PostConfigure + move section under Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- **Breaking — `Granit.Authentication.JwtBearer.Keycloak`.** Two related changes ship together. (1) `AddGranitKeycloak()` now applies its Keycloak-specific JwtBearer overrides via `.Configure<>` instead of `.PostConfigure<>`: the framework's built-in `JwtBearerPostConfigureOptions` is what materialises the `ConfigurationManager<OpenIdConnectConfiguration>` from `Authority`, and it runs in the PostConfigure phase. With the previous registration, if a host provided only the Keycloak section (no `Authentication:*` doublon), `Authority` was still empty when the framework's PostConfigure ran → no ConfigurationManager → no JWKS fetch → every inbound token failed with `IDX10500 ("Signature validation failed. Unable to resolve SignatureValidator…")`. (2) `KeycloakOptions.SectionName` moves from `"Keycloak"` (root) to `"Authentication:Keycloak"` so Keycloak config sits under the same `Authentication:*` parent as `JwtBearerAuthOptions` (section `"Authentication"`). **Migration**: rewrite the host appsettings:
+
+  ```diff
+  - "Keycloak": {
+  -   "Authority": "http://localhost:8080/realms/my-realm",
+  -   "ClientId": "my-api"
+  - }
+  + "Authentication": {
+  +   "Keycloak": {
+  +     "Authority": "http://localhost:8080/realms/my-realm",
+  +     "ClientId": "my-api"
+  +   }
+  + }
+  ```
+
+  Env-var bindings: `Keycloak__Authority` → `Authentication__Keycloak__Authority`. K8s/Vault projections, CI secrets, and ExternalSecret manifests must be updated in the same deploy. The unrelated `KeycloakAdminOptions` section (`"KeycloakAdmin"`, owned by `Granit.Identity.Federated.Keycloak`) is **not** affected.
 - `Granit.Http.SecurityHeaders` / `Granit.Http.ApiDocumentation` — new public marker `AllowsPopupAuthorizationMetadata` (in `Granit.Http.SecurityHeaders.Abstractions`). When attached to an endpoint, the security-headers middleware downgrades `Cross-Origin-Opener-Policy` to `unsafe-none` for that endpoint only; every other route keeps the strict `same-origin` baseline. `UseGranitApiDocumentation()` automatically attaches the marker on the Scalar route when `OAuth2` is configured. The default `same-origin` (and even `same-origin-allow-popups`) severs the opener↔popup window reference the moment the popup navigates to the IdP, breaking Scalar's polling-based Authorization Code flow: the popup completes, but the parent can no longer read its `window.location` to pick up the auth code and shows `"Window was closed without granting authorization."` Without this fix every CSP / RedirectUri change shipped in `[Unreleased]` still left Authorize broken on hosts that enable the strict COOP default.
 - `Granit.Http.ApiDocumentation` — new `ApiDocumentationOptions.OAuth2.RedirectUri` property, propagated to Scalar via `flow.WithRedirectUri(...)`. Workaround for `Scalar.AspNetCore` 2.12.40+ where the default redirect URI changed and breaks Authorization Code popups (scalar/scalar#8165, #8187): the popup returns same-origin but on a URL Scalar no longer recognises, so the auth code is never piped back and the user sees `"Window was closed without granting authorization."` Set this to the absolute URL of the Scalar UI (e.g. `http://localhost:5000/scalar`) and make sure it is registered as a valid redirect URI on the IdP client. Leave unset only when upstream restores the previous default.
 - `Granit.Http.ApiDocumentation` — `ScalarCspContributor` now whitelists `https://api.scalar.com` on `connect-src` (Scalar's Vue.js bootstrap fetches its curated-documents / search registry from `api.scalar.com/vector/registry/*` on mount and on every search keystroke). When `ApiDocumentationOptions.OAuth2` is configured, the contributor also adds the origins (scheme + host + port) of the OAuth2 `AuthorizationUrl` and `TokenUrl` to `connect-src`, allowing Scalar's Authorization Code → Token exchange (browser-side cross-origin POST to the IdP, e.g. `localhost:5000 → localhost:8080`) to complete instead of being blocked by CSP. Without this, the interactive "Authorize" button signed-in state never persisted. `script-src` now also carries `'unsafe-eval'`: the Scalar bundle evaluates code dynamically (template parsing, JSON Schema example rendering) via `eval` / `new Function`, which the previous policy blocked. The relaxation stays scoped to endpoints carrying `ScalarApiReferenceMetadata` and is dev-only by default (`EnableInProduction = false`).

--- a/src/Granit.Authentication.JwtBearer.Keycloak/Extensions/KeycloakServiceCollectionExtensions.cs
+++ b/src/Granit.Authentication.JwtBearer.Keycloak/Extensions/KeycloakServiceCollectionExtensions.cs
@@ -25,12 +25,18 @@ public static class KeycloakServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        // PostConfigure s'exécute après AddGranitJwtBearer (GranitAuthenticationJwtBearerModule),
-        // permettant de surcharger Authority, Audience et NameClaimType pour Keycloak.
-        // Deferred configuration: reads KeycloakOptions at resolution time.
+        // Configure (not PostConfigure) so Keycloak's Authority / Audience are
+        // applied BEFORE the framework's JwtBearerPostConfigureOptions runs:
+        // that built-in PostConfigure is the one that materialises
+        // ConfigurationManager<OpenIdConnectConfiguration> from Authority. If
+        // Authority is still empty at that point, no ConfigurationManager is
+        // built, JWKS is never fetched, and every inbound token fails with
+        // IDX10500 ("Signature validation failed. Unable to resolve
+        // SignatureValidator or SecurityTokenSignatureValidator"). PostConfigure
+        // here would run too late.
         services
             .AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
-            .PostConfigure<IOptions<KeycloakOptions>>((jwt, keycloakOpts) =>
+            .Configure<IOptions<KeycloakOptions>>((jwt, keycloakOpts) =>
             {
                 KeycloakOptions options = keycloakOpts.Value;
                 string audience = options.Audience ?? options.ClientId;

--- a/src/Granit.Authentication.JwtBearer.Keycloak/Options/KeycloakOptions.cs
+++ b/src/Granit.Authentication.JwtBearer.Keycloak/Options/KeycloakOptions.cs
@@ -5,8 +5,13 @@ namespace Granit.Authentication.JwtBearer.Keycloak.Options;
 /// </summary>
 public sealed class KeycloakOptions
 {
-    /// <summary>Section key in the configuration.</summary>
-    public const string SectionName = "Keycloak";
+    /// <summary>
+    /// Section key in configuration. Sits under <c>Authentication:*</c> to match the
+    /// ASP.NET convention used by <c>JwtBearerAuthOptions</c> (section
+    /// <c>"Authentication"</c>) — both blocks live under the same parent so a host
+    /// can see at a glance everything that affects token validation.
+    /// </summary>
+    public const string SectionName = "Authentication:Keycloak";
 
     /// <summary>OIDC authority URL (e.g. https://keycloak.example.com/realms/my-realm).</summary>
     public string Authority { get; set; } = string.Empty;

--- a/templates/granit-api-full/appsettings.json
+++ b/templates/granit-api-full/appsettings.json
@@ -13,10 +13,12 @@
       "Default": "Information"
     }
   },
-  "Keycloak": {
-    "Authority": "http://localhost:8080/realms/my-realm",
-    "ClientId": "my-api",
-    "AdminRole": "admin"
+  "Authentication": {
+    "Keycloak": {
+      "Authority": "http://localhost:8080/realms/my-realm",
+      "ClientId": "my-api",
+      "AdminRole": "admin"
+    }
   },
   "Cors": {
     "AllowedOrigins": ["http://localhost:3000"]

--- a/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/GranitAuthenticationJwtBearerKeycloakModuleTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/GranitAuthenticationJwtBearerKeycloakModuleTests.cs
@@ -25,8 +25,8 @@ public sealed class GranitAuthenticationJwtBearerKeycloakModuleTests
         // Arrange
         GranitAuthenticationJwtBearerKeycloakModule module = new();
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["Keycloak:Authority"] = "https://keycloak.test/realms/test";
-        builder.Configuration["Keycloak:ClientId"] = "test-client";
+        builder.Configuration["Authentication:Keycloak:Authority"] = "https://keycloak.test/realms/test";
+        builder.Configuration["Authentication:Keycloak:ClientId"] = "test-client";
         // Call GranitAuthenticationJwtBearerModule first (dependency)
         ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
         new GranitAuthenticationJwtBearerModule().ConfigureServices(context);
@@ -47,8 +47,8 @@ public sealed class GranitAuthenticationJwtBearerKeycloakModuleTests
         // Arrange
         GranitAuthenticationJwtBearerKeycloakModule module = new();
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["Keycloak:Authority"] = "https://keycloak.test/realms/test";
-        builder.Configuration["Keycloak:ClientId"] = "test-client";
+        builder.Configuration["Authentication:Keycloak:Authority"] = "https://keycloak.test/realms/test";
+        builder.Configuration["Authentication:Keycloak:ClientId"] = "test-client";
         ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
         new GranitAuthenticationJwtBearerModule().ConfigureServices(context);
 

--- a/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakOptionsTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakOptionsTests.cs
@@ -7,8 +7,8 @@ namespace Granit.Authentication.JwtBearer.Keycloak.Tests;
 public sealed class KeycloakOptionsTests
 {
     [Fact]
-    public void SectionName_IsKeycloak() =>
-        KeycloakOptions.SectionName.ShouldBe("Keycloak");
+    public void SectionName_IsAuthenticationKeycloak() =>
+        KeycloakOptions.SectionName.ShouldBe("Authentication:Keycloak");
 
     [Fact]
     public void Defaults_AreCorrect()

--- a/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakServiceCollectionExtensionsTests.cs
@@ -3,7 +3,8 @@
 // =============================================================================
 // Verifies that AddGranitKeycloak correctly registers:
 //   - KeycloakOptions from the "Keycloak" section
-//   - PostConfigure JWT Bearer (Authority, Audience, NameClaimType)
+//   - Configure JWT Bearer (Authority, Audience, NameClaimType) so the
+//     framework's PostConfigure can build ConfigurationManager
 //   - KeycloakClaimsTransformation
 // =============================================================================
 
@@ -29,9 +30,9 @@ public sealed class KeycloakServiceCollectionExtensionsTests
         new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Keycloak:Authority"] = authority,
-                ["Keycloak:ClientId"] = clientId,
-                ["Keycloak:RequireHttpsMetadata"] = "false",
+                ["Authentication:Keycloak:Authority"] = authority,
+                ["Authentication:Keycloak:ClientId"] = clientId,
+                ["Authentication:Keycloak:RequireHttpsMetadata"] = "false",
             })
             .Build();
 
@@ -87,10 +88,10 @@ public sealed class KeycloakServiceCollectionExtensionsTests
         IConfiguration config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Keycloak:Authority"] = "https://keycloak.test/realms/test",
-                ["Keycloak:ClientId"] = "test-client",
-                ["Keycloak:Audience"] = "custom-audience",
-                ["Keycloak:RequireHttpsMetadata"] = "false"
+                ["Authentication:Keycloak:Authority"] = "https://keycloak.test/realms/test",
+                ["Authentication:Keycloak:ClientId"] = "test-client",
+                ["Authentication:Keycloak:Audience"] = "custom-audience",
+                ["Authentication:Keycloak:RequireHttpsMetadata"] = "false"
             })
             .Build();
         services.AddSingleton<IConfiguration>(config);
@@ -106,6 +107,43 @@ public sealed class KeycloakServiceCollectionExtensionsTests
             .Get(JwtBearerDefaults.AuthenticationScheme);
 
         jwtOptions.Audience.ShouldBe("custom-audience");
+    }
+
+    [Fact]
+    public void AddGranitKeycloak_OnlyKeycloakSection_MaterialisesConfigurationManager()
+    {
+        // Regression: a consumer that only provides the "Keycloak" section
+        // (no "Authentication" section) must still get a fully-wired
+        // JwtBearerOptions with a non-null ConfigurationManager. The framework's
+        // built-in JwtBearerPostConfigureOptions is what materialises that
+        // manager from Authority, and it runs in the PostConfigure phase — so
+        // Granit's Keycloak overrides MUST run in the Configure phase (not
+        // PostConfigure), otherwise Authority is still empty when the framework
+        // looks at it, no manager is created, JWKS is never fetched, and every
+        // inbound token fails with IDX10500.
+        ServiceCollection services = new();
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // No "Authentication:*" keys — only Keycloak.
+                ["Authentication:Keycloak:Authority"] = "https://keycloak.test/realms/test",
+                ["Authentication:Keycloak:ClientId"] = "test-client",
+                ["Authentication:Keycloak:RequireHttpsMetadata"] = "false",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddGranitJwtBearer();
+        services.AddGranitKeycloak();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        JwtBearerOptions jwtOptions = sp.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(JwtBearerDefaults.AuthenticationScheme);
+
+        jwtOptions.Authority.ShouldBe("https://keycloak.test/realms/test");
+        jwtOptions.ConfigurationManager.ShouldNotBeNull(
+            "Framework JwtBearerPostConfigureOptions must see Authority set when it runs, " +
+            "otherwise the OpenIdConnectConfiguration manager is never created and JWKS is " +
+            "never fetched (IDX10500 on every inbound token).");
     }
 
     [Fact]


### PR DESCRIPTION
> [!warning]
> **BREAKING — appsettings rewrite required.** `KeycloakOptions.SectionName` moves from `"Keycloak"` (root) to `"Authentication:Keycloak"`. Hosts must update appsettings, env-var prefixes, K8s ExternalSecret manifests, CI secret bindings, and Vault projections in the same deploy. The unrelated `KeycloakAdminOptions` section (`"KeycloakAdmin"`, owned by `Granit.Identity.Federated.Keycloak`) is **not** affected.

## Summary

Two related changes shipped together — order-of-execution fix + section rename — because they share the same root cause: hosts were duplicating Keycloak config under both `Keycloak:*` and `Authentication:*` to work around the bug. Fixing the bug while also collapsing the section under `Authentication:*` removes the doublon at the root.

### 1. `.Configure<>` instead of `.PostConfigure<>`

The framework's built-in `JwtBearerPostConfigureOptions` is what materialises `ConfigurationManager<OpenIdConnectConfiguration>` from `Authority` — and it runs in the **PostConfigure phase**. With the previous registration, if a host provided only the Keycloak section (no `Authentication:*` doublon), `Authority` was still empty when the framework's PostConfigure ran:

- no `ConfigurationManager` created,
- JWKS never fetched,
- every inbound token failed with `IDX10500 ("Signature validation failed. Unable to resolve SignatureValidator…")`.

Moving Granit's Keycloak overrides to the **Configure phase** guarantees `Authority` is set before the framework builds the manager.

### 2. `SectionName` → `"Authentication:Keycloak"`

```diff
- "Keycloak": {
-   "Authority": "http://localhost:8080/realms/my-realm",
-   "ClientId": "my-api"
- }
+ "Authentication": {
+   "Keycloak": {
+     "Authority": "http://localhost:8080/realms/my-realm",
+     "ClientId": "my-api"
+   }
+ }
```

Keycloak config now lives under the same `Authentication:*` parent as `JwtBearerAuthOptions` (section `"Authentication"`). Aligns with the ASP.NET convention and removes the "two top-level blocks for the same concern" smell that drove the workaround.

## Migration

| Surface | Before | After |
|---|---|---|
| appsettings.json | `"Keycloak": { … }` (root) | `"Authentication": { "Keycloak": { … } }` |
| Env var | `Keycloak__Authority` | `Authentication__Keycloak__Authority` |
| K8s `ExternalSecret` | `Keycloak__*` paths | `Authentication__Keycloak__*` paths |
| `KeycloakAdminOptions` (admin API) | `"KeycloakAdmin"` | `"KeycloakAdmin"` — **unchanged** |

Consumers that previously kept a doublon `Authentication:Authority` workaround can drop it once they upgrade.

## Regression test

`AddGranitKeycloak_OnlyKeycloakSection_MaterialisesConfigurationManager` configures only the Keycloak section (no `Authentication:Authority`, no `Authentication:Audience`), resolves `JwtBearerOptions`, and asserts `ConfigurationManager != null`. Fails on the old `.PostConfigure<>` registration; passes on the new `.Configure<>` registration.

## Test plan

- [x] `dotnet test tests/Granit.Authentication.JwtBearer.Keycloak.Tests/...` — 22/22 pass.
- [x] `dotnet format` clean on touched projects.
- [x] `npx markdownlint-cli2 CHANGELOG.md` clean.
- [x] Rebased on latest `origin/develop` (1 unrelated commit ahead at push time).
- [ ] CI green on the `security` shard.
- [ ] Downstream rollout (separate PRs): iot-showcase, microservice-template, showcase, granit-api-full template consumers — bump the resulting `0.1.0-dev.*` and rewrite their appsettings to `Authentication:Keycloak:*`.

## Files

- `src/Granit.Authentication.JwtBearer.Keycloak/Options/KeycloakOptions.cs` — `SectionName` literal + docstring.
- `src/Granit.Authentication.JwtBearer.Keycloak/Extensions/KeycloakServiceCollectionExtensions.cs` — `.PostConfigure<>` → `.Configure<>` with rationale comment.
- `tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakOptionsTests.cs` — section-name assertion.
- `tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakServiceCollectionExtensionsTests.cs` — config keys + new regression test.
- `tests/Granit.Authentication.JwtBearer.Keycloak.Tests/GranitAuthenticationJwtBearerKeycloakModuleTests.cs` — config keys.
- `templates/granit-api-full/appsettings.json` — template rewrite under `Authentication:Keycloak`.
- `CHANGELOG.md` — `[Unreleased] / Fixed`, marked **Breaking**, with the migration diff inline.