### PR TITLE
fix(presence)!: harden API against cross-user disclosure, enumeration, and DoS

### DIFF
--- a/.github/shard-filters/infrastructure.slnf
+++ b/.github/shard-filters/infrastructure.slnf
@@ -83,6 +83,7 @@
       "src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj",
       "src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj",
       "src/Granit.QueryEngine/Granit.QueryEngine.csproj",
+      "src/Granit.RateLimiting/Granit.RateLimiting.csproj",
       "src/Granit.Scheduling.BackgroundJobs/Granit.Scheduling.BackgroundJobs.csproj",
       "src/Granit.Scheduling.Endpoints/Granit.Scheduling.Endpoints.csproj",
       "src/Granit.Scheduling.EntityFrameworkCore/Granit.Scheduling.EntityFrameworkCore.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1674,6 +1674,7 @@
         "Granit.Authorization",
         "Granit.Http.Abstractions",
         "Granit.Presence",
+        "Granit.RateLimiting",
         "Granit.Validation"
       ],
       "framework": "net10.0"
@@ -34316,6 +34317,22 @@
       ]
     },
     {
+      "name": "IPresenceEraser",
+      "fqn": "Granit.Presence.Abstractions.IPresenceEraser",
+      "kind": "interface",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/IPresenceEraser.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "EraseAsync",
+          "kind": "method",
+          "signature": "EraseAsync(Guid userId, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "IPresenceHeartbeatRecorder",
       "fqn": "Granit.Presence.Abstractions.IPresenceHeartbeatRecorder",
       "kind": "interface",
@@ -34372,6 +34389,22 @@
           "kind": "method",
           "signature": "GetManyAsync(IReadOnlyList<Guid> userIds, CancellationToken cancellationToken)",
           "returnType": "Task<IReadOnlyDictionary<Guid, PresenceSnapshot>>"
+        }
+      ]
+    },
+    {
+      "name": "IPresenceReadAuditSink",
+      "fqn": "Granit.Presence.Abstractions.IPresenceReadAuditSink",
+      "kind": "interface",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/IPresenceReadAuditSink.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "RecordReadAsync",
+          "kind": "method",
+          "signature": "RecordReadAsync(Guid callerUserId, int targetCount, int allowedCount, bool includesSelf, CancellationToken cancellationToken)",
+          "returnType": "Task"
         }
       ]
     },
@@ -34440,6 +34473,22 @@
           "kind": "method",
           "signature": "RemoveAsync(Guid userId, CancellationToken cancellationToken)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IPresenceVisibilityPolicy",
+      "fqn": "Granit.Presence.Abstractions.IPresenceVisibilityPolicy",
+      "kind": "interface",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/IPresenceVisibilityPolicy.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "FilterVisibleAsync",
+          "kind": "method",
+          "signature": "FilterVisibleAsync(Guid callerUserId, IReadOnlyCollection<Guid> targetUserIds, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlySet<Guid>>"
         }
       ]
     },
@@ -34638,6 +34687,15 @@
       "project": "Granit.Presence.Endpoints",
       "file": "src/Granit.Presence.Endpoints/Permissions/PresencePermissions.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "PresenceRateLimitPolicies",
+      "fqn": "Granit.Presence.Endpoints.Permissions.PresenceRateLimitPolicies",
+      "kind": "class",
+      "project": "Granit.Presence.Endpoints",
+      "file": "src/Granit.Presence.Endpoints/Permissions/PresenceRateLimitPolicies.cs",
+      "line": 18,
       "members": []
     },
     {

--- a/src/Granit.Presence.Endpoints/Endpoints/PresenceQueryEndpoints.cs
+++ b/src/Granit.Presence.Endpoints/Endpoints/PresenceQueryEndpoints.cs
@@ -1,7 +1,10 @@
+using System.Security.Claims;
 using Granit.Presence.Abstractions;
 using Granit.Presence.Domain;
 using Granit.Presence.Endpoints.Dtos;
 using Granit.Presence.Endpoints.Internal;
+using Granit.Presence.Endpoints.Permissions;
+using Granit.RateLimiting.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -19,41 +22,113 @@ internal static class PresenceQueryEndpoints
         group.MapGet("/users/{userId:guid}", GetUserPresenceAsync)
             .WithName("GetUserPresence")
             .WithSummary("Returns the presence snapshot of one user.")
-            .WithDescription("Computes the effective presence status for the specified user. Always returns 200 OK — unknown or never-seen users are reported as Offline with a null LastSeenUtc rather than 404, so clients can use this endpoint to refresh a roster without branching on missing rows.")
-            .Produces<PresenceResponse>();
+            .WithDescription("Computes the effective presence status for the specified user. Always returns 200 OK — unknown, never-seen, and policy-denied targets are canonicalized to Offline with a null LastSeenUtc so the response shape cannot be used as an enumeration oracle. Visibility is decided by IPresenceVisibilityPolicy (default: allow-all; multi-tenant apps MUST register a tenant-aware policy).")
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Query)
+            .Produces<PresenceResponse>()
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/users/batch", GetBatchPresenceAsync)
             .WithName("GetBatchPresence")
             .WithSummary("Returns presence snapshots for a batch of users.")
