### PR TITLE
fix(timeline)!: align TimelineStreamEntryType with domain enum

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42329,7 +42329,7 @@
       "kind": "enum",
       "project": "Granit.Timeline",
       "file": "src/Granit.Timeline/TimelineStreamEntryType.cs",
-      "line": 7,
+      "line": 12,
       "members": []
     },
     {

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
@@ -92,13 +92,7 @@ internal static class TimelineEntryEndpoints
         TimelineStreamEntryResponse result = new(
             entry.Id,
             entry.CreatedAt,
-            entry.EntryType switch
-            {
-                TimelineEntryType.Comment => TimelineStreamEntryType.Comment,
-                TimelineEntryType.InternalNote => TimelineStreamEntryType.InternalNote,
-                TimelineEntryType.SystemLog => TimelineStreamEntryType.SystemLog,
-                _ => TimelineStreamEntryType.SystemLog,
-            },
+            (TimelineStreamEntryType)entry.EntryType,
             entry.AuthorId,
             entry.AuthorName,
             entry.Body,

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineQuery.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineQuery.cs
@@ -79,13 +79,7 @@ internal sealed class EfCoreTimelineQuery(
             {
                 Id = e.Id,
                 OccurredAt = e.CreatedAt,
-                EntryType = e.EntryType switch
-                {
-                    TimelineEntryType.Comment => TimelineStreamEntryType.Comment,
-                    TimelineEntryType.InternalNote => TimelineStreamEntryType.InternalNote,
-                    TimelineEntryType.SystemLog => TimelineStreamEntryType.SystemLog,
-                    _ => TimelineStreamEntryType.SystemLog,
-                },
+                EntryType = (TimelineStreamEntryType)e.EntryType,
                 AuthorId = e.AuthorId,
                 AuthorName = e.AuthorName,
                 Body = e.Body,

--- a/src/Granit.Timeline/Internal/InMemoryTimelineQuery.cs
+++ b/src/Granit.Timeline/Internal/InMemoryTimelineQuery.cs
@@ -49,13 +49,7 @@ internal sealed class InMemoryTimelineQuery(
         {
             Id = entry.Id,
             OccurredAt = entry.CreatedAt,
-            EntryType = entry.EntryType switch
-            {
-                TimelineEntryType.Comment => TimelineStreamEntryType.Comment,
-                TimelineEntryType.InternalNote => TimelineStreamEntryType.InternalNote,
-                TimelineEntryType.SystemLog => TimelineStreamEntryType.SystemLog,
-                _ => TimelineStreamEntryType.SystemLog,
-            },
+            EntryType = (TimelineStreamEntryType)entry.EntryType,
             AuthorId = entry.AuthorId,
             AuthorName = entry.AuthorName,
             Body = entry.Body,

--- a/src/Granit.Timeline/TimelineStreamEntryType.cs
+++ b/src/Granit.Timeline/TimelineStreamEntryType.cs
@@ -4,14 +4,19 @@ namespace Granit.Timeline;
 /// Discriminator for <see cref="TimelineStreamEntry"/> in the unified activity stream.
 /// Extends <see cref="Domain.TimelineEntryType"/> with future sources.
 /// </summary>
+/// <remarks>
+/// Numeric values MUST stay in lock-step with <see cref="Domain.TimelineEntryType"/> so that the
+/// domain-to-wire projection is a direct cast — a divergence silently swaps InternalNote and
+/// SystemLog on the wire (a staff-only note then leaks as a system log to followers).
+/// </remarks>
 public enum TimelineStreamEntryType
 {
     /// <summary>Human-authored comment.</summary>
     Comment = 0,
 
-    /// <summary>Human-authored internal note (staff-only).</summary>
-    InternalNote = 1,
-
     /// <summary>Auto-generated system log entry.</summary>
-    SystemLog = 2,
+    SystemLog = 1,
+
+    /// <summary>Human-authored internal note (staff-only).</summary>
+    InternalNote = 2,
 }

--- a/tests/Granit.Timeline.Tests/TimelineStreamEntryTypeTests.cs
+++ b/tests/Granit.Timeline.Tests/TimelineStreamEntryTypeTests.cs
@@ -1,3 +1,4 @@
+using Granit.Timeline.Domain;
 using Shouldly;
 using Xunit;
 
@@ -9,15 +10,25 @@ public sealed class TimelineStreamEntryTypeTests
     public void Comment_HasValue_0() => ((int)TimelineStreamEntryType.Comment).ShouldBe(0);
 
     [Fact]
-    public void InternalNote_HasValue_1() => ((int)TimelineStreamEntryType.InternalNote).ShouldBe(1);
+    public void SystemLog_HasValue_1() => ((int)TimelineStreamEntryType.SystemLog).ShouldBe(1);
 
     [Fact]
-    public void SystemLog_HasValue_2() => ((int)TimelineStreamEntryType.SystemLog).ShouldBe(2);
+    public void InternalNote_HasValue_2() => ((int)TimelineStreamEntryType.InternalNote).ShouldBe(2);
 
     [Fact]
     public void Enum_HasExactlyThreeValues()
     {
         string[] names = Enum.GetNames<TimelineStreamEntryType>();
         names.Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public void StreamEnum_NumericValues_MatchDomainEnum()
+    {
+        // Guard: the projection from Domain.TimelineEntryType to TimelineStreamEntryType is a
+        // direct cast — any divergence silently mislabels entries on the wire.
+        ((int)TimelineStreamEntryType.Comment).ShouldBe((int)TimelineEntryType.Comment);
+        ((int)TimelineStreamEntryType.SystemLog).ShouldBe((int)TimelineEntryType.SystemLog);
+        ((int)TimelineStreamEntryType.InternalNote).ShouldBe((int)TimelineEntryType.InternalNote);
     }
 }


### PR DESCRIPTION
## Summary

- `Granit.Timeline.TimelineStreamEntryType` was `(Comment=0, InternalNote=1, SystemLog=2)` while `Granit.Timeline.Domain.TimelineEntryType` is `(Comment=0, SystemLog=1, InternalNote=2)`. Enums serialise numerically (no `JsonStringEnumConverter`), so the domain→wire projection mapped `InternalNote` to wire `1`, which the frontend interpreted as `SystemLog` — a staff-only note then surfaced as a public system log to followers (GDPR / least-privilege concern).
- Align the stream enum to the domain enum so the three `switch` projections (`TimelineEntryEndpoints`, `InMemoryTimelineQuery`, `EfCoreTimelineQuery`) collapse to a direct `(TimelineStreamEntryType)entry.EntryType` cast.
- Add a cross-enum value-pinning test (`StreamEnum_NumericValues_MatchDomainEnum`) to block future drift between the two enums.

## Breaking change

Wire numeric values for `SystemLog` and `InternalNote` swap (`1 ↔ 2`). Pre-1.0 framework — no `[Obsolete]` shim. Consumers decoding `entryType` numerically must realign their enum.

## No DB migration

EF stores `TimelineEntry.EntryType` as `int` with no `HasConversion` — domain enum values (0/1/2) are unchanged. The DB column is untouched.

## Test plan

- [x] `dotnet test tests/Granit.Timeline.Tests` — 157 passed
- [x] `dotnet test tests/Granit.Timeline.Endpoints.Tests` — 61 passed
- [x] `dotnet test tests/Granit.Timeline.EntityFrameworkCore.Tests` — 29 passed
- [x] `dotnet format --verify-no-changes` clean on the 5 touched files
- [ ] CI green on `application` + `core-ai` shards