### PR TITLE
feat(dataexchange): migrate SavedMappingEntity + ExportPresetEntity to typed JSON

### DIFF
--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportPresetEntityConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportPresetEntityConfiguration.cs
@@ -19,7 +19,7 @@ internal sealed class ExportPresetEntityConfiguration : IEntityTypeConfiguration
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
         builder.Property(e => e.PresetName).HasMaxLength(200).IsRequired();
         builder.Property(e => e.TenantId);
-        builder.Property(e => e.FieldsJson).IsRequired();
+        builder.PrimitiveCollection(e => e.Fields).IsRequired();
         builder.Property(e => e.Format).HasMaxLength(10).IsRequired();
         builder.Property(e => e.IncludeIdForImport).IsRequired();
         builder.Property(e => e.SavedAt).IsRequired();

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Entities/ExportPresetEntity.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Entities/ExportPresetEntity.cs
@@ -20,8 +20,8 @@ internal sealed class ExportPresetEntity : IMultiTenant
     /// <summary>Tenant identifier. <c>null</c> when multi-tenancy is not active.</summary>
     public Guid? TenantId { get; set; }
 
-    /// <summary>Serialized <c>string[]</c> of selected field property paths (JSON).</summary>
-    public required string FieldsJson { get; set; }
+    /// <summary>Selected field property paths, persisted as a JSON primitive collection.</summary>
+    public required List<string> Fields { get; set; }
 
     /// <summary>Output format (<c>"xlsx"</c> or <c>"csv"</c>).</summary>
     public required string Format { get; set; }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Stores/EfExportPresetStore.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Stores/EfExportPresetStore.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Export.Entities;
 using Granit.DataExchange.Export;
 using Granit.Guids;
