### PR TITLE
fix(api-keys): use AddGranitIsolatedDbContext so SchemaPerTenant honors tenant schema

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -5701,12 +5701,12 @@
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
       "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitApiKeysEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitApiKeysEntityFrameworkCore(this IServiceCollection services, Action<DbContextOptionsBuilder> configureDbContext)",
+          "signature": "AddGranitApiKeysEntityFrameworkCore(this IServiceCollection services, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IServiceCollection"
         }
       ]

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -12,18 +13,38 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions;
 public static class ApiKeysEntityFrameworkCoreServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the EF Core API key store and <see cref="Internal.AuthenticationApiKeysDbContext"/>.
+    /// Registers the EF Core API key store and <see cref="AuthenticationApiKeysDbContext"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Registers <see cref="AuthenticationApiKeysDbContext"/> via <c>AddGranitIsolatedDbContext</c>
+    /// so the active <c>TenantIsolationStrategy</c> (<c>SharedDatabase</c>,
+    /// <c>SchemaPerTenant</c>, <c>DatabasePerTenant</c>) is honored end-to-end. API keys
+    /// are a tenant-only concern — under <c>SchemaPerTenant</c> the
+    /// <c>TenantSchemaConnectionInterceptor</c> is wired automatically so unqualified
+    /// queries land in the tenant's schema instead of <c>public</c>.
+    /// </para>
+    /// </remarks>
     /// <param name="services">The service collection.</param>
-    /// <param name="configureDbContext">Action to configure the <see cref="Internal.AuthenticationApiKeysDbContext"/> options (e.g., connection string).</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy (always required).</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
     public static IServiceCollection AddGranitApiKeysEntityFrameworkCore(
         this IServiceCollection services,
-        Action<DbContextOptionsBuilder> configureDbContext)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
         ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(configureDbContext);
+        ArgumentNullException.ThrowIfNull(configureShared);
 
-        services.AddGranitDbContext<AuthenticationApiKeysDbContext>(configureDbContext);
+        services.AddGranitIsolatedDbContext<AuthenticationApiKeysDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
 
         services.TryAddScoped<IApiKeyStore, EfCoreApiKeyStore>();
         services.TryAddScoped<IApiKeyAdminStore, EfCoreApiKeyAdminStore>();

--- a/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests.cs
@@ -1,11 +1,9 @@
 using Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions;
 using Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
-using Granit.Guids;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Interceptors;
-using Granit.Timing;
-using Granit.Users;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Shouldly;
@@ -15,15 +13,24 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests;
 
 public sealed class ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests
 {
+    private static ServiceCollection CreateBaseServices()
+    {
+        var services = new ServiceCollection();
+        // AddGranitIsolatedDbContext binds TenantIsolationOptions from configuration
+        // and the IsolatedDbContextFactory logs through ILogger<>. Tests need both.
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<ICurrentTenant>());
+        return services;
+    }
+
     [Fact]
     public void AddGranitApiKeysEntityFrameworkCore_RegistersRequiredServices()
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddSingleton(Substitute.For<ICurrentTenant>());
+        ServiceCollection services = CreateBaseServices();
 
         services.AddGranitApiKeysEntityFrameworkCore(
-            options => options.UseSqlite("DataSource=:memory:"));
+            configureShared: options => options.UseSqlite("DataSource=:memory:"));
 
         ServiceProvider provider = services.BuildServiceProvider();
 
@@ -42,12 +49,12 @@ public sealed class ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddGranitApiKeysEntityFrameworkCore_NullConfigureAction_ThrowsArgumentNullException()
+    public void AddGranitApiKeysEntityFrameworkCore_NullConfigureShared_ThrowsArgumentNullException()
     {
         var services = new ServiceCollection();
 
         Should.Throw<ArgumentNullException>(
-            () => services.AddGranitApiKeysEntityFrameworkCore(null!));
+            () => services.AddGranitApiKeysEntityFrameworkCore(configureShared: null!));
     }
 
     [Fact]
@@ -65,43 +72,59 @@ public sealed class ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests
         services.Count(s => s.ServiceType == typeof(IApiKeyAdminStore)).ShouldBe(1);
     }
 
+    /// <summary>
+    /// Regression: under SchemaPerTenant the registration must wire the schema-keyed factory
+    /// so <c>TenantSchemaConnectionInterceptor</c> is active and queries land in the tenant
+    /// schema instead of <c>public</c> (repro: granit-iot-showcase 42P01 on /api/api-keys).
+    /// </summary>
     [Fact]
-    public void AddGranitApiKeysEntityFrameworkCore_WithInterceptors_ResolvesFactory()
+    public void AddGranitApiKeysEntityFrameworkCore_SchemaPerTenant_RegistersSchemaKeyedFactory()
     {
-        var services = new ServiceCollection();
-
-        // Register real interceptors with substituted dependencies
-        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
-        services.AddSingleton(new AuditedEntityInterceptor(
-            Substitute.For<ICurrentUserService>(),
-            Substitute.For<IClock>(),
-            Substitute.For<IGuidGenerator>(),
-            currentTenant));
-        services.AddSingleton(new SoftDeleteInterceptor(
-            Substitute.For<ICurrentUserService>(),
-            Substitute.For<IClock>()));
+        ServiceCollection services = CreateBaseServices();
 
         services.AddGranitApiKeysEntityFrameworkCore(
-            options => options.UseSqlite("DataSource=:memory:"));
+            configureShared: options => options.UseSqlite("DataSource=:memory:"),
+            configureSchemaPerTenant: options => options.UseSqlite("DataSource=:memory:"));
 
         ServiceProvider provider = services.BuildServiceProvider();
