### PR TITLE
feat(persistence): auto-persist enums as varchar via ApplyGranitConventions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -15405,6 +15405,15 @@
       ]
     },
     {
+      "name": "PersistAsIntAttribute",
+      "fqn": "Granit.Domain.PersistAsIntAttribute",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Domain/PersistAsIntAttribute.cs",
+      "line": 28,
+      "members": []
+    },
+    {
       "name": "SingleValueObject",
       "fqn": "Granit.Domain.SingleValueObject",
       "kind": "class",
@@ -33103,12 +33112,21 @@
       "members": []
     },
     {
+      "name": "MigrationBuilderExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.MigrationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/MigrationBuilderExtensions.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "ModelBuilderExtensions",
       "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.ModelBuilderExtensions",
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "ApplyGranitConventions",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,12 @@ Every `*.Endpoints` module attaches `.WithTags(...)` on its root group. Format: 
 
 Reference: [`docs/framework/data/persistence.md`](docs/framework/data/persistence.md).
 
+### Enum persistence (STRICT)
+
+Every enum property on an entity is persisted as its **PascalCase string name in a `varchar` column** by `ApplyGranitConventions` — no `.HasConversion<string>()` boilerplate in `*Configuration.cs`. Default column width is `max(20, longestValueName + 4)`; an explicit `.HasMaxLength(N)` always wins. Rationale: lisibility for ops/SQL audits, refactor safety, symmetry with the wire format (`JsonStringEnumConverter`).
+
+Opt out per-property with `[PersistAsInt]` (in `Granit.Domain`) — reserve for `[Flags]` bitmasks (auto-skipped anyway), high-write tables where 4 bytes/row matter, or pre-existing DB contracts. Document the reason inline. Migration helper `MigrationBuilderExtensions.AlterEnumColumnIntToString<TEnum>` emits the mandatory PostgreSQL `USING CASE` clause when cascading the convention into apps with existing int columns.
+
 ### DDD — AggregateRoot vs Entity
 
 `AggregateRoot` (or audited variants) when the entity has a state machine, raises domain events, or encapsulates invariants. Plain `Entity` for append-only / config / lookup.

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/Configurations/AuditEntityChangeConfiguration.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/Configurations/AuditEntityChangeConfiguration.cs
@@ -31,7 +31,6 @@ internal sealed class AuditEntityChangeConfiguration : IEntityTypeConfiguration<
             .IsRequired();
 
         builder.Property(e => e.ChangeType)
-            .HasConversion<string>()
             .HasMaxLength(20)
             .IsRequired();
 

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/Configurations/AuditEntryConfiguration.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/Configurations/AuditEntryConfiguration.cs
@@ -30,7 +30,6 @@ internal sealed class AuditEntryConfiguration : IEntityTypeConfiguration<AuditEn
             .HasMaxLength(256);
 
         builder.Property(e => e.Category)
-            .HasConversion<string>()
             .HasMaxLength(50)
             .IsRequired();
 

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
@@ -44,7 +44,7 @@ internal sealed class ApiKeyEntryConfiguration : IEntityTypeConfiguration<ApiKey
         builder.Property(e => e.ModifiedBy).HasMaxLength(200);
         builder.Property(e => e.DeletedBy).HasMaxLength(200);
 
-        builder.Property(e => e.Type).HasConversion<string>().HasMaxLength(20);
-        builder.Property(e => e.CacheBehavior).HasConversion<string>().HasMaxLength(20);
+        builder.Property(e => e.Type).HasMaxLength(20);
+        builder.Property(e => e.CacheBehavior).HasMaxLength(20);
     }
 }

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobDescriptorConfiguration.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobDescriptorConfiguration.cs
@@ -46,10 +46,10 @@ internal sealed class BlobDescriptorConfiguration : IEntityTypeConfiguration<Blo
 
         builder.Property(e => e.SizeBytes);
 
-        // Store enum as string for readability and resilience to reordering.
+        // Persisted as varchar by the Granit enum convention; explicit max length
+        // keeps the original column width.
         builder.Property(e => e.Status)
             .IsRequired()
-            .HasConversion<string>()
             .HasMaxLength(20);
 
         builder.Property(e => e.CreatedAt)

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ImportJobConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ImportJobConfiguration.cs
@@ -26,7 +26,6 @@ internal sealed class ImportJobConfiguration : IEntityTypeConfiguration<ImportJo
 
         builder.Property(e => e.Status)
             .IsRequired()
