### PR TITLE
feat(notifications): register INotificationDefinitionProvider in 9 *.Notifications modules (#2219)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -5157,7 +5157,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Notifications",
       "file": "src/Granit.Auditing.Notifications/GranitAuditingNotificationsModule.cs",
-      "line": 29,
+      "line": 31,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6192,7 +6192,7 @@
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys.Notifications",
       "file": "src/Granit.Authentication.ApiKeys.Notifications/GranitAuthenticationApiKeysNotificationsModule.cs",
-      "line": 26,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -8641,7 +8641,7 @@
       "kind": "class",
       "project": "Granit.BackgroundJobs.Notifications",
       "file": "src/Granit.BackgroundJobs.Notifications/GranitBackgroundJobsNotificationsModule.cs",
-      "line": 18,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -22212,7 +22212,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Notifications",
       "file": "src/Granit.Identity.Federated.Notifications/GranitIdentityFederatedNotificationsModule.cs",
-      "line": 29,
+      "line": 32,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36388,7 +36388,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Notifications",
       "file": "src/Granit.Privacy.Notifications/GranitPrivacyNotificationsModule.cs",
-      "line": 21,
+      "line": 24,
       "members": [
         {
           "name": "ConfigureServices",
@@ -38950,7 +38950,7 @@
       "kind": "class",
       "project": "Granit.Scheduling.Notifications",
       "file": "src/Granit.Scheduling.Notifications/GranitSchedulingNotificationsModule.cs",
-      "line": 18,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -42179,7 +42179,7 @@
       "kind": "class",
       "project": "Granit.Timeline.Notifications",
       "file": "src/Granit.Timeline.Notifications/GranitTimelineNotificationsModule.cs",
-      "line": 19,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -45275,7 +45275,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.Notifications",
       "file": "src/Granit.Webhooks.Notifications/GranitWebhooksNotificationsModule.cs",
-      "line": 18,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -46569,7 +46569,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Notifications",
       "file": "src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs",
-      "line": 35,
+      "line": 38,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Auditing.Notifications/GranitAuditingNotificationsModule.cs
+++ b/src/Granit.Auditing.Notifications/GranitAuditingNotificationsModule.cs
@@ -1,6 +1,8 @@
+using Granit.Auditing.Notifications.Internal;
 using Granit.Auditing.Notifications.Options;
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Templating;
 using Granit.Templating.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,5 +51,7 @@ public sealed class GranitAuditingNotificationsModule : GranitModule
             .BindConfiguration(AuditNotificationOptions.SectionName)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, AuditingNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Auditing.Notifications/Internal/AuditingNotificationDefinitionProvider.cs
+++ b/src/Granit.Auditing.Notifications/Internal/AuditingNotificationDefinitionProvider.cs
@@ -1,0 +1,26 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Auditing.Notifications.Internal;
+
+/// <summary>
+/// Registers auditing notification definitions. Security-critical alerts —
+/// non-opt-outable, feeds SIEM/oncall workflows (ISO 27001 A.12.4 / A.16.1.4).
+/// </summary>
+internal sealed class AuditingNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Security";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(AuditingAnomalyDetectedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Audit Anomaly Detected",
+            Description = "Alerts platform administrators and SOC responders when the audit subsystem detects an anomalous access pattern.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+    }
+}

--- a/src/Granit.Authentication.ApiKeys.Notifications/GranitAuthenticationApiKeysNotificationsModule.cs
+++ b/src/Granit.Authentication.ApiKeys.Notifications/GranitAuthenticationApiKeysNotificationsModule.cs
@@ -1,7 +1,10 @@
+using Granit.Authentication.ApiKeys.Notifications.Internal;
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Templating;
 using Granit.Templating.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Authentication.ApiKeys.Notifications;
 
@@ -37,5 +40,7 @@ public sealed class GranitAuthenticationApiKeysNotificationsModule : GranitModul
         // application registers the actual `Layout.Email` template; if absent, templates
         // render without layout (warning logged, no crash).
         context.Services.AddTemplateLayout("apikeys.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, ApiKeysNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Authentication.ApiKeys.Notifications/Internal/ApiKeysNotificationDefinitionProvider.cs
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Internal/ApiKeysNotificationDefinitionProvider.cs
@@ -1,0 +1,56 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Authentication.ApiKeys.Notifications.Internal;
+
+/// <summary>
+/// Registers API key lifecycle notification definitions. All entries are
+/// non-opt-outable (security alerts, ISO 27001 A.9.4).
+/// </summary>
+internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Security";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(ApiKeyIssuedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "API Key Issued",
+            Description = "Sent when a new API key is issued, with the public-safe metadata (id, name, prefix).",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(ApiKeyRotatedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "API Key Rotated",
+            Description = "Sent when an API key is rotated, signalling that the prior secret is invalidated.",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(ApiKeyRevokedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "API Key Revoked",
+            Description = "Sent when an API key is revoked outside the normal rotation flow.",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(ApiKeyExpiringSoonNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "API Key Expiring Soon",
+            Description = "Warns the owner that an API key is approaching its expiration date so it can be rotated before service disruption.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+    }
+}

--- a/src/Granit.BackgroundJobs.Notifications/GranitBackgroundJobsNotificationsModule.cs
+++ b/src/Granit.BackgroundJobs.Notifications/GranitBackgroundJobsNotificationsModule.cs
@@ -1,7 +1,10 @@
+using Granit.BackgroundJobs.Notifications.Internal;
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Templating;
 using Granit.Templating.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.BackgroundJobs.Notifications;
 
@@ -29,5 +32,7 @@ public sealed class GranitBackgroundJobsNotificationsModule : GranitModule
         // application registers the actual `Layout.Email` template; if absent, templates
         // render without layout (warning logged, no crash).
         context.Services.AddTemplateLayout("jobs.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, BackgroundJobsNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.BackgroundJobs.Notifications/Internal/BackgroundJobsNotificationDefinitionProvider.cs
+++ b/src/Granit.BackgroundJobs.Notifications/Internal/BackgroundJobsNotificationDefinitionProvider.cs
@@ -1,0 +1,26 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.BackgroundJobs.Notifications.Internal;
+
+/// <summary>
+/// Registers background-jobs notification definitions. Operational alerts —
+/// non-opt-outable for platform administrators.
+/// </summary>
+internal sealed class BackgroundJobsNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Operations";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(JobsRecurringFailingNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Recurring Job Failing",
+            Description = "Alerts platform administrators when a recurring background job has failed several consecutive runs.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+    }
+}

--- a/src/Granit.Identity.Federated.Notifications/GranitIdentityFederatedNotificationsModule.cs
+++ b/src/Granit.Identity.Federated.Notifications/GranitIdentityFederatedNotificationsModule.cs
@@ -1,7 +1,10 @@
+using Granit.Identity.Federated.Notifications.Internal;
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Templating;
 using Granit.Templating.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Identity.Federated.Notifications;
 
@@ -40,5 +43,7 @@ public sealed class GranitIdentityFederatedNotificationsModule : GranitModule
         // registers the actual `Layout.Email` template; if absent, templates render
         // without layout (warning logged, no crash).
         context.Services.AddTemplateLayout("identity.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, IdentityFederatedNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Identity.Federated.Notifications/Internal/IdentityFederatedNotificationDefinitionProvider.cs
+++ b/src/Granit.Identity.Federated.Notifications/Internal/IdentityFederatedNotificationDefinitionProvider.cs
@@ -1,0 +1,47 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Identity.Federated.Notifications.Internal;
+
+/// <summary>
+/// Registers federated identity notification definitions. All entries are
+/// non-opt-outable — they carry ISO 27001 A.12.4 (monitoring of privileged
+/// operations) and GDPR Art. 17 audit receipts.
+/// </summary>
+internal sealed class IdentityFederatedNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Security";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(IdentitySyncFailedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Identity Sync Failed",
+            Description = "Alerts platform administrators when synchronization between the federated IdP and the local user cache fails.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(IdentityUserProvisioningRemovedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Federated User Removed",
+            Description = "Tenant-admin receipt that a federated user has been hard-deleted (GDPR Art. 17 audit trail).",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(IdentityTokenExchangeAuditNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Token Exchange Audit",
+            Description = "Alerts platform administrators on token-exchange (service-account impersonation) events.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+    }
+}

--- a/src/Granit.Privacy.Notifications/GranitPrivacyNotificationsModule.cs
+++ b/src/Granit.Privacy.Notifications/GranitPrivacyNotificationsModule.cs
@@ -1,9 +1,12 @@
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Privacy.Notifications.GlobalContexts;
+using Granit.Privacy.Notifications.Internal;
 using Granit.Privacy.Regulations;
 using Granit.Templating;
 using Granit.Templating.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Privacy.Notifications;
 
@@ -36,5 +39,7 @@ public sealed class GranitPrivacyNotificationsModule : GranitModule
         // (warning logged, no crash).
         context.Services.AddTemplateLayout("privacy.*", "Layout.Email");
         context.Services.AddTemplateLayout("Privacy.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, PrivacyNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Privacy.Notifications/Internal/PrivacyNotificationDefinitionProvider.cs
+++ b/src/Granit.Privacy.Notifications/Internal/PrivacyNotificationDefinitionProvider.cs
@@ -1,0 +1,97 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Privacy.Notifications.Internal;
+
+/// <summary>
+/// Registers privacy notification definitions with their GDPR-aligned metadata
+/// (group, opt-out posture, default channels). Most types are non-opt-outable
+/// because they carry GDPR Art. 12 §3 / Art. 17 receipts.
+/// </summary>
+internal sealed class PrivacyNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Privacy";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(PrivacyExportReadyNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Personal Data Export Ready",
+            Description = "Sent to the data subject when the personal data export archive is ready to download.",
+            DefaultSeverity = NotificationSeverity.Success,
+            DefaultChannels = [NotificationChannels.Email],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(PrivacyExportFailedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Personal Data Export Failed",
+            Description = "Sent to the data subject when the personal data export saga failed.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(PrivacyDeletionReminderNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Account Deletion Reminder",
+            Description = "Reminder sent before a deferred deletion request is executed, giving the data subject a final cancellation window.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(PrivacyDeletionDeferredConfirmedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Deletion Scheduled",
+            Description = "Confirms that a deferred deletion request has been accepted and scheduled.",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(PrivacyDeletionCancelledNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Deletion Cancelled",
+            Description = "Confirms that a previously scheduled deletion request has been cancelled by the data subject.",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(PrivacyDeletionAcknowledgedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Deletion Acknowledged",
+            Description = "Acknowledgement that a deletion request was received and is being processed (GDPR Art. 12 §3).",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(PrivacyDeletionConfirmationNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Deletion Completed",
+            Description = "Final receipt sent once the deletion request has been fully executed (GDPR Art. 17).",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.Email],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(PrivacyLegalDocumentObsoleteNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Legal Document Updated",
+            Description = "Notifies the data subject that a legal document (privacy policy, terms of service) has been updated and requires acknowledgement.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email],
+            AllowUserOptOut = false,
+        });
+    }
+}

--- a/src/Granit.Scheduling.Notifications/GranitSchedulingNotificationsModule.cs
+++ b/src/Granit.Scheduling.Notifications/GranitSchedulingNotificationsModule.cs
@@ -1,7 +1,10 @@
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Granit.Scheduling.Notifications.Internal;
 using Granit.Templating;
 using Granit.Templating.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Scheduling.Notifications;
 
@@ -29,5 +32,7 @@ public sealed class GranitSchedulingNotificationsModule : GranitModule
         // application registers the actual `Layout.Email` template; if absent, templates
         // render without layout (warning logged, no crash).
         context.Services.AddTemplateLayout("scheduling.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, SchedulingNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Scheduling.Notifications/Internal/SchedulingNotificationDefinitionProvider.cs
+++ b/src/Granit.Scheduling.Notifications/Internal/SchedulingNotificationDefinitionProvider.cs
@@ -1,0 +1,26 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Scheduling.Notifications.Internal;
+
+/// <summary>
+/// Registers scheduling notification definitions. Operational alerts —
+/// non-opt-outable for tenant administrators.
+/// </summary>
+internal sealed class SchedulingNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Operations";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(SchedulingActionFailedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Scheduled Action Failed",
+            Description = "Alerts tenant administrators when a scheduled action (report, batch export, …) failed and needs investigation.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+    }
+}

--- a/src/Granit.Timeline.Notifications/GranitTimelineNotificationsModule.cs
+++ b/src/Granit.Timeline.Notifications/GranitTimelineNotificationsModule.cs
@@ -1,8 +1,11 @@
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Templating;
 using Granit.Templating.Extensions;
 using Granit.Timeline.Notifications.Extensions;
+using Granit.Timeline.Notifications.Internal;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Timeline.Notifications;
 
@@ -32,5 +35,7 @@ public sealed class GranitTimelineNotificationsModule : GranitModule
         // wrapper if registered. If absent, templates render without layout (warning logged,
         // no crash).
         context.Services.AddTemplateLayout("timeline.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, TimelineNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Timeline.Notifications/Internal/TimelineNotificationDefinitionProvider.cs
+++ b/src/Granit.Timeline.Notifications/Internal/TimelineNotificationDefinitionProvider.cs
@@ -1,0 +1,36 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Timeline.Notifications.Internal;
+
+/// <summary>
+/// Registers timeline notification definitions. Both entries are
+/// user-facing collaboration features — opt-out is allowed.
+/// </summary>
+internal sealed class TimelineNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Collaboration";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(TimelineMentionNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Mentioned in Timeline",
+            Description = "Notifies a user when they are @-mentioned in a timeline entry.",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.InApp, NotificationChannels.SignalR, NotificationChannels.Email],
+            AllowUserOptOut = true,
+        });
+
+        context.Add(new NotificationDefinition(TimelineCommentNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Timeline Comment",
+            Description = "Notifies timeline followers when a new comment is posted on an entity they follow.",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.InApp, NotificationChannels.SignalR],
+            AllowUserOptOut = true,
+        });
+    }
+}

--- a/src/Granit.Webhooks.Notifications/GranitWebhooksNotificationsModule.cs
+++ b/src/Granit.Webhooks.Notifications/GranitWebhooksNotificationsModule.cs
@@ -1,7 +1,10 @@
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Templating;
 using Granit.Templating.Extensions;
+using Granit.Webhooks.Notifications.Internal;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Webhooks.Notifications;
 
@@ -29,5 +32,7 @@ public sealed class GranitWebhooksNotificationsModule : GranitModule
         // registers the actual `Layout.Email` template; if absent, templates render
         // without layout (warning logged, no crash).
         context.Services.AddTemplateLayout("webhooks.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, WebhooksNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Webhooks.Notifications/Internal/WebhooksNotificationDefinitionProvider.cs
+++ b/src/Granit.Webhooks.Notifications/Internal/WebhooksNotificationDefinitionProvider.cs
@@ -1,0 +1,36 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Webhooks.Notifications.Internal;
+
+/// <summary>
+/// Registers webhook notification definitions. All entries are non-opt-outable
+/// because they are operational alerts for tenant administrators.
+/// </summary>
+internal sealed class WebhooksNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Webhooks";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(WebhooksDeliveryFailureThresholdNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Webhook Delivery Failure Threshold",
+            Description = "Alerts tenant administrators when a webhook endpoint trips its delivery failure threshold.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+
+        context.Add(new NotificationDefinition(WebhooksSigningKeyRotationDueNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Webhook Signing Key Rotation Due",
+            Description = "Alerts tenant administrators when a webhook signing key is approaching its rotation deadline.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
+            AllowUserOptOut = false,
+        });
+    }
+}

--- a/src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs
+++ b/src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs
@@ -2,9 +2,12 @@ using Granit.Authorization;
 using Granit.Identity;
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Abstractions;
 using Granit.Templating;
 using Granit.Templating.Extensions;
 using Granit.Workflow.Notifications.Extensions;
+using Granit.Workflow.Notifications.Internal;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Workflow.Notifications;
 
@@ -48,5 +51,7 @@ public sealed class GranitWorkflowNotificationsModule : GranitModule
         // wrapper if registered. If absent, templates render without layout (warning logged,
         // no crash).
         context.Services.AddTemplateLayout("workflow.*", "Layout.Email");
+
+        context.Services.AddSingleton<INotificationDefinitionProvider, WorkflowNotificationDefinitionProvider>();
     }
 }

