### PR TITLE
chore(deps): refresh lockfiles (AWSSDK + Scriban + WireMock patches)

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-05-21
+Dernière mise à jour : 2026-05-25
 
 ---
 
@@ -103,12 +103,12 @@ Dernière mise à jour : 2026-05-21
 
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
-| AWSSDK.CognitoIdentityProvider | 4.0.8.6 | Amazon Web Services, Inc. |
-| AWSSDK.KeyManagementService | 4.0.11 | Amazon Web Services, Inc. |
-| AWSSDK.S3 | 4.0.23.3 | Amazon Web Services, Inc. |
-| AWSSDK.SecretsManager | 4.0.4.23 | Amazon Web Services, Inc. |
-| AWSSDK.SimpleEmailV2 | 4.0.12.16 | Amazon Web Services, Inc. |
-| AWSSDK.SimpleNotificationService | 4.0.2.33 | Amazon Web Services, Inc. |
+| AWSSDK.CognitoIdentityProvider | 4.0.8.7 | Amazon Web Services, Inc. |
+| AWSSDK.KeyManagementService | 4.0.11.1 | Amazon Web Services, Inc. |
+| AWSSDK.S3 | 4.0.23.4 | Amazon Web Services, Inc. |
+| AWSSDK.SecretsManager | 4.0.4.24 | Amazon Web Services, Inc. |
+| AWSSDK.SimpleEmailV2 | 4.0.13 | Amazon Web Services, Inc. |
+| AWSSDK.SimpleNotificationService | 4.0.2.34 | Amazon Web Services, Inc. |
 | Fido2 | 4.0.1 | Copyright (c) 2018 Anders Åberg / passwordless-lib contributors |
 | Fido2.AspNet | 4.0.1 | Copyright (c) 2018 Anders Åberg / passwordless-lib contributors |
 | Fido2.Models | 4.0.1 | Copyright (c) 2018 Anders Åberg / passwordless-lib contributors |
@@ -143,7 +143,7 @@ Dernière mise à jour : 2026-05-21
 
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
-| Scriban | 7.2.0 | Copyright (c) Alexandre Mutel |
+| Scriban | 7.2.1 | Copyright (c) Alexandre Mutel |
 
 ### BSD-3-Clause
 
@@ -196,7 +196,7 @@ Dernière mise à jour : 2026-05-21
 | ------- | ------- | --------- |
 | TngTech.ArchUnitNET | 0.13.3 | Copyright (c) 2019-2025 TNG Technology Consulting GmbH |
 | TngTech.ArchUnitNET.xUnit | 0.13.3 | Copyright (c) 2019-2025 TNG Technology Consulting GmbH |
-| WireMock.Net | 2.6.0 | Copyright (c) WireMock.Net Contributors |
+| WireMock.Net | 2.7.0 | Copyright (c) WireMock.Net Contributors |
 | xunit.v3 | 3.2.2 | Copyright (C) .NET Foundation |
 | xunit.runner.visualstudio | 3.1.5 | Copyright (C) .NET Foundation |
 

