### PR TITLE
fix(presence-wolverine): add README and allowlist as Wolverine adapter (archi tests)

### DIFF
--- a/src/Granit.Presence.Wolverine/README.md
+++ b/src/Granit.Presence.Wolverine/README.md
@@ -1,0 +1,24 @@
+# Granit.Presence.Wolverine
+
+Wolverine integration for `Granit.Presence`. Subscribes to user-account
+lifecycle events (`AccountDeletedEto`) and purges the corresponding presence
+override and cached heartbeat — closes the GDPR Art. 17 (right to erasure) loop
+when `Granit.Identity.Local` is loaded alongside `Granit.Presence`.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Presence.Wolverine
+```
+
+## Dependencies
+
+- `Granit.Identity.Local`
+- `Granit.Presence`
+- `Granit.Wolverine`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/tests/Granit.ArchitectureTests/WolverineCouplingTests.cs
+++ b/tests/Granit.ArchitectureTests/WolverineCouplingTests.cs
@@ -45,6 +45,7 @@ public sealed class WolverineCouplingTests
         "Granit.Scheduling.Wolverine",
         "Granit.Webhooks.Wolverine",
         "Granit.Notifications.Wolverine",
+        "Granit.Presence.Wolverine",
         // Granit.Scheduling.BackgroundJobs carries the catch-up dispatcher which uses
         // Wolverine DeliveryOptions + custom headers tied to ScheduledActionStatusMiddleware.
         "Granit.Scheduling.BackgroundJobs",


### PR DESCRIPTION
## Summary

Architecture tests on `develop` broke after #2230 merged:

1. `TestProjectConventionTests.Every_src_package_should_have_a_README` — `Granit.Presence.Wolverine` was missing `README.md`.
2. `WolverineCouplingTests.Domain_packages_should_not_reference_WolverineFx_package` — `Granit.Presence.Wolverine` references `WolverineFx` but wasn't on the legitimate-adapter allowlist.

This PR fixes both:

- Adds `src/Granit.Presence.Wolverine/README.md` (modeled on `Granit.Notifications.Wolverine`).
- Adds `"Granit.Presence.Wolverine"` to `WolverineCouplingTests.WolverineAdapterProjects` — the package's entire purpose is hosting Wolverine handlers for identity lifecycle events.

Follow-up to #2230 / closes the remaining gap for #2197.

## Test plan

- [x] `dotnet test tests/Granit.ArchitectureTests --filter "WolverineCoupling|TestProjectConvention"` — 4/4 pass