--- a/src/Granit.Workflow.Notifications/Internal/WorkflowNotificationDefinitionProvider.cs
+++ b/src/Granit.Workflow.Notifications/Internal/WorkflowNotificationDefinitionProvider.cs
@@ -1,0 +1,36 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.Workflow.Notifications.Internal;
+
+/// <summary>
+/// Registers workflow notification definitions. These are user-facing
+/// convenience notifications — opt-out is allowed.
+/// </summary>
+internal sealed class WorkflowNotificationDefinitionProvider : INotificationDefinitionProvider
+{
+    private const string GroupName = "Workflow";
+
+    public void Define(INotificationDefinitionContext context)
+    {
+        context.Add(new NotificationDefinition(WorkflowApprovalNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Workflow Approval Requested",
+            Description = "Notifies an approver that a workflow step is awaiting their decision.",
+            DefaultSeverity = NotificationSeverity.Warning,
+            DefaultChannels = [NotificationChannels.InApp, NotificationChannels.Email],
+            AllowUserOptOut = true,
+        });
+
+        context.Add(new NotificationDefinition(WorkflowStateChangedNotificationType.Instance.Name)
+        {
+            GroupName = GroupName,
+            DisplayName = "Workflow State Changed",
+            Description = "Notifies workflow participants when an instance transitions to a new state.",
+            DefaultSeverity = NotificationSeverity.Info,
+            DefaultChannels = [NotificationChannels.InApp, NotificationChannels.SignalR],
+            AllowUserOptOut = true,
+        });
+    }
+}