--- a/src/Granit.BlobStorage.S3/packages.lock.json
+++ b/src/Granit.BlobStorage.S3/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.3",
-        "contentHash": "ASgWIoX8j6gG4plWXc22vGx0vVwDuqtjBwl3I2ICa2g6kqneSk47eYlGtRg61M/I8gvvtP8uDpIN73FsmlwqHg==",
+        "resolved": "4.0.23.4",
+        "contentHash": "hcCTuMCPVk2cX83sQfvSF/e9uOPxK5KxpuhR9LZVFAKqwUMr2fnrsDXwWu3t3h4Vw+Urx4vTjV9V/PV2KLAUtQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -79,8 +79,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -10,8 +10,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -269,10 +269,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.6",
-        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
+        "resolved": "4.0.8.7",
+        "contentHash": "WNq9te/BnFmo6PCv9klAC5L6SAVgrZhOgBPJti61we+T2PzZPJUF90d8ZdyS9QdQN8Du4ac1ac2pRO84Mu70lg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Cronos": {

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.6",
-        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
+        "resolved": "4.0.8.7",
+        "contentHash": "WNq9te/BnFmo6PCv9klAC5L6SAVgrZhOgBPJti61we+T2PzZPJUF90d8ZdyS9QdQN8Du4ac1ac2pRO84Mu70lg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -32,8 +32,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.16",
-        "contentHash": "sVvEFaV37J9uF1MPDcEqsxiYNVF+q7zTvjG0fwo2/KCf5UbHn4ZXOwARcAsxCYu/ZscZicmIOYPQpJkjhhO9Cw==",
+        "resolved": "4.0.13",
+        "contentHash": "9aj/eldgHAFuoiC18Y6S8BHotNgqdmkcGJl3gmQnjSJwWLADjCxU2jxb5Rd5YWHZsaIu2Y4LNqWn3QYaLhArMQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -69,8 +69,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.33",
-        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
+        "resolved": "4.0.2.34",
+        "contentHash": "aL0rVsixtRE5D0i8UY9nE7L9Dj1YPi9m2O2JB29zf8VV5PHivUW4pFLT+xGt77uo4RIZHYQNJqVq9QKFo0I33w==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.33",
-        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
+        "resolved": "4.0.2.34",
+        "contentHash": "aL0rVsixtRE5D0i8UY9nE7L9Dj1YPi9m2O2JB29zf8VV5PHivUW4pFLT+xGt77uo4RIZHYQNJqVq9QKFo0I33w==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Templating.Scriban/packages.lock.json
+++ b/src/Granit.Templating.Scriban/packages.lock.json
@@ -24,8 +24,8 @@
       "Scriban": {
         "type": "Direct",
         "requested": "[7.*, )",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "resolved": "7.2.1",
+        "contentHash": "5Jw6PyOiY6RBhC5XgtZbOO6ZbZOXlqUDS35IVhLdAPRZHclf3iW35Tdh4FCw1/gNCJ9ia1CGVQabypGPYVThbw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -5,19 +5,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.11",
-        "contentHash": "/mKpJBDVwJKccXfxyf2jK+Lo6Z0r0/P6l3P8+6MaJyeVsHt1apOaO8Q5Xf5BoYd2FV256uW4U8MOyODgJCEpyw==",
+        "resolved": "4.0.11.1",
+        "contentHash": "d8qX5yuOuLiOnu+2m811+Sr0AG84FWh6HzJYl+ZQMhzD+zeMvgzY9vjI0/gc/COq28hDegZdLIzpCrIhVTo83g==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.23",
-        "contentHash": "bDg5U9mUC8vvsWDrAln/Y4t3F6paiNzH24aQNMXnz7cPFOWLt380tAe0dYd7IPx6j007RSEXtnfQ/sYb6ietUg==",
+        "resolved": "4.0.4.24",
+        "contentHash": "NOS/KOwrk+ReZqqut3ilcvtRhTv3hcSmTSWCVJRRLldpuZFsS/ExRDNbo4q6nOnxJmkekUKsgVnB40lfxsv4JQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -91,8 +91,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",
@@ -3617,55 +3617,55 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.6",
-        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
+        "resolved": "4.0.8.7",
+        "contentHash": "WNq9te/BnFmo6PCv9klAC5L6SAVgrZhOgBPJti61we+T2PzZPJUF90d8ZdyS9QdQN8Du4ac1ac2pRO84Mu70lg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.11",
-        "contentHash": "/mKpJBDVwJKccXfxyf2jK+Lo6Z0r0/P6l3P8+6MaJyeVsHt1apOaO8Q5Xf5BoYd2FV256uW4U8MOyODgJCEpyw==",
+        "resolved": "4.0.11.1",
+        "contentHash": "d8qX5yuOuLiOnu+2m811+Sr0AG84FWh6HzJYl+ZQMhzD+zeMvgzY9vjI0/gc/COq28hDegZdLIzpCrIhVTo83g==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.3",
-        "contentHash": "ASgWIoX8j6gG4plWXc22vGx0vVwDuqtjBwl3I2ICa2g6kqneSk47eYlGtRg61M/I8gvvtP8uDpIN73FsmlwqHg==",
+        "resolved": "4.0.23.4",
+        "contentHash": "hcCTuMCPVk2cX83sQfvSF/e9uOPxK5KxpuhR9LZVFAKqwUMr2fnrsDXwWu3t3h4Vw+Urx4vTjV9V/PV2KLAUtQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.23",
-        "contentHash": "bDg5U9mUC8vvsWDrAln/Y4t3F6paiNzH24aQNMXnz7cPFOWLt380tAe0dYd7IPx6j007RSEXtnfQ/sYb6ietUg==",
+        "resolved": "4.0.4.24",
+        "contentHash": "NOS/KOwrk+ReZqqut3ilcvtRhTv3hcSmTSWCVJRRLldpuZFsS/ExRDNbo4q6nOnxJmkekUKsgVnB40lfxsv4JQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.16",
-        "contentHash": "sVvEFaV37J9uF1MPDcEqsxiYNVF+q7zTvjG0fwo2/KCf5UbHn4ZXOwARcAsxCYu/ZscZicmIOYPQpJkjhhO9Cw==",
+        "resolved": "4.0.13",
+        "contentHash": "9aj/eldgHAFuoiC18Y6S8BHotNgqdmkcGJl3gmQnjSJwWLADjCxU2jxb5Rd5YWHZsaIu2Y4LNqWn3QYaLhArMQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.33",
-        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
+        "resolved": "4.0.2.34",
+        "contentHash": "aL0rVsixtRE5D0i8UY9nE7L9Dj1YPi9m2O2JB29zf8VV5PHivUW4pFLT+xGt77uo4RIZHYQNJqVq9QKFo0I33w==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Azure.AI.OpenAI": {
@@ -4322,8 +4322,8 @@
       "Scriban": {
         "type": "CentralTransitive",
         "requested": "[7.*, )",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "resolved": "7.2.1",
+        "contentHash": "5Jw6PyOiY6RBhC5XgtZbOO6ZbZOXlqUDS35IVhLdAPRZHclf3iW35Tdh4FCw1/gNCJ9ia1CGVQabypGPYVThbw=="
       },
       "Sep": {
         "type": "CentralTransitive",

--- a/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
@@ -72,8 +72,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",
@@ -541,10 +541,10 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.3",
-        "contentHash": "ASgWIoX8j6gG4plWXc22vGx0vVwDuqtjBwl3I2ICa2g6kqneSk47eYlGtRg61M/I8gvvtP8uDpIN73FsmlwqHg==",
+        "resolved": "4.0.23.4",
+        "contentHash": "hcCTuMCPVk2cX83sQfvSF/e9uOPxK5KxpuhR9LZVFAKqwUMr2fnrsDXwWu3t3h4Vw+Urx4vTjV9V/PV2KLAUtQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -508,10 +508,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.6",
-        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
+        "resolved": "4.0.8.7",
+        "contentHash": "WNq9te/BnFmo6PCv9klAC5L6SAVgrZhOgBPJti61we+T2PzZPJUF90d8ZdyS9QdQN8Du4ac1ac2pRO84Mu70lg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Cronos": {

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.6",
-        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
+        "resolved": "4.0.8.7",
+        "contentHash": "WNq9te/BnFmo6PCv9klAC5L6SAVgrZhOgBPJti61we+T2PzZPJUF90d8ZdyS9QdQN8Du4ac1ac2pRO84Mu70lg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "coverlet.collector": {
@@ -70,14 +70,14 @@
       "WireMock.Net": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.6.0",
-        "contentHash": "VpNKWe2QwxrcGj118VCcr4xqrjZGzQ1waAlcLqPWI961DTb6gWpR5ig9EOjnjSR72MzbOJLtOJEv6ADi7vQFCw==",
+        "resolved": "2.7.0",
+        "contentHash": "wUF6wRH/W9SSY1iwZhXVmEzQ3eYM8fRgfWU0ZkgicKoC+qUlVRNKP8/jpZPpGciEqc8XKJovSwjfWO6Q4rmL1g==",
         "dependencies": {
-          "WireMock.Net.GraphQL": "2.6.0",
-          "WireMock.Net.MimePart": "2.6.0",
-          "WireMock.Net.Minimal": "2.6.0",
-          "WireMock.Net.OpenTelemetry": "2.6.0",
-          "WireMock.Net.ProtoBuf": "2.6.0"
+          "WireMock.Net.GraphQL": "2.7.0",
+          "WireMock.Net.MimePart": "2.7.0",
+          "WireMock.Net.Minimal": "2.7.0",
+          "WireMock.Net.OpenTelemetry": "2.7.0",
+          "WireMock.Net.ProtoBuf": "2.7.0"
         }
       },
       "xunit.runner.visualstudio": {
@@ -102,8 +102,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -167,16 +167,16 @@
       },
       "Handlebars.Net.Helpers": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "jgxIctjCNNBmSJRakKkZ71gc9uMpBzw5bbmedxbFxzoPGY8VMkACKa2iJyaJofLyxUZUUhACQTbBTyIrIgZ2+Q==",
+        "resolved": "2.5.5",
+        "contentHash": "MZ0/Nvy3XdEy/igZD4fJy5HiUKcKUA170Sq+2RmJFsGiWSqlroXzp8TQqJTDCi1aBtETfQOVdBG0YNvuDs9+uQ==",
         "dependencies": {
-          "Handlebars.Net.Helpers.Core": "2.5.2"
+          "Handlebars.Net.Helpers.Core": "2.5.5"
         }
       },
       "Handlebars.Net.Helpers.Core": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "ruZrZfH/nCu3m5reG5URtdCHA0X8i4i2AumHGKKB3g9c9h3D5eMDGXWeT277Nw64OHNwS4+QZxxJiJ4OYkaIKw==",
+        "resolved": "2.5.5",
+        "contentHash": "vLTL6UrLUPPiWDCKig8FLhSU+i9J4n/8RfrhadvnvxqziyK0ArxKMT2gLqQ+X/8vJaRcI9zvD5HxA8KjWbq3Dw==",
         "dependencies": {
           "Handlebars.Net": "2.1.6",
           "Stef.Validation": "0.1.1"
@@ -184,61 +184,61 @@
       },
       "Handlebars.Net.Helpers.Humanizer": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "uohCZ76ae+7fo55ULtwTk4G76N8VnBHdYjcV/q3oVBfNmVJV3ng7arFMpgdb64t0ZkymZSEoY/tBgzQ7ERWdBQ==",
+        "resolved": "2.5.5",
+        "contentHash": "A7TmfLtv7x8HiVckXBmKmOAsO5GKxjSOjxymXS70upqzLLH8BjrhFl+QIGFCdVIWQRx3+yNjGcsz/JXNwt9YZg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
-          "Humanizer": "2.14.1"
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
+          "Humanizer": "[2.14.1, 4.0.0)"
         }
       },
       "Handlebars.Net.Helpers.Json": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "uJRc55nIWXf1J+pWVYqcI1Jg4BsIJfEk1vccXVahKjCeB159fzhJeSCchhQddSbd6ihSj92u6bSCqXnV+q5qdQ==",
+        "resolved": "2.5.5",
+        "contentHash": "iRBo/ik0M8M6ezJt4QzZm5KQptEdeh6bVtnDbieuxh5YPTUsPMFvtoq0gg426PwrahE+5rXoFZmIM11Oy5GwTg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Handlebars.Net.Helpers.Random": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "eRoi7x0Jvik3rSe1da3o0QNRoWE1YCCT4H3Gfd/D6EkcxbefqmyR4mKqkDG+e9SzEgFwbjvWqI1wx4Mea8Jiuw==",
+        "resolved": "2.5.5",
+        "contentHash": "zKcfFDN4QxgEjk4Em9yz/PQu0mBpIgEaqjhacg2Fl6M0oSsF7VBVflae2WRM9MtiVeRTwLkVwcy7TvJ6iqFuVQ==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
           "RandomDataGenerator.Net": "1.0.19"
         }
       },
       "Handlebars.Net.Helpers.Xeger": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "rmhJfzuHAZMVCMpkDT3+mRCJQyk8xoJtj/9IUfo3bOEXE2M3HPgNfwvHlDcg0oGFC8eMXW+lOrYTQK2+UyvoKA==",
