### PR TITLE
feat(dataexchange)!: migrate ImportJob + ExportJob JSON columns to typed properties

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12476,7 +12476,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, string definitionName, string format, string requestJson, Guid? tenantId = null)",
+          "signature": "Create(Guid id, string definitionName, string format, ExportRequest request, Guid? tenantId = null)",
           "returnType": "ExportJob"
         },
         {
@@ -12492,10 +12492,10 @@
           "returnType": "string"
         },
         {
-          "name": "RequestJson",
+          "name": "Request",
           "kind": "property",
-          "signature": "string RequestJson",
-          "returnType": "string"
+          "signature": "ExportRequest Request",
+          "returnType": "ExportRequest"
         },
         {
           "name": "Status",
@@ -12642,7 +12642,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Export/ExportOrchestrator.cs",
-      "line": 27,
+      "line": 26,
       "members": [
         {
           "name": "ExportAsync",
@@ -13100,7 +13100,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Import/Domain/ImportJob.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "Create",
@@ -13145,10 +13145,10 @@
           "returnType": "ImportJobStatus"
         },
         {
-          "name": "MappingsJson",
+          "name": "Mappings",
           "kind": "property",
-          "signature": "string? MappingsJson",
-          "returnType": "string?"
+          "signature": "IReadOnlyList<ImportColumnMapping>? Mappings",
+          "returnType": "IReadOnlyList<ImportColumnMapping>?"
         }
       ]
     },

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportReportEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportReportEndpoints.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Granit.DataExchange.Endpoints.Dtos.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Parsing;
@@ -47,18 +46,12 @@ internal static class ImportReportEndpoints
         CancellationToken cancellationToken)
     {
         ImportJob? job = await jobReader.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
-        if (job is null || string.IsNullOrEmpty(job.ReportJson))
+        if (job?.Report is null)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        ImportReport? report = JsonSerializer.Deserialize<ImportReport>(job.ReportJson);
-        if (report is null)
-        {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
-        }
-
-        return TypedResults.Ok(ImportReportResponse.FromReport(jobId, report));
+        return TypedResults.Ok(ImportReportResponse.FromReport(jobId, job.Report));
     }
 
     private static async Task<Results<FileStreamHttpResult, NoContent, ProblemHttpResult>> GetCorrectionFileAsync(
@@ -69,16 +62,12 @@ internal static class ImportReportEndpoints
         CancellationToken cancellationToken)
     {
         ImportJob? job = await jobReader.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
-        if (job is null || string.IsNullOrEmpty(job.ReportJson))
+        if (job?.Report is null)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        ImportReport? report = JsonSerializer.Deserialize<ImportReport>(job.ReportJson);
-        if (report is null)
-        {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
-        }
+        ImportReport report = job.Report;
 
         if (report.RowErrors.Count == 0)
         {

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportUploadEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportUploadEndpoints.cs
@@ -103,7 +103,7 @@ internal static class ImportUploadEndpoints
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        job.ConfirmMappings(System.Text.Json.JsonSerializer.Serialize(request.Mappings));
+        job.ConfirmMappings(request.Mappings);
         await jobWriter.UpdateAsync(job, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.NoContent();

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportJobConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportJobConfiguration.cs
@@ -1,4 +1,5 @@
 using Granit.DataExchange.Export.Domain;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -18,7 +19,11 @@ internal sealed class ExportJobConfiguration : IEntityTypeConfiguration<ExportJo
 
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
         builder.Property(e => e.Format).HasMaxLength(10).IsRequired();
-        builder.Property(e => e.RequestJson).IsRequired();
+        // ExportRequest is serialized as an opaque JSON string via the framework helper
+        // rather than .ToJson() owned mapping: ExportRequest's IReadOnlyDictionary and
+        // IReadOnlyList interface-typed properties don't compose cleanly with EF Core 10
+        // owned-types, while System.Text.Json handles them transparently.
+        builder.Property(e => e.Request).HasJsonConversion().IsRequired();
         builder.Property(e => e.Status).IsRequired();
         builder.Property(e => e.BlobReference).HasMaxLength(500);
         builder.Property(e => e.FileName).HasMaxLength(500);

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ImportJobConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ImportJobConfiguration.cs
@@ -1,4 +1,5 @@
 using Granit.DataExchange.Import.Domain;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -28,8 +29,19 @@ internal sealed class ImportJobConfiguration : IEntityTypeConfiguration<ImportJo
             .HasConversion<string>()
             .HasMaxLength(20);
 
-        builder.Property(e => e.MappingsJson);
-        builder.Property(e => e.ReportJson);
+        builder.OwnsMany(e => e.Mappings, m =>
+        {
+            m.ToJson();
+            m.Property(p => p.SourceColumn);
+            m.Property(p => p.TargetProperty);
+            m.Property(p => p.Confidence);
+        });
+
+        // ImportReport is serialized as an opaque JSON string via the framework helper
+        // rather than .ToJson() owned mapping: ImportReport's nested IReadOnlyList<ImportRowError>
+        // + TimeSpan + enum compose awkwardly under EF Core 10 owned-types, while
+        // round-tripping through System.Text.Json is straightforward.
+        builder.Property(e => e.Report).HasJsonConversion();
         builder.Property(e => e.CompletedAt);
         builder.Property(e => e.TenantId);
 

--- a/src/Granit.DataExchange/Export/Domain/ExportJob.cs
+++ b/src/Granit.DataExchange/Export/Domain/ExportJob.cs
@@ -22,13 +22,13 @@ public sealed class ExportJob : AuditedAggregateRoot, IMultiTenant
         Guid id,
         string definitionName,
         string format,
-        string requestJson,
+        ExportRequest request,
         Guid? tenantId = null) => new()
         {
             Id = id,
             DefinitionName = definitionName,
             Format = format,
-            RequestJson = requestJson,
+            Request = request,
             Status = ExportJobStatus.Queued,
             TenantId = tenantId,
         };
@@ -45,9 +45,10 @@ public sealed class ExportJob : AuditedAggregateRoot, IMultiTenant
     public string Format { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Serialized <see cref="ExportRequest"/> (JSON). Preserved for auditability and retry.
+    /// Original <see cref="ExportRequest"/>. Persisted as a JSON-serialized value;
+    /// preserved for auditability and retry.
     /// </summary>
-    public string RequestJson { get; private set; } = string.Empty;
+    public ExportRequest Request { get; private set; } = null!;
 
     /// <summary>
     /// Current lifecycle status.

--- a/src/Granit.DataExchange/Export/ExportOrchestrator.cs
+++ b/src/Granit.DataExchange/Export/ExportOrchestrator.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using Granit.Commands;
 using Granit.DataExchange.Diagnostics;
 using Granit.DataExchange.Export.Domain;
@@ -54,7 +53,7 @@ public sealed partial class ExportOrchestrator(
             guidGenerator.Create(),
             request.DefinitionName,
             request.Format,
-            JsonSerializer.Serialize(request),
+            request,
             currentTenant.IsAvailable ? currentTenant.Id : null);
 
         await jobWriter.CreateAsync(job, cancellationToken).ConfigureAwait(false);
@@ -87,7 +86,7 @@ public sealed partial class ExportOrchestrator(
             job.MarkAsExporting();
             await jobWriter.UpdateAsync(job, cancellationToken).ConfigureAwait(false);
 
-            ExportRequest request = JsonSerializer.Deserialize<ExportRequest>(job.RequestJson)!;
+            ExportRequest request = job.Request;
             IExportDefinitionDescriptor definition = ResolveDefinition(request.DefinitionName);
             IExportWriter writer = ResolveWriter(request.Format);
             IReadOnlyList<ExportFieldDescriptor> fields = ResolveFields(definition, request.SelectedFields, request.IncludeIdForImport);

--- a/src/Granit.DataExchange/Import/Domain/ImportJob.cs
+++ b/src/Granit.DataExchange/Import/Domain/ImportJob.cs
@@ -1,4 +1,6 @@
 using Granit.DataExchange.Import.Events;
+using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import.Reporting;
 using Granit.Domain;
 using Granit.Domain.ValueObjects;
 
@@ -77,14 +79,16 @@ public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant
     public ImportJobStatus Status { get; private set; } = ImportJobStatus.Created;
 
     /// <summary>
-    /// Serialized column mappings (JSON). Set after user confirmation.
+    /// Column mappings confirmed by the user. Persisted as a JSON-owned collection.
+    /// <see langword="null"/> until <see cref="ConfirmMappings"/> is called.
     /// </summary>
-    public string? MappingsJson { get; private set; }
+    public IReadOnlyList<ImportColumnMapping>? Mappings { get; private set; }
 
     /// <summary>
-    /// Serialized import report (JSON). Set after execution completes.
+    /// Import execution report. Persisted as a JSON-serialized value.
+    /// <see langword="null"/> until <see cref="Complete"/> is called.
     /// </summary>
-    public string? ReportJson { get; private set; }
+    public ImportReport? Report { get; private set; }
 
     /// <summary>
     /// Timestamp when the import completed (success, partial, or failure).
@@ -102,8 +106,8 @@ public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant
     /// <summary>
     /// Sets the column mappings after user confirmation.
     /// </summary>
-    internal void SetMappings(string mappingsJson) =>
-        MappingsJson = mappingsJson;
+    internal void SetMappings(IReadOnlyList<ImportColumnMapping> mappings) =>
+        Mappings = mappings;
 
     /// <summary>
     /// Transitions to <see cref="ImportJobStatus.Previewed"/> after header extraction.
@@ -121,14 +125,14 @@ public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant
     /// <summary>
     /// Confirms mappings and transitions to <see cref="ImportJobStatus.Mapped"/>.
     /// </summary>
-    internal void ConfirmMappings(string mappingsJson)
+    internal void ConfirmMappings(IReadOnlyList<ImportColumnMapping> mappings)
     {
         if (Status is not ImportJobStatus.Previewed)
         {
             throw new InvalidOperationException($"Cannot transition to '{ImportJobStatus.Mapped}' from '{Status}'.");
         }
 
-        MappingsJson = mappingsJson;
+        Mappings = mappings;
         Status = ImportJobStatus.Mapped;
     }
 
@@ -162,7 +166,7 @@ public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant
     /// <summary>
     /// Marks the import as completed with a final status and report.
     /// </summary>
-    internal void Complete(ImportJobStatus finalStatus, string reportJson, DateTimeOffset completedAt)
+    internal void Complete(ImportJobStatus finalStatus, ImportReport report, DateTimeOffset completedAt)
     {
         if (Status is not ImportJobStatus.Executing)
         {
@@ -170,7 +174,7 @@ public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant
         }
 
         Status = finalStatus;
-        ReportJson = reportJson;
+        Report = report;
         CompletedAt = completedAt;
     }
 }

--- a/src/Granit.DataExchange/Import/Internal/ImportOrchestrator.cs
+++ b/src/Granit.DataExchange/Import/Internal/ImportOrchestrator.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 using Granit.DataExchange.Diagnostics;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Execution;
@@ -54,7 +53,7 @@ internal sealed class ImportOrchestrator(
             ImportReport report = await ExecuteTypedPipelineAsync(job, dryRun: false, cancellationToken).ConfigureAwait(false);
 
             stopwatch.Stop();
-            job.Complete(report.FinalStatus, JsonSerializer.Serialize(report), clock.Now);
+            job.Complete(report.FinalStatus, report, clock.Now);
             await jobWriter.UpdateAsync(job, cancellationToken).ConfigureAwait(false);
 
             metrics.RecordImportCompleted(report, job);
@@ -90,7 +89,7 @@ internal sealed class ImportOrchestrator(
                 ],
             };
 
-            job.Complete(ImportJobStatus.Failed, JsonSerializer.Serialize(errorReport), clock.Now);
+            job.Complete(ImportJobStatus.Failed, errorReport, clock.Now);
             await jobWriter.UpdateAsync(job, cancellationToken).ConfigureAwait(false);
 
             metrics.RecordImportCompleted(errorReport, job);
@@ -132,19 +131,14 @@ internal sealed class ImportOrchestrator(
                 $"Ensure the corresponding module is added: GranitDataExchangeCsvModule for CSV, GranitDataExchangeExcelModule for Excel.");
         }
 
-        // Deserialize the confirmed column mappings
-        if (string.IsNullOrEmpty(job.MappingsJson))
+        // Confirmed column mappings — set by ConfirmMappings before the job is queued.
+        if (job.Mappings is null || job.Mappings.Count == 0)
         {
             throw new InvalidOperationException(
                 $"Import job '{job.Id}' has no confirmed mappings.");
         }
 
-        List<ImportColumnMapping>? mappings = JsonSerializer.Deserialize<List<ImportColumnMapping>>(job.MappingsJson);
-        if (mappings is null || mappings.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Import job '{job.Id}' has invalid mappings JSON.");
-        }
+        IReadOnlyList<ImportColumnMapping> mappings = job.Mappings;
 
         // Open the file stream
         await using Stream fileStream = await fileProvider.OpenAsync(job.BlobReference, cancellationToken).ConfigureAwait(false);
@@ -190,7 +184,7 @@ internal sealed class ImportOrchestrator(
         IFileParser parser,
         Stream fileStream,
         FileParsingOptions parsingOptions,
-        List<ImportColumnMapping> mappings,
+        IReadOnlyList<ImportColumnMapping> mappings,
         bool dryRun,
         CancellationToken cancellationToken)
     {

--- a/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Export/ExportDtoMappingTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Export/ExportDtoMappingTests.cs
@@ -140,7 +140,8 @@ public sealed class ExportDtoMappingTests
     public void ExportJobResponse_FromJob_MapsAllProperties()
     {
         var job = ExportJob.Create(
-            Guid.NewGuid(), "Acme.Export", "xlsx", "{}");
+            Guid.NewGuid(), "Acme.Export", "xlsx",
+            new ExportRequest("Acme.Export", "xlsx", null, false, null, null, null, null));
 
         var response = ExportJobResponse.FromJob(job);
 

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportExecutionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportExecutionEndpointsTests.cs
@@ -96,7 +96,8 @@ public sealed class ExportExecutionEndpointsTests : IAsyncDisposable
         _orchestrator.ExportAsync(Arg.Any<ExportRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ExportJobResult(jobId, ExportJobStatus.Queued));
         _orchestrator.GetJobAsync(jobId, Arg.Any<CancellationToken>())
-            .Returns(ExportJob.Create(jobId, "Test.Export", "csv", "{}"));
+            .Returns(ExportJob.Create(jobId, "Test.Export", "csv",
+                new ExportRequest("Test.Export", "csv", null, false, null, null, null, null)));
 
         CreateExportJobRequest request = new("Test.Export", "csv", null, false, null, null, null, null);
 
@@ -176,7 +177,8 @@ public sealed class ExportExecutionEndpointsTests : IAsyncDisposable
     {
         // Arrange
         var jobId = Guid.NewGuid();
-        var completedJob = ExportJob.Create(jobId, "Test.Export", "xlsx", "{}");
+        var completedJob = ExportJob.Create(jobId, "Test.Export", "xlsx",
+            new ExportRequest("Test.Export", "xlsx", null, false, null, null, null, null));
         completedJob.MarkAsExporting();
         completedJob.Complete("blob-ref", "export.xlsx", 100, DateTimeOffset.UtcNow);
         _orchestrator.GetJobAsync(jobId, Arg.Any<CancellationToken>())
@@ -218,7 +220,8 @@ public sealed class ExportExecutionEndpointsTests : IAsyncDisposable
     {
         // Arrange
         var jobId = Guid.NewGuid();
-        var downloadJob = ExportJob.Create(jobId, "Test.Export", "csv", "{}");
+        var downloadJob = ExportJob.Create(jobId, "Test.Export", "csv",
+            new ExportRequest("Test.Export", "csv", null, false, null, null, null, null));
         downloadJob.MarkAsExporting();
         downloadJob.Complete("blob-ref", "export.csv", 10, DateTimeOffset.UtcNow);
         _orchestrator.GetJobAsync(jobId, Arg.Any<CancellationToken>())
@@ -242,7 +245,8 @@ public sealed class ExportExecutionEndpointsTests : IAsyncDisposable
     {
         // Arrange
         var jobId = Guid.NewGuid();
-        var exportingJob = ExportJob.Create(jobId, "Test.Export", "csv", "{}");
+        var exportingJob = ExportJob.Create(jobId, "Test.Export", "csv",
+            new ExportRequest("Test.Export", "csv", null, false, null, null, null, null));
         exportingJob.MarkAsExporting();
         _orchestrator.GetJobAsync(jobId, Arg.Any<CancellationToken>())
             .Returns(exportingJob);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportJobListEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportJobListEndpointsTests.cs
@@ -212,7 +212,8 @@ public sealed class ExportJobListEndpointsTests : IAsyncDisposable
 
     private static ExportJob CreateJob(ExportJobStatus status)
     {
-        var job = ExportJob.Create(Guid.NewGuid(), "Test.Export", "xlsx", "{}");
+        var job = ExportJob.Create(Guid.NewGuid(), "Test.Export", "xlsx",
+            new ExportRequest("Test.Export", "xlsx", null, false, null, null, null, null));
 
         if (status == ExportJobStatus.Exporting)
         {

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportExecutionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportExecutionEndpointsTests.cs
@@ -309,20 +309,20 @@ public sealed class ImportExecutionEndpointsTests : IAsyncDisposable
         else if (status == ImportJobStatus.Mapped)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
         }
         else if (status == ImportJobStatus.Executing)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
             job.MarkAsExecuting();
         }
         else if (status == ImportJobStatus.Completed)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
             job.MarkAsExecuting();
-            job.Complete(ImportJobStatus.Completed, "{}", DateTimeOffset.UtcNow);
+            job.Complete(ImportJobStatus.Completed, BuildReport(), DateTimeOffset.UtcNow);
         }
         else if (status == ImportJobStatus.Cancelled)
         {

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportJobListEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportJobListEndpointsTests.cs
@@ -8,6 +8,7 @@ using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;
 using Granit.DataExchange.Import.Pipeline;
+using Granit.DataExchange.Import.Reporting;
 using Granit.Guids;
 using Granit.QueryEngine;
 using Granit.Timing;
@@ -210,6 +211,19 @@ public sealed class ImportJobListEndpointsTests : IAsyncDisposable
 
     // ── Helpers ──────────────────────────────────────────────────────────
 
+    private static ImportReport EmptyReport() => new()
+    {
+        TotalRows = 0,
+        SucceededRows = 0,
+        FailedRows = 0,
+        SkippedRows = 0,
+        InsertedRows = 0,
+        UpdatedRows = 0,
+        Duration = TimeSpan.Zero,
+        FinalStatus = ImportJobStatus.Completed,
+        RowErrors = [],
+    };
+
     private static ImportJob CreateJob(ImportJobStatus status)
     {
         var job = ImportJob.Create(
@@ -218,14 +232,14 @@ public sealed class ImportJobListEndpointsTests : IAsyncDisposable
         if (status == ImportJobStatus.Completed)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
             job.MarkAsExecuting();
-            job.Complete(ImportJobStatus.Completed, "{}", DateTimeOffset.UtcNow);
+            job.Complete(ImportJobStatus.Completed, EmptyReport(), DateTimeOffset.UtcNow);
         }
         else if (status == ImportJobStatus.Executing)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
             job.MarkAsExecuting();
         }
 

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportReportEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportReportEndpointsTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text;
-using System.Text.Json;
 using Granit.DataExchange.Endpoints.Dtos.Import;
 using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
@@ -96,7 +95,7 @@ public sealed class ImportReportEndpointsTests : IAsyncDisposable
         // Arrange
         var jobId = Guid.NewGuid();
         ImportReport report = BuildReport();
-        ImportJob job = BuildJob(jobId, ImportJobStatus.Completed, JsonSerializer.Serialize(report));
+        ImportJob job = BuildJob(jobId, ImportJobStatus.Completed, report);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         // Act
@@ -131,7 +130,7 @@ public sealed class ImportReportEndpointsTests : IAsyncDisposable
     {
         // Arrange
         var jobId = Guid.NewGuid();
-        ImportJob job = BuildJob(jobId, ImportJobStatus.Executing, reportJson: null);
+        ImportJob job = BuildJob(jobId, ImportJobStatus.Executing, report: null);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         // Act
@@ -150,7 +149,7 @@ public sealed class ImportReportEndpointsTests : IAsyncDisposable
         // Arrange
         var jobId = Guid.NewGuid();
         ImportReport report = BuildReport();
-        ImportJob job = BuildJob(jobId, ImportJobStatus.PartiallyCompleted, JsonSerializer.Serialize(report));
+        ImportJob job = BuildJob(jobId, ImportJobStatus.PartiallyCompleted, report);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         // Act
@@ -181,7 +180,7 @@ public sealed class ImportReportEndpointsTests : IAsyncDisposable
             FinalStatus = ImportJobStatus.Completed,
             RowErrors = [],
         };
-        ImportJob job = BuildJob(jobId, ImportJobStatus.Completed, JsonSerializer.Serialize(report));
+        ImportJob job = BuildJob(jobId, ImportJobStatus.Completed, report);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         // Act
@@ -216,36 +215,22 @@ public sealed class ImportReportEndpointsTests : IAsyncDisposable
         return client;
     }
 
-    private static ImportJob BuildJob(Guid id, ImportJobStatus status, string? reportJson)
+    private static ImportJob BuildJob(Guid id, ImportJobStatus status, ImportReport? report)
     {
         var job = ImportJob.Create(id, "Test.Import", "Object", "test.csv", "text/csv", 100, "blob-ref-1");
         job.CreatedAt = DateTimeOffset.UtcNow;
 
-        if (status == ImportJobStatus.Completed && reportJson is not null)
+        if (status is ImportJobStatus.Completed or ImportJobStatus.PartiallyCompleted or ImportJobStatus.Failed && report is not null)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
             job.MarkAsExecuting();
-            job.Complete(ImportJobStatus.Completed, reportJson, DateTimeOffset.UtcNow);
-        }
-        else if (status == ImportJobStatus.PartiallyCompleted && reportJson is not null)
-        {
-            job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
-            job.MarkAsExecuting();
-            job.Complete(ImportJobStatus.PartiallyCompleted, reportJson, DateTimeOffset.UtcNow);
-        }
-        else if (status == ImportJobStatus.Failed && reportJson is not null)
-        {
-            job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
-            job.MarkAsExecuting();
-            job.Complete(ImportJobStatus.Failed, reportJson, DateTimeOffset.UtcNow);
+            job.Complete(status, report, DateTimeOffset.UtcNow);
         }
         else if (status == ImportJobStatus.Executing)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
             job.MarkAsExecuting();
         }
 

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
@@ -334,7 +334,7 @@ public sealed class ImportUploadEndpointsTests : IAsyncDisposable
         else if (status == ImportJobStatus.Mapped)
         {
             job.MarkAsPreviewed();
-            job.ConfirmMappings("[]");
+            job.ConfirmMappings([]);
         }
         else if (status == ImportJobStatus.Executing)
         {

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Export/EfExportJobStoreTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Export/EfExportJobStoreTests.cs
@@ -33,7 +33,7 @@ public sealed class EfExportJobStoreTests
         loaded.DefinitionName.ShouldBe("Test.Export");
         loaded.Format.ShouldBe("csv");
         loaded.Status.ShouldBe(ExportJobStatus.Queued);
-        loaded.RequestJson.ShouldBe(job.RequestJson);
+        loaded.Request.ShouldBe(job.Request);
     }
 
     [Fact]
@@ -136,5 +136,5 @@ public sealed class EfExportJobStoreTests
             Guid.NewGuid(),
             "Test.Export",
             "csv",
-            """{"DefinitionName":"Test.Export","Format":"csv"}""");
+            new ExportRequest("Test.Export", "csv", null, false, null, null, null, null));
 }

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Stores/EfImportJobStoreTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Stores/EfImportJobStoreTests.cs
@@ -2,6 +2,8 @@ using Granit.DataExchange.EntityFrameworkCore.Internal;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Stores;
 using Granit.DataExchange.EntityFrameworkCore.Tests.Infrastructure;
 using Granit.DataExchange.Import.Domain;
+using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import.Reporting;
 using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
@@ -100,7 +102,7 @@ public sealed class EfImportJobStoreTests
 
         // Act
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[]");
+        job.ConfirmMappings([]);
         job.MarkAsExecuting();
         job.ModifiedAt = DateTimeOffset.UtcNow;
         job.ModifiedBy = "system";
@@ -121,11 +123,24 @@ public sealed class EfImportJobStoreTests
         EfImportJobStore store = CreateStore(dbName);
         var tenantId = Guid.NewGuid();
         ImportJob job = CreateJobWithTenant(tenantId);
+        ImportColumnMapping[] mappings = [new("A", null, MappingConfidence.Manual)];
+        ImportReport report = new()
+        {
+            TotalRows = 100,
+            SucceededRows = 100,
+            FailedRows = 0,
+            SkippedRows = 0,
+            InsertedRows = 100,
+            UpdatedRows = 0,
+            Duration = TimeSpan.Zero,
+            FinalStatus = ImportJobStatus.Completed,
+            RowErrors = [],
+        };
         // Use internal behavior methods to set state through proper lifecycle
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[{\"sourceColumn\":\"A\"}]");
+        job.ConfirmMappings(mappings);
         job.MarkAsExecuting();
-        job.Complete(ImportJobStatus.Completed, "{\"totalRows\":100}", DateTimeOffset.UtcNow);
+        job.Complete(ImportJobStatus.Completed, report, DateTimeOffset.UtcNow);
 
         // Act
         await store.CreateAsync(job, TestContext.Current.CancellationToken);
@@ -135,8 +150,9 @@ public sealed class EfImportJobStoreTests
         // Assert
         result.ShouldNotBeNull();
         result.TenantId.ShouldBe(tenantId);
-        result.MappingsJson.ShouldBe("[{\"sourceColumn\":\"A\"}]");
-        result.ReportJson.ShouldBe("{\"totalRows\":100}");
+        result.Mappings.ShouldBe(mappings);
+        result.Report.ShouldNotBeNull();
+        result.Report.TotalRows.ShouldBe(100);
         result.CompletedAt.ShouldNotBeNull();
     }
 
@@ -151,11 +167,22 @@ public sealed class EfImportJobStoreTests
 
         // Act — simulate full lifecycle using behavior methods
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[]");
+        job.ConfirmMappings([]);
         job.MarkAsExecuting();
         await store.UpdateAsync(job, TestContext.Current.CancellationToken);
 
-        job.Complete(ImportJobStatus.Completed, "{}", DateTimeOffset.UtcNow);
+        job.Complete(ImportJobStatus.Completed, new ImportReport
+        {
+            TotalRows = 0,
+            SucceededRows = 0,
+            FailedRows = 0,
+            SkippedRows = 0,
+            InsertedRows = 0,
+            UpdatedRows = 0,
+            Duration = TimeSpan.Zero,
+            FinalStatus = ImportJobStatus.Completed,
+            RowErrors = [],
+        }, DateTimeOffset.UtcNow);
         await store.UpdateAsync(job, TestContext.Current.CancellationToken);
 
         // Assert

--- a/tests/Granit.DataExchange.Tests/Domain/ImportJobTests.cs
+++ b/tests/Granit.DataExchange.Tests/Domain/ImportJobTests.cs
@@ -1,4 +1,6 @@
 using Granit.DataExchange.Import.Domain;
+using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import.Reporting;
 using Granit.Domain;
 using Shouldly;
 using Xunit;
@@ -65,7 +67,7 @@ public sealed class ImportJobTests
     }
 
     [Fact]
