### PR TITLE
fix(presence): register EfPresenceStore as Scoped to match factory lifetime

### DIFF
--- a/src/Granit.Presence.EntityFrameworkCore/Extensions/PresenceEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Presence.EntityFrameworkCore/Extensions/PresenceEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class PresenceEntityFrameworkCoreHostApplicationBuilderExtensions
     /// Must be called after <c>AddGranitPresence()</c>. Registers:
     /// <list type="bullet">
     ///   <item><see cref="Internal.PresenceDbContext"/> via <c>IDbContextFactory</c> for thread-safe usage.</item>
-    ///   <item><see cref="Internal.EfPresenceStore"/> as <see cref="IPresenceStore"/>.</item>
+    ///   <item><see cref="Internal.EfPresenceStore"/> as <see cref="IPresenceStore"/> (Scoped).</item>
     /// </list>
     /// </remarks>
     public static IHostApplicationBuilder AddGranitPresenceEntityFrameworkCore(
@@ -32,8 +32,13 @@ public static class PresenceEntityFrameworkCoreHostApplicationBuilderExtensions
 
         builder.Services.AddGranitDbContext<PresenceDbContext>(configure);
 
+        // Scoped: AddGranitDbContext registers IDbContextFactory<T> as Scoped (the EF interceptors
+        // wired by the factory depend on Scoped services such as ICurrentTenant / ICurrentUser).
+        // EfPresenceStore injects the factory and must therefore also be Scoped to avoid captive
+        // dependency violations under ValidateScopes / ValidateOnBuild.
+        builder.Services.AddScoped<EfPresenceStore>();
         builder.Services.Replace(
-            ServiceDescriptor.Singleton<IPresenceStore, EfPresenceStore>());
+            ServiceDescriptor.Scoped<IPresenceStore>(sp => sp.GetRequiredService<EfPresenceStore>()));
 
         return builder;
     }

--- a/src/Granit.Presence/Internal/PresenceStartupChecks.cs
+++ b/src/Granit.Presence/Internal/PresenceStartupChecks.cs
@@ -23,13 +23,17 @@ internal sealed partial class PresenceStartupChecks(
             return Task.CompletedTask;
         }
 
-        IPresenceStore store = services.GetRequiredService<IPresenceStore>();
+        // The store registration may be Scoped (EF Core impl depends on IDbContextFactory which is
+        // itself Scoped). Resolve through a fresh scope rather than from the root provider so that
+        // ValidateScopes does not flag this hosted service.
+        using IServiceScope scope = services.CreateScope();
+        IPresenceStore store = scope.ServiceProvider.GetRequiredService<IPresenceStore>();
         if (store is InMemoryPresenceStore)
         {
             LogInMemoryStoreInProduction(logger);
         }
 
