### PR TITLE
test(language-detection): cover 8 more Granit base cultures in trigram detector

### DIFF
--- a/src/Granit.LanguageDetection.Trigram/Internal/Iso639Map.cs
+++ b/src/Granit.LanguageDetection.Trigram/Internal/Iso639Map.cs
@@ -67,6 +67,16 @@ internal static class Iso639Map
         ["kur"] = "ku",
         // South / South-East Asia
         ["hin"] = "hi",
+        // Hindi-belt (Bihari) macro-language folding: Magahi, Bhojpuri and Maithili
+        // are listed by Franc as siblings of Hindi inside the Devanagari profile set
+        // but have no ISO 639-1 code of their own. They share heavy vocabulary overlap
+        // with Hindi, and Postgres ships only the Hindi stemmer for Devanagari, so
+        // folding them to "hi" matches both the Granit base-culture surface (15 cultures)
+        // and the downstream stemming/indexing reality. Without this, formal Hindi prose
+        // can score closest to "mag" or "bho" and return null.
+        ["mag"] = "hi",
+        ["bho"] = "hi",
+        ["mai"] = "hi",
         ["ben"] = "bn",
         ["pan"] = "pa",
         ["mar"] = "mr",

--- a/src/Granit.LanguageDetection.Trigram/README.md
+++ b/src/Granit.LanguageDetection.Trigram/README.md
@@ -18,6 +18,9 @@ Detection is deterministic — same input always yields the same answer. Suitabl
   Myanmar (3), Ethiopic (2), Hebrew (2).
 - 6 single-language script shortcuts: Greek (`el`), Bengali (`bn`), Thai (`th`),
   Hangul (`ko`), Hiragana/Katakana → Japanese (`ja`), Han → Chinese (`zh`).
+- Detected and asserted on the **15 Granit base cultures** (`en`, `fr`, `nl`, `de`,
+  `es`, `it`, `pt`, `zh`, `ja`, `pl`, `tr`, `ko`, `sv`, `cs`, `hi`) via the
+  `KnownSamples` theory in `Granit.LanguageDetection.Trigram.Tests`.
 
 The Franc dataset also bundles Tibetan and Canadian_Aboriginal multi-language
 scripts; their rank tables ship in `Resources/profiles.json` but `ScriptDetector`

--- a/tests/Granit.LanguageDetection.Trigram.Tests/TrigramLanguageDetectorTests.cs
+++ b/tests/Granit.LanguageDetection.Trigram.Tests/TrigramLanguageDetectorTests.cs
@@ -19,6 +19,14 @@ public sealed class TrigramLanguageDetectorTests
         { "it", "La rapida volpe marrone salta sopra il cane pigro. Questa frase contiene tutte le lettere dell'alfabeto italiano ed è usata frequentemente per testare i caratteri tipografici." },
         { "pt", "A rápida raposa marrom salta sobre o cão preguiçoso. Esta frase é frequentemente usada para testar fontes tipográficas porque contém todas as letras do alfabeto português. Conforme as gramáticas brasileiras e portuguesas, esses caracteres especiais ajudam a distinguir o português de idiomas românicos próximos como o galego e o espanhol." },
         { "nl", "De snelle bruine vos springt over de luie hond. Deze zin wordt vaak gebruikt om lettertypen te testen omdat hij alle letters van het Nederlandse alfabet bevat." },
+        { "pl", "Szybki brązowy lis przeskakuje nad leniwym psem. To zdanie zawiera wszystkie litery polskiego alfabetu i jest często używane do testowania czcionek." },
+        { "tr", "Hızlı kahverengi tilki tembel köpeğin üzerinden atlar. Bu cümle Türk alfabesindeki tüm harfleri içerir ve yazı tiplerini test etmek için sıkça kullanılır. İstanbul'un sokaklarında yürürken çocuklar gülerek koşuyor, kuşlar gökyüzünde özgürce uçuyor ve güneş ağaçların arasından parlıyor. Türkçe dilbilgisinde sesli uyumu önemli bir kuraldır." },
+        { "sv", "Den snabba bruna räven hoppar över den lata hunden. Denna mening innehåller alla bokstäverna i det svenska alfabetet och används ofta för att testa typsnitt." },
+        { "cs", "Rychlá hnědá liška skáče přes líného psa. Tato věta obsahuje všechna písmena české abecedy a často se používá k testování typografických písem." },
+        { "zh", "敏捷的棕色狐狸跳过了懒狗。这句话经常用于测试字体，因为它包含许多常见的中文字符和短语结构。" },
+        { "ja", "素早い茶色のキツネが怠惰な犬を飛び越える。この文章は日本語のひらがなとカタカナを含み、書体のテストに使われます。" },
+        { "ko", "빠른 갈색 여우가 게으른 개를 뛰어넘는다. 이 문장은 한국어의 한글을 사용하여 글꼴을 테스트하기 위해 자주 사용됩니다." },
+        { "hi", "भारत एक विशाल देश है जिसकी जनसंख्या एक अरब से अधिक है। यहाँ अनेक भाषाएँ बोली जाती हैं और हिंदी सबसे अधिक बोली जाने वाली भाषा है। दिल्ली भारत की राजधानी है और मुंबई सबसे बड़ा आर्थिक केंद्र माना जाता है। विद्यार्थी स्कूल और विश्वविद्यालय में शिक्षा प्राप्त करते हैं तथा अपने भविष्य का निर्माण करते हैं। सरकार ने अनेक योजनाएँ बनाई हैं जिनके माध्यम से ग्रामीण क्षेत्रों का विकास किया जा रहा है। किसान खेतों में काम करते हैं और फसल उगाते हैं।" },
     };
 
     [Theory]


### PR DESCRIPTION
## Summary

- Adds `pl`, `tr`, `sv`, `cs`, `zh`, `ja`, `ko`, `hi` to `KnownSamples` in `TrigramLanguageDetectorTests`. Empirical end-to-end coverage grows from **7 → 15 Granit base cultures**, matching the framework's localization surface.
- `Iso639Map` now folds the three Hindi-belt Bihari languages (Magahi `mag`, Bhojpuri `bho`, Maithili `mai`) to `hi`. Without this, modern formal Hindi prose scores closest to Franc's Magahi profile and the detector returns `null`. None of these have an ISO 639-1 code, none are part of the Granit base-culture surface, and Postgres ships only the Hindi stemmer for Devanagari — so folding to `hi` matches both framework coverage and downstream stemming/indexing reality. Rationale documented inline in [Iso639Map.cs](src/Granit.LanguageDetection.Trigram/Internal/Iso639Map.cs).
- README coverage section updated.

## Notes

- Polish/Czech/Swedish/Turkish exercise the Latin multi-language profile path.
- Chinese/Japanese/Korean hit single-language script shortcuts in `ScriptDetector`.
- Hindi exercises the Devanagari multi-language profile path (with the macro-language folding above).
- Turkish initially failed on the short suggested sample — lengthened to ~3 sentences with characteristic constructs (`ı/İ`, `ş`, `ğ`).

Closes #2294.

## Test plan

- [x] `dotnet test tests/Granit.LanguageDetection.Trigram.Tests` — 25/25 pass
- [x] `dotnet test tests/Granit.LanguageDetection.Tests` — 11/11 pass (no regression in parent module)
- [x] `dotnet format style src/Granit.LanguageDetection.Trigram` clean
- [x] `dotnet format style tests/Granit.LanguageDetection.Trigram.Tests` clean
- [x] `npx markdownlint-cli2` clean on README