+        "resolved": "2.5.5",
+        "contentHash": "J+w9KalIuYlTKMeIv8eoisdoMEz44elri0UOLtfTAuDbADwnBBsJGp4kAQI107+hBcqery9OCRCXm8fvH4eCxQ==",
         "dependencies": {
           "Fare": "2.2.1",
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2"
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5"
         }
       },
       "Handlebars.Net.Helpers.XPath": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "miJUZQ3CS11YDMxwsCd4YyNI2hKDwkwCHEVtung0N23opIotJXXCpJcyiwwh5RbdbJhiCYaVfMaD3xAyZLrkmg==",
+        "resolved": "2.5.5",
+        "contentHash": "uUGzjR5w5YCv+BdWQ4RpWAho0tUG0zfAKG5v+abXS6+E+fjbfSshOg7LyoWTVcGTWO0PouukhSMUFaumB2K4tg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
           "XPath2.Extensions": "1.1.5"
         }
       },
       "Handlebars.Net.Helpers.Xslt": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "x8jsTWHEPLn5HLskYQ8AKE5hcaPzT0H/C2s55tvBpR29xCxaA2YJyERpYly0xdc/IbbChNnt5eOlWdebMf/wjQ==",
+        "resolved": "2.5.5",
+        "contentHash": "bOaX47avO4Uja6jTZcBAgS5KjL/2ZaewCpB0Oy7cVegctPyxiiRx/T44XGSt0133hHry9f5nJVsjFKNLrYq0Pg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2"
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5"
         }
       },
       "Humanizer": {
@@ -1072,8 +1072,8 @@
       },
       "Scriban.Signed": {
         "type": "Transitive",
-        "resolved": "7.0.6",
-        "contentHash": "98D1jpulhXIju/NaHSf0ZsGRhjFszC84sxPKIkfvWg3DKctCiBOEY9fL4/n5VbV1p6wcJkfhk10FmdBNYws83Q=="
+        "resolved": "7.2.0",
+        "contentHash": "AGI7QURe/UR9lsfM53yylQngbe77PngBnpzZQ+QV3wcevP4cydyCT+YAMR4rntWEle7v++xUjmfmtXuAvp6Rtw=="
       },
       "SharpYaml": {
         "type": "Transitive",
@@ -1124,102 +1124,102 @@
       },
       "WireMock.Net.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "2Y4ubyog7+cvqs2GTiZFLrgQQ8biNH6zqyJw6ejGqxYkCv4iWaJp95LF7JkGJ1QLG+BVp91ap5qu9wB2JcovSQ=="