-        ICacheValueEncryptor? encryptor = services.GetService<ICacheValueEncryptor>();
+        ICacheValueEncryptor? encryptor = scope.ServiceProvider.GetService<ICacheValueEncryptor>();
         if (encryptor is null || encryptor is NullCacheValueEncryptor)
         {
             LogUnencryptedCache(logger);

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/Granit.Presence.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/Granit.Presence.EntityFrameworkCore.Tests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <!-- EF1001: false positive — the EF Core analyzer treats our own Internal/ types as
+         EF infrastructure APIs even though they are simple internal helpers. -->
+    <NoWarn>$(NoWarn);EF1001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +14,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceScopeValidationTests.cs
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceScopeValidationTests.cs
@@ -1,0 +1,43 @@
+using Granit.Presence.Abstractions;
+using Granit.Presence.EntityFrameworkCore.Extensions;
+using Granit.Presence.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Presence.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: <c>EfPresenceStore</c> consumes <c>IDbContextFactory&lt;PresenceDbContext&gt;</c>,
+/// which <c>AddGranitDbContext</c> registers as Scoped (the EF interceptors capture Scoped
+/// services such as <c>ICurrentTenant</c>). Registering <c>EfPresenceStore</c> as Singleton
+/// triggered a captive-dependency failure on host boot in any consumer running with
+/// <c>ValidateScopes</c> / <c>ValidateOnBuild</c> enabled.
+/// </summary>
+public sealed class PresenceScopeValidationTests
+{
+    [Fact]
+    public void AddGranitPresenceEntityFrameworkCore_should_register_IPresenceStore_as_Scoped()
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(settings: null);
+        builder.Configuration.AddInMemoryCollection();
+
+        builder.AddGranitPresenceEntityFrameworkCore(opts => opts.UseInMemoryDatabase("scope-validation-test"));
+
+        ServiceDescriptor storeDescriptor = builder.Services
+            .Single(s => s.ServiceType == typeof(IPresenceStore));
+
+        storeDescriptor.Lifetime.ShouldBe(
+            ServiceLifetime.Scoped,
+            $"IPresenceStore must be Scoped because EfPresenceStore consumes the Scoped " +
+            $"IDbContextFactory<PresenceDbContext>. Got {storeDescriptor.Lifetime}.");
+
+        ServiceDescriptor concreteDescriptor = builder.Services
+            .Single(s => s.ServiceType == typeof(EfPresenceStore));
+
+        concreteDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/packages.lock.json
@@ -20,6 +20,17 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.InMemory": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "C3T9khx1oiLPrS6ehoSnZptiEuTOIaX60it9SGvCkWTeF5i6+IceK6p7mtx+mkFwWB5qx+v3IhgG51iUEtLq9w==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.8",
+          "Microsoft.Extensions.Caching.Memory": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",


### PR DESCRIPTION
## Summary

`EfPresenceStore` depends on `IDbContextFactory<PresenceDbContext>`, which `AddGranitDbContext` registers as **Scoped** (the EF interceptors it wires capture Scoped services such as `ICurrentTenant` / `ICurrentUser`). Registering `EfPresenceStore` as **Singleton** triggered a captive-dependency failure on host boot in any consumer running with `ValidateScopes` / `ValidateOnBuild` enabled — observed while wiring the module into `granit-showcase-dotnet`:

```
System.AggregateException: Some services are not able to be constructed
Error while validating the service descriptor 'ServiceType:
  Granit.Presence.Abstractions.IPresenceStore Lifetime: Singleton
  ImplementationType: Granit.Presence.EntityFrameworkCore.Internal.EfPresenceStore':
  Cannot consume scoped service
  'Microsoft.EntityFrameworkCore.IDbContextFactory`1[Granit.Presence.EntityFrameworkCore.Internal.PresenceDbContext]'
  from singleton 'Granit.Presence.Abstractions.IPresenceStore'.
```

Four cascading errors followed (`PresenceQueryService`, `PresenceHeartbeatRecorder`, `PresenceOverrideService`, `PresenceEraser`) — all consume `IPresenceStore`.

## Fix

[src/Granit.Presence.EntityFrameworkCore/Extensions/PresenceEntityFrameworkCoreHostApplicationBuilderExtensions.cs](src/Granit.Presence.EntityFrameworkCore/Extensions/PresenceEntityFrameworkCoreHostApplicationBuilderExtensions.cs)
- Register `EfPresenceStore` as **Scoped**.
- Replace the `IPresenceStore` registration with a Scoped factory resolving the concrete instance.
- Mirrors the pattern used by `Granit.BackgroundJobs.EntityFrameworkCore` ([here](src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions.cs)) and includes an inline comment documenting the constraint so the next refactor does not regress it.

[src/Granit.Presence/Internal/PresenceStartupChecks.cs](src/Granit.Presence/Internal/PresenceStartupChecks.cs)
- This `IHostedService` (Singleton) resolved `IPresenceStore` from its injected root `IServiceProvider`. With `IPresenceStore` now Scoped, the resolution must go through a fresh scope to satisfy `ValidateScopes` — wrap the resolve in `using IServiceScope scope = services.CreateScope()`.

[tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceScopeValidationTests.cs](tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceScopeValidationTests.cs) (new)
- Regression test asserting that the `ServiceDescriptor.Lifetime` of `IPresenceStore` after `AddGranitPresenceEntityFrameworkCore(...)` is `Scoped`. Uses the in-memory EF Core provider so no real database is required.

## Test plan

- [x] `dotnet build` on the 4 Presence projects — 0 errors
- [x] `dotnet test` on the 4 Presence test projects — 49/49 green
  - Granit.Presence.Tests: 27 passed
  - Granit.Presence.Endpoints.Tests: 3 passed
  - Granit.Presence.EntityFrameworkCore.Tests: 2 passed (incl. the new regression test)
  - Granit.Presence.Notifications.Tests: 17 passed
- [x] `dotnet format --verify-no-changes` clean on touched projects
- [ ] Unblocks `granit-showcase-dotnet` MR !9 once published as `0.1.0-dev.*`