-    public void SetMappings_stores_json()
+    public void SetMappings_stores_typed_collection()
     {
         var job = ImportJob.Create(
             Guid.NewGuid(),
@@ -75,10 +77,11 @@ public sealed class ImportJobTests
             "text/csv",
             1024,
             "blob/test.csv");
+        ImportColumnMapping[] mappings = [new("A", null, MappingConfidence.Manual)];
 
-        job.SetMappings("[{\"sourceColumn\":\"A\"}]");
+        job.SetMappings(mappings);
 
-        job.MappingsJson.ShouldBe("[{\"sourceColumn\":\"A\"}]");
+        job.Mappings.ShouldBe(mappings);
     }
 
     [Fact]
@@ -93,7 +96,7 @@ public sealed class ImportJobTests
             1024,
             "blob/test.csv");
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[]");
+        job.ConfirmMappings([]);
 
         job.MarkAsExecuting();
 
@@ -113,13 +116,25 @@ public sealed class ImportJobTests
             "blob/test.csv");
         DateTimeOffset completedAt = DateTimeOffset.UtcNow;
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[]");
+        job.ConfirmMappings([]);
         job.MarkAsExecuting();
 
-        job.Complete(ImportJobStatus.Completed, "{\"totalRows\":100}", completedAt);
+        ImportReport report = new()
+        {
+            TotalRows = 100,
+            SucceededRows = 100,
+            FailedRows = 0,
+            SkippedRows = 0,
+            InsertedRows = 100,
+            UpdatedRows = 0,
+            Duration = TimeSpan.Zero,
+            FinalStatus = ImportJobStatus.Completed,
+            RowErrors = [],
+        };
+        job.Complete(ImportJobStatus.Completed, report, completedAt);
 
         job.Status.ShouldBe(ImportJobStatus.Completed);