+        "resolved": "2.7.0",
+        "contentHash": "OubKOs95JrgZ5+mIWIx2lR/iX3igVngrDqEl1hEXK9I6YBVI80uzR2V3oZQ6mMParhHUYLNzJh2IhESJHwuhPw=="
       },
       "WireMock.Net.GraphQL": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "gE4jJgMsIN7ycegmXeYjYg/UKLuy0EbA9OjQ35Eauq5QgvGYAo71hMp+WN5lA8kyrrxdbFe4EOr+eC2/AQzDdA==",
+        "resolved": "2.7.0",
+        "contentHash": "sB3PlNPzLqMtWBTS63oqe+wr3HyuUNtrwrk2WPSG16Pg6eH4VNyNR7kcHo5Zs7eaZuG8+riacX80fwuApOORyQ==",
         "dependencies": {
           "GraphQL.NewtonsoftJson": "8.5.0",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.MimePart": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "h0pssKsBBeGhnESk3KpSly8maklNtNm3gvzL4uUlECcdL5/2urs4WoDtX9mgRu2QWjOV4bE2YSzZ4178B6KU2w==",
+        "resolved": "2.7.0",
+        "contentHash": "IMF9OhV9MU54nIn4FGaxHQ4Ix7Z4OhcmWxPbz4/5HcT5lK8dtIU3AE+lkwT+BHs60eE5XXYtzQAoMMSrWHTGVw==",
         "dependencies": {
           "Stef.Validation": "0.2.0",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.Minimal": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "eBTLPoBAVjKeiMfHkZnHMXGG7DZbtA1vQEsUNF7viGNyOPvu8i6cuByf7E+s9vQqfjxXA4mmbYwJ649Dt1jixA==",
+        "resolved": "2.7.0",
+        "contentHash": "EntqMR/MB7D4FBY+plctyg2PhnANeWJfcXjuftURnH1c1MpfziukOxBMO7ZHH6IkljOz0zToov1sC37SMyzzNA==",
         "dependencies": {
           "JmesPath.Net": "1.1.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.34.0",
           "NJsonSchema.Extensions": "0.2.0",
           "NSwag.Core": "13.16.1",
-          "Scriban.Signed": "7.0.6",
+          "Scriban.Signed": "7.2.0",
           "SimMetrics.Net": "1.0.5",
           "TinyMapper.Signed": "4.0.0",
-          "WireMock.Net.OpenApiParser": "2.6.0",
-          "WireMock.Net.Shared": "2.6.0",
-          "WireMock.Org.Abstractions": "2.6.0"
+          "WireMock.Net.OpenApiParser": "2.7.0",
+          "WireMock.Net.Shared": "2.7.0",
+          "WireMock.Org.Abstractions": "2.7.0"
         }
       },
       "WireMock.Net.OpenApiParser": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "yGcEA+DVTLGuwkvezesKGyZgZ6jkiFIkRgVCvPbMWRQQeX7QsX84DrjrQjG4Ceb1+OjuSMW0K8ApAtbZD141bA==",
+        "resolved": "2.7.0",
+        "contentHash": "6qvH8L2Wn0HiVzEgTR8/16fjPFfRG0AHgCtkvyeEuBqTNM+y/AV6+xGhNembDHVLchMEQETMRXhiGaVySdvQzw==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4",
           "RamlToOpenApiConverter.SourceOnly": "0.11.0",
           "RandomDataGenerator.Net": "1.0.19.1",
           "SharpYaml": "2.1.3",
           "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.6.0",
+          "WireMock.Net.Abstractions": "2.7.0",
           "YamlDotNet": "16.3.0"
         }
       },
       "WireMock.Net.OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "zTqOSRKKtxzhNZXTIKYaepxGBoASixluc0yZzSLwPI2U/2U14w02c+oLzl5jev2Br7pYV5RDbu5xEJTzI1ONbg==",
