### PR TITLE
fix(blob-storage): cancel-pending endpoint, valid-only default filter, configurable orphan window

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -9759,6 +9759,15 @@
       "members": []
     },
     {
+      "name": "BlobCancelPendingRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobCancelPendingRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobCancelPendingRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "BlobCleanupOrphansResponse",
       "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobCleanupOrphansResponse",
       "kind": "record",
@@ -10331,6 +10340,12 @@
           "returnType": "Task<BlobConfirmationResult>"
         },
         {
+          "name": "CancelPendingUploadAsync",
+          "kind": "method",
+          "signature": "CancelPendingUploadAsync(string containerName, Guid blobId, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
           "name": "CleanupOrphansAsync",
           "kind": "method",
           "signature": "CleanupOrphansAsync(CancellationToken cancellationToken = default)",
@@ -10395,6 +10410,12 @@
           "kind": "property",
           "signature": "HashSet<string> AllowedContentTypes",
           "returnType": "HashSet<string>"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "bool RejectUnverifiedContentTypes { get; set; } public TimeSpan OrphanCleanupAge { get; set; } = TimeSpan."
         }
       ]
     },

--- a/src/Granit.BlobStorage.Endpoints/Dtos/BlobCancelPendingRequest.cs
+++ b/src/Granit.BlobStorage.Endpoints/Dtos/BlobCancelPendingRequest.cs
@@ -1,0 +1,8 @@
+namespace Granit.BlobStorage.Endpoints.Dtos;
+
+/// <summary>
+/// Request to cancel a Pending upload whose presigned PUT failed client-side.
+/// </summary>
+/// <param name="ContainerName">Logical container the blob belongs to.</param>
+/// <param name="Reason">Human-readable cancellation reason for the audit trail (e.g. <c>"PUT returned 400 SignatureDoesNotMatch"</c>).</param>
+public sealed record BlobCancelPendingRequest(string ContainerName, string Reason);

--- a/src/Granit.BlobStorage.Endpoints/Endpoints/BlobOperationEndpoints.cs
+++ b/src/Granit.BlobStorage.Endpoints/Endpoints/BlobOperationEndpoints.cs
@@ -40,6 +40,21 @@ internal static class BlobOperationEndpoints
             .ProducesProblem(StatusCodes.Status429TooManyRequests)
             .RequireGranitRateLimiting(BlobStorageRateLimitPolicies.Download);
 
