### PR TITLE
chore: drop VULN-XXX audit-tag references from source and tests

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -361,7 +361,7 @@ de l'organisation (aucun appel vers des services cloud externes).
 
 Ce package est utilisé par `Granit.TextExtraction.Ocr.Tesseract` uniquement pour
 identifier les dimensions d'une image (entête du format) AVANT décodage —
-défense contre les attaques pixel-bomb (VULN-001). La version est épinglée à
+défense contre les attaques pixel-bomb. La version est épinglée à
 **2.\*** car la branche 3.x est passée sous la Six Labors Split License, incompatible
 avec la distribution Apache-2.0 propre de Granit. Aucune donnée de santé ne transite
 par les serveurs Six Labors (bibliothèque purement locale).

--- a/src/Granit.AI.Anthropic/Internal/AnthropicClientCache.cs
+++ b/src/Granit.AI.Anthropic/Internal/AnthropicClientCache.cs
@@ -18,7 +18,8 @@ namespace Granit.AI.Anthropic.Internal;
 /// </para>
 /// <para>
 /// Cache keys are typed <see cref="AICacheKey"/> records carrying the SHA-256 hash of the API
-/// key, never the plaintext (audit VULN-202). Post-eviction callbacks dispose the
+/// key, never the plaintext, so cache keys cannot be coerced back into credential material.
+/// Post-eviction callbacks dispose the
 /// <see cref="AnthropicClient"/>; the <see cref="HttpClient"/> is owned by
 /// <see cref="IHttpClientFactory"/>.
 /// </para>

--- a/src/Granit.AI.Anthropic/Internal/TracingAnthropicChatClient.cs
+++ b/src/Granit.AI.Anthropic/Internal/TracingAnthropicChatClient.cs
@@ -13,7 +13,8 @@ namespace Granit.AI.Anthropic.Internal;
 /// One span per request — both <c>GetResponseAsync</c> and <c>GetStreamingResponseAsync</c> are wrapped.
 /// The decorator tags each span with the resolved credential's <c>Scope</c> and
 /// <c>BilledToTenantId</c> so audit and billing can attribute usage even when the Host fallback
-/// served the request (audit VULN-202 mitigation). Plaintext <c>ApiKey</c> is never recorded.
+/// served the request, preserving traceability when credential cascade falls back to a host-level
+/// scope. Plaintext <c>ApiKey</c> is never recorded.
 /// Disposal is delegated to the wrapped client; the decorator owns no additional resources.
 /// </remarks>
 internal sealed class TracingAnthropicChatClient(

--- a/src/Granit.AI.AzureOpenAI/Options/AzureOpenAIProviderOptions.cs
+++ b/src/Granit.AI.AzureOpenAI/Options/AzureOpenAIProviderOptions.cs
@@ -66,9 +66,9 @@ public sealed class AzureOpenAIProviderOptions
 
     /// <summary>
     /// When <c>true</c>, the resolver falls back to <c>DefaultAzureCredential</c> (Managed Identity)
-    /// when no ApiKey is configured at any cascade layer. Defaults to <c>false</c> (audit VULN-103):
-    /// silently switching from API-key to Managed Identity changes the trust principal in a way
-    /// that may have unintended privilege implications.
+    /// when no ApiKey is configured at any cascade layer. Defaults to <c>false</c>: silently
+    /// switching from API-key to Managed Identity changes the trust principal in a way that may
+    /// have unintended privilege implications, so the fallback must be opted into explicitly.
     /// </summary>
     public bool AllowManagedIdentityFallback { get; set; }
 }

--- a/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
+++ b/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
@@ -74,7 +74,7 @@ public static class AIServiceCollectionExtensions
 
         // Wrap the configured ISettingManager so that writes to Granit.AI.* keys require the
         // AI.Credentials.Manage permission (in addition to the standard Settings.*.Manage). See
-        // AISettingsCredentialsGuard for the rationale (audit VULN-100).
+        // AISettingsCredentialsGuard for the rationale.
         DecorateSettingManagerWithCredentialsGuard(builder.Services);
 
         return builder;

--- a/src/Granit.AI/Tenancy/AIEndpointValidator.cs
+++ b/src/Granit.AI/Tenancy/AIEndpointValidator.cs
@@ -10,7 +10,7 @@ namespace Granit.AI.Tenancy;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Three layers of defence are coordinated by this validator (audit VULN-002):
+/// Three layers of defence are coordinated by this validator:
 /// </para>
 /// <list type="number">
 ///   <item>Static URL inspection (this class) — scheme, port, IDN normalisation, IP literal

--- a/src/Granit.AI/Tenancy/AISettingsCredentialsGuard.cs
+++ b/src/Granit.AI/Tenancy/AISettingsCredentialsGuard.cs
@@ -11,7 +11,7 @@ namespace Granit.AI.Tenancy;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Closes the permission-boundary gap identified in audit VULN-100: AI credentials were
+/// Closes a permission-boundary gap: AI credentials were
 /// previously gated only by <c>Settings.{Tenant,Global}.Manage</c>, which is too broad —
 /// a routine config admin could redirect AI traffic to an attacker endpoint or rotate
 /// the credential under which prompts are sent.

