### PR TITLE
feat(notifications): filter GET /notifications/types by RequiredPermission + RequiredFeature (#2225)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28398,6 +28398,22 @@
       ]
     },
     {
+      "name": "INotificationFeatureGate",
+      "fqn": "Granit.Notifications.Abstractions.INotificationFeatureGate",
+      "kind": "interface",
+      "project": "Granit.Notifications.Abstractions",
+      "file": "src/Granit.Notifications.Abstractions/Abstractions/INotificationFeatureGate.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "IsFeatureEnabledAsync",
+          "kind": "method",
+          "signature": "IsFeatureEnabledAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
       "name": "INotificationPreferenceReader",
       "fqn": "Granit.Notifications.Abstractions.INotificationPreferenceReader",
       "kind": "interface",
@@ -29329,7 +29345,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Endpoints",
       "file": "src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs",
-      "line": 23,
+      "line": 24,
       "members": [
         {
           "name": "MapGranitNotifications",
@@ -30048,7 +30064,7 @@
           "name": "NotificationDefinition",
           "kind": "method",
           "signature": "NotificationDefinition(string name)",
-          "returnType": "bool AllowDoNotDisturbBypass { get; init; } public"
+          "returnType": "bool AllowDoNotDisturbBypass { get; init; } public string? RequiredPermission { get; init; } public string? RequiredFeature { get; init; } public"
         }
       ]
     },

--- a/src/Granit.Auditing.Notifications/Internal/AuditingNotificationDefinitionProvider.cs
+++ b/src/Granit.Auditing.Notifications/Internal/AuditingNotificationDefinitionProvider.cs
@@ -21,6 +21,7 @@ internal sealed class AuditingNotificationDefinitionProvider : INotificationDefi
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "Auditing.AuditEntries.Read",
         });
     }
 }

--- a/src/Granit.Authentication.ApiKeys.Notifications/Internal/ApiKeysNotificationDefinitionProvider.cs
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Internal/ApiKeysNotificationDefinitionProvider.cs
@@ -21,6 +21,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Info,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
         });
 
         context.Add(new NotificationDefinition(ApiKeyRotatedNotificationType.Instance.Name)
@@ -31,6 +32,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Info,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
         });
 
         context.Add(new NotificationDefinition(ApiKeyRevokedNotificationType.Instance.Name)
@@ -41,6 +43,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Info,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
         });
 
         context.Add(new NotificationDefinition(ApiKeyExpiringSoonNotificationType.Instance.Name)
@@ -51,6 +54,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
         });
     }
 }

--- a/src/Granit.BackgroundJobs.Notifications/Internal/BackgroundJobsNotificationDefinitionProvider.cs
+++ b/src/Granit.BackgroundJobs.Notifications/Internal/BackgroundJobsNotificationDefinitionProvider.cs
@@ -21,6 +21,7 @@ internal sealed class BackgroundJobsNotificationDefinitionProvider : INotificati
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "BackgroundJobs.Jobs.Read",
         });
     }
 }

--- a/src/Granit.Identity.Federated.Notifications/Internal/IdentityFederatedNotificationDefinitionProvider.cs
+++ b/src/Granit.Identity.Federated.Notifications/Internal/IdentityFederatedNotificationDefinitionProvider.cs
@@ -22,6 +22,7 @@ internal sealed class IdentityFederatedNotificationDefinitionProvider : INotific
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "Identity.Users.Read",
         });
 
         context.Add(new NotificationDefinition(IdentityUserProvisioningRemovedNotificationType.Instance.Name)
@@ -32,6 +33,7 @@ internal sealed class IdentityFederatedNotificationDefinitionProvider : INotific
             DefaultSeverity = NotificationSeverity.Info,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "Identity.Users.Read",
         });
 
         context.Add(new NotificationDefinition(IdentityTokenExchangeAuditNotificationType.Instance.Name)
@@ -42,6 +44,7 @@ internal sealed class IdentityFederatedNotificationDefinitionProvider : INotific
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "Identity.Users.Read",
         });
     }
 }