-        using IServiceScope scope = provider.CreateScope();
-        IDbContextFactory<AuthenticationApiKeysDbContext> factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AuthenticationApiKeysDbContext>>();
-        factory.ShouldNotBeNull();
+
+        IsolatedDbContextMarker marker = provider
+            .GetServices<IsolatedDbContextMarker>()
+            .Single(m => m.DbContextType == typeof(AuthenticationApiKeysDbContext));
+
+        marker.RegisteredStrategies.ShouldContain(TenantIsolationStrategy.SchemaPerTenant);
+        marker.RegisteredStrategies.ShouldContain(TenantIsolationStrategy.SharedDatabase);
+
+        // Verify the keyed factory descriptor is registered. We don't resolve it because
+        // the SchemaPerTenant factory pulls in ITenantSchemaActivator / ITenantSchemaProvider
+        // which require GranitPersistenceEntityFrameworkCoreModule to be loaded — out of scope
+        // for a unit test of the extension method.
+        services.ShouldContain(d =>
+            d.ServiceType == typeof(IDbContextFactory<AuthenticationApiKeysDbContext>) &&
+            d.IsKeyedService &&
+            Equals(d.ServiceKey, TenantIsolationStrategy.SchemaPerTenant));
     }
 
     [Fact]
-    public void AddGranitApiKeysEntityFrameworkCore_WithoutInterceptors_ResolvesFactory()
+    public void AddGranitApiKeysEntityFrameworkCore_DatabasePerTenant_RegistersDatabaseKeyedFactory()
     {
-        var services = new ServiceCollection();
+        ServiceCollection services = CreateBaseServices();
 
-        // No interceptors registered — the null path in the extension method
         services.AddGranitApiKeysEntityFrameworkCore(
-            options => options.UseSqlite("DataSource=:memory:"));
+            configureShared: options => options.UseSqlite("DataSource=:memory:"),
+            configureDatabasePerTenant: (options, _) => options.UseSqlite("DataSource=:memory:"));
 
         ServiceProvider provider = services.BuildServiceProvider();
-        using IServiceScope scope = provider.CreateScope();
-        IDbContextFactory<AuthenticationApiKeysDbContext> factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AuthenticationApiKeysDbContext>>();
-        factory.ShouldNotBeNull();
+
+        IsolatedDbContextMarker marker = provider
+            .GetServices<IsolatedDbContextMarker>()
+            .Single(m => m.DbContextType == typeof(AuthenticationApiKeysDbContext));
+
+        marker.RegisteredStrategies.ShouldContain(TenantIsolationStrategy.DatabasePerTenant);
+
+        services.ShouldContain(d =>
+            d.ServiceType == typeof(IDbContextFactory<AuthenticationApiKeysDbContext>) &&
+            d.IsKeyedService &&
+            Equals(d.ServiceKey, TenantIsolationStrategy.DatabasePerTenant));
     }
 }


### PR DESCRIPTION
## Summary

- `Granit.Authentication.ApiKeys.EntityFrameworkCore` was missed by **#2021** (the 7-module switch to `AddGranitIsolatedDbContext`). Under `TenantIsolation:Strategy=SchemaPerTenant` the `TenantSchemaConnectionInterceptor` was never wired, the connection opened with `search_path=public`, and `EfCoreApiKeyAdminStore` / `EfCoreApiKeyStore` failed with `42P01: relation "api_keys_entries" does not exist` (reproduced on `granit-iot-showcase-dotnet`, `GET /api/api-keys`).
- ApiKeys is a tenant-only module (*Host vs Tenant — Schema Separation*): its tables belong in per-tenant schemas, exactly like BlobStorage, Documents, Activities, Taxonomy.
- Swapped the registration to `AddGranitIsolatedDbContext<AuthenticationApiKeysDbContext>` via the non-generic overload introduced in #2021. Store registrations (`IApiKeyStore`, `IApiKeyAdminStore`) unchanged.

## Breaking change (pre-1.0, no obsolete shim)

`AddGranitApiKeysEntityFrameworkCore` now takes the same optional-callback set as the 7 modules in #2021:

```csharp
public static IServiceCollection AddGranitApiKeysEntityFrameworkCore(
    this IServiceCollection services,
    Action<DbContextOptionsBuilder> configureShared,
    Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
    Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
    Action<TenantSchemaOptions>? configureTenantSchema = null);
```

Same convention as #2021 — clean break, no `[Obsolete]` graduation (framework is pre-1.0). Downstream callers must rename their argument from `configureDbContext` to `configureShared` (or pass it positionally) and add a `configureSchemaPerTenant` callback if they want SchemaPerTenant to work.

`AuthenticationApiKeysDbContext` stays `internal sealed` and continues to inherit `GranitDbContext` — no model or migration changes; the isolated factory wires options + tenant schema interceptor.

## Test plan

- [x] `dotnet build src/Granit.Authentication.ApiKeys.EntityFrameworkCore` — green
- [x] `dotnet build tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests` — green
- [x] `Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests` — 35/35 green (new tests assert `IsolatedDbContextMarker` registers with `SchemaPerTenant` / `DatabasePerTenant` strategies and that the keyed factory descriptor lands in DI)
- [x] `Granit.ArchitectureTests` — 183/183 green (the widened regex from #2021 already matches `AddGranitIsolatedDbContext<T>`)
- [x] `dotnet format --verify-no-changes` clean on both projects
- [ ] Follow-up (separate showcase PR): bump `granit-iot-showcase-dotnet` to the floating dev package and update `AddGranitApiKeysEntityFrameworkCore` call site to the dual-callback form

Refs #2021.