### PR TITLE
feat(timeline): return DisplayEmoji on reaction aggregates

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -41091,7 +41091,7 @@
       "kind": "record",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs",
-      "line": 20,
+      "line": 31,
       "members": []
     },
     {

--- a/src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs
+++ b/src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs
@@ -13,8 +13,19 @@ public sealed record ReactionToggleResponse(
 
 /// <summary>
 /// Aggregated reaction counts attached to one timeline entry by the stream
-/// endpoint (story C3). Omitted when the entry has zero reactions.
+/// endpoint (story C3). Omitted when the entry has zero reactions. The
+/// dictionary key under which this is stored is the normalized (skin-tone
+/// + VS-16 stripped) form — used as the aggregation identity. The
+/// <c>DisplayEmoji</c> field carries one fully-qualified RGI variant from
+/// the group so renderers (Twemoji, EmojiOne, …) can resolve the
+/// canonical glyph filename without re-implementing TR-51's
+/// emoji-presentation reconstruction.
 /// </summary>
 /// <param name="Count">Total number of reactions of this emoji on the entry.</param>
 /// <param name="ByCurrentUser">Whether the calling user is among the reactors.</param>
-public sealed record ReactionAggregateResponse(int Count, bool ByCurrentUser);
+/// <param name="DisplayEmoji">
+/// One fully-qualified original variant from the aggregate (e.g. <c>"👍🏽"</c>
+/// or <c>"👨‍⚕️"</c>) — the same wire shape <c>POST /reactions/{emoji}</c>
+/// accepts. Stable per entry: the oldest reaction in the group wins.
+/// </param>
+public sealed record ReactionAggregateResponse(int Count, bool ByCurrentUser, string DisplayEmoji);

--- a/src/Granit.Timeline.Endpoints/Internal/TimelineResponseMapper.cs
+++ b/src/Granit.Timeline.Endpoints/Internal/TimelineResponseMapper.cs
@@ -20,34 +20,45 @@ internal static class TimelineResponseMapper
     /// per-emoji summary suitable for the wire payload (story C3).
     /// Skin-tone variants and VS-16 selectors are collapsed via
     /// <see cref="EmojiValidator.NormalizeForAggregate"/> so 👍 / 👍🏽 /
-    /// 👍🏿 share a single counter keyed under the base codepoint. Entries
-    /// with no reactions are absent from the map (caller passes
-    /// <see langword="null"/> for those).
+    /// 👍🏿 share a single counter keyed under the base codepoint. The
+    /// first reaction encountered in each group wins as the
+    /// <see cref="ReactionAggregateResponse.DisplayEmoji"/> (the reader
+    /// orders rows by <c>CreatedAt</c>, so this is the oldest reaction
+    /// — deterministic across calls). Entries with no reactions are
+    /// absent from the map (caller passes <see langword="null"/> for
+    /// those).
     /// </summary>
     internal static IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> AggregateReactions(
         IReadOnlyList<Reaction> reactions,
         Guid? currentUserId)
     {
-        Dictionary<Guid, Dictionary<string, (int Count, bool ByCurrentUser)>> byEntry = [];
+        Dictionary<Guid, Dictionary<string, (int Count, bool ByCurrentUser, string DisplayEmoji)>> byEntry = [];
         foreach (Reaction r in reactions)
         {
-            if (!byEntry.TryGetValue(r.EntryId, out Dictionary<string, (int, bool)>? perEmoji))
+            if (!byEntry.TryGetValue(r.EntryId, out Dictionary<string, (int, bool, string)>? perEmoji))
             {
-                perEmoji = new Dictionary<string, (int, bool)>(StringComparer.Ordinal);
+                perEmoji = new Dictionary<string, (int, bool, string)>(StringComparer.Ordinal);
                 byEntry[r.EntryId] = perEmoji;
             }
             string key = EmojiValidator.NormalizeForAggregate(r.Emoji);
-            perEmoji.TryGetValue(key, out (int Count, bool ByCurrentUser) cur);
-            perEmoji[key] = (cur.Count + 1, cur.ByCurrentUser || (currentUserId is { } uid && r.UserId == uid));
+            bool byCurrentUser = currentUserId is { } uid && r.UserId == uid;
+            if (perEmoji.TryGetValue(key, out (int Count, bool ByCurrentUser, string DisplayEmoji) cur))
+            {
+                perEmoji[key] = (cur.Count + 1, cur.ByCurrentUser || byCurrentUser, cur.DisplayEmoji);
+            }
+            else
+            {
+                perEmoji[key] = (1, byCurrentUser, r.Emoji);
+            }
         }
 
         Dictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result = [];
-        foreach ((Guid entryId, Dictionary<string, (int Count, bool ByCurrentUser)> perEmoji) in byEntry)
+        foreach ((Guid entryId, Dictionary<string, (int Count, bool ByCurrentUser, string DisplayEmoji)> perEmoji) in byEntry)
         {
             Dictionary<string, ReactionAggregateResponse> summary = new(perEmoji.Count, StringComparer.Ordinal);
-            foreach ((string emoji, (int Count, bool ByCurrentUser) agg) in perEmoji)
+            foreach ((string emoji, (int Count, bool ByCurrentUser, string DisplayEmoji) agg) in perEmoji)
             {
-                summary[emoji] = new ReactionAggregateResponse(agg.Count, agg.ByCurrentUser);
+                summary[emoji] = new ReactionAggregateResponse(agg.Count, agg.ByCurrentUser, agg.DisplayEmoji);
             }
             result[entryId] = summary;
         }

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineResponseMapperReactionTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineResponseMapperReactionTests.cs
@@ -27,10 +27,11 @@ public sealed class TimelineResponseMapperReactionTests
         IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result =
             TimelineResponseMapper.AggregateReactions(reactions, currentUser);
 
-        result[entry1]["👍"].ShouldBe(new ReactionAggregateResponse(2, ByCurrentUser: true));
-        // VS-16 stripped by NormalizeForAggregate — aggregate key is the bare heart codepoint.
-        result[entry1]["❤"].ShouldBe(new ReactionAggregateResponse(1, ByCurrentUser: false));
-        result[entry2]["🎉"].ShouldBe(new ReactionAggregateResponse(1, ByCurrentUser: false));
+        result[entry1]["👍"].ShouldBe(new ReactionAggregateResponse(2, ByCurrentUser: true, DisplayEmoji: "👍"));
+        // VS-16 stripped by NormalizeForAggregate — aggregate key is the bare heart codepoint
+        // but DisplayEmoji preserves the original fully-qualified form (with VS-16).
+        result[entry1]["❤"].ShouldBe(new ReactionAggregateResponse(1, ByCurrentUser: false, DisplayEmoji: "❤️"));
+        result[entry2]["🎉"].ShouldBe(new ReactionAggregateResponse(1, ByCurrentUser: false, DisplayEmoji: "🎉"));
     }
 
     [Fact]
@@ -61,6 +62,48 @@ public sealed class TimelineResponseMapperReactionTests
 
         result[entryId].Count.ShouldBe(1);
         result[entryId]["👍"].Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void AggregateReactions_picks_a_fully_qualified_variant_as_DisplayEmoji()
+    {
+        // Two users react with skin-tone variants of the same base. DisplayEmoji
+        // must be a variant (not the normalized/stripped form); first-seen wins.
+        var entryId = Guid.NewGuid();
+        Reaction[] reactions =
+        [
+            R(entryId, Guid.NewGuid(), "👍🏽"),
+            R(entryId, Guid.NewGuid(), "👍🏿"),
+        ];
+
+        IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result =
+            TimelineResponseMapper.AggregateReactions(reactions, currentUserId: null);
+
+        ReactionAggregateResponse aggregate = result[entryId]["👍"];
+        aggregate.Count.ShouldBe(2);
+        aggregate.DisplayEmoji.ShouldBe("👍🏽"); // first-seen variant
+        // Sanity: any variant in the group is acceptable, but never the stripped key.
+        aggregate.DisplayEmoji.ShouldBeOneOf("👍🏽", "👍🏿");
+    }
+
+    [Fact]
+    public void AggregateReactions_preserves_VS16_in_ZWJ_sequence_as_DisplayEmoji()
+    {
+        // 👨‍⚕️ (man health worker) — canonical RGI form includes VS-16 inside
+        // the ZWJ sequence. NormalizeForAggregate strips VS-16 from the key,
+        // but DisplayEmoji must keep the original fully-qualified form so
+        // Twemoji-style asset CDNs find their file (1f468-200d-2695-fe0f.svg).
+        const string manHealthWorker = "👨‍⚕️";
+        var entryId = Guid.NewGuid();
+        Reaction[] reactions = [R(entryId, Guid.NewGuid(), manHealthWorker)];
+
+        IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result =
+            TimelineResponseMapper.AggregateReactions(reactions, currentUserId: null);
+
+        // Single aggregate; the key is the VS-16-stripped form.
+        result[entryId].Count.ShouldBe(1);
+        ReactionAggregateResponse aggregate = result[entryId].Values.Single();
+        aggregate.DisplayEmoji.ShouldBe(manHealthWorker);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `ReactionAggregateResponse` gains a `DisplayEmoji` field carrying one fully-qualified original variant from the group (e.g. `"👍🏽"`, `"👨‍⚕️"`), so renderers like Twemoji can resolve the canonical filename (`1f468-200d-2695-fe0f.svg`) without re-implementing Unicode TR-51 emoji-presentation reconstruction.
- Dictionary key stays the normalized form. Identity / toggle semantics unchanged.
- `TimelineResponseMapper.AggregateReactions` now tracks `(Count, ByCurrentUser, DisplayEmoji)` per normalized key. First-seen wins as the display variant (readers order rows by `CreatedAt` → oldest reaction = visual anchor, deterministic across calls).

## Why

`NormalizeForAggregate` strips VS-16 and Fitzpatrick modifiers to group skin-tone variants. That's correct for the count, but the stripped form isn't a valid rendering identifier:

| Original | Aggregate key (stripped) | RGI filename |
| --- | --- | --- |
| 👨‍⚕️ | 👨‍⚕ | `1f468-200d-2695-fe0f.svg` |
| 🤽‍♂️ | 🤽‍♂ | `1f93d-200d-2642-fe0f.svg` |
| 👍🏽 | 👍 | `1f44d-1f3fd.svg` |

The frontend can't reconstruct the canonical form without a TR-51 lookup table. Cheaper to surface one representative variant from the server, where the original wire shape is already stored on each row.

## Schema impact

None — `Reaction.Emoji` already stores the original fully-qualified form (the `NormalizeForAggregate` doc explicitly states "Storage keeps the original variant on each row"). No EF migration, no backfill.

## Wire shape

```jsonc
{
  "reactions": {
    "👨‍⚕": {  // normalized key (VS-16 stripped) — same as before
      "count": 1,
      "byCurrentUser": true,
      "displayEmoji": "👨‍⚕️"  // new — fully-qualified RGI form
    }
  }
}
```

OpenAPI schema updates automatically once the client regenerates against the new contract.

## Test plan

- [x] `AggregateReactions_picks_a_fully_qualified_variant_as_DisplayEmoji` — skin-tone variants collapse but `DisplayEmoji` ∈ {variants}, first-seen wins
- [x] `AggregateReactions_preserves_VS16_in_ZWJ_sequence_as_DisplayEmoji` — 👨‍⚕️ round-trips intact
- [x] Existing tests updated for the new positional ctor (`Count`, `ByCurrentUser`, `DisplayEmoji`)
- [x] `dotnet build src/Granit.Timeline.Endpoints` clean
- [x] `dotnet test tests/Granit.Timeline.Endpoints.Tests` — 61 green
- [x] `dotnet format src/Granit.Timeline.Endpoints --verify-no-changes` clean

## Notes

Branched off `origin/develop` in a dedicated worktree to avoid disrupting in-flight work in the main checkout.