--- a/tests/Granit.Auditing.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Auditing.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,39 @@
+using Granit.Auditing.Notifications.Internal;
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Auditing.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        AuditingNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            AuditingAnomalyDetectedNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.Authentication.ApiKeys.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,42 @@
+using Granit.Authentication.ApiKeys.Notifications.Internal;
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.ApiKeys.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        ApiKeysNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            ApiKeyIssuedNotificationType.Instance.Name,
+            ApiKeyRotatedNotificationType.Instance.Name,
+            ApiKeyRevokedNotificationType.Instance.Name,
+            ApiKeyExpiringSoonNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.BackgroundJobs.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.BackgroundJobs.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,39 @@
+using Granit.BackgroundJobs.Notifications.Internal;
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BackgroundJobs.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        BackgroundJobsNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            JobsRecurringFailingNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.Identity.Federated.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Identity.Federated.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,41 @@
+using Granit.Identity.Federated.Notifications.Internal;
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        IdentityFederatedNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            IdentitySyncFailedNotificationType.Instance.Name,
+            IdentityUserProvisioningRemovedNotificationType.Instance.Name,
+            IdentityTokenExchangeAuditNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.Privacy.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Privacy.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,47 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Granit.Privacy.Notifications.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        PrivacyNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            PrivacyExportReadyNotificationType.Instance.Name,
+            PrivacyExportFailedNotificationType.Instance.Name,
+            PrivacyDeletionReminderNotificationType.Instance.Name,
+            PrivacyDeletionDeferredConfirmedNotificationType.Instance.Name,
+            PrivacyDeletionCancelledNotificationType.Instance.Name,
+            PrivacyDeletionAcknowledgedNotificationType.Instance.Name,
+            PrivacyDeletionConfirmationNotificationType.Instance.Name,
+            PrivacyLegalDocumentObsoleteNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length,
+            "Definition count should match the number of notification types");
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.Scheduling.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Scheduling.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,39 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Granit.Scheduling.Notifications.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Scheduling.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        SchedulingNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            SchedulingActionFailedNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.Timeline.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Timeline.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,40 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Granit.Timeline.Notifications.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        TimelineNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            TimelineMentionNotificationType.Instance.Name,
+            TimelineCommentNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.Webhooks.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Webhooks.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,40 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Granit.Webhooks.Notifications.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        WebhooksNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            WebhooksDeliveryFailureThresholdNotificationType.Instance.Name,
+            WebhooksSigningKeyRotationDueNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}