+        group.MapDelete("/{id:guid}/pending", CancelPendingUploadAsync)
+            .WithName("CancelPendingBlobUpload")
+            .WithSummary("Cancels a Pending upload whose presigned PUT failed client-side.")
+            .WithDescription(
+                "Short-circuits the orphan-cleanup window by transitioning a Pending blob directly to Rejected. "
+                + "Intended to be called by the client when its PUT to the presigned URL returns 4xx/5xx, "
+                + "so the descriptor does not linger visible for up to BlobStorageOptions.OrphanCleanupAge. "
+                + "Returns 409 Conflict if the blob has already left Pending state.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests)
+            .RequireGranitRateLimiting(BlobStorageRateLimitPolicies.Upload);
+
         group.MapPost("/cleanup-orphans", CleanupOrphansAsync)
             .WithName("CleanupOrphanedBlobs")
             .WithSummary("Cleans up orphaned blobs stuck in Pending or Uploading state.")
@@ -90,6 +105,19 @@ internal static class BlobOperationEndpoints
             .ConfigureAwait(false);
 
         return TypedResults.Ok(new BlobDownloadUrlResponse(url.Url.ToString(), url.ExpiresAt));
+    }
+
+    private static async Task<NoContent> CancelPendingUploadAsync(
+        Guid id,
+        BlobCancelPendingRequest request,
+        [FromServices] IBlobStorage blobStorage,
+        CancellationToken cancellationToken)
+    {
+        await blobStorage
+            .CancelPendingUploadAsync(request.ContainerName, id, request.Reason, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.NoContent();
     }
 
     private static async Task<Ok<BlobCleanupOrphansResponse>> CleanupOrphansAsync(

--- a/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
+++ b/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
@@ -40,6 +40,11 @@ internal sealed class BlobStorageSchemaExampleProvider : ISchemaExampleProvider
             {
                 [ContainerNameProperty] = ExampleContainerName,
             },
+            [typeof(BlobCancelPendingRequest)] = new JsonObject
+            {
+                [ContainerNameProperty] = ExampleContainerName,
+                ["reason"] = "PUT to presigned URL returned 400 SignatureDoesNotMatch",
+            },
             [typeof(BlobDeleteRequest)] = new JsonObject
             {
                 [ContainerNameProperty] = ExampleContainerName,

--- a/src/Granit.BlobStorage.Endpoints/Validators/BlobCancelPendingRequestValidator.cs
+++ b/src/Granit.BlobStorage.Endpoints/Validators/BlobCancelPendingRequestValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using Granit.BlobStorage.Endpoints.Dtos;
+
+namespace Granit.BlobStorage.Endpoints.Validators;
+
+internal sealed class BlobCancelPendingRequestValidator : AbstractValidator<BlobCancelPendingRequest>
+{
+    public BlobCancelPendingRequestValidator()
+    {
+        RuleFor(x => x.ContainerName)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Reason)
+            .NotEmpty()
+            .MaximumLength(512);
+    }
+}

--- a/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
+++ b/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
@@ -161,6 +161,28 @@ public sealed class BlobDescriptor : CreationAuditedAggregateRoot, IMultiTenant
     }
 
     /// <summary>
+    /// Transitions from <see cref="BlobStatus.Pending"/> directly to <see cref="BlobStatus.Rejected"/>,
+    /// short-circuiting the upload lifecycle when the client knows the PUT will not complete
+    /// (e.g. presigned URL returned 4xx, user aborted the dialog). The caller should attempt to
+    /// delete any partially-uploaded S3 object beforehand.
+    /// </summary>
+    /// <param name="reason">Human-readable rejection reason for the audit trail.</param>
+    /// <exception cref="InvalidOperationException">When current status is not <see cref="BlobStatus.Pending"/>.</exception>
+    public void MarkAsCancelled(string reason)
+    {
+        if (Status != BlobStatus.Pending)
+        {
+            throw new InvalidOperationException(
+                $"Cannot cancel BlobDescriptor {Id}: current status is {Status} (expected {BlobStatus.Pending}).");
+        }
+
+        Status = BlobStatus.Rejected;
+        RejectionReason = reason;
+
+        AddDomainEvent(new BlobRejectedEvent(Id, ContainerName, reason));
+    }
+
+    /// <summary>
     /// Transitions from <see cref="BlobStatus.Valid"/> to <see cref="BlobStatus.Deleted"/>.
     /// The S3 object must be physically deleted by the caller before invoking this method.
     /// The record is retained in the database for ISO 27001 audit compliance.

--- a/src/Granit.BlobStorage/IBlobStorage.cs
+++ b/src/Granit.BlobStorage/IBlobStorage.cs
@@ -81,7 +81,28 @@ public interface IBlobStorage
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Cleans up orphaned blobs stuck in Pending/Uploading for over 24 hours.
+    /// Short-circuits a Pending upload that the client knows will never complete
+    /// (e.g. presigned PUT returned 4xx, user cancelled), transitioning the descriptor
+    /// to <see cref="BlobStatus.Rejected"/> immediately instead of waiting for the orphan
+    /// cleanup window. Attempts a best-effort delete of any partially-uploaded S3 object.
+    /// </summary>
+    /// <param name="containerName">Logical container the blob belongs to.</param>
+    /// <param name="blobId">Blob identifier returned by <see cref="InitiateUploadAsync"/>.</param>
+    /// <param name="reason">Human-readable cancellation reason for the audit trail.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="Exceptions.BlobNotFoundException">Blob not found for the current tenant.</exception>
+    /// <exception cref="Granit.Exceptions.ConflictException">
+    /// Blob exists but is not in <see cref="BlobStatus.Pending"/> state.
+    /// </exception>
+    Task CancelPendingUploadAsync(
+        string containerName,
+        Guid blobId,
+        string reason,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Cleans up orphaned blobs stuck in Pending/Uploading beyond
+    /// <see cref="BlobStorageOptions.OrphanCleanupAge"/> (default 24 hours).
     /// </summary>
     Task<int> CleanupOrphansAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Granit.BlobStorage/Internal/DefaultBlobStorage.cs
+++ b/src/Granit.BlobStorage/Internal/DefaultBlobStorage.cs
@@ -3,6 +3,7 @@ using Granit.BlobStorage.Diagnostics;
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Exceptions;
 using Granit.BlobStorage.Options;
+using Granit.Exceptions;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Timing;
@@ -212,9 +213,43 @@ internal sealed partial class DefaultBlobStorage(
     }
 
     /// <inheritdoc/>
+    public async Task CancelPendingUploadAsync(
+        string containerName,
+        Guid blobId,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        BlobDescriptor descriptor = await FindOrThrowAsync(containerName, blobId, cancellationToken).ConfigureAwait(false);
+
+        if (descriptor.Status != BlobStatus.Pending)
+        {
+            throw new ConflictException(
+                "BlobStorage:NotPending",
+                $"Blob '{blobId}' cannot be cancelled: current status is '{descriptor.Status}' (expected '{BlobStatus.Pending}').");
+        }
+
+        // Best-effort cleanup of any partially-uploaded S3 object. The PUT may have streamed
+        // bytes before failing, or the client may simply have abandoned mid-flight.
+        string bucket = keyStrategy.ResolveBucketName(containerName);
+        try
+        {
+            await storeProvider.DeleteAsync(bucket, descriptor.ObjectKey, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogCancelDeleteFailed(blobId, ex);
+        }
+
+        descriptor.MarkAsCancelled(reason);
+        await writer.UpdateAsync(descriptor, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
     public async Task<int> CleanupOrphansAsync(CancellationToken cancellationToken = default)
     {
-        DateTimeOffset cutoff = clock.Now.AddHours(-24);
+        DateTimeOffset cutoff = clock.Now.Subtract(Options.OrphanCleanupAge);
         IReadOnlyList<BlobDescriptor> orphans = await reader.FindOrphanedAsync(cutoff, batchSize: 100, cancellationToken).ConfigureAwait(false);
 
         int cleaned = 0;
@@ -255,4 +290,7 @@ internal sealed partial class DefaultBlobStorage(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete storage object for orphaned blob {BlobId} during cleanup.")]
     private partial void LogOrphanDeleteFailed(Guid blobId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Best-effort delete of storage object for cancelled blob {BlobId} failed; descriptor will still be marked rejected.")]
+    private partial void LogCancelDeleteFailed(Guid blobId, Exception exception);
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/cs.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/cs.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Požadovaný soubor nebyl nalezen.",
+    "BlobStorage:NotPending": "Nahrávání nelze zrušit, protože již není ve stavu čekání.",
     "BlobStorage:NotValid": "Soubor není dostupný ke stažení."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/de.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/de.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validiert am",
     "BlobStorage.Columns.VerifiedContentType": "Verifizierter Inhaltstyp",
     "BlobStorage:NotFound": "Die angeforderte Datei wurde nicht gefunden.",
+    "BlobStorage:NotPending": "Der Upload kann nicht abgebrochen werden, da er nicht mehr ausstehend ist.",
     "BlobStorage:NotValid": "Die Datei steht nicht zum Download zur Verfügung."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/en.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/en.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "The requested file was not found.",
+    "BlobStorage:NotPending": "The upload cannot be cancelled because it is no longer pending.",
     "BlobStorage:NotValid": "The file is not available for download."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/es.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/es.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validado el",
     "BlobStorage.Columns.VerifiedContentType": "Tipo de contenido verificado",
     "BlobStorage:NotFound": "El archivo solicitado no fue encontrado.",
+    "BlobStorage:NotPending": "La carga no puede cancelarse porque ya no está pendiente.",
     "BlobStorage:NotValid": "El archivo no está disponible para su descarga."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/fr.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/fr.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validé le",
     "BlobStorage.Columns.VerifiedContentType": "Type de contenu vérifié",
     "BlobStorage:NotFound": "Le fichier demandé est introuvable.",
+    "BlobStorage:NotPending": "Le téléversement ne peut pas être annulé car il n'est plus en attente.",
     "BlobStorage:NotValid": "Le fichier n'est pas disponible au téléchargement."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/hi.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/hi.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "अनुरोधित फ़ाइल नहीं मिली।",
+    "BlobStorage:NotPending": "अपलोड रद्द नहीं किया जा सकता क्योंकि यह अब लंबित नहीं है।",
     "BlobStorage:NotValid": "फ़ाइल डाउनलोड के लिए उपलब्ध नहीं है।"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/it.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/it.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Il file richiesto non è stato trovato.",
+    "BlobStorage:NotPending": "Il caricamento non può essere annullato perché non è più in sospeso.",
     "BlobStorage:NotValid": "Il file non è disponibile per il download."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/ja.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/ja.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "要求されたファイルが見つかりませんでした。",
+    "BlobStorage:NotPending": "アップロードは保留中ではないためキャンセルできません。",
     "BlobStorage:NotValid": "このファイルはダウンロードできません。"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/ko.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/ko.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "요청한 파일을 찾을 수 없습니다.",
+    "BlobStorage:NotPending": "업로드가 더 이상 대기 중이 아니므로 취소할 수 없습니다.",
     "BlobStorage:NotValid": "파일을 다운로드할 수 없습니다."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/nl.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/nl.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Gevalideerd op",
     "BlobStorage.Columns.VerifiedContentType": "Geverifieerd inhoudstype",
     "BlobStorage:NotFound": "Het gevraagde bestand werd niet gevonden.",
+    "BlobStorage:NotPending": "De upload kan niet worden geannuleerd omdat deze niet meer in behandeling is.",
     "BlobStorage:NotValid": "Het bestand is niet beschikbaar om te downloaden."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/pl.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/pl.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Żądany plik nie został znaleziony.",
+    "BlobStorage:NotPending": "Nie można anulować przesyłania, ponieważ nie jest już w stanie oczekiwania.",
     "BlobStorage:NotValid": "Plik nie jest dostępny do pobrania."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/pt.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/pt.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "O ficheiro solicitado não foi encontrado.",
+    "BlobStorage:NotPending": "O carregamento não pode ser cancelado porque já não está pendente.",
     "BlobStorage:NotValid": "O ficheiro não está disponível para transferência."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/sv.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/sv.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Den begärda filen hittades inte.",
+    "BlobStorage:NotPending": "Uppladdningen kan inte avbrytas eftersom den inte längre väntar.",
     "BlobStorage:NotValid": "Filen är inte tillgänglig för nedladdning."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/tr.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/tr.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "İstenen dosya bulunamadı.",
+    "BlobStorage:NotPending": "Yükleme bekleme durumunda olmadığı için iptal edilemez.",
     "BlobStorage:NotValid": "Dosya indirilebilir durumda değil."
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/zh.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/zh.json
@@ -13,6 +13,7 @@
     "BlobStorage.Columns.ValidatedAt": "Validated At",
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "请求的文件未找到。",
+    "BlobStorage:NotPending": "上传无法取消，因为它已不再处于待处理状态。",
     "BlobStorage:NotValid": "该文件不可下载。"
   }
 }

--- a/src/Granit.BlobStorage/Options/BlobStorageOptions.cs
+++ b/src/Granit.BlobStorage/Options/BlobStorageOptions.cs
@@ -26,4 +26,13 @@ public class BlobStorageOptions
     /// cannot be verified. Defaults to <c>false</c> (pass-through).
     /// </summary>
     public bool RejectUnverifiedContentTypes { get; set; }
+
+    /// <summary>
+    /// Minimum age a blob must reach in <see cref="Domain.BlobStatus.Pending"/> or
+    /// <see cref="Domain.BlobStatus.Uploading"/> before the orphan cleanup job rejects it.
+    /// Defaults to <c>24</c> hours, which is conservative enough to tolerate slow client uploads
+    /// and intermittent network retries. Showcases and CI environments may lower this to
+    /// surface failed flows faster.
+    /// </summary>
+    public TimeSpan OrphanCleanupAge { get; set; } = TimeSpan.FromHours(24);
 }

--- a/src/Granit.BlobStorage/Queries/BlobDescriptorQueryDefinition.cs
+++ b/src/Granit.BlobStorage/Queries/BlobDescriptorQueryDefinition.cs
@@ -30,6 +30,11 @@ public sealed class BlobDescriptorQueryDefinition : QueryDefinition<BlobDescript
             .Column(b => b.ValidatedAt, c => c.Label("Validated At").LabelKey("BlobStorage.Columns.ValidatedAt").Sortable())
             .Column(b => b.DeletedAt, c => c.Label("Deleted At").LabelKey("BlobStorage.Columns.DeletedAt").Sortable())
             .Column(b => b.RejectionReason, c => c.Label("Rejection Reason").LabelKey("BlobStorage.Columns.RejectionReason"))
+            .QuickFilter(
+                "ValidOnly",
+                "Valid uploads only",
+                b => b.Status == BlobStatus.Valid,
+                isDefault: true)
             .GlobalSearch(b => b.OriginalFileName, b => b.ContainerName)
             .DateFilter(b => b.CreatedAt)
             .DefaultSort("-createdAt")

--- a/tests/Granit.BlobStorage.Tests/BlobDescriptorQueryDefinitionTests.cs
+++ b/tests/Granit.BlobStorage.Tests/BlobDescriptorQueryDefinitionTests.cs
@@ -1,0 +1,74 @@
+using System.Linq.Expressions;
+using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Queries;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Tests;
+
+public sealed class BlobDescriptorQueryDefinitionTests
+{
+    [Fact]
+    public void Definition_DeclaresValidOnlyQuickFilter_ActiveByDefault()
+    {
+        // Guards the UI default: Pending/Rejected/Deleted blobs should NOT appear in the admin
+        // listing unless an admin explicitly toggles the filter off. Regression here re-exposes
+        // orphaned uploads (NaN GB rows from failed presigned PUTs).
+        BlobDescriptorQueryDefinition definition = new();
+
+        QuickFilterDescriptor filter = definition.GetQuickFilters().ShouldHaveSingleItem();
+
+        filter.Name.ShouldBe("ValidOnly");
+        filter.IsDefault.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ValidOnlyQuickFilter_PredicateMatchesValidStatusOnly()
+    {
+        BlobDescriptorQueryDefinition definition = new();
+        QuickFilterDescriptor filter = definition.GetQuickFilters().Single();
+        Func<BlobDescriptor, bool> predicate = ((Expression<Func<BlobDescriptor, bool>>)filter.Predicate).Compile();
+
+        predicate(BuildDescriptor(BlobStatus.Valid)).ShouldBeTrue();
+        predicate(BuildDescriptor(BlobStatus.Pending)).ShouldBeFalse();
+        predicate(BuildDescriptor(BlobStatus.Uploading)).ShouldBeFalse();
+        predicate(BuildDescriptor(BlobStatus.Rejected)).ShouldBeFalse();
+        predicate(BuildDescriptor(BlobStatus.Deleted)).ShouldBeFalse();
+    }
+
+    private static BlobDescriptor BuildDescriptor(BlobStatus status)
+    {
+        var descriptor = BlobDescriptor.Create(
+            id: Guid.NewGuid(),
+            tenantId: Guid.NewGuid(),
+            containerName: "documents",
+            objectKey: "tenant/documents/2026/05/abc",
+            request: new BlobUploadRequest("f.pdf", "application/pdf", 1024),
+            createdAt: DateTimeOffset.UtcNow);
+
+        DateTimeOffset later = DateTimeOffset.UtcNow.AddMinutes(5);
+        switch (status)
+        {
+            case BlobStatus.Pending:
+                break;
+            case BlobStatus.Uploading:
+                descriptor.MarkAsUploading();
+                break;
+            case BlobStatus.Valid:
+                descriptor.MarkAsUploading();
+                descriptor.MarkAsValid("application/pdf", 1024, later);
+                break;
+            case BlobStatus.Rejected:
+                descriptor.MarkAsUploading();
+                descriptor.MarkAsRejected("test");
+                break;
+            case BlobStatus.Deleted:
+                descriptor.MarkAsUploading();
+                descriptor.MarkAsValid("application/pdf", 1024, later);
+                descriptor.MarkAsDeleted(later);
+                break;
+        }
+        return descriptor;
+    }
+}

--- a/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
+++ b/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
@@ -133,6 +133,45 @@ public sealed class BlobDescriptorTests
         Should.Throw<InvalidOperationException>(act).Message.ShouldContain($"{illegalStatus}");
     }
 
+    // ── Pending → Rejected (cancellation short-circuit) ──────────────────────
+
+    [Fact]
+    public void MarkAsCancelled_FromPending_ShouldTransitionToRejectedWithReason()
+    {
+        BlobDescriptor descriptor = CreatePending();
+
+        descriptor.MarkAsCancelled("PUT returned 400 SignatureDoesNotMatch");
+
+        descriptor.Status.ShouldBe(BlobStatus.Rejected);
+        descriptor.RejectionReason!.ShouldContain("SignatureDoesNotMatch");
+    }
+
+    [Fact]
+    public void MarkAsCancelled_ShouldEmitBlobRejectedEvent()
+    {
+        BlobDescriptor descriptor = CreatePending();
+
+        descriptor.MarkAsCancelled("client abort");
+
+        BlobRejectedEvent evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobRejectedEvent>();
+        evt.BlobId.ShouldBe(descriptor.Id);
+        evt.RejectionReason.ShouldBe("client abort");
+    }
+
+    [Theory]
+    [InlineData(BlobStatus.Uploading)]
+    [InlineData(BlobStatus.Valid)]
+    [InlineData(BlobStatus.Rejected)]
+    [InlineData(BlobStatus.Deleted)]
+    public void MarkAsCancelled_FromIllegalStatus_ShouldThrow(BlobStatus illegalStatus)
+    {
+        BlobDescriptor descriptor = BuildDescriptorInStatus(illegalStatus);
+
+        Action act = () => descriptor.MarkAsCancelled("anything");
+
+        Should.Throw<InvalidOperationException>(act).Message.ShouldContain($"{illegalStatus}");
+    }
+
     // ── Valid → Deleted (Crypto-Shredding) ───────────────────────────────────
 
     [Fact]

--- a/tests/Granit.BlobStorage.Tests/BlobStorageOptionsTests.cs
+++ b/tests/Granit.BlobStorage.Tests/BlobStorageOptionsTests.cs
@@ -46,4 +46,23 @@ public sealed class BlobStorageOptionsTests
 
         options.DownloadUrlExpiry.ShouldBe(TimeSpan.FromHours(1));
     }
+
+    [Fact]
+    public void DefaultOrphanCleanupAge_Is24Hours()
+    {
+        BlobStorageOptions options = new();
+
+        options.OrphanCleanupAge.ShouldBe(TimeSpan.FromHours(24));
+    }
+
+    [Fact]
+    public void OrphanCleanupAge_CanBeCustomized()
+    {
+        BlobStorageOptions options = new()
+        {
+            OrphanCleanupAge = TimeSpan.FromMinutes(15),
+        };
+
+        options.OrphanCleanupAge.ShouldBe(TimeSpan.FromMinutes(15));
+    }
 }

--- a/tests/Granit.BlobStorage.Tests/DefaultBlobStorageTests.cs
+++ b/tests/Granit.BlobStorage.Tests/DefaultBlobStorageTests.cs
@@ -4,6 +4,7 @@ using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Exceptions;
 using Granit.BlobStorage.Internal;
 using Granit.BlobStorage.Options;
+using Granit.Exceptions;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Timing;
@@ -401,7 +402,100 @@ public sealed class DefaultBlobStorageTests
         await Should.ThrowAsync<BlobNotValidException>(() => _sut.ConfirmUploadAsync("medical-images", blobId));
     }
 
+    // ── CancelPendingUploadAsync ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task CancelPendingUploadAsync_WhenPending_ShouldTransitionToRejectedAndAttemptDelete()
+    {
+        var blobId = Guid.NewGuid();
+        BlobDescriptor pending = BuildDescriptorInStatus(blobId, BlobStatus.Pending);
+        _reader.FindAsync(blobId, Arg.Any<CancellationToken>()).Returns(pending);
+        _keyStrategy.ResolveBucketName("medical-images").Returns("granit-blobs");
+
+        await _sut.CancelPendingUploadAsync("medical-images", blobId, "PUT returned 400", TestContext.Current.CancellationToken);
+
+        await _storeProvider.Received(1).DeleteAsync("granit-blobs", pending.ObjectKey, Arg.Any<CancellationToken>());
+        await _writer.Received(1).UpdateAsync(
+            Arg.Is<BlobDescriptor>(d =>
+                d.Id == blobId &&
+                d.Status == BlobStatus.Rejected &&
+                d.RejectionReason == "PUT returned 400"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelPendingUploadAsync_WhenStoreDeleteFails_ShouldStillTransitionToRejected()
+    {
+        var blobId = Guid.NewGuid();
+        BlobDescriptor pending = BuildDescriptorInStatus(blobId, BlobStatus.Pending);
+        _reader.FindAsync(blobId, Arg.Any<CancellationToken>()).Returns(pending);
+        _keyStrategy.ResolveBucketName("medical-images").Returns("granit-blobs");
+        _storeProvider.DeleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => throw new InvalidOperationException("S3 unreachable"));
+
+        await _sut.CancelPendingUploadAsync("medical-images", blobId, "client abort", TestContext.Current.CancellationToken);
+
+        await _writer.Received(1).UpdateAsync(
+            Arg.Is<BlobDescriptor>(d => d.Status == BlobStatus.Rejected),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelPendingUploadAsync_WhenBlobNotFound_ShouldThrow()
+    {
+        var blobId = Guid.NewGuid();
+        _reader.FindAsync(blobId, Arg.Any<CancellationToken>()).Returns((BlobDescriptor?)null);
+
+        await Should.ThrowAsync<BlobNotFoundException>(() =>
+            _sut.CancelPendingUploadAsync("medical-images", blobId, "anything"));
+    }
+
+    [Theory]
+    [InlineData(BlobStatus.Uploading)]
+    [InlineData(BlobStatus.Valid)]
+    [InlineData(BlobStatus.Rejected)]
+    [InlineData(BlobStatus.Deleted)]
+    public async Task CancelPendingUploadAsync_WhenNotPending_ShouldThrowConflictException(BlobStatus current)
+    {
+        var blobId = Guid.NewGuid();
+        _reader.FindAsync(blobId, Arg.Any<CancellationToken>()).Returns(BuildDescriptorInStatus(blobId, current));
+
+        ConflictException ex = await Should.ThrowAsync<ConflictException>(() =>
+            _sut.CancelPendingUploadAsync("medical-images", blobId, "anything"));
+        ex.ErrorCode.ShouldBe("BlobStorage:NotPending");
+    }
+
+    [Fact]
+    public async Task CancelPendingUploadAsync_WithEmptyReason_ShouldThrow()
+    {
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.CancelPendingUploadAsync("medical-images", Guid.NewGuid(), "   "));
+    }
+
     // ── CleanupOrphansAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CleanupOrphansAsync_ShouldUseConfiguredOrphanCleanupAgeForCutoff()
+    {
+        // Custom 1h cleanup age — cutoff must be Now - 1h, not the hard-coded 24h default.
+        DefaultBlobStorage sut = new(
+            _reader, _writer, _keyStrategy, _storeProvider, _presignedUrlProvider,
+            [], _guidGenerator, _clock, _currentTenant, _metrics,
+            NullLogger<DefaultBlobStorage>.Instance,
+            Microsoft.Extensions.Options.Options.Create(new BlobStorageOptions
+            {
+                OrphanCleanupAge = TimeSpan.FromHours(1),
+            }));
+        _reader.FindOrphanedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<BlobDescriptor>());
+
+        await sut.CleanupOrphansAsync(TestContext.Current.CancellationToken);
+
+        await _reader.Received(1).FindOrphanedAsync(
+            Now.AddHours(-1),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task CleanupOrphansAsync_ShouldRejectOrphans()


### PR DESCRIPTION
## Summary

Closes the UX leak surfaced alongside #2213: a failed presigned PUT left a `Pending` `BlobDescriptor` visible in the admin listing for up to 24h with `NaN GB` size and an empty status. This PR consolidates three independent gaps into one change set.

## A. Default `ValidOnly` quick filter

`BlobDescriptorQueryDefinition` now declares a `ValidOnly` quick filter active by default. The query still exposes every state — admins can toggle the filter off to see orphans / rejections — but the default view is clean. Status column already filterable; no change to the audit trail.

## B. `DELETE /api/blob-storage/blobs/{id}/pending` cancel endpoint

When the client knows its presigned PUT will not complete (4xx returned, user aborts), it can now call:

```
DELETE /api/blob-storage/blobs/{id}/pending
Body: { "containerName": "...", "reason": "PUT returned 400 SignatureDoesNotMatch" }
```

- New aggregate transition `BlobDescriptor.MarkAsCancelled(reason)` — `Pending → Rejected`, emits `BlobRejectedEvent` (existing audit event reused).
- `DefaultBlobStorage.CancelPendingUploadAsync` attempts a best-effort delete of any partially-uploaded S3 object, then persists the transition.
- `404` for unknown blob (`BlobNotFoundException`), `409` (`BlobStorage:NotPending`) for any non-Pending status, `204` on success.
- Rate-limited under the existing `Upload` policy.

## C. `BlobStorageOptions.OrphanCleanupAge`

Replaces the hardcoded `24h` cutoff in `DefaultBlobStorage.CleanupOrphansAsync`. Default unchanged (24h is conservative for prod), but showcases / CI can lower it without touching code:

```json
"BlobStorage": { "OrphanCleanupAge": "00:15:00" }
```

## Localization

`BlobStorage:NotPending` added to all 15 base culture files (cs, de, en, es, fr, hi, it, ja, ko, nl, pl, pt, sv, tr, zh). Regional files (`en-GB`, `fr-CA`, `pt-BR`) inherit per the existing pattern.

## Out of scope (frontend, separate repos)

- `formatBytes(null) → "—"` (showcase-react) — fixes the `NaN GB` rendering.
- `BlobStatus` enum → localized chip mapping.
- Frontend hook to call the new DELETE endpoint on PUT failure (showcase-react / docs callout).

## Follow-up to

- #2211 — `S3PresignedUrlRewriter` (http scheme for MinIO dev)
- #2213 — `RequiredHeaders` symmetry with signed `x-amz-meta-*`

## Test plan

- [x] `tests/Granit.BlobStorage.Tests` — 149 passed (cancel-flow, NotPending → 409, options default, query default filter, predicate)
- [x] `tests/Granit.BlobStorage.Endpoints.Tests` — 58 passed
- [x] `tests/Granit.BlobStorage.EntityFrameworkCore.Tests` — 15 passed
- [x] `tests/Granit.Privacy.BlobStorage.Tests` — 21 passed (downstream `IBlobStorage` consumer)
- [x] `dotnet format --verify-no-changes` clean on every touched file
- [x] JSON validity check on all 18 culture files
- [ ] CI green on `application` shard (includes architecture / localization-shape tests)
- [ ] Manual smoke: showcase upload fails → DELETE `/pending` returns 204 → listing no longer shows the orphan