### PR TITLE
fix(blob-storage-s3): force http scheme on presigned URLs for MinIO dev

### DIFF
--- a/src/Granit.BlobStorage.S3/Internal/S3BlobClient.cs
+++ b/src/Granit.BlobStorage.S3/Internal/S3BlobClient.cs
@@ -21,6 +21,7 @@ internal sealed class S3BlobClient : IBlobStoreProvider, IPresignedUrlProvider, 
 {
     private readonly AmazonS3Client _s3;
     private readonly IClock _clock;
+    private readonly Uri? _httpServiceUrl;
 
     public S3BlobClient(IOptions<S3BlobOptions> options, IClock clock)
     {
@@ -31,6 +32,11 @@ internal sealed class S3BlobClient : IBlobStoreProvider, IPresignedUrlProvider, 
         Amazon.Runtime.BasicAWSCredentials credentials = new(opts.AccessKey, opts.SecretKey);
         _s3 = new AmazonS3Client(credentials, config);
         _clock = clock;
+
+        // See S3PresignedUrlRewriter for why post-rewriting is required on AWSSDK.S3 v4.
+        _httpServiceUrl = opts.ServiceUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            ? new Uri(opts.ServiceUrl)
+            : null;
     }
 
     // ── IPresignedUrlProvider ─────────────────────────────────────────────────
@@ -70,7 +76,7 @@ internal sealed class S3BlobClient : IBlobStoreProvider, IPresignedUrlProvider, 
             }
         }
 
-        string uploadUrl = _s3.GetPreSignedURL(presignRequest);
+        string uploadUrl = S3PresignedUrlRewriter.ForceScheme(_s3.GetPreSignedURL(presignRequest), _httpServiceUrl);
 
         Dictionary<string, string> requiredHeaders = new()
         {
@@ -113,7 +119,7 @@ internal sealed class S3BlobClient : IBlobStoreProvider, IPresignedUrlProvider, 
                 ContentDispositionHelper.BuildAttachmentHeader(options.DownloadFileName);
         }
 
