### PR TITLE
refactor(text-extraction): audit fixes for Granit.Html.* and Granit.TextExtraction.*

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2034,7 +2034,6 @@
     {
       "name": "Granit.TextExtraction.Email",
       "deps": [
-        "Granit.Html",
         "Granit.Html.AngleSharp",
         "Granit.TextExtraction"
       ],
@@ -2072,7 +2071,6 @@
     {
       "name": "Granit.TextExtraction.Text",
       "deps": [
-        "Granit.Html",
         "Granit.Html.AngleSharp",
         "Granit.TextExtraction"
       ],
@@ -18233,7 +18231,7 @@
       "kind": "class",
       "project": "Granit.Html.AngleSharp",
       "file": "src/Granit.Html.AngleSharp/AngleSharpConfiguration.cs",
-      "line": 17,
+      "line": 24,
       "members": [
         {
           "name": "BuildForTrustedTemplates",
@@ -18297,6 +18295,15 @@
       "project": "Granit.Html",
       "file": "src/Granit.Html/GranitHtmlModule.cs",
       "line": 10,
+      "members": []
+    },
+    {
+      "name": "HtmlConverterKeys",
+      "fqn": "Granit.Html.HtmlConverterKeys",
+      "kind": "class",
+      "project": "Granit.Html",
+      "file": "src/Granit.Html/HtmlConverterKeys.cs",
+      "line": 13,
       "members": []
     },
     {
@@ -41497,7 +41504,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Email",
       "file": "src/Granit.TextExtraction.Email/Extensions/ServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitTextExtractionEmail",
@@ -41513,7 +41520,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Email",
       "file": "src/Granit.TextExtraction.Email/GranitTextExtractionEmailModule.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -41545,7 +41552,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction",
       "file": "src/Granit.TextExtraction/Extensions/ServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitTextExtraction",
@@ -41662,11 +41669,11 @@
       ]
     },
     {
-      "name": "AiVisionOcrExtractor",
-      "fqn": "Granit.TextExtraction.Ocr.AI.AiVisionOcrExtractor",
+      "name": "AIVisionOcrExtractor",
+      "fqn": "Granit.TextExtraction.Ocr.AI.AIVisionOcrExtractor",
       "kind": "class",
       "project": "Granit.TextExtraction.Ocr.AI",
-      "file": "src/Granit.TextExtraction.Ocr.AI/AiVisionOcrExtractor.cs",
+      "file": "src/Granit.TextExtraction.Ocr.AI/AIVisionOcrExtractor.cs",
       "line": 28,
       "members": [
         {
@@ -41686,9 +41693,9 @@
       "line": 12,
       "members": [
         {
-          "name": "AddAiVisionOcrExtractor",
+          "name": "AddAIVisionOcrExtractor",
           "kind": "method",
-          "signature": "AddAiVisionOcrExtractor(this IServiceCollection services, Action<AiVisionOcrOptions>? configure = null)",
+          "signature": "AddAIVisionOcrExtractor(this IServiceCollection services, Action<AIVisionOcrOptions>? configure = null)",
           "returnType": "IServiceCollection"
         }
       ]
@@ -41719,11 +41726,11 @@
       ]
     },
     {
-      "name": "AiVisionOcrOptions",
-      "fqn": "Granit.TextExtraction.Ocr.AI.Options.AiVisionOcrOptions",
+      "name": "AIVisionOcrOptions",
+      "fqn": "Granit.TextExtraction.Ocr.AI.Options.AIVisionOcrOptions",
       "kind": "class",
       "project": "Granit.TextExtraction.Ocr.AI",
-      "file": "src/Granit.TextExtraction.Ocr.AI/Options/AiVisionOcrOptions.cs",
+      "file": "src/Granit.TextExtraction.Ocr.AI/Options/AIVisionOcrOptions.cs",
       "line": 7,
       "members": [
         {
@@ -42060,7 +42067,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Text",
       "file": "src/Granit.TextExtraction.Text/Extensions/ServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitTextExtractionText",
@@ -42076,7 +42083,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Text",
       "file": "src/Granit.TextExtraction.Text/GranitTextExtractionTextModule.cs",
-      "line": 11,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -42092,7 +42099,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Text",
       "file": "src/Granit.TextExtraction.Text/HtmlTextExtractor.cs",
-      "line": 23,
+      "line": 20,
       "members": [
         {
           "name": "CanHandle",

--- a/src/Granit.Html.AngleSharp/AngleSharpConfiguration.cs
+++ b/src/Granit.Html.AngleSharp/AngleSharpConfiguration.cs
@@ -3,30 +3,41 @@ using AngleSharp;
 namespace Granit.Html.AngleSharp;
 
 /// <summary>
-/// Factory for AngleSharp <see cref="IConfiguration"/> instances. Exposes two strictly
-/// separated profiles so callers must make the trust decision explicit.
+/// Factory for AngleSharp <see cref="IConfiguration"/> instances. Exposes two named
+/// profiles so the SSRF posture is encoded explicitly at the call site instead of being
+/// inferred from a default.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="BuildForUntrustedContent"/> intentionally OMITS the AngleSharp default loader,
-/// CSS resolution, and script execution. The architecture test in
-/// <c>Granit.Html.AngleSharp.Tests</c> verifies the source code of this type never
-/// invokes the default-loader fluent helper.
+/// Both profiles return <see cref="Configuration.Default"/> today — neither registers an
+/// HTTP requester, so external resources (links, stylesheets, images) are never resolved.
+/// The named factories exist so that future profile drift (e.g. attaching a same-origin
+/// requester to the trusted profile) lands deterministically on Notifications email
+/// templates only, leaving the untrusted ingest path locked down.
+/// </para>
+/// <para>
+/// The architecture test <c>AngleSharpConfigurationTests.Source_must_never_call_WithDefaultLoader</c>
+/// pins the SSRF guard at the source level — if either profile ever needs the AngleSharp
+/// default loader, the test forces an explicit, documented opt-in.
 /// </para>
 /// </remarks>
 public static class AngleSharpConfiguration
 {
     /// <summary>
-    /// Configuration suitable for trusted HTML produced by the host (e.g. Granit-owned
-    /// email templates rendered through Scriban). Matches the historical Notifications.Email
-    /// behaviour — parser only, no CSS engine, no JS engine, no external resource loading.
+    /// Profile for host-owned HTML (e.g. Granit-rendered email templates).
+    /// Returns <see cref="Configuration.Default"/> — parser only, no loader, no CSS engine,
+    /// no JS engine. Consumed by Notifications.Email through the keyed
+    /// <c>HtmlConverterKeys.Trusted</c> registration.
     /// </summary>
     public static IConfiguration BuildForTrustedTemplates() => Configuration.Default;
 
     /// <summary>
-    /// Configuration suitable for HTML that did not originate from the host
-    /// (user uploads, third-party content, indexed documents). NEVER invokes the AngleSharp
-    /// default-loader helper — that would open an SSRF channel.
+    /// Profile for HTML that did not originate from the host (user uploads, indexed
+    /// documents, incoming email bodies). Returns <see cref="Configuration.Default"/> —
+    /// identical to the trusted profile today, but isolated as its own factory so the SSRF
+    /// posture can never silently inherit a future loader added to the trusted profile.
+    /// Consumed by TextExtraction extractors through the keyed
+    /// <c>HtmlConverterKeys.Untrusted</c> registration.
     /// </summary>
     public static IConfiguration BuildForUntrustedContent() => Configuration.Default;
 }

--- a/src/Granit.Html.AngleSharp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Html.AngleSharp/Extensions/ServiceCollectionExtensions.cs
@@ -5,21 +5,38 @@ namespace Granit.Html.AngleSharp.Extensions;
 
 /// <summary>
 /// Extension methods for registering the AngleSharp-backed
-/// <see cref="IHtmlToPlainTextConverter"/> implementation.
+/// <see cref="IHtmlToPlainTextConverter"/> implementations.
 /// </summary>
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers <see cref="AngleSharpHtmlToPlainTextConverter"/> as the default
-    /// <see cref="IHtmlToPlainTextConverter"/>. Uses
-    /// <see cref="AngleSharpConfiguration.BuildForTrustedTemplates"/>. Hosts dealing with
-    /// untrusted content should replace the registration with a converter constructed via
-    /// <see cref="AngleSharpConfiguration.BuildForUntrustedContent"/>.
+    /// Registers the two posture profiles of <see cref="IHtmlToPlainTextConverter"/> as
+    /// keyed singletons:
+    /// <list type="bullet">
+    ///   <item><see cref="HtmlConverterKeys.Trusted"/> →
+    ///   <see cref="AngleSharpConfiguration.BuildForTrustedTemplates"/> (Notifications.Email,
+    ///   host-rendered templates).</item>
+    ///   <item><see cref="HtmlConverterKeys.Untrusted"/> →
+    ///   <see cref="AngleSharpConfiguration.BuildForUntrustedContent"/> (TextExtraction,
+    ///   indexing, anything dealing with externally-sourced HTML).</item>
+    /// </list>
+    /// Consumers pick the profile at injection time with
+    /// <c>[FromKeyedServices(HtmlConverterKeys.Trusted | Untrusted)]</c>.
     /// </summary>
     public static IServiceCollection AddGranitHtmlAngleSharp(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
-        services.TryAddSingleton<IHtmlToPlainTextConverter, AngleSharpHtmlToPlainTextConverter>();
+
+        services.TryAddKeyedSingleton<IHtmlToPlainTextConverter>(
+            HtmlConverterKeys.Trusted,
+            (_, _) => new AngleSharpHtmlToPlainTextConverter(
+                AngleSharpConfiguration.BuildForTrustedTemplates()));
+
+        services.TryAddKeyedSingleton<IHtmlToPlainTextConverter>(
+            HtmlConverterKeys.Untrusted,
+            (_, _) => new AngleSharpHtmlToPlainTextConverter(
+                AngleSharpConfiguration.BuildForUntrustedContent()));
+
         return services;
     }
 }

--- a/src/Granit.Html.AngleSharp/packages.lock.json
+++ b/src/Granit.Html.AngleSharp/packages.lock.json
@@ -23,7 +23,7 @@
       "granit": {
         "type": "Project"
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",

--- a/src/Granit.Html/Granit.Html.csproj
+++ b/src/Granit.Html/Granit.Html.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Granit.Html.Abstractions</PackageId>
-    <Description>HTML processing abstractions for Granit. Provides IHtmlToPlainTextConverter (AngleSharp-backed) and an AngleSharpConfiguration factory with separated trusted-template vs untrusted-content profiles to keep SSRF risks isolated. Shared by Notifications (trusted email templates) and TextExtraction (untrusted uploads).</Description>
+    <PackageId>Granit.Html</PackageId>
+    <Description>HTML processing abstractions for Granit. Provides IHtmlToPlainTextConverter and an AngleSharpConfiguration factory exposing trusted-template vs untrusted-content profiles to keep SSRF risks isolated. Shared by Notifications (trusted email templates) and TextExtraction (untrusted uploads).</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Granit.Html.Abstractions.Tests" />
+    <InternalsVisibleTo Include="Granit.Html.Tests" />
     <InternalsVisibleTo Include="Granit.Notifications.Email" />
     <InternalsVisibleTo Include="Granit.Notifications.Email.Tests" />
     <!-- Required by NSubstitute (Castle.DynamicProxy) to mock internal interfaces in tests -->

--- a/src/Granit.Html/HtmlConverterKeys.cs
+++ b/src/Granit.Html/HtmlConverterKeys.cs
@@ -1,0 +1,27 @@
+namespace Granit.Html;
+
+/// <summary>
+/// Keyed-services identifiers for the two posture profiles of
+/// <see cref="IHtmlToPlainTextConverter"/>.
+/// </summary>
+/// <remarks>
+/// Consumers MUST inject via <c>[FromKeyedServices(HtmlConverterKeys.Trusted)]</c> or
+/// <c>[FromKeyedServices(HtmlConverterKeys.Untrusted)]</c> — the choice encodes the SSRF
+/// posture explicitly at the call site, removing the historical "default profile is
+/// whatever the provider picked" ambiguity.
+/// </remarks>
+public static class HtmlConverterKeys
+{
+    /// <summary>
+    /// Profile for host-owned HTML (e.g. Granit-rendered email templates). May enable
+    /// external resource resolution if the provider chooses to.
+    /// </summary>
+    public const string Trusted = "trusted";
+
+    /// <summary>
+    /// Profile for HTML that did not originate from the host (user uploads, indexed
+    /// documents, incoming email bodies). Providers MUST NOT resolve external resources
+    /// (SSRF guard).
+    /// </summary>
+    public const string Untrusted = "untrusted";
+}

--- a/src/Granit.Notifications.Brevo/packages.lock.json
+++ b/src/Granit.Notifications.Brevo/packages.lock.json
@@ -285,7 +285,7 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -297,7 +297,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -131,7 +131,7 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -143,7 +143,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/packages.lock.json
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/packages.lock.json
@@ -197,7 +197,7 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -209,7 +209,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Notifications.Email.Scaleway/packages.lock.json
+++ b/src/Granit.Notifications.Email.Scaleway/packages.lock.json
@@ -285,7 +285,7 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -297,7 +297,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Notifications.Email.SendGrid/packages.lock.json
+++ b/src/Granit.Notifications.Email.SendGrid/packages.lock.json
@@ -285,7 +285,7 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -297,7 +297,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Notifications.Email.Smtp/packages.lock.json
+++ b/src/Granit.Notifications.Email.Smtp/packages.lock.json
@@ -146,7 +146,7 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -158,7 +158,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -45,7 +45,7 @@ internal sealed partial class EmailNotificationChannel(
     IOptions<EmailChannelOptions> options,
     IRecipientResolver recipientResolver,
     IConfiguration configuration,
-    IHtmlToPlainTextConverter htmlToPlainText,
+    [FromKeyedServices(HtmlConverterKeys.Trusted)] IHtmlToPlainTextConverter htmlToPlainText,
     ILogger<EmailNotificationChannel> logger) : INotificationChannel
 {
     /// <summary>

--- a/src/Granit.Notifications.Email/packages.lock.json
+++ b/src/Granit.Notifications.Email/packages.lock.json
@@ -74,7 +74,7 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -86,7 +86,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.TextExtraction.Email/EmailTextExtractor.cs
+++ b/src/Granit.TextExtraction.Email/EmailTextExtractor.cs
@@ -1,8 +1,8 @@
 using System.Globalization;
 using System.Text;
 using Granit.Html;
-using Granit.Html.AngleSharp;
 using Granit.TextExtraction.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MimeKit;
@@ -48,25 +48,19 @@ public sealed partial class EmailTextExtractor : ITextExtractor
 
     private readonly GranitTextExtractionOptions _options;
     private readonly ILogger<EmailTextExtractor> _logger;
-
-    // The DI-registered converter ships with the trusted-templates profile so that
-    // Notifications.Email keeps its historical behaviour. Email bodies are NOT trusted
-    // content — they originate from outside the host — so we build our own untrusted
-    // converter here. Same posture as Granit.TextExtraction.Text.HtmlTextExtractor.
-#pragma warning disable CA1859
     private readonly IHtmlToPlainTextConverter _htmlConverter;
-#pragma warning restore CA1859
 
     public EmailTextExtractor(
+        [FromKeyedServices(HtmlConverterKeys.Untrusted)] IHtmlToPlainTextConverter htmlConverter,
         IOptions<GranitTextExtractionOptions> options,
         ILogger<EmailTextExtractor> logger)
     {
+        ArgumentNullException.ThrowIfNull(htmlConverter);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(logger);
+        _htmlConverter = htmlConverter;
         _options = options.Value;
         _logger = logger;
-        _htmlConverter = new AngleSharpHtmlToPlainTextConverter(
-            AngleSharpConfiguration.BuildForUntrustedContent());
     }
 
     /// <inheritdoc/>

--- a/src/Granit.TextExtraction.Email/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.TextExtraction.Email/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Html.AngleSharp.Extensions;
 using Granit.TextExtraction.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,14 +11,17 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Registers <see cref="EmailTextExtractor"/> with the <c>Granit.TextExtraction</c>
-    /// pipeline. Implicitly calls <c>AddGranitTextExtraction()</c> so consumers don't have
-    /// to wire the base module separately.
+    /// pipeline. Implicitly calls <c>AddGranitTextExtraction()</c> and
+    /// <c>AddGranitHtmlAngleSharp()</c> so consumers don't have to wire the base modules
+    /// separately — <see cref="EmailTextExtractor"/> needs the keyed
+    /// <c>HtmlConverterKeys.Untrusted</c> converter for the HTML body fallback path.
     /// </summary>
     public static IServiceCollection AddGranitTextExtractionEmail(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddGranitTextExtraction();
+        services.AddGranitHtmlAngleSharp();
         services.AddTextExtractor<EmailTextExtractor>();
 
         return services;

--- a/src/Granit.TextExtraction.Email/Granit.TextExtraction.Email.csproj
+++ b/src/Granit.TextExtraction.Email/Granit.TextExtraction.Email.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Granit.Html\Granit.Html.csproj" />
     <ProjectReference Include="..\Granit.Html.AngleSharp\Granit.Html.AngleSharp.csproj" />
     <ProjectReference Include="..\Granit.TextExtraction\Granit.TextExtraction.csproj" />
   </ItemGroup>

--- a/src/Granit.TextExtraction.Email/GranitTextExtractionEmailModule.cs
+++ b/src/Granit.TextExtraction.Email/GranitTextExtractionEmailModule.cs
@@ -7,8 +7,9 @@ namespace Granit.TextExtraction.Email;
 /// <summary>
 /// Granit module that registers <see cref="EmailTextExtractor"/> with the
 /// <c>Granit.TextExtraction</c> pipeline. Depends on
-/// <see cref="GranitHtmlAngleSharpModule"/> so the SSRF-safe HTML→plain-text
-/// converter is available for the HTML body fallback path.
+/// <see cref="GranitHtmlAngleSharpModule"/> so the keyed
+/// <c>HtmlConverterKeys.Untrusted</c> <c>IHtmlToPlainTextConverter</c> is available
+/// for the HTML body fallback path.
 /// </summary>
 [DependsOn(typeof(GranitHtmlAngleSharpModule), typeof(GranitTextExtractionModule))]
 public sealed class GranitTextExtractionEmailModule : GranitModule

--- a/src/Granit.TextExtraction.Email/packages.lock.json
+++ b/src/Granit.TextExtraction.Email/packages.lock.json
@@ -70,7 +70,7 @@
       "granit": {
         "type": "Project"
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -82,7 +82,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.TextExtraction.Ocr.AI/AIVisionOcrExtractor.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/AIVisionOcrExtractor.cs
@@ -11,7 +11,7 @@ namespace Granit.TextExtraction.Ocr.AI;
 /// Extractor that sends raster images to a multimodal LLM (vision-capable
 /// <see cref="IChatClient"/>) and reads back the verbatim text. Backed by
 /// <see cref="IAIChatClientFactory"/>; the model + endpoint are resolved from the
-/// Granit.AI workspace named by <see cref="AiVisionOcrOptions.WorkspaceName"/>.
+/// Granit.AI workspace named by <see cref="AIVisionOcrOptions.WorkspaceName"/>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -25,7 +25,7 @@ namespace Granit.TextExtraction.Ocr.AI;
 /// applies the quota middleware.
 /// </para>
 /// </remarks>
-public sealed partial class AiVisionOcrExtractor : ITextExtractor
+public sealed partial class AIVisionOcrExtractor : ITextExtractor
 {
     /// <summary>The stable extractor identifier surfaced on metrics and spans.</summary>
     public const string ExtractorName = "granit.text-extraction.ocr-ai";
@@ -33,16 +33,16 @@ public sealed partial class AiVisionOcrExtractor : ITextExtractor
     private readonly IAIChatClientFactory _chatClientFactory;
     private readonly IVisionOcrPromptBuilder _promptBuilder;
     private readonly GranitTextExtractionOptions _extractionOptions;
-    private readonly AiVisionOcrOptions _ocrOptions;
-    private readonly ILogger<AiVisionOcrExtractor> _logger;
+    private readonly AIVisionOcrOptions _ocrOptions;
+    private readonly ILogger<AIVisionOcrExtractor> _logger;
     private readonly HashSet<string> _allowedContentTypes;
 
-    public AiVisionOcrExtractor(
+    public AIVisionOcrExtractor(
         IAIChatClientFactory chatClientFactory,
         IVisionOcrPromptBuilder promptBuilder,
         IOptions<GranitTextExtractionOptions> extractionOptions,
-        IOptions<AiVisionOcrOptions> ocrOptions,
-        ILogger<AiVisionOcrExtractor> logger)
+        IOptions<AIVisionOcrOptions> ocrOptions,
+        ILogger<AIVisionOcrExtractor> logger)
     {
         ArgumentNullException.ThrowIfNull(chatClientFactory);
         ArgumentNullException.ThrowIfNull(promptBuilder);
@@ -159,11 +159,11 @@ public sealed partial class AiVisionOcrExtractor : ITextExtractor
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "AiVisionOcrExtractor failed to resolve IChatClient for workspace {Workspace}.")]
+        Message = "AIVisionOcrExtractor failed to resolve IChatClient for workspace {Workspace}.")]
     private partial void LogChatClientResolutionFailed(Exception exception, string workspace);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "AiVisionOcrExtractor IChatClient call failed for workspace {Workspace}.")]
+        Message = "AIVisionOcrExtractor IChatClient call failed for workspace {Workspace}.")]
     private partial void LogChatClientCallFailed(Exception exception, string workspace);
 }

--- a/src/Granit.TextExtraction.Ocr.AI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/Extensions/ServiceCollectionExtensions.cs
@@ -12,26 +12,26 @@ namespace Granit.TextExtraction.Ocr.AI.Extensions;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers <see cref="AiVisionOcrExtractor"/> with the <c>Granit.TextExtraction</c>
+    /// Registers <see cref="AIVisionOcrExtractor"/> with the <c>Granit.TextExtraction</c>
     /// pipeline. Implicitly calls <c>AddGranitTextExtraction()</c>, binds
-    /// <see cref="AiVisionOcrOptions"/>, and registers the default
+    /// <see cref="AIVisionOcrOptions"/>, and registers the default
     /// <see cref="IVisionOcrPromptBuilder"/>. The host MUST also register a Granit.AI
     /// workspace (via <c>builder.AddGranitAI()</c> + a provider package) — this method
     /// does not configure the AI module itself.
     /// </summary>
-    public static IServiceCollection AddAiVisionOcrExtractor(
+    public static IServiceCollection AddAIVisionOcrExtractor(
         this IServiceCollection services,
-        Action<AiVisionOcrOptions>? configure = null)
+        Action<AIVisionOcrOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddGranitTextExtraction();
-        services.AddTextExtractor<AiVisionOcrExtractor>();
+        services.AddTextExtractor<AIVisionOcrExtractor>();
 
         services.TryAddSingleton<IVisionOcrPromptBuilder, DefaultVisionOcrPromptBuilder>();
 
-        services.AddOptions<AiVisionOcrOptions>()
-            .BindConfiguration(AiVisionOcrOptions.SectionName);
+        services.AddOptions<AIVisionOcrOptions>()
+            .BindConfiguration(AIVisionOcrOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.TextExtraction.Ocr.AI/GranitTextExtractionOcrAIModule.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/GranitTextExtractionOcrAIModule.cs
@@ -5,7 +5,7 @@ namespace Granit.TextExtraction.Ocr.AI;
 /// <summary>
 /// Granit module that registers the AI vision OCR extractor (opt-in). Hosts wire the
 /// extractor via
-/// <see cref="Extensions.ServiceCollectionExtensions.AddAiVisionOcrExtractor"/>;
+/// <see cref="Extensions.ServiceCollectionExtensions.AddAIVisionOcrExtractor"/>;
 /// the module itself does not auto-register anything because enabling vision OCR sends
 /// document bytes to a third-party LLM provider (GDPR Article 28 disclosure required).
 /// </summary>

--- a/src/Granit.TextExtraction.Ocr.AI/IVisionOcrPromptBuilder.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/IVisionOcrPromptBuilder.cs
@@ -3,7 +3,7 @@ namespace Granit.TextExtraction.Ocr.AI;
 /// <summary>
 /// Builds the user-message prompt that accompanies the image when invoking the multimodal
 /// model. Hosts customise the prompt by registering their own implementation BEFORE
-/// calling <c>AddAiVisionOcrExtractor</c>.
+/// calling <c>AddAIVisionOcrExtractor</c>.
 /// </summary>
 public interface IVisionOcrPromptBuilder
 {

--- a/src/Granit.TextExtraction.Ocr.AI/Options/AIVisionOcrOptions.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/Options/AIVisionOcrOptions.cs
@@ -4,10 +4,10 @@ namespace Granit.TextExtraction.Ocr.AI.Options;
 /// Configuration options for the AI vision OCR extractor. Bound from the
 /// <see cref="SectionName"/> section of <c>appsettings.json</c>.
 /// </summary>
-public sealed class AiVisionOcrOptions
+public sealed class AIVisionOcrOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "TextExtraction:OcrAI";
+    public const string SectionName = "TextExtraction:Ocr:AI";
 
     /// <summary>
     /// Name of the Granit.AI workspace whose <see cref="Microsoft.Extensions.AI.IChatClient"/>

--- a/src/Granit.TextExtraction.Ocr.AI/README.md
+++ b/src/Granit.TextExtraction.Ocr.AI/README.md
@@ -36,9 +36,11 @@ configuration with an architecture test on your host application.
 ```json
 {
   "TextExtraction": {
-    "OcrAI": {
-      "WorkspaceName": "vision-ocr",
-      "AllowedContentTypes": ["image/png", "image/jpeg", "image/webp", "image/tiff"]
+    "Ocr": {
+      "AI": {
+        "WorkspaceName": "vision-ocr",
+        "AllowedContentTypes": ["image/png", "image/jpeg", "image/webp", "image/tiff"]
+      }
     }
   }
 }
@@ -51,11 +53,11 @@ at a model with vision/multimodal support (e.g. `gpt-4o`, `claude-3.5-sonnet`,
 ## Custom prompts
 
 Replace the default prompt by registering an `IVisionOcrPromptBuilder` before
-calling `AddAiVisionOcrExtractor`:
+calling `AddAIVisionOcrExtractor`:
 
 ```csharp
 services.AddSingleton<IVisionOcrPromptBuilder, MyDomainPromptBuilder>();
-services.AddAiVisionOcrExtractor();
+services.AddAIVisionOcrExtractor();
 ```
 
 The default prompt asks the model to "extract verbatim text, preserving table

--- a/src/Granit.TextExtraction.Ocr.Tesseract/Options/TesseractOcrOptions.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/Options/TesseractOcrOptions.cs
@@ -7,7 +7,7 @@ namespace Granit.TextExtraction.Ocr.Tesseract.Options;
 public sealed class TesseractOcrOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "TextExtraction:OcrTesseract";
+    public const string SectionName = "TextExtraction:Ocr:Tesseract";
 
     /// <summary>
     /// Default pixel-bomb cap (100 megapixels — covers A1 @ 600 DPI with margin).

--- a/src/Granit.TextExtraction.Pdf/README.md
+++ b/src/Granit.TextExtraction.Pdf/README.md
@@ -32,7 +32,7 @@ dotnet add package Granit.TextExtraction.Pdf
 - Input wrapped in `LimitedStream` (`MaxBodySizeBytes` cap, VULN-001).
 - **Password-protected PDFs** (`PdfDocumentEncryptedException`) are reported
   as an empty `TextExtractionResult` with `IsTruncated = true` and the
-  `granit.text_extraction.extraction.skipped` metric incremented. No silent
+  `granit.text_extraction.document.skipped` metric incremented. No silent
   password prompt is attempted.
 - **Malformed PDFs** (`PdfDocumentFormatException`) follow the same path.
 

--- a/src/Granit.TextExtraction.Text/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.TextExtraction.Text/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Html.AngleSharp.Extensions;
 using Granit.TextExtraction.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,14 +12,16 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Registers <see cref="HtmlTextExtractor"/> and <see cref="MarkdownTextExtractor"/>
     /// with the <c>Granit.TextExtraction</c> pipeline. Implicitly calls
-    /// <c>AddGranitTextExtraction()</c> so consumers don't have to wire the base module
-    /// separately.
+    /// <c>AddGranitTextExtraction()</c> and <c>AddGranitHtmlAngleSharp()</c> so consumers
+    /// don't have to wire the base modules separately — <see cref="HtmlTextExtractor"/>
+    /// needs the keyed <c>HtmlConverterKeys.Untrusted</c> converter.
     /// </summary>
     public static IServiceCollection AddGranitTextExtractionText(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddGranitTextExtraction();
+        services.AddGranitHtmlAngleSharp();
         services.AddTextExtractor<HtmlTextExtractor>();
         services.AddTextExtractor<MarkdownTextExtractor>();
 

--- a/src/Granit.TextExtraction.Text/Granit.TextExtraction.Text.csproj
+++ b/src/Granit.TextExtraction.Text/Granit.TextExtraction.Text.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Granit.Html\Granit.Html.csproj" />
     <ProjectReference Include="..\Granit.Html.AngleSharp\Granit.Html.AngleSharp.csproj" />
     <ProjectReference Include="..\Granit.TextExtraction\Granit.TextExtraction.csproj" />
   </ItemGroup>

--- a/src/Granit.TextExtraction.Text/GranitTextExtractionTextModule.cs
+++ b/src/Granit.TextExtraction.Text/GranitTextExtractionTextModule.cs
@@ -1,3 +1,4 @@
+using Granit.Html.AngleSharp;
 using Granit.Modularity;
 using Granit.TextExtraction.Text.Extensions;
 
@@ -5,9 +6,12 @@ namespace Granit.TextExtraction.Text;
 
 /// <summary>
 /// Granit module that registers the HTML and Markdown text extractors with the
-/// <c>Granit.TextExtraction</c> pipeline.
+/// <c>Granit.TextExtraction</c> pipeline. Depends on
+/// <see cref="GranitHtmlAngleSharpModule"/> so the keyed
+/// <c>HtmlConverterKeys.Untrusted</c> <c>IHtmlToPlainTextConverter</c> is available
+/// for <see cref="HtmlTextExtractor"/>.
 /// </summary>
-[DependsOn(typeof(GranitTextExtractionModule))]
+[DependsOn(typeof(GranitHtmlAngleSharpModule), typeof(GranitTextExtractionModule))]
 public sealed class GranitTextExtractionTextModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.TextExtraction.Text/HtmlTextExtractor.cs
+++ b/src/Granit.TextExtraction.Text/HtmlTextExtractor.cs
@@ -1,24 +1,21 @@
 using Granit.Html;
-using Granit.Html.AngleSharp;
 using Granit.TextExtraction.Exceptions;
 using Granit.TextExtraction.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Granit.TextExtraction.Text;
 
 /// <summary>
 /// Extractor for <c>text/html</c> and <c>application/xhtml+xml</c>. Delegates to
-/// <see cref="IHtmlToPlainTextConverter"/> for the DOM walk and honours the
-/// truncation contract by trimming the resulting plain text to <c>maxCharLength</c>.
+/// the untrusted-profile <see cref="IHtmlToPlainTextConverter"/> for the DOM walk
+/// and honours the truncation contract by trimming the resulting plain text to
+/// <c>maxCharLength</c>.
 /// </summary>
 /// <remarks>
-/// SSRF posture: the extractor constructs its own <see cref="IHtmlToPlainTextConverter"/>
-/// using <see cref="AngleSharpConfiguration.BuildForUntrustedContent"/> by default. When the
-/// host sets <see cref="GranitTextExtractionOptions.ResolveHtmlExternalResources"/> to
-/// <c>true</c> — only appropriate for fully trusted corpora — the converter is rebuilt with
-/// <see cref="AngleSharpConfiguration.BuildForTrustedTemplates"/>. The DI-registered
-/// <see cref="IHtmlToPlainTextConverter"/> is intentionally NOT consumed because it ships
-/// with the trusted-templates profile to keep Notifications.Email behaviour intact.
+/// SSRF posture: the extractor consumes the keyed
+/// <see cref="HtmlConverterKeys.Untrusted"/> converter so the DOM walker is
+/// guaranteed to refuse external resource resolution regardless of provider.
 /// </remarks>
 public sealed class HtmlTextExtractor : ITextExtractor
 {
@@ -26,24 +23,16 @@ public sealed class HtmlTextExtractor : ITextExtractor
     public const string ExtractorName = "granit.text-extraction.html";
 
     private readonly GranitTextExtractionOptions _options;
-
-    // Typed as the abstraction even though only AngleSharp ships today — keeps the
-    // contract surface symmetric with the rest of Granit.TextExtraction.* and lets
-    // downstream tests / forks swap in a different impl without changing this class.
-    // CA1859 prefers the concrete type for a perf nudge; one virtual call per
-    // extraction is dwarfed by the AngleSharp parse it brackets.
-#pragma warning disable CA1859
     private readonly IHtmlToPlainTextConverter _converter;
-#pragma warning restore CA1859
 
-    public HtmlTextExtractor(IOptions<GranitTextExtractionOptions> options)
+    public HtmlTextExtractor(
+        [FromKeyedServices(HtmlConverterKeys.Untrusted)] IHtmlToPlainTextConverter converter,
+        IOptions<GranitTextExtractionOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(converter);
         ArgumentNullException.ThrowIfNull(options);
+        _converter = converter;
         _options = options.Value;
-        _converter = new AngleSharpHtmlToPlainTextConverter(
-            _options.ResolveHtmlExternalResources
-                ? AngleSharpConfiguration.BuildForTrustedTemplates()
-                : AngleSharpConfiguration.BuildForUntrustedContent());
     }
 
     /// <inheritdoc/>

--- a/src/Granit.TextExtraction.Text/README.md
+++ b/src/Granit.TextExtraction.Text/README.md
@@ -23,7 +23,7 @@ dotnet add package Granit.TextExtraction.Text
 
 | Extractor | MIME types | Notes |
 | --------- | ---------- | ----- |
-| `HtmlTextExtractor` | `text/html`, `application/xhtml+xml` | Constructs its own AngleSharp converter via `BuildForUntrustedContent()` by default. Hosts that index trusted templates can opt into `ResolveHtmlExternalResources = true`, which switches to `BuildForTrustedTemplates()`. SSRF-safe by default. |
+| `HtmlTextExtractor` | `text/html`, `application/xhtml+xml` | Consumes the keyed `HtmlConverterKeys.Untrusted` `IHtmlToPlainTextConverter` registered by `Granit.Html.AngleSharp`. SSRF-safe by design — the untrusted profile never resolves external resources. |
 | `MarkdownTextExtractor` | `text/markdown`, `text/x-markdown` | Uses `Markdig.Markdown.ToPlainText` with the `UseAdvancedExtensions()` pipeline (tables, footnotes, task lists, …). |
 
 ## Documentation

--- a/src/Granit.TextExtraction.Text/packages.lock.json
+++ b/src/Granit.TextExtraction.Text/packages.lock.json
@@ -56,7 +56,7 @@
       "granit": {
         "type": "Project"
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -68,7 +68,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.TextExtraction/Diagnostics/TextExtractionMetrics.cs
+++ b/src/Granit.TextExtraction/Diagnostics/TextExtractionMetrics.cs
@@ -23,20 +23,20 @@ public sealed class TextExtractionMetrics
         Meter meter = meterFactory.Create(MeterName);
 
         _success = meter.CreateCounter<long>(
-            "granit.text_extraction.extraction.success",
-            description: "Number of successful text extractions.");
+            "granit.text_extraction.document.extracted",
+            description: "Number of documents successfully extracted to text.");
 
         _failed = meter.CreateCounter<long>(
-            "granit.text_extraction.extraction.failed",
-            description: "Number of failed text extractions (extractor threw or aborted).");
+            "granit.text_extraction.document.failed",
+            description: "Number of documents whose extraction failed (extractor threw or aborted).");
 
         _skipped = meter.CreateCounter<long>(
-            "granit.text_extraction.extraction.skipped",
-            description: "Number of extractions skipped because no extractor claimed the content type.");
+            "granit.text_extraction.document.skipped",
+            description: "Number of documents skipped because no extractor claimed the content type.");
 
         _truncated = meter.CreateCounter<long>(
-            "granit.text_extraction.extraction.truncated",
-            description: "Number of extractions that hit the MaxExtractedCharLength cap.");
+            "granit.text_extraction.document.truncated",
+            description: "Number of documents whose extraction hit the MaxExtractedCharLength cap.");
     }
 
     public void RecordSuccess(string? tenantId, string extractorName, string contentType)

--- a/src/Granit.TextExtraction/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.TextExtraction/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Diagnostics;
+using Granit.MultiTenancy;
 using Granit.TextExtraction.Diagnostics;
 using Granit.TextExtraction.Internal;
 using Granit.TextExtraction.Options;
@@ -32,6 +33,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<TextExtractionMetrics>();
         services.TryAddSingleton<PlainTextExtractor>();
+        services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
         services.TryAddSingleton<ITextExtractionPipeline, TextExtractionPipeline>();
 
         return services;

--- a/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
+++ b/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.TextExtraction.Diagnostics;
 using Granit.TextExtraction.Exceptions;
 using Granit.TextExtraction.Options;
@@ -14,11 +15,13 @@ internal sealed class TextExtractionPipeline(
     IEnumerable<ITextExtractor> extractors,
     PlainTextExtractor fallback,
     TextExtractionMetrics metrics,
+    ICurrentTenant currentTenant,
     IOptions<GranitTextExtractionOptions> options) : ITextExtractionPipeline
 {
     private readonly IReadOnlyList<ITextExtractor> _extractors = [.. extractors];
     private readonly PlainTextExtractor _fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
     private readonly TextExtractionMetrics _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+    private readonly ICurrentTenant _currentTenant = currentTenant ?? throw new ArgumentNullException(nameof(currentTenant));
     private readonly GranitTextExtractionOptions _options =
         options?.Value ?? throw new ArgumentNullException(nameof(options));
 
@@ -31,6 +34,7 @@ internal sealed class TextExtractionPipeline(
         ArgumentException.ThrowIfNullOrEmpty(contentType);
 
         ITextExtractor selected = SelectExtractor(contentType);
+        string? tenantId = ResolveTenantId();
 
         try
         {
@@ -38,17 +42,17 @@ internal sealed class TextExtractionPipeline(
                 .ExtractAsync(source, contentType, _options.MaxExtractedCharLength, cancellationToken)
                 .ConfigureAwait(false);
 
-            _metrics.RecordSuccess(tenantId: null, result.ExtractorName, contentType);
+            _metrics.RecordSuccess(tenantId, result.ExtractorName, contentType);
             if (result.IsTruncated)
             {
-                _metrics.RecordTruncated(tenantId: null, result.ExtractorName, contentType);
+                _metrics.RecordTruncated(tenantId, result.ExtractorName, contentType);
             }
 
             return result;
         }
         catch (TextExtractionException tex)
         {
-            _metrics.RecordFailed(tenantId: null, selected.Name, contentType, tex.Reason);
+            _metrics.RecordFailed(tenantId, selected.Name, contentType, tex.Reason);
             throw;
         }
         catch (OperationCanceledException)
@@ -57,10 +61,13 @@ internal sealed class TextExtractionPipeline(
         }
         catch (Exception ex)
         {
-            _metrics.RecordFailed(tenantId: null, selected.Name, contentType, ex.GetType().Name);
+            _metrics.RecordFailed(tenantId, selected.Name, contentType, ex.GetType().Name);
             throw;
         }
     }
+
+    private string? ResolveTenantId() =>
+        _currentTenant.IsAvailable ? _currentTenant.Id?.ToString() : null;
 
     private ITextExtractor SelectExtractor(string contentType)
     {
@@ -74,7 +81,7 @@ internal sealed class TextExtractionPipeline(
 
         // Universal fallback. RecordSkipped is fired so dashboards surface unmapped MIMEs even
         // though the pipeline still produces a (best-effort) plain-text result.
-        _metrics.RecordSkipped(tenantId: null, contentType);
+        _metrics.RecordSkipped(ResolveTenantId(), contentType);
         return _fallback;
     }
 }

--- a/src/Granit.TextExtraction/Options/GranitTextExtractionOptions.cs
+++ b/src/Granit.TextExtraction/Options/GranitTextExtractionOptions.cs
@@ -56,10 +56,4 @@ public sealed class GranitTextExtractionOptions
     /// Defaults to 100 000 000 (≈ 10 000 × 10 000). Guard against pixel-flood attacks.
     /// </summary>
     public long MaxImagePixels { get; set; } = 100_000_000;
-
-    /// <summary>
-    /// When <c>false</c> (default), HTML extractors MUST NOT resolve external resources
-    /// (links, stylesheets, images) — SSRF guard. Hosts may opt in for trusted corpora.
-    /// </summary>
-    public bool ResolveHtmlExternalResources { get; set; }
 }

--- a/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
@@ -7,12 +7,59 @@ namespace Granit.ArchitectureTests;
 /// <summary>
 /// Architecture rules for the <c>Granit.TextExtraction.*</c> module family (epic #2233).
 /// Pins the VULN-001 input-size contract and the "pure utility, no host plumbing" boundary
-/// across the base package and the extractor providers (PDF, Office, Text).
+/// across the base package and the extractor providers (Email, Office, Pdf, Text, Tika,
+/// Ocr.AI, Ocr.Tesseract).
 /// </summary>
 public sealed class TextExtractionArchitectureTests
 {
     private static readonly string RepoRoot = FindRepoRoot();
     private static readonly string SrcRoot = Path.Join(RepoRoot, "src");
+
+    /// <summary>
+    /// Single source of truth for every <c>Granit.TextExtraction.*</c> provider package
+    /// that ships at least one extractor and must therefore satisfy the framework's
+    /// purity / DependsOn pins.
+    /// </summary>
+    private static readonly string[] ProviderPackageNames =
+    [
+        "Granit.TextExtraction.Email",
+        "Granit.TextExtraction.Ocr.AI",
+        "Granit.TextExtraction.Ocr.Tesseract",
+        "Granit.TextExtraction.Office",
+        "Granit.TextExtraction.Pdf",
+        "Granit.TextExtraction.Text",
+        "Granit.TextExtraction.Tika",
+    ];
+
+    public static TheoryData<string> ProviderPackages
+    {
+        get
+        {
+            TheoryData<string> data = [];
+            foreach (string p in ProviderPackageNames)
+            {
+                data.Add(p);
+            }
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// Provider packages plus the base contract — used for the purity checks (no AspNetCore,
+    /// no EF Core) that apply to every package in the family without exception.
+    /// </summary>
+    public static TheoryData<string> AllPackages
+    {
+        get
+        {
+            TheoryData<string> data = ["Granit.TextExtraction"];
+            foreach (string p in ProviderPackageNames)
+            {
+                data.Add(p);
+            }
+            return data;
+        }
+    }
 
     /// <summary>
     /// Every <c>Granit.TextExtraction.*</c> package that ships at least one
@@ -53,11 +100,7 @@ public sealed class TextExtractionArchitectureTests
     /// background workers, indexing pipelines) to drag the web stack into their build.
     /// </summary>
     [Theory]
-    [InlineData("Granit.TextExtraction")]
-    [InlineData("Granit.TextExtraction.Email")]
-    [InlineData("Granit.TextExtraction.Office")]
-    [InlineData("Granit.TextExtraction.Pdf")]
-    [InlineData("Granit.TextExtraction.Text")]
+    [MemberData(nameof(AllPackages))]
     public void TextExtraction_packages_must_not_reference_AspNetCore(string projectName) =>
         AssertNoPackageReferenceStartsWith(projectName, "Microsoft.AspNetCore.");
 
@@ -68,11 +111,7 @@ public sealed class TextExtractionArchitectureTests
     /// caching extracted text into a table, and suddenly the framework has a DB dependency.
     /// </summary>
     [Theory]
-    [InlineData("Granit.TextExtraction")]
-    [InlineData("Granit.TextExtraction.Email")]
-    [InlineData("Granit.TextExtraction.Office")]
-    [InlineData("Granit.TextExtraction.Pdf")]
-    [InlineData("Granit.TextExtraction.Text")]
+    [MemberData(nameof(AllPackages))]
     public void TextExtraction_packages_must_not_reference_EntityFrameworkCore(string projectName) =>
         AssertNoPackageReferenceStartsWith(projectName, "Microsoft.EntityFrameworkCore");
 
@@ -99,30 +138,27 @@ public sealed class TextExtractionArchitectureTests
     }
 
     /// <summary>
-    /// Every provider package (<c>Granit.TextExtraction.Email</c>,
-    /// <c>Granit.TextExtraction.Office</c>, <c>Granit.TextExtraction.Pdf</c>,
-    /// <c>Granit.TextExtraction.Text</c>) must declare a <c>[DependsOn(...)]</c>
-    /// attribute that references <c>GranitTextExtractionModule</c> — either as the
-    /// sole entry or alongside other module deps. Without this, calling
-    /// <c>AddTextExtractor&lt;T&gt;</c> would silently no-op (no pipeline service
-    /// registered).
+    /// Every provider package must declare a <c>[DependsOn(...)]</c> attribute on its
+    /// <c>*Module</c> class that references <c>GranitTextExtractionModule</c>. Without
+    /// this, calling the provider's <c>Add*Extractor</c> extension would silently no-op
+    /// (no pipeline service registered).
     /// </summary>
     [Theory]
-    [InlineData("Granit.TextExtraction.Email", "GranitTextExtractionEmailModule.cs")]
-    [InlineData("Granit.TextExtraction.Office", "GranitTextExtractionOfficeModule.cs")]
-    [InlineData("Granit.TextExtraction.Pdf", "GranitTextExtractionPdfModule.cs")]
-    [InlineData("Granit.TextExtraction.Text", "GranitTextExtractionTextModule.cs")]
-    public void Extractor_provider_modules_must_DependOn_base(string projectName, string moduleFile)
+    [MemberData(nameof(ProviderPackages))]
+    public void Extractor_provider_modules_must_DependOn_base(string projectName)
     {
-        string modulePath = Path.Join(SrcRoot, projectName, moduleFile);
-        File.Exists(modulePath).ShouldBeTrue($"Expected {modulePath} to exist.");
+        string moduleFile = Directory
+            .EnumerateFiles(Path.Join(SrcRoot, projectName), "Granit*Module.cs", SearchOption.TopDirectoryOnly)
+            .SingleOrDefault()
+            ?? throw new InvalidOperationException(
+                $"Expected exactly one Granit*Module.cs under {projectName}.");
 
-        string source = File.ReadAllText(modulePath);
+        string source = File.ReadAllText(moduleFile);
 
         // Match `[DependsOn(...)]` blocks (possibly spanning multiple typeof args)
         // and assert at least one references GranitTextExtractionModule. The looser
         // form keeps the pin honest for modules that legitimately depend on more
-        // than one upstream module (e.g. Email also depending on Html.AngleSharp).
+        // than one upstream module.
         bool dependsOnBase = System.Text.RegularExpressions.Regex.IsMatch(
             source,
             @"\[DependsOn\([^\]]*typeof\(GranitTextExtractionModule\)[^\]]*\)\]");

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2180,7 +2180,7 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -2191,7 +2191,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )"
+          "Granit.Html": "[0.1.0-dev, )"
         }
       },
       "granit.http.abstractions": {

--- a/tests/Granit.Html.AngleSharp.Tests/GranitHtmlAngleSharpModuleTests.cs
+++ b/tests/Granit.Html.AngleSharp.Tests/GranitHtmlAngleSharpModuleTests.cs
@@ -27,15 +27,40 @@ public sealed class GranitHtmlAngleSharpModuleTests
     }
 
     [Fact]
-    public void AddGranitHtmlAngleSharp_registers_default_converter()
+    public void AddGranitHtmlAngleSharp_registers_trusted_keyed_converter()
     {
         ServiceCollection services = new();
         services.AddGranitHtmlAngleSharp();
 
         using ServiceProvider sp = services.BuildServiceProvider();
-        IHtmlToPlainTextConverter converter = sp.GetRequiredService<IHtmlToPlainTextConverter>();
+        IHtmlToPlainTextConverter converter =
+            sp.GetRequiredKeyedService<IHtmlToPlainTextConverter>(HtmlConverterKeys.Trusted);
 
         converter.ShouldBeOfType<AngleSharpHtmlToPlainTextConverter>();
+    }
+
+    [Fact]
+    public void AddGranitHtmlAngleSharp_registers_untrusted_keyed_converter()
+    {
+        ServiceCollection services = new();
+        services.AddGranitHtmlAngleSharp();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        IHtmlToPlainTextConverter converter =
+            sp.GetRequiredKeyedService<IHtmlToPlainTextConverter>(HtmlConverterKeys.Untrusted);
+
+        converter.ShouldBeOfType<AngleSharpHtmlToPlainTextConverter>();
+    }
+
+    [Fact]
+    public void AddGranitHtmlAngleSharp_does_not_register_unkeyed_default()
+    {
+        ServiceCollection services = new();
+        services.AddGranitHtmlAngleSharp();
+
+        services.Count(d =>
+            d.ServiceType == typeof(IHtmlToPlainTextConverter)
+            && d.ServiceKey is null).ShouldBe(0);
     }
 
     [Fact]
@@ -45,6 +70,11 @@ public sealed class GranitHtmlAngleSharpModuleTests
         services.AddGranitHtmlAngleSharp();
         services.AddGranitHtmlAngleSharp();
 
-        services.Count(d => d.ServiceType == typeof(IHtmlToPlainTextConverter)).ShouldBe(1);
+        services.Count(d =>
+            d.ServiceType == typeof(IHtmlToPlainTextConverter)
+            && Equals(d.ServiceKey, HtmlConverterKeys.Trusted)).ShouldBe(1);
+        services.Count(d =>
+            d.ServiceType == typeof(IHtmlToPlainTextConverter)
+            && Equals(d.ServiceKey, HtmlConverterKeys.Untrusted)).ShouldBe(1);
     }
 }

--- a/tests/Granit.Html.AngleSharp.Tests/packages.lock.json
+++ b/tests/Granit.Html.AngleSharp.Tests/packages.lock.json
@@ -243,7 +243,7 @@
       "granit": {
         "type": "Project"
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Html.Tests/packages.lock.json
+++ b/tests/Granit.Html.Tests/packages.lock.json
@@ -243,7 +243,7 @@
       "granit": {
         "type": "Project"
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",

--- a/tests/Granit.Notifications.Brevo.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Brevo.Tests/packages.lock.json
@@ -462,7 +462,7 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -474,7 +474,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
@@ -304,7 +304,7 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -316,7 +316,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/packages.lock.json
@@ -356,7 +356,7 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -368,7 +368,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Notifications.Email.Scaleway.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Scaleway.Tests/packages.lock.json
@@ -462,7 +462,7 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -474,7 +474,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Notifications.Email.SendGrid.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.SendGrid.Tests/packages.lock.json
@@ -462,7 +462,7 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -474,7 +474,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Notifications.Email.Smtp.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Smtp.Tests/packages.lock.json
@@ -309,7 +309,7 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -321,7 +321,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Notifications.Email.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Tests/packages.lock.json
@@ -334,7 +334,7 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -346,7 +346,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.TextExtraction.Email.Tests/EmailTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Email.Tests/EmailTextExtractorTests.cs
@@ -1,3 +1,5 @@
+using Granit.Html;
+using Granit.Html.AngleSharp;
 using Granit.TextExtraction.Exceptions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
@@ -9,8 +11,12 @@ namespace Granit.TextExtraction.Email.Tests;
 
 public sealed class EmailTextExtractorTests
 {
+    private static readonly IHtmlToPlainTextConverter UntrustedConverter =
+        new AngleSharpHtmlToPlainTextConverter(AngleSharpConfiguration.BuildForUntrustedContent());
+
     private static EmailTextExtractor CreateExtractor(ExtractionOptions? options = null) =>
-        new(MEOptions.Create(options ?? new ExtractionOptions()),
+        new(UntrustedConverter,
+            MEOptions.Create(options ?? new ExtractionOptions()),
             NullLogger<EmailTextExtractor>.Instance);
 
     [Theory]

--- a/tests/Granit.TextExtraction.Email.Tests/packages.lock.json
+++ b/tests/Granit.TextExtraction.Email.Tests/packages.lock.json
@@ -302,7 +302,7 @@
       "granit": {
         "type": "Project"
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -314,7 +314,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
@@ -330,7 +330,6 @@
       "granit.textextraction.email": {
         "type": "Project",
         "dependencies": {
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
           "Granit.Html.AngleSharp": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )",
           "MimeKit": "[4.*, )"

--- a/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrExtractorTests.cs
@@ -11,15 +11,15 @@ using MEOptions = Microsoft.Extensions.Options.Options;
 
 namespace Granit.TextExtraction.Ocr.AI.Tests;
 
-public sealed class AiVisionOcrExtractorTests
+public sealed class AIVisionOcrExtractorTests
 {
     private const string Png = "image/png";
 
-    private static (AiVisionOcrExtractor extractor, IChatClient chatClient, IAIChatClientFactory factory)
+    private static (AIVisionOcrExtractor extractor, IChatClient chatClient, IAIChatClientFactory factory)
         CreateExtractor(
             ChatResponse? response = null,
             ExtractionOptions? extractionOptions = null,
-            AiVisionOcrOptions? ocrOptions = null,
+            AIVisionOcrOptions? ocrOptions = null,
             IVisionOcrPromptBuilder? promptBuilder = null)
     {
         IChatClient chatClient = Substitute.For<IChatClient>();
@@ -40,12 +40,12 @@ public sealed class AiVisionOcrExtractorTests
                 .Returns("default-prompt");
         }
 
-        AiVisionOcrExtractor extractor = new(
+        AIVisionOcrExtractor extractor = new(
             factory,
             prompt,
             MEOptions.Create(extractionOptions ?? new ExtractionOptions()),
-            MEOptions.Create(ocrOptions ?? new AiVisionOcrOptions()),
-            NullLogger<AiVisionOcrExtractor>.Instance);
+            MEOptions.Create(ocrOptions ?? new AIVisionOcrOptions()),
+            NullLogger<AIVisionOcrExtractor>.Instance);
 
         return (extractor, chatClient, factory);
     }
@@ -62,14 +62,14 @@ public sealed class AiVisionOcrExtractorTests
     [InlineData("", false)]
     public void CanHandle_recognises_configured_image_types(string contentType, bool expected)
     {
-        (AiVisionOcrExtractor extractor, _, _) = CreateExtractor();
+        (AIVisionOcrExtractor extractor, _, _) = CreateExtractor();
         extractor.CanHandle(contentType).ShouldBe(expected);
     }
 
     [Fact]
     public async Task Sends_prompt_and_image_data_then_returns_response_text()
     {
-        (AiVisionOcrExtractor extractor, IChatClient chatClient, IAIChatClientFactory factory) =
+        (AIVisionOcrExtractor extractor, IChatClient chatClient, IAIChatClientFactory factory) =
             CreateExtractor(new ChatResponse
             {
                 Messages = [new ChatMessage(ChatRole.Assistant, "Extracted document text.")],
@@ -82,7 +82,7 @@ public sealed class AiVisionOcrExtractorTests
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Content.ShouldBe("Extracted document text.");
-        result.ExtractorName.ShouldBe(AiVisionOcrExtractor.ExtractorName);
+        result.ExtractorName.ShouldBe(AIVisionOcrExtractor.ExtractorName);
         result.IsTruncated.ShouldBeFalse();
 
         // Inspect the messages sent to the chat client to verify the multimodal request.
@@ -101,7 +101,7 @@ public sealed class AiVisionOcrExtractorTests
         {
             Messages = [new ChatMessage(ChatRole.Assistant, new string('x', 5_000))],
         };
-        (AiVisionOcrExtractor extractor, _, _) = CreateExtractor(big);
+        (AIVisionOcrExtractor extractor, _, _) = CreateExtractor(big);
         using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
@@ -115,7 +115,7 @@ public sealed class AiVisionOcrExtractorTests
     public async Task Body_size_cap_throws_input_too_large()
     {
         ExtractionOptions extraction = new() { MaxBodySizeBytes = 16 };
-        (AiVisionOcrExtractor extractor, _, _) = CreateExtractor(extractionOptions: extraction);
+        (AIVisionOcrExtractor extractor, _, _) = CreateExtractor(extractionOptions: extraction);
         using MemoryStream input = Bytes(4096);
 
         TextExtraction.Exceptions.TextExtractionException tex =
@@ -135,11 +135,11 @@ public sealed class AiVisionOcrExtractorTests
             .Throws(new InvalidOperationException("workspace not found"));
 
         IVisionOcrPromptBuilder prompt = Substitute.For<IVisionOcrPromptBuilder>();
-        AiVisionOcrExtractor extractor = new(
+        AIVisionOcrExtractor extractor = new(
             factory, prompt,
             MEOptions.Create(new ExtractionOptions()),
-            MEOptions.Create(new AiVisionOcrOptions()),
-            NullLogger<AiVisionOcrExtractor>.Instance);
+            MEOptions.Create(new AIVisionOcrOptions()),
+            NullLogger<AIVisionOcrExtractor>.Instance);
         using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
@@ -166,11 +166,11 @@ public sealed class AiVisionOcrExtractorTests
         IVisionOcrPromptBuilder prompt = Substitute.For<IVisionOcrPromptBuilder>();
         prompt.BuildPrompt(Arg.Any<string>(), Arg.Any<int>()).Returns("p");
 
-        AiVisionOcrExtractor extractor = new(
+        AIVisionOcrExtractor extractor = new(
             factory, prompt,
             MEOptions.Create(new ExtractionOptions()),
-            MEOptions.Create(new AiVisionOcrOptions()),
-            NullLogger<AiVisionOcrExtractor>.Instance);
+            MEOptions.Create(new AIVisionOcrOptions()),
+            NullLogger<AIVisionOcrExtractor>.Instance);
         using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
@@ -183,8 +183,8 @@ public sealed class AiVisionOcrExtractorTests
     [Fact]
     public async Task Workspace_name_from_options_is_used_to_resolve_chat_client()
     {
-        AiVisionOcrOptions opts = new() { WorkspaceName = "vision-ocr-fr" };
-        (AiVisionOcrExtractor extractor, _, IAIChatClientFactory factory) = CreateExtractor(ocrOptions: opts);
+        AIVisionOcrOptions opts = new() { WorkspaceName = "vision-ocr-fr" };
+        (AIVisionOcrExtractor extractor, _, IAIChatClientFactory factory) = CreateExtractor(ocrOptions: opts);
         using MemoryStream input = Bytes(8);
 
         await extractor.ExtractAsync(
@@ -199,7 +199,7 @@ public sealed class AiVisionOcrExtractorTests
         IVisionOcrPromptBuilder customPrompt = Substitute.For<IVisionOcrPromptBuilder>();
         customPrompt.BuildPrompt(Arg.Any<string>(), Arg.Any<int>()).Returns("custom-prompt-for-test");
 
-        (AiVisionOcrExtractor extractor, IChatClient chatClient, _) =
+        (AIVisionOcrExtractor extractor, IChatClient chatClient, _) =
             CreateExtractor(promptBuilder: customPrompt);
         using MemoryStream input = Bytes(8);
 

--- a/tests/Granit.TextExtraction.Ocr.AI.Tests/GranitTextExtractionOcrAIModuleTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.AI.Tests/GranitTextExtractionOcrAIModuleTests.cs
@@ -26,7 +26,7 @@ public sealed class GranitTextExtractionOcrAIModuleTests
     [Fact]
     public void Module_does_not_auto_register_services()
     {
-        // The module is a marker — the host must opt in via AddAiVisionOcrExtractor.
+        // The module is a marker — the host must opt in via AddAIVisionOcrExtractor.
         // Enabling vision OCR sends document bytes to a third-party LLM provider
         // (GDPR Art. 28 disclosure required), which is why there is no safe default.
         GranitTextExtractionOcrAIModule module = new();
@@ -36,7 +36,7 @@ public sealed class GranitTextExtractionOcrAIModuleTests
 
         overridesConfigureServices.ShouldBeFalse(
             "GranitTextExtractionOcrAIModule must NOT override ConfigureServices — VLM OCR " +
-            "is opt-in and requires explicit AddAiVisionOcrExtractor(...) by the host so the " +
+            "is opt-in and requires explicit AddAIVisionOcrExtractor(...) by the host so the " +
             "GDPR Article 28 sub-processor disclosure is a deliberate decision.");
     }
 }

--- a/tests/Granit.TextExtraction.Tests/GranitTextExtractionOptionsTests.cs
+++ b/tests/Granit.TextExtraction.Tests/GranitTextExtractionOptionsTests.cs
@@ -21,7 +21,6 @@ public sealed class GranitTextExtractionOptionsTests
         options.MaxZipEntries.ShouldBe(10_000);
         options.MaxExtractedCharLength.ShouldBe(500_000);
         options.MaxImagePixels.ShouldBe(100_000_000L);
-        options.ResolveHtmlExternalResources.ShouldBeFalse();
     }
 
     [Fact]
@@ -35,7 +34,6 @@ public sealed class GranitTextExtractionOptionsTests
         {
             ["TextExtraction:MaxBodySizeBytes"] = "12345",
             ["TextExtraction:MaxExtractedCharLength"] = "777",
-            ["TextExtraction:ResolveHtmlExternalResources"] = "true",
         };
 
         IConfiguration configuration = new ConfigurationBuilder()
@@ -52,7 +50,6 @@ public sealed class GranitTextExtractionOptionsTests
 
         bound.MaxBodySizeBytes.ShouldBe(12345);
         bound.MaxExtractedCharLength.ShouldBe(777);
-        bound.ResolveHtmlExternalResources.ShouldBeTrue();
         bound.MaxZipEntries.ShouldBe(10_000); // unset → default preserved
     }
 }

--- a/tests/Granit.TextExtraction.Tests/TextExtractionMetricsTests.cs
+++ b/tests/Granit.TextExtraction.Tests/TextExtractionMetricsTests.cs
@@ -29,7 +29,7 @@ public sealed class TextExtractionMetricsTests : IDisposable
         using MeterListener listener = new();
         listener.InstrumentPublished = (instrument, ml) =>
         {
-            if (instrument.Name == "granit.text_extraction.extraction.success")
+            if (instrument.Name == "granit.text_extraction.document.extracted")
             {
                 ml.EnableMeasurementEvents(instrument);
             }
@@ -61,7 +61,7 @@ public sealed class TextExtractionMetricsTests : IDisposable
         using MeterListener listener = new();
         listener.InstrumentPublished = (instrument, ml) =>
         {
-            if (instrument.Name == "granit.text_extraction.extraction.truncated")
+            if (instrument.Name == "granit.text_extraction.document.truncated")
             {
                 ml.EnableMeasurementEvents(instrument);
             }
@@ -82,7 +82,7 @@ public sealed class TextExtractionMetricsTests : IDisposable
         using MeterListener listener = new();
         listener.InstrumentPublished = (instrument, ml) =>
         {
-            if (instrument.Name == "granit.text_extraction.extraction.skipped")
+            if (instrument.Name == "granit.text_extraction.document.skipped")
             {
                 ml.EnableMeasurementEvents(instrument);
             }
@@ -112,7 +112,7 @@ public sealed class TextExtractionMetricsTests : IDisposable
         using MeterListener listener = new();
         listener.InstrumentPublished = (instrument, ml) =>
         {
-            if (instrument.Name == "granit.text_extraction.extraction.failed")
+            if (instrument.Name == "granit.text_extraction.document.failed")
             {
                 ml.EnableMeasurementEvents(instrument);
             }

--- a/tests/Granit.TextExtraction.Text.Tests/HtmlTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Text.Tests/HtmlTextExtractorTests.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using Granit.Html;
+using Granit.Html.AngleSharp;
 using Granit.TextExtraction.Exceptions;
 using Shouldly;
 using Xunit;
@@ -9,8 +11,11 @@ namespace Granit.TextExtraction.Text.Tests;
 
 public sealed class HtmlTextExtractorTests
 {
+    private static readonly IHtmlToPlainTextConverter UntrustedConverter =
+        new AngleSharpHtmlToPlainTextConverter(AngleSharpConfiguration.BuildForUntrustedContent());
+
     private static HtmlTextExtractor CreateExtractor(ExtractionOptions? options = null) =>
-        new(MEOptions.Create(options ?? new ExtractionOptions()));
+        new(UntrustedConverter, MEOptions.Create(options ?? new ExtractionOptions()));
 
     private static MemoryStream Utf8(string text) => new(Encoding.UTF8.GetBytes(text));
 

--- a/tests/Granit.TextExtraction.Text.Tests/packages.lock.json
+++ b/tests/Granit.TextExtraction.Text.Tests/packages.lock.json
@@ -282,7 +282,7 @@
       "granit": {
         "type": "Project"
       },
-      "Granit.Html.Abstractions": {
+      "granit.html": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
@@ -294,7 +294,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.*, )",
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
+          "Granit.Html": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
@@ -310,7 +310,6 @@
       "granit.textextraction.text": {
         "type": "Project",
         "dependencies": {
-          "Granit.Html.Abstractions": "[0.1.0-dev, )",
           "Granit.Html.AngleSharp": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )",
           "Markdig": "[0.*, )"


### PR DESCRIPTION
## Summary

Sweep of the framework-audit findings on the new TE-F1/F2/F3/F4/F5 modules plus the `Granit.Html` abstraction extracted in #2267. No new features — each change tightens a documented Granit convention or removes a footgun.

### Breaking changes (pre-1.0, clean break — no `[Obsolete]` graduation)

- **Keyed DI for `IHtmlToPlainTextConverter`** — two profiles (`HtmlConverterKeys.Trusted` / `Untrusted`) live side by side; consumers inject the posture they need via `[FromKeyedServices(...)]`. The historical unkeyed default registration is removed — it hid an SSRF posture choice behind a "first writer wins" race between Notifications.Email and TextExtraction. `EmailNotificationChannel` consumes `Trusted`; `HtmlTextExtractor` + `EmailTextExtractor` consume `Untrusted`. `GranitTextExtractionOptions.ResolveHtmlExternalResources` removed (orphaned by the keyed wiring).
- **`Granit.Html` PackageId** `Granit.Html.Abstractions` → `Granit.Html` (project = package). Downstream `packages.lock.json` files refreshed across Notifications.* and TextExtraction.Email.
- **`SectionName` hierarchy** colon-aligned with namespace: `TextExtraction:OcrAI` → `TextExtraction:Ocr:AI`, `TextExtraction:OcrTesseract` → `TextExtraction:Ocr:Tesseract`.
- **Metric rename** — entity `extraction` → `document`, action verbalised: `granit.text_extraction.extraction.{success,failed,skipped,truncated}` → `granit.text_extraction.document.{extracted,failed,skipped,truncated}`.
- **Acronym casing** in `Granit.TextExtraction.Ocr.AI`: `AiVisionOcr*` → `AIVisionOcr*`, `AddAiVisionOcrExtractor` → `AddAIVisionOcrExtractor`.

### Non-breaking

- `TextExtractionPipeline` injects `ICurrentTenant` (default `NullTenantContext.Instance`) so metric tags carry the real `tenant_id` instead of always `global`.
- `AngleSharpConfiguration` docstrings rewritten to be honest about what both profile factories actually return today (both `Configuration.Default` — SSRF guard is anchored by the existing `Source_must_never_call_WithDefaultLoader` archi test).
- `Granit.Html` csproj `InternalsVisibleTo` fixed: `Granit.Html.Tests` (was `Granit.Html.Abstractions.Tests`, a project that does not exist).
- `TextExtractionArchitectureTests` refactored to a single `MemberData` source so the no-AspNetCore / no-EFCore / DependsOn-base pins now cover the three new modules (`Tika`, `Ocr.AI`, `Ocr.Tesseract`) that were silently exempted before.
- Redundant `Granit.Html` `ProjectReference` removed from `Granit.TextExtraction.Text` and `Granit.TextExtraction.Email` (already transitive via `Granit.Html.AngleSharp`).

## Test plan

- [x] `dotnet build .github/shard-filters/{infrastructure,architecture}.slnf` clean
- [x] `Granit.ArchitectureTests` 212/212
- [x] `Granit.Html.Tests` + `Granit.Html.AngleSharp.Tests` 43/43
- [x] `Granit.TextExtraction.*Tests` (8 projects) 186/186
- [x] `Granit.Notifications.Email.Tests` (regression on keyed DI) 46/46
- [x] `dotnet format --verify-no-changes` on 23 touched projects: clean
- [ ] Downstream apps that adopted TE need to update `SectionName`, metric names, and `IHtmlToPlainTextConverter` consumers
- [ ] Doc page on `granit-docs` (separate PR — out of scope of this branch)