### PR TITLE
fix(auditing): materialise alias-resolved type set to string[] for Npgsql translation

### DIFF
--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
@@ -72,10 +72,12 @@ internal sealed class EfCoreAuditingReader(
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         // Resolve every CLR type the audit log may have stamped for this
-        // canonical name (ADR-051 split persistence). The cache key uses the
-        // canonical name only since the resolved set is deterministic given
-        // the registered providers.
-        IReadOnlySet<string> matchTypes = aliasProviders.Resolve(entityType);
+        // canonical name (ADR-051 split persistence). Materialise to string[]
+        // because Npgsql translates Contains on arrays/lists to a SQL IN-list
+        // but does not recognise IReadOnlySet<string> — the query would fall
+        // back to client evaluation (silently empty on InMemory in tests, hard
+        // failure on Postgres at runtime).
+        string[] matchTypes = [.. aliasProviders.Resolve(entityType)];
 
         IQueryable<AuditEntry> queryable = dbContext.AuditEntries
             .Include(e => e.EntityChanges)


### PR DESCRIPTION
Hotfix for #2206. EfCoreAuditingReader resolved aliases into IReadOnlySet<string>, then called Contains() in a Where lambda. Npgsql does not whitelist IReadOnlySet<T> in its Contains translator, so the query falls back to client evaluation and silently returns zero rows on Postgres - the symptom from the showcase deployment. InMemory provider evaluates as LINQ-to-Objects so the alias tests passed locally. Fix: materialise to string[] before the LINQ expression. SQL becomes a deterministic IN (...). No public API change. 128 unit tests green; Postgres testcontainer integration is a follow-up.