### PR TITLE
test(indexing-architecture): close out I-F5.2 architecture tests

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -26047,6 +26047,33 @@
       ]
     },
     {
+      "name": "IndexRebuildAbortedEvent",
+      "fqn": "Granit.Indexing.BackgroundJobs.Events.IndexRebuildAbortedEvent",
+      "kind": "record",
+      "project": "Granit.Indexing.BackgroundJobs",
+      "file": "src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildAbortedEvent.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "IndexRebuildCompletedEvent",
+      "fqn": "Granit.Indexing.BackgroundJobs.Events.IndexRebuildCompletedEvent",
+      "kind": "record",
+      "project": "Granit.Indexing.BackgroundJobs",
+      "file": "src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildCompletedEvent.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IndexRebuildStartedEvent",
+      "fqn": "Granit.Indexing.BackgroundJobs.Events.IndexRebuildStartedEvent",
+      "kind": "record",
+      "project": "Granit.Indexing.BackgroundJobs",
+      "file": "src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildStartedEvent.cs",
+      "line": 22,
+      "members": []
+    },
+    {
       "name": "RebuildAlreadyInProgressException",
       "fqn": "Granit.Indexing.BackgroundJobs.Exceptions.RebuildAlreadyInProgressException",
       "kind": "class",
@@ -26065,6 +26092,22 @@
           "kind": "method",
           "signature": "RebuildAlreadyInProgressException(Guid? tenantId, string sourceName, Exception? innerException = null)",
           "returnType": "Guid? TenantId { get; } public string SourceName { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "RebuildBudgetExceededException",
+      "fqn": "Granit.Indexing.BackgroundJobs.Exceptions.RebuildBudgetExceededException",
+      "kind": "class",
+      "project": "Granit.Indexing.BackgroundJobs",
+      "file": "src/Granit.Indexing.BackgroundJobs/Exceptions/RebuildBudgetExceededException.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "RebuildBudgetExceededException",
+          "kind": "method",
+          "signature": "RebuildBudgetExceededException(string reason, Guid? tenantId, string sourceName, long processedCount)",
+          "returnType": "string Reason { get; } public Guid? TenantId { get; } public string SourceName { get; } public long ProcessedCount { get; } public"
         }
       ]
     },
@@ -26143,7 +26186,7 @@
       "kind": "record",
       "project": "Granit.Indexing.BackgroundJobs",
       "file": "src/Granit.Indexing.BackgroundJobs/Jobs/RebuildIndexJob.cs",
-      "line": 19,
+      "line": 29,
       "members": []
     },
     {
@@ -26192,7 +26235,7 @@
       "kind": "class",
       "project": "Granit.Indexing.BackgroundJobs",
       "file": "src/Granit.Indexing.BackgroundJobs/Services/RebuildIndexService.cs",
-      "line": 28,
+      "line": 48,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -26047,12 +26047,34 @@
       ]
     },
     {
+      "name": "RebuildAlreadyInProgressException",
+      "fqn": "Granit.Indexing.BackgroundJobs.Exceptions.RebuildAlreadyInProgressException",
+      "kind": "class",
+      "project": "Granit.Indexing.BackgroundJobs",
+      "file": "src/Granit.Indexing.BackgroundJobs/Exceptions/RebuildAlreadyInProgressException.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Reason",
+          "kind": "property",
+          "signature": "string Reason",
+          "returnType": "string"
+        },
+        {
+          "name": "RebuildAlreadyInProgressException",
+          "kind": "method",
+          "signature": "RebuildAlreadyInProgressException(Guid? tenantId, string sourceName, Exception? innerException = null)",
+          "returnType": "Guid? TenantId { get; } public string SourceName { get; } public"
+        }
+      ]
+    },
+    {
       "name": "ServiceCollectionExtensions",
       "fqn": "Granit.Indexing.BackgroundJobs.Extensions.ServiceCollectionExtensions",
       "kind": "class",
       "project": "Granit.Indexing.BackgroundJobs",
       "file": "src/Granit.Indexing.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitIndexingBackgroundJobs",
@@ -26121,7 +26143,7 @@
       "kind": "record",
       "project": "Granit.Indexing.BackgroundJobs",
       "file": "src/Granit.Indexing.BackgroundJobs/Jobs/RebuildIndexJob.cs",
-      "line": 25,
+      "line": 19,
       "members": []
     },
     {
@@ -26145,6 +26167,24 @@
           "returnType": "int"
         }
       ]
+    },
+    {
+      "name": "IndexingRebuildPermissions",
+      "fqn": "Granit.Indexing.BackgroundJobs.Permissions.IndexingRebuildPermissions",
+      "kind": "class",
+      "project": "Granit.Indexing.BackgroundJobs",
+      "file": "src/Granit.Indexing.BackgroundJobs/Permissions/IndexingRebuildPermissions.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "Rebuild",
+      "fqn": "Granit.Indexing.BackgroundJobs.Permissions.Rebuild",
+      "kind": "class",
+      "project": "Granit.Indexing.BackgroundJobs",
+      "file": "src/Granit.Indexing.BackgroundJobs/Permissions/IndexingRebuildPermissions.cs",
+      "line": 34,
+      "members": []
     },
     {
       "name": "RebuildIndexService",
@@ -26479,7 +26519,7 @@
       "kind": "class",
       "project": "Granit.Indexing.EntityFrameworkCore",
       "file": "src/Granit.Indexing.EntityFrameworkCore/IndexingRebuildCheckpointRow.cs",
-      "line": 20,
+      "line": 32,
       "members": [
         {
           "name": "TenantId",
@@ -26492,6 +26532,12 @@
           "kind": "property",
           "signature": "string LastProcessedKey",
           "returnType": "string"
+        },
+        {
+          "name": "UpdatedAt",
+          "kind": "property",
+          "signature": "DateTimeOffset UpdatedAt",
+          "returnType": "DateTimeOffset"
         }
       ]
     },

--- a/src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildAbortedEvent.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildAbortedEvent.cs
@@ -1,0 +1,25 @@
+using Granit.Events;
+
+namespace Granit.Indexing.BackgroundJobs.Events;
+
+/// <summary>
+/// Raised when a rebuild run is cut short before reaching end-of-stream — by the
+/// consecutive-failure circuit-breaker, by a budget cutoff, or by cancellation.
+/// The checkpoint is preserved so a re-dispatch resumes. Local (<see cref="IDomainEvent"/>).
+/// </summary>
+/// <param name="TenantId">Target tenant. <c>null</c> = cross-tenant rebuild.</param>
+/// <param name="SourceName"><see cref="IIndexedEntrySource{TKey}.Name"/> being rebuilt.</param>
+/// <param name="KeyTypeName">Closed generic <c>TKey</c> discriminator.</param>
+/// <param name="Reason">
+/// Stable cause identifier. One of: <c>"max_consecutive_failures"</c>,
+/// <c>"max_entries_per_run"</c>, <c>"max_run_duration"</c>, <c>"cancelled"</c>.
+/// </param>
+/// <param name="EntriesProcessed">Total entries processed before the cutoff (indexed + skipped + failed).</param>
+/// <param name="DispatchedByUserId">Dispatching principal's user id, when available.</param>
+public sealed record IndexRebuildAbortedEvent(
+    Guid? TenantId,
+    string SourceName,
+    string KeyTypeName,
+    string Reason,
+    long EntriesProcessed,
+    string? DispatchedByUserId) : IDomainEvent;

--- a/src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildCompletedEvent.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildCompletedEvent.cs
@@ -1,0 +1,23 @@
+using Granit.Events;
+
+namespace Granit.Indexing.BackgroundJobs.Events;
+
+/// <summary>
+/// Raised when a rebuild run reaches end-of-stream successfully and clears its
+/// checkpoint. Local (<see cref="IDomainEvent"/>).
+/// </summary>
+/// <param name="TenantId">Target tenant. <c>null</c> = cross-tenant rebuild.</param>
+/// <param name="SourceName"><see cref="IIndexedEntrySource{TKey}.Name"/> rebuilt.</param>
+/// <param name="KeyTypeName">Closed generic <c>TKey</c> discriminator.</param>
+/// <param name="EntriesIndexed">Per-entry indexing successes during the run.</param>
+/// <param name="EntriesSkipped">Per-entry skips (resource no longer exists at source).</param>
+/// <param name="EntriesFailed">Per-entry failures (build error or indexer fault).</param>
+/// <param name="DispatchedByUserId">Dispatching principal's user id, when available.</param>
+public sealed record IndexRebuildCompletedEvent(
+    Guid? TenantId,
+    string SourceName,
+    string KeyTypeName,
+    long EntriesIndexed,
+    long EntriesSkipped,
+    long EntriesFailed,
+    string? DispatchedByUserId) : IDomainEvent;

--- a/src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildStartedEvent.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Events/IndexRebuildStartedEvent.cs
@@ -1,0 +1,27 @@
+using Granit.Events;
+
+namespace Granit.Indexing.BackgroundJobs.Events;
+
+/// <summary>
+/// Raised at the very start of a rebuild run, before the first key is read. Local
+/// (<see cref="IDomainEvent"/>) — handler chain runs in-process so audit subscribers
+/// can persist the run intent atomically with checkpoint setup.
+/// </summary>
+/// <param name="TenantId">Target tenant. <c>null</c> = cross-tenant rebuild.</param>
+/// <param name="SourceName"><see cref="IIndexedEntrySource{TKey}.Name"/> being rebuilt.</param>
+/// <param name="KeyTypeName">Closed generic <c>TKey</c> discriminator (e.g. <c>"System.Guid"</c>).</param>
+/// <param name="ResumedFromCheckpoint">
+/// <c>true</c> when a prior checkpoint was present and the run resumes past it;
+/// <c>false</c> when starting from the beginning.
+/// </param>
+/// <param name="DispatchedByUserId">
+/// Dispatching principal's user id, when one is associated with the current scope.
+/// <c>null</c> for jobs dispatched outside a user context (host start-up, scheduled
+/// triggers without a principal).
+/// </param>
+public sealed record IndexRebuildStartedEvent(
+    Guid? TenantId,
+    string SourceName,
+    string KeyTypeName,
+    bool ResumedFromCheckpoint,
+    string? DispatchedByUserId) : IDomainEvent;