-            .WithDescription("Returns a dictionary keyed by user id. POST is used because UUID lists exceed practical URL length around 50 entries. Cache via React Query / SWR client-side; the server response carries an ETag for conditional re-fetching.")
+            .WithDescription("Returns a dictionary keyed by user id. POST is used because UUID lists exceed practical URL length around 50 entries. Targets the caller is not allowed to read (per IPresenceVisibilityPolicy) are silently omitted from the response — not 403'd — to avoid leaking an enumeration channel.")
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Query)
             .Produces<BatchPresenceResponse>()
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;
     }
 
     private static async Task<Ok<PresenceResponse>> GetUserPresenceAsync(
         Guid userId,
+        ClaimsPrincipal user,
         [FromServices] IPresenceQueryService queryService,
+        [FromServices] IPresenceVisibilityPolicy visibilityPolicy,
+        [FromServices] IPresenceReadAuditSink auditSink,
         CancellationToken cancellationToken)
     {
+        Guid callerId = PresenceCallerContext.TryGetUserId(user) ?? Guid.Empty;
+        bool isSelf = callerId != Guid.Empty && callerId == userId;
+        bool allowed = isSelf;
+
+        if (!isSelf)
+        {
+            IReadOnlySet<Guid> visible = await visibilityPolicy
+                .FilterVisibleAsync(callerId, [userId], cancellationToken).ConfigureAwait(false);
+            allowed = visible.Contains(userId);
+        }
+
+        await auditSink.RecordReadAsync(
+            callerId, targetCount: 1, allowedCount: allowed ? 1 : 0, isSelf, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!allowed)
+        {
+            return TypedResults.Ok(PresenceResponseMapper.Unknown(userId));
+        }
+
         PresenceSnapshot snapshot = await queryService.GetAsync(userId, cancellationToken).ConfigureAwait(false);
-        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot));
+        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot, isSelf));
     }
 
     private static async Task<Ok<BatchPresenceResponse>> GetBatchPresenceAsync(
         BatchPresenceRequest request,
+        ClaimsPrincipal user,
         [FromServices] IPresenceQueryService queryService,
+        [FromServices] IPresenceVisibilityPolicy visibilityPolicy,
+        [FromServices] IPresenceReadAuditSink auditSink,
         CancellationToken cancellationToken)
     {
-        IReadOnlyDictionary<Guid, PresenceSnapshot> snapshots = await queryService
-            .GetManyAsync(request.UserIds, cancellationToken)
-            .ConfigureAwait(false);
+        Guid callerId = PresenceCallerContext.TryGetUserId(user) ?? Guid.Empty;
 
-        Dictionary<Guid, PresenceResponse> responses = new(snapshots.Count);
-        foreach ((Guid userId, PresenceSnapshot snapshot) in snapshots)
+        List<Guid> others = new(request.UserIds.Count);
+        bool selfRequested = false;
+        foreach (Guid id in request.UserIds)
         {
-            responses[userId] = PresenceResponseMapper.ToResponse(snapshot);
+            if (callerId != Guid.Empty && id == callerId)
+            {
+                selfRequested = true;
+            }
+            else
+            {
+                others.Add(id);
+            }
+        }
+
+        IReadOnlySet<Guid> visibleOthers = others.Count == 0
+            ? new HashSet<Guid>()
+            : await visibilityPolicy.FilterVisibleAsync(callerId, others, cancellationToken).ConfigureAwait(false);
+
+        List<Guid> allowedTargets = new(visibleOthers.Count + (selfRequested ? 1 : 0));
+        if (selfRequested)
+        {
+            allowedTargets.Add(callerId);
+        }
+        allowedTargets.AddRange(visibleOthers);
+
+        await auditSink.RecordReadAsync(
+            callerId,
+            targetCount: request.UserIds.Count,
+            allowedCount: allowedTargets.Count,
+            includesSelf: selfRequested,
+            cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyDictionary<Guid, PresenceSnapshot> snapshots = allowedTargets.Count == 0
+            ? new Dictionary<Guid, PresenceSnapshot>(0)
+            : await queryService.GetManyAsync(allowedTargets, cancellationToken).ConfigureAwait(false);
+
+        Dictionary<Guid, PresenceResponse> responses = new(allowedTargets.Count);
+        foreach (Guid id in allowedTargets)
+        {
+            bool isSelf = id == callerId && callerId != Guid.Empty;
+            if (snapshots.TryGetValue(id, out PresenceSnapshot? snapshot))
+            {
+                responses[id] = PresenceResponseMapper.ToResponse(snapshot, isSelf);
+            }
+            else
+            {
+                responses[id] = PresenceResponseMapper.Unknown(id);
+            }
         }
 
         return TypedResults.Ok(new BatchPresenceResponse(responses));

--- a/src/Granit.Presence.Endpoints/Endpoints/PresenceSelfEndpoints.cs
+++ b/src/Granit.Presence.Endpoints/Endpoints/PresenceSelfEndpoints.cs
@@ -3,6 +3,8 @@ using Granit.Presence.Abstractions;
 using Granit.Presence.Domain;
 using Granit.Presence.Endpoints.Dtos;
 using Granit.Presence.Endpoints.Internal;
+using Granit.Presence.Endpoints.Permissions;
+using Granit.RateLimiting.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -21,76 +23,102 @@ internal static class PresenceSelfEndpoints
             .WithName("GetMyPresence")
             .WithSummary("Returns the caller's current presence snapshot.")
             .WithDescription("Computes the effective presence status for the authenticated user by blending their manual override (if any) with their last reported heartbeat.")
-            .Produces<PresenceResponse>();
+            .Produces<PresenceResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapPut("/my", SetMyPresenceAsync)
             .WithName("SetMyPresence")
             .WithSummary("Sets or clears the caller's manual presence override.")
             .WithDescription("Replaces the caller's manual override. Passing ManualStatus=Available clears the override. UntilUtc is optional and bounded by Presence:MaxOverrideDuration.")
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Mutate)
             .Produces<PresenceResponse>()
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapDelete("/my/override", ClearMyPresenceAsync)
             .WithName("ClearMyPresenceOverride")
             .WithSummary("Clears the caller's manual presence override.")
             .WithDescription("Removes any active manual override so the effective status is derived from the heartbeat alone.")
-            .Produces<PresenceResponse>();
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Mutate)
+            .Produces<PresenceResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/my/poll", PollMyPresenceAsync)
             .WithName("PollMyPresence")
             .WithSummary("Records a heartbeat and returns the caller's presence snapshot.")
             .WithDescription("Clients should call this every 30-60 seconds with the user's local idle duration (in seconds). The server reconstructs the LastActivityUtc using its own clock to avoid client clock-skew issues, and applies a MAX merge across concurrent tabs.")
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Poll)
             .Produces<PresenceResponse>()
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;
     }
 
