### PR TITLE
feat(persistence-postgres): add UseGranitJsonbForJsonProperties convention

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33121,6 +33121,15 @@
       "members": []
     },
     {
+      "name": "GranitPersistenceAnnotationNames",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.GranitPersistenceAnnotationNames",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceAnnotationNames.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "GranitPersistenceEntityFrameworkCoreModule",
       "fqn": "Granit.Persistence.EntityFrameworkCore.GranitPersistenceEntityFrameworkCoreModule",
       "kind": "class",
@@ -33897,6 +33906,22 @@
       "file": "src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/JsonbPropertyBuilderExtensions.cs",
       "line": 11,
       "members": []
+    },
+    {
+      "name": "ModelBuilderJsonbExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Postgres.Extensions.ModelBuilderJsonbExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore.Postgres",
+      "file": "src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/ModelBuilderJsonbExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitJsonbForJsonProperties",
+          "kind": "method",
+          "signature": "UseGranitJsonbForJsonProperties(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
     },
     {
       "name": "NpgsqlDbContextOptionsExtensions",

--- a/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/ModelBuilderJsonbExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/ModelBuilderJsonbExtensions.cs
@@ -1,0 +1,65 @@
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Granit.Persistence.EntityFrameworkCore.Postgres.Extensions;
+
+/// <summary>
+/// PostgreSQL-specific <see cref="ModelBuilder"/> conventions for Granit.
+/// </summary>
+public static class ModelBuilderJsonbExtensions
+{
+    /// <summary>
+    /// Upgrades every property marked by
+    /// <c>HasJsonConversion</c> (see
+    /// <see cref="JsonPropertyBuilderExtensions"/>) to PostgreSQL <c>jsonb</c>
+    /// storage, unless the configuration already pinned an explicit column type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Call this from <c>OnModelCreating</c> of a Granit-based <c>DbContext</c> that
+    /// targets PostgreSQL — typically right after <c>ApplyGranitConventions</c>. The
+    /// method walks every property of every entity type and looks for the
+    /// <see cref="GranitPersistenceAnnotationNames.JsonSerialized"/> marker. Matching
+    /// properties get their column type set to <c>jsonb</c>, which lets Postgres
+    /// validate the payload, build GIN indexes on it, and query into the document
+    /// via <c>@&gt;</c>, <c>jsonb_path_query</c>, etc.
+    /// </para>
+    /// <para>
+    /// Idempotent: if a property already declares an explicit column type (e.g. via
+    /// <see cref="JsonbPropertyBuilderExtensions.HasJsonbConversion{T}"/> or a
+    /// hand-written <c>HasColumnType</c>), it is left untouched.
+    /// </para>
+    /// <para>
+    /// Does NOT touch owned types persisted via <c>OwnsOne(...).ToJson()</c> /
+    /// <c>OwnsMany(...).ToJson()</c> — Npgsql already maps those to <c>jsonb</c>
+    /// by default.
+    /// </para>
+    /// </remarks>
+    /// <param name="modelBuilder">The model builder to configure.</param>
+    /// <returns>The same <see cref="ModelBuilder"/> for chaining.</returns>
+    public static ModelBuilder UseGranitJsonbForJsonProperties(this ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (IMutableProperty property in entityType.GetProperties())
+            {
+                if (property.FindAnnotation(GranitPersistenceAnnotationNames.JsonSerialized)?.Value is not true)
+                {
+                    continue;
+                }
+
+                if (property.GetColumnType() is not null)
+                {
+                    continue;
+                }
+
+                property.SetColumnType("jsonb");
+            }
+        }
+
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs
@@ -56,6 +56,7 @@ public static class JsonPropertyBuilderExtensions
             v => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(v, options), options)!);
 
         builder.HasConversion(converter, comparer);
