### PR TITLE
fix(timeline): accept Unicode tag sequences in EmojiValidator

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40943,7 +40943,7 @@
       "kind": "class",
       "project": "Granit.Timeline",
       "file": "src/Granit.Timeline/Domain/EmojiValidator.cs",
-      "line": 30,
+      "line": 32,
       "members": [
         {
           "name": "IsValid",

--- a/src/Granit.Timeline/Domain/EmojiValidator.cs
+++ b/src/Granit.Timeline/Domain/EmojiValidator.cs
@@ -8,7 +8,9 @@ namespace Granit.Timeline.Domain;
 /// a doctrine-aligned <i>closed by upstream standard</i> rule
 /// (ADR-040 §5): any sequence formed of recognised emoji codepoints
 /// (joined by ZWJ, optionally suffixed by VS-16, Fitzpatrick skin-tone
-/// modifiers, or the combining enclosing keycap) is accepted.
+/// modifiers, the combining enclosing keycap, or a Unicode tag sequence
+/// terminated by U+E007F — used by subdivision flags such as 🏴󠁧󠁢󠁥󠁮󠁧󠁿)
+/// is accepted.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -41,6 +43,9 @@ public static class EmojiValidator
     private const int KeycapCombiner = 0x20E3;
     private const int FitzpatrickMin = 0x1F3FB;
     private const int FitzpatrickMax = 0x1F3FF;
+    private const int TagCharMin = 0xE0020;
+    private const int TagCharMax = 0xE007E;
+    private const int TagEnd = 0xE007F;
 
     /// <summary>
     /// Returns <see langword="true"/> when <paramref name="emoji"/> is a
@@ -84,12 +89,33 @@ public static class EmojiValidator
                         return false;
                     }
                     break;
+                case RuneKind.TagChar:
+                    // Tag chars (U+E0020..U+E007E) form the payload of an
+                    // Emoji_Tag_Sequence after a base — e.g. the
+                    // subdivision flags 🏴󠁧󠁢󠁥󠁮󠁧󠁿 (England). They are never
+                    // valid at start, after a combiner, or after a ZWJ.
+                    if (previous is not (RuneKind.Base or RuneKind.TagChar))
+                    {
+                        return false;
+                    }
+                    break;
+                case RuneKind.TagEnd:
+                    // Cancel-tag (U+E007F) terminates an open tag sequence
+                    // and is only valid right after at least one tag char.
+                    if (previous != RuneKind.TagChar)
+                    {
+                        return false;
+                    }
+                    break;
             }
             previous = kind;
         }
 
-        // Trailing ZWJ leaves a dangling joiner — reject.
-        return hasBase && previous != RuneKind.Zwj;
+        // Trailing ZWJ leaves a dangling joiner; trailing tag chars without
+        // the cancel-tag leave the sequence open — reject both.
+        return hasBase
+            && previous != RuneKind.Zwj
+            && previous != RuneKind.TagChar;
     }
 
     /// <summary>
@@ -154,6 +180,8 @@ public static class EmojiValidator
         Zwj,
         KeycapBase,
         KeycapCombiner,
+        TagChar,
+        TagEnd,
     }
 
     private static RuneKind Classify(int cp)
@@ -173,6 +201,14 @@ public static class EmojiValidator
         if (cp >= FitzpatrickMin && cp <= FitzpatrickMax)
         {
             return RuneKind.Modifier;
+        }
+        if (cp == TagEnd)
+        {
+            return RuneKind.TagEnd;
+        }
+        if (cp >= TagCharMin && cp <= TagCharMax)
+        {
+            return RuneKind.TagChar;
         }
         if (IsKeycapBase(cp))
         {

--- a/tests/Granit.Timeline.Tests/ReactionTests.cs
+++ b/tests/Granit.Timeline.Tests/ReactionTests.cs
@@ -111,6 +111,56 @@ public sealed class EmojiValidatorTests
     }
 
     [Theory]