--- a/tests/Granit.Workflow.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
+++ b/tests/Granit.Workflow.Notifications.Tests/NotificationTypeDefinitionDriftTests.cs
@@ -1,0 +1,40 @@
+using Granit.Notifications;
+using Granit.Notifications.Abstractions;
+using Granit.Workflow.Notifications.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workflow.Notifications.Tests;
+
+public sealed class NotificationTypeDefinitionDriftTests
+{
+    [Fact]
+    public void All_notification_types_have_matching_definitions()
+    {
+        WorkflowNotificationDefinitionProvider provider = new();
+        CollectingContext context = new();
+        provider.Define(context);
+
+        string[] expectedNames =
+        [
+            WorkflowApprovalNotificationType.Instance.Name,
+            WorkflowStateChangedNotificationType.Instance.Name,
+        ];
+
+        foreach (string name in expectedNames)
+        {
+            context.Definitions.ShouldContain(d => d.Name == name,
+                $"Missing NotificationDefinition for type '{name}'");
+        }
+
+        context.Definitions.Count.ShouldBe(expectedNames.Length);
+    }
+
+    private sealed class CollectingContext : INotificationDefinitionContext
+    {
+        public List<NotificationDefinition> Definitions { get; } = [];
+
+        public void Add(NotificationDefinition definition) =>
+            Definitions.Add(definition);
+    }
+}