--- a/src/Granit.AI/Tenancy/GranitSafeConnectCallback.cs
+++ b/src/Granit.AI/Tenancy/GranitSafeConnectCallback.cs
@@ -9,7 +9,7 @@ namespace Granit.AI.Tenancy;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Defeats DNS rebinding (audit VULN-002, item 8). At endpoint-write time the validator
+/// Defeats DNS rebinding. At endpoint-write time the validator
 /// inspects either the hostname or the IP literal; an attacker who controls authoritative DNS
 /// can return a public IP at validation time and a private/metadata IP at HTTP-call time.
 /// Attaching this delegate to the <see cref="HttpClient"/> via a

--- a/src/Granit.Browsing.Playwright/Internal/PlaywrightBrowserPage.cs
+++ b/src/Granit.Browsing.Playwright/Internal/PlaywrightBrowserPage.cs
@@ -134,7 +134,7 @@ internal sealed partial class PlaywrightBrowserPage : IBrowserPage
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Defense-in-depth chain (VULN-101): the URL is validated pre-navigation by
+    /// Defense-in-depth chain: the URL is validated pre-navigation by
     /// <see cref="IUrlSafetyValidator"/>; sub-resource requests are intercepted by the
     /// <see cref="RequestRouter"/> when <see cref="IBrowserSandboxProfile.BlockPrivateNetworks"/>
     /// is set; the final URL is re-validated after navigation to defeat redirect chains
@@ -169,7 +169,7 @@ internal sealed partial class PlaywrightBrowserPage : IBrowserPage
             _maxRenderDuration,
             cancellationToken).ConfigureAwait(false);
 
-        // VULN-101 — re-validate the final URL (after redirects). Catches redirect chains
+        // Re-validate the final URL (after redirects). Catches redirect chains
         // landing on a hostname that resolves to a private IP at fetch time.
         if (_sandbox.BlockPrivateNetworks
             && Uri.TryCreate(_page.Url, UriKind.Absolute, out Uri? finalUrl)

--- a/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerBrowserPage.cs
+++ b/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerBrowserPage.cs
@@ -133,7 +133,7 @@ internal sealed partial class PuppeteerBrowserPage : IBrowserPage
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Defense-in-depth chain (VULN-101): the URL is validated pre-navigation by
+    /// Defense-in-depth chain: the URL is validated pre-navigation by
     /// <see cref="IUrlSafetyValidator"/>; sub-resource requests are intercepted by the
     /// <see cref="RequestRouter"/> when <see cref="IBrowserSandboxProfile.BlockPrivateNetworks"/>
     /// is set; the final URL is re-validated after navigation to defeat redirect chains
@@ -166,7 +166,7 @@ internal sealed partial class PuppeteerBrowserPage : IBrowserPage
             _maxRenderDuration,
             cancellationToken).ConfigureAwait(false);
 
-        // VULN-101 — re-validate the final URL (after redirects). Catches redirect chains
+        // Re-validate the final URL (after redirects). Catches redirect chains
         // landing on a hostname that resolves to a private IP at fetch time.
         if (_sandbox.BlockPrivateNetworks
             && Uri.TryCreate(_page.Url, UriKind.Absolute, out Uri? finalUrl)

--- a/src/Granit.DocumentGeneration.Pdf/Internal/BrowsingPdfRenderer.cs
+++ b/src/Granit.DocumentGeneration.Pdf/Internal/BrowsingPdfRenderer.cs
@@ -42,7 +42,7 @@ internal sealed partial class BrowsingPdfRenderer(
 
         PdfRenderOptions opts = options.Value;
 
-        // VULN-305 — bound HTML size to protect the Chromium renderer process from OOM.
+        // Bound HTML size to protect the Chromium renderer process from OOM.
         // Char count overestimates byte count when UTF-16 chars are ASCII (good) and underestimates
         // for surrogate pairs (rare). Use ByteCount for a tight check.
         int htmlByteLength = Encoding.UTF8.GetByteCount(html);
@@ -53,7 +53,7 @@ internal sealed partial class BrowsingPdfRenderer(
                 nameof(html));
         }
 
-        // VULN-204 — header/footer templates are trusted strings from configuration. Validate that
+        // Header/footer templates are trusted strings from configuration. Validate that
         // no remote-fetch primitive smuggled in; defense-in-depth against config-store compromise
         // / tenant-controlled overrides (the page-level route-abort does not apply to Chromium's
         // print-preview header/footer render context).

--- a/src/Granit.Html.AngleSharp/Granit.Html.AngleSharp.csproj
+++ b/src/Granit.Html.AngleSharp/Granit.Html.AngleSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.Html.AngleSharp</PackageId>
-    <Description>AngleSharp-backed implementation of Granit.Html. Ships AngleSharpHtmlToPlainTextConverter (email + indexing) and AngleSharpConfiguration with separated trusted-template vs untrusted-content profiles (VULN-300 SSRF guard).</Description>
+    <Description>AngleSharp-backed implementation of Granit.Html. Ships AngleSharpHtmlToPlainTextConverter (email + indexing) and AngleSharpConfiguration with separated trusted-template vs untrusted-content profiles (SSRF-hardened: untrusted profile never enables the default network loader).</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.TextExtraction.Email/EmailTextExtractor.cs
+++ b/src/Granit.TextExtraction.Email/EmailTextExtractor.cs
@@ -46,7 +46,7 @@ public sealed partial class EmailTextExtractor : ITextExtractor
     private const string EmlAlt = "application/eml";
     private const string EncryptedPlaceholder = "[encrypted message]";
 
-    // VULN-401: cap MimeKit recursion. The .eml format allows message/rfc822 parts to nest
+    // Cap MimeKit recursion. The .eml format allows message/rfc822 parts to nest
     // arbitrarily; a crafted file inside the body-size cap can still exercise quadratic
     // parser paths. 16 is generous (real-world forwards rarely exceed 5) without giving an
     // attacker anything to play with. MaxAddressGroupDepth bounds the analogous quadratic
@@ -96,7 +96,7 @@ public sealed partial class EmailTextExtractor : ITextExtractor
         ArgumentNullException.ThrowIfNull(source);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCharLength);
 