-            .HasConversion<string>()
             .HasMaxLength(20);
 
         builder.OwnsMany(e => e.Mappings, m =>

--- a/src/Granit.Notifications.EntityFrameworkCore/Configurations/MobilePushTokenConfiguration.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Configurations/MobilePushTokenConfiguration.cs
@@ -25,7 +25,7 @@ internal sealed class MobilePushTokenConfiguration : IEntityTypeConfiguration<Mo
         // TenantId for exact-match upsert / remove on the encrypted token column.
         builder.Property(x => x.DeviceTokenHash).HasMaxLength(64).IsRequired();
 
-        builder.Property(x => x.Platform).HasConversion<string>().HasMaxLength(16);
+        builder.Property(x => x.Platform).HasMaxLength(16);
         builder.Property(x => x.CreatedBy).HasMaxLength(256);
 
         // Unique constraint: one device token per tenant — keyed on the lookup

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/MigrationBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/MigrationBuilderExtensions.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+
+namespace Granit.Persistence.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Helpers for writing EF Core migrations that follow Granit conventions.
+/// </summary>
+/// <remarks>
+/// Designed for PostgreSQL — uses <c>varchar</c> and PG's <c>USING</c> clause syntax.
+/// SQL Server / SQLite would need adapted flavours.
+/// </remarks>
+public static class MigrationBuilderExtensions
+{
+    /// <summary>
+    /// Emits an <c>ALTER COLUMN</c> that converts an enum column from <c>integer</c>
+    /// to <c>varchar(N)</c> with a <c>USING CASE</c> clause that maps each enum
+    /// ordinal to its PascalCase name. Paired with the Granit enum persistence
+    /// convention applied by <c>ApplyGranitConventions</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// EF Core does <b>not</b> generate the <c>USING CASE</c> clause automatically.
+    /// Without it, PostgreSQL either rejects the migration (no implicit cast) or, if
+    /// you use the naive <c>USING status::varchar</c>, silently corrupts data by
+    /// writing <c>"0"</c>, <c>"1"</c>, … instead of the enum names. This helper
+    /// generates the correct clause from the enum's reflected values.
+    /// </para>
+    /// <para>Use it inside a migration's <c>Up()</c> method:</para>
+    /// <code>
+    /// migrationBuilder.AlterEnumColumnIntToString&lt;ExportJobStatus&gt;(
+    ///     table: "data_exchange_export_jobs",
+    ///     column: "status");
+    /// </code>
+    /// <para>Pair with <see cref="AlterEnumColumnStringToInt{TEnum}"/> in <c>Down()</c>.</para>
+    /// </remarks>
+    /// <typeparam name="TEnum">The enum type backing the column. Must be int-based.</typeparam>
+    /// <param name="migrationBuilder">The migration builder.</param>
+    /// <param name="table">Unqualified table name.</param>
+    /// <param name="column">Column name to alter.</param>
+    /// <param name="schema">Optional schema name; <c>null</c> targets the default schema.</param>
+    /// <param name="maxLength">
+    /// Explicit <c>varchar</c> length. When <c>null</c> (default), uses
+    /// <c>max(20, longestEnumValueName + 4)</c> — matches the convention auto-applied
+    /// by <see cref="ModelBuilderExtensions.ApplyGranitConventions"/>.
+    /// </param>
+    public static OperationBuilder<SqlOperation> AlterEnumColumnIntToString<TEnum>(
+        this MigrationBuilder migrationBuilder,
+        string table,
+        string column,
+        string? schema = null,
+        int? maxLength = null)
+        where TEnum : struct, Enum
+    {
+        ArgumentNullException.ThrowIfNull(migrationBuilder);
+        ArgumentException.ThrowIfNullOrEmpty(table);
+        ArgumentException.ThrowIfNullOrEmpty(column);
+
+        int length = maxLength ?? Math.Max(20, Enum.GetNames<TEnum>().Max(name => name.Length) + 4);
+        string qualifiedTable = QualifyTable(table, schema);
+        string quotedColumn = Quote(column);
+
+        StringBuilder caseClause = new();
+        caseClause.Append("CASE ").Append(quotedColumn).Append(' ');
+        foreach (TEnum value in Enum.GetValues<TEnum>())
+        {
+            long ordinal = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+            caseClause.Append("WHEN ").Append(ordinal.ToString(CultureInfo.InvariantCulture))
+                .Append(" THEN '").Append(value.ToString()).Append("' ");
+        }
+
+        caseClause.Append("END");
+
+        string sql = $"ALTER TABLE {qualifiedTable} ALTER COLUMN {quotedColumn} TYPE varchar({length}) USING {caseClause};";
+        return migrationBuilder.Sql(sql);
+    }
+
+    /// <summary>
+    /// Inverse of <see cref="AlterEnumColumnIntToString{TEnum}"/>. Converts a
+    /// <c>varchar</c> enum column back to <c>integer</c> via a <c>USING CASE</c>
+    /// clause mapping each PascalCase name to its ordinal. Use in a migration's
+    /// <c>Down()</c> method to make the migration reversible.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type backing the column. Must be int-based.</typeparam>
+    /// <param name="migrationBuilder">The migration builder.</param>
+    /// <param name="table">Unqualified table name.</param>
+    /// <param name="column">Column name to alter.</param>
+    /// <param name="schema">Optional schema name; <c>null</c> targets the default schema.</param>
+    public static OperationBuilder<SqlOperation> AlterEnumColumnStringToInt<TEnum>(
+        this MigrationBuilder migrationBuilder,
+        string table,
+        string column,
+        string? schema = null)
+        where TEnum : struct, Enum
+    {
+        ArgumentNullException.ThrowIfNull(migrationBuilder);
+        ArgumentException.ThrowIfNullOrEmpty(table);
+        ArgumentException.ThrowIfNullOrEmpty(column);
+
+        string qualifiedTable = QualifyTable(table, schema);
+        string quotedColumn = Quote(column);
+
+        StringBuilder caseClause = new();
+        caseClause.Append("CASE ").Append(quotedColumn).Append(' ');
+        foreach (TEnum value in Enum.GetValues<TEnum>())
+        {
+            long ordinal = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+            caseClause.Append("WHEN '").Append(value.ToString())
+                .Append("' THEN ").Append(ordinal.ToString(CultureInfo.InvariantCulture)).Append(' ');
+        }
+
+        caseClause.Append("END");
+
+        string sql = $"ALTER TABLE {qualifiedTable} ALTER COLUMN {quotedColumn} TYPE integer USING {caseClause};";
+        return migrationBuilder.Sql(sql);
+    }
+
+    // PostgreSQL identifier quoting (double quotes preserve case + reserved words).
+    private static string Quote(string identifier) => $"\"{identifier}\"";
+
+    private static string QualifyTable(string table, string? schema)
+        => schema is null ? Quote(table) : $"{Quote(schema)}.{Quote(table)}";
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.ValueConverters;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Granit.Persistence.EntityFrameworkCore.Extensions;
 
@@ -45,6 +46,13 @@ public static class ModelBuilderExtensions
     ///   </item>
     ///   <item><b>Translation conventions</b>:
     ///     <see cref="ITranslation{TParent}"/> → FK, cascade delete, unique index (ParentId, Culture).
+    ///   </item>
+    ///   <item><b>Enum persistence convention</b>:
+    ///     Every enum property is persisted as its PascalCase string name in a
+    ///     <c>varchar</c> column sized to the longest value (min 20). Opt out per
+    ///     property with <see cref="PersistAsIntAttribute"/>; <see cref="FlagsAttribute"/>
+    ///     enums are skipped automatically. Explicit
+    ///     <c>HasConversion&lt;...&gt;()</c> calls in entity configurations always win.
     ///   </item>
     /// </list>
     /// </summary>
@@ -168,7 +176,77 @@ public static class ModelBuilderExtensions
         //    SingleValueObject<T>, mapping them to the underlying primitive column type.
         ApplySingleValueObjectConverters(modelBuilder);
 
+        // --- Enum persistence convention ---
+        // Persist enum properties as their PascalCase string name (varchar) by default.
+        // Opt out per property with [PersistAsInt]; [Flags] enums are skipped automatically.
+        ApplyEnumStringConverters(modelBuilder);
+
         return modelBuilder;
+    }
+
+    // Auto-applies EnumToStringConverter<TEnum> to every enum property in the model,
+    // unless an explicit converter is already configured, the property is marked
+    // [PersistAsInt], or the enum carries [Flags] (bitmask semantics).
+    //
+    // Rationale: persisting enums as their string name (e.g. "Pending") instead of
+    // the underlying ordinal (e.g. 0) protects against silent breakage when enum
+    // values are reordered, and keeps the database lisible for ops/SQL audits. The
+    // wire format already uses string names via JsonStringEnumConverter — this
+    // convention restores symmetry between the HTTP surface and the DB columns.
+    private static void ApplyEnumStringConverters(ModelBuilder modelBuilder)
+    {
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (IMutableProperty property in entityType.GetProperties())
+            {
+                Type? enumType = GetEnumType(property.ClrType);
+                if (enumType is null)
+                {
+                    continue;
+                }
+
+                // Respect explicit overrides: a HasConversion<...>() call in the
+                // entity configuration always wins over the convention.
+                if (property.GetValueConverter() is not null)
+                {
+                    continue;
+                }
+
+                // Skip opt-out: property marked [PersistAsInt] with a documented reason.
+                if (property.PropertyInfo?.GetCustomAttribute<PersistAsIntAttribute>() is not null)
+                {
+                    continue;
+                }
+
+                // [Flags] enums encode multiple values bitwise — storing them as a single
+                // string name would lose information. Keep the int column unless an
+                // explicit converter was configured above.
+                if (enumType.GetCustomAttribute<FlagsAttribute>() is not null)
+                {
+                    continue;
+                }
+
+                Type converterType = typeof(EnumToStringConverter<>).MakeGenericType(enumType);
+                property.SetValueConverter(
+                    (ValueConverter)Activator.CreateInstance(converterType)!);
+
+                // Preserve any explicit HasMaxLength(N) the entity configuration already set
+                // (e.g. AuditEntry.Category keeps its 50-char column even though the convention
+                // floor would compute a smaller value). Only apply the default when missing.
+                if (property.GetMaxLength() is null)
+                {
+                    int longestName = Enum.GetNames(enumType).Max(name => name.Length);
+                    property.SetMaxLength(Math.Max(20, longestName + 4));
+                }
+            }
+        }
+    }
+
+    // Returns the enum CLR type for an enum or Nullable<TEnum> property, or null otherwise.
+    private static Type? GetEnumType(Type clrType)
+    {
+        Type underlying = Nullable.GetUnderlyingType(clrType) ?? clrType;
+        return underlying.IsEnum ? underlying : null;
     }
 
     // Removes any SingleValueObject<T> subclass that EF Core auto-discovered as an entity type.