-        job.ReportJson.ShouldBe("{\"totalRows\":100}");
+        job.Report.ShouldBe(report);
         job.CompletedAt.ShouldBe(completedAt);
     }
 }

--- a/tests/Granit.DataExchange.Tests/Export/Domain/ExportJobTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/Domain/ExportJobTests.cs
@@ -7,12 +7,15 @@ namespace Granit.DataExchange.Tests.Export.Domain;
 
 public sealed class ExportJobTests
 {
+    private static ExportRequest SampleRequest(string format = "xlsx") =>
+        new("Acme.PatientExport", format, null, false, null, null, null, null);
+
     private static ExportJob CreateJob(Guid? tenantId = null) =>
         ExportJob.Create(
             Guid.NewGuid(),
             "Acme.PatientExport",
             "xlsx",
-            """{"definitionName":"Acme.PatientExport","format":"xlsx"}""",
+            SampleRequest(),
             tenantId);
 
     [Fact]
@@ -20,18 +23,19 @@ public sealed class ExportJobTests
     {
         var id = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
+        ExportRequest request = SampleRequest("csv");
 
         var job = ExportJob.Create(
             id,
             "Acme.PatientExport",
             "csv",
-            """{"format":"csv"}""",
+            request,
             tenantId);
 
         job.Id.ShouldBe(id);
         job.DefinitionName.ShouldBe("Acme.PatientExport");
         job.Format.ShouldBe("csv");
-        job.RequestJson.ShouldBe("""{"format":"csv"}""");
+        job.Request.ShouldBe(request);
         job.Status.ShouldBe(ExportJobStatus.Queued);
         job.TenantId.ShouldBe(tenantId);
         job.BlobReference.ShouldBeNull();

--- a/tests/Granit.DataExchange.Tests/Export/ExportJobTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportJobTests.cs
@@ -19,7 +19,7 @@ public sealed class ExportJobTests
             Guid.NewGuid(),
             "Test",
             "xlsx",
-            "{}");
+            new ExportRequest("Test", "xlsx", null, false, null, null, null, null));
 
         job.Status.ShouldBe(ExportJobStatus.Queued);
     }