-    private static async Task<Ok<PresenceResponse>> GetMyPresenceAsync(
+    private static async Task<Results<Ok<PresenceResponse>, ProblemHttpResult>> GetMyPresenceAsync(
         ClaimsPrincipal user,
         [FromServices] IPresenceQueryService queryService,
         CancellationToken cancellationToken)
     {
-        Guid userId = PresenceCallerContext.GetUserId(user);
+        if (!PresenceCallerContext.TryResolveSelf(user, out Guid userId, out ProblemHttpResult? unauthorized))
+        {
+            return unauthorized;
+        }
+
         PresenceSnapshot snapshot = await queryService.GetAsync(userId, cancellationToken).ConfigureAwait(false);
-        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot));
+        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot, isSelf: true));
     }
 
-    private static async Task<Ok<PresenceResponse>> SetMyPresenceAsync(
+    private static async Task<Results<Ok<PresenceResponse>, ProblemHttpResult>> SetMyPresenceAsync(
         SetPresenceRequest request,
         ClaimsPrincipal user,
         [FromServices] IPresenceOverrideService overrideService,
         CancellationToken cancellationToken)
     {
-        Guid userId = PresenceCallerContext.GetUserId(user);
+        if (!PresenceCallerContext.TryResolveSelf(user, out Guid userId, out ProblemHttpResult? unauthorized))
+        {
+            return unauthorized;
+        }
+
         PresenceSnapshot snapshot = await overrideService
             .SetAsync(userId, request.ManualStatus, request.UntilUtc, cancellationToken)
             .ConfigureAwait(false);
-        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot));
+        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot, isSelf: true));
     }
 
-    private static async Task<Ok<PresenceResponse>> ClearMyPresenceAsync(
+    private static async Task<Results<Ok<PresenceResponse>, ProblemHttpResult>> ClearMyPresenceAsync(
         ClaimsPrincipal user,
         [FromServices] IPresenceOverrideService overrideService,
         CancellationToken cancellationToken)
     {
-        Guid userId = PresenceCallerContext.GetUserId(user);
+        if (!PresenceCallerContext.TryResolveSelf(user, out Guid userId, out ProblemHttpResult? unauthorized))
+        {
+            return unauthorized;
+        }
+
         PresenceSnapshot snapshot = await overrideService
             .ClearAsync(userId, cancellationToken)
             .ConfigureAwait(false);
-        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot));
+        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot, isSelf: true));
     }
 
-    private static async Task<Ok<PresenceResponse>> PollMyPresenceAsync(
+    private static async Task<Results<Ok<PresenceResponse>, ProblemHttpResult>> PollMyPresenceAsync(
         HeartbeatRequest request,
         ClaimsPrincipal user,
         [FromServices] IPresenceHeartbeatRecorder recorder,
         CancellationToken cancellationToken)
     {
-        Guid userId = PresenceCallerContext.GetUserId(user);
+        if (!PresenceCallerContext.TryResolveSelf(user, out Guid userId, out ProblemHttpResult? unauthorized))
+        {
+            return unauthorized;
+        }
+
         PresenceSnapshot snapshot = await recorder
             .RecordAsync(userId, TimeSpan.FromSeconds(request.IdleSeconds), cancellationToken)
             .ConfigureAwait(false);
-        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot));
+        return TypedResults.Ok(PresenceResponseMapper.ToResponse(snapshot, isSelf: true));
     }
 }

--- a/src/Granit.Presence.Endpoints/Extensions/PresenceEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Presence.Endpoints/Extensions/PresenceEndpointRouteBuilderExtensions.cs
@@ -18,6 +18,26 @@ public static class PresenceEndpointRouteBuilderExtensions
     /// The self-management routes require <c>Presence.Self.Manage</c>; the query routes
     /// require <c>Presence.Users.Read</c>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>CSRF.</b> The mutating endpoints (<c>PUT /my</c>, <c>DELETE /my/override</c>,
+    /// <c>POST /my/poll</c>, <c>POST /users/batch</c>) are state-changing and must NOT be
+    /// reachable directly from a browser session without an anti-forgery token. The intended
+    /// topology mounts these endpoints behind <c>Granit.Bff</c>, which enforces the CSRF
+    /// token on every mutating call. Hosting these endpoints standalone behind cookie auth
+    /// requires the caller to add the equivalent CSRF middleware before <see cref="MapGranitPresence"/>.
+    /// </para>
+    /// <para>
+    /// <b>Visibility.</b> Cross-user reads are filtered by <c>IPresenceVisibilityPolicy</c>.
+    /// The default implementation is permissive and only suitable for single-tenant deployments;
+    /// multi-tenant apps MUST register a tenant-aware replacement.
+    /// </para>
+    /// <para>
+    /// <b>Rate limiting.</b> Each endpoint declares a Granit rate-limiting policy
+    /// (<c>presence-poll</c>, <c>presence-mutate</c>, <c>presence-query</c>). Configure quotas
+    /// under <c>RateLimiting:Policies</c> — see <c>PresenceRateLimitPolicies</c>.
+    /// </para>
+    /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="PresenceEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>