--- a/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/DeletionRequestEntityConfiguration.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/DeletionRequestEntityConfiguration.cs
@@ -18,7 +18,6 @@ internal sealed class DeletionRequestEntityConfiguration : IEntityTypeConfigurat
             .IsRequired();
 
         builder.Property(e => e.State)
-            .HasConversion<string>()
             .HasMaxLength(30)
             .IsRequired();
 

--- a/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/ExportRequestEntityConfiguration.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/ExportRequestEntityConfiguration.cs
@@ -19,7 +19,6 @@ internal sealed class ExportRequestEntityConfiguration : IEntityTypeConfiguratio
             .IsRequired();
 
         builder.Property(e => e.State)
-            .HasConversion<string>()
             .HasMaxLength(30)
             .IsRequired();
 

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentConfiguration.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentConfiguration.cs
@@ -29,7 +29,6 @@ internal sealed class LegalDocumentConfiguration : IEntityTypeConfiguration<Lega
             .HasMaxLength(500);
 
         builder.Property(e => e.LifecycleStatus)
-            .HasConversion<string>()
             .HasMaxLength(20)
             .IsRequired();
 

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateRevisionEntityConfiguration.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateRevisionEntityConfiguration.cs
@@ -26,7 +26,6 @@ internal sealed class TemplateRevisionEntityConfiguration
 
         builder.Property(e => e.LifecycleStatus)
             .IsRequired()