@@ -31,7 +31,7 @@ public sealed class ExportJobTests
             Guid.NewGuid(),
             "Test",
             "csv",
-            "{}");
+            new ExportRequest("Test", "csv", null, false, null, null, null, null));
 
         job.BlobReference.ShouldBeNull();
         job.FileName.ShouldBeNull();
@@ -47,17 +47,20 @@ public sealed class ExportJobTests
         var id = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
 
+        var request = new ExportRequest(
+            "Acme.PatientExport", "xlsx", null, false, null,
+            new Dictionary<string, string> { ["status"] = "active" }, null, null);
         var job = ExportJob.Create(
             id,
             "Acme.PatientExport",
             "xlsx",
-            """{"filter":"active"}""",
+            request,
             tenantId);
 
         job.Id.ShouldBe(id);
         job.DefinitionName.ShouldBe("Acme.PatientExport");
         job.Format.ShouldBe("xlsx");
-        job.RequestJson.ShouldBe("""{"filter":"active"}""");
+        job.Request.ShouldBe(request);
         job.Status.ShouldBe(ExportJobStatus.Queued);
         job.TenantId.ShouldBe(tenantId);
     }
@@ -69,7 +72,7 @@ public sealed class ExportJobTests
             Guid.NewGuid(),
             "Test",
             "xlsx",
