### PR TITLE
fix(persistence-migrations): pin Phase/Status as varchar in MigrationProgressConfiguration

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressConfiguration.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressConfiguration.cs
@@ -19,10 +19,20 @@ internal sealed class MigrationProgressConfiguration : IEntityTypeConfiguration<
             .HasMaxLength(200)
             .IsRequired();
 
+        // Persist Phase/Status as varchar to stay in sync with the host DbContext, which
+        // applies ApplyGranitConventions() and stores enums as their PascalCase name. This
+        // internal DbContext deliberately skips ApplyGranitConventions (no soft-delete /
+        // audit filters on a system table), so the conversion must be configured here
+        // explicitly — otherwise the runtime model treats the columns as int and emits
+        // "WHERE Status = 0", which fails against the varchar schema (PG 42883).
         builder.Property(e => e.Phase)
+            .HasConversion<string>()
+            .HasMaxLength(20)
             .IsRequired();
 
         builder.Property(e => e.Status)
+            .HasConversion<string>()
+            .HasMaxLength(20)
             .IsRequired();
 
         builder.Property(e => e.ProcessedRows)


### PR DESCRIPTION
## Summary
- `MigrationProgressDbContext` deliberately skips `ApplyGranitConventions()` (system DbContext — no soft-delete / audit filters on the tracking table).
- The host DbContext does apply the convention (via `ConfigureMigrationsModule` + `ApplyGranitConventions`), so `data_migration_progress.Status`/`Phase` ship as `varchar(20)` on disk.
- The migrations service's runtime model still treats the columns as `int`, so `MigrationStartupService.ResumeAsync` emits `WHERE "Status" = 0` and PostgreSQL throws **42883: operator does not exist: character varying = integer** at startup.

## Fix
Pin the conversion explicitly in `MigrationProgressConfiguration` — both DbContexts now converge on the same column shape regardless of whether `ApplyGranitConventions` runs.

```csharp
builder.Property(e => e.Phase)
    .HasConversion<string>()
    .HasMaxLength(20)
    .IsRequired();

builder.Property(e => e.Status)
    .HasConversion<string>()
    .HasMaxLength(20)
    .IsRequired();
```

Width 20 matches the convention's `max(20, longestName + 4)` formula (longest enum name is `InProgress` = 10 chars).

## Context
3rd cascade from #2215 (auto-persist enums as varchar):
1. #2216 — convention guard must check `ProviderClrType`
2. 4 `HasFilter` int→string fixes in business modules
3. **This PR** — `MigrationProgressDbContext` reproduced the same int/varchar drift because it bypasses conventions.

## Test plan
- [x] `dotnet build src/Granit.Persistence.EntityFrameworkCore.Migrations` — clean
- [x] `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests` — 69/69 passing
- [ ] Showcase startup with pending `data_migration_progress` rows no longer throws 42883