-        string downloadUrl = _s3.GetPreSignedURL(presignRequest);
+        string downloadUrl = S3PresignedUrlRewriter.ForceScheme(_s3.GetPreSignedURL(presignRequest), _httpServiceUrl);
 
         PresignedDownloadUrl result = new(
             Url: new Uri(downloadUrl),

--- a/src/Granit.BlobStorage.S3/Internal/S3PresignedUrlRewriter.cs
+++ b/src/Granit.BlobStorage.S3/Internal/S3PresignedUrlRewriter.cs
@@ -1,0 +1,34 @@
+namespace Granit.BlobStorage.S3.Internal;
+
+/// <summary>
+/// Rewrites the scheme of presigned URLs emitted by AWSSDK.S3 to match the configured endpoint.
+/// </summary>
+/// <remarks>
+/// AWSSDK.S3 v4's endpoint-rules engine regenerates the scheme as <c>https://</c> on presigned
+/// URLs even when <c>ServiceURL</c> is <c>http://</c> and <c>UseHttp=true</c> — a behaviour
+/// change from v3. The signature is canonicalised on host only (scheme is not part of
+/// <c>SignedHeaders</c>), so rewriting the scheme client-side does not invalidate
+/// <c>X-Amz-Signature</c>.
+/// </remarks>
+internal static class S3PresignedUrlRewriter
+{
+    /// <summary>
+    /// Rewrites <paramref name="presignedUrl"/> to use <c>http</c> and the port of
+    /// <paramref name="httpServiceUrl"/>. Returns the input unchanged when
+    /// <paramref name="httpServiceUrl"/> is <c>null</c> (configured endpoint is HTTPS).
+    /// </summary>
+    public static string ForceScheme(string presignedUrl, Uri? httpServiceUrl)
+    {
+        if (httpServiceUrl is null)
+        {
+            return presignedUrl;
+        }
+
+        UriBuilder builder = new(presignedUrl)
+        {
+            Scheme = Uri.UriSchemeHttp,
+            Port = httpServiceUrl.Port,
+        };
+        return builder.Uri.ToString();
+    }
+}

--- a/tests/Granit.BlobStorage.S3.Tests/S3PresignedUrlRewriterTests.cs
+++ b/tests/Granit.BlobStorage.S3.Tests/S3PresignedUrlRewriterTests.cs
@@ -1,0 +1,86 @@
+using Granit.BlobStorage.S3.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.S3.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S3PresignedUrlRewriter"/>.
+/// Locks in the post-rewrite that compensates AWSSDK.S3 v4's endpoint-rules engine
+/// regenerating <c>https://</c> on presigned URLs for <c>http://</c> MinIO endpoints.
+/// </summary>
+public sealed class S3PresignedUrlRewriterTests
+{
+    [Fact]
+    public void ForceScheme_HttpsServiceUrl_ReturnsInputUnchanged()
+    {
+        string presigned = "https://s3.eu-west-1.amazonaws.com/bucket/key?X-Amz-Signature=abc";
+
+        string result = S3PresignedUrlRewriter.ForceScheme(presigned, httpServiceUrl: null);
+
+        result.ShouldBe(presigned);
+    }
+
+    [Fact]
+    public void ForceScheme_HttpServiceUrl_RewritesHttpsToHttpAndPreservesPort()
+    {
+        string presigned = "https://localhost/showcase/2026/05/blob?X-Amz-Signature=abc";
+        Uri serviceUrl = new("http://localhost:9000");
+
+        string result = S3PresignedUrlRewriter.ForceScheme(presigned, serviceUrl);
+
+        Uri uri = new(result);
+        uri.Scheme.ShouldBe("http");
+        uri.Port.ShouldBe(9000);
+        uri.Host.ShouldBe("localhost");
+        uri.AbsolutePath.ShouldBe("/showcase/2026/05/blob");
+        uri.Query.ShouldBe("?X-Amz-Signature=abc");
+    }
+
+    [Fact]
+    public void ForceScheme_HttpServiceUrlAlreadyHttp_PreservesPortFromServiceUrl()
+    {
+        // AWSSDK could emit either scheme; this case proves the rewriter is idempotent on http.
+        string presigned = "http://localhost:9000/bucket/key?X-Amz-Signature=abc";
+        Uri serviceUrl = new("http://localhost:9000");
+
+        string result = S3PresignedUrlRewriter.ForceScheme(presigned, serviceUrl);
+
+        Uri uri = new(result);
+        uri.Scheme.ShouldBe("http");
+        uri.Port.ShouldBe(9000);
+    }
+
+    [Fact]
+    public void ForceScheme_HttpServiceUrlOnCustomPort_OverwritesPresignedPort()
+    {
+        // AWS SDK may emit port 443 with https; rewriting to http must restore the service port,
+        // not fall back to 80 (UriBuilder's default for the http scheme).
+        string presigned = "https://localhost:443/bucket/key?X-Amz-Signature=abc";
+        Uri serviceUrl = new("http://localhost:9123");
+
+        string result = S3PresignedUrlRewriter.ForceScheme(presigned, serviceUrl);
+
+        Uri uri = new(result);
+        uri.Scheme.ShouldBe("http");
+        uri.Port.ShouldBe(9123);
+    }
+
+    [Fact]
+    public void ForceScheme_QueryStringIsPreservedVerbatim()
+    {
+        // Signature must remain bit-identical — host (not scheme) is in SignedHeaders, but the
+        // signed query parameters (X-Amz-Signature, X-Amz-SignedHeaders, ...) must not be touched.
+        string query =
+            "?X-Amz-Expires=900&X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+            "&X-Amz-Credential=minioadmin%2F20260523%2Fus-east-1%2Fs3%2Faws4_request" +
+            "&X-Amz-Date=20260523T175245Z&X-Amz-SignedHeaders=content-type%3Bhost" +
+            "&X-Amz-Signature=d5e5d942e439c237dbda63c6789824979047579dfe3b3eb0e1a4225bff1f6bcb";
+        string presigned = $"https://localhost:9000/showcase/blob{query}";
+        Uri serviceUrl = new("http://localhost:9000");
+
+        string result = S3PresignedUrlRewriter.ForceScheme(presigned, serviceUrl);
+
+        new Uri(result).Query.ShouldBe(query);
+    }
+}


### PR DESCRIPTION
## Summary

- AWSSDK.S3 v4's endpoint-rules engine regenerates `https://` on presigned URLs even when `ServiceURL` is `http://` and `UseHttp=true`, breaking MinIO dev (browser blocks the mixed-content PUT against `https://localhost:9000`).
- Post-rewrite the scheme client-side via `S3PresignedUrlRewriter.ForceScheme(...)` on both upload and download presigned URLs. The signature is canonicalised on host only (`scheme` is not in `SignedHeaders`), so the rewrite does not invalidate `X-Amz-Signature`.
- Restore the configured port — `UriBuilder.Scheme = "http"` would reset the port to `80`, dropping any non-standard MinIO port.

## Repro

Showcase host with `BlobStorage:ServiceUrl = http://localhost:9000` returned upload tickets pointing at `https://localhost:9000/...`. After this fix the scheme matches the configured endpoint.

## Test plan

- [x] `dotnet build src/Granit.BlobStorage.S3` — clean
- [x] `dotnet build tests/Granit.BlobStorage.S3.Tests` — clean
- [x] `S3PresignedUrlRewriterTests` — 5/5 pass (https → unchanged, https→http rewrite + port preserved, idempotent on http, custom port restored over the default 80, query string preserved verbatim)
- [ ] Manual sanity: trigger a document upload from showcase-react against MinIO dev — the returned `uploadUrl` is `http://localhost:9000/...` and the PUT succeeds