### PR TITLE
feat(auditing): alias entity-type lookups across split-persistence aggregates

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -923,6 +923,7 @@
       "name": "Granit.Identity",
       "deps": [
         "Granit",
+        "Granit.Auditing",
         "Granit.DataExchange.Abstractions",
         "Granit.Entities.Abstractions",
         "Granit.QueryEngine.Abstractions"
@@ -4918,6 +4919,22 @@
       ]
     },
     {
+      "name": "AuditEntityTypeAliasProviderExtensions",
+      "fqn": "Granit.Auditing.Extensions.AuditEntityTypeAliasProviderExtensions",
+      "kind": "class",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/Extensions/AuditEntityTypeAliasProviderExtensions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Resolve",
+          "kind": "method",
+          "signature": "Resolve(this IEnumerable<IAuditEntityTypeAliasProvider> providers, string logicalEntityType)",
+          "returnType": "IReadOnlySet<string>"
+        }
+      ]
+    },
+    {
       "name": "AuditingServiceCollectionExtensions",
       "fqn": "Granit.Auditing.Extensions.AuditingServiceCollectionExtensions",
       "kind": "class",
@@ -4962,6 +4979,22 @@
           "kind": "method",
           "signature": "PersistAsync(AuditingBatch batch, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IAuditEntityTypeAliasProvider",
+      "fqn": "Granit.Auditing.IAuditEntityTypeAliasProvider",
+      "kind": "interface",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/IAuditEntityTypeAliasProvider.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "GetAliases",
+          "kind": "method",
+          "signature": "GetAliases(string logicalEntityType)",
+          "returnType": "IReadOnlySet<string>"
         }
       ]
     },
@@ -5366,6 +5399,15 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "StaticAuditEntityTypeAliasProvider",
+      "fqn": "Granit.Auditing.StaticAuditEntityTypeAliasProvider",
+      "kind": "class",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/StaticAuditEntityTypeAliasProvider.cs",
+      "line": 11,
+      "members": []
     },
     {
       "name": "ApiKeyAuthenticationDefaults",
@@ -21328,7 +21370,7 @@
       "kind": "class",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitIdentity",
@@ -22551,7 +22593,7 @@
       "kind": "class",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/GranitIdentityModule.cs",
-      "line": 25,
+      "line": 27,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.slnf/infrastructure.slnf
+++ b/.slnf/infrastructure.slnf
@@ -5,6 +5,7 @@
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Auditing/Granit.Auditing.csproj",
       "src/Granit.Authorization/Granit.Authorization.csproj",
       "src/Granit.BackgroundJobs.Endpoints/Granit.BackgroundJobs.Endpoints.csproj",
       "src/Granit.BackgroundJobs.EntityFrameworkCore/Granit.BackgroundJobs.EntityFrameworkCore.csproj",

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
@@ -1,4 +1,5 @@
 using Granit.Auditing.Domain;
+using Granit.Auditing.Extensions;
 using Granit.Auditing.Options;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -17,6 +18,7 @@ internal sealed class EfCoreAuditingReader(
     IDbContextFactory<AuditingDbContext> dbContextFactory,
     IFusionCache cache,
     ICurrentTenant currentTenant,
+    IEnumerable<IAuditEntityTypeAliasProvider> aliasProviders,
     IOptions<AuditingOptions> options) : IAuditingReader
 {
     private readonly AuditingOptions _options = options.Value;
@@ -69,11 +71,17 @@ internal sealed class EfCoreAuditingReader(
         await using AuditingDbContext dbContext = await dbContextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
+        // Resolve every CLR type the audit log may have stamped for this
+        // canonical name (ADR-051 split persistence). The cache key uses the
+        // canonical name only since the resolved set is deterministic given
+        // the registered providers.
+        IReadOnlySet<string> matchTypes = aliasProviders.Resolve(entityType);
+
         IQueryable<AuditEntry> queryable = dbContext.AuditEntries
             .Include(e => e.EntityChanges)
                 .ThenInclude(ec => ec.PropertyChanges)
             .Where(e => e.EntityChanges.Any(ec =>
-                ec.EntityType == entityType && ec.EntityId == entityId))
+                matchTypes.Contains(ec.EntityType) && ec.EntityId == entityId))
             .AsNoTracking();
 
         PagedResult<AuditEntry> result = await queryable

--- a/src/Granit.Auditing/Extensions/AuditEntityTypeAliasProviderExtensions.cs
+++ b/src/Granit.Auditing/Extensions/AuditEntityTypeAliasProviderExtensions.cs
@@ -1,0 +1,31 @@
+namespace Granit.Auditing.Extensions;
+
+/// <summary>
+/// Helpers for unioning the contributions of multiple
+/// <see cref="IAuditEntityTypeAliasProvider"/> instances.
+/// </summary>
+public static class AuditEntityTypeAliasProviderExtensions
+{
+    /// <summary>
+    /// Resolves the full set of CLR type names a read query should match for
+    /// the supplied canonical name. The returned set always contains the
+    /// logical name itself plus every alias contributed by any provider.
+    /// </summary>
+    public static IReadOnlySet<string> Resolve(
+        this IEnumerable<IAuditEntityTypeAliasProvider> providers,
+        string logicalEntityType)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        ArgumentException.ThrowIfNullOrEmpty(logicalEntityType);
+
+        HashSet<string> result = new(StringComparer.Ordinal) { logicalEntityType };
+        foreach (IAuditEntityTypeAliasProvider provider in providers)
+        {
+            foreach (string alias in provider.GetAliases(logicalEntityType))
+            {
+                result.Add(alias);
+            }
+        }
+        return result;
+    }
+}

