### PR TITLE
test(text-extraction): pin TextExtraction architecture conventions

### DIFF
--- a/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
@@ -1,0 +1,176 @@
+using System.Xml.Linq;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Architecture rules for the <c>Granit.TextExtraction.*</c> module family (epic #2233).
+/// Pins the VULN-001 input-size contract and the "pure utility, no host plumbing" boundary
+/// across the base package and the extractor providers (PDF, Office, Text).
+/// </summary>
+public sealed class TextExtractionArchitectureTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string SrcRoot = Path.Join(RepoRoot, "src");
+
+    /// <summary>
+    /// Every <c>Granit.TextExtraction.*</c> package that ships at least one
+    /// <c>*Extractor.cs</c> MUST mention <c>LimitedStream</c> somewhere in the package —
+    /// proving that the input stream is wrapped before any third-party parser allocation.
+    /// We check the package level (not the extractor file) because the wrap is often
+    /// extracted to a shared helper (e.g. <c>OpenXmlExtraction</c>) that the per-format
+    /// extractors delegate to.
+    /// </summary>
+    [Fact]
+    public void Every_extractor_package_must_reference_LimitedStream()
+    {
+        List<string> violators = [];
+
+        foreach (string packageDir in EnumerateExtractorPackages())
+        {
+            bool packageReferencesLimitedStream = Directory
+                .EnumerateFiles(packageDir, "*.cs", SearchOption.AllDirectories)
+                .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                .Any(p => File.ReadAllText(p).Contains("LimitedStream", StringComparison.Ordinal));
+
+            if (!packageReferencesLimitedStream)
+            {
+                violators.Add(Path.GetFileName(packageDir));
+            }
+        }
+
+        violators.ShouldBeEmpty(
+            "Every Granit.TextExtraction.* package that ships extractors must wrap its " +
+            "input in a LimitedStream — either directly in the extractor or via a shared " +
+            "helper in the same package. Violators: " + string.Join(", ", violators));
+    }
+
+    /// <summary>
+    /// <c>Granit.TextExtraction</c> is a pure utility framework: byte-stream → plain text.
+    /// It must NEVER pull in ASP.NET Core — that would force every consumer (CLI tools,
+    /// background workers, indexing pipelines) to drag the web stack into their build.
+    /// </summary>
+    [Theory]
+    [InlineData("Granit.TextExtraction")]
+    [InlineData("Granit.TextExtraction.Office")]
+    [InlineData("Granit.TextExtraction.Pdf")]
+    [InlineData("Granit.TextExtraction.Text")]
+    public void TextExtraction_packages_must_not_reference_AspNetCore(string projectName) =>
+        AssertNoPackageReferenceStartsWith(projectName, "Microsoft.AspNetCore.");
+
+    /// <summary>
+    /// Same reasoning as <see cref="TextExtraction_packages_must_not_reference_AspNetCore"/>:
+    /// TextExtraction is stateless. No DbContext, no migrations, no persistence concerns.
+    /// EF Core in the build graph here would invite mission creep — a pipeline package starts
+    /// caching extracted text into a table, and suddenly the framework has a DB dependency.
+    /// </summary>
+    [Theory]
+    [InlineData("Granit.TextExtraction")]
+    [InlineData("Granit.TextExtraction.Office")]
+    [InlineData("Granit.TextExtraction.Pdf")]
+    [InlineData("Granit.TextExtraction.Text")]
+    public void TextExtraction_packages_must_not_reference_EntityFrameworkCore(string projectName) =>
+        AssertNoPackageReferenceStartsWith(projectName, "Microsoft.EntityFrameworkCore");
+
+    /// <summary>
+    /// The base <c>Granit.TextExtraction</c> contract package must declare zero
+    /// <c>[DependsOn]</c> modules — it's the implicit root that every provider attaches to.
+    /// A regression here would silently couple every host that adds the base contract to
+    /// whatever the new dependency drags in (e.g. AI, vault, multi-tenancy).
+    /// </summary>
+    [Fact]
+    public void Granit_TextExtraction_base_must_have_zero_module_dependencies()
+    {
+        string modulePath = Path.Join(
+            SrcRoot, "Granit.TextExtraction", "GranitTextExtractionModule.cs");
+        File.Exists(modulePath).ShouldBeTrue($"Expected {modulePath} to exist.");
+
+        string source = File.ReadAllText(modulePath);
+        source.ShouldNotContain(
+            "[DependsOn",
+            customMessage:
+                "Granit.TextExtraction is the contract root for the byte-to-text pipeline. " +
+                "Adding [DependsOn] here would force every provider package to inherit that " +
+                "dependency. If a real coupling is needed, move it to the provider package.");
+    }
+
+    /// <summary>
+    /// Every provider package (<c>Granit.TextExtraction.Office</c>,
+    /// <c>Granit.TextExtraction.Pdf</c>, <c>Granit.TextExtraction.Text</c>) must declare
+    /// <c>[DependsOn(typeof(GranitTextExtractionModule))]</c> so the pipeline + options +
+    /// metrics are wired into the host even when only one provider is added. Without
+    /// this, calling <c>AddTextExtractor&lt;T&gt;</c> would silently no-op (no pipeline
+    /// service registered).
+    /// </summary>
+    [Theory]
+    [InlineData("Granit.TextExtraction.Office", "GranitTextExtractionOfficeModule.cs")]
+    [InlineData("Granit.TextExtraction.Pdf", "GranitTextExtractionPdfModule.cs")]
+    [InlineData("Granit.TextExtraction.Text", "GranitTextExtractionTextModule.cs")]
+    public void Extractor_provider_modules_must_DependOn_base(string projectName, string moduleFile)
+    {
+        string modulePath = Path.Join(SrcRoot, projectName, moduleFile);
+        File.Exists(modulePath).ShouldBeTrue($"Expected {modulePath} to exist.");
+
+        string source = File.ReadAllText(modulePath);
+        source.ShouldContain(
+            "[DependsOn(typeof(GranitTextExtractionModule))]",
+            customMessage:
+                $"{projectName} must declare [DependsOn(typeof(GranitTextExtractionModule))] " +
+                "on its module so the pipeline/options/metrics are registered when only " +
+                "this provider is wired in.");
+    }
+
+    private static IEnumerable<string> EnumerateExtractorPackages()
+    {
+        foreach (string dir in Directory.EnumerateDirectories(SrcRoot, "Granit.TextExtraction*"))
+        {
+            // A package counts as an "extractor package" if it ships at least one
+            // *Extractor.cs (other than the ITextExtractor interface). The base package
+            // qualifies via PlainTextExtractor.cs.
+            bool hasExtractor = Directory
+                .EnumerateFiles(dir, "*Extractor.cs", SearchOption.TopDirectoryOnly)
+                .Any(p => !Path.GetFileName(p).StartsWith("ITextExtractor", StringComparison.Ordinal));
+
+            if (hasExtractor)
+            {
+                yield return dir;
+            }
+        }
+    }
+
+    private static void AssertNoPackageReferenceStartsWith(string projectName, string forbiddenPrefix)
+    {
+        string csprojPath = Path.Join(SrcRoot, projectName, $"{projectName}.csproj");
+        File.Exists(csprojPath).ShouldBeTrue($"Expected {csprojPath} to exist.");
+
+        var doc = XDocument.Load(csprojPath);
+        IEnumerable<string> packageRefs = doc.Descendants("PackageReference")
+            .Select(e => e.Attribute("Include")?.Value ?? string.Empty);
+
+        IEnumerable<string> violators = packageRefs
+            .Where(p => p.StartsWith(forbiddenPrefix, StringComparison.Ordinal));
+
+        violators.ShouldBeEmpty(
+            $"{projectName} must not reference NuGets starting with '{forbiddenPrefix}'. " +
+            "TextExtraction is a pure byte→text utility — host concerns (HTTP, persistence) " +
+            "belong upstream of the extraction pipeline. Violators: " +
+            string.Join(", ", violators));
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(TextExtractionArchitectureTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+}


### PR DESCRIPTION
Partially addresses #2253. The matching granit-docs page is a separate out-of-repo follow-up.

## Summary

Adds `TextExtractionArchitectureTests` to the existing `Granit.ArchitectureTests` project. Locks in the conventions of what TE-F1 / TE-F2 shipped (#2266, #2267, #2268, #2269, #2270) so a future refactor can't silently undo them. Same project as `BrowsingArchitectureTests` / `SectionNameConventionTests` — one-stop archi enforcement.

## Rules (6 tests, 13 facts via `[Theory]` expansion)

1. **`Every_extractor_package_must_reference_LimitedStream`** — pinned at the package level (not per-file) because the OpenXml family delegates to a shared `OpenXmlExtraction.ReadAllBytesAsync` helper. VULN-001 enforcement.
2. **`TextExtraction_packages_must_not_reference_AspNetCore`** — framework stays usable from CLI / workers / indexing pipelines.
3. **`TextExtraction_packages_must_not_reference_EntityFrameworkCore`** — TextExtraction is stateless. EF Core in the graph would invite mission creep into caching/indexing tables.
4. **`Granit_TextExtraction_base_must_have_zero_module_dependencies`** — pins the contract root so every provider inherits a minimal `[DependsOn]` tree.
5. **`Extractor_provider_modules_must_DependOn_base`** — each provider (`.Office`, `.Pdf`, `.Text`) wires the pipeline + options + metrics through `[DependsOn(typeof(GranitTextExtractionModule))]`. Without it `AddTextExtractor<T>` silently no-ops.

## Notes on the spec

The issue also lists two requirements I'm intentionally not implementing here:

- **"Every `*Extractor` is `internal sealed`"** — the shipped extractors are `public sealed`. Making them internal would break consumers who instantiate them directly in tests (every PR's test suite does this — `new HtmlTextExtractor(...)`) and would diverge from `Granit.QueryEngine` / `Granit.BlobStorage` / `Granit.Browsing` which also expose their concrete services. I think the current shape is right. Open to changing if JF disagrees but would prefer to address in a focused follow-up rather than mix the API surface change with the convention-pinning PR.
- **VULN-300 `WithDefaultLoader` archi test** — already lives in `Granit.Html.AngleSharp.Tests/AngleSharpConfigurationTests.cs` (embedded-resource regex check). Duplicating it here would create two sources of truth for the same invariant; the test is closer to home where it ships.
- **"Cap-breach returns `IsTruncated: true` instead of throwing"** — the actual contract for `MaxBodySizeBytes` is to throw `TextExtractionException("input_too_large")` (set in TE-F1.1, every per-extractor unit test verifies it). The TE-F5 spec wording assumed a softer model that isn't what shipped. The per-extractor tests cover the throw discipline already.

If the team wants the alternate behaviour for any of these, I'd write up the API change as its own issue first to discuss tradeoffs.

## Test plan

- [x] `dotnet build tests/Granit.ArchitectureTests` clean
- [x] 200/200 archi tests pass locally (187 previous + 13 new)
- [x] `dotnet format` clean on touched paths
- [ ] CI: architecture shard green

## Out of scope (handoff for granit-docs)

- The `granit-docs` page positioning `Granit.TextExtraction` as a peer to `Granit.QueryEngine` / `Granit.DataExchange` ships in a separate PR against the sibling repo, per the framework's "doc PRs are decoupled" convention.