### PR TITLE
feat(domain,authorization,persistence): add IOwnable marker with index convention and auth handler

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7289,6 +7289,15 @@
       "members": []
     },
     {
+      "name": "OwnedRequirement",
+      "fqn": "Granit.Authorization.Authorization.OwnedRequirement",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Authorization/OwnedRequirement.cs",
+      "line": 14,
+      "members": []
+    },
+    {
       "name": "PermissionRequirement",
       "fqn": "Granit.Authorization.Authorization.PermissionRequirement",
       "kind": "class",
@@ -15460,6 +15469,15 @@
       "project": "Granit",
       "file": "src/Granit/Domain/IMultiTenant.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "IOwnable",
+      "fqn": "Granit.Domain.IOwnable",
+      "kind": "interface",
+      "project": "Granit",
+      "file": "src/Granit/Domain/IOwnable.cs",
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.Authorization/Authorization/OwnedByCurrentUserHandler.cs
+++ b/src/Granit.Authorization/Authorization/OwnedByCurrentUserHandler.cs
@@ -1,0 +1,33 @@
+using Granit.Domain;
+using Granit.Users;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Granit.Authorization.Authorization;
+
+/// <summary>
+/// Resource-based authorization handler that grants access when the current user's
+/// typed identity (<see cref="ICurrentUserService.UserGuid"/>) matches the
+/// <see cref="IOwnable.OwnerId"/> of the resource being authorized.
+/// </summary>
+/// <remarks>
+/// Best-effort: when <see cref="ICurrentUserService.UserGuid"/> is <c>null</c>
+/// (non-Guid <c>sub</c> claim, machine actor, unauthenticated request), the
+/// handler returns silently without succeeding — the requirement remains
+/// unsatisfied and a stacked handler (permission-based, role-based) may still
+/// grant access. The handler never calls <c>context.Fail()</c>.
+/// </remarks>
+internal sealed class OwnedByCurrentUserHandler(ICurrentUserService currentUser)
+    : AuthorizationHandler<OwnedRequirement, IOwnable>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        OwnedRequirement requirement,
+        IOwnable resource)
+    {
+        if (currentUser.UserGuid is Guid id && id == resource.OwnerId)
+        {
+            context.Succeed(requirement);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/src/Granit.Authorization/Authorization/OwnedRequirement.cs
+++ b/src/Granit.Authorization/Authorization/OwnedRequirement.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Granit.Authorization.Authorization;
+
+/// <summary>
+/// Authorization requirement satisfied when the current user owns the
+/// <see cref="Granit.Domain.IOwnable"/> resource being authorized.
+/// </summary>
+/// <remarks>
+/// Pair with a resource-based authorization call:
+/// <c>authorizationService.AuthorizeAsync(user, resource, new OwnedRequirement())</c>.
+/// The matching handler is <c>OwnedByCurrentUserHandler</c>.
+/// </remarks>
+public sealed class OwnedRequirement : IAuthorizationRequirement;

--- a/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -56,6 +56,7 @@ public static class AuthorizationServiceCollectionExtensions
 
         services.AddSingleton<IAuthorizationPolicyProvider, DynamicPermissionPolicyProvider>();
         services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
+        services.AddScoped<IAuthorizationHandler, OwnedByCurrentUserHandler>();
 
         return services;
     }

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -44,6 +44,11 @@ public static class ModelBuilderExtensions
     ///     Implementors of <see cref="IHasMergeTombstone"/> get the <c>MergedIntoId</c> +
     ///     <c>MergedAt</c> columns and an index on <c>MergedIntoId</c> auto-applied.
     ///   </item>
+    ///   <item><b>Ownership index convention</b>:
+    ///     Implementors of <see cref="IOwnable"/> get an index on <c>(TenantId, OwnerId)</c>
+    ///     when also <see cref="IMultiTenant"/>, or on <c>(OwnerId)</c> alone otherwise.
+    ///     Aligned with the multi-tenant query filter for efficient "my entities" lookups.
+    ///   </item>
     ///   <item><b>Translation conventions</b>:
     ///     <see cref="ITranslation{TParent}"/> → FK, cascade delete, unique index (ParentId, Culture).
     ///   </item>
@@ -141,6 +146,14 @@ public static class ModelBuilderExtensions
                 .Invoke(null, [modelBuilder]);
         }
 