+        "resolved": "2.7.0",
+        "contentHash": "vZiPE6NjtmUelnt5JwIrUHhz/26tAo2fIdakstXLcgQYLQfimaOPwXBhA3mkxISsLWtWo7NLcapuCCf84/9q0w==",
         "dependencies": {
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.Instrumentation.AspNetCore": "1.15.2",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.ProtoBuf": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "LhwlxZ4I0E96nUW+8rF+f1Mh/5QrgsxiKpBNJXINeVzZxvV78FEUJRxx/cF/Vfwc7m64iKsC0tyo3hg694vMRQ==",
+        "resolved": "2.7.0",
+        "contentHash": "3nba5PZBc8jiYF+/XOiFaOIfYp2F5T31JRWMKqq2Xvyl9HRNhWO0OmROfheLGVjKFVCcfPtMxHM0qH/nBQxtCg==",
         "dependencies": {
           "ProtoBufJsonConverter": "0.11.0",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.Shared": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "SqlitlU3Y9kMih3IBVVtSEoCZuCa0GL7E7+bO9V3nvHHrY1GHdB09VcBnmqEmzIu/nK+E5VnS1kbIUTCl9vLrQ==",
+        "resolved": "2.7.0",
+        "contentHash": "fLfsvGzhlHMBQzPWx3uXhqjDNix7JfR5jzhRTwtipK7K/igtkwXUD0Uba4ifmXrW/OfEwyx3t8IF7ZqPt3kLdQ==",
         "dependencies": {
           "AnyOf": "0.5.0.1",
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Humanizer": "2.5.2",
-          "Handlebars.Net.Helpers.Json": "2.5.2",
-          "Handlebars.Net.Helpers.Random": "2.5.2",
-          "Handlebars.Net.Helpers.XPath": "2.5.2",
-          "Handlebars.Net.Helpers.Xeger": "2.5.2",
-          "Handlebars.Net.Helpers.Xslt": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Humanizer": "2.5.5",
+          "Handlebars.Net.Helpers.Json": "2.5.5",
+          "Handlebars.Net.Helpers.Random": "2.5.5",
+          "Handlebars.Net.Helpers.XPath": "2.5.5",
+          "Handlebars.Net.Helpers.Xeger": "2.5.5",
+          "Handlebars.Net.Helpers.Xslt": "2.5.5",
           "JsonConverter.Newtonsoft.Json": "0.9.0",
           "Microsoft.AspNetCore.Http": "2.3.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.6.0"
+          "WireMock.Net.Abstractions": "2.7.0"
         }
       },
       "WireMock.Org.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "mj69+IaQwEcg0parQARx5NPbxSNMKKa2tQpzTnHPU5FpOcXBmhqH+1ySx+8uN7mcdpQeJBlV27fowx+X7oSKWg=="
+        "resolved": "2.7.0",
+        "contentHash": "6s6xpvOcz0PCUZB6c03SgM6dyeBCeHZoNm2wZINlS5KH2vjjgUd+swfI2ylCj22bWyPjMCQVUjKeIgbazFgWfA=="
       },
       "XPath2": {
         "type": "Transitive",

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -487,10 +487,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.6",
-        "contentHash": "F7oH2jOkGn1g4rSLZwsc75BciTbRCxNIpTvYCphIl24xoCv6Un41qeOT4751uN+Vr0bhVdBezAhKN2RHRGtBeQ==",
+        "resolved": "4.0.8.7",
+        "contentHash": "WNq9te/BnFmo6PCv9klAC5L6SAVgrZhOgBPJti61we+T2PzZPJUF90d8ZdyS9QdQN8Du4ac1ac2pRO84Mu70lg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
@@ -61,14 +61,14 @@
       "WireMock.Net": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.6.0",
-        "contentHash": "VpNKWe2QwxrcGj118VCcr4xqrjZGzQ1waAlcLqPWI961DTb6gWpR5ig9EOjnjSR72MzbOJLtOJEv6ADi7vQFCw==",
+        "resolved": "2.7.0",
+        "contentHash": "wUF6wRH/W9SSY1iwZhXVmEzQ3eYM8fRgfWU0ZkgicKoC+qUlVRNKP8/jpZPpGciEqc8XKJovSwjfWO6Q4rmL1g==",
         "dependencies": {
-          "WireMock.Net.GraphQL": "2.6.0",
-          "WireMock.Net.MimePart": "2.6.0",
-          "WireMock.Net.Minimal": "2.6.0",
-          "WireMock.Net.OpenTelemetry": "2.6.0",
-          "WireMock.Net.ProtoBuf": "2.6.0"
+          "WireMock.Net.GraphQL": "2.7.0",
+          "WireMock.Net.MimePart": "2.7.0",
+          "WireMock.Net.Minimal": "2.7.0",
+          "WireMock.Net.OpenTelemetry": "2.7.0",
+          "WireMock.Net.ProtoBuf": "2.7.0"
         }
       },
       "xunit.runner.visualstudio": {
@@ -153,16 +153,16 @@
       },
       "Handlebars.Net.Helpers": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "jgxIctjCNNBmSJRakKkZ71gc9uMpBzw5bbmedxbFxzoPGY8VMkACKa2iJyaJofLyxUZUUhACQTbBTyIrIgZ2+Q==",
+        "resolved": "2.5.5",
+        "contentHash": "MZ0/Nvy3XdEy/igZD4fJy5HiUKcKUA170Sq+2RmJFsGiWSqlroXzp8TQqJTDCi1aBtETfQOVdBG0YNvuDs9+uQ==",
         "dependencies": {
-          "Handlebars.Net.Helpers.Core": "2.5.2"
+          "Handlebars.Net.Helpers.Core": "2.5.5"
         }
       },
       "Handlebars.Net.Helpers.Core": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "ruZrZfH/nCu3m5reG5URtdCHA0X8i4i2AumHGKKB3g9c9h3D5eMDGXWeT277Nw64OHNwS4+QZxxJiJ4OYkaIKw==",
+        "resolved": "2.5.5",
+        "contentHash": "vLTL6UrLUPPiWDCKig8FLhSU+i9J4n/8RfrhadvnvxqziyK0ArxKMT2gLqQ+X/8vJaRcI9zvD5HxA8KjWbq3Dw==",
         "dependencies": {
           "Handlebars.Net": "2.1.6",
           "Stef.Validation": "0.1.1"
@@ -170,61 +170,61 @@
       },
       "Handlebars.Net.Helpers.Humanizer": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "uohCZ76ae+7fo55ULtwTk4G76N8VnBHdYjcV/q3oVBfNmVJV3ng7arFMpgdb64t0ZkymZSEoY/tBgzQ7ERWdBQ==",