-            .HasConversion<string>()
             .HasMaxLength(20);
 
         builder.Property(e => e.IsPublished).IsRequired();

--- a/src/Granit.Workflow.EntityFrameworkCore/Configurations/VersionedWorkflowEntityBaseConfiguration.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/Configurations/VersionedWorkflowEntityBaseConfiguration.cs
@@ -64,7 +64,6 @@ public abstract class VersionedWorkflowEntityBaseConfiguration<T> : IEntityTypeC
             .IsRequired();
 
         builder.Property(e => e.LifecycleStatus)
-            .HasConversion<string>()
             .HasMaxLength(20)
             .IsRequired();
 

--- a/src/Granit/Domain/PersistAsIntAttribute.cs
+++ b/src/Granit/Domain/PersistAsIntAttribute.cs
@@ -1,0 +1,28 @@
+namespace Granit.Domain;
+
+/// <summary>
+/// Opt-out marker for the Granit enum persistence convention.
+/// </summary>
+/// <remarks>
+/// <para>
+/// By default, <c>ApplyGranitConventions</c> persists every enum property as its
+/// PascalCase string name in a <c>varchar</c> column — see the framework
+/// documentation for the rationale (readability, refactor safety, symmetry with
+/// the wire format, resilience to enum reordering).
+/// </para>
+/// <para>
+/// Apply this attribute to a property to keep the EF Core default behaviour
+/// (persistence as the enum's underlying integer). Use sparingly. Valid reasons:
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="FlagsAttribute"/> bitmask enums where composition semantics require an int column.</item>
+///   <item>High-write tables where the 4-byte savings per row are measurable (presence, telemetry).</item>
+///   <item>Pre-existing database contracts that cannot be migrated.</item>
+/// </list>
+/// <para>
+/// Document the reason in an XML comment above the property — future maintainers
+/// need to understand why this site deviates from the convention.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class PersistAsIntAttribute : Attribute;

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/EnumPersistenceConventionTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/EnumPersistenceConventionTests.cs
@@ -1,0 +1,190 @@
+// =============================================================================
+// Tests - Enum persistence convention
+// =============================================================================
+// Verifies that ApplyGranitConventions auto-applies EnumToStringConverter<TEnum>
+// to every enum property, with the right MaxLength, except in three cases:
+//   1. An explicit HasConversion<...>() in the entity configuration wins.
+//   2. The property is marked [PersistAsInt] (documented opt-out).
+//   3. The enum carries [Flags] (bitmask semantics, skipped automatically).
+//
+// All tests are model-only: they inspect IModel metadata after OnModelCreating,
+// without actually persisting anything. This keeps them fast and provider-agnostic.
+// =============================================================================
+
+using Granit.Domain;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class EnumPersistenceConventionTests
+{
+    [Fact]
+    public void Convention_AppliesEnumToStringConverter_OnStandardEnumProperty()
+    {
+        IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.Status));
+
+        ValueConverter? converter = property.GetValueConverter();
+        converter.ShouldNotBeNull();
+        converter.ShouldBeOfType<EnumToStringConverter<SampleStatus>>();
+    }
+
+    [Fact]
+    public void Convention_SetsMaxLength_BasedOnLongestEnumValueName()
+    {
+        // SampleStatus values: Pending (7), Active (6), Cancelled (9) → max name = 9 → 20 (floor)
+        IProperty status = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.Status));
+        status.GetMaxLength().ShouldBe(20);
+
+        // LongNameStatus longest value name → name length + 4 (growth margin)
+        int longestName = Enum.GetNames<LongNameStatus>().Max(name => name.Length);
+        IProperty longStatus = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.LongStatus));
+        longStatus.GetMaxLength().ShouldBe(Math.Max(20, longestName + 4));
+    }
+
+    [Fact]
+    public void Convention_AppliesToNullableEnumProperty()
+    {
+        IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.OptionalStatus));
+
+        ValueConverter? converter = property.GetValueConverter();
+        converter.ShouldNotBeNull();
+        // EF Core unwraps Nullable<T> for the converter — the same EnumToStringConverter<T> applies.
+        converter.ShouldBeOfType<EnumToStringConverter<SampleStatus>>();
+        property.IsNullable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Convention_SkipsProperty_MarkedPersistAsInt()
+    {
+        IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.OptInIntStatus));
+        property.GetValueConverter().ShouldBeNull();
+        property.ClrType.ShouldBe(typeof(SampleStatus));
+    }
+
+    [Fact]
+    public void Convention_SkipsFlagsEnum_ByDefault()
+    {
+        IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.Permissions));
+        property.GetValueConverter().ShouldBeNull();
+        property.ClrType.ShouldBe(typeof(SamplePermissions));
+    }
+
+    [Fact]
+    public void Convention_RespectsExplicitConversion_HasConversionString()
+    {
+        // Idempotent: an entity configuration that already wrote .HasConversion<string>()
+        // keeps its own converter rather than being overwritten by the convention.
+        IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.ExplicitStringStatus));
+        ValueConverter? converter = property.GetValueConverter();
+        converter.ShouldNotBeNull();
+        converter.ProviderClrType.ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void Convention_PreservesExplicitMaxLength_OnEnumWithoutConverter()
+    {
+        // CustomMaxLengthStatus property has .HasMaxLength(64) set explicitly in the
+        // DbContext (no HasConversion call). The convention applies its converter but
+        // must NOT overwrite the explicit max length — this matters for migrated
+        // configurations like AuditEntry.Category which kept 50 chars.
+        IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.CustomMaxLengthStatus));
+
+        ValueConverter? converter = property.GetValueConverter();
+        converter.ShouldNotBeNull();
+        converter.ShouldBeOfType<EnumToStringConverter<SampleStatus>>();
+        property.GetMaxLength().ShouldBe(64);
+    }
+
+    [Fact]
+    public void Convention_DoesNotApply_ToNonEnumProperties()
+    {
+        IProperty intProperty = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.Counter));
+        intProperty.GetValueConverter().ShouldBeNull();
+
+        IProperty stringProperty = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.Name));
+        stringProperty.GetValueConverter().ShouldBeNull();
+    }
+
+    private static IProperty GetProperty<TContext, TEntity>(string propertyName)
+        where TContext : DbContext, new()
+        where TEntity : class
+    {
+        using TContext context = new();
+        IEntityType entityType = context.Model.FindEntityType(typeof(TEntity))
+            ?? throw new InvalidOperationException($"Entity {typeof(TEntity).Name} not found in model.");
+        return entityType.FindProperty(propertyName)
+            ?? throw new InvalidOperationException($"Property {propertyName} not found on {typeof(TEntity).Name}.");
+    }
+}
+
+#pragma warning disable CA1812 // instantiated by EF Core via reflection
+internal sealed class EnumTestDbContext : DbContext
+{
+    public DbSet<EnumTestEntity> Entities => Set<EnumTestEntity>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseInMemoryDatabase("enum-persistence-convention-tests");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<EnumTestEntity>(builder =>
+        {
+            builder.Property(e => e.ExplicitStringStatus).HasConversion<string>().HasMaxLength(50);
+            builder.Property(e => e.CustomMaxLengthStatus).HasMaxLength(64);
+        });
+
+        modelBuilder.ApplyGranitConventions();
+    }
+}
+
+internal sealed class EnumTestEntity
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int Counter { get; set; }
+
+    public SampleStatus Status { get; set; }
+
+    public SampleStatus? OptionalStatus { get; set; }
+
+    public LongNameStatus LongStatus { get; set; }
+
+    [PersistAsInt]
+    public SampleStatus OptInIntStatus { get; set; }
+
+    public SamplePermissions Permissions { get; set; }
+
+    public SampleStatus ExplicitStringStatus { get; set; }
+
+    public SampleStatus CustomMaxLengthStatus { get; set; }
+}
+
+internal enum SampleStatus
+{
+    Pending,
+    Active,
+    Cancelled,
+}
+
+internal enum LongNameStatus
+{
+    Short,
+    ThisIsTwentyFiveCharacters,
+}
+
+[Flags]
+internal enum SamplePermissions
+{
+    None = 0,
+    Read = 1,
+    Write = 2,
+    Admin = 4,
+}
+#pragma warning restore CA1812


