### PR TITLE
fix(persistence): convention guard must check ProviderClrType, not only ValueConverter

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -205,9 +205,20 @@ public static class ModelBuilderExtensions
                     continue;
                 }
 
-                // Respect explicit overrides: a HasConversion<...>() call in the
-                // entity configuration always wins over the convention.
-                if (property.GetValueConverter() is not null)
+                // Respect explicit overrides: a HasConversion<...>() call in the entity
+                // configuration always wins over the convention. EF Core exposes the
+                // override in two different ways depending on the overload:
+                //   - HasConversion(ValueConverter) / HasConversion<TConverter>()
+                //       → SetValueConverter, surfaced by GetValueConverter()
+                //   - HasConversion<TProvider>()  (e.g. HasConversion<short>())
+                //       → SetProviderClrType only; the ValueConverter is materialised
+                //         later from the type mapping, so GetValueConverter() is null
+                //         at convention-application time. Without the second check the
+                //         convention stacks EnumToStringConverter on top of the
+                //         provider type and EF crashes on default-value sanitisation
+                //         (FormatException trying to parse "Available" as short).
+                if (property.GetValueConverter() is not null
+                    || property.GetProviderClrType() is not null)
                 {
                     continue;
                 }

--- a/src/Granit.Presence/Domain/UserPresence.cs
+++ b/src/Granit.Presence/Domain/UserPresence.cs
@@ -54,6 +54,15 @@ public sealed class UserPresence : AuditedAggregateRoot
     /// never read <c>ManualStatus</c> directly in business logic, BI extracts, or ad-hoc
     /// SQL queries without joining on <c>OverrideUntilUtc &gt; now</c>.
     /// </remarks>
+    /// <remarks>
+    /// Persisted as <c>smallint</c> (see <see cref="PersistAsIntAttribute"/>): the
+    /// presence cache is a high-write hot path and the 4-byte savings per row matter
+    /// at scale (one row per active user × multi-tenant deployments). The
+    /// <c>HasConversion&lt;short&gt;()</c> call in <c>UserPresenceConfiguration</c>
+    /// pins the column type — the attribute documents intent at the entity level so
+    /// the framework convention does not stack a string converter on top.
+    /// </remarks>
+    [PersistAsInt]
     public ManualPresenceStatus ManualStatus { get; private set; }
 
     /// <summary>

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/EnumPersistenceConventionTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/EnumPersistenceConventionTests.cs
@@ -78,11 +78,40 @@ public sealed class EnumPersistenceConventionTests
     public void Convention_RespectsExplicitConversion_HasConversionString()
     {
         // Idempotent: an entity configuration that already wrote .HasConversion<string>()
-        // keeps its own converter rather than being overwritten by the convention.
+        // is left untouched by the convention. HasConversion<TProvider>() sets only the
+        // provider CLR type — the actual ValueConverter is materialised later from the
+        // type mapping, so the convention guard checks GetProviderClrType() as well as
+        // GetValueConverter() to detect the opt-out. End result: schema stays varchar(50),
+        // wire format stays string PascalCase.
         IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.ExplicitStringStatus));
-        ValueConverter? converter = property.GetValueConverter();
-        converter.ShouldNotBeNull();
-        converter.ProviderClrType.ShouldBe(typeof(string));
+        property.GetProviderClrType().ShouldBe(typeof(string));
+        property.GetMaxLength().ShouldBe(50);
+    }
+
+    [Fact]
+    public void Convention_RespectsExplicitProviderType_HasConversionShort()
+    {
+        // Regression for the UserPresence.ManualStatus crash: HasConversion<short>()
+        // sets ProviderClrType only — the ValueConverter is materialised later from
+        // the type mapping, so GetValueConverter() returns null when the convention
+        // runs. Without checking GetProviderClrType() the convention would stack
+        // EnumToStringConverter on top and EF would crash on default-value
+        // sanitisation (FormatException trying to parse "Available" as short).
+        IProperty property = GetProperty<EnumTestDbContext, EnumTestEntity>(nameof(EnumTestEntity.ShortBackedStatus));
+        property.GetProviderClrType().ShouldBe(typeof(short));
+        property.GetValueConverter().ShouldBeNull();
+    }
+
+    [Fact]
+    public void Convention_DoesNotCrash_OnRelationalModelMaterialization_WithShortConversionAndDefaultValue()
+    {
+        // End-to-end regression: builds the relational schema (the path that
+        // `dotnet ef migrations add` walks). Before the GetProviderClrType() guard
+        // was added, this threw FormatException during IColumn.TryGetDefaultValue
+        // because EnumToStringConverter was stacked on top of the short provider
+        // type, then asked to round-trip the default "Available" through short.
+        using EnumRelationalTestDbContext context = new();
+        Should.NotThrow(() => context.Database.EnsureCreated());
     }
 
     [Fact]
@@ -123,6 +152,31 @@ public sealed class EnumPersistenceConventionTests
 }
 
 #pragma warning disable CA1812 // instantiated by EF Core via reflection