-            "{}");
+            new ExportRequest("Test", "xlsx", null, false, null, null, null, null));
         DateTimeOffset now = DateTimeOffset.UtcNow;
         job.MarkAsExporting();
 
@@ -89,7 +92,7 @@ public sealed class ExportJobTests
             Guid.NewGuid(),
             "Test",
             "csv",
-            "{}");
+            new ExportRequest("Test", "csv", null, false, null, null, null, null));
 
         job.MarkAsExporting();
 
@@ -103,7 +106,7 @@ public sealed class ExportJobTests
             Guid.NewGuid(),
             "Test",
             "csv",
-            "{}");
+            new ExportRequest("Test", "csv", null, false, null, null, null, null));
         DateTimeOffset now = DateTimeOffset.UtcNow;
         job.MarkAsExporting();
 

--- a/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using Granit.Commands;
 using Granit.DataExchange.Diagnostics;
 using Granit.DataExchange.Export;
@@ -50,8 +49,7 @@ public sealed class ExportOrchestratorTests
                     id,
                     "Test.Export",
                     "csv",
-                    JsonSerializer.Serialize(new ExportRequest(
-                        "Test.Export", "csv", null, false, null, null, null, null)));
+                    new ExportRequest("Test.Export", "csv", null, false, null, null, null, null));
             });
     }
 