--- a/src/Granit.Auditing/IAuditEntityTypeAliasProvider.cs
+++ b/src/Granit.Auditing/IAuditEntityTypeAliasProvider.cs
@@ -1,0 +1,36 @@
+namespace Granit.Auditing;
+
+/// <summary>
+/// Resolves alternate CLR type names that audited entries may have been
+/// stamped with on the audit log. Required when one logical entity is
+/// persisted across multiple CLR types (e.g. <c>User</c> + <c>LocalIdentity</c>
+/// + <c>FederatedIdentity</c> per ADR-051) so that read APIs can surface the
+/// full audit history under the canonical name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The mapping is <strong>directional</strong> — <em>logical → physicals</em>.
+/// A query for the logical name returns rows stamped with the logical name
+/// itself <em>or</em> any of its registered physical aliases. A query for a
+/// physical CLR name returns only rows for that exact name; forensics and
+/// auth-only investigations keep their precision.
+/// </para>
+/// <para>
+/// Register multiple implementations via <c>TryAddEnumerable</c>; consumers
+/// take all providers and union the results. The default container is empty
+/// (no aliases) when no provider is registered, which preserves the
+/// pre-aliasing behaviour for hosts that don't use any split-persistence
+/// aggregate.
+/// </para>
+/// </remarks>
+public interface IAuditEntityTypeAliasProvider
+{
+    /// <summary>
+    /// Returns the set of CLR type names that may appear on the audit log for
+    /// rows whose canonical name is <paramref name="logicalEntityType"/>. The
+    /// logical name itself is added by callers and must <em>not</em> be
+    /// returned here. Returns an empty set when this provider has no aliases
+    /// for the supplied type.
+    /// </summary>
+    IReadOnlySet<string> GetAliases(string logicalEntityType);
+}