+    [InlineData("🏴󠁧󠁢󠁥󠁮󠁧󠁿")] // England
+    [InlineData("🏴󠁧󠁢󠁳󠁣󠁴󠁿")] // Scotland
+    [InlineData("🏴󠁧󠁢󠁷󠁬󠁳󠁿")] // Wales
+    public void IsValid_accepts_unicode_tag_subdivision_flags(string flag) =>
+        EmojiValidator.IsValid(flag).ShouldBeTrue();
+
+    [Fact]
+    public void IsValid_still_accepts_lone_black_flag_without_tag_suffix() =>
+        EmojiValidator.IsValid("🏴").ShouldBeTrue();
+
+    [Fact]
+    public void IsValid_still_accepts_regional_indicator_flags() =>
+        EmojiValidator.IsValid("🇧🇪").ShouldBeTrue();
+
+    [Fact]
+    public void IsValid_rejects_tag_sequence_without_cancel_tag()
+    {
+        // 🏴 + 'g' 'b' 'e' 'n' 'g' tag chars, no U+E007F terminator.
+        string truncated = "🏴\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067";
+        EmojiValidator.IsValid(truncated).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_rejects_cancel_tag_with_no_tag_chars_between()
+    {
+        // 🏴 immediately followed by U+E007F, no tag chars in between.
+        string immediateCancel = "🏴\U000E007F";
+        EmojiValidator.IsValid(immediateCancel).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_rejects_lone_tag_char_without_base() =>
+        EmojiValidator.IsValid("\U000E0067").ShouldBeFalse();
+
+    [Fact]
+    public void IsValid_rejects_tag_char_after_zwj()
+    {
+        // 👨 ZWJ tag char — not a defined sequence.
+        string bad = "👨‍\U000E0067";
+        EmojiValidator.IsValid(bad).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NormalizeForAggregate_leaves_subdivision_flags_intact()
+    {
+        const string england = "🏴󠁧󠁢󠁥󠁮󠁧󠁿";
+        EmojiValidator.NormalizeForAggregate(england).ShouldBe(england);
+    }
+
+    [Theory]
     [InlineData("👍", "👍")]            // no modifiers — unchanged
     [InlineData("👍🏽", "👍")]           // Fitzpatrick stripped
     [InlineData("👍🏿", "👍")]


### PR DESCRIPTION
## Summary

- Adds `RuneKind.TagChar` and `RuneKind.TagEnd` to `EmojiValidator`, with constants for the tag-char range (`U+E0020`–`U+E007E`) and the cancel-tag (`U+E007F`).
- Extends the state machine: a tag char must follow either the base (`Base`) or another tag char; the cancel-tag must immediately follow at least one tag char; tag chars at start, after ZWJ/combiners, or unterminated at end-of-input are rejected.
- Existing rules unchanged: lone 🏴, regional-indicator flags (🇧🇪, 🇫🇷, …), ZWJ families, keycaps, Fitzpatrick variants — all continue to pass.
- `NormalizeForAggregate` is unchanged: tag chars carry subdivision identity and must not collapse.

## Why

`EmojiValidator.IsValid` rejected the three RGI subdivision flags 🏴󠁧󠁢󠁥󠁮󠁧󠁿 (England), 🏴󠁧󠁢󠁳󠁣󠁴󠁿 (Scotland), 🏴󠁧󠁢󠁷󠁬󠁳󠁿 (Wales) because their tag-sequence form (🏴 + tag chars + `U+E007F`) maps every tag codepoint to `RuneKind.Invalid`. emoji-mart on the frontend offers these in the picker, so any user reacting with one got a 400 (`reaction-emoji-not-supported`). The granit-front soft validator gets the matching regex update in a sibling commit so the soft and hard validators stay in sync.

## Test plan

- [x] Accept: 🏴󠁧󠁢󠁥󠁮󠁧󠁿 / 🏴󠁧󠁢󠁳󠁣󠁴󠁿 / 🏴󠁧󠁢󠁷󠁬󠁳󠁿
- [x] Lone 🏴 still accepted (no tag suffix is fine)
- [x] 🇧🇪 still accepted (regression check on regional indicators)
- [x] Reject 🏴 + tag chars WITHOUT cancel-tag
- [x] Reject 🏴 + cancel-tag with no tag chars between
- [x] Reject lone tag char without a base
- [x] Reject tag char after ZWJ
- [x] `NormalizeForAggregate` leaves 🏴󠁧󠁢󠁥󠁮󠁧󠁿 unchanged
- [x] `dotnet build src/Granit.Timeline` clean
- [x] `dotnet test tests/Granit.Timeline.Tests` — 156 green
- [x] `dotnet format src/Granit.Timeline --verify-no-changes` clean