--- a/src/Granit.Notifications.Abstractions/Abstractions/INotificationFeatureGate.cs
+++ b/src/Granit.Notifications.Abstractions/Abstractions/INotificationFeatureGate.cs
@@ -1,0 +1,29 @@
+namespace Granit.Notifications.Abstractions;
+
+/// <summary>
+/// Optional adapter the <c>GET /notifications/types</c> endpoint resolves to
+/// decide whether a <see cref="NotificationDefinition.RequiredFeature"/> is
+/// enabled for the current tenant.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Not registered by default. Hosts that want feature-gated visibility of
+/// notification preferences ship their own implementation — typically a thin
+/// adapter over <c>Granit.Features.IFeatureChecker</c>:
+/// </para>
+/// <code>
+/// services.AddSingleton&lt;INotificationFeatureGate, FeaturesGateAdapter&gt;();
+/// </code>
+/// <para>
+/// When no implementation is registered, the endpoint skips the feature filter
+/// and shows definitions regardless of their <see cref="NotificationDefinition.RequiredFeature"/>.
+/// </para>
+/// </remarks>
+public interface INotificationFeatureGate
+{
+    /// <summary>
+    /// Returns <c>true</c> when the feature named <paramref name="featureName"/>
+    /// is enabled for the current tenant / plan context.
+    /// </summary>
+    Task<bool> IsFeatureEnabledAsync(string featureName, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Notifications.Abstractions/NotificationDefinition.cs
+++ b/src/Granit.Notifications.Abstractions/NotificationDefinition.cs
@@ -39,6 +39,35 @@ public sealed class NotificationDefinition
     /// </summary>
     public bool AllowDoNotDisturbBypass { get; init; }
 
+    /// <summary>
+    /// Permission name (<c>Group.Resource.Action</c>) the recipient must hold for
+    /// this notification to surface in the preferences UI. When <c>null</c>
+    /// (default), no permission gate is applied — the notification is visible to
+    /// every authenticated user. When set, the <c>GET /notifications/types</c>
+    /// endpoint filters out definitions whose permission the current user does
+    /// not have (resolved via <c>IPermissionChecker</c> when available).
+    /// </summary>
+    /// <remarks>
+    /// This is a UI-only filter; it does not gate fan-out. Fan-out remains
+    /// driven by <see cref="DefaultChannels"/> and <see cref="AllowUserOptOut"/>
+    /// — a notification dispatched to a recipient is delivered even if the
+    /// recipient lacks the permission listed here.
+    /// </remarks>
+    public string? RequiredPermission { get; init; }
+
+    /// <summary>
+    /// Feature name (<c>Granit.Features</c>) that must be enabled on the current
+    /// tenant for this notification to surface in the preferences UI. When
+    /// <c>null</c> (default), no feature gate is applied. When set, the
+    /// <c>GET /notifications/types</c> endpoint filters via
+    /// <see cref="Abstractions.INotificationFeatureGate"/> if the host registered one.
+    /// </summary>
+    /// <remarks>
+    /// UI-only filter; does not gate fan-out (same rationale as
+    /// <see cref="RequiredPermission"/>).
+    /// </remarks>
+    public string? RequiredFeature { get; init; }
+
     public NotificationDefinition(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);

--- a/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
@@ -346,9 +346,15 @@ public static class NotificationEndpointRouteBuilderExtensions
                     enabled.Add(feature);
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch
             {
-                // Same safe-default as permissions: an unknown feature stays hidden rather than crashing the UI.
+                // Safe default: any other failure of a host-supplied gate keeps the notification hidden
+                // rather than 500-ing the preferences endpoint. The gate impl is third-party from the
+                // framework's perspective, so we can't narrow to a known exception type.
             }
         }
 

--- a/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Granit.Authorization;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
@@ -229,11 +230,129 @@ public static class NotificationEndpointRouteBuilderExtensions
         return TypedResults.NoContent();
     }
 