+        "resolved": "2.5.5",
+        "contentHash": "A7TmfLtv7x8HiVckXBmKmOAsO5GKxjSOjxymXS70upqzLLH8BjrhFl+QIGFCdVIWQRx3+yNjGcsz/JXNwt9YZg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
-          "Humanizer": "2.14.1"
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
+          "Humanizer": "[2.14.1, 4.0.0)"
         }
       },
       "Handlebars.Net.Helpers.Json": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "uJRc55nIWXf1J+pWVYqcI1Jg4BsIJfEk1vccXVahKjCeB159fzhJeSCchhQddSbd6ihSj92u6bSCqXnV+q5qdQ==",
+        "resolved": "2.5.5",
+        "contentHash": "iRBo/ik0M8M6ezJt4QzZm5KQptEdeh6bVtnDbieuxh5YPTUsPMFvtoq0gg426PwrahE+5rXoFZmIM11Oy5GwTg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Handlebars.Net.Helpers.Random": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "eRoi7x0Jvik3rSe1da3o0QNRoWE1YCCT4H3Gfd/D6EkcxbefqmyR4mKqkDG+e9SzEgFwbjvWqI1wx4Mea8Jiuw==",
+        "resolved": "2.5.5",
+        "contentHash": "zKcfFDN4QxgEjk4Em9yz/PQu0mBpIgEaqjhacg2Fl6M0oSsF7VBVflae2WRM9MtiVeRTwLkVwcy7TvJ6iqFuVQ==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
           "RandomDataGenerator.Net": "1.0.19"
         }
       },
       "Handlebars.Net.Helpers.Xeger": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "rmhJfzuHAZMVCMpkDT3+mRCJQyk8xoJtj/9IUfo3bOEXE2M3HPgNfwvHlDcg0oGFC8eMXW+lOrYTQK2+UyvoKA==",
+        "resolved": "2.5.5",
+        "contentHash": "J+w9KalIuYlTKMeIv8eoisdoMEz44elri0UOLtfTAuDbADwnBBsJGp4kAQI107+hBcqery9OCRCXm8fvH4eCxQ==",
         "dependencies": {
           "Fare": "2.2.1",
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2"
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5"
         }
       },
       "Handlebars.Net.Helpers.XPath": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "miJUZQ3CS11YDMxwsCd4YyNI2hKDwkwCHEVtung0N23opIotJXXCpJcyiwwh5RbdbJhiCYaVfMaD3xAyZLrkmg==",
+        "resolved": "2.5.5",
+        "contentHash": "uUGzjR5w5YCv+BdWQ4RpWAho0tUG0zfAKG5v+abXS6+E+fjbfSshOg7LyoWTVcGTWO0PouukhSMUFaumB2K4tg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5",
           "XPath2.Extensions": "1.1.5"
         }
       },
       "Handlebars.Net.Helpers.Xslt": {
         "type": "Transitive",
-        "resolved": "2.5.2",
-        "contentHash": "x8jsTWHEPLn5HLskYQ8AKE5hcaPzT0H/C2s55tvBpR29xCxaA2YJyERpYly0xdc/IbbChNnt5eOlWdebMf/wjQ==",
+        "resolved": "2.5.5",
+        "contentHash": "bOaX47avO4Uja6jTZcBAgS5KjL/2ZaewCpB0Oy7cVegctPyxiiRx/T44XGSt0133hHry9f5nJVsjFKNLrYq0Pg==",
         "dependencies": {
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Core": "2.5.2"
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Core": "2.5.5"
         }
       },
       "Humanizer": {
@@ -1172,8 +1172,8 @@
       },
       "Scriban.Signed": {
         "type": "Transitive",
-        "resolved": "7.0.6",
-        "contentHash": "98D1jpulhXIju/NaHSf0ZsGRhjFszC84sxPKIkfvWg3DKctCiBOEY9fL4/n5VbV1p6wcJkfhk10FmdBNYws83Q=="
+        "resolved": "7.2.0",
+        "contentHash": "AGI7QURe/UR9lsfM53yylQngbe77PngBnpzZQ+QV3wcevP4cydyCT+YAMR4rntWEle7v++xUjmfmtXuAvp6Rtw=="
       },
       "SharpYaml": {
         "type": "Transitive",
@@ -1229,102 +1229,102 @@
       },
       "WireMock.Net.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "2Y4ubyog7+cvqs2GTiZFLrgQQ8biNH6zqyJw6ejGqxYkCv4iWaJp95LF7JkGJ1QLG+BVp91ap5qu9wB2JcovSQ=="
+        "resolved": "2.7.0",
+        "contentHash": "OubKOs95JrgZ5+mIWIx2lR/iX3igVngrDqEl1hEXK9I6YBVI80uzR2V3oZQ6mMParhHUYLNzJh2IhESJHwuhPw=="
       },
       "WireMock.Net.GraphQL": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "gE4jJgMsIN7ycegmXeYjYg/UKLuy0EbA9OjQ35Eauq5QgvGYAo71hMp+WN5lA8kyrrxdbFe4EOr+eC2/AQzDdA==",