@@ -58,7 +57,6 @@ internal sealed class EfExportPresetStore(
     {
         await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
-        string fieldsJson = JsonSerializer.Serialize(preset.SelectedFields);
 
         ExportPresetEntity? existing = await context.ExportPresets
             .FirstOrDefaultAsync(
@@ -68,7 +66,7 @@ internal sealed class EfExportPresetStore(
 
         if (existing is not null)
         {
-            existing.FieldsJson = fieldsJson;
+            existing.Fields = [.. preset.SelectedFields];
             existing.Format = preset.Format;
             existing.IncludeIdForImport = preset.IncludeIdForImport;
             existing.SavedAt = clock.Now;
@@ -81,7 +79,7 @@ internal sealed class EfExportPresetStore(
                 DefinitionName = preset.DefinitionName,
                 PresetName = preset.PresetName,
                 TenantId = tenantId,
-                FieldsJson = fieldsJson,
+                Fields = [.. preset.SelectedFields],
                 Format = preset.Format,
                 IncludeIdForImport = preset.IncludeIdForImport,
                 SavedAt = clock.Now,
@@ -112,14 +110,11 @@ internal sealed class EfExportPresetStore(
         }
     }
 
-    private static ExportPreset ToPreset(ExportPresetEntity entity)
-    {
-        List<string>? fields = JsonSerializer.Deserialize<List<string>>(entity.FieldsJson);
-        return new ExportPreset(
+    private static ExportPreset ToPreset(ExportPresetEntity entity) =>
+        new(
             entity.DefinitionName,
             entity.PresetName,
-            fields?.AsReadOnly() ?? (IReadOnlyList<string>)[],
+            entity.Fields.AsReadOnly(),
             entity.Format,
             entity.IncludeIdForImport);
-    }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/SavedMappingEntityConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/SavedMappingEntityConfiguration.cs
@@ -18,7 +18,13 @@ internal sealed class SavedMappingEntityConfiguration : IEntityTypeConfiguration
 
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
         builder.Property(e => e.TenantId);
-        builder.Property(e => e.MappingsJson).IsRequired();
+        builder.OwnsMany(e => e.Mappings, m =>
+        {
+            m.ToJson();
+            m.Property(p => p.SourceColumn);
+            m.Property(p => p.TargetProperty);
+            m.Property(p => p.Confidence);
+        });
         builder.Property(e => e.SavedAt).IsRequired();
         builder.Property(e => e.SavedBy).HasMaxLength(200).IsRequired();
 

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Entities/SavedMappingEntity.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Entities/SavedMappingEntity.cs
@@ -1,3 +1,4 @@
+using Granit.DataExchange.Import.Mapping;
 using Granit.Domain;
 
 namespace Granit.DataExchange.EntityFrameworkCore.Internal.Import.Entities;
@@ -17,8 +18,8 @@ internal sealed class SavedMappingEntity : IMultiTenant
     /// <summary>Tenant identifier. <c>null</c> when multi-tenancy is not active.</summary>
     public Guid? TenantId { get; set; }
 
-    /// <summary>Serialized <c>ImportColumnMapping[]</c> as JSON.</summary>
-    public required string MappingsJson { get; set; }
+    /// <summary>Column mappings persisted as a JSON-owned collection.</summary>
+    public required List<ImportColumnMapping> Mappings { get; set; }
 
     /// <summary>When the mappings were saved.</summary>
     public DateTimeOffset SavedAt { get; set; }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfMappingStore.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfMappingStore.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Entities;
 using Granit.DataExchange.Import.Mapping;
 using Granit.Guids;
@@ -32,13 +31,7 @@ internal sealed class EfMappingStore(
             .FirstOrDefaultAsync(
                 e => e.DefinitionName == definitionName && e.TenantId == tenantId, cancellationToken).ConfigureAwait(false);
 
-        if (entity is null)
-        {
-            return [];
-        }
-
-        List<ImportColumnMapping>? mappings = JsonSerializer.Deserialize<List<ImportColumnMapping>>(entity.MappingsJson);
-        return mappings?.AsReadOnly() ?? (IReadOnlyList<ImportColumnMapping>)[];
+        return entity?.Mappings.AsReadOnly() ?? (IReadOnlyList<ImportColumnMapping>)[];
     }
 
     /// <inheritdoc/>
@@ -49,7 +42,6 @@ internal sealed class EfMappingStore(
     {
         await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
-        string json = JsonSerializer.Serialize(mappings);
 
         SavedMappingEntity? existing = await context.SavedMappings
             .FirstOrDefaultAsync(
@@ -57,7 +49,7 @@ internal sealed class EfMappingStore(
 
         if (existing is not null)
         {
-            existing.MappingsJson = json;
+            existing.Mappings = [.. mappings];
             existing.SavedAt = clock.Now;
         }
         else
@@ -67,7 +59,7 @@ internal sealed class EfMappingStore(
                 Id = guidGenerator.Create(),
                 DefinitionName = definitionName,
                 TenantId = tenantId,
-                MappingsJson = json,
+                Mappings = [.. mappings],
                 SavedAt = clock.Now,
                 SavedBy = currentUser.UserId ?? "system",
             });


### PR DESCRIPTION
## Summary

Migrates two EFC-internal entities from hand-rolled JSON strings to EF Core native typed JSON mapping. Companion to #2175 / #2176 in the .NET 11 EF JSON-mapping readiness sequence.

| Entity | Before | After |
|---|---|---|
| [SavedMappingEntity](src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Entities/SavedMappingEntity.cs) | `string MappingsJson` | `List<ImportColumnMapping> Mappings` via `OwnsMany(...).ToJson()` |
| [ExportPresetEntity](src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Entities/ExportPresetEntity.cs) | `string FieldsJson` | `List<string> Fields` via `PrimitiveCollection` |

Two stores drop their `JsonSerializer.Serialize`/`Deserialize` plumbing:
- [EfMappingStore](src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfMappingStore.cs) — entity exposes typed mappings; store just reads/writes the property.
- [EfExportPresetStore](src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Stores/EfExportPresetStore.cs) — `ToPreset` becomes a plain projection.

## Why now

The 2 entities are `internal` to `Granit.DataExchange.EntityFrameworkCore`. Pure refactor, no API breaks. Storage layout is improved (queryable JSON column instead of opaque string), and the code path is shorter — fewer string ↔ object hops.

## Scope (intentionally reduced from initial plan)

`ImportJob.MappingsJson`, `ImportJob.ReportJson`, `ExportJob.RequestJson` are **deferred**. Those columns belong to domain aggregates (`AuditedAggregateRoot`) whose lifecycle methods (`ConfirmMappings(string)`, `Complete(... string reportJson, ...)`, `ExportJob.Create(... string requestJson, ...)`) take strings as part of their state machine. Migrating them requires:
- Changing public/internal domain signatures
- Updating both orchestrators (`ImportOrchestrator`, `ExportOrchestrator`)
- Touching tests in `Granit.DataExchange.Tests` + integration tests

That's a separate PR — to be tracked as a follow-up issue.

## Test plan

- [x] `Granit.DataExchange.EntityFrameworkCore.Tests` — 48 passed (unchanged: existing tests cover the new code paths without modification, since they hit the same store API)
- [x] `Granit.ArchitectureTests` — 183 passed
- [x] `dotnet format` clean on both csprojs
- [ ] CI green on relevant shards