-        // Wrap before any MimeKit allocation — VULN-001. persistent:false makes MimeKit
+        // Wrap before any MimeKit allocation to enforce the body-size cap. persistent:false makes MimeKit
         // copy the message into memory eagerly so the wrapped stream is fully consumed
         // up-front, keeping the size cap deterministic.
         LimitedStream limited = new(source, _options.MaxBodySizeBytes);
@@ -231,7 +231,7 @@ public sealed partial class EmailTextExtractor : ITextExtractor
         StringBuilder buf = new(value.Length);
         foreach (char c in value)
         {
-            // VULN-301: drop ALL control chars (incl. CR / LF) from header values. A
+            // Drop ALL control chars (incl. CR / LF) from header values. A
             // structured-log consumer that ingests Content as a field could otherwise
             // see spliced fake header lines if an attacker embedded an LF inside a
             // RFC 2047-encoded Subject (e.g. "ok\nFrom: attacker@evil"). Tabs are also

--- a/src/Granit.TextExtraction.Email/README.md
+++ b/src/Granit.TextExtraction.Email/README.md
@@ -61,8 +61,8 @@ Body resolution:
 
 ## Security posture
 
-- Input wrapped in `LimitedStream` (`MaxBodySizeBytes` cap, VULN-001) before
-  any MimeKit allocation.
+- Input wrapped in `LimitedStream` (`MaxBodySizeBytes` cap) before any
+  MimeKit allocation.
 - Header values are sanitised — control characters (`< 0x20`, except `\n`
   and `\t`) are stripped to prevent log/header injection through indexed
   content (an attacker crafting a `Subject` with embedded CR/LF cannot splice

--- a/src/Granit.TextExtraction.Ocr.AI/AIVisionOcrExtractor.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/AIVisionOcrExtractor.cs
@@ -85,7 +85,7 @@ public sealed partial class AIVisionOcrExtractor : ITextExtractor
         ArgumentException.ThrowIfNullOrEmpty(contentType);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCharLength);
 
-        // VULN-001: cap the request body before sending to the model. The byte cap is also
+        // Cap the request body before sending to the model. The byte cap is also
         // the effective pixel-bomb defence — a 100k×100k decoded image far exceeds 100 MB
         // long before reaching the provider.
         byte[] bytes = await ReadAllBytesAsync(
@@ -108,7 +108,7 @@ public sealed partial class AIVisionOcrExtractor : ITextExtractor
         {
             using IChatClient _ = chatClient;
 
-            // VULN-200 defence-in-depth: a system message that nails down the OCR-only
+            // Prompt-injection defence-in-depth: a system message that nails down the OCR-only
             // contract, complementing the envelope markers the prompt builder injects.
             // Most modern multimodal models respect a clear system-message boundary even
             // when the image embeds adversarial text.

--- a/src/Granit.TextExtraction.Ocr.AI/Internal/DefaultVisionOcrPromptBuilder.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/Internal/DefaultVisionOcrPromptBuilder.cs
@@ -3,8 +3,8 @@ namespace Granit.TextExtraction.Ocr.AI.Internal;
 /// <summary>
 /// Default <see cref="IVisionOcrPromptBuilder"/>. Produces a prompt that asks the model to
 /// extract verbatim text inside a sentinel-delimited envelope. The envelope is the
-/// VULN-200 defence: it lets downstream code strip everything outside the markers, defeating
-/// the "ignore previous instructions" style of prompt injection where the image itself
+/// prompt-injection defence: it lets downstream code strip everything outside the markers,
+/// defeating the "ignore previous instructions" style of attack where the image itself
 /// contains text masquerading as orchestration instructions.
 /// </summary>
 internal sealed class DefaultVisionOcrPromptBuilder : IVisionOcrPromptBuilder

--- a/src/Granit.TextExtraction.Ocr.Tesseract/TesseractOcrExtractor.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/TesseractOcrExtractor.cs
@@ -18,7 +18,7 @@ namespace Granit.TextExtraction.Ocr.Tesseract;
 /// Point <see cref="TesseractOcrOptions.DataPath"/> at the directory.
 /// </para>
 /// <para>
-/// Pixel-bomb defence (VULN-001): the image header is read BEFORE any decode and the
+/// Pixel-bomb defence: the image header is read BEFORE any decode and the
 /// surface (<c>width × height</c>) is checked against
 /// <see cref="TesseractOcrOptions.MaxImagePixels"/>. Oversized images soft-skip without
 /// allocating a decoded buffer.
@@ -85,12 +85,12 @@ public sealed partial class TesseractOcrExtractor : ITextExtractor
         ArgumentException.ThrowIfNullOrEmpty(contentType);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCharLength);
 
-        // VULN-001 byte cap — Tesseract's Pix.LoadFromMemory will decode whatever we hand
+        // Byte cap — Tesseract's Pix.LoadFromMemory will decode whatever we hand
         // it, so the body-size cap from the base module is the first line of defence.
         byte[] bytes = await ReadAllBytesAsync(
             source, _extractionOptions.MaxBodySizeBytes, cancellationToken).ConfigureAwait(false);
 
-        // VULN-001 pixel-bomb defence — identify dimensions from the format header without
+        // Pixel-bomb defence — identify dimensions from the format header without
         // decoding. A 100 KB PNG can claim 100 000 × 100 000 pixels (~40 GB RGBA buffer);
         // we reject those before they hit Leptonica.
         IImageInfo? info;

--- a/src/Granit.TextExtraction.Office/Internal/OpenXmlGate.cs
+++ b/src/Granit.TextExtraction.Office/Internal/OpenXmlGate.cs
@@ -15,7 +15,7 @@ namespace Granit.TextExtraction.Office.Internal;
 /// <list type="bullet">
 ///   <item><b>Cumulative size</b> — the sum of declared uncompressed entry lengths is capped
 ///   by <see cref="GranitTextExtractionOptions.MaxDecompressedBytes"/>.</item>
-///   <item><b>Per-entry compression ratio</b> — VULN-201 defence. The central-directory
+///   <item><b>Per-entry compression ratio</b> — zip-bomb defence. The central-directory
 ///   <see cref="ZipArchiveEntry.Length"/> is a hint, not a guarantee: a crafted package can
 ///   advertise a tiny size while OpenXml's streaming reader pulls much more from the local
 ///   header on decompression. We reject any entry whose declared length is more than
@@ -70,7 +70,7 @@ internal static class OpenXmlGate
                 long declared = entry.Length;
                 long compressed = entry.CompressedLength;
 
-                // VULN-201: catch declarations whose ratio is implausible for any
+                // Catch declarations whose ratio is implausible for any
                 // legitimate compressible payload (XML, embedded media).
                 if (compressed >= RatioCheckMinCompressedBytes &&
                     declared > compressed * MaxCompressionRatio)

--- a/src/Granit.TextExtraction.Office/README.md
+++ b/src/Granit.TextExtraction.Office/README.md
@@ -26,7 +26,7 @@ dotnet add package Granit.TextExtraction.Office
 | `ExcelTextExtractor` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | Iterates each `WorksheetPart`, resolves shared-string cells via the `SharedStringTablePart`, joins by tab + newline. |
 | `PowerPointTextExtractor` | `application/vnd.openxmlformats-officedocument.presentationml.presentation` | Iterates `SlidePart.Slide.InnerText` per slide, joined with blank lines. |
 
-## Security posture (VULN-001)
+## Security posture
 
 OpenXml files are ZIP archives. The extractors apply zip-bomb and
 decompression-bomb defences **before** handing the stream to the parser:

--- a/src/Granit.TextExtraction.Pdf/README.md
+++ b/src/Granit.TextExtraction.Pdf/README.md
@@ -29,7 +29,7 @@ dotnet add package Granit.TextExtraction.Pdf
 
 ## Security posture
 
-- Input wrapped in `LimitedStream` (`MaxBodySizeBytes` cap, VULN-001).
+- Input wrapped in `LimitedStream` (`MaxBodySizeBytes` cap).
 - **Password-protected PDFs** (`PdfDocumentEncryptedException`) are reported
   as an empty `TextExtractionResult` with `IsTruncated = true` and the
   `granit.text_extraction.document.skipped` metric incremented. No silent

--- a/src/Granit.TextExtraction.Text/HtmlTextExtractor.cs
+++ b/src/Granit.TextExtraction.Text/HtmlTextExtractor.cs
@@ -60,7 +60,7 @@ public sealed class HtmlTextExtractor : ITextExtractor
         ArgumentNullException.ThrowIfNull(source);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCharLength);
 
-        // Wrap the source for VULN-001 protection before feeding it to AngleSharp.
+        // Wrap the source for size-cap protection before feeding it to AngleSharp.
         // AngleSharp reads the full HTML into a string internally, so we materialise here.
         LimitedStream limited = new(source, _options.MaxBodySizeBytes);
 

--- a/src/Granit.TextExtraction.Tika/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.TextExtraction.Tika/Extensions/ServiceCollectionExtensions.cs
@@ -55,7 +55,7 @@ public static class ServiceCollectionExtensions
             services.Configure(configure);
         }
 