-    private static Ok<IReadOnlyList<NotificationDefinition>> GetNotificationTypes(
-        [FromServices] INotificationDefinitionStore definitionStore)
+    private static async Task<Ok<IReadOnlyList<NotificationDefinition>>> GetNotificationTypes(
+        [FromServices] INotificationDefinitionStore definitionStore,
+        [FromServices] IPermissionChecker permissionChecker,
+        [FromServices] IServiceProvider serviceProvider,
+        CancellationToken cancellationToken)
     {
         IReadOnlyList<NotificationDefinition> definitions = definitionStore.GetAll();
-        return TypedResults.Ok(definitions);
+        if (definitions.Count == 0)
+        {
+            return TypedResults.Ok(definitions);
+        }
+
+        IReadOnlyList<NotificationDefinition> filtered = await FilterAsync(
+            definitions, permissionChecker, serviceProvider, cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Ok(filtered);
+    }
+
+    private static async Task<IReadOnlyList<NotificationDefinition>> FilterAsync(
+        IReadOnlyList<NotificationDefinition> definitions,
+        IPermissionChecker permissionChecker,
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken)
+    {
+        HashSet<string> grantedPermissions = await ResolveGrantedPermissionsAsync(
+            definitions, permissionChecker, cancellationToken).ConfigureAwait(false);
+
+        var featureGate = (INotificationFeatureGate?)serviceProvider.GetService(typeof(INotificationFeatureGate));
+        HashSet<string> enabledFeatures = await ResolveEnabledFeaturesAsync(
+            definitions, featureGate, cancellationToken).ConfigureAwait(false);
+
+        List<NotificationDefinition> result = new(definitions.Count);
+        foreach (NotificationDefinition def in definitions)
+        {
+            if (def.RequiredPermission is { Length: > 0 } perm
+                && !grantedPermissions.Contains(perm))
+            {
+                continue;
+            }
+
+            if (def.RequiredFeature is { Length: > 0 } feat
+                && featureGate is not null
+                && !enabledFeatures.Contains(feat))
+            {
+                continue;
+            }
+
+            result.Add(def);
+        }
+
+        return result;
+    }
+
+    private static async Task<HashSet<string>> ResolveGrantedPermissionsAsync(
+        IReadOnlyList<NotificationDefinition> definitions,
+        IPermissionChecker permissionChecker,
+        CancellationToken cancellationToken)
+    {
+        HashSet<string> requested = new(StringComparer.Ordinal);
+        foreach (NotificationDefinition def in definitions)
+        {
+            if (def.RequiredPermission is { Length: > 0 } perm)
+            {
+                requested.Add(perm);
+            }
+        }
+
+        if (requested.Count == 0)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        try
+        {
+            IReadOnlyList<string> granted = await permissionChecker.GetGrantedAsync(
+                [.. requested], cancellationToken).ConfigureAwait(false);
+            return new HashSet<string>(granted, StringComparer.Ordinal);
+        }
+        catch (InvalidOperationException)
+        {
+            // One of the referenced permissions wasn't declared in the host (typically because
+            // the corresponding *.Endpoints module isn't mounted). Treat all of them as not
+            // granted so the unfit notifications stay hidden from the preferences UI.
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+    }
+
+    private static async Task<HashSet<string>> ResolveEnabledFeaturesAsync(
+        IReadOnlyList<NotificationDefinition> definitions,
+        INotificationFeatureGate? featureGate,
+        CancellationToken cancellationToken)
+    {
+        HashSet<string> enabled = new(StringComparer.Ordinal);
+        if (featureGate is null)
+        {
+            return enabled;
+        }
+
+        HashSet<string> requested = new(StringComparer.Ordinal);
+        foreach (NotificationDefinition def in definitions)
+        {
+            if (def.RequiredFeature is { Length: > 0 } feat)
+            {
+                requested.Add(feat);
+            }
+        }
+
+        foreach (string feature in requested)
+        {
+            try
+            {
+                if (await featureGate.IsFeatureEnabledAsync(feature, cancellationToken).ConfigureAwait(false))
+                {
+                    enabled.Add(feature);
+                }
+            }
+            catch
+            {
+                // Same safe-default as permissions: an unknown feature stays hidden rather than crashing the UI.
+            }
+        }
+
+        return enabled;
     }
 
     // -------------------------------------------------------------------------

--- a/src/Granit.Scheduling.Notifications/Internal/SchedulingNotificationDefinitionProvider.cs
+++ b/src/Granit.Scheduling.Notifications/Internal/SchedulingNotificationDefinitionProvider.cs
@@ -21,6 +21,7 @@ internal sealed class SchedulingNotificationDefinitionProvider : INotificationDe
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "Scheduling.Actions.Manage",
         });
     }
 }