### PR DESCRIPTION
Closes #2219. Refs epic #1306.

## Summary

- Adds the missing `INotificationDefinitionProvider` in 9 `*.Notifications` modules
  (Privacy, ApiKeys, Identity.Federated, Workflow, Webhooks, Timeline, BackgroundJobs,
  Auditing, Scheduling), patterned after `IdentityNotificationDefinitionProvider`.
- Each provider mirrors `NotificationType<T>.DefaultChannels` and applies the
  audience-correct `AllowUserOptOut` posture (false for security/operational/RGPD,
  true for Workflow approvals and Timeline mentions/comments).
- Adds a `NotificationTypeDefinitionDriftTests` to each `*.Notifications.Tests` project
  (pattern lifted from `Granit.Identity.Local.Notifications.Tests`).

## Why

`NotificationFanoutHandler` reads its routing decisions exclusively from the
`INotificationDefinitionStore` ([`NotificationFanoutHandler.cs:52-55`](src/Granit.Notifications/Handlers/NotificationFanoutHandler.cs#L52-L55)).
Without a registered definition, fanout silently collapses to InApp-only and
lets `AllowUserOptOut` fall back to `true` — breaking the non-opt-out posture
intended for security/GDPR alerts. The `/api/v1/notifications/types` endpoint
also returned an empty list for these 24 types.

Epic #1306 stories #1321/#1322/#1324/#1326/#1327/#1328 each listed the provider
in their DoD ("opt-out non-opt-outable…") but were closed without the
provider class actually being shipped — the opt-out posture was documented in
intent only, not enforced at runtime. Pre-Epic packages (Privacy, Workflow,
Timeline) never had a provider either because [`conventions.mdx:120`](https://github.com/granit-fx/granit-docs/blob/develop/src/content/docs/dotnet/infrastructure/notifications/conventions.mdx#L120)
(delivered by D4 #1331) marked the registration as "Optional".

## Test plan

- [x] Per-project build clean — 9 src + 9 tests
- [x] `NotificationTypeDefinitionDriftTests` passes in each of the 9 test projects
- [x] `dotnet format --verify-no-changes --no-restore` clean on all 18 affected projects
- [ ] Full shard runs (security / application / api-data / infrastructure) — CI
- [ ] Smoke: `GET /api/v1/notifications/types` returns the new types when the showcase
      mounts these modules

## Follow-ups (separate PRs/issues)

- #2220 — convention doc: rewrite "Optional" → "Required" in `granit-docs`
- #2221 — architecture test: assert every `NotificationType<>` assembly ships a registered provider
- #2223 — spike: auto-discover `NotificationType<T>.Instance` to remove the manual registration step
- (new) follow-up — audience filter on `/types` endpoint via `RequiredPermission` + `RequiredFeature` metadata