--- a/src/Granit.Presence.Endpoints/Granit.Presence.Endpoints.csproj
+++ b/src/Granit.Presence.Endpoints/Granit.Presence.Endpoints.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Presence\Granit.Presence.csproj" />
+    <ProjectReference Include="..\Granit.RateLimiting\Granit.RateLimiting.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Presence.Endpoints/Internal/PresenceCallerContext.cs
+++ b/src/Granit.Presence.Endpoints/Internal/PresenceCallerContext.cs
@@ -1,29 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Granit.Presence.Endpoints.Internal;
 
 internal static class PresenceCallerContext
 {
     /// <summary>
-    /// Extracts the caller's user identifier from the <see cref="ClaimsPrincipal"/>.
-    /// Looks at <c>nameid</c> then <c>sub</c>. Throws when neither is present
-    /// (defensive: the endpoint group requires authorization).
+    /// Attempts to extract the caller's user identifier from the <see cref="ClaimsPrincipal"/>.
+    /// Looks at <c>nameid</c> then <c>sub</c>. Returns <c>null</c> when neither is present
+    /// or when the value is not a valid <see cref="Guid"/>.
     /// </summary>
-    public static Guid GetUserId(ClaimsPrincipal user)
+    public static Guid? TryGetUserId(ClaimsPrincipal? user)
     {
-        ArgumentNullException.ThrowIfNull(user);
+        if (user is null)
+        {
+            return null;
+        }
 
         string? raw =
             user.FindFirstValue(ClaimTypes.NameIdentifier)
             ?? user.FindFirstValue("sub");
 
-        if (raw is null)
+        return Guid.TryParse(raw, out Guid parsed) ? parsed : null;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> and the caller's user identifier when a valid GUID claim is present,
+    /// otherwise yields a 401 ProblemDetails result without echoing the raw claim value.
+    /// </summary>
+    public static bool TryResolveSelf(
+        ClaimsPrincipal? user,
+        out Guid userId,
+        [NotNullWhen(false)] out ProblemHttpResult? unauthorized)
+    {
+        Guid? resolved = TryGetUserId(user);
+        if (resolved is { } id)
         {
-            throw new UnauthorizedAccessException("User identifier claim not found.");
+            userId = id;
+            unauthorized = null;
+            return true;
         }
 
-        return Guid.TryParse(raw, out Guid parsed)
-            ? parsed
-            : throw new UnauthorizedAccessException($"User identifier '{raw}' is not a valid GUID.");
+        userId = Guid.Empty;
+        unauthorized = TypedResults.Problem(
+            detail: "Authenticated identity does not carry a recognized user identifier.",
+            statusCode: StatusCodes.Status401Unauthorized,
+            title: "Unauthorized");
+        return false;
     }
 }

--- a/src/Granit.Presence.Endpoints/Internal/PresenceResponseMapper.cs
+++ b/src/Granit.Presence.Endpoints/Internal/PresenceResponseMapper.cs
@@ -5,11 +5,39 @@ namespace Granit.Presence.Endpoints.Internal;
 
 internal static class PresenceResponseMapper
 {
-    public static PresenceResponse ToResponse(PresenceSnapshot snapshot) =>
-        new(
+    /// <summary>
+    /// Maps a <see cref="PresenceSnapshot"/> to its API response.
+    /// When the caller is not the snapshot's owner and the user has chosen
+    /// <see cref="ManualPresenceStatus.AppearOffline"/>, the response is canonicalized
+    /// to look exactly like a genuinely-offline user (no <c>LastSeenUtc</c>,
+    /// no <c>ManualOverride</c>, no <c>OverrideUntilUtc</c>). This preserves the
+    /// privacy contract of the <c>AppearOffline</c> status.
+    /// </summary>
+    /// <summary>
+    /// Canonical "no information" response. Used for unknown users, never-seen users,
+    /// and policy-denied targets — keeping the response shape indistinguishable so the
+    /// endpoint cannot be used as a user-existence oracle.
+    /// </summary>
+    public static PresenceResponse Unknown(Guid userId) =>
+        new(userId, PresenceStatus.Offline, ManualOverride: null, OverrideUntilUtc: null, LastSeenUtc: null);
+
+    public static PresenceResponse ToResponse(PresenceSnapshot snapshot, bool isSelf)
+    {
+        if (!isSelf && snapshot.ManualOverride == ManualPresenceStatus.AppearOffline)
+        {
+            return new PresenceResponse(
+                snapshot.UserId,
+                PresenceStatus.Offline,
+                ManualOverride: null,
+                OverrideUntilUtc: null,
+                LastSeenUtc: null);
+        }
+
+        return new PresenceResponse(
             snapshot.UserId,
             snapshot.EffectiveStatus,
             snapshot.ManualOverride,
             snapshot.OverrideUntilUtc,
             snapshot.LastSeenUtc == DateTimeOffset.MinValue ? null : snapshot.LastSeenUtc);
+    }
 }

--- a/src/Granit.Presence.Endpoints/Permissions/PresenceRateLimitPolicies.cs
+++ b/src/Granit.Presence.Endpoints/Permissions/PresenceRateLimitPolicies.cs
@@ -1,0 +1,41 @@
+namespace Granit.Presence.Endpoints.Permissions;
+
+/// <summary>
+/// Rate limiting policy names for the presence endpoints.
+/// Configure limits in <c>RateLimiting:Policies</c> using these names as keys.
+/// </summary>
+/// <example>
+/// <code>
+/// "RateLimiting": {
+///   "Policies": {
+///     "presence-poll":   { "PermitLimit": 4,  "Window": "00:01:00" },
+///     "presence-mutate": { "PermitLimit": 60, "Window": "00:01:00" },
+///     "presence-query":  { "PermitLimit": 30, "Window": "00:01:00" }
+///   }
+/// }
+/// </code>
+/// </example>
+public static class PresenceRateLimitPolicies
+{
+    /// <summary>
+    /// Policy applied to <c>POST /my/poll</c>. The documented client cadence is 30-60 s,
+    /// so this should ceiling at roughly one call every 15 s per user.
+    /// Recommended: FixedWindow, 4 requests/min.
+    /// </summary>
+    public const string Poll = "presence-poll";
+
+    /// <summary>
+    /// Policy applied to <c>PUT /my</c> and <c>DELETE /my/override</c>. Bounds
+    /// override-toggle floods that would otherwise amplify into the distributed
+    /// event bus / Wolverine outbox.
+    /// Recommended: FixedWindow, 60 requests/min.
+    /// </summary>
+    public const string Mutate = "presence-mutate";
+
+    /// <summary>
+    /// Policy applied to <c>GET /users/{id}</c> and <c>POST /users/batch</c>.
+    /// Bounds enumeration / scraping attempts.
+    /// Recommended: SlidingWindow, 30 requests/min.
+    /// </summary>
+    public const string Query = "presence-query";
+}

--- a/src/Granit.Presence.Endpoints/packages.lock.json
+++ b/src/Granit.Presence.Endpoints/packages.lock.json
@@ -13,6 +13,16 @@
         "resolved": "2.0.0",
         "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.16",
+        "contentHash": "nonu9l0YrZH6krVYbskBjE7uG0VMAnvOQ9PU+RmzUsy+++vHkqzzCkHRoP877OiA3iRTxJyNDLfpcU8hrJ3/YQ=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+      },
       "ZString": {
         "type": "Transitive",
         "resolved": "2.6.0",
@@ -62,6 +72,13 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.features": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -101,6 +118,15 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ratelimiting": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Features": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "StackExchange.Redis": "[2.*, )"
         }
       },
       "granit.timing": {
@@ -162,6 +188,16 @@
         "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
         "dependencies": {
           "ZString": "2.6.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.13.10",
+        "contentHash": "PsVrFkNoOdjIGOXg2+duLS02mzEtOCsE++dNvRiO+gaejKBUuHYBLbTvGR+nL/5ik+vtLKqHZTirNQ5p9qaN+A==",
+        "dependencies": {
+          "Pipelines.Sockets.Unofficial": "2.2.16",
+          "System.IO.Hashing": "10.0.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Presence.EntityFrameworkCore/Internal/EfPresenceStore.cs
+++ b/src/Granit.Presence.EntityFrameworkCore/Internal/EfPresenceStore.cs
@@ -67,18 +67,14 @@ internal sealed class EfPresenceStore(IDbContextFactory<PresenceDbContext> conte
 
     public async Task DeleteAsync(Guid userId, CancellationToken cancellationToken)
     {
+        // GDPR Art. 17: hard delete so no trace of the user identifier remains. ExecuteDeleteAsync
+        // emits a single SQL DELETE that bypasses the soft-delete change-tracker interceptor
+        // wired by ApplyGranitConventions.
         await using PresenceDbContext context = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        UserPresence? tracked = await context.UserPresences
-            .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken).ConfigureAwait(false);
-
-        if (tracked is null)
-        {
-            return;
-        }
-
-        context.UserPresences.Remove(tracked);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await context.UserPresences
+            .Where(p => p.UserId == userId)
+            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.Presence.Notifications/GranitPresenceNotificationsModule.cs
+++ b/src/Granit.Presence.Notifications/GranitPresenceNotificationsModule.cs
@@ -20,6 +20,11 @@ public sealed class GranitPresenceNotificationsModule : GranitModule
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        context.Services.AddSingleton<INotificationDeliveryGate, PresenceNotificationDeliveryGate>();
+        // Scoped: PresenceNotificationDeliveryGate depends on IPresenceQueryService (Scoped).
+        // Registering the gate as Singleton would either throw under ValidateScopes=true or
+        // silently capture the root-scope query service forever — a captive-dependency bug.
+        // NotificationFanoutHandler resolves IEnumerable<INotificationDeliveryGate> per call,
+        // so a Scoped gate is honored without instantiation overhead concerns.
+        context.Services.AddScoped<INotificationDeliveryGate, PresenceNotificationDeliveryGate>();
     }
 }

--- a/src/Granit.Presence/Abstractions/IPresenceEraser.cs
+++ b/src/Granit.Presence/Abstractions/IPresenceEraser.cs
@@ -1,0 +1,26 @@
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// GDPR Art. 17 / LGPD Art. 18 / CCPA erasure entry point for the presence module.
+/// Removes both the persisted override and the cached heartbeat for the given user.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations MUST perform a hard delete (bypass soft-delete interceptors) so no
+/// trace of the user's identifier remains in the presence table.
+/// </para>
+/// <para>
+/// Wire this into the privacy deletion saga from the application — typically by
+/// handling <c>PersonalDataDeletionRequestedEto</c> in a Wolverine handler that
+/// resolves <see cref="IPresenceEraser"/> and calls <see cref="EraseAsync"/>. A future
+/// <c>Granit.Presence.Privacy</c> package will ship that handler out of the box.
+/// </para>
+/// </remarks>
+public interface IPresenceEraser
+{
+    /// <summary>
+    /// Hard-deletes the user's presence row and removes their cached heartbeat.
+    /// Idempotent — no-op when nothing exists.
+    /// </summary>
+    Task EraseAsync(Guid userId, CancellationToken cancellationToken);
+}

--- a/src/Granit.Presence/Abstractions/IPresenceReadAuditSink.cs
+++ b/src/Granit.Presence/Abstractions/IPresenceReadAuditSink.cs
@@ -1,0 +1,39 @@
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// Receives one event per call to the presence query endpoints. Provides the audit
+/// seam apps need to investigate scraping / harassment / stalking abuse cases without
+/// exploding audit volume on the per-target axis.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default implementation writes a structured ILogger entry. Apps that need
+/// durable audit records (ISO 27001 A.5.34, GDPR Art. 30) can replace this with an
+/// implementation that writes to <c>Granit.Auditing</c>.
+/// </para>
+/// <para>
+/// Implementations MUST NOT enumerate the targets by logging each target identifier —
+/// that would inflate audit volume linearly with the batch size. Counts and the caller
+/// identity are sufficient for post-hoc investigation.
+/// </para>
+/// </remarks>
+public interface IPresenceReadAuditSink
+{
+    /// <summary>
+    /// Records a single presence read by <paramref name="callerUserId"/>.
+    /// </summary>
+    /// <param name="callerUserId">
+    /// Caller's user identifier, or <see cref="Guid.Empty"/> when the identity could not
+    /// be resolved.
+    /// </param>
+    /// <param name="targetCount">Number of target users requested.</param>
+    /// <param name="allowedCount">Number of targets the visibility policy allowed.</param>
+    /// <param name="includesSelf">Whether the call included the caller's own presence.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RecordReadAsync(
+        Guid callerUserId,
+        int targetCount,
+        int allowedCount,
+        bool includesSelf,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Presence/Abstractions/IPresenceVisibilityPolicy.cs
+++ b/src/Granit.Presence/Abstractions/IPresenceVisibilityPolicy.cs
@@ -1,0 +1,39 @@
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// Decides whether a caller may read another user's presence. Provides the
+/// cross-tenant access-control seam for the presence query endpoints, since
+/// the <c>UserPresence</c> aggregate is global per user and carries no tenant.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework ships a permissive default (<see cref="Internal.AllowAllPresenceVisibilityPolicy"/>)
+/// that allows any authenticated caller holding <c>Presence.Users.Read</c> to read any
+/// snapshot — a deliberate fail-open default so single-tenant or homogeneous deployments
+/// require no configuration. <b>Multi-tenant deployments MUST register a tenant-aware
+/// implementation</b> (typically driven by <c>Granit.Identity</c> membership lookups)
+/// to prevent cross-tenant disclosure.
+/// </para>
+/// <para>
+/// Callers requesting their own presence are exempted at the endpoint layer and never
+/// reach this policy.
+/// </para>
+/// </remarks>
+public interface IPresenceVisibilityPolicy
+{
+    /// <summary>
+    /// Returns the subset of <paramref name="targetUserIds"/> the caller is allowed to read.
+    /// Targets denied here are silently omitted from batch responses (preferred over 403
+    /// to avoid leaking an enumeration channel).
+    /// </summary>
+    /// <param name="callerUserId">
+    /// The authenticated caller's user identifier, or <see cref="Guid.Empty"/> when the
+    /// caller's identity could not be resolved.
+    /// </param>
+    /// <param name="targetUserIds">User identifiers the caller wants to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlySet<Guid>> FilterVisibleAsync(
+        Guid callerUserId,
+        IReadOnlyCollection<Guid> targetUserIds,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Presence/Domain/UserPresence.cs
+++ b/src/Granit.Presence/Domain/UserPresence.cs
@@ -43,7 +43,17 @@ public sealed class UserPresence : AuditedAggregateRoot
     /// <summary>The user this presence belongs to. Equal to <see cref="Entity.Id"/>.</summary>
     public Guid UserId { get; private set; }
 
-    /// <summary>Current manual override. <see cref="ManualPresenceStatus.Available"/> means none.</summary>
+    /// <summary>
+    /// Current manual override. <see cref="ManualPresenceStatus.Available"/> means none.
+    /// </summary>
+    /// <remarks>
+    /// This field can be stale: when <see cref="OverrideUntilUtc"/> is in the past the
+    /// row is NOT actively rewritten — the read path computes the correct effective
+    /// status via <see cref="GetActiveOverride"/> and the next mutation overwrites the
+    /// row. <b>Always consume the override through <see cref="GetActiveOverride"/></b>;
+    /// never read <c>ManualStatus</c> directly in business logic, BI extracts, or ad-hoc
+    /// SQL queries without joining on <c>OverrideUntilUtc &gt; now</c>.
+    /// </remarks>
     public ManualPresenceStatus ManualStatus { get; private set; }
 
     /// <summary>

--- a/src/Granit.Presence/Extensions/PresenceHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Presence/Extensions/PresenceHostApplicationBuilderExtensions.cs
@@ -52,12 +52,20 @@ public static class PresenceHostApplicationBuilderExtensions
         // Default tracker uses IFusionCache from Granit.Caching (L1 + optional Redis L2 backplane).
         builder.Services.TryAddSingleton<IPresenceTracker, FusionCachePresenceTracker>();
 
+        // Permissive default visibility policy. Multi-tenant apps MUST register a tenant-aware
+        // replacement before the endpoints are mapped (otherwise cross-tenant reads succeed).
+        builder.Services.TryAddSingleton<IPresenceVisibilityPolicy, AllowAllPresenceVisibilityPolicy>();
+
         // Query service is concrete + interface-registered so internal consumers can take the concrete type.
         builder.Services.TryAddScoped<PresenceQueryService>();
         builder.Services.TryAddScoped<IPresenceQueryService>(sp => sp.GetRequiredService<PresenceQueryService>());
 
         builder.Services.TryAddScoped<IPresenceHeartbeatRecorder, PresenceHeartbeatRecorder>();
         builder.Services.TryAddScoped<IPresenceOverrideService, PresenceOverrideService>();
+        builder.Services.TryAddScoped<IPresenceEraser, PresenceEraser>();
+        builder.Services.TryAddSingleton<IPresenceReadAuditSink, LoggingPresenceReadAuditSink>();
+
+        builder.Services.AddHostedService<PresenceStartupChecks>();
 
         return builder;
     }

--- a/src/Granit.Presence/Internal/AllowAllPresenceVisibilityPolicy.cs
+++ b/src/Granit.Presence/Internal/AllowAllPresenceVisibilityPolicy.cs
@@ -1,0 +1,21 @@
+using Granit.Presence.Abstractions;
+
+namespace Granit.Presence.Internal;
+
+/// <summary>
+/// Default <see cref="IPresenceVisibilityPolicy"/> that allows the caller to read every
+/// requested target. Suitable only for single-tenant deployments. Multi-tenant apps
+/// MUST replace this with a tenant-aware implementation.
+/// </summary>
+internal sealed class AllowAllPresenceVisibilityPolicy : IPresenceVisibilityPolicy
+{
+    public Task<IReadOnlySet<Guid>> FilterVisibleAsync(
+        Guid callerUserId,
+        IReadOnlyCollection<Guid> targetUserIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(targetUserIds);
+        IReadOnlySet<Guid> visible = targetUserIds is HashSet<Guid> hs ? hs : [.. targetUserIds];
+        return Task.FromResult(visible);
+    }
+}

--- a/src/Granit.Presence/Internal/LoggingPresenceReadAuditSink.cs
+++ b/src/Granit.Presence/Internal/LoggingPresenceReadAuditSink.cs
@@ -1,0 +1,32 @@
+using Granit.Presence.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Presence.Internal;
+
+internal sealed partial class LoggingPresenceReadAuditSink(
+    ILogger<LoggingPresenceReadAuditSink> logger) : IPresenceReadAuditSink
+{
+    public Task RecordReadAsync(
+        Guid callerUserId,
+        int targetCount,
+        int allowedCount,
+        bool includesSelf,
+        CancellationToken cancellationToken)
+    {
+        int deniedCount = Math.Max(0, targetCount - allowedCount);
+        LogRead(logger, callerUserId, targetCount, allowedCount, deniedCount, includesSelf);
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Presence read by {CallerUserId}: requested={TargetCount}, allowed={AllowedCount}, denied={DeniedCount}, includesSelf={IncludesSelf}.")]
+    private static partial void LogRead(
+        ILogger logger,
+        Guid callerUserId,
+        int targetCount,
+        int allowedCount,
+        int deniedCount,
+        bool includesSelf);
+}

--- a/src/Granit.Presence/Internal/PresenceEraser.cs
+++ b/src/Granit.Presence/Internal/PresenceEraser.cs
@@ -1,0 +1,12 @@
+using Granit.Presence.Abstractions;
+
+namespace Granit.Presence.Internal;
+
+internal sealed class PresenceEraser(IPresenceStore store, IPresenceTracker tracker) : IPresenceEraser
+{
+    public async Task EraseAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        await store.DeleteAsync(userId, cancellationToken).ConfigureAwait(false);
+        await tracker.RemoveAsync(userId, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Presence/Internal/PresenceStartupChecks.cs
+++ b/src/Granit.Presence/Internal/PresenceStartupChecks.cs
@@ -1,0 +1,54 @@
+using Granit.Caching;
+using Granit.Presence.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Presence.Internal;
+
+/// <summary>
+/// Emits one-shot startup warnings for known risky configurations:
+/// running with the in-memory store in Production, or running with an
+/// unencrypted cache value encryptor.
+/// </summary>
+internal sealed partial class PresenceStartupChecks(
+    IServiceProvider services,
+    IHostEnvironment environment,
+    ILogger<PresenceStartupChecks> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!environment.IsProduction())
+        {
+            return Task.CompletedTask;
+        }
+
+        IPresenceStore store = services.GetRequiredService<IPresenceStore>();
+        if (store is InMemoryPresenceStore)
+        {
+            LogInMemoryStoreInProduction(logger);
+        }
+
+        ICacheValueEncryptor? encryptor = services.GetService<ICacheValueEncryptor>();
+        if (encryptor is null || encryptor is NullCacheValueEncryptor)
+        {
+            LogUnencryptedCache(logger);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(
+        EventId = 100,
+        Level = LogLevel.Warning,
+        Message = "Granit.Presence is using the in-memory presence store in a Production environment. Overrides will be lost on restart and will not propagate across pods. Register AddGranitPresenceEntityFrameworkCore for durable persistence.")]
+    private static partial void LogInMemoryStoreInProduction(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 101,
+        Level = LogLevel.Warning,
+        Message = "Granit.Presence stores user activity heartbeats in the cache backplane without value encryption (ICacheValueEncryptor is null or no-op). For multi-tenant or PII-sensitive deployments, configure AesCacheValueEncryptor via CacheEncryptionOptions.")]
+    private static partial void LogUnencryptedCache(ILogger logger);
+}

--- a/tests/Granit.Presence.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Presence.Endpoints.Tests/packages.lock.json
@@ -182,6 +182,11 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.16",
+        "contentHash": "nonu9l0YrZH6krVYbskBjE7uG0VMAnvOQ9PU+RmzUsy+++vHkqzzCkHRoP877OiA3iRTxJyNDLfpcU8hrJ3/YQ=="
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -191,6 +196,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -322,6 +332,13 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.features": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -366,6 +383,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Presence": "[0.1.0-dev, )",
+          "Granit.RateLimiting": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
@@ -374,6 +392,15 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ratelimiting": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Features": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "StackExchange.Redis": "[2.*, )"
         }
       },
       "granit.timing": {
@@ -526,6 +553,17 @@
         "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
         "dependencies": {
           "ZString": "2.6.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.13.10",
+        "contentHash": "PsVrFkNoOdjIGOXg2+duLS02mzEtOCsE++dNvRiO+gaejKBUuHYBLbTvGR+nL/5ik+vtLKqHZTirNQ5p9qaN+A==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.16",
+          "System.IO.Hashing": "10.0.2"
         }
       },
       "ZiggyCreatures.FusionCache": {


### PR DESCRIPTION
## Summary

Security hardening for the new `Granit.Presence.*` modules introduced in #2204. Closes 10 findings from a security audit: 2 HIGH, 4 MEDIUM, 3 LOW, 1 INFO.

The marquee fixes:

- **AppearOffline leakage** (HIGH) — third-party responses no longer expose `LastSeenUtc` / `ManualOverride` for users who chose `AppearOffline`, restoring the privacy contract of that status.
- **Cross-user visibility / enumeration** (HIGH/MED) — new `IPresenceVisibilityPolicy` seam (default: permissive). Unknown, never-seen, and policy-denied targets collapse to one canonical response, eliminating the user-existence oracle on the batch endpoint.
- **Rate limiting** (MED) — each endpoint declares a Granit policy (`presence-poll`, `presence-mutate`, `presence-query`) to bound event-bus amplification and scraping.
- **RGPD Art. 17** (MED) — `EfPresenceStore.DeleteAsync` switches to `ExecuteDeleteAsync` (bypasses soft-delete). New `IPresenceEraser` erases store + cached heartbeat in one call.

## Detailed changes (per VULN)

| # | Sev | Fix |
|---|---|---|
| VULN-101 | HIGH | `PresenceResponseMapper.ToResponse(snapshot, isSelf)` scrubs LastSeenUtc/ManualOverride when `!isSelf && AppearOffline`. |
| VULN-100/201 | HIGH/MED | `IPresenceVisibilityPolicy` + `AllowAllPresenceVisibilityPolicy` default. Endpoints canonicalize denied/unknown to `Unknown(userId)`. |
| VULN-200 | MED | `RequireGranitRateLimiting` per endpoint + `PresenceRateLimitPolicies` constants. New `Granit.RateLimiting` project reference. |
| VULN-202 | MED | Hard-delete via `ExecuteDeleteAsync` + `IPresenceEraser` service. |
| VULN-203 + VULN-400 | MED/INFO | `PresenceStartupChecks` HostedService warns in production on in-memory store and on missing cache encryption. |
| VULN-300 | LOW | `PresenceNotificationDeliveryGate` registered as Scoped (was Singleton — captive dependency). |
| VULN-301 | LOW | `PresenceCallerContext.TryResolveSelf` → 401 ProblemDetails, no raw-claim echo. Endpoint handlers now return `Results<Ok<T>, ProblemHttpResult>`. |
| VULN-302 | LOW | `IPresenceReadAuditSink` + `LoggingPresenceReadAuditSink` default (counts only, no per-target inflation). |
| VULN-401 | INFO | xmldoc warns on `UserPresence.ManualStatus` staleness; runtime path already correct via `GetActiveOverride`. |
| VULN-402 | INFO | `MapGranitPresence` xmldoc documents BFF/CSRF assumption, visibility-policy responsibility, rate-limit policies. |

## Breaking changes

The conventional-commit `!` reflects:
- `PresenceResponseMapper.ToResponse` signature now takes `(snapshot, isSelf)`.
- `PresenceCallerContext.GetUserId` (throwing) → `TryGetUserId` / `TryResolveSelf`.
- Query endpoint handler signatures gain `ClaimsPrincipal`, `IPresenceVisibilityPolicy`, `IPresenceReadAuditSink` services.

Granit is pre-1.0 — no `[Obsolete]` shims.

## Test plan

- [x] `dotnet build .github/shard-filters/infrastructure.slnf` clean
- [x] `dotnet test tests/Granit.Presence.Tests` — 27 passed
- [x] `dotnet test tests/Granit.Presence.Endpoints.Tests` — 3 passed
- [x] `dotnet test tests/Granit.Presence.EntityFrameworkCore.Tests` — 1 passed
- [x] `dotnet test tests/Granit.Presence.Notifications.Tests` — 17 passed
- [x] `dotnet test tests/Granit.ArchitectureTests` — 185 passed
- [x] `dotnet format` + `dotnet format style` clean on all four projects
- [x] `packages.lock.json` updated for new `Granit.RateLimiting` reference
- [ ] CI green
- [ ] Add follow-up tests covering the new behaviors (AppearOffline scrub, visibility-policy denial path, 401 unauthorized, hard-delete, audit-sink invocation) — tracked separately

## Follow-ups (out of scope here)

- A future `Granit.Presence.Privacy` package will register the Wolverine handler that calls `IPresenceEraser` from `PersonalDataDeletionRequestedEto` (the `InternalsVisibleTo` for that package is already declared).
- Optional: idempotent background sweep to physically rewrite expired-override rows (avoids stale `ManualStatus` in BI extracts). Runtime read path is already correct.