--- a/src/Granit.Webhooks.Notifications/Internal/WebhooksNotificationDefinitionProvider.cs
+++ b/src/Granit.Webhooks.Notifications/Internal/WebhooksNotificationDefinitionProvider.cs
@@ -21,6 +21,7 @@ internal sealed class WebhooksNotificationDefinitionProvider : INotificationDefi
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "Webhooks.Subscriptions.Manage",
         });
 
         context.Add(new NotificationDefinition(WebhooksSigningKeyRotationDueNotificationType.Instance.Name)
@@ -31,6 +32,7 @@ internal sealed class WebhooksNotificationDefinitionProvider : INotificationDefi
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
+            RequiredPermission = "Webhooks.Subscriptions.Manage",
         });
     }
 }

--- a/tests/Granit.Notifications.Endpoints.Tests/NotificationEndpointsTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/NotificationEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Granit.Authorization;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
@@ -34,6 +35,7 @@ public sealed class NotificationEndpointsTests : IAsyncDisposable
     private readonly INotificationSubscriptionReader _subscriptionReader = Substitute.For<INotificationSubscriptionReader>();
     private readonly INotificationSubscriptionWriter _subscriptionWriter = Substitute.For<INotificationSubscriptionWriter>();
     private readonly INotificationDefinitionStore _definitionStore = Substitute.For<INotificationDefinitionStore>();
+    private readonly IPermissionChecker _permissionChecker = Substitute.For<IPermissionChecker>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly WebApplication _app;
@@ -62,6 +64,7 @@ public sealed class NotificationEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_subscriptionReader);
         builder.Services.AddSingleton(_subscriptionWriter);
         builder.Services.AddSingleton(_definitionStore);
+        builder.Services.AddSingleton(_permissionChecker);
         builder.Services.AddSingleton(_currentTenant);
         builder.Services.AddSingleton(_clock);
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
@@ -211,6 +214,75 @@ public sealed class NotificationEndpointsTests : IAsyncDisposable
             $"{Prefix}/types", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetNotificationTypes_Hides_definitions_whose_RequiredPermission_user_lacks()
+    {
+        _definitionStore.GetAll().Returns(
+        [
+            new NotificationDefinition("ungated.event"),
+            new NotificationDefinition("gated.event") { RequiredPermission = "Test.Resource.Read" },
+        ]);
+        _permissionChecker.GetGrantedAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<string>());
+
+        List<NotificationDefinition> response = await _authClient.GetFromJsonAsync<List<NotificationDefinition>>(
+            $"{Prefix}/types", TestContext.Current.CancellationToken)
+            ?? throw new InvalidOperationException();
+
+        response.Select(d => d.Name).ShouldBe(["ungated.event"]);
+    }
+
+    [Fact]
+    public async Task GetNotificationTypes_Shows_definitions_whose_RequiredPermission_user_has()
+    {
+        _definitionStore.GetAll().Returns(
+        [
+            new NotificationDefinition("gated.event") { RequiredPermission = "Test.Resource.Read" },
+        ]);
+        _permissionChecker.GetGrantedAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(["Test.Resource.Read"]);
+
+        List<NotificationDefinition> response = await _authClient.GetFromJsonAsync<List<NotificationDefinition>>(
+            $"{Prefix}/types", TestContext.Current.CancellationToken)
+            ?? throw new InvalidOperationException();
+
+        response.Select(d => d.Name).ShouldBe(["gated.event"]);
+    }
+
+    [Fact]
+    public async Task GetNotificationTypes_Treats_unknown_permission_as_not_granted()
+    {
+        _definitionStore.GetAll().Returns(
+        [
+            new NotificationDefinition("gated.event") { RequiredPermission = "Missing.Permission" },
+        ]);
+        _permissionChecker.GetGrantedAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<string>>(_ => throw new InvalidOperationException("not declared"));
+
+        List<NotificationDefinition> response = await _authClient.GetFromJsonAsync<List<NotificationDefinition>>(
+            $"{Prefix}/types", TestContext.Current.CancellationToken)
+            ?? throw new InvalidOperationException();
+
+        response.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetNotificationTypes_With_no_feature_gate_registered_shows_RequiredFeature_definitions()
+    {
+        _definitionStore.GetAll().Returns(
+        [
+            new NotificationDefinition("feature.gated") { RequiredFeature = "Workflow.Enabled" },
+        ]);
+        _permissionChecker.GetGrantedAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<string>());
+
+        List<NotificationDefinition> response = await _authClient.GetFromJsonAsync<List<NotificationDefinition>>(
+            $"{Prefix}/types", TestContext.Current.CancellationToken)
+            ?? throw new InvalidOperationException();
+
+        response.Select(d => d.Name).ShouldBe(["feature.gated"]);
     }
 
     // ── GET /subscriptions ─────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2225. Refs #2219, #1306.