--- a/src/Granit.Auditing/StaticAuditEntityTypeAliasProvider.cs
+++ b/src/Granit.Auditing/StaticAuditEntityTypeAliasProvider.cs
@@ -1,0 +1,35 @@
+namespace Granit.Auditing;
+
+/// <summary>
+/// Dictionary-backed <see cref="IAuditEntityTypeAliasProvider"/> for modules
+/// that own a known set of split-persistence aliases at compile time.
+/// </summary>
+/// <remarks>
+/// Use ordinal string comparison: audit-log <c>EntityType</c> values are CLR
+/// type names, which are case-sensitive.
+/// </remarks>
+public sealed class StaticAuditEntityTypeAliasProvider : IAuditEntityTypeAliasProvider
+{
+    private static readonly IReadOnlySet<string> Empty = new HashSet<string>(StringComparer.Ordinal);
+
+    private readonly IReadOnlyDictionary<string, IReadOnlySet<string>> _aliases;
+
+    /// <summary>
+    /// Creates a provider backed by the supplied logical-to-physicals map.
+    /// </summary>
+    /// <param name="aliases">
+    /// Keys are canonical names exposed by readers; values are the CLR type
+    /// names the audit log may have stamped for that canonical entity.
+    /// </param>
+    public StaticAuditEntityTypeAliasProvider(IReadOnlyDictionary<string, IReadOnlySet<string>> aliases)
+    {
+        ArgumentNullException.ThrowIfNull(aliases);
+        _aliases = aliases;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlySet<string> GetAliases(string logicalEntityType) =>
+        _aliases.TryGetValue(logicalEntityType, out IReadOnlySet<string>? aliases)
+            ? aliases
+            : Empty;
+}

--- a/src/Granit.Identity.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Endpoints/packages.lock.json
@@ -34,6 +34,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -75,6 +85,12 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.apidocumentation": {
         "type": "Project",
         "dependencies": {
@@ -105,6 +121,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
@@ -107,6 +107,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -165,6 +177,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -93,6 +93,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -172,6 +184,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -115,6 +115,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -180,6 +192,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
@@ -36,6 +36,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -84,6 +94,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
@@ -227,6 +227,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -319,6 +331,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.EntraId/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId/packages.lock.json
@@ -266,6 +266,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -344,6 +356,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
+++ b/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
@@ -129,6 +129,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -179,6 +191,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
@@ -227,6 +227,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -319,6 +331,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.Keycloak/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak/packages.lock.json
@@ -266,6 +266,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -344,6 +356,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Federated.Notifications/packages.lock.json
@@ -38,6 +38,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -88,6 +100,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Federated.Privacy/packages.lock.json
@@ -60,6 +60,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.blobstorage": {
         "type": "Project",
         "dependencies": {
@@ -146,6 +158,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Federated/packages.lock.json
+++ b/src/Granit.Identity.Federated/packages.lock.json
@@ -16,6 +16,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -58,6 +68,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Local.AspNetIdentity/packages.lock.json
+++ b/src/Granit.Identity.Local.AspNetIdentity/packages.lock.json
@@ -113,6 +113,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -182,6 +192,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -143,6 +143,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Local.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Local.Notifications/packages.lock.json
@@ -50,6 +50,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -127,6 +139,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Local.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Local.Privacy/packages.lock.json
@@ -60,6 +60,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -155,6 +167,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Local/packages.lock.json
+++ b/src/Granit.Identity.Local/packages.lock.json
@@ -11,6 +11,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -74,6 +84,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs
+++ b/src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing;
 using Granit.Diagnostics;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Internal;
@@ -29,8 +30,29 @@ public static class IdentityServiceCollectionExtensions
         services.TryAddScoped<IIdentityProviderCapabilities, NullIdentityProviderCapabilities>();
         services.TryAddScoped<IUserLookupService, NullUserLookupService>();
         services.TryAddScoped<IUserCacheStats, NullUserCacheStats>();
+
+        RegisterAuditEntityTypeAliases(services);
+
         return services;
     }
+
+    // ADR-051: the canonical User aggregate shares its Guid with two sibling
+    // CLR types — LocalIdentity (auth secrets) and FederatedIdentity (IdP
+    // cache). Their audit log rows must surface on /timeline/User/{id} and
+    // through IAuditingReader.GetByEntityAsync("User", ...). The reverse is
+    // intentionally not aliased: a forensic lookup by "LocalIdentity" still
+    // returns auth-only writes.
+    private static void RegisterAuditEntityTypeAliases(IServiceCollection services) =>
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAuditEntityTypeAliasProvider>(
+            new StaticAuditEntityTypeAliasProvider(
+                new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+                {
+                    ["User"] = new HashSet<string>(StringComparer.Ordinal)
+                    {
+                        "LocalIdentity",
+                        "FederatedIdentity",
+                    },
+                })));
 
     /// <summary>
     /// Registers a custom <see cref="IIdentityProvider"/> implementation,

--- a/src/Granit.Identity/Granit.Identity.csproj
+++ b/src/Granit.Identity/Granit.Identity.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />

--- a/src/Granit.Identity/GranitIdentityModule.cs
+++ b/src/Granit.Identity/GranitIdentityModule.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing;
 using Granit.DataExchange.Extensions;
 using Granit.Entities.Extensions;
 using Granit.Identity.Domain;
@@ -21,6 +22,7 @@ namespace Granit.Identity;
 /// <c>Granit.Identity.EntityFrameworkCore</c> to wire the EF Core
 /// <see cref="IUserDirectoryQueryableSource"/> impl.
 /// </summary>
+[DependsOn(typeof(GranitAuditingModule))]
 [DependsOn(typeof(GranitQueryEngineAbstractionsModule))]
 public sealed class GranitIdentityModule : GranitModule
 {

--- a/src/Granit.Identity/packages.lock.json
+++ b/src/Granit.Identity/packages.lock.json
@@ -8,8 +8,25 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -32,6 +49,14 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -39,10 +64,34 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.workflow.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
         }
       }
     }

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -400,6 +400,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -497,6 +509,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -408,6 +408,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -324,6 +324,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication": {
         "type": "Project",
         "dependencies": {
@@ -414,6 +424,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -298,6 +298,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication": {
         "type": "Project",
         "dependencies": {
@@ -382,6 +392,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -273,6 +273,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -342,6 +352,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/Granit.Timeline.Auditing/Internal/AuditingTimelineSource.cs
+++ b/src/Granit.Timeline.Auditing/Internal/AuditingTimelineSource.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text.Json;
 using Granit.Auditing;
 using Granit.Auditing.Domain;
+using Granit.Auditing.Extensions;
 using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
 
@@ -13,7 +14,9 @@ namespace Granit.Timeline.Auditing.Internal;
 /// <c>AddGranitTimelineAuditing</c>; once present, every audited mutation on
 /// an entity shows up in that entity's timeline without per-module wiring.
 /// </summary>
-internal sealed class AuditingTimelineSource(IAuditingReader auditing) : ITimelineSource
+internal sealed class AuditingTimelineSource(
+    IAuditingReader auditing,
+    IEnumerable<IAuditEntityTypeAliasProvider> aliasProviders) : ITimelineSource
 {
     /// <inheritdoc/>
     public string SourceKey => "auditing";
@@ -25,13 +28,15 @@ internal sealed class AuditingTimelineSource(IAuditingReader auditing) : ITimeli
         int limit,
         CancellationToken cancellationToken = default)
     {
+        IReadOnlySet<string> matchTypes = aliasProviders.Resolve(entityType);
+
         // Single page sized to the merger's fetch budget — the reader only
         // ever asks for top-K and merges across sources.
         PagedResult<AuditEntry> result = await auditing
             .GetByEntityAsync(entityType, entityId, page: 1, pageSize: limit, cancellationToken)
             .ConfigureAwait(false);
 
-        return [.. result.Items.Select(e => Project(entityType, entityId, e))];
+        return [.. result.Items.Select(e => Project(matchTypes, entityId, e))];
     }
 
     /// <inheritdoc/>
@@ -52,19 +57,22 @@ internal sealed class AuditingTimelineSource(IAuditingReader auditing) : ITimeli
             return null;
         }
 
+        IReadOnlySet<string> matchTypes = aliasProviders.Resolve(entityType);
+
         // Security: refuse to anchor an audit row that does not target this
-        // entity — the caller's URL claims an entity scope that must match.
+        // entity — the caller's URL claims an entity scope that must match
+        // either the canonical name or any aliased CLR name.
         bool targetsEntity = entry.EntityChanges.Any(c =>
-            string.Equals(c.EntityType, entityType, StringComparison.Ordinal) &&
+            matchTypes.Contains(c.EntityType) &&
             string.Equals(c.EntityId, entityId, StringComparison.Ordinal));
 
-        return targetsEntity ? Project(entityType, entityId, entry) : null;
+        return targetsEntity ? Project(matchTypes, entityId, entry) : null;
     }
 