+        "resolved": "2.7.0",
+        "contentHash": "sB3PlNPzLqMtWBTS63oqe+wr3HyuUNtrwrk2WPSG16Pg6eH4VNyNR7kcHo5Zs7eaZuG8+riacX80fwuApOORyQ==",
         "dependencies": {
           "GraphQL.NewtonsoftJson": "8.5.0",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.MimePart": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "h0pssKsBBeGhnESk3KpSly8maklNtNm3gvzL4uUlECcdL5/2urs4WoDtX9mgRu2QWjOV4bE2YSzZ4178B6KU2w==",
+        "resolved": "2.7.0",
+        "contentHash": "IMF9OhV9MU54nIn4FGaxHQ4Ix7Z4OhcmWxPbz4/5HcT5lK8dtIU3AE+lkwT+BHs60eE5XXYtzQAoMMSrWHTGVw==",
         "dependencies": {
           "Stef.Validation": "0.2.0",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.Minimal": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "eBTLPoBAVjKeiMfHkZnHMXGG7DZbtA1vQEsUNF7viGNyOPvu8i6cuByf7E+s9vQqfjxXA4mmbYwJ649Dt1jixA==",
+        "resolved": "2.7.0",
+        "contentHash": "EntqMR/MB7D4FBY+plctyg2PhnANeWJfcXjuftURnH1c1MpfziukOxBMO7ZHH6IkljOz0zToov1sC37SMyzzNA==",
         "dependencies": {
           "JmesPath.Net": "1.1.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.34.0",
           "NJsonSchema.Extensions": "0.2.0",
           "NSwag.Core": "13.16.1",
-          "Scriban.Signed": "7.0.6",
+          "Scriban.Signed": "7.2.0",
           "SimMetrics.Net": "1.0.5",
           "TinyMapper.Signed": "4.0.0",
-          "WireMock.Net.OpenApiParser": "2.6.0",
-          "WireMock.Net.Shared": "2.6.0",
-          "WireMock.Org.Abstractions": "2.6.0"
+          "WireMock.Net.OpenApiParser": "2.7.0",
+          "WireMock.Net.Shared": "2.7.0",
+          "WireMock.Org.Abstractions": "2.7.0"
         }
       },
       "WireMock.Net.OpenApiParser": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "yGcEA+DVTLGuwkvezesKGyZgZ6jkiFIkRgVCvPbMWRQQeX7QsX84DrjrQjG4Ceb1+OjuSMW0K8ApAtbZD141bA==",
+        "resolved": "2.7.0",
+        "contentHash": "6qvH8L2Wn0HiVzEgTR8/16fjPFfRG0AHgCtkvyeEuBqTNM+y/AV6+xGhNembDHVLchMEQETMRXhiGaVySdvQzw==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4",
           "RamlToOpenApiConverter.SourceOnly": "0.11.0",
           "RandomDataGenerator.Net": "1.0.19.1",
           "SharpYaml": "2.1.3",
           "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.6.0",
+          "WireMock.Net.Abstractions": "2.7.0",
           "YamlDotNet": "16.3.0"
         }
       },
       "WireMock.Net.OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "zTqOSRKKtxzhNZXTIKYaepxGBoASixluc0yZzSLwPI2U/2U14w02c+oLzl5jev2Br7pYV5RDbu5xEJTzI1ONbg==",
+        "resolved": "2.7.0",
+        "contentHash": "vZiPE6NjtmUelnt5JwIrUHhz/26tAo2fIdakstXLcgQYLQfimaOPwXBhA3mkxISsLWtWo7NLcapuCCf84/9q0w==",
         "dependencies": {
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.Instrumentation.AspNetCore": "1.15.2",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.ProtoBuf": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "LhwlxZ4I0E96nUW+8rF+f1Mh/5QrgsxiKpBNJXINeVzZxvV78FEUJRxx/cF/Vfwc7m64iKsC0tyo3hg694vMRQ==",
+        "resolved": "2.7.0",
+        "contentHash": "3nba5PZBc8jiYF+/XOiFaOIfYp2F5T31JRWMKqq2Xvyl9HRNhWO0OmROfheLGVjKFVCcfPtMxHM0qH/nBQxtCg==",
         "dependencies": {
           "ProtoBufJsonConverter": "0.11.0",
-          "WireMock.Net.Shared": "2.6.0"
+          "WireMock.Net.Shared": "2.7.0"
         }
       },
       "WireMock.Net.Shared": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "SqlitlU3Y9kMih3IBVVtSEoCZuCa0GL7E7+bO9V3nvHHrY1GHdB09VcBnmqEmzIu/nK+E5VnS1kbIUTCl9vLrQ==",
+        "resolved": "2.7.0",
+        "contentHash": "fLfsvGzhlHMBQzPWx3uXhqjDNix7JfR5jzhRTwtipK7K/igtkwXUD0Uba4ifmXrW/OfEwyx3t8IF7ZqPt3kLdQ==",
         "dependencies": {
           "AnyOf": "0.5.0.1",
-          "Handlebars.Net.Helpers": "2.5.2",
-          "Handlebars.Net.Helpers.Humanizer": "2.5.2",
-          "Handlebars.Net.Helpers.Json": "2.5.2",
-          "Handlebars.Net.Helpers.Random": "2.5.2",
-          "Handlebars.Net.Helpers.XPath": "2.5.2",
-          "Handlebars.Net.Helpers.Xeger": "2.5.2",
-          "Handlebars.Net.Helpers.Xslt": "2.5.2",
+          "Handlebars.Net.Helpers": "2.5.5",
+          "Handlebars.Net.Helpers.Humanizer": "2.5.5",
+          "Handlebars.Net.Helpers.Json": "2.5.5",
+          "Handlebars.Net.Helpers.Random": "2.5.5",
+          "Handlebars.Net.Helpers.XPath": "2.5.5",
+          "Handlebars.Net.Helpers.Xeger": "2.5.5",
+          "Handlebars.Net.Helpers.Xslt": "2.5.5",
           "JsonConverter.Newtonsoft.Json": "0.9.0",
           "Microsoft.AspNetCore.Http": "2.3.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.6.0"
+          "WireMock.Net.Abstractions": "2.7.0"
         }
       },
       "WireMock.Org.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "mj69+IaQwEcg0parQARx5NPbxSNMKKa2tQpzTnHPU5FpOcXBmhqH+1ySx+8uN7mcdpQeJBlV27fowx+X7oSKWg=="