## Summary

- `NotificationDefinition` gains two optional fields: `RequiredPermission` (string, `Group.Resource.Action`) and `RequiredFeature` (string, feature name).
- `GET /api/v1/notifications/types` now filters out definitions whose permission the current user doesn't have, and whose feature isn't enabled — when the corresponding checkers are available.
- New optional adapter `INotificationFeatureGate` in `Granit.Notifications.Abstractions` (no default impl — hosts opt in).
- Six of the nine providers shipped in #2219 are annotated with their natural `RequiredPermission`. Workflow / Timeline / Privacy / Identity.Local stay unannotated (end-user recipients, not admins).

## Why

With #2219 landed, every authenticated user sees all 33+ notification definitions in their preferences panel — including operator-only items (\`Audit Anomaly Detected\`, \`Webhook Delivery Failure Threshold\`, …). The UI becomes noisy and confusing. This PR adds the visibility filter the user explicitly requested.

## Design notes

- **Hard dep on `IPermissionChecker`**: `Granit.Notifications.Endpoints` already references `Granit.Authorization`. Free.
- **Soft dep on feature gating**: `Granit.Notifications.Abstractions` introduces `INotificationFeatureGate` (one-method interface). No core registration. Hosts that use `Granit.Features` wire a tiny adapter; hosts that don't get a no-op.
- **Batched permission lookup**: `IPermissionChecker.GetGrantedAsync` is called once per request with all distinct permissions in the store → single DB roundtrip.
- **Unknown permission = not granted**: when the host hasn't mounted the `*.Endpoints` module that declares a permission, `GetGrantedAsync` throws \`InvalidOperationException\`. We catch and treat as not granted (safe default — hide rather than crash).
- **Fan-out unaffected**: `RequiredPermission` / `RequiredFeature` are UI-only filters. A notification dispatched via `INotificationPublisher` is still delivered even if the recipient doesn't have the listed permission — fan-out remains driven by `DefaultChannels` + `AllowUserOptOut`. Documented inline on the new fields.

## Test plan

- [x] 4 new endpoint tests cover: no constraint visible, permission ungranted hidden, permission granted visible, unknown permission hidden, no feature gate registered → visible
- [x] All 9 `NotificationTypeDefinitionDriftTests` from #2219 still green with the new annotations
- [x] `dotnet format --verify-no-changes` clean on all 9 impacted projects
- [ ] CI shards — full run

## Follow-ups

- Ship an official `INotificationFeatureGate` adapter over `IFeatureChecker` (likely in `Granit.Notifications` itself, gated by `Granit.Features` dep) — separate small story
- Annotate `RequiredFeature` on each module's providers once the per-module feature catalog stories land
- Document the two fields in `granit-docs` (companion of #2220)