### PR DESCRIPTION
## Summary

Phase 1 of the framework-wide enum persistence alignment (audit identified 7 outliers in granit-dotnet, 22 in granit-business, plus 3 desynced TS types in granit-front). This PR ships the foundation — convention auto + opt-out + migration helper — so all downstream work (granit-business, showcases, frontend) becomes a mechanical cascade rather than 30+ manual fixes.

### What changes

- **New convention** in `ApplyGranitConventions`: every enum property persists as its PascalCase string name in a `varchar` column (sized to `max(20, longestValueName + 4)`). Restores symmetry with the global `JsonStringEnumConverter` on the wire.
- **New opt-out** `[PersistAsInt]` (in `Granit.Domain`) for the rare legitimate int-storage cases. `[Flags]` enums are skipped automatically.
- **New migration helper** `MigrationBuilderExtensions.AlterEnumColumnIntToString<TEnum>` (and its inverse) emit the mandatory PostgreSQL `USING CASE` clause that EF Core does NOT generate — without it, the migration either fails or corrupts data into `"0"`, `"1"`, … strings.
- **Idempotent cleanup** of the 11 entity configurations that already wrote `.HasConversion<string>()` manually — convention takes over, explicit `HasMaxLength(N)` is preserved everywhere (so columns like `AuditEntry.Category varchar(50)` stay exactly as before).
- **Convention guard**: explicit `HasMaxLength` always wins — convention only fills in the default when none is set.
- **CLAUDE.md** updated with a strict-rule encart.

