### PR TITLE
chore(options)!: homogenize SectionName convention across framework

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -64,7 +64,7 @@ FLAGS
     anatomy       Module structure and layering
     layer-purity  Detect domain code leaking into .Endpoints / .EntityFrameworkCore
     code          C# 14 idioms, anti-patterns, modern patterns
-    naming        Permissions, events, jobs, DTOs, module homogeneity
+    naming        Permissions, events, jobs, DTOs, module homogeneity, SectionName hierarchy
     http          HTTP conventions, status codes, pagination, caching
     openapi       Endpoint metadata (5 mandatory elements)
     persistence   DbContext, EF Core, interceptors, concurrency
@@ -254,6 +254,12 @@ After auditing individual modules, perform cross-cutting checks:
 5b. **Module naming homogeneity** — all classes, methods, string literals, and
    namespaces consistently use the current module name (detect rename residues via
    `git log --diff-filter=R`)
+5c. **`SectionName` hierarchy** — every `public const string SectionName` follows
+   the colon-separated namespace-aligned convention, no `Granit:` prefix, no
+   PascalCase-glued names; covered by `SectionNameConventionTests` in
+   `Granit.ArchitectureTests`. Audit checks (a) the assertion lines up with
+   `Granit.{X}.Y` namespace, (b) `templates/granit-*/appsettings.json` keys are
+   aligned, (c) doc/XML comments reference the canonical path
 6. **Health check uniformity** — readiness/startup tags, 10s timeout, no PII
 7. **Localization completeness** — all 18 cultures present in every module
 8. **[DependsOn] consistency** — matches actual `<ProjectReference>` graph

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -149,6 +149,45 @@ Ref: `docs-site/…/concepts/dependency-injection.mdx`
 - [ ] `ValidateOnStart()` for fail-fast on misconfiguration
 - [ ] No secrets in `appsettings.json` — use env vars, User Secrets, or Vault
 
+#### `SectionName` convention (STRICT)
+
+Format: `{Module}[:{SubModule}[:{Feature}]]` — colon-separated, ASP.NET-style.
+Aligned on the project namespace after stripping the `Granit` prefix.
+Example: `Granit.Foo.Bar.Baz` → `"Foo:Bar:Baz"`.
+
+- [ ] **Never starts with `Granit:`** — `Granit` is the code namespace, not a
+  configuration root. `"Granit:ApiKeys"` → `"Authentication:ApiKeys"`,
+  `"Granit:IO:TempFiles"` → `"IO:TempFiles"`, etc.
+- [ ] **No PascalCase-glued tokens** — `"FooBar"` is forbidden whenever
+  `"Foo:Bar"` applies. Specifically forbidden patterns:
+  - `*Endpoints` → split as `*:Endpoints` (e.g. `BlobStorageEndpoints` →
+    `BlobStorage:Endpoints`)
+  - `Wolverine*` → split as `Wolverine:*` (e.g. `WolverinePostgresql` →
+    `Wolverine:Postgresql`)
+  - `GranitMigrations` → `Persistence:Migrations`
+  - `TenantSchema` → `MultiTenancy:TenantSchema`
+- [ ] **Single-segment SectionName** is allowed ONLY for top-level modules whose
+  project is the root namespace (`Notifications`, `Authentication`, `Vault`,
+  `BlobStorage`, `Cache`, `Bff`, …). Any compound concept MUST be hierarchical.
+- [ ] **Aligned with namespace** — a sub-project under `Granit.Foo.Bar` should
+  bind to `"Foo:Bar"`, never invent a new root (`"AzureCommunicationServices:Email"`
+  for `Granit.Notifications.Email.AzureCommunicationServices` is wrong — should be
+  `"Notifications:Email:AzureCommunicationServices"`).
+- [ ] **No collision** — two `Options` classes never share the same SectionName
+  string. ASP.NET allows a section to host both bound properties AND child
+  sub-sections, but two distinct Options classes pointing at the same path
+  break binding silently (real incident: `ImportOptions` and the parent
+  `DataExchange` root both used `"DataExchange"`).
+- [ ] **Test asserts the SectionName** — every `*Options` ships an
+  `OptionsTests.cs` with `SectionName.ShouldBe("Expected:Path")` so renames
+  surface in CI.
+- [ ] **`appsettings.json` examples reflect the current name** — in
+  `templates/`, doc XML, and embedded examples.
+
+Enforced by `Granit.ArchitectureTests.SectionNameConventionTests`. When you
+need a new top-level section, add it to `AllowedSingleSegmentSections` in that
+file along with a one-line rationale.
+
 Ref: `docs-site/…/concepts/configuration.mdx`
 
 ---
@@ -267,6 +306,31 @@ Ref: `CLAUDE.md §Background Jobs`
 - [ ] Identifiers: UUID v7 with dashes
 
 Ref: `CLAUDE.md §DTOs`, `docs-site/…/architecture/http-conventions.md`
+
+### 3d-bis. `SectionName` homogeneity (`--scope naming`)
+
+Full rule list under §1d. Quick checklist for the naming pass:
+
+- [ ] No SectionName starts with `Granit:` (use bare hierarchical path)
+- [ ] No PascalCase-glued SectionName for compound concepts (`FooBar` →
+  `Foo:Bar`)
+- [ ] `*.Endpoints` SectionName follows `Module:Endpoints` (and
+  `Module:Endpoints:Feature` for feature subsets) — never `ModuleEndpoints`
+- [ ] Sub-projects under `Granit.Notifications.{Channel}.{Provider}` SectionName
+  is `Notifications:{Channel}:{Provider}` (don't skip the channel segment, don't
+  invent a vendor root)
+- [ ] Sub-projects under `Granit.Identity.Federated.{Provider}` SectionName is
+  `Identity:Federated:{Provider}` (don't use the legacy `{Provider}Admin` flat
+  form)
+- [ ] `Granit.{Family}.{Subprovider}` (Vault, Wolverine, Cache, Mcp, AI, …) →
+  `{Family}:{Subprovider}` (Wolverine.Postgresql → `Wolverine:Postgresql`)
+- [ ] Every Options class has a unit test asserting `SectionName.ShouldBe(...)`
+  with the canonical path; assertion is up to date after any rename
+- [ ] `templates/granit-*/appsettings.json` keys match the current SectionName
+
+Enforced by `Granit.ArchitectureTests.SectionNameConventionTests`. If the test
+flags a new top-level section that you intend to keep, edit
+`AllowedSingleSegmentSections` with a one-line rationale.
 
 ### 3e. Module naming homogeneity (post-rename check)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,135 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
-### Fixed
+### Changed (framework — BREAKING: appsettings)
 
-- **Breaking — `Granit.Authentication.JwtBearer.Keycloak`.** Two related changes ship together. (1) `AddGranitKeycloak()` now applies its Keycloak-specific JwtBearer overrides via `.Configure<>` instead of `.PostConfigure<>`: the framework's built-in `JwtBearerPostConfigureOptions` is what materialises the `ConfigurationManager<OpenIdConnectConfiguration>` from `Authority`, and it runs in the PostConfigure phase. With the previous registration, if a host provided only the Keycloak section (no `Authentication:*` doublon), `Authority` was still empty when the framework's PostConfigure ran → no ConfigurationManager → no JWKS fetch → every inbound token failed with `IDX10500 ("Signature validation failed. Unable to resolve SignatureValidator…")`. (2) `KeycloakOptions.SectionName` moves from `"Keycloak"` (root) to `"Authentication:Keycloak"` so Keycloak config sits under the same `Authentication:*` parent as `JwtBearerAuthOptions` (section `"Authentication"`). **Migration**: rewrite the host appsettings:
+- **`SectionName` homogenization across the framework.** Every `public const string SectionName` on a Granit options class now follows the same convention: a colon-separated, ASP.NET-style hierarchical path aligned on the project namespace after stripping the internal `Granit` prefix (`Granit.Foo.Bar.Baz` → `"Foo:Bar:Baz"`). Three classes of legacy values were eliminated: (1) the `Granit:` root prefix (which was leaking the code namespace into config — `"Granit:ApiKeys"`, `"Granit:IO:TempFiles"`, `"Granit:Templating:App"`, `"Granit:DataExchange:BlobStorage"`); (2) PascalCase-glued compound names that hid a real hierarchy (`"WolverinePostgresql"`, `"WolverineSqlServer"`, `"GranitMigrations"`, `"TenantSchema"`, every `"*Endpoints"` umbrella, every `Http.*` flat name); (3) vendor-rooted or wrong-segmented names under `Notifications.*` and `Identity.Federated.*` (`"AzureCommunicationServices:Email"`, `"Notifications:Smtp"`, `"KeycloakAdmin"`, `"EntraIdAdmin"`, `"CognitoAdmin"`, `"Identity:UserCacheHasher"`, …). One real binding collision was also fixed: `ImportOptions` and the root data-exchange config both bound to `"DataExchange"`, silently shadowing one another — `ImportOptions` now lives at `"DataExchange:Import"` and `ExportOptions` at `"DataExchange:Export"`. The convention is enforced going forward by `Granit.ArchitectureTests.SectionNameConventionTests` (forbids `Granit:` root, forbids flat compound names, requires SectionName uniqueness). Every renamed section also has its `*OptionsTests.SectionName.ShouldBe(...)` assertion updated, and the `templates/granit-api-full/appsettings.json` was repointed (`"Cors"` → `"Http:Cors"`). The Keycloak JwtBearer rename (`"Keycloak"` → `"Authentication:Keycloak"`) shipped earlier in this release is part of the same sweep.
+
+  **Migration** — rewrite the host `appsettings.json` (only the sections you actually use):
 
   ```diff
-  - "Keycloak": {
-  -   "Authority": "http://localhost:8080/realms/my-realm",
-  -   "ClientId": "my-api"
-  - }
-  + "Authentication": {
-  +   "Keycloak": {
-  +     "Authority": "http://localhost:8080/realms/my-realm",
-  +     "ClientId": "my-api"
-  +   }
+  - "Keycloak":              { ... }      // JwtBearer
+  + "Authentication": { "Keycloak": { ... } }
+
+  - "Cognito":               { ... }
+  - "EntraId":               { ... }
+  - "GoogleCloudAuth":       { ... }
+  + "Authentication": { "Cognito": { ... }, "EntraId": { ... }, "GoogleCloud": { ... } }
+
+  - "Granit:ApiKeys":        { ... }
+  + "Authentication": { "ApiKeys": { ... } }
+
+  - "WolverinePostgresql":   { ... }
+  - "WolverineSqlServer":    { ... }
+  + "Wolverine": { "Postgresql": { ... }, "SqlServer": { ... } }
+
+  - "GranitMigrations":      { ... }
+  + "Persistence": { "Migrations": { ... } }
+
+  - "TenantSchema":          { ... }
+  + "MultiTenancy": { "TenantSchema": { ... } }
+
+  - "TokenManagement":       { ... }
+  + "Oidc": { "TokenManagement": { ... } }
+
+  - "ReEncryption":          { ... }
+  + "Vault": { "ReEncryption": { ... } }
+
+  - "Granit:IO:TempFiles":   { ... }
+  + "IO": { "TempFiles": { ... } }
+
+  - "Granit:Templating:App": { ... }
+  + "Templating": { "App": { ... } }
+
+  - "Granit:DataExchange:BlobStorage": { ... }
+  + "DataExchange": { "BlobStorage": { ... } }
+
+  # *.Endpoints umbrella sections (one example, applies to every Endpoints module):
+  - "BlobStorageEndpoints":  { ... }
+  + "BlobStorage": { "Endpoints": { ... } }
+  - "AIEndpoints":           { ... }
+  + "AI": { "Endpoints": { ... } }
+  - "ApiKeysEndpoints":      { ... }
+  + "Authentication": { "ApiKeys": { "Endpoints": { ... } } }
+  - "AuthorizationEndpoints":{ ... }
+  + "Authorization": { "Endpoints": { ... } }
+  - "BackgroundJobsEndpoints":{ ... }
+  + "BackgroundJobs": { "Endpoints": { ... } }
+  - "DataExchangeEndpoints": { ... }
+  + "DataExchange": { "Endpoints": { ... } }
+  - "IdentityEndpoints":     { ... }
+  - "IdentityProviderEndpoints": { ... }
+  - "IdentityWebhook":       { ... }
+  + "Identity": { "Endpoints": { ... , "Provider": { ... } }, "Webhook": { ... } }
+  - "SchedulingEndpoints":   { ... }
+  + "Scheduling": { "Endpoints": { ... } }
+  - "TimelineEndpoints":     { ... }
+  + "Timeline": { "Endpoints": { ... } }
+  - "WebhooksEndpoints":     { ... }
+  + "Webhooks": { "Endpoints": { ... } }
+  - "WorkflowEndpoints":     { ... }
+  + "Workflow": { "Endpoints": { ... } }
+
+  # Http.* — all flat names now under "Http:":
+  - "ApiDocumentation":      { ... }
+  - "ApiVersioning":         { ... }
+  - "Bulkhead":              { ... }
+  - "Cors":                  { ... }
+  - "Cookies":               { ... }
+  - "Klaro":                 { ... }
+  - "HttpResilience":        { ... }
+  - "Idempotency":           { ... }
+  - "OutputCaching":         { ... }
+  - "OutputCaching:Redis":   { ... }
+  - "ResponseCompression":   { ... }
+  - "SecurityHeaders":       { ... }
+  + "Http": {
+  +   "ApiDocumentation": { ... }, "ApiVersioning": { ... }, "Bulkhead": { ... },
+  +   "Cors": { ... }, "Cookies": { ..., "Klaro": { ... } }, "Resilience": { ... },
+  +   "Idempotency": { ... }, "OutputCaching": { ..., "Redis": { ... } },
+  +   "ResponseCompression": { ... }, "SecurityHeaders": { ... }
   + }
+
+  # Notifications.* — missing channel segment / wrong root:
+  - "Notifications:Smtp":             { ... }
+  - "Notifications:AwsSes":           { ... }
+  - "AzureCommunicationServices:Email":  { ... }
+  - "AzureCommunicationServices:Sms":    { ... }
+  - "Notifications:AzureNotificationHubs":{ ... }
+  - "Notifications:Push":             { ... }  // WebPush
+  + "Notifications": {
+  +   "Email": { "Smtp": { ... }, "AwsSes": { ... }, "AzureCommunicationServices": { ... } },
+  +   "Sms":   { "AzureCommunicationServices": { ... } },
+  +   "MobilePush": { "AzureNotificationHubs": { ... } },
+  +   "WebPush": { ... }
+  + }
+
+  # Identity.Federated.* — admin providers and sub-options:
+  - "KeycloakAdmin":              { ... }
+  - "KeycloakAdmin:ClientRoleSync":{ ... }
+  - "CognitoAdmin":               { ... }
+  - "CognitoAdmin:ClientRoleSync": { ... }
+  - "EntraIdAdmin":               { ... }
+  - "EntraIdAdmin:ClientRoleSync": { ... }
+  - "Identity:GoogleCloud":       { ... }
+  - "Identity:UserCacheHasher":   { ... }
+  - "IdentityUserCache":          { ... }
+  - "IdentityFederatedNotifications": { ... }
+  + "Identity": { "Federated": {
+  +   "Keycloak":    { ..., "ClientRoleSync": { ... } },
+  +   "Cognito":     { ..., "ClientRoleSync": { ... } },
+  +   "EntraId":     { ..., "ClientRoleSync": { ... } },
+  +   "GoogleCloud": { ... },
+  +   "UserCacheHasher": { ... }, "UserCache": { ... },
+  +   "Notifications":   { ... }
+  + } }
   ```
 
