### PR TITLE
fix(blob-storage-s3): include signed metadata headers in PresignedUploadTicket.RequiredHeaders

### DIFF
--- a/src/Granit.BlobStorage.S3/Internal/S3BlobClient.cs
+++ b/src/Granit.BlobStorage.S3/Internal/S3BlobClient.cs
@@ -64,24 +64,25 @@ internal sealed class S3BlobClient : IBlobStoreProvider, IPresignedUrlProvider, 
             ContentType = request.ContentType,
         };
 
-        // Embed declared content-type and original filename as S3 metadata.
-        presignRequest.Metadata.Add("x-amz-meta-original-filename", request.FileName);
-        presignRequest.Metadata.Add("x-amz-meta-declared-content-type", request.ContentType);
-
-        if (request.Metadata is not null)
+        // Embed declared content-type, original filename, and any caller metadata as signed
+        // x-amz-meta-* headers. The same dictionary feeds RequiredHeaders below so the client
+        // echoes exactly what was signed — otherwise MinIO/S3 returns 400 SignatureDoesNotMatch.
+        Dictionary<string, string> signedMetadata = S3UploadMetadataBuilder.Build(request);
+        foreach (KeyValuePair<string, string> entry in signedMetadata)
         {
-            foreach (KeyValuePair<string, string> entry in request.Metadata)
-            {
-                presignRequest.Metadata.Add($"x-amz-meta-{entry.Key}", entry.Value);
-            }
+            presignRequest.Metadata.Add(entry.Key, entry.Value);
         }
 
         string uploadUrl = S3PresignedUrlRewriter.ForceScheme(_s3.GetPreSignedURL(presignRequest), _httpServiceUrl);
 
-        Dictionary<string, string> requiredHeaders = new()
+        Dictionary<string, string> requiredHeaders = new(StringComparer.OrdinalIgnoreCase)
         {
             ["Content-Type"] = request.ContentType,
         };
+        foreach (KeyValuePair<string, string> entry in signedMetadata)
+        {
+            requiredHeaders[entry.Key] = entry.Value;
+        }
 
         PresignedUploadTicket ticket = new(
             BlobId: blobId,

--- a/src/Granit.BlobStorage.S3/Internal/S3UploadMetadataBuilder.cs
+++ b/src/Granit.BlobStorage.S3/Internal/S3UploadMetadataBuilder.cs
@@ -1,0 +1,50 @@
+namespace Granit.BlobStorage.S3.Internal;
+
+/// <summary>
+/// Builds the canonical set of <c>x-amz-meta-*</c> headers attached to an S3 presigned PUT.
+/// The same dictionary feeds both <see cref="Amazon.S3.Model.GetPreSignedUrlRequest.Metadata"/>
+/// (driving the signature) and <see cref="PresignedUploadTicket.RequiredHeaders"/> (what the
+/// client must echo on the wire), guaranteeing symmetry by construction.
+/// </summary>
+/// <remarks>
+/// If the signed metadata diverges from <c>RequiredHeaders</c>, S3 / MinIO will recompute the
+/// canonical request with a different header set and reject the PUT with
+/// <c>400 SignatureDoesNotMatch</c>.
+/// <para>
+/// Values are stored verbatim — the AWS SDK does not URL-encode metadata values when signing.
+/// Non-ASCII characters in <see cref="BlobUploadRequest.FileName"/> or
+/// <see cref="BlobUploadRequest.Metadata"/> will be signed as raw bytes; callers responsible for
+/// the upload must transmit those same bytes in the HTTP header, which is fragile and best
+/// avoided.
+/// </para>
+/// </remarks>
+internal static class S3UploadMetadataBuilder
+{
+    internal const string OriginalFileNameHeader = "x-amz-meta-original-filename";
+    internal const string DeclaredContentTypeHeader = "x-amz-meta-declared-content-type";
+
+    /// <summary>
+    /// Returns the <c>x-amz-meta-*</c> headers to sign for the given upload request, keyed
+    /// case-insensitively.
+    /// </summary>
+    internal static Dictionary<string, string> Build(BlobUploadRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Dictionary<string, string> signedMetadata = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [OriginalFileNameHeader] = request.FileName,
+            [DeclaredContentTypeHeader] = request.ContentType,
+        };
+
+        if (request.Metadata is not null)
+        {
+            foreach (KeyValuePair<string, string> entry in request.Metadata)
+            {
+                signedMetadata[$"x-amz-meta-{entry.Key}"] = entry.Value;
+            }
+        }
+
+        return signedMetadata;
+    }
+}

