### PR TITLE
fix(authentication-apikeys-ef): widen HashedKey column to fit versioned hash prefix

### DIFF
--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
@@ -36,7 +36,7 @@ internal sealed class ApiKeyEntryConfiguration : IEntityTypeConfiguration<ApiKey
             .HasDatabaseName($"ix_{GranitApiKeysDbProperties.DbTablePrefix}entries_expiring_scan");
 
         builder.Property(e => e.Name).HasMaxLength(200).IsRequired();
-        builder.Property(e => e.HashedKey).HasMaxLength(64).IsRequired(); // SHA-256 hex = 64 chars
+        builder.Property(e => e.HashedKey).HasMaxLength(100).IsRequired(); // "vN$" prefix + SHA-256 hex (64 chars); 100 leaves headroom for future schemes
         builder.Property(e => e.Prefix).HasMaxLength(20).IsRequired();
         builder.Property(e => e.LastFourChars).HasMaxLength(4).IsRequired();
         builder.Property(e => e.Environment).HasMaxLength(10).IsRequired();


### PR DESCRIPTION
## Summary

- `ApiKeyHasher` emits `vN$` + 64 hex chars (= 67 chars) since #1905, but `ApiKeyEntryConfiguration` still pinned `HashedKey` at `varchar(64)` — Postgres rejected every insert with `22001: value too long for type character varying(64)`.
- Bumps `HasMaxLength(64)` → `100` to absorb the `v1$` / `v2$` prefix and leave headroom for future hashing schemes.
- Inline comment documents the version-prefix scheme so the next maintainer doesn't tighten it back to 64.

## Downstream impact

Consuming apps need an `ALTER COLUMN api_key_entries.hashed_key TYPE varchar(100)` migration — the framework ships no migrations of its own ([`feedback_no_migrations_in_framework`](https://github.com/granit-fx/granit-dotnet/blob/develop/CLAUDE.md)).

## Test plan

- [ ] `dotnet build src/Granit.Authentication.ApiKeys.EntityFrameworkCore`
- [ ] `dotnet test tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests`
- [ ] Manual repro on the downstream app: regenerate migration, run `dotnet ef database update`, exercise `POST /api-keys` end-to-end (no 22001).
- [ ] Follow-up: add an integration test that hashes via `ApiKeyHasher` and persists `ApiKeyEntry` on a Postgres testcontainer to lock the schema/hasher contract.