-  Env-var bindings: `Keycloak__Authority` → `Authentication__Keycloak__Authority`. K8s/Vault projections, CI secrets, and ExternalSecret manifests must be updated in the same deploy. The unrelated `KeycloakAdminOptions` section (`"KeycloakAdmin"`, owned by `Granit.Identity.Federated.Keycloak`) is **not** affected.
+  **Operational impact**: every Granit-using host must rewrite its `appsettings.json`, K8s/Vault projections (the `__` env-var syntax mirrors the new key), CI secrets, and ExternalSecret manifests in the same deploy. Containers should be rolled together: a mixed fleet will see whichever pods still read the old key fall back to defaults silently. The accompanying Keycloak JwtBearer fix (described next) addresses an `IDX10500` regression introduced by the previous Keycloak section split.
+
+### Fixed
+
+- **Breaking — `Granit.Authentication.JwtBearer.Keycloak`.** `AddGranitKeycloak()` now applies its Keycloak-specific JwtBearer overrides via `.Configure<>` instead of `.PostConfigure<>`: the framework's built-in `JwtBearerPostConfigureOptions` is what materialises the `ConfigurationManager<OpenIdConnectConfiguration>` from `Authority`, and it runs in the PostConfigure phase. With the previous registration, if a host provided only the Keycloak section (no `Authentication:*` doublon), `Authority` was still empty when the framework's PostConfigure ran → no ConfigurationManager → no JWKS fetch → every inbound token failed with `IDX10500 ("Signature validation failed. Unable to resolve SignatureValidator…")`. The companion `SectionName` move (`"Keycloak"` → `"Authentication:Keycloak"`) is documented in the "SectionName homogenization" entry above; see that section for the appsettings migration diff and the wider sweep across all Granit modules.
 - `Granit.Http.SecurityHeaders` / `Granit.Http.ApiDocumentation` — new public marker `AllowsPopupAuthorizationMetadata` (in `Granit.Http.SecurityHeaders.Abstractions`). When attached to an endpoint, the security-headers middleware downgrades `Cross-Origin-Opener-Policy` to `unsafe-none` for that endpoint only; every other route keeps the strict `same-origin` baseline. `UseGranitApiDocumentation()` automatically attaches the marker on the Scalar route when `OAuth2` is configured. The default `same-origin` (and even `same-origin-allow-popups`) severs the opener↔popup window reference the moment the popup navigates to the IdP, breaking Scalar's polling-based Authorization Code flow: the popup completes, but the parent can no longer read its `window.location` to pick up the auth code and shows `"Window was closed without granting authorization."` Without this fix every CSP / RedirectUri change shipped in `[Unreleased]` still left Authorize broken on hosts that enable the strict COOP default.
 - `Granit.Http.ApiDocumentation` — new `ApiDocumentationOptions.OAuth2.RedirectUri` property, propagated to Scalar via `flow.WithRedirectUri(...)`. Workaround for `Scalar.AspNetCore` 2.12.40+ where the default redirect URI changed and breaks Authorization Code popups (scalar/scalar#8165, #8187): the popup returns same-origin but on a URL Scalar no longer recognises, so the auth code is never piped back and the user sees `"Window was closed without granting authorization."` Set this to the absolute URL of the Scalar UI (e.g. `http://localhost:5000/scalar`) and make sure it is registered as a valid redirect URI on the IdP client. Leave unset only when upstream restores the previous default.
 - `Granit.Http.ApiDocumentation` — `ScalarCspContributor` now whitelists `https://api.scalar.com` on `connect-src` (Scalar's Vue.js bootstrap fetches its curated-documents / search registry from `api.scalar.com/vector/registry/*` on mount and on every search keystroke). When `ApiDocumentationOptions.OAuth2` is configured, the contributor also adds the origins (scheme + host + port) of the OAuth2 `AuthorizationUrl` and `TokenUrl` to `connect-src`, allowing Scalar's Authorization Code → Token exchange (browser-side cross-origin POST to the IdP, e.g. `localhost:5000 → localhost:8080`) to complete instead of being blocked by CSP. Without this, the interactive "Authorize" button signed-in state never persisted. `script-src` now also carries `'unsafe-eval'`: the Scalar bundle evaluates code dynamically (template parsing, JSON Schema example rendering) via `eval` / `new Function`, which the previous policy blocked. The relaxation stays scoped to endpoints carrying `ScalarApiReferenceMetadata` and is dev-only by default (`EnableInProduction = false`).

--- a/src/Granit.AI.Endpoints/Options/AIEndpointsOptions.cs
+++ b/src/Granit.AI.Endpoints/Options/AIEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.AI.Endpoints.Options;
 public sealed class AIEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "AIEndpoints";
+    public const string SectionName = "AI:Endpoints";
 
     /// <summary>
     /// Route prefix for all AI endpoints.

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Options/ApiKeysEndpointsOptions.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Options/ApiKeysEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Authentication.ApiKeys.Endpoints.Options;
 public sealed class ApiKeysEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "ApiKeysEndpoints";
+    public const string SectionName = "Authentication:ApiKeys:Endpoints";
 
     /// <summary>Route prefix for API key endpoints. Default: <c>authentication</c>.</summary>
     public string RoutePrefix { get; set; } = "authentication";

--- a/src/Granit.Authentication.ApiKeys/Options/ApiKeysOptions.cs
+++ b/src/Granit.Authentication.ApiKeys/Options/ApiKeysOptions.cs
@@ -11,9 +11,9 @@ namespace Granit.Authentication.ApiKeys.Options;
 public sealed class ApiKeysOptions
 {
     /// <summary>
-    /// Default configuration section: <c>"Granit:ApiKeys"</c>.
+    /// Default configuration section: <c>"Authentication:ApiKeys"</c>.
     /// </summary>
-    public const string SectionName = "Granit:ApiKeys";
+    public const string SectionName = "Authentication:ApiKeys";
 
     /// <summary>
     /// Number of days before <see cref="Domain.ApiKeyEntry.ExpiresAt"/> at which the

--- a/src/Granit.Authentication.JwtBearer.Cognito/Options/CognitoOptions.cs
+++ b/src/Granit.Authentication.JwtBearer.Cognito/Options/CognitoOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Authentication.JwtBearer.Cognito.Options;
 public sealed class CognitoOptions
 {
     /// <summary>Section key in the configuration.</summary>
-    public const string SectionName = "Cognito";
+    public const string SectionName = "Authentication:Cognito";
 
     /// <summary>
     /// OIDC authority URL (e.g. <c>https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_XXXXXXXXX</c>).

--- a/src/Granit.Authentication.JwtBearer.EntraId/Options/EntraIdOptions.cs
+++ b/src/Granit.Authentication.JwtBearer.EntraId/Options/EntraIdOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Authentication.JwtBearer.EntraId.Options;
 public sealed class EntraIdOptions
 {
     /// <summary>Section key in the configuration.</summary>
-    public const string SectionName = "EntraId";
+    public const string SectionName = "Authentication:EntraId";
 
     /// <summary>
     /// Azure AD instance URL. Default: <c>https://login.microsoftonline.com/</c>.

--- a/src/Granit.Authentication.JwtBearer.GoogleCloud/Options/GoogleCloudAuthenticationOptions.cs
+++ b/src/Granit.Authentication.JwtBearer.GoogleCloud/Options/GoogleCloudAuthenticationOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Authentication.JwtBearer.GoogleCloud.Options;
 public sealed class GoogleCloudAuthenticationOptions
 {
     /// <summary>Section key in the configuration.</summary>
-    public const string SectionName = "GoogleCloudAuth";
+    public const string SectionName = "Authentication:GoogleCloud";
 
     /// <summary>
     /// GCP project ID. Used to derive the OIDC authority

--- a/src/Granit.Authorization.Endpoints/Options/AuthorizationEndpointsOptions.cs
+++ b/src/Granit.Authorization.Endpoints/Options/AuthorizationEndpointsOptions.cs
@@ -2,13 +2,13 @@ namespace Granit.Authorization.Endpoints.Options;
 
 /// <summary>
 /// Configuration options for the authorization management endpoints.
-/// Bind from <c>"AuthorizationEndpoints"</c> or pass an action to
+/// Bind from <c>"Authorization:Endpoints"</c> or pass an action to
 /// <see cref="Extensions.AuthorizationEndpointRouteBuilderExtensions.MapGranitAuthorization"/>.
 /// </summary>
 public sealed class AuthorizationEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "AuthorizationEndpoints";
+    public const string SectionName = "Authorization:Endpoints";
 
     /// <summary>
     /// Route prefix for all authorization endpoints.

--- a/src/Granit.BackgroundJobs.Endpoints/Options/BackgroundJobsEndpointsOptions.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Options/BackgroundJobsEndpointsOptions.cs
@@ -2,13 +2,13 @@ namespace Granit.BackgroundJobs.Endpoints.Options;
 
 /// <summary>
 /// Configuration options for the background jobs administration endpoints.
-/// Bind from <c>"BackgroundJobsEndpoints"</c> or pass an action to
+/// Bind from <c>"BackgroundJobs:Endpoints"</c> or pass an action to
 /// <see cref="Extensions.BackgroundJobsEndpointRouteBuilderExtensions.MapGranitBackgroundJobs"/>.
 /// </summary>
 public sealed class BackgroundJobsEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "BackgroundJobsEndpoints";
+    public const string SectionName = "BackgroundJobs:Endpoints";
 
     /// <summary>
     /// Route prefix for all background jobs endpoints.

--- a/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointsHostApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class BlobStorageEndpointsHostApplicationBuilderExtensions
     /// <summary>
     /// Adds <c>Granit.BlobStorage.Endpoints</c> services: binds
     /// <see cref="BlobStorageEndpointsOptions"/> from the
-    /// <c>"BlobStorageEndpoints"</c> configuration section and registers the
+    /// <c>"BlobStorage:Endpoints"</c> configuration section and registers the
     /// OpenAPI schema example provider.
     /// </summary>
     /// <param name="builder">The host application builder.</param>

--- a/src/Granit.BlobStorage.Endpoints/Options/BlobStorageEndpointsOptions.cs
+++ b/src/Granit.BlobStorage.Endpoints/Options/BlobStorageEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.BlobStorage.Endpoints.Options;
 public sealed class BlobStorageEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "BlobStorageEndpoints";
+    public const string SectionName = "BlobStorage:Endpoints";
 
     /// <summary>
     /// Route prefix for all blob storage endpoints.

--- a/src/Granit.DataExchange.BlobStorage/Options/DataExchangeBlobStorageOptions.cs
+++ b/src/Granit.DataExchange.BlobStorage/Options/DataExchangeBlobStorageOptions.cs
@@ -10,7 +10,7 @@ public sealed class DataExchangeBlobStorageOptions
     /// <summary>
     /// Configuration section name.
     /// </summary>
-    public const string SectionName = "Granit:DataExchange:BlobStorage";
+    public const string SectionName = "DataExchange:BlobStorage";
 
     /// <summary>
     /// Logical container name used as a key-prefix segment in the object key path

--- a/src/Granit.DataExchange.Endpoints/Options/DataExchangeEndpointsOptions.cs
+++ b/src/Granit.DataExchange.Endpoints/Options/DataExchangeEndpointsOptions.cs
@@ -2,13 +2,13 @@ namespace Granit.DataExchange.Endpoints.Options;
 
 /// <summary>
 /// Configuration options for the data exchange endpoints (import + export).
-/// Bind from <c>"DataExchangeEndpoints"</c> or pass an action to
+/// Bind from <c>"DataExchange:Endpoints"</c> or pass an action to
 /// <see cref="Extensions.DataExchangeEndpointRouteBuilderExtensions.MapGranitDataExchange"/>.
 /// </summary>
 public sealed class DataExchangeEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "DataExchangeEndpoints";
+    public const string SectionName = "DataExchange:Endpoints";
 
     /// <summary>
     /// Route prefix for all data exchange endpoints.

--- a/src/Granit.DataExchange/Export/ExportOptions.cs
+++ b/src/Granit.DataExchange/Export/ExportOptions.cs
@@ -6,14 +6,14 @@ namespace Granit.DataExchange.Export;
 /// Configuration options for the data export pipeline.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>DataExport</c> configuration section.
+/// Bound to the <c>DataExchange:Export</c> configuration section.
 /// </remarks>
 public sealed class ExportOptions
 {
     /// <summary>
     /// Configuration section name.
     /// </summary>
-    public const string SectionName = "DataExport";
+    public const string SectionName = "DataExchange:Export";
 
     /// <summary>
     /// Row count threshold above which the export is dispatched to a background job.

--- a/src/Granit.DataExchange/Import/ImportOptions.cs
+++ b/src/Granit.DataExchange/Import/ImportOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.DataExchange.Import;
 public sealed class ImportOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "DataExchange";
+    public const string SectionName = "DataExchange:Import";
 
     /// <summary>
     /// Default maximum file size in megabytes.

--- a/src/Granit.Http.ApiDocumentation/Options/ApiDocumentationOptions.cs
+++ b/src/Granit.Http.ApiDocumentation/Options/ApiDocumentationOptions.cs
@@ -4,7 +4,7 @@ namespace Granit.Http.ApiDocumentation.Options;
 public sealed class ApiDocumentationOptions
 {
     /// <summary>Configuration section name in appsettings.json.</summary>
-    public const string SectionName = "ApiDocumentation";
+    public const string SectionName = "Http:ApiDocumentation";
 
     /// <summary>
     /// Major API version numbers to document. Each entry generates a distinct OpenAPI document

--- a/src/Granit.Http.ApiVersioning/Options/GranitApiVersioningOptions.cs
+++ b/src/Granit.Http.ApiVersioning/Options/GranitApiVersioningOptions.cs
@@ -4,7 +4,7 @@ namespace Granit.Http.ApiVersioning.Options;
 public sealed class GranitApiVersioningOptions
 {
     /// <summary>Configuration section name in appsettings.json.</summary>
-    public const string SectionName = "ApiVersioning";
+    public const string SectionName = "Http:ApiVersioning";
 
     /// <summary>
     /// Default API major version assumed when the client does not specify one.

--- a/src/Granit.Http.Bulkhead/Options/GranitBulkheadOptions.cs
+++ b/src/Granit.Http.Bulkhead/Options/GranitBulkheadOptions.cs
@@ -9,7 +9,7 @@ namespace Granit.Http.Bulkhead.Options;
 public sealed class GranitBulkheadOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Bulkhead";
+    public const string SectionName = "Http:Bulkhead";
 
     /// <summary>Whether bulkhead isolation is enabled. Default: <see langword="true"/>.</summary>
     public bool Enabled { get; set; } = true;

--- a/src/Granit.Http.Cookies.Klaro/Options/KlaroOptions.cs
+++ b/src/Granit.Http.Cookies.Klaro/Options/KlaroOptions.cs
@@ -12,7 +12,7 @@ namespace Granit.Http.Cookies.Klaro.Options;
 public sealed class KlaroOptions
 {
     /// <summary>Section key in the configuration.</summary>
-    public const string SectionName = "Klaro";
+    public const string SectionName = "Http:Cookies:Klaro";
 
     /// <summary>
     /// Name of the cookie where Klaro stores consent decisions.

--- a/src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs
+++ b/src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Http.Cookies.Options;
 public sealed class GranitCookiesOptions
 {
     /// <summary>Section key in the configuration.</summary>
-    public const string SectionName = "Cookies";
+    public const string SectionName = "Http:Cookies";
 
     /// <summary>
     /// When <c>true</c>, writing an unregistered cookie throws <see cref="Exceptions.UnregisteredCookieException"/>.

--- a/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
+++ b/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
@@ -13,7 +13,7 @@ namespace Granit.Http.Cors.Options;
 public sealed class GranitCorsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Cors";
+    public const string SectionName = "Http:Cors";
 
     /// <summary>
     /// Allowed CORS origins. At least one origin must be configured.

--- a/src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs
@@ -9,7 +9,7 @@ namespace Granit.Http.Idempotency.Models;
 public sealed class IdempotencyOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Idempotency";
+    public const string SectionName = "Http:Idempotency";
 
     /// <summary>Name of the HTTP header carrying the idempotency key. Default: <c>Idempotency-Key</c>.</summary>
     [Required]

--- a/src/Granit.Http.OutputCaching.StackExchangeRedis/Options/RedisOutputCachingOptions.cs
+++ b/src/Granit.Http.OutputCaching.StackExchangeRedis/Options/RedisOutputCachingOptions.cs
@@ -2,12 +2,12 @@ namespace Granit.Http.OutputCaching.StackExchangeRedis.Options;
 
 /// <summary>
 /// Configuration options for the Redis output cache store.
-/// Section <c>"OutputCaching:Redis"</c> in <c>appsettings.json</c>.
+/// Section <c>"Http:OutputCaching:Redis"</c> in <c>appsettings.json</c>.
 /// </summary>
 public sealed class RedisOutputCachingOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "OutputCaching:Redis";
+    public const string SectionName = "Http:OutputCaching:Redis";
 
     /// <summary>
     /// Enables or disables the Redis output cache store.

--- a/src/Granit.Http.OutputCaching/Options/OutputCachingOptions.cs
+++ b/src/Granit.Http.OutputCaching/Options/OutputCachingOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Http.OutputCaching.Options;
 public sealed class OutputCachingOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "OutputCaching";
+    public const string SectionName = "Http:OutputCaching";
 
     /// <summary>
     /// Default response cache duration applied to the base policy.

--- a/src/Granit.Http.Resilience/Options/HttpResilienceOptions.cs
+++ b/src/Granit.Http.Resilience/Options/HttpResilienceOptions.cs
@@ -18,5 +18,5 @@ namespace Granit.Http.Resilience.Options;
 public static class HttpResilienceOptions
 {
     /// <summary>The root appsettings section under which per-client overrides are nested.</summary>
-    public const string SectionName = "HttpResilience";
+    public const string SectionName = "Http:Resilience";
 }

--- a/src/Granit.Http.ResponseCompression/Options/GranitResponseCompressionOptions.cs
+++ b/src/Granit.Http.ResponseCompression/Options/GranitResponseCompressionOptions.cs
@@ -36,7 +36,7 @@ namespace Granit.Http.ResponseCompression.Options;
 public sealed class GranitResponseCompressionOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "ResponseCompression";
+    public const string SectionName = "Http:ResponseCompression";
 
     /// <summary>
     /// Whether to compress responses served over HTTPS.

--- a/src/Granit.Http.SecurityHeaders/Options/GranitSecurityHeadersOptions.cs
+++ b/src/Granit.Http.SecurityHeaders/Options/GranitSecurityHeadersOptions.cs
@@ -10,7 +10,7 @@ public sealed class GranitSecurityHeadersOptions
     /// <summary>
     /// Configuration section name in <c>appsettings.json</c>.
     /// </summary>
-    public const string SectionName = "SecurityHeaders";
+    public const string SectionName = "Http:SecurityHeaders";
 
     // -------------------------------------------------------------------------
     // Server fingerprinting

--- a/src/Granit.IO/Options/TempFileOptions.cs
+++ b/src/Granit.IO/Options/TempFileOptions.cs
@@ -7,8 +7,8 @@ namespace Granit.IO.Options;
 /// </summary>
 public sealed class TempFileOptions
 {
-    /// <summary>Configuration section name: <c>Granit:IO:TempFiles</c>.</summary>
-    public const string SectionName = "Granit:IO:TempFiles";
+    /// <summary>Configuration section name: <c>IO:TempFiles</c>.</summary>
+    public const string SectionName = "IO:TempFiles";
 
     /// <summary>Default root directory: <c>{Path.GetTempPath()}/granit</c>.</summary>
     public static string DefaultRootDirectory { get; } = Path.Combine(Path.GetTempPath(), "granit");

--- a/src/Granit.Identity.Endpoints/Options/IdentityEndpointsOptions.cs
+++ b/src/Granit.Identity.Endpoints/Options/IdentityEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Endpoints.Options;
 public sealed class IdentityEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "IdentityEndpoints";
+    public const string SectionName = "Identity:Endpoints";
 
     /// <summary>
     /// Route prefix for all identity user cache endpoints.

--- a/src/Granit.Identity.Endpoints/Options/IdentityProviderEndpointsOptions.cs
+++ b/src/Granit.Identity.Endpoints/Options/IdentityProviderEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Endpoints.Options;
 public sealed class IdentityProviderEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "IdentityProviderEndpoints";
+    public const string SectionName = "Identity:Endpoints:Provider";
 
     /// <summary>
     /// Route prefix for all identity provider endpoints.

--- a/src/Granit.Identity.Endpoints/Options/IdentityWebhookOptions.cs
+++ b/src/Granit.Identity.Endpoints/Options/IdentityWebhookOptions.cs
@@ -2,12 +2,12 @@ namespace Granit.Identity.Endpoints.Options;
 
 /// <summary>
 /// Configuration options for the identity webhook endpoint.
-/// Bind to the <c>IdentityWebhook</c> configuration section.
+/// Bind to the <c>Identity:Webhook</c> configuration section.
 /// </summary>
 public sealed class IdentityWebhookOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "IdentityWebhook";
+    public const string SectionName = "Identity:Webhook";
 
     /// <summary>
     /// Shared secret for HMAC-SHA256 signature validation.

--- a/src/Granit.Identity.Federated.Cognito/Options/CognitoAdminOptions.cs
+++ b/src/Granit.Identity.Federated.Cognito/Options/CognitoAdminOptions.cs
@@ -12,7 +12,7 @@ namespace Granit.Identity.Federated.Cognito.Options;
 public sealed class CognitoAdminOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "CognitoAdmin";
+    public const string SectionName = "Identity:Federated:Cognito";
 
     /// <summary>AWS region (e.g. <c>eu-west-1</c>).</summary>
     [Required]

--- a/src/Granit.Identity.Federated.Cognito/Options/CognitoClientRoleSyncOptions.cs
+++ b/src/Granit.Identity.Federated.Cognito/Options/CognitoClientRoleSyncOptions.cs
@@ -24,8 +24,8 @@ namespace Granit.Identity.Federated.Cognito.Options;
 /// </remarks>
 public sealed class CognitoClientRoleSyncOptions
 {
-    /// <summary>Configuration section: <c>CognitoAdmin:ClientRoleSync</c>.</summary>
-    public const string SectionName = "CognitoAdmin:ClientRoleSync";
+    /// <summary>Configuration section: <c>Identity:Federated:Cognito:ClientRoleSync</c>.</summary>
+    public const string SectionName = "Identity:Federated:Cognito:ClientRoleSync";
 
     /// <summary>
     /// When <see langword="false"/>, the sync contributor becomes a no-op even if

--- a/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
@@ -24,7 +24,7 @@ namespace Granit.Identity.Federated.EntraId.Options;
 public sealed class EntraIdAdminOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "EntraIdAdmin";
+    public const string SectionName = "Identity:Federated:EntraId";
 
     /// <summary>
     /// Azure AD tenant ID (e.g. <c>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</c>).

--- a/src/Granit.Identity.Federated.EntraId/Options/EntraIdClientRoleSyncOptions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Options/EntraIdClientRoleSyncOptions.cs
@@ -10,8 +10,8 @@ namespace Granit.Identity.Federated.EntraId.Options;
 /// </summary>
 public sealed class EntraIdClientRoleSyncOptions
 {
-    /// <summary>Configuration section: <c>EntraIdAdmin:ClientRoleSync</c>.</summary>
-    public const string SectionName = "EntraIdAdmin:ClientRoleSync";
+    /// <summary>Configuration section: <c>Identity:Federated:EntraId:ClientRoleSync</c>.</summary>
+    public const string SectionName = "Identity:Federated:EntraId:ClientRoleSync";
 
     /// <summary>
     /// When <see langword="false"/>, the sync contributor becomes a no-op even if tracked

--- a/src/Granit.Identity.Federated.GoogleCloud/Options/GoogleCloudIdentityOptions.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Options/GoogleCloudIdentityOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Federated.GoogleCloud.Options;
 public sealed class GoogleCloudIdentityOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Identity:GoogleCloud";
+    public const string SectionName = "Identity:Federated:GoogleCloud";
 
     /// <summary>GCP project ID. Required.</summary>
     [Required]

--- a/src/Granit.Identity.Federated.Keycloak/Options/KeycloakAdminOptions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Options/KeycloakAdminOptions.cs
@@ -24,7 +24,7 @@ namespace Granit.Identity.Federated.Keycloak.Options;
 public sealed class KeycloakAdminOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "KeycloakAdmin";
+    public const string SectionName = "Identity:Federated:Keycloak";
 
     /// <summary>
     /// Keycloak server base URL (e.g. <c>https://keycloak.example.com</c>).

--- a/src/Granit.Identity.Federated.Keycloak/Options/KeycloakClientRoleSyncOptions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Options/KeycloakClientRoleSyncOptions.cs
@@ -10,8 +10,8 @@ namespace Granit.Identity.Federated.Keycloak.Options;
 /// </summary>
 public sealed class KeycloakClientRoleSyncOptions
 {
-    /// <summary>Configuration section: <c>KeycloakAdmin:ClientRoleSync</c>.</summary>
-    public const string SectionName = "KeycloakAdmin:ClientRoleSync";
+    /// <summary>Configuration section: <c>Identity:Federated:Keycloak:ClientRoleSync</c>.</summary>
+    public const string SectionName = "Identity:Federated:Keycloak:ClientRoleSync";
 
     /// <summary>
     /// When <see langword="false"/>, the sync contributor becomes a no-op even if tracked

--- a/src/Granit.Identity.Federated/Options/IdentityFederatedNotificationOptions.cs
+++ b/src/Granit.Identity.Federated/Options/IdentityFederatedNotificationOptions.cs
@@ -5,12 +5,12 @@ namespace Granit.Identity.Federated.Options;
 /// <summary>
 /// Configuration options for federated-identity audit notifications, currently
 /// covering the <c>IdentityUserSyncFailedEto</c> emission cadence.
-/// Bind to the <c>IdentityFederatedNotifications</c> configuration section.
+/// Bind to the <c>Identity:Federated:Notifications</c> configuration section.
 /// </summary>
 public sealed class IdentityFederatedNotificationOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "IdentityFederatedNotifications";
+    public const string SectionName = "Identity:Federated:Notifications";
 
     /// <summary>
     /// Cool-off window, in minutes, used to rate-limit

--- a/src/Granit.Identity.Federated/Options/UserCacheHasherOptions.cs
+++ b/src/Granit.Identity.Federated/Options/UserCacheHasherOptions.cs
@@ -21,7 +21,7 @@ namespace Granit.Identity.Federated.Options;
 public sealed class UserCacheHasherOptions
 {
     /// <summary>Configuration section name for binding from <c>appsettings.json</c>.</summary>
-    public const string SectionName = "Identity:UserCacheHasher";
+    public const string SectionName = "Identity:Federated:UserCacheHasher";
 
     /// <summary>
     /// HMAC pepper for email lookups. Accepts either a hex string (e.g. 64 hex chars

--- a/src/Granit.Identity.Federated/Options/UserCacheOptions.cs
+++ b/src/Granit.Identity.Federated/Options/UserCacheOptions.cs
@@ -2,12 +2,12 @@ namespace Granit.Identity.Federated.Options;
 
 /// <summary>
 /// Configuration options for the identity user cache.
-/// Bind to the <c>IdentityUserCache</c> configuration section.
+/// Bind to the <c>Identity:Federated:UserCache</c> configuration section.
 /// </summary>
 public sealed class UserCacheOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "IdentityUserCache";
+    public const string SectionName = "Identity:Federated:UserCache";
 
     /// <summary>
     /// Duration after which a cached user entry is considered stale and eligible for re-fetch

--- a/src/Granit.Notifications.Email.AwsSes/Options/AwsSesOptions.cs
+++ b/src/Granit.Notifications.Email.AwsSes/Options/AwsSesOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Notifications.Email.AwsSes.Options;
 public sealed class AwsSesOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Notifications:AwsSes";
+    public const string SectionName = "Notifications:Email:AwsSes";
 
     /// <summary>AWS region endpoint (e.g. "eu-west-1"). Required.</summary>
     [Required]

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptions.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Notifications.Email.AzureCommunicationServices.Options;
 public sealed class AcsEmailOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "AzureCommunicationServices:Email";
+    public const string SectionName = "Notifications:Email:AzureCommunicationServices";
 
     /// <summary>
     /// ACS connection string. When provided, takes precedence over <see cref="Endpoint"/>.

--- a/src/Granit.Notifications.Email.Smtp/Options/SmtpOptions.cs
+++ b/src/Granit.Notifications.Email.Smtp/Options/SmtpOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Notifications.Email.Smtp.Options;
 public sealed class SmtpOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Notifications:Smtp";
+    public const string SectionName = "Notifications:Email:Smtp";
 
     /// <summary>SMTP server hostname.</summary>
     public string Host { get; set; } = "localhost";

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -154,7 +154,7 @@ internal sealed partial class EmailNotificationChannel(
         string? resolvedUrl = urlResolver is not null
             ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
             : null;
-        string? baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : configuration["Granit:Templating:App:BaseUrl"];
+        string? baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : configuration["Templating:App:BaseUrl"];
 
         return string.IsNullOrEmpty(baseUrl) ? "" : baseUrl.TrimEnd('/') + "/notifications/preferences";
     }

--- a/src/Granit.Notifications.MobilePush.AzureNotificationHubs/Options/AzureNotificationHubsOptions.cs
+++ b/src/Granit.Notifications.MobilePush.AzureNotificationHubs/Options/AzureNotificationHubsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Notifications.MobilePush.AzureNotificationHubs.Options;
 public sealed class AzureNotificationHubsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Notifications:AzureNotificationHubs";
+    public const string SectionName = "Notifications:MobilePush:AzureNotificationHubs";
 
     /// <summary>
     /// Azure Notification Hubs connection string. Required.

--- a/src/Granit.Notifications.Sms.AzureCommunicationServices/Options/AcsSmsOptions.cs
+++ b/src/Granit.Notifications.Sms.AzureCommunicationServices/Options/AcsSmsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Notifications.Sms.AzureCommunicationServices.Options;
 public sealed class AcsSmsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "AzureCommunicationServices:Sms";
+    public const string SectionName = "Notifications:Sms:AzureCommunicationServices";
 
     /// <summary>
     /// ACS connection string. When provided, takes precedence over <see cref="Endpoint"/>.

--- a/src/Granit.Notifications.WebPush/Options/PushChannelOptions.cs
+++ b/src/Granit.Notifications.WebPush/Options/PushChannelOptions.cs
@@ -4,7 +4,7 @@ namespace Granit.Notifications.WebPush.Options;
 public sealed class PushChannelOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "Notifications:Push";
+    public const string SectionName = "Notifications:WebPush";
 
     /// <summary>VAPID subject (mailto: or https: URL).</summary>
     public string VapidSubject { get; set; } = string.Empty;

--- a/src/Granit.Oidc.TokenManagement/Options/TokenManagementOptions.cs
+++ b/src/Granit.Oidc.TokenManagement/Options/TokenManagementOptions.cs
@@ -8,7 +8,7 @@ public sealed class TokenManagementOptions
     /// <summary>
     /// The configuration section name used by <c>IConfiguration.GetSection()</c>.
     /// </summary>
-    public const string SectionName = "TokenManagement";
+    public const string SectionName = "Oidc:TokenManagement";
 
     /// <summary>
     /// The default margin subtracted from token lifetimes before caching,

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs
@@ -46,7 +46,7 @@ public static class PersistenceMigrationsHostApplicationBuilderExtensions
     ///   </item>
     ///   <item>
     ///     <see cref="MigrationStartupOptions"/> — bound from the
-    ///     <c>"GranitMigrations"</c> configuration section.
+    ///     <c>"Persistence:Migrations"</c> configuration section.
     ///   </item>
     /// </list>
     /// </para>
@@ -94,7 +94,7 @@ public static class PersistenceMigrationsHostApplicationBuilderExtensions
         // Hosted service — resumes pending and in-progress cycles at startup.
         builder.Services.AddHostedService<MigrationStartupService>();
 
-        // Options — bound from the "GranitMigrations" configuration section.
+        // Options — bound from the "Persistence:Migrations" configuration section.
         builder.Services
             .AddOptions<MigrationStartupOptions>()
             .BindConfiguration(MigrationStartupOptions.SectionName)

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Options/MigrationStartupOptions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Options/MigrationStartupOptions.cs
@@ -2,14 +2,14 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Options;
 
 /// <summary>
 /// Configuration options for <c>MigrationStartupService</c>.
-/// Bound from the <c>"GranitMigrations"</c> section in <c>appsettings.json</c>.
+/// Bound from the <c>"Persistence:Migrations"</c> section in <c>appsettings.json</c>.
 /// </summary>
 public sealed class MigrationStartupOptions
 {
     /// <summary>
     /// Configuration section name in <c>appsettings.json</c>.
     /// </summary>
-    public const string SectionName = "GranitMigrations";
+    public const string SectionName = "Persistence:Migrations";
 
     /// <summary>
     /// Default number of rows to process per batch.

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantSchemaOptions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantSchemaOptions.cs
@@ -28,12 +28,12 @@ public enum TenantSchemaNamingConvention
 
 /// <summary>
 /// Options for the per-tenant schema isolation strategy.
-/// Bound from the <c>"TenantSchema"</c> configuration section.
+/// Bound from the <c>"MultiTenancy:TenantSchema"</c> configuration section.
 /// </summary>
 public sealed class TenantSchemaOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "TenantSchema";
+    public const string SectionName = "MultiTenancy:TenantSchema";
 
     /// <summary>
     /// Naming convention used to derive the PostgreSQL schema name from the tenant context.

--- a/src/Granit.Scheduling.Endpoints/Options/SchedulingEndpointsOptions.cs
+++ b/src/Granit.Scheduling.Endpoints/Options/SchedulingEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Scheduling.Endpoints.Options;
 public sealed class SchedulingEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "SchedulingEndpoints";
+    public const string SectionName = "Scheduling:Endpoints";
 
     /// <summary>
     /// Route prefix for all scheduling endpoints.

--- a/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContextOptions.cs
+++ b/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContextOptions.cs
@@ -2,7 +2,7 @@ namespace Granit.Templating.Scriban.GlobalContexts;
 
 /// <summary>
 /// Configuration options for the <c>app</c> template global context.
-/// Bind from <c>Granit:Templating:App</c> in appsettings.json.
+/// Bind from <c>Templating:App</c> in appsettings.json.
 /// </summary>
 /// <remarks>
 /// These values are exposed in every Scriban template under <c>{{ app.* }}</c>.
@@ -11,7 +11,7 @@ namespace Granit.Templating.Scriban.GlobalContexts;
 public sealed class AppGlobalContextOptions
 {
     /// <summary>Configuration section path.</summary>
-    public const string SectionName = "Granit:Templating:App";
+    public const string SectionName = "Templating:App";
 
     /// <summary>
     /// The application display name (e.g., <c>"Guava Admin"</c>).

--- a/src/Granit.Timeline.Endpoints/Options/TimelineEndpointsOptions.cs
+++ b/src/Granit.Timeline.Endpoints/Options/TimelineEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Timeline.Endpoints.Options;
 public sealed class TimelineEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "TimelineEndpoints";
+    public const string SectionName = "Timeline:Endpoints";
 
     /// <summary>
     /// Route prefix for all timeline endpoints.

--- a/src/Granit.Vault/Options/ReEncryptionOptions.cs
+++ b/src/Granit.Vault/Options/ReEncryptionOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Vault.Options;
 public sealed class ReEncryptionOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "ReEncryption";
+    public const string SectionName = "Vault:ReEncryption";
 
     /// <summary>
     /// Set of key versions that are considered retired (e.g. <c>"v1"</c>, <c>"v2"</c>).

--- a/src/Granit.Webhooks.Endpoints/Options/WebhooksEndpointsOptions.cs
+++ b/src/Granit.Webhooks.Endpoints/Options/WebhooksEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Webhooks.Endpoints.Options;
 public sealed class WebhooksEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "WebhooksEndpoints";
+    public const string SectionName = "Webhooks:Endpoints";
 
     /// <summary>
     /// Route prefix for all webhook endpoints.

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -33,7 +33,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
     /// </para>
     /// <para>
     /// Reads <see cref="WolverinePostgresqlOptions"/> from the
-    /// <c>"WolverinePostgresql"</c> configuration section and validates at startup.
+    /// <c>"Wolverine:Postgresql"</c> configuration section and validates at startup.
     /// </para>
     /// <para>
     /// Configures:
@@ -72,7 +72,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
     /// before the host is built.
     /// </para>
     /// <para>
-    /// Reads <see cref="WolverinePostgresqlOptions"/> from the <c>"WolverinePostgresql"</c>
+    /// Reads <see cref="WolverinePostgresqlOptions"/> from the <c>"Wolverine:Postgresql"</c>
     /// configuration section. The <c>TransportConnectionString</c> targets the shared Wolverine
     /// Outbox database; per-tenant application data is routed by
     /// <see cref="ITenantConnectionStringProvider"/>.

--- a/src/Granit.Wolverine.Postgresql/GranitWolverinePostgresqlModule.cs
+++ b/src/Granit.Wolverine.Postgresql/GranitWolverinePostgresqlModule.cs
@@ -12,7 +12,7 @@ namespace Granit.Wolverine.Postgresql;
 /// Adds a PostgreSQL Outbox and EF Core transaction integration on top of the
 /// provider-agnostic core configured by <see cref="GranitWolverineModule"/>.
 /// <para>
-/// Reads <see cref="WolverinePostgresqlOptions"/> from the <c>"WolverinePostgresql"</c>
+/// Reads <see cref="WolverinePostgresqlOptions"/> from the <c>"Wolverine:Postgresql"</c>
 /// section in <c>appsettings.json</c>. The connection string is validated at startup.
 /// </para>
 /// <para>

--- a/src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs
+++ b/src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs
@@ -4,7 +4,7 @@ namespace Granit.Wolverine.Postgresql.Options;
 
 /// <summary>
 /// Configuration options for the PostgreSQL Wolverine provider.
-/// Bound from the <c>"WolverinePostgresql"</c> section of <c>appsettings.json</c>.
+/// Bound from the <c>"Wolverine:Postgresql"</c> section of <c>appsettings.json</c>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -20,7 +20,7 @@ namespace Granit.Wolverine.Postgresql.Options;
 public sealed class WolverinePostgresqlOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "WolverinePostgresql";
+    public const string SectionName = "Wolverine:Postgresql";
 
     /// <summary>
     /// Explicit PostgreSQL connection string for the Wolverine Outbox tables.
@@ -38,7 +38,7 @@ public sealed class WolverinePostgresqlOptions
     /// <code>
     /// // appsettings.json
     /// {
-    ///   "WolverinePostgresql": {
+    ///   "Wolverine:Postgresql": {
     ///     "TransportConnectionStringName": "catalog-db"
     ///   }
     /// }

--- a/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
     /// </para>
     /// <para>
     /// Reads <see cref="WolverineSqlServerOptions"/> from the
-    /// <c>"WolverineSqlServer"</c> configuration section and validates at startup.
+    /// <c>"Wolverine:SqlServer"</c> configuration section and validates at startup.
     /// </para>
     /// <para>
     /// Configures:
@@ -69,7 +69,7 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
     /// before the host is built.
     /// </para>
     /// <para>
-    /// Reads <see cref="WolverineSqlServerOptions"/> from the <c>"WolverineSqlServer"</c>
+    /// Reads <see cref="WolverineSqlServerOptions"/> from the <c>"Wolverine:SqlServer"</c>
     /// configuration section. The <c>TransportConnectionString</c> targets the shared Wolverine
     /// Outbox database; per-tenant application data is routed by
     /// <see cref="ITenantConnectionStringProvider"/>.

--- a/src/Granit.Wolverine.SqlServer/GranitWolverineSqlServerModule.cs
+++ b/src/Granit.Wolverine.SqlServer/GranitWolverineSqlServerModule.cs
@@ -12,7 +12,7 @@ namespace Granit.Wolverine.SqlServer;
 /// Adds a SQL Server Outbox and EF Core transaction integration on top of the
 /// provider-agnostic core configured by <see cref="GranitWolverineModule"/>.
 /// <para>
-/// Reads <see cref="WolverineSqlServerOptions"/> from the <c>"WolverineSqlServer"</c>
+/// Reads <see cref="WolverineSqlServerOptions"/> from the <c>"Wolverine:SqlServer"</c>
 /// section in <c>appsettings.json</c>. The connection string is validated at startup.
 /// </para>
 /// <para>

--- a/src/Granit.Wolverine.SqlServer/Options/WolverineSqlServerOptions.cs
+++ b/src/Granit.Wolverine.SqlServer/Options/WolverineSqlServerOptions.cs
@@ -5,7 +5,7 @@ namespace Granit.Wolverine.SqlServer.Options;
 
 /// <summary>
 /// Configuration options for the SQL Server Wolverine provider.
-/// Bound from the <c>"WolverineSqlServer"</c> section of <c>appsettings.json</c>.
+/// Bound from the <c>"Wolverine:SqlServer"</c> section of <c>appsettings.json</c>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -21,7 +21,7 @@ namespace Granit.Wolverine.SqlServer.Options;
 public sealed class WolverineSqlServerOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "WolverineSqlServer";
+    public const string SectionName = "Wolverine:SqlServer";
 
     /// <summary>
     /// SQL Server connection string for the Wolverine Outbox tables.

--- a/src/Granit.Workflow.Endpoints/Options/WorkflowEndpointsOptions.cs
+++ b/src/Granit.Workflow.Endpoints/Options/WorkflowEndpointsOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Workflow.Endpoints.Options;
 public sealed class WorkflowEndpointsOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "WorkflowEndpoints";
+    public const string SectionName = "Workflow:Endpoints";
 
     /// <summary>
     /// Route prefix for all workflow endpoints.

--- a/templates/granit-api-full/appsettings.json
+++ b/templates/granit-api-full/appsettings.json
@@ -20,7 +20,9 @@
       "AdminRole": "admin"
     }
   },
-  "Cors": {
-    "AllowedOrigins": ["http://localhost:3000"]
+  "Http": {
+    "Cors": {
+      "AllowedOrigins": ["http://localhost:3000"]
+    }
   }
 }

--- a/tests/Granit.ArchitectureTests/SectionNameConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SectionNameConventionTests.cs
@@ -1,0 +1,193 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces the Granit <c>SectionName</c> convention for options classes:
+/// <list type="bullet">
+///   <item>Hierarchical, ASP.NET-style, colon-separated (<c>"Foo:Bar:Baz"</c>).</item>
+///   <item>No PascalCase-glued tokens (<c>"FooBar"</c> forbidden when <c>"Foo:Bar"</c> applies).</item>
+///   <item><c>"Granit"</c> MUST NOT be used as a root segment — it is an internal namespace
+///         prefix, not a configuration root.</item>
+///   <item>No two distinct <c>Options</c> classes may share the same section path
+///         (parent/child collisions silently break binding).</item>
+/// </list>
+/// </summary>
+public sealed partial class SectionNameConventionTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    /// <summary>
+    /// A handful of single-segment top-level sections kept on purpose because their owning
+    /// project IS the root namespace (no sub-feature). They satisfy the convention
+    /// "namespace without Granit prefix" — they just happen to be one segment long.
+    /// </summary>
+    private static readonly HashSet<string> AllowedSingleSegmentSections =
+    [
+        "AI",
+        "Auditing",
+        "Authentication",
+        "Authorization",
+        "BackgroundJobs",
+        "Bff",
+        "BlobStorage",
+        "Browsing",
+        "Cache",
+        "Encryption",
+        "Mcp",
+        "Mergeable",
+        "MultiTenancy",
+        "Notifications",
+        "Observability",
+        "Privacy",
+        "RateLimiting",
+        "Settings",
+        "Vault",
+        "Webhooks",
+        "Wolverine",
+    ];
+
+    /// <summary>
+    /// SectionName values must never start with <c>"Granit"</c> — Granit is the internal
+    /// namespace prefix, not a configuration root.
+    /// </summary>
+    [Fact]
+    public void SectionName_must_not_start_with_Granit()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        List<string> violations = [];
+
+        foreach ((string file, int line, string value) in EnumerateSectionNames(srcDir))
+        {
+            if (value.StartsWith("Granit:", StringComparison.Ordinal)
+                || value.Equals("Granit", StringComparison.Ordinal))
+            {
+                violations.Add($"{Path.GetRelativePath(RepoRoot, file)}:{line} \"{value}\"");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "SectionName must not be prefixed with 'Granit:' — Granit is a code-level "
+            + "namespace, not a configuration root. Use the bare hierarchical path "
+            + "(e.g. 'IO:TempFiles', not 'Granit:IO:TempFiles'). Violators: "
+            + string.Join("; ", violations));
+    }
+
+    /// <summary>
+    /// SectionName values must be hierarchical (colon-separated). Multi-word names
+    /// that span two clear concepts (<c>"FooBar"</c>) must be split with <c>:</c>.
+    /// Single-segment sections are allowed only for top-level modules (see
+    /// <see cref="AllowedSingleSegmentSections"/>).
+    /// </summary>
+    [Fact]
+    public void SectionName_must_be_hierarchical()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        List<string> violations = [];
+
+        foreach ((string file, int line, string value) in EnumerateSectionNames(srcDir))
+        {
+            if (value.Contains(':', StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (AllowedSingleSegmentSections.Contains(value))
+            {
+                continue;
+            }
+
+            violations.Add($"{Path.GetRelativePath(RepoRoot, file)}:{line} \"{value}\"");
+        }
+
+        violations.ShouldBeEmpty(
+            "Flat (non-colon-separated) SectionName values are reserved for top-level modules. "
+            + "Compound names must use the hierarchical 'Parent:Child' form. "
+            + "If you intentionally introduce a new top-level section, add it to "
+            + nameof(AllowedSingleSegmentSections) + ". Violators: "
+            + string.Join("; ", violations));
+    }
+
+    /// <summary>
+    /// No two <c>Options</c> classes may declare the same SectionName. A section path
+    /// can be bound to its own Options class AND host child sub-sections (ASP.NET
+    /// configuration supports that) — what is forbidden is two unrelated Options
+    /// classes pointing at the same string.
+    /// </summary>
+    [Fact]
+    public void SectionName_values_must_be_unique()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        Dictionary<string, List<string>> byValue = [];
+
+        foreach ((string file, int line, string value) in EnumerateSectionNames(srcDir))
+        {
+            if (!byValue.TryGetValue(value, out List<string>? locations))
+            {
+                locations = [];
+                byValue[value] = locations;
+            }
+
+            locations.Add($"{Path.GetRelativePath(RepoRoot, file)}:{line}");
+        }
+
+        List<string> duplicates = [.. byValue
+            .Where(kv => kv.Value.Count > 1)
+            .Select(kv => $"\"{kv.Key}\" used by [{string.Join(", ", kv.Value)}]")];
+
+        duplicates.ShouldBeEmpty(
+            "SectionName values must be unique across the framework. Duplicates: "
+            + string.Join("; ", duplicates));
+    }
+
+    private static IEnumerable<(string File, int Line, string Value)> EnumerateSectionNames(string srcDir)
+    {
+        foreach (string csFile in Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (csFile.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
+                || csFile.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+            {
+                continue;
+            }
+
+            int lineNumber = 0;
+            foreach (string line in File.ReadLines(csFile))
+            {
+                lineNumber++;
+                Match match = SectionNameConstant().Match(line);
+                if (!match.Success)
+                {
+                    continue;
+                }
+
+                yield return (csFile, lineNumber, match.Groups[1].Value);
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(SectionNameConventionTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    /// <summary>
+    /// Matches <c>public const string SectionName = "Value";</c>.
+    /// Group 1: the string value.
+    /// </summary>
+    [GeneratedRegex(@"public\s+const\s+string\s+SectionName\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
+    private static partial Regex SectionNameConstant();
+}

--- a/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/Options/ApiKeysEndpointsOptionsTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/Options/ApiKeysEndpointsOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class ApiKeysEndpointsOptionsTests
 {
     [Fact]
     public void SectionName_IsApiKeysEndpoints() =>
-        ApiKeysEndpointsOptions.SectionName.ShouldBe("ApiKeysEndpoints");
+        ApiKeysEndpointsOptions.SectionName.ShouldBe("Authentication:ApiKeys:Endpoints");
 
     [Fact]
     public void Defaults_AreCorrect()

--- a/tests/Granit.Authentication.JwtBearer.Cognito.Tests/CognitoOptionsTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.Cognito.Tests/CognitoOptionsTests.cs
@@ -7,8 +7,8 @@ namespace Granit.Authentication.JwtBearer.Cognito.Tests;
 public sealed class CognitoOptionsTests
 {
     [Fact]
-    public void SectionName_IsCognito() =>
-        CognitoOptions.SectionName.ShouldBe("Cognito");
+    public void SectionName_IsAuthenticationCognito() =>
+        CognitoOptions.SectionName.ShouldBe("Authentication:Cognito");
 
     [Fact]
     public void Defaults_AreCorrect()

--- a/tests/Granit.Authentication.JwtBearer.EntraId.Tests/EntraIdOptionsTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.EntraId.Tests/EntraIdOptionsTests.cs
@@ -7,8 +7,8 @@ namespace Granit.Authentication.JwtBearer.EntraId.Tests;
 public sealed class EntraIdOptionsTests
 {
     [Fact]
-    public void SectionName_IsEntraId() =>
-        EntraIdOptions.SectionName.ShouldBe("EntraId");
+    public void SectionName_IsAuthenticationEntraId() =>
+        EntraIdOptions.SectionName.ShouldBe("Authentication:EntraId");
 
     [Fact]
     public void Defaults_AreCorrect()

--- a/tests/Granit.Authentication.JwtBearer.EntraId.Tests/EntraIdServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.EntraId.Tests/EntraIdServiceCollectionExtensionsTests.cs
@@ -2,7 +2,7 @@
 // Tests - EntraIdServiceCollectionExtensions
 // =============================================================================
 // Verifies that AddGranitEntraId correctly registers:
-//   - EntraIdOptions from the "EntraId" section
+//   - EntraIdOptions from the "Authentication:EntraId" section
 //   - PostConfigure JWT Bearer (Authority, Audience, NameClaimType)
 //   - EntraIdClaimsTransformation
 // =============================================================================

--- a/tests/Granit.Authentication.JwtBearer.GoogleCloud.Tests/GoogleCloudAuthenticationOptionsTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.GoogleCloud.Tests/GoogleCloudAuthenticationOptionsTests.cs
@@ -7,8 +7,8 @@ namespace Granit.Authentication.JwtBearer.GoogleCloud.Tests;
 public sealed class GoogleCloudAuthenticationOptionsTests
 {
     [Fact]
-    public void SectionName_IsGoogleCloudAuth() =>
-        GoogleCloudAuthenticationOptions.SectionName.ShouldBe("GoogleCloudAuth");
+    public void SectionName_IsAuthenticationGoogleCloud() =>
+        GoogleCloudAuthenticationOptions.SectionName.ShouldBe("Authentication:GoogleCloud");
 
     [Fact]
     public void Authority_IsDerivedFromProjectId()

--- a/tests/Granit.Authentication.JwtBearer.GoogleCloud.Tests/GoogleCloudAuthenticationServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.GoogleCloud.Tests/GoogleCloudAuthenticationServiceCollectionExtensionsTests.cs
@@ -19,7 +19,7 @@ public sealed class GoogleCloudAuthenticationServiceCollectionExtensionsTests
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(config ?? new Dictionary<string, string?>
             {
-                ["GoogleCloudAuth:ProjectId"] = "my-project",
+                ["Authentication:GoogleCloud:ProjectId"] = "my-project",
             })
             .Build();
         services.AddSingleton(configuration);

--- a/tests/Granit.BlobStorage.Endpoints.Tests/BlobStorageEndpointsOptionsTests.cs
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/BlobStorageEndpointsOptionsTests.cs
@@ -17,5 +17,5 @@ public sealed class BlobStorageEndpointsOptionsTests
 
     [Fact]
     public void SectionName_should_be_BlobStorageEndpoints() =>
-        BlobStorageEndpointsOptions.SectionName.ShouldBe("BlobStorageEndpoints");
+        BlobStorageEndpointsOptions.SectionName.ShouldBe("BlobStorage:Endpoints");
 }

--- a/tests/Granit.BlobStorage.Endpoints.Tests/Options/BlobStorageEndpointsOptionsTests.cs
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/Options/BlobStorageEndpointsOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.BlobStorage.Endpoints.Tests.Options;
 public sealed class BlobStorageEndpointsOptionsTests
 {
     [Fact]
-    public void SectionName_IsExpected() => BlobStorageEndpointsOptions.SectionName.ShouldBe("BlobStorageEndpoints");
+    public void SectionName_IsExpected() => BlobStorageEndpointsOptions.SectionName.ShouldBe("BlobStorage:Endpoints");
 
     [Fact]
     public void DefaultRoutePrefix_IsBlobs()

--- a/tests/Granit.DataExchange.Endpoints.Tests/Options/DataExchangeEndpointsOptionsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Options/DataExchangeEndpointsOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class DataExchangeEndpointsOptionsTests
 {
     [Fact]
     public void SectionName_IsDataExchangeEndpoints() =>
-        DataExchangeEndpointsOptions.SectionName.ShouldBe("DataExchangeEndpoints");
+        DataExchangeEndpointsOptions.SectionName.ShouldBe("DataExchange:Endpoints");
 
     [Fact]
     public void Default_RoutePrefix_IsDataExchange()

--- a/tests/Granit.DataExchange.Tests/Export/ExportOptionsTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportOptionsTests.cs
@@ -7,8 +7,8 @@ namespace Granit.DataExchange.Tests.Export;
 public sealed class ExportOptionsTests
 {
     [Fact]
-    public void SectionName_IsDataExport() =>
-        ExportOptions.SectionName.ShouldBe("DataExport");
+    public void SectionName_IsDataExchangeExport() =>
+        ExportOptions.SectionName.ShouldBe("DataExchange:Export");
 
     [Fact]
     public void DefaultBackgroundThreshold_Is1000()

--- a/tests/Granit.DataExchange.Tests/ImportOptionsTests.cs
+++ b/tests/Granit.DataExchange.Tests/ImportOptionsTests.cs
@@ -7,8 +7,8 @@ namespace Granit.DataExchange.Tests;
 public sealed class ImportOptionsTests
 {
     [Fact]
-    public void SectionName_is_DataExchange() =>
-        ImportOptions.SectionName.ShouldBe("DataExchange");
+    public void SectionName_is_DataExchange_Import() =>
+        ImportOptions.SectionName.ShouldBe("DataExchange:Import");
 
     [Fact]
     public void Default_max_file_size_is_50()

--- a/tests/Granit.Http.ApiDocumentation.Tests/ApiDocumentationOptionsTests.cs
+++ b/tests/Granit.Http.ApiDocumentation.Tests/ApiDocumentationOptionsTests.cs
@@ -14,7 +14,7 @@ public sealed class ApiDocumentationOptionsTests
 {
     [Fact]
     public void SectionName_IsApiDocumentation() =>
-        ApiDocumentationOptions.SectionName.ShouldBe("ApiDocumentation");
+        ApiDocumentationOptions.SectionName.ShouldBe("Http:ApiDocumentation");
 
     [Fact]
     public void MajorVersions_DefaultsToListWithOne()

--- a/tests/Granit.Http.ApiVersioning.Tests/ApiVersioningOptionsTests.cs
+++ b/tests/Granit.Http.ApiVersioning.Tests/ApiVersioningOptionsTests.cs
@@ -14,7 +14,7 @@ public sealed class GranitApiVersioningOptionsTests
 {
     [Fact]
     public void SectionName_IsApiVersioning() =>
-        GranitApiVersioningOptions.SectionName.ShouldBe("ApiVersioning");
+        GranitApiVersioningOptions.SectionName.ShouldBe("Http:ApiVersioning");
 
     [Fact]
     public void DefaultMajorVersion_DefaultsToOne()

--- a/tests/Granit.Http.Bulkhead.Tests/OptionsTests.cs
+++ b/tests/Granit.Http.Bulkhead.Tests/OptionsTests.cs
@@ -38,7 +38,7 @@ public sealed class OptionsTests
 
     [Fact]
     public void SectionName_IsBulkhead() =>
-        GranitBulkheadOptions.SectionName.ShouldBe("Bulkhead");
+        GranitBulkheadOptions.SectionName.ShouldBe("Http:Bulkhead");
 
     [Fact]
     public void Policies_CaseInsensitive()

--- a/tests/Granit.Http.Cookies.Klaro.Tests/KlaroOptionsTests.cs
+++ b/tests/Granit.Http.Cookies.Klaro.Tests/KlaroOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class KlaroOptionsTests
 {
     [Fact]
     public void SectionName_IsKlaro() =>
-        KlaroOptions.SectionName.ShouldBe("Klaro");
+        KlaroOptions.SectionName.ShouldBe("Http:Cookies:Klaro");
 
     [Fact]
     public void DefaultCookieName_IsKlaro()

--- a/tests/Granit.Http.Cookies.Tests/GranitCookiesOptionsTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/GranitCookiesOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class GranitCookiesOptionsTests
 {
     [Fact]
     public void SectionName_IsCookies() =>
-        GranitCookiesOptions.SectionName.ShouldBe("Cookies");
+        GranitCookiesOptions.SectionName.ShouldBe("Http:Cookies");
 
     [Fact]
     public void ThrowOnUnregistered_DefaultsToTrue() =>

--- a/tests/Granit.Http.Cors.Tests/GranitCorsOptionsTests.cs
+++ b/tests/Granit.Http.Cors.Tests/GranitCorsOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class GranitCorsOptionsTests
 {
     [Fact]
     public void SectionName_IsCors() =>
-        GranitCorsOptions.SectionName.ShouldBe("Cors");
+        GranitCorsOptions.SectionName.ShouldBe("Http:Cors");
 
     [Fact]
     public void AllowedOrigins_DefaultsToEmpty() =>

--- a/tests/Granit.Http.Idempotency.Tests/IdempotencyOptionsTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotencyOptionsTests.cs
@@ -11,7 +11,7 @@ public sealed class IdempotencyOptionsTests
     // =========================================================================
 
     [Fact]
-    public void SectionName_IsIdempotency() => IdempotencyOptions.SectionName.ShouldBe("Idempotency");
+    public void SectionName_IsIdempotency() => IdempotencyOptions.SectionName.ShouldBe("Http:Idempotency");
 
     [Fact]
     public void DefaultHeaderName_IsIdempotencyKey()

--- a/tests/Granit.Http.Idempotency.Tests/IdempotencyServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotencyServiceCollectionExtensionsTests.cs
@@ -24,12 +24,12 @@ public sealed class IdempotencyServiceCollectionExtensionsTests
         IConfiguration config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Idempotency:HeaderName"] = "X-Idempotency-Key",
-                ["Idempotency:KeyPrefix"] = "myapp",
+                ["Http:Idempotency:HeaderName"] = "X-Idempotency-Key",
+                ["Http:Idempotency:KeyPrefix"] = "myapp",
             })
             .Build();
 
-        services.AddGranitIdempotency(config.GetSection("Idempotency"));
+        services.AddGranitIdempotency(config.GetSection("Http:Idempotency"));
 
         services.ShouldContain(d =>
             d.ServiceType == typeof(IConfigureOptions<IdempotencyOptions>));

--- a/tests/Granit.Http.OutputCaching.StackExchangeRedis.Tests/RedisOutputCachingOptionsTests.cs
+++ b/tests/Granit.Http.OutputCaching.StackExchangeRedis.Tests/RedisOutputCachingOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class RedisOutputCachingOptionsTests
 {
     [Fact]
     public void SectionName_IsOutputCachingRedis() =>
-        RedisOutputCachingOptions.SectionName.ShouldBe("OutputCaching:Redis");
+        RedisOutputCachingOptions.SectionName.ShouldBe("Http:OutputCaching:Redis");
 
     [Fact]
     public void IsEnabled_DefaultsToTrue() =>

--- a/tests/Granit.Http.OutputCaching.Tests/OutputCachingOptionsTests.cs
+++ b/tests/Granit.Http.OutputCaching.Tests/OutputCachingOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class OutputCachingOptionsTests
 {
     [Fact]
     public void SectionName_IsOutputCaching() =>
-        OutputCachingOptions.SectionName.ShouldBe("OutputCaching");
+        OutputCachingOptions.SectionName.ShouldBe("Http:OutputCaching");
 
     [Fact]
     public void DefaultExpiration_DefaultsTo60Seconds() =>

--- a/tests/Granit.Http.Resilience.Tests/HttpResilienceOptionsTests.cs
+++ b/tests/Granit.Http.Resilience.Tests/HttpResilienceOptionsTests.cs
@@ -8,5 +8,5 @@ public sealed class HttpResilienceOptionsTests
 {
     [Fact]
     public void SectionName_IsHttpResilience() =>
-        HttpResilienceOptions.SectionName.ShouldBe("HttpResilience");
+        HttpResilienceOptions.SectionName.ShouldBe("Http:Resilience");
 }

--- a/tests/Granit.Http.ResponseCompression.Tests/GranitResponseCompressionOptionsTests.cs
+++ b/tests/Granit.Http.ResponseCompression.Tests/GranitResponseCompressionOptionsTests.cs
@@ -9,7 +9,7 @@ public sealed class GranitResponseCompressionOptionsTests
 {
     [Fact]
     public void SectionName_IsResponseCompression() =>
-        GranitResponseCompressionOptions.SectionName.ShouldBe("ResponseCompression");
+        GranitResponseCompressionOptions.SectionName.ShouldBe("Http:ResponseCompression");
 
     [Fact]
     public void Defaults_EnableForHttps_IsTrue() =>

--- a/tests/Granit.Http.SecurityHeaders.Tests/GranitSecurityHeadersOptionsTests.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/GranitSecurityHeadersOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class GranitSecurityHeadersOptionsTests
 {
     [Fact]
     public void SectionName_IsSecurityHeaders() =>
-        GranitSecurityHeadersOptions.SectionName.ShouldBe("SecurityHeaders");
+        GranitSecurityHeadersOptions.SectionName.ShouldBe("Http:SecurityHeaders");
 
     [Fact]
     public void SuppressServerHeader_DefaultsToTrue() =>

--- a/tests/Granit.IO.Tests/TempFileOptionsTests.cs
+++ b/tests/Granit.IO.Tests/TempFileOptionsTests.cs
@@ -22,7 +22,7 @@ public sealed class TempFileOptionsTests
 
     [Fact]
     public void SectionName_IsCorrect() =>
-        TempFileOptions.SectionName.ShouldBe("Granit:IO:TempFiles");
+        TempFileOptions.SectionName.ShouldBe("IO:TempFiles");
 
     [Fact]
     public void EffectiveRootDirectory_FallsBackToDefault_WhenUnset()

--- a/tests/Granit.Identity.Endpoints.Tests/Options/IdentityEndpointsOptionsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/Options/IdentityEndpointsOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Endpoints.Tests.Options;
 public sealed class IdentityEndpointsOptionsTests
 {
     [Fact]
-    public void SectionName_IsIdentityEndpoints() => IdentityEndpointsOptions.SectionName.ShouldBe("IdentityEndpoints");
+    public void SectionName_IsIdentityEndpoints() => IdentityEndpointsOptions.SectionName.ShouldBe("Identity:Endpoints");
 
     [Fact]
     public void Defaults_RoutePrefixIsIdentityUsers()

--- a/tests/Granit.Identity.Endpoints.Tests/Options/IdentityProviderEndpointsOptionsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/Options/IdentityProviderEndpointsOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Endpoints.Tests.Options;
 public sealed class IdentityProviderEndpointsOptionsTests
 {
     [Fact]
-    public void SectionName_IsIdentityProviderEndpoints() => IdentityProviderEndpointsOptions.SectionName.ShouldBe("IdentityProviderEndpoints");
+    public void SectionName_IsIdentityProviderEndpoints() => IdentityProviderEndpointsOptions.SectionName.ShouldBe("Identity:Endpoints:Provider");
 
     [Fact]
     public void Defaults_RoutePrefixIsIdentityProvider()

--- a/tests/Granit.Identity.Endpoints.Tests/Options/IdentityWebhookOptionsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/Options/IdentityWebhookOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Endpoints.Tests.Options;
 public sealed class IdentityWebhookOptionsTests
 {
     [Fact]
-    public void SectionName_IsIdentityWebhook() => IdentityWebhookOptions.SectionName.ShouldBe("IdentityWebhook");
+    public void SectionName_IsIdentityWebhook() => IdentityWebhookOptions.SectionName.ShouldBe("Identity:Webhook");
 
     [Fact]
     public void Defaults_SecretIsEmpty()

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoAdminOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoAdminOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Federated.Cognito.Tests;
 public sealed class CognitoAdminOptionsTests
 {
     [Fact]
-    public void SectionName_IsCognitoAdmin() => CognitoAdminOptions.SectionName.ShouldBe("CognitoAdmin");
+    public void SectionName_IsCognitoAdmin() => CognitoAdminOptions.SectionName.ShouldBe("Identity:Federated:Cognito");
 
     [Fact]
     public void DefaultValues_AreEmptyStrings()

--- a/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsClientRoleTests.cs
@@ -24,8 +24,8 @@ public sealed class IdentityCognitoServiceCollectionExtensionsClientRoleTests
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["CognitoAdmin:Region"] = "eu-west-1",
-                ["CognitoAdmin:UserPoolId"] = "eu-west-1_TEST",
+                ["Identity:Federated:Cognito:Region"] = "eu-west-1",
+                ["Identity:Federated:Cognito:UserPoolId"] = "eu-west-1_TEST",
             }).Build());
 
         services.AddLogging();

--- a/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsTests.cs
@@ -19,8 +19,8 @@ public sealed class IdentityCognitoServiceCollectionExtensionsTests
     {
         Dictionary<string, string?> config = new()
         {
-            ["CognitoAdmin:Region"] = "eu-west-1",
-            ["CognitoAdmin:UserPoolId"] = "eu-west-1_TEST",
+            ["Identity:Federated:Cognito:Region"] = "eu-west-1",
+            ["Identity:Federated:Cognito:UserPoolId"] = "eu-west-1_TEST",
         };
 
         IConfiguration configuration = new ConfigurationBuilder()

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsAdditionalTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsAdditionalTests.cs
@@ -16,7 +16,7 @@ public sealed class EntraIdAdminOptionsAdditionalTests
     };
 
     [Fact]
-    public void SectionName_IsEntraIdAdmin() => EntraIdAdminOptions.SectionName.ShouldBe("EntraIdAdmin");
+    public void SectionName_IsEntraIdAdmin() => EntraIdAdminOptions.SectionName.ShouldBe("Identity:Federated:EntraId");
 
     [Fact]
     public void DefaultValues_AreEmptyStrings()

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
@@ -156,5 +156,5 @@ public sealed class EntraIdAdminOptionsTests
 
     [Fact]
     public void SectionName_IsEntraIdAdmin() =>
-        EntraIdAdminOptions.SectionName.ShouldBe("EntraIdAdmin");
+        EntraIdAdminOptions.SectionName.ShouldBe("Identity:Federated:EntraId");
 }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderCapabilitiesTests.cs
@@ -55,10 +55,10 @@ public sealed class EntraIdIdentityProviderCapabilitiesTests
     public void AddGranitIdentityEntraId_RegistersEntraIdCapabilities()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "test-tenant-id";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "admin-service";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-obj-id";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "test-tenant-id";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-obj-id";
 
         builder.Services.AddGranitIdentityEntraId();
 

--- a/tests/Granit.Identity.Federated.EntraId.Tests/GranitIdentityFederatedEntraIdModuleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/GranitIdentityFederatedEntraIdModuleTests.cs
@@ -33,10 +33,10 @@ public sealed class GranitIdentityFederatedEntraIdModuleTests
     public void ConfigureServices_RegistersEntraIdIdentityProvider()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "test-tenant-id";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "admin-service";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-obj-id";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "test-tenant-id";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-obj-id";
 
         var context = new ServiceConfigurationContext(builder.Services, builder.Configuration, builder);
         var module = new GranitIdentityFederatedEntraIdModule();
@@ -54,10 +54,10 @@ public sealed class GranitIdentityFederatedEntraIdModuleTests
     public void ConfigureServices_RegistersTokenServiceAsSingleton()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "test-tenant-id";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "admin-service";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-obj-id";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "test-tenant-id";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-obj-id";
 
         var context = new ServiceConfigurationContext(builder.Services, builder.Configuration, builder);
         var module = new GranitIdentityFederatedEntraIdModule();

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
@@ -27,10 +27,10 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsClientRoleTests
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["EntraIdAdmin:TenantId"] = "test-tenant-id",
-                ["EntraIdAdmin:ClientId"] = "admin-service",
-                ["EntraIdAdmin:ClientSecret"] = "secret",
-                ["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-object-id",
+                ["Identity:Federated:EntraId:TenantId"] = "test-tenant-id",
+                ["Identity:Federated:EntraId:ClientId"] = "admin-service",
+                ["Identity:Federated:EntraId:ClientSecret"] = "secret",
+                ["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-object-id",
             }).Build());
 
         services.AddLogging();

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsTests.cs
@@ -13,10 +13,10 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsTests
     public void AddGranitIdentityEntraId_RegistersIdentityProvider()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "test-tenant-id";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "admin-service";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-obj-id";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "test-tenant-id";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-obj-id";
 
         builder.Services.AddGranitIdentityEntraId();
 
@@ -30,10 +30,10 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsTests
     public void AddGranitIdentityEntraId_RegistersHttpClient()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "test-tenant-id";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "admin-service";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-obj-id";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "test-tenant-id";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-obj-id";
 
         builder.Services.AddGranitIdentityEntraId();
 
@@ -45,10 +45,10 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsTests
     public void AddGranitIdentityEntraId_RegistersTokenServiceAsSingleton()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "test-tenant-id";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "admin-service";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-obj-id";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "test-tenant-id";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-obj-id";
 
         builder.Services.AddGranitIdentityEntraId();
 
@@ -62,10 +62,10 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsTests
     public void AddGranitIdentityEntraId_ReturnsSameServiceCollection()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "test-tenant-id";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "admin-service";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-obj-id";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "test-tenant-id";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "sp-obj-id";
 
         IServiceCollection result = builder.Services.AddGranitIdentityEntraId();
 
@@ -76,10 +76,10 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsTests
     public void AddGranitIdentityEntraId_ConfiguresOptionsFromConfiguration()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["EntraIdAdmin:TenantId"] = "my-tenant";
-        builder.Configuration["EntraIdAdmin:ClientId"] = "my-client";
-        builder.Configuration["EntraIdAdmin:ClientSecret"] = "my-secret";
-        builder.Configuration["EntraIdAdmin:ServicePrincipalObjectId"] = "my-sp";
+        builder.Configuration["Identity:Federated:EntraId:TenantId"] = "my-tenant";
+        builder.Configuration["Identity:Federated:EntraId:ClientId"] = "my-client";
+        builder.Configuration["Identity:Federated:EntraId:ClientSecret"] = "my-secret";
+        builder.Configuration["Identity:Federated:EntraId:ServicePrincipalObjectId"] = "my-sp";
 
         builder.Services.AddGranitIdentityEntraId();
 

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Federated.GoogleCloud.Tests;
 public sealed class GoogleCloudIdentityOptionsTests
 {
     [Fact]
-    public void SectionName_IsIdentityGoogleCloud() => GoogleCloudIdentityOptions.SectionName.ShouldBe("Identity:GoogleCloud");
+    public void SectionName_IsIdentityGoogleCloud() => GoogleCloudIdentityOptions.SectionName.ShouldBe("Identity:Federated:GoogleCloud");
 
     [Fact]
     public void Defaults_ProjectIdIsEmpty()

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/IdentityGoogleCloudServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/IdentityGoogleCloudServiceCollectionExtensionsTests.cs
@@ -18,7 +18,7 @@ public sealed class IdentityGoogleCloudServiceCollectionExtensionsTests
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(config ?? new Dictionary<string, string?>
             {
-                ["Identity:GoogleCloud:ProjectId"] = "test-project",
+                ["Identity:Federated:GoogleCloud:ProjectId"] = "test-project",
             })
             .Build();
         services.AddSingleton(configuration);

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/KeycloakClientRoleSyncTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/KeycloakClientRoleSyncTests.cs
@@ -35,14 +35,14 @@ public sealed class KeycloakClientRoleSyncTests(KeycloakFixture keycloak)
         ServiceCollection services = [];
         Dictionary<string, string?> config = new()
         {
-            ["KeycloakAdmin:BaseUrl"] = _keycloak.BaseUrl,
-            ["KeycloakAdmin:Realm"] = KeycloakFixture.Realm,
-            ["KeycloakAdmin:ClientId"] = KeycloakFixture.AdminClientId,
-            ["KeycloakAdmin:ClientSecret"] = KeycloakFixture.AdminClientSecret,
+            ["Identity:Federated:Keycloak:BaseUrl"] = _keycloak.BaseUrl,
+            ["Identity:Federated:Keycloak:Realm"] = KeycloakFixture.Realm,
+            ["Identity:Federated:Keycloak:ClientId"] = KeycloakFixture.AdminClientId,
+            ["Identity:Federated:Keycloak:ClientSecret"] = KeycloakFixture.AdminClientSecret,
         };
         for (int i = 0; i < trackedClientIds.Length; i++)
         {
-            config[$"KeycloakAdmin:ClientRoleSync:TrackedClientIds:{i}"] = trackedClientIds[i];
+            config[$"Identity:Federated:Keycloak:ClientRoleSync:TrackedClientIds:{i}"] = trackedClientIds[i];
         }
 
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder()

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/GranitIdentityFederatedKeycloakModuleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/GranitIdentityFederatedKeycloakModuleTests.cs
@@ -33,10 +33,10 @@ public sealed class GranitIdentityFederatedKeycloakModuleTests
     public void ConfigureServices_RegistersKeycloakIdentityProvider()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "test-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "admin-service";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "test-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "secret";
 
         var context = new ServiceConfigurationContext(builder.Services, builder.Configuration, builder);
         var module = new GranitIdentityFederatedKeycloakModule();
@@ -54,10 +54,10 @@ public sealed class GranitIdentityFederatedKeycloakModuleTests
     public void ConfigureServices_RegistersTokenServiceAsSingleton()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "test-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "admin-service";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "test-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "secret";
 
         var context = new ServiceConfigurationContext(builder.Services, builder.Configuration, builder);
         var module = new GranitIdentityFederatedKeycloakModule();

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsClientRoleTests.cs
@@ -26,10 +26,10 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsClientRoleTests
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["KeycloakAdmin:BaseUrl"] = "https://keycloak.test",
-                ["KeycloakAdmin:Realm"] = "test",
-                ["KeycloakAdmin:ClientId"] = "admin",
-                ["KeycloakAdmin:ClientSecret"] = "secret",
+                ["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test",
+                ["Identity:Federated:Keycloak:Realm"] = "test",
+                ["Identity:Federated:Keycloak:ClientId"] = "admin",
+                ["Identity:Federated:Keycloak:ClientSecret"] = "secret",
             }).Build());
 
         services.AddLogging();

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsTests.cs
@@ -13,10 +13,10 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsTests
     public void AddGranitIdentityKeycloak_RegistersIdentityProvider()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "test-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "admin-service";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "test-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "secret";
 
         builder.Services.AddGranitIdentityKeycloak();
 
@@ -30,10 +30,10 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsTests
     public void AddGranitIdentityKeycloak_RegistersTokenService()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "test-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "admin-service";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "test-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "secret";
 
         builder.Services.AddGranitIdentityKeycloak();
 
@@ -47,10 +47,10 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsTests
     public void AddGranitIdentityKeycloak_RegistersHttpClient()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "test-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "admin-service";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "test-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "secret";
 
         builder.Services.AddGranitIdentityKeycloak();
 
@@ -63,10 +63,10 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsTests
     public void AddGranitIdentityKeycloak_ReturnsSameServiceCollection()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "test-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "admin-service";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "test-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "secret";
 
         IServiceCollection result = builder.Services.AddGranitIdentityKeycloak();
 
@@ -77,10 +77,10 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsTests
     public void AddGranitIdentityKeycloak_ConfiguresOptionsFromConfiguration()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "my-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "my-client";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "my-secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "my-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "my-client";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "my-secret";
 
         builder.Services.AddGranitIdentityKeycloak();
 

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakAdminOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakAdminOptionsTests.cs
@@ -15,8 +15,8 @@ public sealed class KeycloakAdminOptionsTests
     };
 
     [Fact]
-    public void SectionName_IsKeycloakAdmin() =>
-        KeycloakAdminOptions.SectionName.ShouldBe("KeycloakAdmin");
+    public void SectionName_IsIdentityFederatedKeycloak() =>
+        KeycloakAdminOptions.SectionName.ShouldBe("Identity:Federated:Keycloak");
 
     [Fact]
     public void GetTokenEndpoint_ReturnsCorrectUrl()

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderCapabilitiesTests.cs
@@ -55,10 +55,10 @@ public sealed class KeycloakIdentityProviderCapabilitiesTests
     public void AddGranitIdentityKeycloak_RegistersKeycloakCapabilities()
     {
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Configuration["KeycloakAdmin:BaseUrl"] = "https://keycloak.test";
-        builder.Configuration["KeycloakAdmin:Realm"] = "test-realm";
-        builder.Configuration["KeycloakAdmin:ClientId"] = "admin-service";
-        builder.Configuration["KeycloakAdmin:ClientSecret"] = "secret";
+        builder.Configuration["Identity:Federated:Keycloak:BaseUrl"] = "https://keycloak.test";
+        builder.Configuration["Identity:Federated:Keycloak:Realm"] = "test-realm";
+        builder.Configuration["Identity:Federated:Keycloak:ClientId"] = "admin-service";
+        builder.Configuration["Identity:Federated:Keycloak:ClientSecret"] = "secret";
 
         builder.Services.AddGranitIdentityKeycloak();
 

--- a/tests/Granit.Identity.Federated.Tests/Options/UserCacheOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Options/UserCacheOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Federated.Tests.Options;
 public sealed class UserCacheOptionsTests
 {
     [Fact]
-    public void SectionName_IsIdentityUserCache() => UserCacheOptions.SectionName.ShouldBe("IdentityUserCache");
+    public void SectionName_IsIdentityFederatedUserCache() => UserCacheOptions.SectionName.ShouldBe("Identity:Federated:UserCache");
 
     [Fact]
     public void Defaults_StalenessThresholdIs24Hours()

--- a/tests/Granit.Notifications.Email.Smtp.Tests/SmtpOptionsTests.cs
+++ b/tests/Granit.Notifications.Email.Smtp.Tests/SmtpOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class SmtpOptionsTests
 {
     [Fact]
     public void SectionName_IsNotificationsSmtp() =>
-        SmtpOptions.SectionName.ShouldBe("Notifications:Smtp");
+        SmtpOptions.SectionName.ShouldBe("Notifications:Email:Smtp");
 
     [Fact]
     public void Host_Default_IsLocalhost() =>

--- a/tests/Granit.Notifications.MobilePush.AzureNotificationHubs.Tests/AzureNotificationHubsOptionsValidatorTests.cs
+++ b/tests/Granit.Notifications.MobilePush.AzureNotificationHubs.Tests/AzureNotificationHubsOptionsValidatorTests.cs
@@ -117,7 +117,7 @@ public sealed class AzureNotificationHubsOptionsValidatorTests
 
     [Fact]
     public void SectionName_IsNotificationsAzureNotificationHubs() =>
-        AzureNotificationHubsOptions.SectionName.ShouldBe("Notifications:AzureNotificationHubs");
+        AzureNotificationHubsOptions.SectionName.ShouldBe("Notifications:MobilePush:AzureNotificationHubs");
 
     [Fact]
     public void ConnectionString_Default_IsEmpty() =>

--- a/tests/Granit.Notifications.WebPush.Tests/PushChannelOptionsTests.cs
+++ b/tests/Granit.Notifications.WebPush.Tests/PushChannelOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class PushChannelOptionsTests
 {
     [Fact]
     public void SectionName_IsCorrect() =>
-        PushChannelOptions.SectionName.ShouldBe("Notifications:Push");
+        PushChannelOptions.SectionName.ShouldBe("Notifications:WebPush");
 
     [Fact]
     public void Defaults_VapidSubjectIsEmpty()

--- a/tests/Granit.Oidc.TokenManagement.Tests/Options/TokenManagementOptionsTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Options/TokenManagementOptionsTests.cs
@@ -8,7 +8,7 @@ public sealed class TokenManagementOptionsTests
 {
     [Fact]
     public void SectionName_IsCorrect() =>
-        TokenManagementOptions.SectionName.ShouldBe("TokenManagement");
+        TokenManagementOptions.SectionName.ShouldBe("Oidc:TokenManagement");
 
     [Fact]
     public void DefaultCacheMargin_DefaultsTo30Seconds() =>

--- a/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationStartupOptionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationStartupOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Tests;
 public sealed class MigrationStartupOptionsTests
 {
     [Fact]
-    public void SectionName_HasExpectedValue() => MigrationStartupOptions.SectionName.ShouldBe("GranitMigrations");
+    public void SectionName_HasExpectedValue() => MigrationStartupOptions.SectionName.ShouldBe("Persistence:Migrations");
 
     [Fact]
     public void Default_DefaultBatchSize_Is500()

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantSchemaOptionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantSchemaOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Tests.MultiTenancy;
 public sealed class TenantSchemaOptionsTests
 {
     [Fact]
-    public void SectionName_HasExpectedValue() => TenantSchemaOptions.SectionName.ShouldBe("TenantSchema");
+    public void SectionName_HasExpectedValue() => TenantSchemaOptions.SectionName.ShouldBe("MultiTenancy:TenantSchema");
 
     [Fact]
     public void Default_NamingConvention_IsTenantId()

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineEndpointsOptionsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineEndpointsOptionsTests.cs
@@ -11,7 +11,7 @@ public sealed class TimelineEndpointsOptionsTests
 {
     [Fact]
     public void SectionName_is_TimelineEndpoints() =>
-        TimelineEndpointsOptions.SectionName.ShouldBe("TimelineEndpoints");
+        TimelineEndpointsOptions.SectionName.ShouldBe("Timeline:Endpoints");
 
     [Fact]
     public void Default_RoutePrefix_is_timeline()

--- a/tests/Granit.Vault.Tests/ReEncryptionOptionsTests.cs
+++ b/tests/Granit.Vault.Tests/ReEncryptionOptionsTests.cs
@@ -7,7 +7,7 @@ namespace Granit.Vault.Tests;
 public sealed class ReEncryptionOptionsTests
 {
     [Fact]
-    public void SectionName_IsReEncryption() => ReEncryptionOptions.SectionName.ShouldBe("ReEncryption");
+    public void SectionName_IsReEncryption() => ReEncryptionOptions.SectionName.ShouldBe("Vault:ReEncryption");
 
     [Fact]
     public void RetiredKeyVersions_DefaultsToEmptySet()

--- a/tests/Granit.Webhooks.Endpoints.Tests/WebhooksEndpointsOptionsTests.cs
+++ b/tests/Granit.Webhooks.Endpoints.Tests/WebhooksEndpointsOptionsTests.cs
@@ -16,5 +16,5 @@ public sealed class WebhooksEndpointsOptionsTests
 
     [Fact]
     public void SectionName_ShouldBeWebhooksEndpoints() =>
-        WebhooksEndpointsOptions.SectionName.ShouldBe("WebhooksEndpoints");
+        WebhooksEndpointsOptions.SectionName.ShouldBe("Webhooks:Endpoints");
 }

--- a/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
@@ -55,7 +55,7 @@ public sealed class GranitWolverinePostgresqlModuleTests
         };
         settings.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["WolverinePostgresql:TransportConnectionString"] =
+            ["Wolverine:Postgresql:TransportConnectionString"] =
                 "Host=localhost;Database=test;Username=test;Password=test",
         });
         HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);

--- a/tests/Granit.Wolverine.Postgresql.Tests/WolverinePostgresqlOptionsTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/WolverinePostgresqlOptionsTests.cs
@@ -21,7 +21,7 @@ public sealed class WolverinePostgresqlOptionsTests
 
     [Fact]
     public void SectionName_IsWolverinePostgresql() =>
-        WolverinePostgresqlOptions.SectionName.ShouldBe("WolverinePostgresql");
+        WolverinePostgresqlOptions.SectionName.ShouldBe("Wolverine:Postgresql");
 
     [Fact]
     public void DefaultTransportConnectionString_IsNull() =>

--- a/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
@@ -55,7 +55,7 @@ public sealed class GranitWolverineSqlServerModuleTests
         };
         settings.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["WolverineSqlServer:TransportConnectionString"] =
+            ["Wolverine:SqlServer:TransportConnectionString"] =
                 "Server=localhost;Database=test;User Id=sa;Password=test;TrustServerCertificate=True",
         });
         HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);

--- a/tests/Granit.Wolverine.SqlServer.Tests/WolverineSqlServerOptionsTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/WolverineSqlServerOptionsTests.cs
@@ -21,7 +21,7 @@ public sealed class WolverineSqlServerOptionsTests
 
     [Fact]
     public void SectionName_IsWolverineSqlServer() =>
-        WolverineSqlServerOptions.SectionName.ShouldBe("WolverineSqlServer");
+        WolverineSqlServerOptions.SectionName.ShouldBe("Wolverine:SqlServer");
 
     [Fact]
     public void DefaultTransportConnectionString_IsEmpty() =>

--- a/tests/Granit.Workflow.Endpoints.Tests/WorkflowEndpointsOptionsTests.cs
+++ b/tests/Granit.Workflow.Endpoints.Tests/WorkflowEndpointsOptionsTests.cs
@@ -11,7 +11,7 @@ public sealed class WorkflowEndpointsOptionsTests
 {
     [Fact]
     public void SectionName_is_WorkflowEndpoints() =>
-        WorkflowEndpointsOptions.SectionName.ShouldBe("WorkflowEndpoints");
+        WorkflowEndpointsOptions.SectionName.ShouldBe("Workflow:Endpoints");
 
     [Fact]
     public void Default_RoutePrefix_is_workflow()


### PR DESCRIPTION
## Summary

- **Single rule for every `SectionName`**: colon-separated, ASP.NET-style, aligned on the project namespace after stripping the internal `Granit` prefix (`Granit.Foo.Bar` → `"Foo:Bar"`). Three legacy patterns eliminated — `Granit:` root prefix, PascalCase-glued compound names (`WolverinePostgresql`, every `*Endpoints` umbrella, all flat `Http.*`), vendor-rooted names under `Notifications.*` / `Identity.Federated.*`. ~50 sections renamed across 128 files.
- **Real binding collision fixed**: `ImportOptions` and the root data-exchange config both bound to `"DataExchange"`, silently shadowing one another → now `DataExchange:Import` / `DataExchange:Export`.
- **New architecture test** `SectionNameConventionTests` enforces the convention going forward (forbids `Granit:` root, forbids flat compound names outside an explicit allowlist, requires uniqueness). Every `*OptionsTests.SectionName.ShouldBe(...)` assertion updated; `templates/granit-api-full/appsettings.json` repointed (`"Cors"` → `"Http:Cors"`); `/audit` skill checklist gains §1d/§3d-bis on the convention.

## BREAKING for hosts

Every Granit-using `appsettings.json`, env-var mapping (`Foo__Bar`), K8s/Vault projection, and ExternalSecret manifest must be rewritten in the same deploy. Mixed fleets where some pods still read the old keys will fall back to defaults silently. Full migration diff in `CHANGELOG.md` covering: `Authentication:*`, `Wolverine:*`, `Persistence:Migrations`, `MultiTenancy:TenantSchema`, `Oidc:TokenManagement`, `Vault:ReEncryption`, `IO:TempFiles`, `Templating:App`, `DataExchange:*`, every `*.Endpoints`, every `Http:*`, complete `Notifications:*` and `Identity:Federated:*` trees.

The Keycloak JwtBearer section move shipped in #2177 is part of the same sweep and is now folded under the unified CHANGELOG entry.

## Test plan

- [ ] CI: 6 shards build clean (`architecture`, `infrastructure`, `security`, `application`, `api-data`, `core-ai`) — verified locally
- [ ] CI: `Granit.ArchitectureTests.SectionNameConventionTests` (3 facts) passes on develop
- [ ] CI: 21 sampled `SectionName_*` tests + 501 DI/integration tests on the touched packages pass — verified locally
- [ ] Reviewer: scan the CHANGELOG migration diff against any internal `appsettings.json` already in flight to flag pending host migrations
- [ ] Reviewer: confirm the `AllowedSingleSegmentSections` list in `SectionNameConventionTests` matches the actual top-level modules (no accidental allowlisting of a compound name)