### PR TITLE
fix(privacy): use AddGranitIsolatedDbContext so SchemaPerTenant honors tenant schema

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35266,12 +35266,12 @@
       "kind": "class",
       "project": "Granit.Privacy.EntityFrameworkCore",
       "file": "src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitPrivacyEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitPrivacyEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitPrivacyEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]

--- a/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.Privacy.EntityFrameworkCore.Internal;
 using Granit.Privacy.LegalAgreements;
 using Microsoft.EntityFrameworkCore;
@@ -11,12 +12,42 @@ namespace Granit.Privacy.EntityFrameworkCore.Extensions;
 /// <summary>Extension methods for registering EF Core persistence for Granit.Privacy.</summary>
 public static class PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions
 {
-    /// <summary>Registers EF Core persistence for Granit.Privacy legal document management.</summary>
+    /// <summary>
+    /// Registers EF Core persistence for Granit.Privacy legal document management,
+    /// deletion requests and export requests.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Registers <see cref="PrivacyDbContext"/> via <c>AddGranitIsolatedDbContext</c>
+    /// so the active <c>TenantIsolationStrategy</c> (<c>SharedDatabase</c>,
+    /// <c>SchemaPerTenant</c>, <c>DatabasePerTenant</c>) is honored end-to-end. Privacy
+    /// entities (<c>DeletionRequest</c>, <c>ExportRequest</c>, <c>LegalDocument</c>) are
+    /// tenant-scoped — under <c>SchemaPerTenant</c> the
+    /// <c>TenantSchemaConnectionInterceptor</c> is wired automatically so unqualified
+    /// queries land in the tenant's schema instead of <c>public</c>.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy (always required).</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
+    /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitPrivacyEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
-        builder.Services.AddGranitDbContext<PrivacyDbContext>(configure);
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureShared);
+
+        builder.Services.AddGranitIsolatedDbContext<PrivacyDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
 
         builder.Services.AddScoped<EfLegalDocumentStore>();
         builder.Services.TryAddScoped<ILegalDocumentReader>(sp => sp.GetRequiredService<EfLegalDocumentStore>());

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensionsTests.cs
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,110 @@
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Privacy.EntityFrameworkCore.Extensions;
+using Granit.Privacy.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.EntityFrameworkCore.Tests;
+
+public sealed class PrivacyEntityFrameworkCoreHostApplicationBuilderExtensionsTests
+{
+    private static HostApplicationBuilder CreateBuilder()
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton(Substitute.For<ICurrentTenant>());
+        return builder;
+    }
+
+    [Fact]
+    public void AddGranitPrivacyEntityFrameworkCore_RegistersRequiredServices()
+    {
+        HostApplicationBuilder builder = CreateBuilder();
+
+        builder.AddGranitPrivacyEntityFrameworkCore(
+            configureShared: options => options.UseSqlite("DataSource=:memory:"));
+
+        ServiceProvider provider = builder.Services.BuildServiceProvider();
+
+        provider.GetService<IDbContextFactory<PrivacyDbContext>>().ShouldNotBeNull();
+
+        builder.Services.ShouldContain(d => d.ServiceType == typeof(EfLegalDocumentStore));
+    }
+
+    [Fact]
+    public void AddGranitPrivacyEntityFrameworkCore_NullBuilder_ThrowsArgumentNullException()
+    {
+        IHostApplicationBuilder builder = null!;
+
+        Should.Throw<ArgumentNullException>(
+            () => builder.AddGranitPrivacyEntityFrameworkCore(_ => { }));
+    }
+
+    [Fact]
+    public void AddGranitPrivacyEntityFrameworkCore_NullConfigureShared_ThrowsArgumentNullException()
+    {
+        HostApplicationBuilder builder = CreateBuilder();
+
+        Should.Throw<ArgumentNullException>(
+            () => builder.AddGranitPrivacyEntityFrameworkCore(configureShared: null!));
+    }
+
+    /// <summary>
+    /// Regression: under SchemaPerTenant the registration must wire the schema-keyed factory
+    /// so <c>TenantSchemaConnectionInterceptor</c> is active and queries land in the tenant
+    /// schema instead of <c>public</c> — same class of bug as the 42P01 fixed for ApiKeys.
+    /// </summary>
+    [Fact]
+    public void AddGranitPrivacyEntityFrameworkCore_SchemaPerTenant_RegistersSchemaKeyedFactory()
+    {
+        HostApplicationBuilder builder = CreateBuilder();
+
+        builder.AddGranitPrivacyEntityFrameworkCore(
+            configureShared: options => options.UseSqlite("DataSource=:memory:"),
+            configureSchemaPerTenant: options => options.UseSqlite("DataSource=:memory:"));
+
+        ServiceProvider provider = builder.Services.BuildServiceProvider();
+
+        IsolatedDbContextMarker marker = provider
+            .GetServices<IsolatedDbContextMarker>()
+            .Single(m => m.DbContextType == typeof(PrivacyDbContext));
+
+        marker.RegisteredStrategies.ShouldContain(TenantIsolationStrategy.SchemaPerTenant);
+        marker.RegisteredStrategies.ShouldContain(TenantIsolationStrategy.SharedDatabase);
+
+        // Verify the keyed factory descriptor is registered. We don't resolve it because
+        // the SchemaPerTenant factory pulls in ITenantSchemaActivator / ITenantSchemaProvider
+        // which require GranitPersistenceEntityFrameworkCoreModule to be loaded.
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IDbContextFactory<PrivacyDbContext>) &&
+            d.IsKeyedService &&
+            Equals(d.ServiceKey, TenantIsolationStrategy.SchemaPerTenant));
+    }
+
+    [Fact]
+    public void AddGranitPrivacyEntityFrameworkCore_DatabasePerTenant_RegistersDatabaseKeyedFactory()
+    {
+        HostApplicationBuilder builder = CreateBuilder();
+
+        builder.AddGranitPrivacyEntityFrameworkCore(
+            configureShared: options => options.UseSqlite("DataSource=:memory:"),
+            configureDatabasePerTenant: (options, _) => options.UseSqlite("DataSource=:memory:"));
+
+        ServiceProvider provider = builder.Services.BuildServiceProvider();
+
+        IsolatedDbContextMarker marker = provider
+            .GetServices<IsolatedDbContextMarker>()
+            .Single(m => m.DbContextType == typeof(PrivacyDbContext));
+
+        marker.RegisteredStrategies.ShouldContain(TenantIsolationStrategy.DatabasePerTenant);
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IDbContextFactory<PrivacyDbContext>) &&
+            d.IsKeyedService &&
+            Equals(d.ServiceKey, TenantIsolationStrategy.DatabasePerTenant));
+    }
+}