@@ -148,7 +146,7 @@ public sealed class ExportOrchestratorTests
         ExportOrchestrator sut = CreateOrchestrator();
         var jobId = Guid.NewGuid();
         ExportRequest request = new("Test.Export", "csv", ["Name"], false, null, null, null, null);
-        var job = ExportJob.Create(jobId, "Test.Export", "csv", JsonSerializer.Serialize(request));
+        var job = ExportJob.Create(jobId, "Test.Export", "csv", request);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         IExportWriter capturedWriter = Substitute.For<IExportWriter>();
@@ -187,7 +185,7 @@ public sealed class ExportOrchestratorTests
         ExportOrchestrator sut = CreateOrchestrator();
         var jobId = Guid.NewGuid();
         ExportRequest request = new("Test.Export", "csv", ["Company.Name"], false, null, null, null, null);
-        var job = ExportJob.Create(jobId, "Test.Export", "csv", JsonSerializer.Serialize(request));
+        var job = ExportJob.Create(jobId, "Test.Export", "csv", request);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         List<IReadOnlyDictionary<string, object?>> capturedRows = [];
@@ -259,7 +257,7 @@ public sealed class ExportOrchestratorTests
         // Arrange
         var jobId = Guid.NewGuid();
         ExportRequest request = new("Test.QueryExport", "csv", null, false, "-Name", null, null, null);
-        var job = ExportJob.Create(jobId, "Test.QueryExport", "csv", JsonSerializer.Serialize(request));
+        var job = ExportJob.Create(jobId, "Test.QueryExport", "csv", request);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         FakeQueryEngine queryEngine = new();
@@ -283,7 +281,7 @@ public sealed class ExportOrchestratorTests
         ExportOrchestrator sut = CreateOrchestrator();
         var jobId = Guid.NewGuid();
         ExportRequest request = new("Test.Export", "csv", [], false, null, null, null, null);
-        var job = ExportJob.Create(jobId, "Test.Export", "csv", JsonSerializer.Serialize(request));
+        var job = ExportJob.Create(jobId, "Test.Export", "csv", request);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         IReadOnlyList<ExportFieldDescriptor>? capturedFields = null;
@@ -320,7 +318,7 @@ public sealed class ExportOrchestratorTests
         ExportOrchestrator sut = CreateOrchestrator();
         var jobId = Guid.NewGuid();
         ExportRequest request = new("Test.Export", "csv", ["Email", "Name"], false, null, null, null, null);