-    private static TimelineStreamEntry Project(string entityType, string entityId, AuditEntry entry)
+    private static TimelineStreamEntry Project(IReadOnlySet<string> matchTypes, string entityId, AuditEntry entry)
     {
         AuditEntityChange? change = entry.EntityChanges.FirstOrDefault(c =>
-            string.Equals(c.EntityType, entityType, StringComparison.Ordinal) &&
+            matchTypes.Contains(c.EntityType) &&
             string.Equals(c.EntityId, entityId, StringComparison.Ordinal));
 
         return new TimelineStreamEntry

--- a/src/Granit.Workflow.Notifications/packages.lock.json
+++ b/src/Granit.Workflow.Notifications/packages.lock.json
@@ -63,6 +63,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -110,10 +122,19 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -677,6 +677,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2311,6 +2311,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingReaderCachingTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingReaderCachingTests.cs
@@ -40,7 +40,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
         await SeedEntryAsync(entryId);
 
         IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
-        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, _options);
+        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, [], _options);
 
         // Act — first call loads from DB
         AuditEntry? first = await reader.GetByIdAsync(entryId, TestContext.Current.CancellationToken);
@@ -66,7 +66,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
     {
         // Arrange
         IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
-        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, _options);
+        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, [], _options);
 
         var missingId = Guid.NewGuid();
 
@@ -87,7 +87,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
         await SeedEntryWithEntityChangeAsync(entryId, "Invoice", "INV-001");
 
         IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
-        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, _options);
+        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, [], _options);
 
         // Act — first call loads from DB
         PagedResult<AuditEntry> first = await reader.GetByEntityAsync("Invoice", "INV-001", cancellationToken: TestContext.Current.CancellationToken);
@@ -118,7 +118,7 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
         await SeedEntryWithEntityChangeAsync(entryId2, "A", "B:C");
 
         IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
-        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, _options);
+        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, [], _options);
 
         // Act
         PagedResult<AuditEntry> result1 = await reader.GetByEntityAsync("A:B", "C", cancellationToken: TestContext.Current.CancellationToken);