--- a/src/Granit.Indexing.BackgroundJobs/Exceptions/RebuildAlreadyInProgressException.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Exceptions/RebuildAlreadyInProgressException.cs
@@ -1,0 +1,33 @@
+namespace Granit.Indexing.BackgroundJobs.Exceptions;
+
+/// <summary>
+/// Thrown when a <c>RebuildIndexJob</c> dispatch races a concurrent run for the same
+/// <c>(TenantId, SourceName)</c> tuple and loses on the checkpoint store's optimistic
+/// concurrency check.
+/// </summary>
+/// <remarks>
+/// Wolverine's default retry/DLQ policy dead-letters the duplicate so it does not clobber
+/// the winning run's checkpoint. Hosts that want to swallow the duplicate (idempotent
+/// dispatch) can catch the exception in a Wolverine policy and discard the envelope.
+/// </remarks>
+public sealed class RebuildAlreadyInProgressException : Exception
+{
+    /// <summary>Stable identifier for the cause. Always <c>rebuild_already_in_progress</c>.</summary>
+    public string Reason { get; } = "rebuild_already_in_progress";
+
+    /// <summary>Tenant scope of the racing checkpoint write.</summary>
+    public Guid? TenantId { get; }
+
+    /// <summary>Source name of the racing checkpoint write.</summary>
+    public string SourceName { get; }
+
+    public RebuildAlreadyInProgressException(Guid? tenantId, string sourceName, Exception? innerException = null)
+        : base(
+            $"A rebuild is already in progress for source '{sourceName}' on tenant '{tenantId?.ToString() ?? "global"}'.",
+            innerException)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourceName);
+        TenantId = tenantId;
+        SourceName = sourceName;
+    }
+}

--- a/src/Granit.Indexing.BackgroundJobs/Exceptions/RebuildBudgetExceededException.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Exceptions/RebuildBudgetExceededException.cs
@@ -1,0 +1,43 @@
+namespace Granit.Indexing.BackgroundJobs.Exceptions;
+
+/// <summary>
+/// Thrown when a rebuild run exceeds <c>MaxEntriesPerRun</c> or
+/// <c>MaxRunDurationSeconds</c>. The checkpoint is preserved before the exception is
+/// raised so Wolverine's retry policy re-dispatches the job and resumes past the last
+/// successfully processed key.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="RebuildAlreadyInProgressException"/>: this represents a
+/// healthy budget cutoff (the run will be resumed), not a concurrency conflict
+/// (the run is rejected).
+/// </remarks>
+public sealed class RebuildBudgetExceededException : Exception
+{
+    /// <summary>
+    /// Stable cause identifier. One of <c>"max_entries_per_run"</c>,
+    /// <c>"max_run_duration"</c>.
+    /// </summary>
+    public string Reason { get; }
+
+    /// <summary>Tenant scope of the run that hit the budget.</summary>
+    public Guid? TenantId { get; }
+
+    /// <summary>Source name of the run that hit the budget.</summary>
+    public string SourceName { get; }
+
+    /// <summary>Number of entries processed (indexed + skipped + failed) before the cutoff.</summary>
+    public long ProcessedCount { get; }
+
+    public RebuildBudgetExceededException(string reason, Guid? tenantId, string sourceName, long processedCount)
+        : base(
+            $"Rebuild budget '{reason}' exceeded for source '{sourceName}' on tenant '{tenantId?.ToString() ?? "global"}' "
+            + $"after {processedCount} entries — checkpoint preserved, retry will resume.")
+    {
+        ArgumentException.ThrowIfNullOrEmpty(reason);
+        ArgumentException.ThrowIfNullOrEmpty(sourceName);
+        Reason = reason;
+        TenantId = tenantId;
+        SourceName = sourceName;
+        ProcessedCount = processedCount;
+    }
+}

--- a/src/Granit.Indexing.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Granit.Diagnostics;
 using Granit.Indexing.BackgroundJobs.Diagnostics;
 using Granit.Indexing.BackgroundJobs.Internal;
 using Granit.Indexing.BackgroundJobs.Options;