### Compatibility

Zero schema change for any of the 11 cleaned-up sites (convention is byte-for-byte equivalent). Downstream apps that consume the framework get the convention auto-applied to enum properties that were previously persisted as int — those need a one-time migration (see follow-up PRs in showcases / business / iot-showcase).

## Test plan

- [x] `tests/Granit.Persistence.EntityFrameworkCore.Tests` — 353/353 (includes 8 new `EnumPersistenceConventionTests` covering: standard enum, nullable enum, MaxLength sizing, `[PersistAsInt]` opt-out, `[Flags]` skip, explicit `HasConversion<string>` respected, explicit `HasMaxLength` preserved, non-enum properties untouched)
- [x] `tests/Granit.BlobStorage.Tests` + `tests/Granit.BlobStorage.EntityFrameworkCore.Tests` — 164/164
- [x] `tests/Granit.DataExchange.Tests` + `.EntityFrameworkCore.Tests` — 401/401
- [x] `tests/Granit.Auditing.Tests` + `.EntityFrameworkCore.Tests` — 238/238
- [x] `tests/Granit.Authentication.ApiKeys.Tests` + `.EntityFrameworkCore.Tests` — 166/166
- [x] `tests/Granit.Notifications.Tests` + `.EntityFrameworkCore.Tests` — 294/294
- [x] `tests/Granit.Workflow.Tests` + `.EntityFrameworkCore.Tests` — 159/159
- [x] `tests/Granit.Templating.Tests` + `.EntityFrameworkCore.Tests` — 175/175
- [x] `tests/Granit.Privacy.Tests` + `.EntityFrameworkCore.Tests` — 201/201
- [x] `tests/Granit.ArchitectureTests` — 185/185
- [x] `dotnet format style --verify-no-changes` on `Granit`, `Granit.Persistence.EntityFrameworkCore`, and the tests project — clean
- [x] `npx markdownlint-cli2 CLAUDE.md` — clean