@@ -127,6 +127,88 @@ public sealed class EfCoreAuditingReaderCachingTests : IDisposable
         // Assert — each query returns its own entry, not the other's cached result
         result1.Items.ShouldAllBe(e => e.EntityChanges.Any(ec => ec.EntityType == "A:B"));
         result2.Items.ShouldAllBe(e => e.EntityChanges.Any(ec => ec.EntityType == "A"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Alias resolution — ADR-051 split persistence
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetByEntityAsync_WithAliasProvider_ReturnsRowsStampedWithAliasedClrName()
+    {
+        // Arrange — audit rows are stamped "LocalIdentity" (CLR name), but a
+        // reader query for "User" must surface them because of the alias.
+        const string SharedId = "user-42";
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "LocalIdentity", SharedId);
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "FederatedIdentity", SharedId);
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "User", SharedId);
+
+        StaticAuditEntityTypeAliasProvider aliasProvider = new(
+            new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+            {
+                ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity", "FederatedIdentity" },
+            });
+
+        IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
+        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, [aliasProvider], _options);
+
+        // Act
+        PagedResult<AuditEntry> result = await reader
+            .GetByEntityAsync("User", SharedId, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert — all three rows surface under the canonical name.
+        result.Items.Count.ShouldBe(3);
+        result.Items.SelectMany(e => e.EntityChanges)
+            .Select(c => c.EntityType)
+            .ShouldBe(new[] { "User", "LocalIdentity", "FederatedIdentity" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task GetByEntityAsync_QueryByPhysicalAlias_DoesNotIncludeCanonicalRows()
+    {
+        // Arrange — directional alias: a lookup by "LocalIdentity" must NOT
+        // bleed in "User" rows. Forensic precision is preserved.
+        const string SharedId = "user-42";
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "LocalIdentity", SharedId);
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "User", SharedId);
+
+        StaticAuditEntityTypeAliasProvider aliasProvider = new(
+            new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+            {
+                ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity" },
+            });
+
+        IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
+        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, [aliasProvider], _options);
+
+        // Act
+        PagedResult<AuditEntry> result = await reader
+            .GetByEntityAsync("LocalIdentity", SharedId, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert — only the LocalIdentity row.
+        result.Items.Count.ShouldBe(1);
+        result.Items.Single().EntityChanges.Single().EntityType.ShouldBe("LocalIdentity");
+    }
+
+    [Fact]
+    public async Task GetByEntityAsync_WithNoProviders_BehavesAsBefore()
+    {
+        // Arrange — hosts without any IAuditEntityTypeAliasProvider see the
+        // pre-aliasing behaviour: strict ordinal match on EntityType.
+        const string SharedId = "user-42";
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "LocalIdentity", SharedId);
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "User", SharedId);
+
+        IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
+        EfCoreAuditingReader reader = new(factory, _cache, _currentTenant, [], _options);
+
+        // Act
+        PagedResult<AuditEntry> result = await reader
+            .GetByEntityAsync("User", SharedId, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert — only the canonical row, the LocalIdentity row stays hidden.
+        result.Items.Count.ShouldBe(1);
+        result.Items.Single().EntityChanges.Single().EntityType.ShouldBe("User");
     }
 
     // --- Helpers ---