@@ -22,8 +21,6 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddGranitIndexingBackgroundJobs(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
-
-        GranitActivitySourceRegistry.Register(IndexingBackgroundJobsMetrics.MeterName);
 
         services.AddOptions<IndexingBackgroundJobsOptions>()
             .BindConfiguration(IndexingBackgroundJobsOptions.SectionName)

--- a/src/Granit.Indexing.BackgroundJobs/Jobs/RebuildIndexHandler.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Jobs/RebuildIndexHandler.cs
@@ -11,7 +11,7 @@ namespace Granit.Indexing.BackgroundJobs.Jobs;
 /// therefore <c>public</c> with a public constructor, the method is
 /// <c>public static</c>. See CLAUDE.md §Wolverine handlers.
 /// </remarks>
-public class RebuildIndexHandler
+public sealed class RebuildIndexHandler
 {
     public static Task HandleAsync<TKey>(
         RebuildIndexJob<TKey> job,

--- a/src/Granit.Indexing.BackgroundJobs/Jobs/RebuildIndexJob.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Jobs/RebuildIndexJob.cs
@@ -9,18 +9,22 @@ namespace Granit.Indexing.BackgroundJobs.Jobs;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Not auto-scheduled.</b> The <see cref="RecurringJobAttribute"/> carries a
-/// <c>null</c> cron — hosts dispatch the job explicitly via
+/// <b>Not auto-scheduled.</b> No <see cref="RecurringJobAttribute"/> is applied — that
+/// attribute is reserved for cron-driven recurring jobs and its constructor rejects a
+/// null cron. Hosts dispatch this job explicitly via
 /// <c>IBackgroundJobDispatcher.PublishAsync</c> after a schema upgrade, tenant
-/// onboarding, or operator intervention.
+/// onboarding, or operator intervention. Hosts that want a periodic full rebuild
+/// (e.g. nightly re-tokenisation) wire their own cron-driven trigger that emits
+/// <see cref="RebuildIndexJob{TKey}"/>.
 /// </para>
 /// <para>
-/// <b>Name.</b> <c>indexing-rebuild-index</c> per the framework
-/// <c>{module-kebab}-{action-kebab}</c> convention. The same name covers every
-/// <typeparamref name="TKey"/> instantiation — the message type carries the
-/// discriminator.
+/// <b>Authorization.</b> The handler trusts <c>TenantId</c> as-is — there is no
+/// runtime principal at handler time. The dispatch site MUST enforce
+/// <see cref="Granit.Indexing.BackgroundJobs.Permissions.IndexingRebuildPermissions.Rebuild.Execute"/>
+/// (tenant-scoped), and additionally
+/// <see cref="Granit.Indexing.BackgroundJobs.Permissions.IndexingRebuildPermissions.Rebuild.ExecuteGlobal"/>
+/// when dispatching with <c>TenantId == null</c> (cross-tenant rebuild).
 /// </para>
 /// </remarks>
-[RecurringJob(cronExpression: null!, name: "indexing-rebuild-index")]
 public sealed record RebuildIndexJob<TKey>(Guid? TenantId) : IBackgroundJob
     where TKey : notnull;

--- a/src/Granit.Indexing.BackgroundJobs/Options/IndexingBackgroundJobsOptions.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Options/IndexingBackgroundJobsOptions.cs
@@ -27,4 +27,27 @@ public sealed class IndexingBackgroundJobsOptions
     /// </summary>
     [Range(1, 1_000_000)]
     public int MaxConsecutiveFailures { get; set; } = 50;
+
+    /// <summary>
+    /// Upper bound on the number of entries a single rebuild run processes before
+    /// checkpointing and yielding. <c>null</c> (default) leaves the run unbounded —
+    /// suitable for dev and single-tenant deployments. Production multi-tenant hosts
+    /// SHOULD cap it (typical: 100k–1M) so that a hostile or accidental dispatch
+    /// cannot exhaust the indexer / embedding budget in one shot. When the cap is
+    /// hit the service checkpoints, raises
+    /// <c>RebuildBudgetExceededException</c> with <c>Reason = "max_entries_per_run"</c>,
+    /// and Wolverine re-dispatches via its retry policy.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int? MaxEntriesPerRun { get; set; }
+
+    /// <summary>
+    /// Wall-clock budget (seconds) for a single rebuild run. <c>null</c> (default) is
+    /// unbounded. When the budget is exceeded the service checkpoints, raises
+    /// <c>RebuildBudgetExceededException</c> with <c>Reason = "max_run_duration"</c>,
+    /// and Wolverine re-dispatches via its retry policy. Combine with
+    /// <see cref="MaxEntriesPerRun"/> to bound both per-run cost and latency.
+    /// </summary>
+    [Range(1, 86_400)]
+    public int? MaxRunDurationSeconds { get; set; }
 }

--- a/src/Granit.Indexing.BackgroundJobs/Permissions/IndexingRebuildPermissions.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Permissions/IndexingRebuildPermissions.cs
@@ -1,0 +1,46 @@
+namespace Granit.Indexing.BackgroundJobs.Permissions;
+
+/// <summary>
+/// Permission constants for the indexing-rebuild job. The framework module ships only
+/// the canonical name — host applications grant it through their own
+/// <c>IPermissionDefinitionProvider</c> and enforce it at the dispatch site before
+/// calling <c>IBackgroundJobDispatcher.PublishAsync(new RebuildIndexJob&lt;TKey&gt;(...))</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why host-enforced.</b> The job runs out of band of the originating HTTP request,
+/// so the framework cannot derive the principal from <c>HttpContext</c> at handler time.
+/// The handler trusts the envelope; the dispatch site is the trust boundary. Without an
+/// enforced permission gate, any in-process code that obtains
+/// <see cref="Granit.BackgroundJobs.Abstractions.IBackgroundJobDispatcher"/> can trigger
+/// a rebuild for any tenant — including the privileged <c>TenantId == null</c>
+/// (cross-tenant) variant.
+/// </para>
+/// <para>
+/// <b>Recommended grants.</b>
+/// <list type="bullet">
+///   <item><see cref="Rebuild.Execute"/> — single tenant rebuild; safe for tenant admins.</item>
+///   <item><see cref="Rebuild.ExecuteGlobal"/> — cross-tenant (<c>TenantId == null</c>)
+///         rebuild; restrict to host-side operators (<c>MultiTenancySides.Host</c>).</item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class IndexingRebuildPermissions
+{
+    /// <summary>Permission group name used in <c>IPermissionDefinitionContext.AddGroup()</c>.</summary>
+    public const string GroupName = "Indexing";
+
+    /// <summary>Permissions for triggering the rebuild background job.</summary>
+    public static class Rebuild
+    {
+        /// <summary>Grants tenant-scoped rebuild dispatch — the dispatcher must pass its own tenant id.</summary>
+        public const string Execute = "Indexing.Rebuild.Execute";
+
+        /// <summary>
+        /// Grants cross-tenant rebuild dispatch — i.e. the ability to publish a
+        /// <c>RebuildIndexJob</c> with <c>TenantId == null</c>. Restrict to host-side
+        /// operators; this scans the entire dataset.
+        /// </summary>
+        public const string ExecuteGlobal = "Indexing.Rebuild.ExecuteGlobal";
+    }
+}

--- a/src/Granit.Indexing.BackgroundJobs/README.md
+++ b/src/Granit.Indexing.BackgroundJobs/README.md
@@ -33,16 +33,57 @@ but state is lost on restart.
 ## Triggering a rebuild
 
 ```csharp
-public sealed class RebuildController(IBackgroundJobDispatcher dispatcher)
+public sealed class RebuildController(
+    IBackgroundJobDispatcher dispatcher,
+    IPermissionChecker permissionChecker,
+    ICurrentTenant currentTenant)
 {
-    public Task TriggerAsync(Guid tenantId, CancellationToken ct) =>
-        dispatcher.PublishAsync(new RebuildIndexJob<Guid>(tenantId), cancellationToken: ct);
+    public async Task TriggerAsync(CancellationToken ct)
+    {
+        // Tenant-scoped — caller must hold Indexing.Rebuild.Execute.
+        if (!await permissionChecker.IsGrantedAsync(IndexingRebuildPermissions.Rebuild.Execute))
+            throw new ForbiddenException();
+
+        await dispatcher.PublishAsync(new RebuildIndexJob<Guid>(currentTenant.Id), cancellationToken: ct);
+    }
 }
 ```
 
-`RebuildIndexJob` carries a `null` cron — it's NOT auto-scheduled. Hosts that want a
-recurring rebuild (e.g. nightly re-tokenisation) wire their own cron-driven trigger
-that emits the job.
+`RebuildIndexJob` is on-demand — it has no `[RecurringJob]` attribute and is NOT
+auto-scheduled. Hosts that want a recurring rebuild (e.g. nightly re-tokenisation)
+wire their own cron-driven trigger that emits the job.
+
+> [!IMPORTANT]
+> **Authorization is host-enforced.** The framework ships the canonical permission
+> names in `IndexingRebuildPermissions` but does **not** wire a runtime check inside
+> the handler — by the time the Wolverine handler runs, the originating HTTP context
+> is gone and the only principal information is what the dispatcher captured in the
+> envelope. **You MUST enforce the permission at the dispatch site.** Without that
+> check, any in-process code path that obtains `IBackgroundJobDispatcher` can rebuild
+> any tenant.
+>
+> Two grants ship:
+>
+> - `Indexing.Rebuild.Execute` — tenant-scoped rebuild (pass the caller's own tenant id).
+> - `Indexing.Rebuild.ExecuteGlobal` — cross-tenant rebuild (`TenantId: null`). Restrict
+>   to host-side operators; this scans the entire dataset and is the most expensive
+>   operation the module exposes.
+
+## Resource budget
+
+The rebuild iterates every key emitted by the source and calls `IIndexer<TKey>.IndexAsync`
+once per entry — which in hosts wiring `Granit.Indexing.Embeddings` triggers one LLM
+embedding call per entry. To bound the blast radius of a runaway or hostile dispatch:
+
+| Option | Default | Purpose |
+| ------ | ------- | ------- |
+| `MaxEntriesPerRun` | `null` (unbounded) | Hard cap on entries processed in a single run. Set this in production. |
+| `MaxRunDuration` | `null` (unbounded) | Wall-clock budget. The service checkpoints + throws `RebuildBudgetExceededException` once exceeded; Wolverine retries from the checkpoint. |
+| `MaxConsecutiveFailures` | `50` | Circuit-breaker on per-key faults. |
+
+When either budget is hit the checkpoint is preserved and a typed exception
+(`RebuildBudgetExceededException`) is raised. Hosts wire this to a Wolverine retry
+policy that re-dispatches the job after a cool-down.
 
 ## Crash recovery
 
@@ -63,8 +104,24 @@ preserved so a follow-up trigger resumes from where the corruption started.
   "Indexing": {
     "BackgroundJobs": {
       "CheckpointBatchSize": 100,
-      "MaxConsecutiveFailures": 50
+      "MaxConsecutiveFailures": 50,
+      "MaxEntriesPerRun": 1000000,
+      "MaxRunDurationSeconds": 3600
     }
   }
 }
 ```
+
+## Operational events
+
+Every rebuild raises in-process domain events on `ILocalEventBus` so audit / SIEM
+subscribers correlate dispatch-time identity with the run lifecycle:
+
+- `IndexRebuildStartedEvent` — at the very start, before reading the first key.
+- `IndexRebuildCompletedEvent` — on successful end-of-stream.
+- `IndexRebuildAbortedEvent` — when `MaxConsecutiveFailures`, `MaxEntriesPerRun`,
+  or `MaxRunDuration` cuts the run short, or on cancellation. Carries the abort reason.
+
+Each event carries `TenantId`, `SourceName`, `TKey` discriminator, processed count,
+and (when available) the dispatching `UserId` — wire it into `Granit.Auditing` for a
+GDPR-grade processing log.

--- a/src/Granit.Indexing.BackgroundJobs/Services/RebuildIndexService.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Services/RebuildIndexService.cs
@@ -1,5 +1,9 @@
+using Granit.Events;
 using Granit.Indexing.BackgroundJobs.Diagnostics;
+using Granit.Indexing.BackgroundJobs.Events;
+using Granit.Indexing.BackgroundJobs.Exceptions;
 using Granit.Indexing.BackgroundJobs.Options;
+using Granit.Users;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -19,20 +23,41 @@ namespace Granit.Indexing.BackgroundJobs.Services;
 /// same deterministic order.
 /// </para>
 /// <para>
-/// <b>Run abort.</b> If <see cref="IndexingBackgroundJobsOptions.MaxConsecutiveFailures"/>
-/// is exceeded the service aborts the run, records the metric, and re-throws so
-/// Wolverine's retry/DLQ policy kicks in. The checkpoint is preserved so a manual
-/// follow-up trigger can resume — partial work is not wasted.
+/// <b>Cutoff conditions.</b> The run terminates and re-throws (Wolverine retry/DLQ
+/// then takes over) when any of the following is hit:
+/// <list type="bullet">
+///   <item><see cref="IndexingBackgroundJobsOptions.MaxConsecutiveFailures"/> exceeded
+///         — circuit-breaker against broken-data rollouts.</item>
+///   <item><see cref="IndexingBackgroundJobsOptions.MaxEntriesPerRun"/> hit — budget
+///         cap on per-run cost; raises <see cref="RebuildBudgetExceededException"/>.</item>
+///   <item><see cref="IndexingBackgroundJobsOptions.MaxRunDurationSeconds"/> elapsed
+///         — wall-clock budget; raises <see cref="RebuildBudgetExceededException"/>.</item>
+///   <item>External cancellation — <see cref="OperationCanceledException"/> propagates.</item>
+/// </list>
+/// In every case the checkpoint is preserved before propagating so a follow-up dispatch
+/// resumes from the last successful key — partial work is not wasted.
+/// </para>
+/// <para>
+/// <b>Audit trail.</b> The service publishes <see cref="IndexRebuildStartedEvent"/>,
+/// <see cref="IndexRebuildCompletedEvent"/>, and <see cref="IndexRebuildAbortedEvent"/>
+/// on <see cref="ILocalEventBus"/>. Subscribers (typically <c>Granit.Auditing</c>)
+/// persist a GDPR-grade processing log keyed off the dispatching user id when one is
+/// associated with the scope.
 /// </para>
 /// </remarks>
 public sealed partial class RebuildIndexService<TKey>
     where TKey : notnull
 {
+    private static readonly string KeyTypeName = typeof(TKey).FullName ?? typeof(TKey).Name;
+
     private readonly IIndexer<TKey> _indexer;
     private readonly IIndexedEntrySource<TKey> _source;
     private readonly IRebuildCheckpointStore<TKey> _checkpoints;
     private readonly IndexingBackgroundJobsOptions _options;
     private readonly IndexingBackgroundJobsMetrics _metrics;
+    private readonly ILocalEventBus _eventBus;
+    private readonly ICurrentUserService _currentUser;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<RebuildIndexService<TKey>> _logger;
 
     public RebuildIndexService(
@@ -41,6 +66,9 @@ public sealed partial class RebuildIndexService<TKey>
         IRebuildCheckpointStore<TKey> checkpoints,
         IOptions<IndexingBackgroundJobsOptions> options,
         IndexingBackgroundJobsMetrics metrics,
+        ILocalEventBus eventBus,
+        ICurrentUserService currentUser,
+        TimeProvider timeProvider,
         ILogger<RebuildIndexService<TKey>> logger)
     {
         ArgumentNullException.ThrowIfNull(indexer);
@@ -48,12 +76,18 @@ public sealed partial class RebuildIndexService<TKey>
         ArgumentNullException.ThrowIfNull(checkpoints);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(metrics);
+        ArgumentNullException.ThrowIfNull(eventBus);
+        ArgumentNullException.ThrowIfNull(currentUser);
+        ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(logger);
         _indexer = indexer;
         _source = source;
         _checkpoints = checkpoints;
         _options = options.Value;
         _metrics = metrics;
+        _eventBus = eventBus;
+        _currentUser = currentUser;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -62,25 +96,47 @@ public sealed partial class RebuildIndexService<TKey>
     {
         string tenantTag = tenantId?.ToString() ?? "global";
         string sourceName = _source.Name;
+        string? dispatchedBy = _currentUser.UserId;
 
         TKey? checkpoint = await _checkpoints
             .GetLastCheckpointAsync(tenantId, sourceName, cancellationToken)
             .ConfigureAwait(false);
 
-        if (checkpoint is null)
-        {
-            _metrics.RecordRebuildStarted(tenantTag, sourceName);
-            LogStarted(tenantTag, sourceName);
-        }
-        else
+        // Quirk: with `TKey : notnull`, `TKey?` collapses to non-nullable `TKey` for
+        // value-type instantiations, so `checkpoint is null` is always false. The
+        // store's "no checkpoint" sentinel is therefore `default(TKey)` — see
+        // InMemoryRebuildCheckpointStoreTests.GetLastCheckpointAsync_returns_default_when_no_checkpoint_set.
+        bool resumed = !EqualityComparer<TKey?>.Default.Equals(checkpoint, default);
+        if (resumed)
         {
             _metrics.RecordRebuildResumed(tenantTag, sourceName);
             LogResumed(tenantTag, sourceName);
         }
+        else
+        {
+            _metrics.RecordRebuildStarted(tenantTag, sourceName);
+            LogStarted(tenantTag, sourceName);
+        }
 
+        await _eventBus.PublishAsync(
+            new IndexRebuildStartedEvent(tenantId, sourceName, KeyTypeName, resumed, dispatchedBy),
+            cancellationToken).ConfigureAwait(false);
+
+        long indexed = 0;
+        long skipped = 0;
+        long failed = 0;
+        // `processedInBatch > 0` is the sole guard for checkpoint writes (a positive count
+        // implies the loop body assigned `lastSuccessfulKey` before incrementing). We do NOT
+        // gate on `lastSuccessfulKey is not null` because `TKey?` collapses to non-nullable
+        // `TKey` under the `notnull` constraint for value-type instantiations.
         int processedInBatch = 0;
         int consecutiveFailures = 0;
         TKey? lastSuccessfulKey = checkpoint;
+
+        long startTimestamp = _timeProvider.GetTimestamp();
+        TimeSpan? maxDuration = _options.MaxRunDurationSeconds is int s
+            ? TimeSpan.FromSeconds(s)
+            : null;
 
         try
         {
@@ -99,11 +155,13 @@ public sealed partial class RebuildIndexService<TKey>
                     if (entry is null)
                     {
                         _metrics.RecordEntrySkipped(tenantTag, sourceName);
+                        skipped++;
                     }
                     else
                     {
                         await _indexer.IndexAsync(entry, cancellationToken).ConfigureAwait(false);
                         _metrics.RecordEntryIndexed(tenantTag, sourceName);
+                        indexed++;
                     }
 
                     lastSuccessfulKey = key;
@@ -117,43 +175,122 @@ public sealed partial class RebuildIndexService<TKey>
                 catch (Exception ex)
                 {
                     consecutiveFailures++;
+                    failed++;
                     _metrics.RecordEntryFailed(tenantTag, sourceName, "build_or_index_error");
                     LogEntryFailed(tenantTag, sourceName, ex.Message);
 
                     if (consecutiveFailures >= _options.MaxConsecutiveFailures)
                     {
-                        _metrics.RecordRebuildAborted(tenantTag, sourceName);
+                        await AbortAsync(
+                            "max_consecutive_failures",
+                            tenantId,
+                            tenantTag,
+                            sourceName,
+                            lastSuccessfulKey,
+                            processedInBatch,
+                            indexed + skipped + failed,
+                            dispatchedBy,
+                            cancellationToken).ConfigureAwait(false);
                         LogAborted(tenantTag, sourceName, consecutiveFailures);
                         throw;
                     }
                 }
 
-                if (processedInBatch >= _options.CheckpointBatchSize && lastSuccessfulKey is not null)
+                if (processedInBatch >= _options.CheckpointBatchSize)
                 {
                     await _checkpoints
-                        .SetCheckpointAsync(tenantId, sourceName, lastSuccessfulKey, cancellationToken)
+                        .SetCheckpointAsync(tenantId, sourceName, lastSuccessfulKey!, cancellationToken)
                         .ConfigureAwait(false);
                     _metrics.RecordCheckpointWritten(tenantTag, sourceName);
                     processedInBatch = 0;
+                }
+
+                long processedTotal = indexed + skipped + failed;
+
+                if (_options.MaxEntriesPerRun is int maxEntries && processedTotal >= maxEntries)
+                {
+                    await AbortAsync(
+                        "max_entries_per_run",
+                        tenantId,
+                        tenantTag,
+                        sourceName,
+                        lastSuccessfulKey,
+                        processedInBatch,
+                        processedTotal,
+                        dispatchedBy,
+                        cancellationToken).ConfigureAwait(false);
+                    LogBudgetExceeded(tenantTag, sourceName, "max_entries_per_run", processedTotal);
+                    throw new RebuildBudgetExceededException("max_entries_per_run", tenantId, sourceName, processedTotal);
+                }
+
+                if (maxDuration is TimeSpan budget && _timeProvider.GetElapsedTime(startTimestamp) >= budget)
+                {
+                    await AbortAsync(
+                        "max_run_duration",
+                        tenantId,
+                        tenantTag,
+                        sourceName,
+                        lastSuccessfulKey,
+                        processedInBatch,
+                        processedTotal,
+                        dispatchedBy,
+                        cancellationToken).ConfigureAwait(false);
+                    LogBudgetExceeded(tenantTag, sourceName, "max_run_duration", processedTotal);
+                    throw new RebuildBudgetExceededException("max_run_duration", tenantId, sourceName, processedTotal);
                 }
             }
 
             await _checkpoints.ClearAsync(tenantId, sourceName, cancellationToken).ConfigureAwait(false);
             _metrics.RecordRebuildCompleted(tenantTag, sourceName);
             LogCompleted(tenantTag, sourceName);
+
+            await _eventBus.PublishAsync(
+                new IndexRebuildCompletedEvent(tenantId, sourceName, KeyTypeName, indexed, skipped, failed, dispatchedBy),
+                cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
             // Persist progress on graceful cancellation so a re-dispatch resumes.
-            if (lastSuccessfulKey is not null && processedInBatch > 0)
+            if (processedInBatch > 0)
             {
                 await _checkpoints
-                    .SetCheckpointAsync(tenantId, sourceName, lastSuccessfulKey, CancellationToken.None)
+                    .SetCheckpointAsync(tenantId, sourceName, lastSuccessfulKey!, CancellationToken.None)
                     .ConfigureAwait(false);
                 _metrics.RecordCheckpointWritten(tenantTag, sourceName);
             }
+
+            // Best-effort: cancellation may be racing event-bus shutdown, so use a fresh token.
+            await _eventBus.PublishAsync(
+                new IndexRebuildAbortedEvent(tenantId, sourceName, KeyTypeName, "cancelled", indexed + skipped + failed, dispatchedBy),
+                CancellationToken.None).ConfigureAwait(false);
             throw;
         }
+    }
+
+    private async Task AbortAsync(
+        string reason,
+        Guid? tenantId,
+        string tenantTag,
+        string sourceName,
+        TKey? lastSuccessfulKey,
+        int processedInBatch,
+        long entriesProcessed,
+        string? dispatchedBy,
+        CancellationToken cancellationToken)
+    {
+        if (processedInBatch > 0)
+        {
+            await _checkpoints
+                .SetCheckpointAsync(tenantId, sourceName, lastSuccessfulKey!, cancellationToken)
+                .ConfigureAwait(false);
+            _metrics.RecordCheckpointWritten(tenantTag, sourceName);
+        }
+
+        _metrics.RecordRebuildAborted(tenantTag, sourceName);
+
+        await _eventBus.PublishAsync(
+            new IndexRebuildAbortedEvent(tenantId, sourceName, KeyTypeName, reason, entriesProcessed, dispatchedBy),
+            cancellationToken).ConfigureAwait(false);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Rebuild starting from beginning for tenant {TenantId} source {Source}")]
@@ -170,4 +307,7 @@ public sealed partial class RebuildIndexService<TKey>
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Rebuild aborted for tenant {TenantId} source {Source} after {ConsecutiveFailures} consecutive failures")]
     private partial void LogAborted(string tenantId, string source, int consecutiveFailures);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Rebuild budget {Reason} exceeded for tenant {TenantId} source {Source} after {Processed} entries — checkpoint preserved for retry")]
+    private partial void LogBudgetExceeded(string tenantId, string source, string reason, long processed);
 }

--- a/src/Granit.Indexing.Elasticsearch/packages.lock.json
+++ b/src/Granit.Indexing.Elasticsearch/packages.lock.json
@@ -38,11 +38,24 @@
           "Granit.LanguageDetection": "[0.1.0-dev, )"
         }
       },
+      "granit.indexing.embeddings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Indexing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.languagedetection": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.6.0",
+        "contentHash": "JCkVoyqBqi9r3Vs5Qo5PfZobT0+CWeOx+9y9yggBxtW9s/X5CAoa7Iw/tP/rfUdz+nxRKMSBmrytYgwmu60lgA=="
       }
     }
   }

--- a/src/Granit.Indexing.EntityFrameworkCore/Configurations/IndexingRebuildCheckpointRowConfiguration.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/Configurations/IndexingRebuildCheckpointRowConfiguration.cs
@@ -16,5 +16,9 @@ internal sealed class IndexingRebuildCheckpointRowConfiguration : IEntityTypeCon
 
         builder.Property(e => e.SourceName).IsRequired().HasMaxLength(128);
         builder.Property(e => e.LastProcessedKey).IsRequired().HasMaxLength(256);
+
+        // ConcurrencyStamp is auto-wired by ApplyGranitConventions (IsConcurrencyToken +
+        // ConcurrencyStampInterceptor). We only fix the physical column shape here.
+        builder.Property(e => e.ConcurrencyStamp).IsRequired().HasMaxLength(36);
     }
 }

--- a/src/Granit.Indexing.EntityFrameworkCore/IndexingRebuildCheckpointRow.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/IndexingRebuildCheckpointRow.cs
@@ -1,3 +1,6 @@
+using Granit.DataProtection;
+using Granit.Domain;
+
 namespace Granit.Indexing.EntityFrameworkCore;
 
 /// <summary>
@@ -7,7 +10,7 @@ namespace Granit.Indexing.EntityFrameworkCore;
 /// string round-trip so the same row shape works for any <c>TKey</c>.
 /// </summary>
 /// <remarks>
-/// String round-trip rather than a generic column type:
+/// <para>String round-trip rather than a generic column type:</para>
 /// <list type="bullet">
 ///   <item>EF Core can't map a generic <c>TKey</c> to a single physical column type
 ///         in a non-generic entity without per-key migrations.</item>
@@ -16,8 +19,17 @@ namespace Granit.Indexing.EntityFrameworkCore;
 ///   <item>The checkpoint table is tiny (one row per rebuild target) so the cost of
 ///         the string conversion is negligible.</item>
 /// </list>
+/// <para>
+/// <b>Sensitive data.</b> <see cref="LastProcessedKey"/> carries an opaque
+/// resume cursor whose content is host-defined. For hosts using <c>Guid</c> /
+/// <c>long</c> keys it is non-personal, but a host using <c>IIndexedEntrySource&lt;string&gt;</c>
+/// with usernames or e-mails would write those identifiers verbatim into the row.
+/// The property is therefore annotated <see cref="SensitiveDataAttribute"/> so
+/// audit interceptors, log redaction, MCP output sanitisers and GDPR exports
+/// treat it conservatively by default.
+/// </para>
 /// </remarks>
-public sealed class IndexingRebuildCheckpointRow
+public sealed class IndexingRebuildCheckpointRow : IConcurrencyAware
 {
     /// <summary>Tenant scope. <c>null</c> for ops-driven cross-tenant rebuilds.</summary>
     public Guid? TenantId { get; set; }
@@ -25,9 +37,24 @@ public sealed class IndexingRebuildCheckpointRow
     /// <summary>Source identifier — <see cref="IIndexedEntrySource{TKey}.Name"/>.</summary>
     public string SourceName { get; set; } = string.Empty;
 
-    /// <summary>String round-trip of the last successfully processed <c>TKey</c>.</summary>
+    /// <summary>
+    /// String round-trip of the last successfully processed <c>TKey</c>. May contain
+    /// host-defined identifiers — treat as sensitive by default.
+    /// </summary>
+    [SensitiveData(Level = Sensitivity.Internal, Mode = SensitiveDataMode.Mask)]
     public string LastProcessedKey { get; set; } = string.Empty;
 
     /// <summary>UTC timestamp of the last checkpoint write — informational, surfaced on metrics.</summary>
     public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Optimistic-concurrency token (auto-managed by <c>ConcurrencyStampInterceptor</c>
+    /// and wired by <c>ApplyGranitConventions</c>). A second worker racing on the same
+    /// <c>(TenantId, SourceName)</c> tuple loses with
+    /// <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>, which
+    /// <see cref="Granit.Indexing.EntityFrameworkCore.Internal.EfRebuildCheckpointStore{TKey}"/>
+    /// rethrows as <see cref="Granit.Indexing.BackgroundJobs.Exceptions.RebuildAlreadyInProgressException"/>
+    /// so Wolverine can dead-letter the duplicate.
+    /// </summary>
+    public string ConcurrencyStamp { get; set; } = string.Empty;
 }

--- a/src/Granit.Indexing.EntityFrameworkCore/Internal/EfRebuildCheckpointStore.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/Internal/EfRebuildCheckpointStore.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
 using Granit.Indexing.BackgroundJobs;
+using Granit.Indexing.BackgroundJobs.Exceptions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Indexing.EntityFrameworkCore.Internal;
@@ -9,6 +11,25 @@ namespace Granit.Indexing.EntityFrameworkCore.Internal;
 /// through its <see cref="TypeConverter"/> so the same physical row shape works for any
 /// key type (Guid, long, string, …).
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Multi-tenant filter bypass.</b> Every query call <c>.IgnoreQueryFilters([MultiTenant])</c>
+/// because the job's target <c>tenantId</c> is dictated by the message payload and may
+/// differ from the ambient <see cref="Granit.MultiTenancy.ICurrentTenant"/> (operator
+/// rebuilds use <c>null</c>). Isolation is preserved by the explicit
+/// <c>r.TenantId == tenantId</c> predicate on every read/write — DO NOT remove or relax
+/// it. The integration test
+/// <c>EfRebuildCheckpointStoreCrossTenantIsolationTests</c> locks this invariant.
+/// </para>
+/// <para>
+/// <b>Concurrency.</b> The row implements <see cref="Granit.Domain.IConcurrencyAware"/>,
+/// so a duplicate dispatcher racing on the same <c>(TenantId, SourceName)</c> tuple loses
+/// on <see cref="DbContext.SaveChangesAsync(CancellationToken)"/> with
+/// <see cref="DbUpdateConcurrencyException"/>. This store maps it to a typed
+/// <see cref="RebuildAlreadyInProgressException"/> so Wolverine can dead-letter the duplicate
+/// instead of dropping silent updates.
+/// </para>
+/// </remarks>
 internal sealed class EfRebuildCheckpointStore<TKey> : IRebuildCheckpointStore<TKey>
     where TKey : notnull
 {
@@ -35,8 +56,11 @@ internal sealed class EfRebuildCheckpointStore<TKey> : IRebuildCheckpointStore<T
         ArgumentException.ThrowIfNullOrEmpty(sourceName);
 
         await using IndexingDbContext db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // Tenant filter bypass — see class remarks. Isolation rests on the explicit
+        // equality below; do not remove `r.TenantId == tenantId`.
         IndexingRebuildCheckpointRow? row = await db.Set<IndexingRebuildCheckpointRow>()
-            .IgnoreQueryFilters([Granit.Persistence.EntityFrameworkCore.GranitFilterNames.MultiTenant])
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             .AsNoTracking()
             .FirstOrDefaultAsync(r => r.TenantId == tenantId && r.SourceName == sourceName, cancellationToken)
             .ConfigureAwait(false);
@@ -66,8 +90,9 @@ internal sealed class EfRebuildCheckpointStore<TKey> : IRebuildCheckpointStore<T
         await using IndexingDbContext db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         DbSet<IndexingRebuildCheckpointRow> set = db.Set<IndexingRebuildCheckpointRow>();
 
+        // Tenant filter bypass — see class remarks.
         IndexingRebuildCheckpointRow? existing = await set
-            .IgnoreQueryFilters([Granit.Persistence.EntityFrameworkCore.GranitFilterNames.MultiTenant])
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             .FirstOrDefaultAsync(r => r.TenantId == tenantId && r.SourceName == sourceName, cancellationToken)
             .ConfigureAwait(false);
 
@@ -89,7 +114,14 @@ internal sealed class EfRebuildCheckpointStore<TKey> : IRebuildCheckpointStore<T
             existing.UpdatedAt = now;
         }
 
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            throw new RebuildAlreadyInProgressException(tenantId, sourceName, ex);
+        }
     }
 
     public async Task ClearAsync(
@@ -100,8 +132,10 @@ internal sealed class EfRebuildCheckpointStore<TKey> : IRebuildCheckpointStore<T
         ArgumentException.ThrowIfNullOrEmpty(sourceName);
 
         await using IndexingDbContext db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // Tenant filter bypass — see class remarks.
         await db.Set<IndexingRebuildCheckpointRow>()
-            .IgnoreQueryFilters([Granit.Persistence.EntityFrameworkCore.GranitFilterNames.MultiTenant])
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             .Where(r => r.TenantId == tenantId && r.SourceName == sourceName)
             .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/tests/Granit.ArchitectureTests/IndexingArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/IndexingArchitectureTests.cs
@@ -1,0 +1,327 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Architecture rules for the <c>Granit.Indexing.*</c> module family (epic #2234).
+/// Pins the authorization-boundary contract, the VULN-201 atomic-delete invariant on
+/// embeddings, and the layer-purity rules that close out the indexing horizontal
+/// framework.
+/// </summary>
+public sealed partial class IndexingArchitectureTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string SrcRoot = Path.Join(RepoRoot, "src");
+
+    /// <summary>
+    /// Every <c>Granit.Indexing.*</c> package shipped at the time this test was authored.
+    /// Add to this list when a new sub-module ships; the layer-purity tests below iterate
+    /// it to ensure no sub-module quietly slips a forbidden dependency.
+    /// </summary>
+    private static readonly string[] IndexingPackages =
+    [
+        "Granit.Indexing",
+        "Granit.Indexing.AI",
+        "Granit.Indexing.BackgroundJobs",
+        "Granit.Indexing.Elasticsearch",
+        "Granit.Indexing.Embeddings",
+        "Granit.Indexing.EntityFrameworkCore",
+        "Granit.Indexing.Privacy",
+    ];
+
+    public static TheoryData<string> AllIndexingPackages
+    {
+        get
+        {
+            TheoryData<string> data = [];
+            foreach (string p in IndexingPackages)
+            {
+                data.Add(p);
+            }
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// VULN-003: <c>SearchPage&lt;TResult&gt;.BackendHitCount</c> is internal telemetry —
+    /// it MUST NOT leak through any <c>.Endpoints</c> package, otherwise a malicious
+    /// principal could use the value as a per-call existence oracle (see the property's
+    /// remarks on <c>[JsonIgnore]</c> + <c>[EditorBrowsable(Never)]</c>).
+    /// The framework currently ships no <c>Granit.Indexing.Endpoints</c> package; this test
+    /// also protects against future consumers shipping endpoints that reach across the
+    /// boundary.
+    /// </summary>
+    [Fact]
+    public void BackendHitCount_must_not_be_referenced_from_any_Endpoints_package()
+    {
+        List<string> violators = [];
+
+        foreach (string endpointsDir in Directory.EnumerateDirectories(SrcRoot, "*.Endpoints"))
+        {
+            foreach (string file in Directory.EnumerateFiles(endpointsDir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string text = File.ReadAllText(file);
+                if (text.Contains("BackendHitCount", StringComparison.Ordinal))
+                {
+                    violators.Add(Path.GetRelativePath(RepoRoot, file));
+                }
+            }
+        }
+
+        violators.ShouldBeEmpty(
+            "SearchPage<TResult>.BackendHitCount is internal telemetry tagged "
+            + "[JsonIgnore] + [EditorBrowsable(Never)] — it must never be projected, "
+            + "logged, or wire-serialised by any .Endpoints package. Surfacing it gives "
+            + "an attacker a per-query existence oracle. Violators: "
+            + string.Join(", ", violators));
+    }
+
+    /// <summary>
+    /// VULN-201: embeddings ARE personal data (CJEU 2024). The Granit framework persists
+    /// them on the SAME row as <c>Content</c> so the existing
+    /// <c>IIndexedDataEraser.EraseAsync</c> cascade purges both atomically. A sidecar
+    /// table keyed only by the indexed entry's key would create a hard-to-cascade
+    /// orphan and break Art. 17 conformance.
+    /// </summary>
+    [Fact]
+    public void Embeddings_must_live_on_the_same_row_as_Content_no_sidecar_entity_types()
+    {
+        // We enforce by scanning for any class declaration whose name carries the
+        // "Embedding" semantic AND looks like an EF Core entity (sealed class with a
+        // public Key/Id-ish property OR has a Configuration<X> sibling). The base
+        // IndexedEntryRow<TKey> is whitelisted because it carries Content alongside
+        // Embedding — that IS the sanctioned shape.
+        List<string> violators = [];
+
+        foreach (string packageDir in EnumerateIndexingPackageDirs())
+        {
+            foreach (string file in Directory.EnumerateFiles(packageDir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (IsBuildOutput(file))
+                {
+                    continue;
+                }
+
+                string text = File.ReadAllText(file);
+                Match match = EmbeddingEntityClassDeclaration().Match(text);
+                if (!match.Success)
+                {
+                    continue;
+                }
+
+                string className = match.Groups[1].Value;
+                if (string.Equals(className, "IndexedEntryRow", StringComparison.Ordinal)
+                    || string.Equals(className, "IndexedEntryDocument", StringComparison.Ordinal))
+                {
+                    // Sanctioned shapes — the row carries Content + Embedding together.
+                    continue;
+                }
+
+                violators.Add($"{Path.GetRelativePath(RepoRoot, file)} -> {className}");
+            }
+        }
+
+        violators.ShouldBeEmpty(
+            "VULN-201: embedding columns must live on the same row as Content so the "
+            + "GDPR Art. 17 cascade purges both atoms in a single statement. No sidecar "
+            + "Embedding* entity types allowed in the Granit.Indexing.* family. "
+            + "Sanctioned shapes: IndexedEntryRow (EF), IndexedEntryDocument (ES). "
+            + "Violators: " + string.Join("; ", violators));
+    }
+
+    /// <summary>
+    /// Defence-in-depth on the tenant query filter: <c>IgnoreQueryFilters</c> on
+    /// <c>IndexedEntryRow&lt;TKey&gt;</c> queries is permitted ONLY in the three
+    /// well-known call sites — the EF indexer's upsert lookup, the EF eraser's GDPR
+    /// fan-out, and the EF vector backend's tenant-scoped kNN (which filters by tenant
+    /// in the predicate itself). Any new <c>IgnoreQueryFilters</c> call site MUST be
+    /// added to the allowlist below + reviewed for tenant safety.
+    /// </summary>
+    [Fact]
+    public void IgnoreQueryFilters_calls_in_Granit_Indexing_EntityFrameworkCore_stay_within_the_audit_allowlist()
+    {
+        string[] allowlist =
+        [
+            "Internal/EfIndexer.cs",
+            "Internal/EfIndexedDataEraser.cs",
+            "Internal/EfRebuildCheckpointStore.cs",
+        ];
+
+        string packageDir = Path.Join(SrcRoot, "Granit.Indexing.EntityFrameworkCore");
+        List<string> unexpected = [];
+
+        foreach (string file in Directory.EnumerateFiles(packageDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (IsBuildOutput(file))
+            {
+                continue;
+            }
+
+            string text = File.ReadAllText(file);
+            if (!text.Contains("IgnoreQueryFilters", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string rel = Path.GetRelativePath(packageDir, file).Replace('\\', '/');
+            if (!allowlist.Contains(rel, StringComparer.Ordinal))
+            {
+                unexpected.Add(rel);
+            }
+        }
+
+        unexpected.ShouldBeEmpty(
+            "IgnoreQueryFilters opens a hole in the parameterised tenant filter shipped "
+            + "by GranitDbContext. New call sites must be added to the architecture-test "
+            + "allowlist after explicit tenant-safety review. Violators: "
+            + string.Join(", ", unexpected));
+    }
+
+    /// <summary>
+    /// Layer purity: the indexing framework ships no <c>.Endpoints</c> package, so no
+    /// <c>Granit.Indexing.*</c> package should pull <c>Microsoft.AspNetCore.*</c>.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllIndexingPackages))]
+    public void Granit_Indexing_packages_must_not_reference_Microsoft_AspNetCore(string packageName)
+    {
+        AssertNoPackageReferenceStartsWith(packageName, "Microsoft.AspNetCore.");
+    }
+
+    /// <summary>
+    /// Layer purity: EF Core dependencies are confined to the
+    /// <c>Granit.Indexing.EntityFrameworkCore</c> backend.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllIndexingPackages))]
+    public void EntityFrameworkCore_NuGets_only_in_the_EntityFrameworkCore_backend(string packageName)
+    {
+        if (string.Equals(packageName, "Granit.Indexing.EntityFrameworkCore", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        AssertNoPackageReferenceStartsWith(packageName, "Microsoft.EntityFrameworkCore");
+        AssertNoPackageReferenceStartsWith(packageName, "Npgsql.EntityFrameworkCore");
+        AssertNoPackageReferenceStartsWith(packageName, "Pgvector.EntityFrameworkCore");
+    }
+
+    /// <summary>
+    /// Telemetry purity: <c>IIndexer&lt;TKey&gt;</c> implementations route observability
+    /// through <c>IndexingMetrics</c> and <c>IndexingActivitySource</c>, never through
+    /// raw <c>Console</c> / <c>Trace</c> calls — those break aggregation and leak
+    /// content into stdout.
+    /// </summary>
+    [Fact]
+    public void IIndexer_implementations_must_not_call_Console_or_Trace()
+    {
+        // Scan candidate files: any file matching *Indexer.cs (skip *IndexerTests.cs)
+        // under src/Granit.Indexing*/. The framework's indexer impls follow this naming.
+        List<string> violators = [];
+
+        foreach (string packageDir in EnumerateIndexingPackageDirs())
+        {
+            foreach (string file in Directory.EnumerateFiles(packageDir, "*Indexer.cs", SearchOption.AllDirectories))
+            {
+                if (IsBuildOutput(file))
+                {
+                    continue;
+                }
+
+                string fileName = Path.GetFileName(file);
+                if (fileName.EndsWith("IndexerTests.cs", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string text = File.ReadAllText(file);
+                if (ConsoleOrTraceCall().IsMatch(text))
+                {
+                    violators.Add(Path.GetRelativePath(RepoRoot, file));
+                }
+            }
+        }
+
+        violators.ShouldBeEmpty(
+            "IIndexer<TKey> implementations must emit observability through IndexingMetrics "
+            + "and IndexingActivitySource — never via Console.* or Trace.* which break "
+            + "structured aggregation and risk leaking indexed content. Violators: "
+            + string.Join(", ", violators));
+    }
+
+    private static IEnumerable<string> EnumerateIndexingPackageDirs()
+    {
+        foreach (string name in IndexingPackages)
+        {
+            string dir = Path.Join(SrcRoot, name);
+            if (Directory.Exists(dir))
+            {
+                yield return dir;
+            }
+        }
+    }
+
+    private static bool IsBuildOutput(string file) =>
+        file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+
+    private static void AssertNoPackageReferenceStartsWith(string projectName, string forbiddenPrefix)
+    {
+        string csprojPath = Path.Join(SrcRoot, projectName, $"{projectName}.csproj");
+        File.Exists(csprojPath).ShouldBeTrue($"Expected {csprojPath} to exist.");
+
+        var doc = XDocument.Load(csprojPath);
+        IEnumerable<string> packageRefs = doc.Descendants("PackageReference")
+            .Select(e => e.Attribute("Include")?.Value ?? string.Empty);
+
+        IEnumerable<string> violators = packageRefs
+            .Where(p => p.StartsWith(forbiddenPrefix, StringComparison.Ordinal));
+
+        violators.ShouldBeEmpty(
+            $"{projectName} must not reference NuGets starting with '{forbiddenPrefix}'. "
+            + "Layer purity: indexing concerns stay below the HTTP / persistence boundaries. "
+            + "Violators: " + string.Join(", ", violators));
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(IndexingArchitectureTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    /// <summary>
+    /// Matches a class declaration whose simple name carries the "Embedding" semantic.
+    /// Group 1 = the simple class name (e.g. <c>EmbeddingRow</c>, <c>EmbeddingDocument</c>,
+    /// <c>IndexedEntryRow</c>). Generic type-parameter list (if any) is consumed but not
+    /// captured.
+    /// </summary>
+    [GeneratedRegex(@"\bclass\s+(\w*(?:Embedding\w*Row|Embedding\w*Document|IndexedEntryRow|IndexedEntryDocument))\b")]
+    private static partial Regex EmbeddingEntityClassDeclaration();
+
+    /// <summary>
+    /// Matches a call to <c>Console.&lt;anything&gt;</c> or <c>Trace.&lt;anything&gt;</c>
+    /// — namespaces don't count (<c>System.Diagnostics.Trace</c> in xmldoc / using lines
+    /// passes through because we require the identifier immediately followed by a dot
+    /// + member access).
+    /// </summary>
+    [GeneratedRegex(@"\b(Console|Trace)\.[A-Z]\w*\s*\(", RegexOptions.Multiline)]
+    private static partial Regex ConsoleOrTraceCall();
+}

--- a/tests/Granit.Indexing.BackgroundJobs.Tests/Granit.Indexing.BackgroundJobs.Tests.csproj
+++ b/tests/Granit.Indexing.BackgroundJobs.Tests/Granit.Indexing.BackgroundJobs.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Indexing.BackgroundJobs.Tests/IndexingBackgroundJobsOptionsTests.cs
+++ b/tests/Granit.Indexing.BackgroundJobs.Tests/IndexingBackgroundJobsOptionsTests.cs
@@ -1,0 +1,29 @@
+using Granit.Indexing.BackgroundJobs.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Indexing.BackgroundJobs.Tests;
+
+public sealed class IndexingBackgroundJobsOptionsTests
+{
+    [Fact]
+    public void SectionName_matches_namespace_aligned_canonical_path()
+    {
+        // Locked here so a rename of the project / namespace surfaces in CI before
+        // it silently breaks host appsettings.json bindings.
+        IndexingBackgroundJobsOptions.SectionName.ShouldBe("Indexing:BackgroundJobs");
+    }
+
+    [Fact]
+    public void Defaults_are_safe_for_production()
+    {
+        var options = new IndexingBackgroundJobsOptions();
+
+        options.CheckpointBatchSize.ShouldBe(100);
+        options.MaxConsecutiveFailures.ShouldBe(50);
+        // Budgets default to null (unbounded) — the framework cannot pick a sensible
+        // numeric default that fits every host. Hosts opt in via configuration.
+        options.MaxEntriesPerRun.ShouldBeNull();
+        options.MaxRunDurationSeconds.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Indexing.BackgroundJobs.Tests/RebuildIndexJobAttributeTests.cs
+++ b/tests/Granit.Indexing.BackgroundJobs.Tests/RebuildIndexJobAttributeTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Granit.BackgroundJobs;
+using Granit.Indexing.BackgroundJobs.Jobs;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Indexing.BackgroundJobs.Tests;
+
+public sealed class RebuildIndexJobAttributeTests
+{
+    [Fact]
+    public void RebuildIndexJob_must_not_carry_RecurringJob_attribute()
+    {
+        // The job is on-demand. Decorating it with [RecurringJob] would crash any host
+        // that runs RecurringJobDiscovery (it instantiates the attribute, whose ctor
+        // rejects null/whitespace cron expressions) — caught the hard way in the
+        // initial wiring of #2271. Guard against a regression.
+        Type job = typeof(RebuildIndexJob<>);
+
+        RecurringJobAttribute? attr = job.GetCustomAttribute<RecurringJobAttribute>();
+
+        attr.ShouldBeNull(
+            "RebuildIndexJob is dispatched on-demand — [RecurringJob] is for cron-driven jobs only.");
+    }
+}

--- a/tests/Granit.Indexing.BackgroundJobs.Tests/RebuildIndexServiceTests.cs
+++ b/tests/Granit.Indexing.BackgroundJobs.Tests/RebuildIndexServiceTests.cs
@@ -1,10 +1,15 @@
 using System.Diagnostics.Metrics;
+using Granit.Events;
 using Granit.Indexing.BackgroundJobs.Diagnostics;
+using Granit.Indexing.BackgroundJobs.Events;
+using Granit.Indexing.BackgroundJobs.Exceptions;
 using Granit.Indexing.BackgroundJobs.Internal;
 using Granit.Indexing.BackgroundJobs.Options;
 using Granit.Indexing.BackgroundJobs.Services;
+using Granit.Users;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -124,6 +129,111 @@ public sealed class RebuildIndexServiceTests
             .ShouldBe(ok);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_publishes_Started_and_Completed_events_on_success()
+    {
+        // GDPR-grade audit trail: every rebuild lifecycle transition publishes a domain
+        // event on ILocalEventBus so audit subscribers correlate dispatch-time identity
+        // (DispatchedByUserId) with the run outcome.
+        Harness h = new();
+        h.WithKeys(Guid.NewGuid(), Guid.NewGuid());
+
+        RebuildIndexService<Guid> service = h.Build();
+        await service.ExecuteAsync(TenantA, TestContext.Current.CancellationToken);
+
+        IndexRebuildStartedEvent started = h.EventBus.Published.OfType<IndexRebuildStartedEvent>().ShouldHaveSingleItem();
+        started.TenantId.ShouldBe(TenantA);
+        started.SourceName.ShouldBe("documents");
+        started.ResumedFromCheckpoint.ShouldBeFalse();
+        started.DispatchedByUserId.ShouldBe("user-7");
+
+        IndexRebuildCompletedEvent completed = h.EventBus.Published.OfType<IndexRebuildCompletedEvent>().ShouldHaveSingleItem();
+        completed.EntriesIndexed.ShouldBe(2);
+        completed.EntriesSkipped.ShouldBe(0);
+        completed.EntriesFailed.ShouldBe(0);
+        completed.DispatchedByUserId.ShouldBe("user-7");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_publishes_Aborted_event_when_MaxConsecutiveFailures_trips()
+    {
+        // The abort path emits IndexRebuildAbortedEvent with a stable Reason — required
+        // for SIEM rules that distinguish circuit-breaker trips from budget cutoffs.
+        Harness h = new();
+        h.Options.CheckpointBatchSize = 1;
+        h.Options.MaxConsecutiveFailures = 2;
+        var f1 = Guid.NewGuid();
+        var f2 = Guid.NewGuid();
+        h.WithKeys(f1, f2);
+        h.Source.BuildEntryAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IndexedEntry<Guid>?>>(_ => throw new InvalidOperationException("boom"));
+
+        RebuildIndexService<Guid> service = h.Build();
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            service.ExecuteAsync(TenantA, TestContext.Current.CancellationToken));
+
+        IndexRebuildAbortedEvent aborted = h.EventBus.Published.OfType<IndexRebuildAbortedEvent>().ShouldHaveSingleItem();
+        aborted.Reason.ShouldBe("max_consecutive_failures");
+        h.EventBus.Published.OfType<IndexRebuildCompletedEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_throws_RebuildBudgetExceeded_when_MaxEntriesPerRun_is_hit_and_preserves_checkpoint()
+    {
+        // Denial-of-Wallet defense: a host that caps entries-per-run gets a deterministic
+        // cutoff, the checkpoint is preserved so the retry resumes, and a typed exception
+        // signals to Wolverine that this is a budget yield (not a fault).
+        Harness h = new();
+        h.Options.CheckpointBatchSize = 100; // do not flush mid-batch
+        h.Options.MaxEntriesPerRun = 2;
+        var k1 = Guid.NewGuid();
+        var k2 = Guid.NewGuid();
+        var k3 = Guid.NewGuid();
+        h.WithKeys(k1, k2, k3);
+
+        RebuildIndexService<Guid> service = h.Build();
+        RebuildBudgetExceededException ex = await Should.ThrowAsync<RebuildBudgetExceededException>(() =>
+            service.ExecuteAsync(TenantA, TestContext.Current.CancellationToken));
+
+        ex.Reason.ShouldBe("max_entries_per_run");
+        ex.ProcessedCount.ShouldBe(2);
+
+        // Checkpoint preserved at last successful key so retry resumes past k2.
+        (await h.Checkpoints.GetLastCheckpointAsync(TenantA, h.Source.Name, TestContext.Current.CancellationToken))
+            .ShouldBe(k2);
+
+        IndexRebuildAbortedEvent aborted = h.EventBus.Published.OfType<IndexRebuildAbortedEvent>().ShouldHaveSingleItem();
+        aborted.Reason.ShouldBe("max_entries_per_run");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_throws_RebuildBudgetExceeded_when_MaxRunDuration_elapses()
+    {
+        // Wall-clock budget cutoff. We advance the FakeTimeProvider between keys so the
+        // service notices the budget overrun on the first per-key budget check.
+        Harness h = new();
+        h.Options.CheckpointBatchSize = 100;
+        h.Options.MaxRunDurationSeconds = 30;
+        var k1 = Guid.NewGuid();
+        var k2 = Guid.NewGuid();
+        h.WithKeys(k1, k2);
+        // Advance the clock when BuildEntryAsync(k1) is called so the post-key check trips.
+        h.Source.BuildEntryAsync(k1, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                h.TimeProvider.Advance(TimeSpan.FromMinutes(1));
+                return Task.FromResult<IndexedEntry<Guid>?>(new IndexedEntry<Guid> { Key = k1, TenantId = TenantA, Content = "x" });
+            });
+
+        RebuildIndexService<Guid> service = h.Build();
+        RebuildBudgetExceededException ex = await Should.ThrowAsync<RebuildBudgetExceededException>(() =>
+            service.ExecuteAsync(TenantA, TestContext.Current.CancellationToken));
+
+        ex.Reason.ShouldBe("max_run_duration");
+        h.EventBus.Published.OfType<IndexRebuildAbortedEvent>().ShouldHaveSingleItem()
+            .Reason.ShouldBe("max_run_duration");
+    }
+
     private sealed class Harness
     {
         public IIndexer<Guid> Indexer { get; } = Substitute.For<IIndexer<Guid>>();
@@ -132,11 +242,15 @@ public sealed class RebuildIndexServiceTests
         public IndexingBackgroundJobsOptions Options { get; } = new();
         public TestMeterFactory MeterFactory { get; } = new();
         public IndexingBackgroundJobsMetrics Metrics { get; }
+        public RecordingEventBus EventBus { get; } = new();
+        public ICurrentUserService CurrentUser { get; } = Substitute.For<ICurrentUserService>();
+        public FakeTimeProvider TimeProvider { get; } = new();
 
         public Harness()
         {
             Source.Name.Returns("documents");
             Metrics = new IndexingBackgroundJobsMetrics(MeterFactory);
+            CurrentUser.UserId.Returns("user-7");
         }
 
         public void WithKeys(params Guid[] keys)
@@ -184,6 +298,9 @@ public sealed class RebuildIndexServiceTests
             Checkpoints,
             Microsoft.Extensions.Options.Options.Create(Options),
             Metrics,
+            EventBus,
+            CurrentUser,
+            TimeProvider,
             NullLogger<RebuildIndexService<Guid>>.Instance);
 
         private static async IAsyncEnumerable<Guid> AsAsync(IEnumerable<Guid> keys)
@@ -201,5 +318,17 @@ public sealed class RebuildIndexServiceTests
         public Meter Meter { get; } = new(IndexingBackgroundJobsMetrics.MeterName);
         public Meter Create(MeterOptions options) => Meter;
         public void Dispose() => Meter.Dispose();
+    }
+
+    private sealed class RecordingEventBus : ILocalEventBus
+    {
+        public List<object> Published { get; } = [];
+
+        public Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            Published.Add(localEvent);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/Granit.Indexing.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Indexing.BackgroundJobs.Tests/packages.lock.json
@@ -31,6 +31,12 @@
           "Microsoft.Extensions.Telemetry.Abstractions": "10.6.0"
         }
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.6.0",
+        "contentHash": "qQDiaYWpvIymGbu+kXaMDS8YdqfeQkv6DOxPF2GSwC+eSzIKqOOnSP34TYt7gKqvB7p8/aSptexnW6nF0CUdnw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",

--- a/tests/Granit.Indexing.Elasticsearch.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Indexing.Elasticsearch.Tests.Integration/packages.lock.json
@@ -343,7 +343,15 @@
         "type": "Project",
         "dependencies": {
           "Elastic.Clients.Elasticsearch": "[8.*, )",
-          "Granit.Indexing": "[0.1.0-dev, )"
+          "Granit.Indexing": "[0.1.0-dev, )",
+          "Granit.Indexing.Embeddings": "[0.1.0-dev, )"
+        }
+      },
+      "granit.indexing.embeddings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Indexing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
         }
       },
       "granit.languagedetection": {
@@ -361,6 +369,12 @@
           "Elastic.Esql": "0.11.0",
           "Elastic.Transport": "0.17.1"
         }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.6.0",
+        "contentHash": "JCkVoyqBqi9r3Vs5Qo5PfZobT0+CWeOx+9y9yggBxtW9s/X5CAoa7Iw/tP/rfUdz+nxRKMSBmrytYgwmu60lgA=="
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.Indexing.Elasticsearch.Tests/packages.lock.json
+++ b/tests/Granit.Indexing.Elasticsearch.Tests/packages.lock.json
@@ -242,7 +242,15 @@
         "type": "Project",
         "dependencies": {
           "Elastic.Clients.Elasticsearch": "[8.*, )",
-          "Granit.Indexing": "[0.1.0-dev, )"
+          "Granit.Indexing": "[0.1.0-dev, )",
+          "Granit.Indexing.Embeddings": "[0.1.0-dev, )"
+        }
+      },
+      "granit.indexing.embeddings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Indexing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
         }
       },
       "granit.languagedetection": {
@@ -260,6 +268,12 @@
           "Elastic.Esql": "0.11.0",
           "Elastic.Transport": "0.17.1"
         }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.6.0",
+        "contentHash": "JCkVoyqBqi9r3Vs5Qo5PfZobT0+CWeOx+9y9yggBxtW9s/X5CAoa7Iw/tP/rfUdz+nxRKMSBmrytYgwmu60lgA=="
       }
     }
   }

--- a/tests/Granit.Indexing.Embeddings.Tests/packages.lock.json
+++ b/tests/Granit.Indexing.Embeddings.Tests/packages.lock.json
@@ -322,6 +322,29 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.LanguageDetection": "[0.1.0-dev, )"
+        }
+      },
+      "granit.indexing.embeddings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Indexing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.languagedetection": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests/EfRebuildCheckpointStoreCrossTenantIsolationTests.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests/EfRebuildCheckpointStoreCrossTenantIsolationTests.cs
@@ -1,0 +1,116 @@
+// EF1001: instantiates an "Internal" namespace type. Acceptable here because the
+// store is the unit under test and we own the assembly via InternalsVisibleTo —
+// the analyzer is a cross-package guard, not a real access boundary.
+#pragma warning disable EF1001
+using Granit.Indexing.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Indexing.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Locks the cross-tenant isolation invariant for <see cref="EfRebuildCheckpointStore{TKey}"/>.
+/// The store deliberately bypasses <c>GranitFilterNames.MultiTenant</c> on every read/write
+/// because the rebuild job's target tenant id is dictated by the message payload, which may
+/// differ from the ambient <c>ICurrentTenant</c>. Isolation rests entirely on the explicit
+/// <c>r.TenantId == tenantId</c> equality predicate — these tests fail loudly if a future
+/// refactor drops it.
+/// </summary>
+public sealed class EfRebuildCheckpointStoreCrossTenantIsolationTests
+{
+    private static readonly Guid TenantA = new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = new("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private const string SourceName = "documents";
+
+    [Fact]
+    public async Task GetLastCheckpointAsync_does_not_return_another_tenants_row_with_same_source()
+    {
+        // Both tenants own a checkpoint row for the same source. Reading tenant A MUST
+        // return tenant A's value — never tenant B's, never the ambient tenant's, never
+        // the first row encountered.
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken, typeof(Guid));
+
+        var store = new EfRebuildCheckpointStore<Guid>(h.Factory, TimeProvider.System);
+        var checkpointA = Guid.NewGuid();
+        var checkpointB = Guid.NewGuid();
+
+        await store.SetCheckpointAsync(TenantA, SourceName, checkpointA, TestContext.Current.CancellationToken);
+        await store.SetCheckpointAsync(TenantB, SourceName, checkpointB, TestContext.Current.CancellationToken);
+
+        (await store.GetLastCheckpointAsync(TenantA, SourceName, TestContext.Current.CancellationToken))
+            .ShouldBe(checkpointA);
+        (await store.GetLastCheckpointAsync(TenantB, SourceName, TestContext.Current.CancellationToken))
+            .ShouldBe(checkpointB);
+    }
+
+    [Fact]
+    public async Task ClearAsync_does_not_delete_another_tenants_row()
+    {
+        // ExecuteDelete is the most dangerous variant — it bypasses change tracking. A
+        // missing predicate would wipe every row matching SourceName across all tenants.
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken, typeof(Guid));
+
+        var store = new EfRebuildCheckpointStore<Guid>(h.Factory, TimeProvider.System);
+        var checkpointA = Guid.NewGuid();
+        var checkpointB = Guid.NewGuid();
+
+        await store.SetCheckpointAsync(TenantA, SourceName, checkpointA, TestContext.Current.CancellationToken);
+        await store.SetCheckpointAsync(TenantB, SourceName, checkpointB, TestContext.Current.CancellationToken);
+
+        await store.ClearAsync(TenantA, SourceName, TestContext.Current.CancellationToken);
+
+        (await store.GetLastCheckpointAsync(TenantA, SourceName, TestContext.Current.CancellationToken))
+            .ShouldBe(default);
+        // Tenant B's row must survive.
+        (await store.GetLastCheckpointAsync(TenantB, SourceName, TestContext.Current.CancellationToken))
+            .ShouldBe(checkpointB);
+    }
+
+    [Fact]
+    public async Task SetCheckpointAsync_for_ambient_tenant_A_can_write_for_a_different_tenant_B()
+    {
+        // The store explicitly bypasses the tenant filter so an ops-driven cross-tenant
+        // rebuild can checkpoint against a tenant other than the ambient one. This is
+        // intentional, but it MUST require explicit equality (locked here).
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken, typeof(Guid));
+
+        var store = new EfRebuildCheckpointStore<Guid>(h.Factory, TimeProvider.System);
+        var checkpointForB = Guid.NewGuid();
+
+        await store.SetCheckpointAsync(TenantB, SourceName, checkpointForB, TestContext.Current.CancellationToken);
+
+        (await store.GetLastCheckpointAsync(TenantB, SourceName, TestContext.Current.CancellationToken))
+            .ShouldBe(checkpointForB);
+        (await store.GetLastCheckpointAsync(TenantA, SourceName, TestContext.Current.CancellationToken))
+            .ShouldBe(default);
+    }
+
+    [Fact]
+    public async Task ConcurrencyStamp_blocks_a_stale_update_so_duplicate_dispatch_cannot_clobber()
+    {
+        // Locks the EF concurrency wiring: a stale OriginalValue on ConcurrencyStamp
+        // must surface DbUpdateConcurrencyException, which the store maps to
+        // RebuildAlreadyInProgressException for the dead-letter path.
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken, typeof(Guid));
+
+        var store = new EfRebuildCheckpointStore<Guid>(h.Factory, TimeProvider.System);
+        await store.SetCheckpointAsync(TenantA, SourceName, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await using IndexingDbContext stale = await h.Factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        IndexingRebuildCheckpointRow staleRow = await stale.Set<IndexingRebuildCheckpointRow>()
+            .IgnoreQueryFilters([Granit.Persistence.EntityFrameworkCore.GranitFilterNames.MultiTenant])
+            .FirstAsync(r => r.TenantId == TenantA && r.SourceName == SourceName, TestContext.Current.CancellationToken);
+
+        // Simulate a competing writer that has already moved the stamp forward.
+        stale.Entry(staleRow).Property(e => e.ConcurrencyStamp).OriginalValue = Guid.NewGuid().ToString();
+        staleRow.LastProcessedKey = Guid.NewGuid().ToString();
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(
+            () => stale.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+}


### PR DESCRIPTION
## Summary

New `tests/Granit.ArchitectureTests/IndexingArchitectureTests.cs` locks the horizontal-framework invariants for the `Granit.Indexing.*` module family — closes the architecture-tests half of #2262.

### Invariants pinned

| # | Invariant | How it's enforced |
|---|---|---|
| 1 | **VULN-003** — `SearchPage<TResult>.BackendHitCount` must NOT appear in any `*.Endpoints` package | File-text scan across `src/Granit.*.Endpoints/**/*.cs` |
| 2 | **VULN-201** — Embeddings live on the same row as `Content`; no sidecar entity types | Regex scan for `class *Embedding*Row` / `*Embedding*Document` declarations in `src/Granit.Indexing.*` — sanctioned shapes (`IndexedEntryRow`, `IndexedEntryDocument`) are whitelisted |
| 3 | **Tenant-filter bypass allowlist** — `IgnoreQueryFilters` calls in `Granit.Indexing.EntityFrameworkCore` are pinned to the three known safe sites (EF indexer upsert, GDPR eraser, rebuild checkpoint store) | File-text scan compared against a static allowlist |
| 4 | **Layer purity (HTTP)** — No `Microsoft.AspNetCore.*` reference in any `Granit.Indexing.*` package (indexing ships no Endpoints) | `XDocument` scan per `csproj` |
| 5 | **Layer purity (EF Core)** — `Microsoft.EntityFrameworkCore` / `Npgsql.EntityFrameworkCore` / `Pgvector.EntityFrameworkCore` confined to the EF backend | `XDocument` scan per `csproj` |
| 6 | **Telemetry purity** — `IIndexer<TKey>` impls don't call `Console.*` or `Trace.*` (must use `IndexingMetrics` + `IndexingActivitySource`) | Regex scan over `*Indexer.cs` files |

## Test plan

- [x] 18/18 new tests passing (3 [Fact] + 2 [Theory] × 7 packages + 1 [Theory] excluding EFC).
- [x] 231/231 full architecture suite passing — no regression on the rest of the family.
- [x] `dotnet format style --verify-no-changes` clean.

## Out of scope (handed off)

- **granit-docs page** for `Granit.Indexing` — published in a separate PR against the `granit-docs` sibling repo per CLAUDE.md (doc PRs are decoupled). The page covers the pluggable-backend model, authorization boundary, AI provider opt-ins, embeddings + hybrid RRF, GDPR Art. 17 path, and the ES-vs-Postgres / HNSW-reindex security trade-offs called out in the story. Cross-links from `Granit.QueryEngine`, `Granit.DataExchange`, `Granit.TextExtraction`, `Granit.Documents` land in the same granit-docs PR.

## Stack note

Logically on top of #2308 (Granit.Indexing.BackgroundJobs) — invariant #3 references `EfRebuildCheckpointStore.cs` shipped there. If #2308 lands first the rebase is clean.