+        "resolved": "2.7.0",
+        "contentHash": "6s6xpvOcz0PCUZB6c03SgM6dyeBCeHZoNm2wZINlS5KH2vjjgUd+swfI2ylCj22bWyPjMCQVUjKeIgbazFgWfA=="
       },
       "XPath2": {
         "type": "Transitive",

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -381,10 +381,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.16",
-        "contentHash": "sVvEFaV37J9uF1MPDcEqsxiYNVF+q7zTvjG0fwo2/KCf5UbHn4ZXOwARcAsxCYu/ZscZicmIOYPQpJkjhhO9Cw==",
+        "resolved": "4.0.13",
+        "contentHash": "9aj/eldgHAFuoiC18Y6S8BHotNgqdmkcGJl3gmQnjSJwWLADjCxU2jxb5Rd5YWHZsaIu2Y4LNqWn3QYaLhArMQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -310,10 +310,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.33",
-        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
+        "resolved": "4.0.2.34",
+        "contentHash": "aL0rVsixtRE5D0i8UY9nE7L9Dj1YPi9m2O2JB29zf8VV5PHivUW4pFLT+xGt77uo4RIZHYQNJqVq9QKFo0I33w==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -309,10 +309,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.33",
-        "contentHash": "YviozKoXi89RQewIpRaADxVj9r9z1rHTf6H+3zqmeOPoATGH1kca19tfd0gsIrzxj6Ij6as8EgOuX2hj3DWW2A==",
+        "resolved": "4.0.2.34",
+        "contentHash": "aL0rVsixtRE5D0i8UY9nE7L9Dj1YPi9m2O2JB29zf8VV5PHivUW4pFLT+xGt77uo4RIZHYQNJqVq9QKFo0I33w==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Templating.Scriban.Tests/packages.lock.json
+++ b/tests/Granit.Templating.Scriban.Tests/packages.lock.json
@@ -365,8 +365,8 @@
       "Scriban": {
         "type": "CentralTransitive",
         "requested": "[7.*, )",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "resolved": "7.2.1",
+        "contentHash": "5Jw6PyOiY6RBhC5XgtZbOO6ZbZOXlqUDS35IVhLdAPRZHclf3iW35Tdh4FCw1/gNCJ9ia1CGVQabypGPYVThbw=="
       }
     }
   }

--- a/tests/Granit.Vault.Aws.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Aws.Tests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.7.1",
-        "contentHash": "XA0GHLwEMkoVu3u8neKnLEDD9ViXpn26ie9UhKXZXYRzCRfSFrLWpBOhupWlf+cJEFBYCC5mx2NsN8h59Y+M2Q=="
+        "resolved": "4.0.7.3",
+        "contentHash": "F7x7IREeF8nd5pQUz0bYQf7TyrREZBQBqUdswkeGf1BWg91uHT8/lvENTb8+cN5xLxbf+m06FANDOD+GK8NrHw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -407,19 +407,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.11",
-        "contentHash": "/mKpJBDVwJKccXfxyf2jK+Lo6Z0r0/P6l3P8+6MaJyeVsHt1apOaO8Q5Xf5BoYd2FV256uW4U8MOyODgJCEpyw==",
+        "resolved": "4.0.11.1",
+        "contentHash": "d8qX5yuOuLiOnu+2m811+Sr0AG84FWh6HzJYl+ZQMhzD+zeMvgzY9vjI0/gc/COq28hDegZdLIzpCrIhVTo83g==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.23",
-        "contentHash": "bDg5U9mUC8vvsWDrAln/Y4t3F6paiNzH24aQNMXnz7cPFOWLt380tAe0dYd7IPx6j007RSEXtnfQ/sYb6ietUg==",
+        "resolved": "4.0.4.24",
+        "contentHash": "NOS/KOwrk+ReZqqut3ilcvtRhTv3hcSmTSWCVJRRLldpuZFsS/ExRDNbo4q6nOnxJmkekUKsgVnB40lfxsv4JQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.7.1, 5.0.0)"
+          "AWSSDK.Core": "[4.0.7.3, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {


### PR DESCRIPTION
## Summary

Force-evaluated NuGet lockfiles after a HTTP-cache flush to pick up patch-level drift accumulated since the last refresh. No `.csproj` changes — only resolved versions move.

### Direct production dependencies

| Package | Old | New |
| ------- | --- | --- |
| AWSSDK.Core | 4.0.7.1 | 4.0.7.3 |
| AWSSDK.CognitoIdentityProvider | 4.0.8.6 | 4.0.8.7 |
| AWSSDK.KeyManagementService | 4.0.11 | 4.0.11.1 |
| AWSSDK.S3 | 4.0.23.3 | 4.0.23.4 |
| AWSSDK.SecretsManager | 4.0.4.23 | 4.0.4.24 |
| AWSSDK.SimpleEmailV2 | 4.0.12.16 | 4.0.13 |
| AWSSDK.SimpleNotificationService | 4.0.2.33 | 4.0.2.34 |
| Scriban | 7.2.0 | 7.2.1 |

### Test-only dependencies

| Package | Old | New |
| ------- | --- | --- |
| WireMock.Net (+ 8 sub-packages) | 2.6.0 | 2.7.0 |
| Handlebars.Net.Helpers (+ 7 sub-packages, transitive of WireMock) | 2.5.2 | 2.5.5 |
| Scriban.Signed (transitive of WireMock) | 7.0.6 | 7.2.0 |

### Licenses

No license changes. All bumps stay on the same SPDX classification (Apache-2.0 for AWSSDK / WireMock, BSD-2-Clause for Scriban).

`THIRD-PARTY-NOTICES.md` updated with the new versions + audit date `2026-05-25`.

## Test plan

- [x] `dotnet nuget locals http-cache --clear`
- [x] `dotnet restore Granit.slnx --force-evaluate` — clean
- [x] `npx markdownlint-cli2 THIRD-PARTY-NOTICES.md` — 0 errors