--- a/tests/Granit.Auditing.Tests/AuditEntityTypeAliasProviderTests.cs
+++ b/tests/Granit.Auditing.Tests/AuditEntityTypeAliasProviderTests.cs
@@ -1,0 +1,89 @@
+using Granit.Auditing.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Auditing.Tests;
+
+public sealed class AuditEntityTypeAliasProviderTests
+{
+    [Fact]
+    public void Resolve_NoProviders_ReturnsLogicalNameOnly()
+    {
+        IReadOnlySet<string> result = Array.Empty<IAuditEntityTypeAliasProvider>().Resolve("User");
+
+        result.ShouldBe(new[] { "User" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Resolve_SingleProvider_IncludesAliasesAndLogicalName()
+    {
+        StaticAuditEntityTypeAliasProvider provider = new(
+            new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+            {
+                ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity", "FederatedIdentity" },
+            });
+
+        IReadOnlySet<string> result = new[] { (IAuditEntityTypeAliasProvider)provider }.Resolve("User");
+
+        result.ShouldBe(new[] { "User", "LocalIdentity", "FederatedIdentity" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Resolve_MultipleProviders_UnionsTheirAliases()
+    {
+        StaticAuditEntityTypeAliasProvider provider1 = new(
+            new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+            {
+                ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity" },
+            });
+        StaticAuditEntityTypeAliasProvider provider2 = new(
+            new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+            {
+                ["User"] = new HashSet<string>(StringComparer.Ordinal) { "FederatedIdentity" },
+            });
+
+        IReadOnlySet<string> result = new IAuditEntityTypeAliasProvider[] { provider1, provider2 }.Resolve("User");
+
+        result.ShouldBe(new[] { "User", "LocalIdentity", "FederatedIdentity" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Resolve_UnknownLogicalType_ReturnsLogicalNameOnly()
+    {
+        StaticAuditEntityTypeAliasProvider provider = new(
+            new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+            {
+                ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity" },
+            });
+
+        IReadOnlySet<string> result = new[] { (IAuditEntityTypeAliasProvider)provider }.Resolve("Invoice");
+
+        result.ShouldBe(new[] { "Invoice" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Resolve_IsDirectional_PhysicalLookupDoesNotIncludeLogical()
+    {
+        // Forensic invariant: GetByEntityAsync("LocalIdentity", id) must NOT
+        // bleed back into "User" rows — only auth-only writes are returned.
+        StaticAuditEntityTypeAliasProvider provider = new(
+            new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+            {
+                ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity" },
+            });
+
+        IReadOnlySet<string> result = new[] { (IAuditEntityTypeAliasProvider)provider }.Resolve("LocalIdentity");
+
+        result.ShouldBe(new[] { "LocalIdentity" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Resolve_NullProviders_Throws() =>
+        Should.Throw<ArgumentNullException>(() =>
+            ((IEnumerable<IAuditEntityTypeAliasProvider>)null!).Resolve("User"));
+
+    [Fact]
+    public void Resolve_EmptyLogicalType_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            Array.Empty<IAuditEntityTypeAliasProvider>().Resolve(""));
+}

--- a/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
@@ -515,6 +515,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -562,6 +574,14 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.http.apidocumentation": {
         "type": "Project",
         "dependencies": {
@@ -592,6 +612,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
@@ -362,6 +362,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -420,6 +432,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -325,6 +325,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -404,6 +416,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -1315,6 +1315,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -1380,6 +1392,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -325,6 +325,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -390,6 +402,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
@@ -337,6 +337,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -393,6 +405,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
@@ -459,6 +459,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -551,6 +563,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
@@ -1420,6 +1420,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -1498,6 +1510,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
@@ -459,6 +459,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -537,6 +549,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
@@ -315,6 +315,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -365,6 +377,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
@@ -459,6 +459,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -551,6 +563,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
@@ -715,6 +715,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -804,6 +816,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
@@ -470,6 +470,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -548,6 +560,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Notifications.Tests/packages.lock.json
@@ -276,6 +276,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -326,6 +338,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
@@ -292,6 +292,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.blobstorage": {
         "type": "Project",
         "dependencies": {
@@ -378,6 +390,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Federated.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Tests/packages.lock.json
@@ -252,6 +252,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -294,6 +304,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -600,6 +600,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/packages.lock.json
@@ -317,6 +317,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -386,6 +396,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -634,6 +634,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
@@ -282,6 +282,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -359,6 +371,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
@@ -292,6 +292,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -387,6 +399,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Tests/packages.lock.json
@@ -235,6 +235,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -298,6 +308,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Tests/GranitIdentityModuleTests.cs
+++ b/tests/Granit.Identity.Tests/GranitIdentityModuleTests.cs
@@ -1,3 +1,5 @@
+using Granit.Auditing;
+using Granit.Auditing.Extensions;
 using Granit.Identity.Internal;
 using Granit.Modularity;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,5 +34,23 @@ public sealed class GranitIdentityModuleTests
         var module = new GranitIdentityModule();
 
         module.ShouldBeAssignableTo<GranitModule>();
+    }
+
+    [Fact]
+    public void ConfigureServices_RegistersUserAuditAliasForLocalAndFederatedIdentity()
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        var context = new ServiceConfigurationContext(builder.Services, builder.Configuration, builder);
+        var module = new GranitIdentityModule();
+
+        module.ConfigureServices(context);
+
+        ServiceProvider provider = builder.Services.BuildServiceProvider();
+        IEnumerable<IAuditEntityTypeAliasProvider> aliasProviders =
+            provider.GetServices<IAuditEntityTypeAliasProvider>();
+
+        IReadOnlySet<string> aliasesForUser = aliasProviders.Resolve("User");
+
+        aliasesForUser.ShouldBe(new[] { "User", "LocalIdentity", "FederatedIdentity" }, ignoreOrder: true);
     }
 }

--- a/tests/Granit.Identity.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Tests/packages.lock.json
@@ -319,6 +319,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -340,10 +352,19 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
@@ -354,6 +375,14 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
       "granit.workflow.abstractions": {

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -614,6 +614,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -711,6 +723,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -679,6 +679,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -491,6 +491,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication": {
         "type": "Project",
         "dependencies": {
@@ -581,6 +591,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
@@ -486,6 +486,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication": {
         "type": "Project",
         "dependencies": {
@@ -570,6 +580,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -806,6 +806,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -488,6 +488,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -557,6 +567,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
@@ -620,6 +620,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.backgroundjobs": {
         "type": "Project",
         "dependencies": {
@@ -766,6 +778,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Timeline.Auditing.Tests/AuditingTimelineSourceTests.cs
+++ b/tests/Granit.Timeline.Auditing.Tests/AuditingTimelineSourceTests.cs
@@ -22,7 +22,16 @@ public sealed class AuditingTimelineSourceTests
     private readonly IAuditingReader _auditing = Substitute.For<IAuditingReader>();
     private readonly AuditingTimelineSource _source;
 
-    public AuditingTimelineSourceTests() => _source = new AuditingTimelineSource(_auditing);
+    public AuditingTimelineSourceTests() => _source = new AuditingTimelineSource(_auditing, []);
+
+    private static AuditingTimelineSource WithUserAlias(IAuditingReader auditing) =>
+        new(auditing, [
+            new StaticAuditEntityTypeAliasProvider(
+                new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+                {
+                    ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity", "FederatedIdentity" },
+                }),
+        ]);
 
     [Fact]
     public void SourceKey_IsAuditing() => _source.SourceKey.ShouldBe("auditing");
@@ -106,6 +115,111 @@ public sealed class AuditingTimelineSourceTests
     {
         TimelineStreamEntry? result = await _source
             .GetEntryAsync("User", "user-42", "not-a-guid", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Alias resolution — ADR-051 split persistence
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetEntriesAsync_WithAliasProvider_ProjectsEntriesStampedWithAliasedClrName()
+    {
+        // Audit row stamped "LocalIdentity" (auth-secret mutation), queried
+        // via the canonical "User" endpoint — must surface and project the
+        // matching change.
+        var auditId = Guid.NewGuid();
+        var entry = new AuditEntry
+        {
+            Id = auditId,
+            Timestamp = DateTimeOffset.UtcNow,
+            UserId = "u-1",
+            UserName = "Alice",
+            Category = AuditCategory.DataMutation,
+            EntityChanges = [new AuditEntityChange
+            {
+                EntityType = "LocalIdentity",
+                EntityId = "user-42",
+                ChangeType = AuditChangeType.Modified,
+                PropertyChanges = [new AuditPropertyChange
+                {
+                    PropertyName = "PasswordHash",
+                    OriginalValue = "***",
+                    NewValue = "***",
+                }],
+            }],
+        };
+
+        _auditing.GetByEntityAsync("User", "user-42", 1, 50, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<AuditEntry>([entry], 1, false));
+
+        AuditingTimelineSource source = WithUserAlias(_auditing);
+
+        IReadOnlyList<TimelineStreamEntry> result = await source
+            .GetEntriesAsync("User", "user-42", 50, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        using var payload = JsonDocument.Parse(result[0].Body);
+        payload.RootElement.GetProperty("changeType").GetString().ShouldBe("Modified");
+        payload.RootElement.GetProperty("changes")[0].GetProperty("property").GetString().ShouldBe("PasswordHash");
+    }
+
+    [Fact]
+    public async Task GetEntryAsync_WithAliasProvider_AcceptsAuditRowStampedWithAliasedClrName()
+    {
+        // Security check must accept aliased CLR names — otherwise the entry
+        // anchored from /timeline/User/{id} would be rejected.
+        var auditId = Guid.NewGuid();
+        var entry = new AuditEntry
+        {
+            Id = auditId,
+            Timestamp = DateTimeOffset.UtcNow,
+            UserId = "u-1",
+            EntityChanges = [new AuditEntityChange
+            {
+                EntityType = "FederatedIdentity",
+                EntityId = "user-42",
+                ChangeType = AuditChangeType.Modified,
+            }],
+        };
+
+        _auditing.GetByIdAsync(auditId, Arg.Any<CancellationToken>()).Returns(entry);
+
+        AuditingTimelineSource source = WithUserAlias(_auditing);
+
+        TimelineStreamEntry? result = await source
+            .GetEntryAsync("User", "user-42", auditId.ToString(), TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.SourceId.ShouldBe(auditId.ToString("D"));
+    }
+
+    [Fact]
+    public async Task GetEntryAsync_QueriedByPhysicalAlias_DoesNotMatchCanonicalRow()
+    {
+        // Directional alias: forensic lookup by "LocalIdentity" must NOT
+        // accept rows stamped "User".
+        var auditId = Guid.NewGuid();
+        var entry = new AuditEntry
+        {
+            Id = auditId,
+            Timestamp = DateTimeOffset.UtcNow,
+            UserId = "u-1",
+            EntityChanges = [new AuditEntityChange
+            {
+                EntityType = "User",
+                EntityId = "user-42",
+                ChangeType = AuditChangeType.Modified,
+            }],
+        };
+
+        _auditing.GetByIdAsync(auditId, Arg.Any<CancellationToken>()).Returns(entry);
+
+        AuditingTimelineSource source = WithUserAlias(_auditing);
+
+        TimelineStreamEntry? result = await source
+            .GetEntryAsync("LocalIdentity", "user-42", auditId.ToString(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }

--- a/tests/Granit.Workflow.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Workflow.Notifications.Tests/packages.lock.json
@@ -282,6 +282,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -329,10 +341,19 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"


### PR DESCRIPTION
## Summary

ADR-051 splits the canonical `User` aggregate over three CLR types — `User`, `LocalIdentity` (auth secrets), `FederatedIdentity` (IdP cache) — sharing the same `Guid`. `ChangeTrackingCaptureService` stamps `EntityType` with the runtime CLR name, so password / lockout / 2FA / profile writes on `LocalIdentity` never surfaced on `/timeline/User/{id}` and not on `IAuditingReader.GetByEntityAsync(\"User\", ...)` either.

This PR resolves aliases **at read time** rather than rewriting capture, so the audit log keeps its precise CLR-type fidelity (ISO 27001 A.12.4 / forensic precision).

## Design

- **New contract** `IAuditEntityTypeAliasProvider` in `Granit.Auditing` (+ `StaticAuditEntityTypeAliasProvider` + `Resolve()` extension on `IEnumerable<IAuditEntityTypeAliasProvider>`).
- **Reader-side resolution** — `EfCoreAuditingReader.GetByEntityAsync` and `AuditingTimelineSource` (`GetEntriesAsync`, `GetEntryAsync`, projection security check) all resolve the canonical name to a `HashSet<string>` of CLR aliases and filter via `Contains`.
- **Directional alias** — `Resolve(\"User\")` → `{User, LocalIdentity, FederatedIdentity}`; `Resolve(\"LocalIdentity\")` → `{LocalIdentity}`. Forensic lookups by physical CLR name stay precise.
- **Registration** in `GranitIdentityModule` via `TryAddEnumerable` — multiple modules can contribute aliases without overriding each other.

### Why reader-side, not a `[AuditedAs]` attribute on entities

Discussed off-PR. Reader-side avoids:

- writing a polymorphic `EntityType=\"User\"` into the audit log (would degrade every other consumer — exports, BI, admin grid, forensic queries),
- needing to backfill historical rows (alias applies at every read),
- new public attribute API in pre-1.0 `Granit.Auditing` and a reflection scanner for `N = 2` cases.

The ADR-051 mapping knowledge lives in `Granit.Identity` (the module that owns `User`).

## Split-persistence survey

| CLR type | Canonical aggregate | Shared Guid | Aliased? |
|---|---|---|---|
| `LocalIdentity` | `Granit.Identity.Domain.User` | yes (via `UserId` FK, equal on greenfield) | ✅ `User` |
| `FederatedIdentity` | `Granit.Identity.Domain.User` | yes (via `UserId` FK, equal on greenfield) | ✅ `User` |
| `GranitUserGroup` | (no canonical counterpart in `Granit.Identity.Domain`) | n/a | ❌ |
| `GranitRole` | (no canonical counterpart in `Granit.Identity.Domain`) | n/a | ❌ |

## Tests

| Project | New | Total |
|---|---|---|
| `Granit.Auditing.Tests` | 7 (resolver: union, directionality, guards, unknown type, multi-provider) | 110 ✅ |
| `Granit.Auditing.EntityFrameworkCore.Tests` | 3 (alias match, directional precision, no-provider parity) | 128 ✅ |
| `Granit.Timeline.Auditing.Tests` | 3 (aliased projection, security check accepts aliases, directional rejection) | 7 ✅ |
| `Granit.Identity.Tests` | 1 (DI registration end-to-end) | 147 ✅ |
| `Granit.ArchitectureTests` | — | 185 ✅ |
| `Granit.Identity.Endpoints.Tests` | — | 175 ✅ |
| `Granit.Identity.Local.Tests` | — | 31 ✅ |
| `Granit.Identity.Local.AspNetIdentity.Tests` | — | 146 ✅ |

`dotnet format --verify-no-changes` clean on every touched project.

## Back-compat notes

- **No behaviour change** for hosts without any registered provider — the resolver returns `{logicalType}` and the reader query reduces to the previous ordinal equality.
- **Historical rows surface immediately** — alias applies at every read, no backfill required.
- **`ChangeTrackingCaptureService` untouched** — `EntityType` keeps stamping the CLR name; the audit log stays precise and reversible.

## Test plan

- [x] Unit: `AuditEntityTypeAliasProviderTests` cover union, directionality, multi-provider, guards
- [x] Integration: `EfCoreAuditingReaderCachingTests` exercise the EF Core path against an in-memory store with seeded `LocalIdentity` / `FederatedIdentity` / `User` rows
- [x] Integration: `AuditingTimelineSourceTests` cover the projection + security check
- [x] DI: `GranitIdentityModuleTests` boots the module and asserts the `User` alias is wired
- [x] No regressions: 8 affected test projects clean, 185 architecture tests green
- [ ] Smoke in the consuming app once merged: user's timeline page should start surfacing `LocalIdentity` mutations under `/timeline/User/{id}` immediately, including historical rows