--- a/tests/Granit.BlobStorage.S3.Tests/S3UploadMetadataBuilderTests.cs
+++ b/tests/Granit.BlobStorage.S3.Tests/S3UploadMetadataBuilderTests.cs
@@ -1,0 +1,85 @@
+using Granit.BlobStorage.S3.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.S3.Tests;
+
+/// <summary>
+/// Guards the symmetry between the headers signed into the S3 presigned URL and the
+/// <c>RequiredHeaders</c> echoed back to the client — a divergence would resurface the
+/// <c>400 SignatureDoesNotMatch</c> bug from the showcase.
+/// </summary>
+public sealed class S3UploadMetadataBuilderTests
+{
+    [Fact]
+    public void Build_AlwaysIncludesOriginalFileNameAndDeclaredContentType()
+    {
+        BlobUploadRequest request = new(
+            FileName: "invoice.pdf",
+            ContentType: "application/pdf",
+            MaxAllowedBytes: 1024);
+
+        Dictionary<string, string> result = S3UploadMetadataBuilder.Build(request);
+
+        result["x-amz-meta-original-filename"].ShouldBe("invoice.pdf");
+        result["x-amz-meta-declared-content-type"].ShouldBe("application/pdf");
+    }
+
+    [Fact]
+    public void Build_PrefixesCustomMetadataWithXAmzMeta()
+    {
+        Dictionary<string, string> custom = new(StringComparer.Ordinal)
+        {
+            ["tenant-id"] = "acme",
+            ["case-id"] = "42",
+        };
+        BlobUploadRequest request = new(
+            FileName: "f.txt",
+            ContentType: "text/plain",
+            MaxAllowedBytes: 1,
+            Metadata: custom);
+
+        Dictionary<string, string> result = S3UploadMetadataBuilder.Build(request);
+
+        result["x-amz-meta-tenant-id"].ShouldBe("acme");
+        result["x-amz-meta-case-id"].ShouldBe("42");
+    }
+
+    [Fact]
+    public void Build_WithNullMetadata_OnlyEmitsBuiltInHeaders()
+    {
+        BlobUploadRequest request = new("f.txt", "text/plain", 1);
+
+        Dictionary<string, string> result = S3UploadMetadataBuilder.Build(request);
+
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Build_KeyLookup_IsCaseInsensitive()
+    {
+        // The AWS SDK canonicalises signed headers to lowercase; downstream code must be able to
+        // round-trip the dictionary regardless of casing.
+        BlobUploadRequest request = new("f.txt", "text/plain", 1);
+
+        Dictionary<string, string> result = S3UploadMetadataBuilder.Build(request);
+
+        result.ContainsKey("X-Amz-Meta-Original-FileName").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Build_CustomMetadataCollidesWithBuiltIn_CustomWins()
+    {
+        // Reasonable: callers can override the declared filename/content-type by passing the
+        // same suffix. Behaviour pinned so a future refactor doesn't silently flip it.
+        Dictionary<string, string> custom = new(StringComparer.Ordinal)
+        {
+            ["original-filename"] = "renamed.pdf",
+        };
+        BlobUploadRequest request = new("first.pdf", "application/pdf", 1, custom);
+
+        Dictionary<string, string> result = S3UploadMetadataBuilder.Build(request);
+
+        result["x-amz-meta-original-filename"].ShouldBe("renamed.pdf");
+    }
+}


### PR DESCRIPTION
## Summary

- `GenerateUploadTicketAsync` signed three `x-amz-meta-*` headers (`original-filename`, `declared-content-type`, plus any caller-supplied `BlobUploadRequest.Metadata`) into the AWS-SDK `GetPreSignedUrlRequest.Metadata`, but `PresignedUploadTicket.RequiredHeaders` only carried `Content-Type`. Clients echoed `Content-Type` alone, S3/MinIO recomputed the canonical request with a smaller signed-header set, and the PUT failed with `400 SignatureDoesNotMatch`.
- Extracted `S3UploadMetadataBuilder` (internal, pure) as the single source of truth for the signed metadata map. The same dictionary feeds `presignRequest.Metadata` and `RequiredHeaders`, so signature inputs and client headers stay symmetric by construction.
- 5 new unit tests pin the symmetry contract — they're the canary that catches future drift (case-insensitive lookup, custom-metadata prefixing, custom-overrides-builtin behaviour).

## Sequence of MinIO presign fixes

1. #2089 — initial presigned URL handling
2. #2211 — `S3PresignedUrlRewriter` forces `http://` on MinIO dev (frontend can now reach the endpoint without TLS errors)
3. **this PR** — `RequiredHeaders` now mirrors the signed metadata so the canonical-request signatures match

## Notes / open questions

- **Filename encoding**: AWSSDK V4 `MetadataCollection` stores values verbatim and signs the raw bytes. Non-ASCII characters in `BlobUploadRequest.FileName` will be signed as-is; the client must transmit the same raw bytes on the wire. That's fragile (HTTP/1.1 header values are nominally ASCII) but matches what the SDK signed — documented as a caveat in the helper's XML doc. A separate hardening pass should consider rejecting non-ASCII filenames upstream.
- **Header casing**: AWS SigV4 canonicalises headers to lowercase. Dictionary uses `OrdinalIgnoreCase` so consumers can read keys by any casing; the wire still sees the lowercase form the SDK signed.
- **No live integration test**: `S3BlobClient` is `[ExcludeFromCodeCoverage]` (no Testcontainers infra in `Granit.BlobStorage.S3.Tests`). Coverage comes from the pure helper instead — a Testcontainers MinIO run is a worthwhile follow-up but is out of scope for this fix.
- **Symmetric concern on download**: `GenerateDownloadUrlAsync` only sets `ResponseHeaderOverrides.ContentDisposition`, which is signed as a query-string param (`response-content-disposition`), not as a request header — so the GET flow has no analogous header-symmetry trap.

## Test plan

- [x] `dotnet test tests/Granit.BlobStorage.S3.Tests` — 48 passed (43 prior + 5 new)
- [x] `dotnet format --verify-no-changes` clean on the 3 touched files
- [ ] CI green on `infrastructure` shard
- [ ] Manual verification on the showcase: upload via presigned PUT to MinIO returns 200 (no 400 SignatureDoesNotMatch)