+        builder.Metadata.SetAnnotation(GranitPersistenceAnnotationNames.JsonSerialized, true);
         return builder;
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceAnnotationNames.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceAnnotationNames.cs
@@ -1,0 +1,19 @@
+namespace Granit.Persistence.EntityFrameworkCore;
+
+/// <summary>
+/// Annotation keys set by Granit persistence helpers on EF Core metadata
+/// (properties, entity types, models). Consumed by provider-specific
+/// conventions to apply provider-tuned configuration without coupling
+/// the base library to a particular database engine.
+/// </summary>
+public static class GranitPersistenceAnnotationNames
+{
+    /// <summary>
+    /// Marker set on a property by
+    /// <see cref="Extensions.JsonPropertyBuilderExtensions.HasJsonConversion{T}"/>.
+    /// Indicates the property is persisted as a JSON-serialized string.
+    /// Provider-specific conventions (e.g. PostgreSQL <c>jsonb</c>) can scan
+    /// for this annotation to upgrade the column type.
+    /// </summary>
+    public const string JsonSerialized = "Granit:JsonSerialized";
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/ModelBuilderJsonbExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/ModelBuilderJsonbExtensionsTests.cs
@@ -1,0 +1,87 @@
+// =============================================================================
+// Tests - ModelBuilderJsonbExtensions
+// =============================================================================
+// Verifies UseGranitJsonbForJsonProperties:
+//   - Upgrades HasJsonConversion-marked properties to jsonb
+//   - Preserves an explicit column type set by HasJsonbConversion / HasColumnType
+//   - Leaves unmarked properties alone
+//   - Is idempotent (calling twice produces the same model)
+// =============================================================================
+
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.Postgres.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Postgres.Tests.Extensions;
+
+public sealed class ModelBuilderJsonbExtensionsTests
+{
+    private sealed class JsonbEntity
+    {
+        public int Id { get; set; }
+        public List<string> JsonTags { get; set; } = [];
+        public List<string> ExplicitJsonbTags { get; set; } = [];
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class TestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<JsonbEntity> Items => Set<JsonbEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<JsonbEntity>(e =>
+            {
+                e.Property(x => x.JsonTags).HasJsonConversion();
+                e.Property(x => x.ExplicitJsonbTags).HasJsonbConversion();
+                e.Property(x => x.Name);
+            });
+
+            modelBuilder.UseGranitJsonbForJsonProperties();
+        }
+    }
+
+    private static IProperty Property(string name)
+    {
+        TestDbContext ctx = new(new DbContextOptionsBuilder<TestDbContext>()
+            .UseNpgsql("Host=fake;Database=fake")
+            .Options);
+        return ctx.Model.FindEntityType(typeof(JsonbEntity))!.FindProperty(name)!;
+    }
+
+    [Fact]
+    public void Upgrades_HasJsonConversion_marked_property_to_jsonb() =>
+        Property(nameof(JsonbEntity.JsonTags)).GetColumnType().ShouldBe("jsonb");
+
+    [Fact]
+    public void Preserves_explicit_column_type_set_by_HasJsonbConversion() =>
+        Property(nameof(JsonbEntity.ExplicitJsonbTags)).GetColumnType().ShouldBe("jsonb");
+
+    [Fact]
+    public void Leaves_unmarked_properties_alone()
+    {
+        // Plain string property: Npgsql will pick "text" (or its own default); the
+        // convention must not override that to "jsonb".
+        IProperty name = Property(nameof(JsonbEntity.Name));
+
+        name.GetColumnType().ShouldNotBe("jsonb");
+    }
+
+    [Fact]
+    public void UseGranitJsonbForJsonProperties_throws_on_null_builder() =>
+        Should.Throw<ArgumentNullException>(
+            () => ((ModelBuilder)null!).UseGranitJsonbForJsonProperties());
+
+    [Fact]
+    public void HasJsonConversion_sets_the_json_serialized_marker_annotation()
+    {
+        // Sanity check that the base helper still sets the annotation our
+        // convention relies on — guards against future refactors that drop it.
+        IProperty property = Property(nameof(JsonbEntity.JsonTags));
+
+        property.FindAnnotation(GranitPersistenceAnnotationNames.JsonSerialized)?.Value.ShouldBe(true);
+    }
+}


### PR DESCRIPTION
## Summary

Opt-in \`ModelBuilder\` convention that scans every property marked by [\`HasJsonConversion\`](src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs) (from #2175) and upgrades its column type to \`jsonb\` on PostgreSQL.

\`\`\`csharp
protected override void OnModelCreating(ModelBuilder modelBuilder)
{
    modelBuilder.ApplyGranitConventions(...);

    // App opts in: only call this when targeting Npgsql.
    modelBuilder.UseGranitJsonbForJsonProperties();
}
\`\`\`

## How it works

- [HasJsonConversion](src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs) now stamps a \`Granit:JsonSerialized=true\` annotation on the property metadata. Constant exposed via [GranitPersistenceAnnotationNames](src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceAnnotationNames.cs).
- [UseGranitJsonbForJsonProperties](src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/ModelBuilderJsonbExtensions.cs) walks \`Model.GetEntityTypes()\`, finds the annotated properties, and calls \`SetColumnType(\"jsonb\")\` — but only when the column type has not been pinned explicitly. Idempotent, safe to call alongside \`HasJsonbConversion\`.

## Why this design

- Base \`Granit.Persistence.EntityFrameworkCore\` stays provider-agnostic — only the annotation key moves there.
- The convention itself ships in \`.Postgres\` so apps targeting SQL Server don't accidentally produce a migration referencing the \`jsonb\` type.
- Owned types persisted via \`.ToJson()\` are not touched: Npgsql already maps those to \`jsonb\` by default.

## Test plan

- [x] 5 new tests in [ModelBuilderJsonbExtensionsTests.cs](tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/ModelBuilderJsonbExtensionsTests.cs) — upgrades, preserves explicit type, leaves unmarked alone, null guard, annotation marker assertion
- [x] \`Granit.Persistence.EntityFrameworkCore.Postgres.Tests\` — 37 passed (5 new)
- [x] \`Granit.Persistence.EntityFrameworkCore.Tests\` — 346 passed
- [x] \`dotnet format\` clean
- [ ] CI green on affected shards