+        // --- Ownership index convention ---
+        // Detects IOwnable implementors and adds an index on (TenantId, OwnerId) when also
+        // IMultiTenant, or on (OwnerId) alone otherwise. Aligned with the multi-tenant
+        // query filter so that "my entities in this tenant" lookups remain a seek.
+        // No query filter is registered — ownership is an exposed column (admin must be
+        // able to list "all entities owned by Alice"), not a hidden filter.
+        ApplyOwnershipIndexes(modelBuilder);
+
         // --- Translation conventions ---
         // Detects ITranslation<TParent> implementations and configures:
         //   - FK from Translation.ParentId → Parent.Id with cascade delete
@@ -182,6 +195,53 @@ public static class ModelBuilderExtensions
         ApplyEnumStringConverters(modelBuilder);
 
         return modelBuilder;
+    }
+
+    // Adds an automatic composite index on (TenantId, OwnerId) for IOwnable + IMultiTenant
+    // entities, or on (OwnerId) alone otherwise. Uses the Fluent API
+    // modelBuilder.Entity(...).HasIndex(...) rather than the low-level
+    // entityType.AddIndex(...) to stay aligned with ModelBuilder validations.
+    //
+    // Skips entities without their own table (TPH derived types, keyless query types).
+    // De-duplicates: if an index over the same property set already exists, no new
+    // index is added — module authors keep the freedom to declare it explicitly with
+    // a custom name when they want one.
+    private static void ApplyOwnershipIndexes(ModelBuilder modelBuilder)
+    {
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            if (!typeof(IOwnable).IsAssignableFrom(entityType.ClrType))
+            {
+                continue;
+            }
+
+            string? tableName = entityType.GetTableName();
+            if (tableName is null)
+            {
+                // Keyless / TPH-derived / view-mapped — no own table to index.
+                continue;
+            }
+
+            bool isMultiTenant = typeof(IMultiTenant).IsAssignableFrom(entityType.ClrType);
+            string[] propertyNames = isMultiTenant
+                ? [nameof(IMultiTenant.TenantId), nameof(IOwnable.OwnerId)]
+                : [nameof(IOwnable.OwnerId)];
+
+            // De-dup: skip if an index over the exact same property set already exists.
+            bool alreadyIndexed = entityType.GetIndexes().Any(idx =>
+                idx.Properties.Count == propertyNames.Length
+                && idx.Properties.Select(p => p.Name).SequenceEqual(propertyNames));
+
+            if (alreadyIndexed)
+            {
+                continue;
+            }
+
+            string suffix = isMultiTenant ? "tenant_owner" : "owner";
+            modelBuilder.Entity(entityType.ClrType)
+                .HasIndex(propertyNames)
+                .HasDatabaseName($"ix_{tableName}_{suffix}");
+        }
     }
 
     // Auto-applies EnumToStringConverter<TEnum> to every enum property in the model,

--- a/src/Granit/Domain/IOwnable.cs
+++ b/src/Granit/Domain/IOwnable.cs
@@ -1,0 +1,27 @@
+namespace Granit.Domain;
+
+/// <summary>
+/// Marker for entities owned by a specific user — semantically distinct from
+/// <see cref="IMultiTenant"/> (tenant scope) and from <c>CreatedBy</c> (immutable
+/// audit identity).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="IMultiTenant.TenantId"/>, <see cref="OwnerId"/> is <b>not</b>
+/// injected automatically by the persistence interceptor. Ownership is a domain
+/// decision: the caller is not always the owner (imports, transfers, service
+/// accounts, GDPR reassignment flows). The aggregate factory MUST require an
+/// explicit <see cref="Guid"/> owner and fail loudly when none is resolvable.
+/// </para>
+/// <para>
+/// EF Core materialises the underlying property via the entity's <c>private set</c>;
+/// the get-only interface preserves DDD encapsulation while exposing the marker
+/// for the index convention applied by <c>ApplyGranitConventions</c> and for the
+/// <c>OwnedByCurrentUserHandler</c> in <c>Granit.Authorization</c>.
+/// </para>
+/// </remarks>
+public interface IOwnable
+{
+    /// <summary>Identifier of the user who owns this entity.</summary>
+    Guid OwnerId { get; }
+}

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
@@ -228,6 +228,47 @@ public static class DomainConventionRules
             $"Violators: {string.Join(", ", violations)}");
     }
 