-        // VULN-102: enforce RequireMutualTls at startup by inspecting the named client's
+        // Enforce RequireMutualTls at startup by inspecting the named client's
         // HttpClientFactoryOptions handler-chain configuration. The post-configurator throws
         // on first resolution of the named client when RequireMutualTls=true and no host
         // handler has been wired through .ConfigurePrimaryHttpMessageHandler(...).

--- a/src/Granit.TextExtraction.Tika/README.md
+++ b/src/Granit.TextExtraction.Tika/README.md
@@ -46,7 +46,7 @@ tika:
 }
 ```
 
-## Security posture (VULN-102)
+## Security posture
 
 - **`AllowedHosts`** — explicit allowlist of hostnames the extractor will talk
   to. Empty allowlist + non-empty `Uri` → the module refuses to start with a

--- a/src/Granit.TextExtraction.Tika/TikaSidecarTextExtractor.cs
+++ b/src/Granit.TextExtraction.Tika/TikaSidecarTextExtractor.cs
@@ -20,7 +20,7 @@ namespace Granit.TextExtraction.Tika;
 /// integration without coupling.
 /// </para>
 /// <para>
-/// VULN-102 enforcement: <see cref="TikaSidecarOptions.AllowedHosts"/> is checked at
+/// Host allow-list enforcement: <see cref="TikaSidecarOptions.AllowedHosts"/> is checked at
 /// startup (module validation) and the request body is wrapped in
 /// <see cref="LimitedStream"/> with <see cref="GranitTextExtractionOptions.MaxBodySizeBytes"/>
 /// before upload. Response is truncated at <c>maxCharLength</c> on read.
@@ -85,7 +85,7 @@ public sealed partial class TikaSidecarTextExtractor : ITextExtractor
         ArgumentException.ThrowIfNullOrEmpty(contentType);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCharLength);
 
-        // VULN-001: read the request body through a LimitedStream so a malicious
+        // Read the request body through a LimitedStream so a malicious
         // upstream can't push more than MaxBodySizeBytes at us before Tika even sees
         // the bytes. Materialised to byte[] because HttpContent expects a content-length
         // for the Tika endpoint to allocate efficiently.
@@ -102,7 +102,7 @@ public sealed partial class TikaSidecarTextExtractor : ITextExtractor
         request.Content = content;
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
 
-        // VULN-400: refuse the recursive parser path. Tika historically had SSRF / fetch
+        // Refuse the recursive parser path. Tika historically had SSRF / fetch
         // CVEs in embedded-resource handling (CVE-2022-30126 etc.); the option lets the
         // host opt back in only when it explicitly wants recursive indexing.
         if (_tikaOptions.SkipEmbeddedResources)

--- a/src/Granit.TextExtraction/Diagnostics/TextExtractionMetrics.cs
+++ b/src/Granit.TextExtraction/Diagnostics/TextExtractionMetrics.cs
@@ -13,7 +13,7 @@ namespace Granit.TextExtraction.Diagnostics;
 /// it lands in any <see cref="TagList"/>: only the bare <c>type/subtype</c> survives, parameters
 /// (<c>; charset=…</c>, <c>; boundary=…</c>) are dropped, and unparseable input degrades to a
 /// fixed <c>invalid</c> sentinel. Without that step an attacker controlling the content type
-/// could explode time-series cardinality on every counter (VULN-103, CWE-770).
+/// could explode time-series cardinality on every counter (CWE-770).
 /// </remarks>
 public sealed class TextExtractionMetrics
 {

--- a/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
+++ b/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
@@ -67,13 +67,13 @@ internal sealed class TextExtractionPipeline : ITextExtractionPipeline, IDisposa
         ITextExtractor selected = SelectExtractor(contentType);
         string? tenantId = ResolveTenantId();
 
-        // VULN-100: bound the number of in-flight extractions across the host process.
+        // Bound the number of in-flight extractions across the host process.
         // Done OUTSIDE the timeout link so queue time doesn't eat the per-extraction budget.
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
-            // VULN-101: link the caller's token with our extraction timeout so slow parsers
+            // Link the caller's token with our extraction timeout so slow parsers
             // surface as a structured failure (extraction_timeout) instead of hanging the
             // semaphore slot indefinitely. A non-positive timeout means "disabled" — host
             // can opt down for offline batch jobs by setting ExtractionTimeout = 0.

--- a/src/Granit.TextExtraction/LimitedStream.cs
+++ b/src/Granit.TextExtraction/LimitedStream.cs
@@ -6,7 +6,7 @@ namespace Granit.TextExtraction;
 /// Read-only stream wrapper that throws <see cref="TextExtractionException"/> with reason
 /// <c>input_too_large</c> as soon as the total number of bytes read crosses
 /// <see cref="MaxBytes"/>. Mandatory wrapping for every extractor — protects parser libraries
-/// from decompression bombs and unbounded uploads (VULN-001).
+/// from decompression bombs and unbounded uploads.
 /// </summary>
 /// <remarks>
 /// The wrapper does NOT own <see cref="InnerStream"/>; disposing the <see cref="LimitedStream"/>

--- a/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
@@ -6,7 +6,7 @@ namespace Granit.ArchitectureTests;
 
 /// <summary>
 /// Architecture rules for the <c>Granit.TextExtraction.*</c> module family (epic #2233).
-/// Pins the VULN-001 input-size contract and the "pure utility, no host plumbing" boundary
+/// Pins the LimitedStream input-size contract and the "pure utility, no host plumbing" boundary
 /// across the base package and the extractor providers (Email, Office, Pdf, Text, Tika,
 /// Ocr.AI, Ocr.Tesseract).
 /// </summary>

--- a/tests/Granit.Html.AngleSharp.Tests/AngleSharpConfigurationTests.cs
+++ b/tests/Granit.Html.AngleSharp.Tests/AngleSharpConfigurationTests.cs
@@ -26,8 +26,8 @@ public sealed class AngleSharpConfigurationTests
     }
 
     /// <summary>
-    /// VULN-300: the untrusted-content profile MUST NEVER opt into AngleSharp's default loader.
-    /// Doing so would let untrusted HTML fetch arbitrary URLs (SSRF / data exfiltration).
+    /// The untrusted-content profile MUST NEVER opt into AngleSharp's default loader. Doing so
+    /// would let untrusted HTML fetch arbitrary URLs (SSRF / data exfiltration).
     ///
     /// We anchor the invariant on the source code rather than runtime behaviour because the
     /// loader is registered via a fluent builder — there is no public surface to inspect once
@@ -42,7 +42,7 @@ public sealed class AngleSharpConfigurationTests
 
         using Stream? stream = assembly.GetManifestResourceStream(resourceName);
         stream.ShouldNotBeNull(
-            $"Embedded resource '{resourceName}' is required for the VULN-300 archi test. " +
+            $"Embedded resource '{resourceName}' is required for the SSRF-loader archi test. " +
             "Check the EmbeddedResource entry in Granit.Html.AngleSharp.Tests.csproj.");
 
         using StreamReader reader = new(stream);
@@ -54,7 +54,7 @@ public sealed class AngleSharpConfigurationTests
         bool callsWithDefaultLoader = WithDefaultLoaderCallRegex.IsMatch(code);
 
         callsWithDefaultLoader.ShouldBeFalse(
-            "VULN-300: AngleSharpConfiguration must not invoke WithDefaultLoader — that " +
+            "AngleSharpConfiguration must not invoke WithDefaultLoader — that " +
             "would let untrusted HTML resolve external resources (SSRF). If a loader is " +
             "ever required for trusted templates, document the use case in the PR and " +
             "update this invariant deliberately.");

--- a/tests/Granit.Html.AngleSharp.Tests/Granit.Html.AngleSharp.Tests.csproj
+++ b/tests/Granit.Html.AngleSharp.Tests/Granit.Html.AngleSharp.Tests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Architecture test reads its own source to verify VULN-300 invariant. -->
+    <!-- Architecture test reads its own source to verify the SSRF-loader invariant. -->
     <EmbeddedResource Include="..\..\src\Granit.Html.AngleSharp\AngleSharpConfiguration.cs"
                       LogicalName="Granit.Html.AngleSharp.Source.AngleSharpConfiguration.cs"
                       Visible="false" />

--- a/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
+++ b/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
@@ -140,7 +140,7 @@ public sealed class DefaultUrlSafetyValidatorTests
         result.Violation!.Kind.ShouldBe(UrlSafetyViolationKind.SchemeNotAllowed);
     }
 
-    // VULN-202 — defense in depth: listing "file" in AllowedSchemes is not enough on its own.
+    // Defense in depth: listing "file" in AllowedSchemes is not enough on its own.
     [Fact]
     public async Task FileScheme_InAllowlistButOptOutFalse_StillRejected()
     {
@@ -153,7 +153,7 @@ public sealed class DefaultUrlSafetyValidatorTests
         result.Violation!.Kind.ShouldBe(UrlSafetyViolationKind.SchemeNotAllowed);
     }
 
-    // VULN-202 — UNC file:// path triggers SMB egress on Windows; reject even when opted in.
+    // UNC file:// path triggers SMB egress on Windows; reject even when opted in.
     [Fact]
     public async Task FileScheme_UncPath_Rejected()
     {

--- a/tests/Granit.Http.Security.Tests/PrivateNetworkClassifierTests.cs
+++ b/tests/Granit.Http.Security.Tests/PrivateNetworkClassifierTests.cs
@@ -105,7 +105,7 @@ public sealed class PrivateNetworkClassifierTests
             PrivateNetworkClassifier.Classify(null!, out _));
 
     [Theory]
-    // VULN-200 — reserved ranges
+    // Reserved ranges
     [InlineData("224.0.0.1", UrlSafetyViolationKind.ReservedAddress)]          // multicast
     [InlineData("239.255.255.255", UrlSafetyViolationKind.ReservedAddress)]    // multicast
     [InlineData("240.0.0.0", UrlSafetyViolationKind.ReservedAddress)]          // reserved future
@@ -131,7 +131,7 @@ public sealed class PrivateNetworkClassifierTests
     }
 
     [Theory]
-    // VULN-100 — IPv6 transitional / embedded-IPv4 bypass primitives
+    // IPv6 transitional / embedded-IPv4 bypass primitives
     // NAT64 64:ff9b::/96 wrapping loopback / IMDS / RFC1918
     [InlineData("64:ff9b::7f00:1", UrlSafetyViolationKind.IPv6EmbeddedIPv4)]      // → 127.0.0.1
     [InlineData("64:ff9b::a9fe:a9fe", UrlSafetyViolationKind.MetadataEndpoint)]   // → 169.254.169.254

--- a/tests/Granit.Http.Security.Tests/ReservedTldClassifierTests.cs
+++ b/tests/Granit.Http.Security.Tests/ReservedTldClassifierTests.cs
@@ -14,7 +14,7 @@ public sealed class ReservedTldClassifierTests
     [InlineData("foo.test", "test")]
     [InlineData("example.com.example", "example")]
     [InlineData("missing.invalid", "invalid")]
-    // VULN-300 — newly added reserved TLDs
+    // Newly added reserved TLDs
     [InlineData("home.arpa", "arpa")]
     [InlineData("0.0.127.in-addr.arpa", "arpa")]
     [InlineData("foo.alt", "alt")]

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PersonalDataDeletionCascadeTests.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PersonalDataDeletionCascadeTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Granit.Indexing.EntityFrameworkCore.Tests.Integration;
 
 /// <summary>
-/// End-to-end VULN-004 cascade test: a personal-data deletion request reaches the
+/// End-to-end privacy-cascade test: a personal-data deletion request reaches the
 /// indexing privacy bridge, the EF eraser runs a single <c>ExecuteDelete</c> per
 /// registered TKey, and only rows tied to the subject in the calling tenant are removed.
 /// </summary>

--- a/tests/Granit.TextExtraction.Email.Tests/EmailTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Email.Tests/EmailTextExtractorTests.cs
@@ -230,7 +230,7 @@ public sealed class EmailTextExtractorTests
     [Fact]
     public async Task Strips_embedded_LF_from_subject_to_prevent_log_line_splicing()
     {
-        // VULN-301: an RFC 2047 encoded Subject whose decoded value contains a literal LF
+        // An RFC 2047 encoded Subject whose decoded value contains a literal LF
         // must NOT survive into the emitted "Subject: …\n" line, or a structured-log
         // consumer would see a spliced fake header.
         //
@@ -260,7 +260,7 @@ public sealed class EmailTextExtractorTests
     [Fact]
     public async Task Strips_carriage_returns_too()
     {
-        // Belt-and-braces for VULN-301: \r alone (no \n) is also a structured-log threat.
+        // Belt-and-braces: \r alone (no \n) is also a structured-log threat.
         string raw =
             "From: sender@example.com\r\n" +
             "To: rec@example.com\r\n" +

--- a/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrExtractorTests.cs
@@ -216,7 +216,7 @@ public sealed class AIVisionOcrExtractorTests
     [Fact]
     public async Task Strips_vlm_envelope_from_model_response()
     {
-        // VULN-200: model is asked to wrap output in <granit-vlm-ocr>…</granit-vlm-ocr>.
+        // The model is asked to wrap output in <granit-vlm-ocr>…</granit-vlm-ocr>.
         // Anything outside the envelope is discarded — defends against prompt-injection text
         // the model may have synthesised from inside the image bytes.
         const string modelEcho =
@@ -237,7 +237,7 @@ public sealed class AIVisionOcrExtractorTests
     [Fact]
     public async Task Result_is_tagged_as_model_generated()
     {
-        // VULN-402: downstream consumers must be able to tell VLM output apart from
+        // Downstream consumers must be able to tell VLM output apart from
         // deterministic parser output so they don't re-prompt with attacker-influenced text.
         (AIVisionOcrExtractor extractor, _, _) = CreateExtractor(new ChatResponse
         {
@@ -273,7 +273,7 @@ public sealed class AIVisionOcrExtractorTests
     private static bool HasPromptAndImage(IEnumerable<ChatMessage> messages, string mime, byte[] imageBytes)
     {
         ChatMessage[] msgs = [.. messages];
-        // System + user — VULN-200 hardening adds a system message ahead of the user
+        // System + user — prompt-injection hardening adds a system message ahead of the user
         // multimodal payload. Anything else means the contract has drifted.
         if (msgs.Length != 2) { return false; }
         if (msgs[0].Role != ChatRole.System) { return false; }

--- a/tests/Granit.TextExtraction.Office.Tests/OfficeFixtures.cs
+++ b/tests/Granit.TextExtraction.Office.Tests/OfficeFixtures.cs
@@ -186,8 +186,8 @@ internal static class OfficeFixtures
     /// Builds a single-entry zip whose payload is <paramref name="rawSize"/> bytes of zeros
     /// using <see cref="CompressionLevel.SmallestSize"/>. Zeros compress to a handful of
     /// dictionary tokens, so the resulting CompressedLength/Length ratio comfortably exceeds
-    /// the OpenXmlGate's <c>MaxCompressionRatio</c> (200×). Exercises the VULN-201 gate
-    /// branch (<c>SuspiciousCompressionRatio</c>).
+    /// the OpenXmlGate's <c>MaxCompressionRatio</c> (200×). Exercises the suspicious
+    /// compression-ratio gate branch.
     /// </summary>
     public static byte[] ZipWithHighCompressionRatio(int rawSize)
     {

--- a/tests/Granit.TextExtraction.Office.Tests/OpenXmlGateTests.cs
+++ b/tests/Granit.TextExtraction.Office.Tests/OpenXmlGateTests.cs
@@ -35,7 +35,7 @@ public sealed class OpenXmlGateTests
     [Fact]
     public void Inspect_returns_SuspiciousCompressionRatio_on_high_ratio_payloads()
     {
-        // VULN-201: 8 MB of zeros lands well above the 1 KB compressed-size floor of the
+        // 8 MB of zeros lands well above the 1 KB compressed-size floor of the
         // ratio gate and still compresses with a ratio comfortably above 200× — the gate
         // must catch this before OpenXml streams the local-header bytes.
         byte[] package = OfficeFixtures.ZipWithHighCompressionRatio(rawSize: 8 * 1024 * 1024);

--- a/tests/Granit.TextExtraction.Tests/TextExtractionMetricsTests.cs
+++ b/tests/Granit.TextExtraction.Tests/TextExtractionMetricsTests.cs
@@ -108,7 +108,7 @@ public sealed class TextExtractionMetricsTests : IDisposable
     [Fact]
     public void NormalizeContentType_strips_parameters_and_lowercases()
     {
-        // VULN-103: a malicious upstream submitting a fresh boundary= per request would
+        // A malicious upstream submitting a fresh boundary= per request would
         // explode metric cardinality unless we normalise. NormalizeContentType is the
         // single chokepoint — all four RecordXxx call it.
         TextExtractionMetrics.NormalizeContentType("APPLICATION/JSON; charset=utf-8")

--- a/tests/Granit.TextExtraction.Tests/TextExtractionPipelineTests.cs
+++ b/tests/Granit.TextExtraction.Tests/TextExtractionPipelineTests.cs
@@ -129,7 +129,7 @@ public sealed class TextExtractionPipelineTests
     [Fact]
     public async Task ExtractionTimeout_translates_slow_extractor_to_extraction_timeout_failure()
     {
-        // VULN-101: a slow parser must surface as a structured failure, not pin a slot.
+        // A slow parser must surface as a structured failure, not pin a slot.
         ExtractionOptions options = new() { ExtractionTimeout = TimeSpan.FromMilliseconds(50) };
         (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline(
             s => s.AddTextExtractor<SlowExtractor>(),
@@ -167,7 +167,7 @@ public sealed class TextExtractionPipelineTests
     [Fact]
     public async Task MaxConcurrentExtractions_caps_in_flight_calls()
     {
-        // VULN-100: the (N+1)th call must queue behind the first N slots.
+        // The (N+1)th call must queue behind the first N slots.
         ExtractionOptions options = new()
         {
             MaxConcurrentExtractions = 2,

--- a/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarOptionsValidationTests.cs
+++ b/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarOptionsValidationTests.cs
@@ -87,7 +87,7 @@ public sealed class TikaSidecarOptionsValidationTests
         resolved.Uri.Host.ShouldBe("tika.internal");
     }
 
-    // ──── VULN-104 — HTTPS scheme enforcement ─────────────────────────────────────
+    // ──── HTTPS scheme enforcement ────────────────────────────────────────────────
 
     [Fact]
     public void Http_scheme_on_non_localhost_uri_fails_validation_when_RequireHttps_true()
@@ -134,7 +134,7 @@ public sealed class TikaSidecarOptionsValidationTests
         resolved.Uri.Scheme.ShouldBe("http");
     }
 
-    // ──── VULN-102 — RequireMutualTls enforcement ────────────────────────────────
+    // ──── RequireMutualTls enforcement ────────────────────────────────────────────
 
     [Fact]
     public void RequireMutualTls_true_without_custom_handler_throws_when_client_is_created()

--- a/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarTextExtractorTests.cs
@@ -149,7 +149,7 @@ public sealed class TikaSidecarTextExtractorTests
     [Fact]
     public async Task Sends_skip_embedded_resources_header_by_default()
     {
-        // VULN-400: defence against Tika SSRF/fetch-recursion CVEs via embedded parsing.
+        // Defence against Tika SSRF/fetch-recursion CVEs via embedded parsing.
         (TikaSidecarTextExtractor extractor, StubHttpMessageHandler handler) = CreateExtractor();
         using MemoryStream input = Utf8("body");
 


### PR DESCRIPTION
## Summary

- Removes internal audit identifiers (`VULN-001/100/101/102/103/104/200/201/202/204/300/301/305/400/401/402`) embedded in XML doc comments, inline comments, csproj `<Description>` metadata, test section banners, README "Security posture" headings and `THIRD-PARTY-NOTICES.md`.
- Each tag is replaced with prose that names the threat or invariant directly (e.g. *"defence against pixel-bomb"*, *"defeats DNS rebinding"*, *"prompt-injection defence-in-depth"*), so framework consumers reading the docs no longer need access to an internal audit tracker to understand the rationale.
- No behaviour change: comments / docs / package metadata only.

## Test plan

- [x] `dotnet build` on every touched `src/Granit.TextExtraction*` project — clean.
- [ ] CI shards (`core-ai`, `infrastructure`, `application`, `security`, `architecture`).
- [ ] Spot-check published NuGet `Granit.Html.AngleSharp` description renders the new copy.