+
+// Sqlite-backed DbContext used by Convention_DoesNotCrash_OnRelationalModelMaterialization.
+// We need a relational provider (not InMemory) to exercise the column default-value
+// sanitisation path that previously crashed on UserPresence.ManualStatus.
+internal sealed class EnumRelationalTestDbContext : DbContext
+{
+    public DbSet<EnumTestEntity> Entities => Set<EnumTestEntity>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlite("DataSource=:memory:");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<EnumTestEntity>(builder =>
+        {
+            builder.HasKey(e => e.Id);
+            builder.Property(e => e.ShortBackedStatus)
+                .HasConversion<short>()
+                .HasDefaultValue(SampleStatus.Active);
+        });
+
+        modelBuilder.ApplyGranitConventions();
+    }
+}
+
 internal sealed class EnumTestDbContext : DbContext
 {
     public DbSet<EnumTestEntity> Entities => Set<EnumTestEntity>();
@@ -136,6 +190,11 @@ internal sealed class EnumTestDbContext : DbContext
         {
             builder.Property(e => e.ExplicitStringStatus).HasConversion<string>().HasMaxLength(50);
             builder.Property(e => e.CustomMaxLengthStatus).HasMaxLength(64);
+            // Mirrors UserPresence.ManualStatus: HasConversion<short>() + HasDefaultValue
+            // exercises the ProviderClrType-only opt-out path.
+            builder.Property(e => e.ShortBackedStatus)
+                .HasConversion<short>()
+                .HasDefaultValue(SampleStatus.Active);
         });
 
         modelBuilder.ApplyGranitConventions();
@@ -164,6 +223,8 @@ internal sealed class EnumTestEntity
     public SampleStatus ExplicitStringStatus { get; set; }
 
     public SampleStatus CustomMaxLengthStatus { get; set; }
+
+    public SampleStatus ShortBackedStatus { get; set; }
 }
 
 internal enum SampleStatus


### PR DESCRIPTION
## Summary

Hotfix for #2215 — the enum persistence convention crashes any cascading consumer that uses `HasConversion<short>()` / `HasConversion<int>()` / `HasConversion<long>()` (the provider-type overload) together with `HasDefaultValue(...)`.

Reported by the granit-showcase-dotnet Phase 2 cascade run: `dotnet ef migrations add EnumPersistenceAsString` on `ShowcaseHostDbContext` blew up with

```
System.FormatException: The input string 'Available' was not in a correct format.
   at lambda_method127(Closure, ManualPresenceStatus)
   at ValueConverter`2.<>c__DisplayClass2_0`2.<SanitizeConverter>b__1(Object v)
   at IColumn.TryGetDefaultValue(...)
```

on `UserPresence.ManualStatus` (`HasConversion<short>() + HasDefaultValue(ManualPresenceStatus.Available)`).

## Root cause

`HasConversion<TProvider>()` only stores the provider CLR type on the property; the `ValueConverter` is materialised later from the type mapping. So when the convention runs:

- `GetValueConverter()` returns **null** (the converter doesn't exist yet)
- The convention thinks the property is unclaimed and stacks `EnumToStringConverter<TEnum>` on top
- EF then asks the chained converter (`enum → string → short`) to round-trip the default value `"Available"` through `short` → `FormatException`

The original PR description claimed the guard would respect explicit conversions, but only checked `GetValueConverter()` — missing the second EF API.

## Fix

Convention now skips when **either** `GetValueConverter()` **or** `GetProviderClrType()` is set:

```csharp
if (property.GetValueConverter() is not null
    || property.GetProviderClrType() is not null)
{
    continue;
}
```

Belt and suspenders: `UserPresence.ManualStatus` gets `[PersistAsInt]` so the entity-level intent is documented (previously only the EF config carried the opt-out signal — fragile against future refactors).

## Test plan

- [x] `EnumPersistenceConventionTests.Convention_RespectsExplicitProviderType_HasConversionShort` — metadata-level guard check
- [x] `EnumPersistenceConventionTests.Convention_DoesNotCrash_OnRelationalModelMaterialization_WithShortConversionAndDefaultValue` — end-to-end Sqlite + `EnsureCreated()` exercises the exact `IColumn.TryGetDefaultValue` path that crashed
- [x] `Convention_RespectsExplicitConversion_HasConversionString` tightened: was passing for the wrong reason — the explicit `HasConversion<string>()` was being silently overwritten by the convention, and the assertion happened to match because the convention's converter also has `ProviderClrType = string`. Now asserts against `GetProviderClrType()` + `GetMaxLength()` directly.
- [x] `Granit.Persistence.EntityFrameworkCore.Tests` — 356/356 (added 1 + tightened 1 = net +2 since #2215)
- [x] `Granit.Presence.Tests` + `Granit.Presence.EntityFrameworkCore.Tests` — 29/29
- [x] All 11 module test projects affected by #2215 — 1135/1135 cumulative, identical to pre-fix
- [x] `Granit.ArchitectureTests` — 185/185
- [x] `dotnet format style --verify-no-changes` on the 3 touched projects — clean

## Follow-up

Once this merges and a new dev package is published, the showcase-dotnet Phase 2 cascade is unblocked. The agent's branch `feature/enum-persistence-as-string` can resume from where it stopped.