### PR DESCRIPTION
## Summary

- `Granit.Privacy.EntityFrameworkCore` was missed by **#2021** (the 7-module switch to `AddGranitIsolatedDbContext`). `PrivacyDbContext` hosts tenant-scoped entities (`DeletionRequestEntity`, `ExportRequestEntity`, `LegalDocument` — all `IMultiTenant`) and `GranitPrivacyDbProperties.DbSchema` falls back to `GranitDbDefaults.DbSchema` (the tenant default — i.e. tenant-only intent, unlike the 6 dual-scope modules kept on `AddGranitDbContext` by #2021).
- Under `TenantIsolation:Strategy=SchemaPerTenant` the `TenantSchemaConnectionInterceptor` was never wired, the connection opened with `search_path=public`, and queries against `privacy_deletion_requests` / `privacy_export_requests` / `privacy_legal_documents` would miss the per-tenant schema — same latent `42P01` class of bug as ApiKeys (#2178).
- Swapped the registration to `AddGranitIsolatedDbContext<PrivacyDbContext>` via the non-generic overload introduced in #2021. Store registrations (`EfLegalDocumentStore`, `ILegalDocumentReader`, `ILegalDocumentWriter`, `ILegalDocumentPublicationService`) unchanged.

## Breaking change (pre-1.0, no obsolete shim)

`AddGranitPrivacyEntityFrameworkCore` now takes the same optional-callback set as the 7 modules in #2021:

```csharp
public static IHostApplicationBuilder AddGranitPrivacyEntityFrameworkCore(
    this IHostApplicationBuilder builder,
    Action<DbContextOptionsBuilder> configureShared,
    Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
    Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
    Action<TenantSchemaOptions>? configureTenantSchema = null);
```

Same convention as #2021 / #2178 — clean break, no `[Obsolete]` graduation. Downstream callers must rename their argument from `configure` to `configureShared` (or pass positionally) and add a `configureSchemaPerTenant` callback if they want SchemaPerTenant to work.

`PrivacyDbContext` stays `internal sealed` and continues to inherit `GranitDbContext` — no model or migration changes.

## Test plan

- [x] `dotnet build src/Granit.Privacy.EntityFrameworkCore` — green
- [x] `dotnet build tests/Granit.Privacy.EntityFrameworkCore.Tests` — green
- [x] `Granit.Privacy.EntityFrameworkCore.Tests` — 22/22 green (new tests assert `IsolatedDbContextMarker` registers with `SchemaPerTenant` / `DatabasePerTenant` strategies and the keyed factory descriptor lands in DI; null-arg + happy-path coverage on the new signature)
- [x] `Granit.ArchitectureTests` — 183/183 green (the widened regex from #2021 already matches `AddGranitIsolatedDbContext<T>`)
- [x] `dotnet format --verify-no-changes` clean on both projects
- [ ] Follow-up (separate showcase PRs): any downstream host calling `AddGranitPrivacyEntityFrameworkCore` must rename `configure` → `configureShared` (or pass positionally) and add `configureSchemaPerTenant` if running on SchemaPerTenant

Refs #2021 #2178.