## Follow-ups (separate PRs)

- **granit-business** — 22 violations to align (13 covered automatically by this convention once the framework is bumped; 9 sites with explicit `.HasConversion<int>()` need either retrieval or `[PersistAsInt]` decoration depending on intent).
- **granit-dotnet outliers** — 7 sites currently relying on EF default int storage: `ExportJob.Status`, `ScheduledAction.Status`, `MigrationProgress.{Phase,Status}`, `TimelineEntry.EntryType`, `WebhookSigningKey.Status`, `WebhookSubscription.Status`. Convention now applies automatically on next dev-package consumption — migration EFs to be generated in showcase/business apps cascading from the dev package bump.
- **granit-showcase-dotnet** + **granit-iot-showcase-dotnet** — generate the `EnumPersistenceAsString` migrations (use the new `AlterEnumColumnIntToString<T>` helper).
- **granit-front** + **granit-showcase-react** — align 3 TS types (`WebhookSubscriptionStatus`, `ScheduledActionStatus`, `TimelineEntryType`) currently typed as numeric enums to the string-union form already used for `ExportJobStatus`, `ImportJobStatus`.
- **granit-docs** — new page `dotnet/data/enum-persistence.mdx` + ADR + cross-links from 4 existing pages.
- **Architecture test** — add `EnumPersistenceConventionTests` in `Granit.ArchitectureTests` to detect future drift (orphan `.HasConversion<int>()` without `[PersistAsInt]`).