+    /// <summary>
+    /// Every concrete <c>IOwnable</c> implementor must expose <c>OwnerId</c> with a
+    /// non-public setter (private set or init). Ownership is a domain decision; allowing
+    /// callers to overwrite <c>OwnerId</c> directly bypasses the <c>TransferOwnership</c>
+    /// behaviour method and the domain event emission that goes with it.
+    /// </summary>
+    public static void IOwnableTypesShouldHavePrivateSetOnOwnerId(
+        Architecture architecture,
+        string typePrefix)
+    {
+        List<string> violations = [];
+
+        foreach (Class c in architecture.Classes
+            .Where(c => c.FullName.StartsWith(typePrefix, StringComparison.Ordinal)
+                && !c.IsAbstract.GetValueOrDefault()
+                && ImplementsInterface(c, "Granit.Domain.IOwnable")))
+        {
+            // ArchUnitNET exposes property setters as methods named "set_PropertyName".
+            // A public set_OwnerId means OwnerId has a public setter.
+            MethodMember? publicOwnerIdSetter = c.Members.OfType<MethodMember>()
+                .FirstOrDefault(m => m.Name.StartsWith("set_OwnerId", StringComparison.Ordinal)
+                    && m.Visibility == Visibility.Public
+                    && !m.Name.Contains('.'));
+
+            if (publicOwnerIdSetter is not null)
+            {
+                violations.Add(c.FullName);
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "IOwnable implementors must not expose a public setter on OwnerId — " +
+            "use a TransferOwnership(Guid) behaviour method instead. " +
+            $"Violators: {string.Join(", ", violations)}");
+    }
+
+    private static bool ImplementsInterface(Class c, string interfaceFullName) =>
+        c.Dependencies.Any(d =>
+            d is ArchUnitNET.Domain.Dependencies.ImplementsInterfaceDependency
+            && d.Target.FullName == interfaceFullName);
+
     private static bool IsAssignableToValueObject(Class c) =>
         HasBaseClass(c, "Granit.Domain.ValueObject");
 

--- a/tests/Granit.ArchitectureTests/DomainConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/DomainConventionTests.cs
@@ -36,6 +36,10 @@ public sealed class DomainConventionTests
     public void Event_naming_should_follow_convention() =>
         DomainConventionRules.EventNamingShouldFollowConvention(Architecture, "Granit.");
 
+    [Fact]
+    public void IOwnable_types_should_have_private_set_on_OwnerId() =>
+        DomainConventionRules.IOwnableTypesShouldHavePrivateSetOnOwnerId(Architecture, "Granit.");
+
     /// <summary>
     /// No type should manually implement <c>IDomainEventSource</c> — use aggregate root base classes instead.
     /// </summary>

--- a/tests/Granit.Authorization.Tests/OwnedByCurrentUserHandlerTests.cs
+++ b/tests/Granit.Authorization.Tests/OwnedByCurrentUserHandlerTests.cs
@@ -1,0 +1,109 @@
+// =============================================================================
+// Tests - OwnedByCurrentUserHandler
+// =============================================================================
+// Resource-based handler: succeeds when the current user's UserGuid matches the
+// resource's IOwnable.OwnerId. Fail-silent on non-Guid sub (machine actors,
+// federated identities), never calls context.Fail().
+// =============================================================================
+
+using System.Security.Claims;
+using Granit.Authorization.Authorization;
+using Granit.Domain;
+using Granit.Users;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.Tests;
+
+public sealed class OwnedByCurrentUserHandlerTests
+{
+    private static readonly Guid AliceId = Guid.Parse("c2c61eaf-1a3a-4bbf-90d7-9c8a5e2d6f12");
+    private static readonly Guid BobId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public async Task HandleAsync_UserGuidMatchesOwnerId_ContextSucceeds()
+    {
+        // NSubstitute proxies every interface member including default-impls — UserGuid
+        // must be stubbed explicitly. Tests for the default-impl itself live in
+        // Granit.Users.Tests.ICurrentUserServiceDefaultsTests.
+        ICurrentUserService currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserGuid.Returns(AliceId);
+
+        OwnedByCurrentUserHandler handler = new(currentUser);
+        OwnedRequirement requirement = new();
+        AuthorizationHandlerContext context = new(
+            [requirement],
+            new ClaimsPrincipal(),
+            resource: new OwnedResource(AliceId));
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserGuidDoesNotMatchOwnerId_ContextDoesNotSucceed()
+    {
+        ICurrentUserService currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserGuid.Returns(AliceId);
+
+        OwnedByCurrentUserHandler handler = new(currentUser);
+        OwnedRequirement requirement = new();
+        AuthorizationHandlerContext context = new(
+            [requirement],
+            new ClaimsPrincipal(),
+            resource: new OwnedResource(BobId));
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.ShouldBeFalse();
+        context.HasFailed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserGuidIsNull_ContextDoesNotSucceed_AndDoesNotFail()
+    {
+        // Non-Guid sub (Google numeric, Cognito federated, anonymous) — UserGuid is null.
+        ICurrentUserService currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserGuid.Returns((Guid?)null);
+
+        OwnedByCurrentUserHandler handler = new(currentUser);
+        OwnedRequirement requirement = new();
+        AuthorizationHandlerContext context = new(
+            [requirement],
+            new ClaimsPrincipal(),
+            resource: new OwnedResource(AliceId));
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.ShouldBeFalse();
+        // Fail-silent: other handlers (permission-based, role-based) can still grant access.
+        context.HasFailed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ResourceIsNotIOwnable_HandlerIsNotInvoked()
+    {
+        // ASP.NET only dispatches AuthorizationHandler<TReq, TRes> when the resource
+        // matches TRes. With a non-IOwnable resource, the handler is bypassed entirely
+        // and the requirement remains unsatisfied.
+        ICurrentUserService currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserGuid.Returns(AliceId);
+
+        OwnedByCurrentUserHandler handler = new(currentUser);
+        OwnedRequirement requirement = new();
+        AuthorizationHandlerContext context = new(
+            [requirement],
+            new ClaimsPrincipal(),
+            resource: "not-an-iownable");
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.ShouldBeFalse();
+        context.HasFailed.ShouldBeFalse();
+    }
+
+    private sealed record OwnedResource(Guid OwnerId) : IOwnable;
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/OwnershipIndexConventionTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/OwnershipIndexConventionTests.cs
@@ -1,0 +1,148 @@
+// =============================================================================
+// Tests - IOwnable index convention
+// =============================================================================
+// Verifies that ApplyGranitConventions auto-creates an index on (TenantId, OwnerId)
+// for IOwnable + IMultiTenant entities, or (OwnerId) alone otherwise, with the
+// expected database-name pattern. De-duplicates against manual indexes.
+// =============================================================================
+
+using Granit.Domain;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class OwnershipIndexConventionTests
+{
+    [Fact]
+    public void Convention_AddsIndex_OnTenantIdAndOwnerId_ForIOwnableMultiTenantEntity()
+    {
+        IIndex? index = FindOwnerIndex<OwnableMultiTenantTestEntity>();
+
+        index.ShouldNotBeNull();
+        index.Properties.Select(p => p.Name).ShouldBe([nameof(IMultiTenant.TenantId), nameof(IOwnable.OwnerId)]);
+        index.GetDatabaseName().ShouldBe("ix_ownable_multi_tenant_test_entities_tenant_owner");
+    }
+
+    [Fact]
+    public void Convention_AddsIndex_OnOwnerIdAlone_ForIOwnableNonMultiTenantEntity()
+    {
+        IIndex? index = FindOwnerIndex<OwnableOnlyTestEntity>();
+
+        index.ShouldNotBeNull();
+        index.Properties.Select(p => p.Name).ShouldBe([nameof(IOwnable.OwnerId)]);
+        index.GetDatabaseName().ShouldBe("ix_ownable_only_test_entities_owner");
+    }
+
+    [Fact]
+    public void Convention_DoesNotAddIndex_ForNonOwnableEntity()
+    {
+        IEntityType entityType = GetEntityType<NonOwnableTestEntity>();
+        // No IOwnable interface ⇒ convention skips the entity entirely.
+        entityType.GetIndexes().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Convention_DoesNotDuplicate_WhenIdenticalManualIndexAlreadyExists()
+    {
+        IEntityType entityType = GetEntityType<ManuallyIndexedOwnableTestEntity>();
+
+        // Only the manual index should be present — convention de-dupes by checking
+        // for an existing index over the same property set.
+        var indexes = entityType.GetIndexes()
+            .Where(i => i.Properties.Select(p => p.Name)
+                .SequenceEqual([nameof(IMultiTenant.TenantId), nameof(IOwnable.OwnerId)]))
+            .ToList();
+
+        indexes.Count.ShouldBe(1);
+        // The manual index name wins — convention did not overwrite.
+        indexes[0].GetDatabaseName().ShouldBe("ix_manual_tenant_owner_custom");
+    }
+
+    private static IIndex? FindOwnerIndex<TEntity>() where TEntity : class
+    {
+        IEntityType entityType = GetEntityType<TEntity>();
+        return entityType.GetIndexes().FirstOrDefault(idx =>
+            idx.Properties.Any(p => p.Name == nameof(IOwnable.OwnerId)));
+    }
+
+    private static IEntityType GetEntityType<TEntity>() where TEntity : class
+    {
+        using OwnershipTestDbContext context = new();
+        return context.Model.FindEntityType(typeof(TEntity))
+            ?? throw new InvalidOperationException($"Entity {typeof(TEntity).Name} not found in model.");
+    }
+}
+
+#pragma warning disable CA1812 // instantiated by EF Core via reflection
+
+internal sealed class OwnershipTestDbContext : DbContext
+{
+    public DbSet<OwnableMultiTenantTestEntity> MultiTenantOwned => Set<OwnableMultiTenantTestEntity>();
+    public DbSet<OwnableOnlyTestEntity> Owned => Set<OwnableOnlyTestEntity>();
+    public DbSet<NonOwnableTestEntity> NonOwnable => Set<NonOwnableTestEntity>();
+    public DbSet<ManuallyIndexedOwnableTestEntity> ManuallyIndexed => Set<ManuallyIndexedOwnableTestEntity>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlite("DataSource=:memory:");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Stable table names so the expected index database names below are deterministic.
+        modelBuilder.Entity<OwnableMultiTenantTestEntity>(b =>
+        {
+            b.ToTable("ownable_multi_tenant_test_entities");
+            b.HasKey(e => e.Id);
+        });
+        modelBuilder.Entity<OwnableOnlyTestEntity>(b =>
+        {
+            b.ToTable("ownable_only_test_entities");
+            b.HasKey(e => e.Id);
+        });
+        modelBuilder.Entity<NonOwnableTestEntity>(b =>
+        {
+            b.ToTable("non_ownable_test_entities");
+            b.HasKey(e => e.Id);
+        });
+        modelBuilder.Entity<ManuallyIndexedOwnableTestEntity>(b =>
+        {
+            b.ToTable("manual_ownable_test_entities");
+            b.HasKey(e => e.Id);
+            // Pre-existing manual index on the same property set — the convention must
+            // detect this and not stack a second index.
+            b.HasIndex(nameof(IMultiTenant.TenantId), nameof(IOwnable.OwnerId))
+                .HasDatabaseName("ix_manual_tenant_owner_custom");
+        });
+
+        modelBuilder.ApplyGranitConventions();
+    }
+}
+
+internal sealed class OwnableMultiTenantTestEntity : IMultiTenant, IOwnable
+{
+    public Guid Id { get; set; }
+    public Guid? TenantId { get; set; }
+    public Guid OwnerId { get; private set; }
+}
+
+internal sealed class OwnableOnlyTestEntity : IOwnable
+{
+    public Guid Id { get; set; }
+    public Guid OwnerId { get; private set; }
+}
+
+internal sealed class NonOwnableTestEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+internal sealed class ManuallyIndexedOwnableTestEntity : IMultiTenant, IOwnable
+{
+    public Guid Id { get; set; }
+    public Guid? TenantId { get; set; }
+    public Guid OwnerId { get; private set; }
+}


### PR DESCRIPTION
> **Stacked on #2298** (UserGuid default-impl). Once #2298 merges, rebase this PR onto `develop`.

## Summary

Introduces `IOwnable` as a get-only marker interface on `Granit.Domain` — the ownership counterpart to `IMultiTenant`. Wires three framework integrations:

1. **Persistence convention** — `ApplyGranitConventions` adds an automatic composite index on `(TenantId, OwnerId)` for `IOwnable + IMultiTenant` entities, or on `(OwnerId)` alone otherwise.
2. **Resource-based authorization** — `OwnedRequirement` + `OwnedByCurrentUserHandler` register a reusable "current user owns this resource" policy in `Granit.Authorization`.
3. **Architecture rule** — `IOwnableTypesShouldHavePrivateSetOnOwnerId` enforces that every concrete `IOwnable` implementor keeps `OwnerId` non-publicly settable.

## Design notes

### Why get-only on the interface, not `{ get; set; }` like `IMultiTenant`

Unlike `IMultiTenant.TenantId` — which is ambient (one tenant per request) and auto-injected by `AuditedEntityInterceptor` — `OwnerId` is a **domain decision** (caller is not always the owner: imports, transfers, service accounts, GDPR reassignment). Auto-injection in the interceptor would hide a domain concern behind infrastructure and surface failures at `SaveChanges` rather than at the command-handler boundary.

The aggregate factory MUST require an explicit `Guid` owner and fail loudly when none is resolvable — typically via `currentUserService.UserGuid ?? throw new InvalidOperationException(...)`. The get-only interface signals this contract.

### Why a separate handler (not a fallback to `CreatedBy`)

`IOwnable.OwnerId : Guid` (typed FK, transferable) and `CreationAuditedEntity.CreatedBy : string` (JWT sub, immutable historical metadata) are semantically distinct. A handler that silently falls back to `CreatedBy` would let the original creator retain a hidden right after a `TransferOwnership` — defeating the purpose of the ownership model. If a "created-by" auth flow is needed later, it gets its own `CreatedByCurrentUserRequirement` and consumers compose them via policy.

### Why Fluent API for the index, not low-level `AddIndex`

`modelBuilder.Entity(...).HasIndex(...)` runs through `ModelBuilder` validations; `entityType.AddIndex(...)` bypasses them and risks incompatibility with future EF Core versions. De-duplicates against existing manual indexes over the same property set, so module authors keep the freedom to declare a custom-named index when they want one.

### Why fail-silent in the handler (not `context.Fail()`)

Non-Guid sub claims (Google numeric, Cognito federated, machine actors) yield `UserGuid == null`. The handler returns without succeeding so stacked handlers (permission-based, role-based) can still grant access. `context.Fail()` would short-circuit the entire policy chain — undesirable for a "best-effort" ownership check.

## Test plan

- [x] `dotnet test tests/Granit.Authorization.Tests` — 4/4 new `OwnedByCurrentUserHandlerTests` pass (match, mismatch, null `UserGuid`, non-IOwnable resource bypassed)
- [x] `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Tests` — 4/4 new `OwnershipIndexConventionTests` pass; full project 360/360 green
- [x] `dotnet test .github/shard-filters/security.slnf` — full security shard passes (no consumer of `IAuthorizationHandler` broken)
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 213/213 archi tests pass (was 212, +1 `IOwnableTypesShouldHavePrivateSetOnOwnerId`)
- [x] `dotnet format --verify-no-changes` clean on all 7 touched projects

## Next in the sequence

- granit-business `Granit.Documents` adopts `IOwnable` — `Document` and `Folder` rename `OwnerUserId → OwnerId`, factory contract, `TransferOwnership` method, dedicated permission (GitLab story).
- `UserDeletionRequestedEto` / `UserAnonymizedEto` privacy cascade (#2288) can ship in parallel.

Closes #2287