### PR TITLE
refactor(presence): drop redundant null-conditional in PresenceQueryService.Compose

### DIFF
--- a/src/Granit.Presence/Internal/PresenceQueryService.cs
+++ b/src/Granit.Presence/Internal/PresenceQueryService.cs
@@ -61,7 +61,7 @@ internal sealed class PresenceQueryService(
         DateTimeOffset lastSeen = heartbeat?.LastPollUtc ?? DateTimeOffset.MinValue;
 
         ManualPresenceStatus? activeOverride = presence?.GetActiveOverride(clock);
-        DateTimeOffset? overrideUntil = activeOverride is null ? null : presence?.OverrideUntilUtc;
+        DateTimeOffset? overrideUntil = activeOverride is null ? null : presence!.OverrideUntilUtc;
 
         PresenceStatus effective = activeOverride switch
         {


### PR DESCRIPTION
## Summary
- Follow-up to #2204 — addresses a `github-code-quality` finding flagged after merge.
- `presence?.OverrideUntilUtc` in `PresenceQueryService.Compose` is only reached when `activeOverride is not null`, which already implies `presence` is non-null (it came from `presence?.GetActiveOverride(clock)`). Replaced with `presence!.OverrideUntilUtc` to make the invariant explicit and skip the redundant null-check.

The bot's second suggestion on `InMemoryPresenceStore.GetManyAsync` (replace `TryGetValue` foreach with `Where(ContainsKey) + ToDictionary(_, indexer)`) was **dismissed**: it would double the per-id concurrent-dictionary lookups for a style-only "Note" and open a tiny race window between `ContainsKey` and the indexer on a `ConcurrentDictionary`.

## Test plan
- [x] `dotnet build src/Granit.Presence` — clean, 0 warnings.
- [x] `dotnet test tests/Granit.Presence.Tests` — 27/27 passing.
- [x] `dotnet format style src/Granit.Presence --verify-no-changes` — clean.