-        var job = ExportJob.Create(jobId, "Test.Export", "csv", JsonSerializer.Serialize(request));
+        var job = ExportJob.Create(jobId, "Test.Export", "csv", request);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         IReadOnlyList<ExportFieldDescriptor>? capturedFields = null;
@@ -379,7 +377,7 @@ public sealed class ExportOrchestratorTests
         Dictionary<string, string> filter = new() { ["name.eq"] = "Alice" };
         Dictionary<string, string> presets = new() { ["status"] = "Active" };
         ExportRequest request = new("Test.QueryExport", "csv", null, false, "-Name", filter, presets, "test search");
-        var job = ExportJob.Create(jobId, "Test.QueryExport", "csv", JsonSerializer.Serialize(request));
+        var job = ExportJob.Create(jobId, "Test.QueryExport", "csv", request);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
 
         FakeQueryEngine queryEngine = new();
@@ -496,7 +494,7 @@ public sealed class ExportOrchestratorTests
         // Arrange — xlsx format
         ExportOrchestrator sut = CreateOrchestrator();
         var jobId = Guid.NewGuid();
-        var job = ExportJob.Create(jobId, "Test.Export", "xlsx", "{}");
+        var job = ExportJob.Create(jobId, "Test.Export", "xlsx", new ExportRequest("Test.Export", "xlsx", null, false, null, null, null, null));
         job.MarkAsExporting();
         job.Complete("blob-ref-xlsx", "test_export.xlsx", 0, DateTimeOffset.UtcNow);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
@@ -568,7 +566,7 @@ public sealed class ExportOrchestratorTests
         ExportOrchestrator sut = CreateOrchestrator();
         var jobId = Guid.NewGuid();
         var job = ExportJob.Create(jobId, "Test.Export", "csv",
-            JsonSerializer.Serialize(new ExportRequest("Test.Export", "csv", null, false, null, null, null, null)));
+            new ExportRequest("Test.Export", "csv", null, false, null, null, null, null));
         job.MarkAsExporting();
         job.Complete("blob-ref-export", "test_export.csv", 10, DateTimeOffset.UtcNow);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
@@ -708,8 +706,7 @@ public sealed class ExportOrchestratorTests
             id,
             "Test.Export",
             "csv",
-            JsonSerializer.Serialize(new ExportRequest(
-                "Test.Export", "csv", null, false, null, null, null, null)));
+            new ExportRequest("Test.Export", "csv", null, false, null, null, null, null));
 
         // Transition to desired status using behavior methods
         if (status == ExportJobStatus.Exporting)

--- a/tests/Granit.DataExchange.Tests/Export/NullExportJobStoreTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/NullExportJobStoreTests.cs
@@ -1,3 +1,4 @@
+using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
 using Granit.DataExchange.Export.Internal;
 using Shouldly;
@@ -21,7 +22,8 @@ public sealed class NullExportJobStoreTests
     [Fact]
     public async Task CreateAsync_DoesNotThrow()
     {
-        var job = ExportJob.Create(Guid.NewGuid(), "Test", "csv", "{}");
+        var job = ExportJob.Create(Guid.NewGuid(), "Test", "csv",
+            new ExportRequest("Test", "csv", null, false, null, null, null, null));
 
         await Should.NotThrowAsync(() =>
             _store.CreateAsync(job, TestContext.Current.CancellationToken));
@@ -30,7 +32,8 @@ public sealed class NullExportJobStoreTests
     [Fact]
     public async Task UpdateAsync_DoesNotThrow()
     {
-        var job = ExportJob.Create(Guid.NewGuid(), "Test", "csv", "{}");
+        var job = ExportJob.Create(Guid.NewGuid(), "Test", "csv",
+            new ExportRequest("Test", "csv", null, false, null, null, null, null));
 
         await Should.NotThrowAsync(() =>
             _store.UpdateAsync(job, TestContext.Current.CancellationToken));

--- a/tests/Granit.DataExchange.Tests/Import/Domain/ImportJobTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/Domain/ImportJobTests.cs
@@ -1,4 +1,6 @@
 using Granit.DataExchange.Import.Domain;
+using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import.Reporting;
 using Shouldly;
 using Xunit;
 
@@ -6,6 +8,22 @@ namespace Granit.DataExchange.Tests.Import.Domain;
 
 public sealed class ImportJobTests
 {
+    private static readonly ImportColumnMapping[] SampleMappings =
+        [new("Email", "Email", MappingConfidence.Manual)];
+
+    private static ImportReport SampleReport(ImportJobStatus status = ImportJobStatus.Completed, int totalRows = 100) => new()
+    {
+        TotalRows = totalRows,
+        SucceededRows = totalRows,
+        FailedRows = 0,
+        SkippedRows = 0,
+        InsertedRows = totalRows,
+        UpdatedRows = 0,
+        Duration = TimeSpan.Zero,
+        FinalStatus = status,
+        RowErrors = [],
+    };
+
     private static ImportJob CreateJob(Guid? tenantId = null) =>
         ImportJob.Create(
             Guid.NewGuid(),
@@ -42,8 +60,8 @@ public sealed class ImportJobTests
         job.BlobReference.Value.ShouldBe("blob/ref");
         job.Status.ShouldBe(ImportJobStatus.Created);
         job.TenantId.ShouldBe(tenantId);
-        job.MappingsJson.ShouldBeNull();
-        job.ReportJson.ShouldBeNull();
+        job.Mappings.ShouldBeNull();
+        job.Report.ShouldBeNull();
         job.CompletedAt.ShouldBeNull();
     }
 
@@ -66,27 +84,25 @@ public sealed class ImportJobTests
     }
 
     [Fact]
-    public void SetMappings_StoresMappingsJson()
+    public void SetMappings_StoresTypedMappings()
     {
         ImportJob job = CreateJob();
-        const string json = """[{"SourceColumn":"Email","TargetProperty":"Email"}]""";
 
-        job.SetMappings(json);
+        job.SetMappings(SampleMappings);
 
-        job.MappingsJson.ShouldBe(json);
+        job.Mappings.ShouldBe(SampleMappings);
     }
 
     [Fact]
     public void ConfirmMappings_SetsMappingsAndTransitionsToMapped()
     {
         ImportJob job = CreateJob();
-        const string json = """[{"SourceColumn":"Email","TargetProperty":"Email"}]""";
         job.MarkAsPreviewed();
 
-        job.ConfirmMappings(json);
+        job.ConfirmMappings(SampleMappings);
 
         job.Status.ShouldBe(ImportJobStatus.Mapped);
-        job.MappingsJson.ShouldBe(json);
+        job.Mappings.ShouldBe(SampleMappings);
     }
 
     [Fact]
@@ -94,7 +110,7 @@ public sealed class ImportJobTests
     {
         ImportJob job = CreateJob();
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[]");
+        job.ConfirmMappings([]);
 
         job.MarkAsExecuting();
 
@@ -106,15 +122,15 @@ public sealed class ImportJobTests
     {
         ImportJob job = CreateJob();
         DateTimeOffset completedAt = DateTimeOffset.UtcNow;
-        const string reportJson = """{"totalRows":100}""";
+        ImportReport report = SampleReport();
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[]");
+        job.ConfirmMappings([]);
         job.MarkAsExecuting();
 
-        job.Complete(ImportJobStatus.Completed, reportJson, completedAt);
+        job.Complete(ImportJobStatus.Completed, report, completedAt);
 
         job.Status.ShouldBe(ImportJobStatus.Completed);
-        job.ReportJson.ShouldBe(reportJson);
+        job.Report.ShouldBe(report);
         job.CompletedAt.ShouldBe(completedAt);
     }
 
@@ -124,10 +140,10 @@ public sealed class ImportJobTests
         ImportJob job = CreateJob();
         DateTimeOffset completedAt = DateTimeOffset.UtcNow;
         job.MarkAsPreviewed();
-        job.ConfirmMappings("[]");
+        job.ConfirmMappings([]);
         job.MarkAsExecuting();
 
-        job.Complete(ImportJobStatus.PartiallyCompleted, "{}", completedAt);
+        job.Complete(ImportJobStatus.PartiallyCompleted, SampleReport(ImportJobStatus.PartiallyCompleted), completedAt);
 
         job.Status.ShouldBe(ImportJobStatus.PartiallyCompleted);
     }


### PR DESCRIPTION
Closes #2181 — completes the .NET 11 EF JSON readiness sequence (#2173, #2175, #2176, #2180, #2183).

## Summary

Replaces three string-JSON columns on the data-exchange domain aggregates with typed properties round-tripped via EF Core native JSON mapping.

### Domain changes

| Before | After |
|--------|-------|
| \`ImportJob.MappingsJson: string?\` | \`Mappings: IReadOnlyList<ImportColumnMapping>?\` via \`OwnsMany().ToJson()\` |
| \`ImportJob.ReportJson: string?\` | \`Report: ImportReport?\` via \`HasJsonConversion<ImportReport>\` |
| \`ExportJob.RequestJson: string\` | \`Request: ExportRequest\` via \`HasJsonConversion<ExportRequest>\` |

Method signatures updated accordingly:
- \`ImportJob.SetMappings(string)\` → \`SetMappings(IReadOnlyList<ImportColumnMapping>)\`
- \`ImportJob.ConfirmMappings(string)\` → \`ConfirmMappings(IReadOnlyList<ImportColumnMapping>)\`
- \`ImportJob.Complete(status, string, completedAt)\` → \`Complete(status, ImportReport, completedAt)\`
- \`ExportJob.Create(..., string requestJson, ...)\` → \`Create(..., ExportRequest request, ...)\`

### Why two flavours of EF JSON mapping?

The owned-type \`.ToJson()\` mapping is the default-first policy (per ADR-058 in granit-docs#63), but \`ImportReport\` and \`ExportRequest\` have shapes that don't compose cleanly with EF Core 10 owned-types:

- \`ImportReport\` contains \`IReadOnlyList<ImportRowError>\` + \`TimeSpan\` + an enum — JSON-serialize cleanly, EF owned-types choke on the nested list of records.
- \`ExportRequest\` is a record with two \`IReadOnlyDictionary<string, string>?\` properties — interfaces that EF owned-types can't construct.

Both go through the [HasJsonConversion](src/Granit.Persistence.EntityFrameworkCore/Extensions/JsonPropertyBuilderExtensions.cs) helper from #2175. Apps targeting PostgreSQL get queryable \`jsonb\` columns for free via [UseGranitJsonbForJsonProperties](src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/ModelBuilderJsonbExtensions.cs) (#2183).

### Call sites updated

- [ImportOrchestrator](src/Granit.DataExchange/Import/Internal/ImportOrchestrator.cs): 3 sites — drops \`JsonSerializer.Serialize(report)\` (2 paths) and \`JsonSerializer.Deserialize<List<ImportColumnMapping>>(job.MappingsJson)\`.
- [ExportOrchestrator](src/Granit.DataExchange/Export/ExportOrchestrator.cs): 2 sites — drops \`JsonSerializer.Serialize(request)\` and \`JsonSerializer.Deserialize<ExportRequest>(job.RequestJson)\`.
- [ImportUploadEndpoints](src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportUploadEndpoints.cs) + [ImportReportEndpoints](src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportReportEndpoints.cs): 3 sites — endpoints now pass / read typed values directly.

## Breaking change

⚠️ Public domain method signatures change shape. Pre-1.0 break, no \`[Obsolete]\` graduation per [project policy](https://github.com/granit-fx/granit-dotnet/blob/develop/CLAUDE.md).

**Cross-repo audit (done before this PR):**
- \`granit-business\`: **zero impact**. Consumes \`ExportDefinition<T, TFilter>\` only, never \`ImportJob\` / \`ExportJob\` domain types.
- \`granit-showcase-dotnet\`: **zero hand-written impact**. Only EF migration snapshots reference these columns and will be auto-regenerated on next \`dotnet ef migrations add\`.

## Test plan

- [x] \`Granit.DataExchange.Tests\` — 353 passed
- [x] \`Granit.DataExchange.EntityFrameworkCore.Tests\` — 48 passed
- [x] \`Granit.DataExchange.Endpoints.Tests\` — 120 passed
- [x] \`Granit.ArchitectureTests\` — 186 passed
- [x] \`dotnet format\` clean on 6 csprojs
- [ ] CI green on relevant shards