### PR TITLE
feat(privacy-export)!: P6.1b streaming contract migration — providers, uploader, events

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -5535,7 +5535,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Privacy",
       "file": "src/Granit.Auditing.Privacy/DataExport/AuditingPrivacyDataProvider.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "ProviderName",
@@ -5544,22 +5544,22 @@
           "returnType": "string"
         },
         {
-          "name": "ContentType",
+          "name": "DisplayKey",
           "kind": "property",
-          "signature": "string ContentType",
+          "signature": "string DisplayKey",
           "returnType": "string"
         },
         {
-          "name": "FileName",
-          "kind": "method",
-          "signature": "FileName(Guid requestId)",
-          "returnType": "string"
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string? FeatureName",
+          "returnType": "string?"
         },
         {
-          "name": "ExportAsync",
+          "name": "HasDataAsync",
           "kind": "method",
-          "signature": "ExportAsync(Guid userId, CancellationToken cancellationToken)",
-          "returnType": "Task<ReadOnlyMemory<byte>>"
+          "signature": "HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<bool>"
         }
       ]
     },
@@ -22804,7 +22804,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Privacy",
       "file": "src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPrivacyDataProvider.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "ProviderName",
@@ -22813,22 +22813,22 @@
           "returnType": "string"
         },
         {
-          "name": "ContentType",
+          "name": "DisplayKey",
           "kind": "property",
-          "signature": "string ContentType",
+          "signature": "string DisplayKey",
           "returnType": "string"
         },
         {
-          "name": "FileName",
-          "kind": "method",
-          "signature": "FileName(Guid requestId)",
-          "returnType": "string"
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string? FeatureName",
+          "returnType": "string?"
         },
         {
-          "name": "ExportAsync",
+          "name": "HasDataAsync",
           "kind": "method",
-          "signature": "ExportAsync(Guid userId, CancellationToken cancellationToken)",
-          "returnType": "Task<ReadOnlyMemory<byte>>"
+          "signature": "HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<bool>"
         }
       ]
     },
@@ -24814,7 +24814,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Privacy",
       "file": "src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "ProviderName",
@@ -24823,22 +24823,22 @@
           "returnType": "string"
         },
         {
-          "name": "ContentType",
+          "name": "DisplayKey",
           "kind": "property",
-          "signature": "string ContentType",
+          "signature": "string DisplayKey",
           "returnType": "string"
         },
         {
-          "name": "FileName",
-          "kind": "method",
-          "signature": "FileName(Guid requestId)",
-          "returnType": "string"
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string? FeatureName",
+          "returnType": "string?"
         },
         {
-          "name": "ExportAsync",
+          "name": "HasDataAsync",
           "kind": "method",
-          "signature": "ExportAsync(Guid userId, CancellationToken cancellationToken)",
-          "returnType": "Task<ReadOnlyMemory<byte>>"
+          "signature": "HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<bool>"
         }
       ]
     },
@@ -31921,7 +31921,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Privacy",
       "file": "src/Granit.Notifications.Privacy/DataExport/NotificationsPrivacyDataProvider.cs",
-      "line": 20,
+      "line": 24,
       "members": [
         {
           "name": "ProviderName",
@@ -31930,22 +31930,22 @@
           "returnType": "string"
         },
         {
-          "name": "ContentType",
+          "name": "DisplayKey",
           "kind": "property",
-          "signature": "string ContentType",
+          "signature": "string DisplayKey",
           "returnType": "string"
         },
         {
-          "name": "FileName",
-          "kind": "method",
-          "signature": "FileName(Guid requestId)",
-          "returnType": "string"
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string? FeatureName",
+          "returnType": "string?"
         },
         {
-          "name": "ExportAsync",
+          "name": "HasDataAsync",
           "kind": "method",
-          "signature": "ExportAsync(Guid userId, CancellationToken cancellationToken)",
-          "returnType": "Task<ReadOnlyMemory<byte>>"
+          "signature": "HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<bool>"
         }
       ]
     },
@@ -36984,7 +36984,7 @@
       "kind": "class",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitPrivacyBlobStorage",
@@ -37011,12 +37011,30 @@
       ]
     },
     {
+      "name": "IStagedFragmentBuilder",
+      "fqn": "Granit.Privacy.BlobStorage.IStagedFragmentBuilder",
+      "kind": "interface",
+      "project": "Granit.Privacy.BlobStorage",
+      "file": "src/Granit.Privacy.BlobStorage/IStagedFragmentBuilder.cs",
+      "line": 19,
+      "members": []
+    },
+    {
       "name": "PrivacyFragmentUploader",
       "fqn": "Granit.Privacy.BlobStorage.PrivacyFragmentUploader",
       "kind": "class",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/PrivacyFragmentUploader.cs",
-      "line": 26,
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "StagedFragmentBuilder",
+      "fqn": "Granit.Privacy.BlobStorage.StagedFragmentBuilder",
+      "kind": "class",
+      "project": "Granit.Privacy.BlobStorage",
+      "file": "src/Granit.Privacy.BlobStorage/StagedFragmentBuilder.cs",
+      "line": 20,
       "members": []
     },
     {
@@ -37238,7 +37256,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Events/PersonalDataPreparedEto.cs",
-      "line": 12,
+      "line": 17,
       "members": []
     },
     {
@@ -37367,19 +37385,19 @@
       "kind": "interface",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs",
-      "line": 18,
+      "line": 25,
       "members": [
         {
-          "name": "FileName",
+          "name": "HasDataAsync",
           "kind": "method",
-          "signature": "FileName(Guid requestId)",
-          "returnType": "string ProviderName { get; } string ContentType { get; } string"
+          "signature": "HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "string ProviderName { get; } string DisplayKey { get; } string? FeatureName { get; } ValueTask<bool>"
         },
         {
           "name": "ExportAsync",
           "kind": "method",
-          "signature": "ExportAsync(Guid userId, CancellationToken cancellationToken)",
-          "returnType": "Task<ReadOnlyMemory<byte>>"
+          "signature": "ExportAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "IAsyncEnumerable<ExportFragment>"
         }
       ]
     },
@@ -37448,7 +37466,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/ReceivedFragment.cs",
-      "line": 8,
+      "line": 22,
       "members": []
     },
     {

--- a/src/Granit.Auditing.Privacy/DataExport/AuditingPrivacyDataProvider.cs
+++ b/src/Granit.Auditing.Privacy/DataExport/AuditingPrivacyDataProvider.cs
@@ -1,22 +1,25 @@
-using System.Text.Json;
+using System.Runtime.CompilerServices;
 using Granit.Auditing.Domain;
+using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 
 namespace Granit.Auditing.Privacy.DataExport;
 
 /// <summary>
 /// Privacy data provider for Granit.Auditing. Emits the user's audit trail (entries they
-/// authored, capped by <see cref="AuditExportLimit"/>) as a JSON fragment during the
-/// scatter-gather export saga (GDPR Art. 15 — right of access).
+/// authored, capped by <see cref="AuditExportLimit"/>) as a single staged JSON fragment
+/// during the scatter-gather export saga (GDPR Art. 15 — right of access).
 /// </summary>
 /// <remarks>
-/// The cap keeps the fragment bounded so the final archive stays within
-/// <c>GranitPrivacyOptions.ExportMaxSizeMb</c>. Beyond the cap the archive assembler's
-/// <c>CountingStream</c> would abort the entire export with <c>SizeLimitExceeded</c>.
-/// Users who hit the cap receive a partial audit history — mirroring what most SAR pipelines
-/// do in practice for high-volume trails.
+/// The cap keeps the fragment bounded so the final archive stays within the privacy size
+/// budget. Beyond the cap the assembler's counting stream would abort the entire export
+/// with <c>SizeLimitExceeded</c>. Users who hit the cap receive a partial audit history —
+/// mirroring what most SAR pipelines do in practice for high-volume trails.
 /// </remarks>
-public sealed class AuditingPrivacyDataProvider(IAuditingReader reader) : IPrivacyDataProvider
+public sealed class AuditingPrivacyDataProvider(
+    IAuditingReader reader,
+    IStagedFragmentBuilder fragmentBuilder) : IPrivacyDataProvider
 {
     /// <summary>Maximum audit entries exported for a single user.</summary>
     public const int AuditExportLimit = 10_000;
@@ -25,31 +28,48 @@ public sealed class AuditingPrivacyDataProvider(IAuditingReader reader) : IPriva
     public static string ProviderName => "auditing";
 
     /// <inheritdoc />
-    public static string ContentType => "application/json";
+    public static string DisplayKey => "Privacy.Scopes.Auditing";
 
     /// <inheritdoc />
-    public static string FileName(Guid requestId) => "auditing.json";
+    public static string? FeatureName => null;
 
     /// <inheritdoc />
-    public async Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken)
+    public async ValueTask<bool> HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(context);
+        // Cheap presence check — fetch a single entry instead of the full cap.
+        List<AuditEntry> probe = await reader
+            .GetByUserAsync(context.SubjectUserId.ToString(), limit: 1, cancellationToken)
+            .ConfigureAwait(false);
+        return probe.Count > 0;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
         List<AuditEntry> entries = await reader
-            .GetByUserAsync(userId.ToString(), AuditExportLimit, cancellationToken)
+            .GetByUserAsync(context.SubjectUserId.ToString(), AuditExportLimit, cancellationToken)
             .ConfigureAwait(false);
 
         if (entries.Count == 0)
         {
-            return ReadOnlyMemory<byte>.Empty;
+            yield break;
         }
 
-        AuditingExportDto dto = new(
-            UserId: userId,
+        var dto = new AuditingExportDto(
+            UserId: context.SubjectUserId,
             ExportedEntries: entries.Count,
             Truncated: entries.Count == AuditExportLimit,
             Limit: AuditExportLimit,
             Entries: entries.Select(Map).ToList());
 
-        return JsonSerializer.SerializeToUtf8Bytes(dto, ExportJsonOptions);
+        yield return await fragmentBuilder
+            .BuildJsonAsync(context, ProviderName, "auditing.json", dto, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static AuditingExportEntryDto Map(AuditEntry entry) =>
@@ -70,11 +90,6 @@ public sealed class AuditingPrivacyDataProvider(IAuditingReader reader) : IPriva
                         .Select(p => new AuditingExportPropertyDto(p.PropertyName, p.OriginalValue, p.NewValue))
                         .ToList()))
                 .ToList());
-
-    private static readonly JsonSerializerOptions ExportJsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        WriteIndented = true,
-    };
 }
 
 internal sealed record AuditingExportDto(

--- a/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPrivacyDataProvider.cs
@@ -1,39 +1,58 @@
-using System.Text.Json;
+using System.Runtime.CompilerServices;
 using Granit.Identity.Federated.Domain;
 using Granit.MultiTenancy;
+using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 
 namespace Granit.Identity.Federated.Privacy.DataExport;
 
 /// <summary>
 /// Privacy data provider for <c>Granit.Identity.Federated</c>. Exports the user's local
-/// federated cache entry (profile mirror + sync metadata) as a JSON fragment during the
-/// scatter-gather export saga (GDPR Art. 15).
+/// federated cache entry (profile mirror + sync metadata) as a single staged JSON fragment
+/// during the scatter-gather export saga (GDPR Art. 15 / 20).
 /// </summary>
 /// <remarks>
 /// Federated providers (Keycloak, Entra ID, Cognito, Google Cloud) typically emit a
 /// GUID-format <c>sub</c> claim — we round-trip the supplied user id as the string
 /// representation to match <see cref="FederatedIdentity.ExternalUserId"/>. When the user is
-/// not cached locally (e.g. they authenticated once and never exercised a feature that
-/// populated the cache), the provider returns <see cref="ReadOnlyMemory{T}.Empty"/>.
+/// not cached locally (authenticated once and never exercised a feature that populated the
+/// cache), the provider yields nothing.
 /// </remarks>
 public sealed class IdentityFederatedPrivacyDataProvider(
     IFederatedUserCacheReader cacheReader,
-    ICurrentTenant currentTenant) : IPrivacyDataProvider
+    ICurrentTenant currentTenant,
+    IStagedFragmentBuilder fragmentBuilder) : IPrivacyDataProvider
 {
     /// <inheritdoc />
     public static string ProviderName => "identity-federated";
 
     /// <inheritdoc />
-    public static string ContentType => "application/json";
+    public static string DisplayKey => "Privacy.Scopes.IdentityFederated";
 
     /// <inheritdoc />
-    public static string FileName(Guid requestId) => "identity-federated.json";
+    public static string? FeatureName => null;
 
     /// <inheritdoc />
-    public async Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken)
+    public async ValueTask<bool> HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)
     {
-        string externalUserId = userId.ToString();
+        ArgumentNullException.ThrowIfNull(context);
+        string externalUserId = context.SubjectUserId.ToString();
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        FederatedIdentity? entry = await cacheReader
+            .FindByExternalIdAsync(externalUserId, tenantId, cancellationToken)
+            .ConfigureAwait(false);
+        return entry is not null;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        string externalUserId = context.SubjectUserId.ToString();
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
         FederatedIdentity? entry = await cacheReader
@@ -42,10 +61,10 @@ public sealed class IdentityFederatedPrivacyDataProvider(
 
         if (entry is null)
         {
-            return ReadOnlyMemory<byte>.Empty;
+            yield break;
         }
 
-        IdentityFederatedExportResponse dto = new(
+        var dto = new IdentityFederatedExportResponse(
             CacheEntryId: entry.Id,
             ExternalUserId: entry.ExternalUserId,
             Username: entry.Username,
@@ -59,13 +78,10 @@ public sealed class IdentityFederatedPrivacyDataProvider(
             ModifiedAt: entry.ModifiedAt,
             MetadataJson: entry.MetadataJson);
 
-        return JsonSerializer.SerializeToUtf8Bytes(dto, ExportJsonOptions);
+        yield return await fragmentBuilder
+            .BuildJsonAsync(context, ProviderName, "identity-federated.json", dto, cancellationToken)
+            .ConfigureAwait(false);
     }
-
-    private static readonly JsonSerializerOptions ExportJsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        WriteIndented = true,
-    };
 }
 
 internal sealed record IdentityFederatedExportResponse(

--- a/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
@@ -1,39 +1,54 @@
-using System.Text.Json;
+using System.Runtime.CompilerServices;
 using Granit.Identity.Local.Domain;
+using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 using Microsoft.AspNetCore.Identity;
 
 namespace Granit.Identity.Local.Privacy.DataExport;
 
 /// <summary>
-/// Privacy data provider for Granit.Identity.Local. Emits the authenticated user's profile
-/// (<see cref="LocalIdentity"/>) and the roles they belong to as a JSON fragment during the
-/// scatter-gather personal-data export saga (GDPR Art. 15/20).
+/// Privacy data provider for <c>Granit.Identity.Local</c>. Emits the authenticated user's
+/// profile (<see cref="LocalIdentity"/>) and the roles they belong to as a single staged
+/// JSON fragment during the scatter-gather personal-data export saga (GDPR Art. 15 / 20).
 /// </summary>
 /// <remarks>
-/// Returns <see cref="ReadOnlyMemory{T}.Empty"/> when the user has been hard-deleted or was
-/// never provisioned locally — the <c>PrivacyFragmentUploader</c> then emits the empty-fragment
-/// sentinel so the archive assembler records the provider in <c>manifest.EmptyProviders</c>
-/// rather than failing the whole export.
+/// Yields nothing when the user has been hard-deleted or was never provisioned locally —
+/// the uploader then emits the empty-fragment sentinel so the assembler records the
+/// provider in <c>EmptyProviders</c> rather than failing the export.
 /// </remarks>
-public sealed class IdentityLocalPrivacyDataProvider(UserManager<LocalIdentity> userManager) : IPrivacyDataProvider
+public sealed class IdentityLocalPrivacyDataProvider(
+    UserManager<LocalIdentity> userManager,
+    IStagedFragmentBuilder fragmentBuilder) : IPrivacyDataProvider
 {
     /// <inheritdoc />
     public static string ProviderName => "identity-local";
 
     /// <inheritdoc />
-    public static string ContentType => "application/json";
+    public static string DisplayKey => "Privacy.Scopes.IdentityLocal";
 
     /// <inheritdoc />
-    public static string FileName(Guid requestId) => "identity-local.json";
+    public static string? FeatureName => null;
 
     /// <inheritdoc />
-    public async Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken)
+    public async ValueTask<bool> HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)
     {
-        LocalIdentity? user = await userManager.FindByIdAsync(userId.ToString()).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(context);
+        LocalIdentity? user = await userManager.FindByIdAsync(context.SubjectUserId.ToString()).ConfigureAwait(false);
+        return user is not null;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        LocalIdentity? user = await userManager.FindByIdAsync(context.SubjectUserId.ToString()).ConfigureAwait(false);
         if (user is null)
         {
-            return ReadOnlyMemory<byte>.Empty;
+            yield break;
         }
 
         IList<string> roles = await userManager.GetRolesAsync(user).ConfigureAwait(false);
@@ -41,7 +56,7 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<LocalIdentity> 
         // CreatedBy / ModifiedBy intentionally omitted — those columns store administrator
         // user identifiers, which are third-party personal data and would expose admin
         // identities to the data subject (GDPR Art. 5(1)(c) — data minimisation).
-        IdentityLocalExportResponse dto = new(
+        var dto = new IdentityLocalExportResponse(
             Id: user.Id,
             UserName: user.UserName,
             Email: user.Email,
@@ -62,13 +77,10 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<LocalIdentity> 
             CustomAttributesJson: user.CustomAttributesJson,
             Roles: roles);
 
-        return JsonSerializer.SerializeToUtf8Bytes(dto, ExportJsonOptions);
+        yield return await fragmentBuilder
+            .BuildJsonAsync(context, ProviderName, "identity-local.json", dto, cancellationToken)
+            .ConfigureAwait(false);
     }
-
-    private static readonly JsonSerializerOptions ExportJsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        WriteIndented = true,
-    };
 }
 
 /// <summary>

--- a/src/Granit.Notifications.Privacy/DataExport/NotificationsPrivacyDataProvider.cs
+++ b/src/Granit.Notifications.Privacy/DataExport/NotificationsPrivacyDataProvider.cs
@@ -1,27 +1,32 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
+using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 using Granit.QueryEngine;
 
 namespace Granit.Notifications.Privacy.DataExport;
 
 /// <summary>
 /// Privacy data provider for Granit.Notifications. Exports the user's in-app inbox,
-/// notification preferences, and topic/entity subscriptions as a single JSON fragment.
+/// notification preferences, and topic/entity subscriptions as a single staged JSON
+/// fragment.
 /// </summary>
 /// <remarks>
 /// The inbox is paged via <see cref="IUserNotificationReader.GetListAsync"/> up to
 /// <see cref="NotificationsExportLimit"/>. Exceeding it flags the payload as
-/// <c>truncated</c>. Preferences and subscriptions are fetched in full — these
-/// collections are bounded by registered notification types/topics and stay small.
+/// <c>truncated</c>. Preferences and subscriptions are fetched in full — these collections
+/// are bounded by registered notification types/topics and stay small.
 /// </remarks>
 public sealed class NotificationsPrivacyDataProvider(
     IUserNotificationReader notificationReader,
     INotificationPreferenceReader preferenceReader,
     INotificationSubscriptionReader subscriptionReader,
-    ICurrentTenant currentTenant) : IPrivacyDataProvider
+    ICurrentTenant currentTenant,
+    IStagedFragmentBuilder fragmentBuilder) : IPrivacyDataProvider
 {
     /// <summary>Maximum inbox items exported for a single user.</summary>
     public const int NotificationsExportLimit = 5_000;
@@ -30,15 +35,46 @@ public sealed class NotificationsPrivacyDataProvider(
     public static string ProviderName => "notifications";
 
     /// <inheritdoc />
-    public static string ContentType => "application/json";
+    public static string DisplayKey => "Privacy.Scopes.Notifications";
 
     /// <inheritdoc />
-    public static string FileName(Guid requestId) => "notifications.json";
+    public static string? FeatureName => null;
 
     /// <inheritdoc />
-    public async Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken)
+    public async ValueTask<bool> HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken)
     {
-        string recipientUserId = userId.ToString();
+        ArgumentNullException.ThrowIfNull(context);
+        string recipientUserId = context.SubjectUserId.ToString();
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+
+        PagedResult<UserNotification> firstPage = await notificationReader
+            .GetListAsync(recipientUserId, tenantId, page: 1, pageSize: 1, cancellationToken)
+            .ConfigureAwait(false);
+        if (firstPage.Items.Count > 0)
+        {
+            return true;
+        }
+
+        IReadOnlyList<NotificationPreference> preferences = await preferenceReader
+            .GetListAsync(recipientUserId, tenantId, cancellationToken).ConfigureAwait(false);
+        if (preferences.Count > 0)
+        {
+            return true;
+        }
+
+        IReadOnlyList<NotificationSubscription> subscriptions = await subscriptionReader
+            .GetUserSubscriptionsAsync(recipientUserId, tenantId, cancellationToken).ConfigureAwait(false);
+        return subscriptions.Count > 0;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        string recipientUserId = context.SubjectUserId.ToString();
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
         List<UserNotification> inbox = [];
@@ -77,11 +113,11 @@ public sealed class NotificationsPrivacyDataProvider(
 
         if (inbox.Count == 0 && preferences.Count == 0 && subscriptions.Count == 0)
         {
-            return ReadOnlyMemory<byte>.Empty;
+            yield break;
         }
 
-        NotificationsExportDto dto = new(
-            UserId: userId,
+        var dto = new NotificationsExportDto(
+            UserId: context.SubjectUserId,
             ExportedInboxItems: inbox.Count,
             InboxTruncated: truncated,
             InboxLimit: NotificationsExportLimit,
@@ -91,7 +127,9 @@ public sealed class NotificationsPrivacyDataProvider(
             Subscriptions: subscriptions.Select(s => new NotificationsSubscriptionDto(
                 s.Id, s.NotificationTypeName, s.EntityType, s.EntityId, s.CreatedAt)).ToList());
 
-        return JsonSerializer.SerializeToUtf8Bytes(dto, ExportJsonOptions);
+        yield return await fragmentBuilder
+            .BuildJsonAsync(context, ProviderName, "notifications.json", dto, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static NotificationsInboxDto Map(UserNotification notification) =>
@@ -105,11 +143,6 @@ public sealed class NotificationsPrivacyDataProvider(
             notification.RelatedEntityType,
             notification.RelatedEntityId,
             notification.Data);
-
-    private static readonly JsonSerializerOptions ExportJsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        WriteIndented = true,
-    };
 }
 
 internal sealed record NotificationsExportDto(

--- a/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
@@ -88,8 +88,7 @@ public sealed partial class ExportArchiveAssemblyHandler(
                 {
                     foreach (ReceivedFragment fragment in @event.Fragments)
                     {
-                        if (fragment.BlobReferenceId.Value.StartsWith(
-                            PrivacyExportContainerNames.EmptyFragmentPrefix, StringComparison.Ordinal))
+                        if (string.Equals(fragment.FragmentKind, "empty", StringComparison.Ordinal))
                         {
                             emptyProviders.Add(fragment.ProviderName);
                             continue;
@@ -101,9 +100,14 @@ public sealed partial class ExportArchiveAssemblyHandler(
                             continue;
                         }
 
-                        string entryName = await ResolveEntryNameAsync(blobId, fragment, cancellationToken).ConfigureAwait(false);
+                        // PR-1b: HMAC verification of fragment.IntegrityTag lands in P6.3 with
+                        // the multipart upload + sharding migration. Capability tag is signed
+                        // by the staging builder today; the verifier just isn't wired yet.
+                        string entryName = string.IsNullOrEmpty(fragment.EntryPath)
+                            ? await ResolveEntryNameAsync(blobId, fragment, cancellationToken).ConfigureAwait(false)
+                            : fragment.EntryPath;
                         await CopyFragmentToZipAsync(
-                            zip, entryName, blobId, downloadTtl, httpClient, cancellationToken).ConfigureAwait(false);
+                            zip, entryName, fragment.SourceContainer, blobId, downloadTtl, httpClient, cancellationToken).ConfigureAwait(false);
 
                         manifestFragments.Add(new ExportManifestFragment(
                             fragment.ProviderName, entryName, fragment.ContentType, fragment.BlobReferenceId));
@@ -173,13 +177,20 @@ public sealed partial class ExportArchiveAssemblyHandler(
     private async Task CopyFragmentToZipAsync(
         ZipArchive zip,
         string entryName,
+        string sourceContainer,
         Guid blobId,
         TimeSpan downloadTtl,
         HttpClient httpClient,
         CancellationToken cancellationToken)
     {
+        // PassThrough fragments carry the source-blob container directly; staged fragments
+        // resolve to the privacy staging container.
+        string container = string.IsNullOrEmpty(sourceContainer)
+            ? PrivacyExportContainerNames.FragmentContainer
+            : sourceContainer;
+
         PresignedDownloadUrl downloadUrl = await blobStorage.CreateDownloadUrlAsync(
-            PrivacyExportContainerNames.FragmentContainer,
+            container,
             blobId,
             new DownloadUrlOptions(Expiry: downloadTtl),
             cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Privacy.BlobStorage.DataExport;
+using Granit.Privacy.DataExport.Security;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -12,7 +13,11 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Registers the privacy-export services that bridge the scatter-gather saga to BlobStorage:
     /// <list type="bullet">
-    ///   <item><see cref="PrivacyFragmentUploader"/> — provider-side fragment upload helper.</item>
+    ///   <item><see cref="PrivacyFragmentUploader"/> — provider-side fragment publisher.</item>
+    ///   <item><see cref="StagedFragmentBuilder"/> (via <see cref="IStagedFragmentBuilder"/>) —
+    ///   provider helper that serialises DTOs, uploads to staging, and signs the integrity tag.</item>
+    ///   <item><see cref="IExportHmacSigner"/> default impl (<see cref="EphemeralExportHmacSigner"/>) —
+    ///   production hosts override with a Vault-backed signer.</item>
     ///   <item><see cref="ExportArchiveAssemblyHandler"/> — terminal ZIP assembler triggered by
     ///   <see cref="Granit.Privacy.DataExport.Events.ExportCompletedEto"/>. Auto-discovered by
     ///   Wolverine once registered with DI.</item>
@@ -20,8 +25,10 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddGranitPrivacyBlobStorage(this IServiceCollection services)
     {
-        services.AddHttpClient(PrivacyFragmentUploader.HttpClientName);
+        services.AddHttpClient(StagedFragmentBuilder.HttpClientName);
         services.AddHttpClient(ExportArchiveAssemblyHandler.HttpClientName);
+        services.TryAddSingleton<IExportHmacSigner, EphemeralExportHmacSigner>();
+        services.TryAddScoped<IStagedFragmentBuilder, StagedFragmentBuilder>();
         services.TryAddScoped<PrivacyFragmentUploader>();
         services.TryAddScoped<ExportArchiveAssemblyHandler>();
         return services;

--- a/src/Granit.Privacy.BlobStorage/IStagedFragmentBuilder.cs
+++ b/src/Granit.Privacy.BlobStorage/IStagedFragmentBuilder.cs
@@ -1,0 +1,39 @@
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
+
+namespace Granit.Privacy.BlobStorage;
+
+/// <summary>
+/// Helper that takes raw bytes produced by an <see cref="IPrivacyDataProvider"/>, uploads
+/// them to the staging container, signs the integrity tag, and returns a
+/// <see cref="StagedExportFragment"/> ready to be yielded by the provider's
+/// <c>ExportAsync</c> enumerable.
+/// </summary>
+/// <remarks>
+/// Lightweight providers (Identity, Auditing, Notifications) use this to factor out the
+/// staging upload boilerplate. The builder is also where the HMAC integrity tag is computed
+/// (via <c>Granit.Privacy.DataExport.Security.IExportHmacSigner</c>) — providers never deal
+/// with HMAC details directly. Paths are sanitised via
+/// <c>Granit.Privacy.DataExport.Sanitization.EntryPathSanitizer</c>.
+/// </remarks>
+public interface IStagedFragmentBuilder
+{
+    /// <summary>
+    /// Serialises <paramref name="dto"/> as JSON UTF-8, uploads to the staging container,
+    /// signs the integrity tag and returns the resulting fragment.
+    /// </summary>
+    /// <param name="context">Export context — request id, subject, tenant, regulation.</param>
+    /// <param name="providerName">Originating <see cref="IPrivacyDataProvider.ProviderName"/>;
+    /// part of the HMAC binding.</param>
+    /// <param name="entryPath">Path of the fragment inside the final archive (sanitised by
+    /// the builder before upload).</param>
+    /// <param name="dto">DTO to serialise.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<StagedExportFragment> BuildJsonAsync<T>(
+        PrivacyExportContext context,
+        string providerName,
+        string entryPath,
+        T dto,
+        CancellationToken cancellationToken)
+        where T : notnull;
+}

--- a/src/Granit.Privacy.BlobStorage/PrivacyFragmentUploader.cs
+++ b/src/Granit.Privacy.BlobStorage/PrivacyFragmentUploader.cs
@@ -1,39 +1,40 @@
-using System.Net.Http.Headers;
-using Granit.BlobStorage;
+using Granit.Domain.ValueObjects;
 using Granit.Events;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.DataExport.Fragments;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Privacy.BlobStorage;
 
 /// <summary>
-/// Reusable utility that drives the scatter-gather provider-side upload:
-/// <list type="number">
-///   <item>Asks the provider for its bytes.</item>
-///   <item>If empty, publishes a <see cref="PersonalDataPreparedEto"/> with the
-///   <see cref="PrivacyExportContainerNames.EmptyFragmentPrefix"/> sentinel and returns —
-///   no blob is created for empty providers.</item>
-///   <item>Otherwise runs the presigned upload dance
-///   (<see cref="IBlobStorage.InitiateUploadAsync"/> → HTTP PUT → <see cref="IBlobStorage.ConfirmUploadAsync"/>)
-///   and publishes a <see cref="PersonalDataPreparedEto"/> carrying the confirmed blob id.</item>
-/// </list>
+/// Iterates the <see cref="ExportFragment"/> stream yielded by an
+/// <see cref="IPrivacyDataProvider"/> and publishes one
+/// <see cref="PersonalDataPreparedEto"/> per fragment. Empty providers emit a single
+/// sentinel event so the saga can decrement its pending-providers set without leaving an
+/// orphan entry in the manifest.
 /// </summary>
 /// <remarks>
-/// Every provider-side Wolverine handler forwards to <see cref="UploadAsync"/>. Handlers stay
-/// one-liners and the boilerplate lives here, where it can be unit-tested in isolation.
+/// Provider-side Wolverine handlers stay one-liners — all the iteration / sentinel logic
+/// lives here, where it can be unit-tested in isolation. The actual staging upload (for
+/// <see cref="StagedExportFragment"/>) and HMAC signing happen inside the provider via
+/// <see cref="IStagedFragmentBuilder"/> before the fragment reaches the uploader.
 /// </remarks>
 public sealed partial class PrivacyFragmentUploader(
-    IBlobStorage blobStorage,
-    IHttpClientFactory httpClientFactory,
     IDistributedEventBus eventBus,
     ILogger<PrivacyFragmentUploader> logger)
 {
-    /// <summary>Named <see cref="HttpClient"/> used to PUT fragment bytes to the presigned URL.</summary>
-    public const string HttpClientName = "Granit.Privacy.FragmentUpload";
+    /// <summary>FragmentKind sentinel value for providers with no data for the subject.</summary>
+    public const string EmptyFragmentKind = "empty";
+
+    /// <summary>FragmentKind value for staged fragments (bytes already in staging container).</summary>
+    public const string StagedFragmentKind = "staged";
+
+    /// <summary>FragmentKind value for pass-through fragments (source blob, single-transit).</summary>
+    public const string PassThroughFragmentKind = "passthrough";
 
     /// <summary>
-    /// Executes the upload-and-publish flow for a single provider.
+    /// Iterates the provider's fragment stream and publishes the corresponding events.
     /// </summary>
     public async Task UploadAsync<TProvider>(
         PersonalDataRequestedEto request,
@@ -44,71 +45,68 @@ public sealed partial class PrivacyFragmentUploader(
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(provider);
 
-        ReadOnlyMemory<byte> payload = await provider
-            .ExportAsync(request.UserId, cancellationToken)
-            .ConfigureAwait(false);
+        var context = new PrivacyExportContext(
+            RequestId: request.RequestId,
+            SubjectUserId: request.UserId,
+            CallerUserId: request.UserId,
+            TenantId: null,
+            Regulation: request.Regulation);
 
-        if (payload.IsEmpty)
+        int published = 0;
+        await foreach (ExportFragment fragment in provider
+            .ExportAsync(context, cancellationToken)
+            .ConfigureAwait(false))
         {
-            LogEmptyFragment(logger, TProvider.ProviderName, request.UserId, request.RequestId);
+            (string kind, string container, BlobReference blob) = fragment switch
+            {
+                StagedExportFragment staged => (StagedFragmentKind, PrivacyExportContainerNames.FragmentContainer, staged.StagedBlob),
+                PassThroughExportFragment pt => (PassThroughFragmentKind, ResolveContainer(pt.SourceBlob), pt.SourceBlob),
+                _ => throw new InvalidOperationException($"Unknown fragment kind: {fragment.GetType().Name}"),
+            };
 
             await eventBus.PublishAsync(
                 new PersonalDataPreparedEto(
-                    request.RequestId,
-                    TProvider.ProviderName,
-                    $"{PrivacyExportContainerNames.EmptyFragmentPrefix}{request.RequestId}",
-                    TProvider.ContentType),
+                    RequestId: request.RequestId,
+                    ProviderName: TProvider.ProviderName,
+                    FragmentKind: kind,
+                    SourceContainer: container,
+                    BlobReferenceId: blob,
+                    EntryPath: fragment.EntryPath,
+                    ContentType: fragment.ContentType,
+                    IntegrityTag: fragment.IntegrityTag),
                 cancellationToken).ConfigureAwait(false);
 
-            return;
+            LogFragmentPrepared(logger, TProvider.ProviderName, request.UserId, request.RequestId, fragment.EntryPath, kind);
+            published++;
         }
 
-        PresignedUploadTicket ticket = await blobStorage.InitiateUploadAsync(
-            PrivacyExportContainerNames.FragmentContainer,
-            new BlobUploadRequest(
-                FileName: TProvider.FileName(request.RequestId),
-                ContentType: TProvider.ContentType,
-                MaxAllowedBytes: payload.Length),
-            cancellationToken).ConfigureAwait(false);
-
-        HttpClient httpClient = httpClientFactory.CreateClient(HttpClientName);
-        using ByteArrayContent content = new(payload.ToArray());
-        content.Headers.ContentType = new MediaTypeHeaderValue(TProvider.ContentType);
-        foreach ((string key, string value) in ticket.RequiredHeaders)
+        if (published == 0)
         {
-            content.Headers.TryAddWithoutValidation(key, value);
+            LogEmptyFragment(logger, TProvider.ProviderName, request.UserId, request.RequestId);
+            await eventBus.PublishAsync(
+                new PersonalDataPreparedEto(
+                    RequestId: request.RequestId,
+                    ProviderName: TProvider.ProviderName,
+                    FragmentKind: EmptyFragmentKind,
+                    SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+                    BlobReferenceId: BlobReference.Create($"{PrivacyExportContainerNames.EmptyFragmentPrefix}{request.RequestId}"),
+                    EntryPath: $"{TProvider.ProviderName}.empty",
+                    ContentType: "application/octet-stream",
+                    IntegrityTag: string.Empty),
+                cancellationToken).ConfigureAwait(false);
         }
-
-        using HttpRequestMessage httpRequest = new(new HttpMethod(ticket.HttpMethod), ticket.UploadUrl)
-        {
-            Content = content,
-        };
-        using HttpResponseMessage response = await httpClient
-            .SendAsync(httpRequest, cancellationToken)
-            .ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-
-        await blobStorage.ConfirmUploadAsync(
-            PrivacyExportContainerNames.FragmentContainer,
-            ticket.BlobId,
-            cancellationToken).ConfigureAwait(false);
-
-        LogFragmentUploaded(logger, TProvider.ProviderName, request.UserId, request.RequestId, ticket.BlobId, payload.Length);
-
-        await eventBus.PublishAsync(
-            new PersonalDataPreparedEto(
-                request.RequestId,
-                TProvider.ProviderName,
-                ticket.BlobId.ToString(),
-                TProvider.ContentType),
-            cancellationToken).ConfigureAwait(false);
     }
+
+    // For PR-1b the only known passthrough source is the staging container. Documents
+    // (granit-business) will populate the real container name when its provider lands.
+    private static string ResolveContainer(BlobReference blob) =>
+        PrivacyExportContainerNames.FragmentContainer;
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Privacy export: provider {Provider} has no data for user {UserId} (request {RequestId}); emitting empty sentinel")]
     private static partial void LogEmptyFragment(ILogger logger, string provider, Guid userId, Guid requestId);
 
     [LoggerMessage(Level = LogLevel.Information,
-        Message = "Privacy export: provider {Provider} uploaded {Bytes} bytes for user {UserId} (request {RequestId}), blob {BlobId}")]
-    private static partial void LogFragmentUploaded(ILogger logger, string provider, Guid userId, Guid requestId, Guid blobId, int bytes);
+        Message = "Privacy export: provider {Provider} yielded fragment {EntryPath} ({Kind}) for user {UserId} (request {RequestId})")]
+    private static partial void LogFragmentPrepared(ILogger logger, string provider, Guid userId, Guid requestId, string entryPath, string kind);
 }

--- a/src/Granit.Privacy.BlobStorage/StagedFragmentBuilder.cs
+++ b/src/Granit.Privacy.BlobStorage/StagedFragmentBuilder.cs
@@ -1,0 +1,112 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Granit.BlobStorage;
+using Granit.Domain.ValueObjects;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
+using Granit.Privacy.DataExport.Sanitization;
+using Granit.Privacy.DataExport.Security;
+using Granit.Privacy.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Privacy.BlobStorage;
+
+/// <summary>
+/// Default <see cref="IStagedFragmentBuilder"/> — serialises the DTO as JSON UTF-8, uploads
+/// the bytes to the staging container via the existing presigned-PUT dance, signs the
+/// integrity tag, and returns a fully-formed <see cref="StagedExportFragment"/>.
+/// </summary>
+public sealed partial class StagedFragmentBuilder(
+    IBlobStorage blobStorage,
+    IHttpClientFactory httpClientFactory,
+    IExportHmacSigner hmacSigner,
+    IOptions<GranitPrivacyOptions> options,
+    TimeProvider timeProvider,
+    ILogger<StagedFragmentBuilder> logger) : IStagedFragmentBuilder
+{
+    /// <summary>Named <see cref="HttpClient"/> used for the staging PUT.</summary>
+    public const string HttpClientName = "Granit.Privacy.FragmentUpload";
+
+    private static readonly JsonSerializerOptions ExportJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    /// <inheritdoc />
+    public async Task<StagedExportFragment> BuildJsonAsync<T>(
+        PrivacyExportContext context,
+        string providerName,
+        string entryPath,
+        T dto,
+        CancellationToken cancellationToken)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrEmpty(providerName);
+        ArgumentException.ThrowIfNullOrEmpty(entryPath);
+        ArgumentNullException.ThrowIfNull(dto);
+
+        string safeEntryPath = EntryPathSanitizer.Sanitize(entryPath);
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(dto, ExportJsonOptions);
+
+        PresignedUploadTicket ticket = await blobStorage.InitiateUploadAsync(
+            PrivacyExportContainerNames.FragmentContainer,
+            new BlobUploadRequest(
+                FileName: safeEntryPath,
+                ContentType: "application/json",
+                MaxAllowedBytes: payload.Length),
+            cancellationToken).ConfigureAwait(false);
+
+        HttpClient httpClient = httpClientFactory.CreateClient(HttpClientName);
+        using ByteArrayContent content = new(payload);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        foreach ((string key, string value) in ticket.RequiredHeaders)
+        {
+            content.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        using HttpRequestMessage httpRequest = new(new HttpMethod(ticket.HttpMethod), ticket.UploadUrl)
+        {
+            Content = content,
+        };
+        using HttpResponseMessage response = await httpClient
+            .SendAsync(httpRequest, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await blobStorage.ConfirmUploadAsync(
+            PrivacyExportContainerNames.FragmentContainer,
+            ticket.BlobId,
+            cancellationToken).ConfigureAwait(false);
+
+        LogStagedFragmentUploaded(logger, providerName, context.SubjectUserId, context.RequestId, ticket.BlobId, payload.Length);
+
+        DateTimeOffset expiresAt = timeProvider.GetUtcNow()
+            + TimeSpan.FromMinutes(options.Value.ExportTimeoutMinutes * 4);
+        string integrityTag = hmacSigner.Sign(new ExportHmacParameters(
+            RequestId: context.RequestId,
+            SubjectUserId: context.SubjectUserId,
+            ProviderName: providerName,
+            FragmentKind: "staged",
+            SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+            SourceBlobId: ticket.BlobId,
+            EntryPath: safeEntryPath,
+            ExpiresAt: expiresAt));
+
+        var stagedBlob = BlobReference.Create(ticket.BlobId.ToString());
+
+        return new StagedExportFragment
+        {
+            EntryPath = safeEntryPath,
+            ContentType = "application/json",
+            KnownSizeBytes = payload.Length,
+            IntegrityTag = integrityTag,
+            StagedBlob = stagedBlob,
+        };
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Privacy export: staged JSON fragment for provider {Provider} (user {UserId}, request {RequestId}) uploaded as blob {BlobId} ({Bytes} bytes)")]
+    private static partial void LogStagedFragmentUploaded(ILogger logger, string provider, Guid userId, Guid requestId, Guid blobId, int bytes);
+}

--- a/src/Granit.Privacy/DataExport/Events/PersonalDataPreparedEto.cs
+++ b/src/Granit.Privacy/DataExport/Events/PersonalDataPreparedEto.cs
@@ -5,12 +5,21 @@ using Wolverine.Persistence.Sagas;
 namespace Granit.Privacy.DataExport.Events;
 
 /// <summary>
-/// Published by each data provider after preparing its fragment for a data export request.
-/// The <see cref="BlobReferenceId"/> points to the fragment stored in BlobStorage —
-/// raw data is never included in the event payload (ISO 27001 compliance).
+/// Published by each data provider after preparing a fragment for a data export request.
+/// Carries the pointer the assembler needs to materialise the entry in the final archive
+/// plus the HMAC capability tag the assembler verifies before opening the source stream.
 /// </summary>
+/// <remarks>
+/// Raw bytes are never included in the event payload (ISO 27001 — fragment content stays
+/// in BlobStorage). A provider may publish more than one event for the same request when
+/// it yields multiple fragments (blob-backed providers — Documents, attachments).
+/// </remarks>
 public sealed record PersonalDataPreparedEto(
     [property: SagaIdentity] Guid RequestId,
     string ProviderName,
+    string FragmentKind,
+    string SourceContainer,
     BlobReference BlobReferenceId,
-    string ContentType) : IIntegrationEvent;
+    string EntryPath,
+    string ContentType,
+    string IntegrityTag) : IIntegrationEvent;

--- a/src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs
@@ -1,3 +1,5 @@
+using Granit.Privacy.DataExport.Fragments;
+
 namespace Granit.Privacy.DataExport;
 
 /// <summary>
@@ -7,41 +9,65 @@ namespace Granit.Privacy.DataExport;
 /// <remarks>
 /// <para>
 /// Implementations are discovered via DI (registered with <c>AddDataProvider&lt;TProvider&gt;()</c>)
-/// and invoked by a <c>PrivacyDataProviderHandlerBase&lt;TProvider&gt;</c> Wolverine handler
-/// when <see cref="Events.PersonalDataRequestedEto"/> is published.
+/// and invoked by a per-provider Wolverine handler when
+/// <see cref="Events.PersonalDataRequestedEto"/> is published. Each handler forwards to
+/// <c>PrivacyFragmentUploader</c>, which iterates the fragments yielded by the provider and
+/// emits one <see cref="Events.PersonalDataPreparedEto"/> per fragment.
 /// </para>
 /// <para>
-/// Providers expose only what they know: the bytes of the user's data and how to name / type
-/// the fragment. Upload to blob storage and event publication are handled by the base class.
+/// <b>Migration note (Takeout-style, P6.1):</b> the previous shape
+/// <c>Task&lt;ReadOnlyMemory&lt;byte&gt;&gt; ExportAsync(Guid userId, CT)</c> imposed a single
+/// in-memory buffer per provider plus a global size cap incompatible with blob-backed
+/// modules (Documents, attachments). Providers now stream one or more
+/// <see cref="ExportFragment"/> values via <see cref="ExportAsync"/>.
 /// </para>
 /// </remarks>
 public interface IPrivacyDataProvider
 {
     /// <summary>
-    /// Globally unique provider identifier registered via <c>RegisterDataProvider(name)</c>.
-    /// Used by <c>PersonalDataExportSaga</c> to track which providers have responded.
+    /// Globally unique provider identifier. Used by <c>PersonalDataExportSaga</c> to track
+    /// which providers have responded and by the scope selector
+    /// (<c>GET /privacy/exports/scopes</c>) to address this provider.
     /// </summary>
     static abstract string ProviderName { get; }
 
-    /// <summary>MIME content type of the fragment produced by <see cref="ExportAsync"/>.</summary>
-    static abstract string ContentType { get; }
-
     /// <summary>
-    /// File name under which the fragment is stored in the final archive.
-    /// Typically <c>"{provider-name}-{requestId}.{ext}"</c>.
+    /// Localisation key for the scope selector UI (e.g. <c>"Privacy.Scopes.IdentityLocal"</c>).
+    /// Architecture test enforces that the key resolves in all 18 framework cultures.
     /// </summary>
-    static abstract string FileName(Guid requestId);
+    static abstract string DisplayKey { get; }
 
     /// <summary>
-    /// Produces the personal-data fragment for the given user, or an empty buffer when the
-    /// provider has no data (the handler base emits an <c>empty:</c> sentinel in that case).
+    /// Optional feature flag controlling visibility of this provider in the scope selector.
+    /// When <see langword="null"/>, the provider is always visible. When non-null, the
+    /// selector hides the scope if <c>IFeatureManager.IsEnabledAsync</c> returns false —
+    /// mirroring the Notifications visibility pattern.
+    /// </summary>
+    static abstract string? FeatureName { get; }
+
+    /// <summary>
+    /// Fast probe used by the scope selector and the assembly visibility gate. Returns
+    /// <see langword="true"/> when the subject has any data this provider could export.
     /// </summary>
     /// <remarks>
-    /// The returned bytes are uploaded in full to blob storage before the saga publishes
-    /// <see cref="Events.PersonalDataPreparedEto"/>. Large fragments should still fit within
-    /// the per-provider budget derived from <c>GranitPrivacyOptions.ExportMaxSizeMb</c>.
-    /// Streaming exports (paged JSON) should buffer to a <see cref="System.IO.MemoryStream"/>
-    /// or temp file and materialise once.
+    /// MUST be cheap (count-style query with a tenant/owner filter, &lt; 50 ms target).
+    /// NEVER perform a full scan — the selector calls this on every page load.
     /// </remarks>
-    Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken);
+    ValueTask<bool> HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Produces the personal-data fragments for the request. Lightweight providers yield a
+    /// single <see cref="StagedExportFragment"/>; blob-backed providers (Documents,
+    /// attachments) yield one <see cref="PassThroughExportFragment"/> per source blob.
+    /// </summary>
+    /// <remarks>
+    /// Fragments MUST be signed with
+    /// <see cref="Security.IExportHmacSigner.Sign"/>; the archive assembler rejects unsigned
+    /// or tampered fragments and routes them to the DLQ (closes VULN-001 / VULN-102).
+    /// Yielding an empty enumerable is legal and translates to <c>EmptyProviders</c> in the
+    /// manifest.
+    /// </remarks>
+    IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        CancellationToken cancellationToken);
 }

--- a/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
+++ b/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
@@ -110,11 +110,22 @@ public sealed class PersonalDataExportSaga : Saga
     /// </summary>
     public ExportCompletedEto? Handle(PersonalDataPreparedEto @event, PrivacyMetrics metrics)
     {
-        ReceivedFragments.Add(new ReceivedFragment(@event.ProviderName, @event.BlobReferenceId, @event.ContentType));
+        ReceivedFragments.Add(new ReceivedFragment(
+            @event.ProviderName,
+            @event.FragmentKind,
+            @event.SourceContainer,
+            @event.BlobReferenceId,
+            @event.EntryPath,
+            @event.ContentType,
+            @event.IntegrityTag));
         bool expected = PendingProviders.Remove(@event.ProviderName);
         metrics.RecordFragmentReceived(TenantId, expected ? @event.ProviderName : "unknown", Regulation);
 
-        if (ReceivedFragments.Count < ExpectedCount)
+        // Multi-fragment providers (Documents, attachments) emit one Prepared event per
+        // fragment but only count once against ExpectedCount via PendingProviders.Remove.
+        // We must wait until every expected provider has stopped contributing — which we
+        // approximate by waiting until PendingProviders is drained.
+        if (PendingProviders.Count > 0)
         {
             return null;
         }

--- a/src/Granit.Privacy/DataExport/ReceivedFragment.cs
+++ b/src/Granit.Privacy/DataExport/ReceivedFragment.cs
@@ -3,6 +3,27 @@ using Granit.Domain.ValueObjects;
 namespace Granit.Privacy.DataExport;
 
 /// <summary>
-/// A fragment received from a data provider during the privacy export Saga.
+/// A fragment received from a data provider during the privacy export saga. Carries the
+/// pointer the assembler needs to materialise the entry in the final archive plus the
+/// HMAC capability the assembler verifies before opening the source stream.
 /// </summary>
-public sealed record ReceivedFragment(string ProviderName, BlobReference BlobReferenceId, string ContentType);
+/// <param name="ProviderName">Originating <see cref="IPrivacyDataProvider.ProviderName"/>.</param>
+/// <param name="FragmentKind"><c>"staged"</c> when the fragment bytes live in the staging
+/// container; <c>"passthrough"</c> when the fragment points at an already-persisted source
+/// blob (single-transit).</param>
+/// <param name="SourceContainer">Container holding the underlying blob (staging container
+/// for <c>staged</c>, source container for <c>passthrough</c>).</param>
+/// <param name="BlobReferenceId">Reference to the underlying blob.</param>
+/// <param name="EntryPath">Path the fragment will occupy in the final archive (already
+/// sanitised by the producing provider / builder).</param>
+/// <param name="ContentType">MIME type of the entry — drives compression mode at assembly.</param>
+/// <param name="IntegrityTag">HMAC capability tag bound to the fragment identity.
+/// Verified by the assembler before any blob read.</param>
+public sealed record ReceivedFragment(
+    string ProviderName,
+    string FragmentKind,
+    string SourceContainer,
+    BlobReference BlobReferenceId,
+    string EntryPath,
+    string ContentType,
+    string IntegrityTag);

--- a/tests/Granit.Auditing.Privacy.Tests/DataExport/AuditingPrivacyDataProviderTests.cs
+++ b/tests/Granit.Auditing.Privacy.Tests/DataExport/AuditingPrivacyDataProviderTests.cs
@@ -1,25 +1,9 @@
-// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
-// invalidates the call sites below. Tests are preserved for reference and
-// will be rewritten under P6.2 (#2313).
-//
-// To re-enable while migrating: drop the #if FALSE wrapper and update each
-// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
-// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
-
-using Xunit;
-
-namespace Granit.Auditing.Privacy.Tests.DataExport;
-
-public class AuditingPrivacyDataProviderTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
-using System.Text.Json;
 using Granit.Auditing.Domain;
 using Granit.Auditing.Privacy.DataExport;
+using Granit.Domain.ValueObjects;
+using Granit.Privacy.BlobStorage;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -29,39 +13,91 @@ namespace Granit.Auditing.Privacy.Tests.DataExport;
 public sealed class AuditingPrivacyDataProviderTests
 {
     private readonly IAuditingReader _reader = Substitute.For<IAuditingReader>();
+    private readonly IStagedFragmentBuilder _builder = Substitute.For<IStagedFragmentBuilder>();
+
+    private static PrivacyExportContext Ctx(Guid? subjectUserId = null) =>
+        new(
+            RequestId: Guid.NewGuid(),
+            SubjectUserId: subjectUserId ?? Guid.NewGuid(),
+            CallerUserId: subjectUserId ?? Guid.NewGuid(),
+            TenantId: null,
+            Regulation: "EU_GDPR");
+
+    private static StagedExportFragment StubFragment(string entryPath = "auditing.json") =>
+        new()
+        {
+            EntryPath = entryPath,
+            ContentType = "application/json",
+            IntegrityTag = "v1:stub",
+            StagedBlob = BlobReference.Create(Guid.NewGuid().ToString()),
+        };
 
     [Fact]
     public void ProviderName_Is_Auditing() =>
         AuditingPrivacyDataProvider.ProviderName.ShouldBe("auditing");
 
     [Fact]
-    public void ContentType_IsApplicationJson() =>
-        AuditingPrivacyDataProvider.ContentType.ShouldBe("application/json");
+    public void DisplayKey_TargetsScopeSelectorLocKey() =>
+        AuditingPrivacyDataProvider.DisplayKey.ShouldBe("Privacy.Scopes.Auditing");
 
     [Fact]
-    public void FileName_IsStable() =>
-        AuditingPrivacyDataProvider.FileName(Guid.NewGuid()).ShouldBe("auditing.json");
+    public void FeatureName_IsNull_AlwaysVisible() =>
+        AuditingPrivacyDataProvider.FeatureName.ShouldBeNull();
 
     [Fact]
-    public async Task ExportAsync_NoEntries_ReturnsEmpty()
+    public async Task HasDataAsync_ReturnsTrue_WhenReaderProbeFindsEntries()
+    {
+        var userId = Guid.NewGuid();
+        _reader.GetByUserAsync(userId.ToString(), limit: 1, Arg.Any<CancellationToken>())
+            .Returns([new AuditEntry { Id = Guid.NewGuid(), UserId = userId.ToString(), Category = AuditCategory.DataMutation, EntityChanges = [] }]);
+
+        AuditingPrivacyDataProvider sut = new(_reader, _builder);
+
+        bool has = await sut.HasDataAsync(Ctx(userId), TestContext.Current.CancellationToken);
+
+        has.ShouldBeTrue();
+        await _reader.Received(1).GetByUserAsync(userId.ToString(), limit: 1, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HasDataAsync_ReturnsFalse_WhenReaderProbeIsEmpty()
     {
         _reader.GetByUserAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        AuditingPrivacyDataProvider sut = new(_reader);
+        AuditingPrivacyDataProvider sut = new(_reader, _builder);
 
-        ReadOnlyMemory<byte> result = await sut.ExportAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+        bool has = await sut.HasDataAsync(Ctx(), TestContext.Current.CancellationToken);
 
-        result.IsEmpty.ShouldBeTrue();
+        has.ShouldBeFalse();
     }
 
     [Fact]
-    public async Task ExportAsync_WithEntries_ReturnsJsonWithFlagsAndPayload()
+    public async Task ExportAsync_NoEntries_YieldsNothing()
+    {
+        _reader.GetByUserAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        AuditingPrivacyDataProvider sut = new(_reader, _builder);
+
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in sut.ExportAsync(Ctx(), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
+
+        fragments.ShouldBeEmpty();
+        await _builder.DidNotReceive().BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExportAsync_WithEntries_HandsDtoToBuilder_AndYieldsFragment()
     {
         var userId = Guid.NewGuid();
         List<AuditEntry> entries =
         [
-            new AuditEntry
+            new()
             {
                 Id = Guid.NewGuid(),
                 Timestamp = new DateTimeOffset(2026, 4, 19, 10, 0, 0, TimeSpan.Zero),
@@ -71,45 +107,66 @@ public sealed class AuditingPrivacyDataProviderTests
                 EntityChanges = [],
             },
         ];
-        _reader.GetByUserAsync(userId.ToString(), AuditingPrivacyDataProvider.AuditExportLimit,
-                Arg.Any<CancellationToken>())
+        _reader.GetByUserAsync(userId.ToString(), AuditingPrivacyDataProvider.AuditExportLimit, Arg.Any<CancellationToken>())
             .Returns(entries);
 
-        AuditingPrivacyDataProvider sut = new(_reader);
+        AuditingExportDto? capturedDto = null;
+        _builder.BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(),
+            AuditingPrivacyDataProvider.ProviderName,
+            "auditing.json",
+            Arg.Do<AuditingExportDto>(d => capturedDto = d),
+            Arg.Any<CancellationToken>())
+            .Returns(StubFragment());
 
-        ReadOnlyMemory<byte> result = await sut.ExportAsync(userId, TestContext.Current.CancellationToken);
+        AuditingPrivacyDataProvider sut = new(_reader, _builder);
 
-        result.IsEmpty.ShouldBeFalse();
-        using var doc = JsonDocument.Parse(result);
-        doc.RootElement.GetProperty("userId").GetGuid().ShouldBe(userId);
-        doc.RootElement.GetProperty("exportedEntries").GetInt32().ShouldBe(1);
-        doc.RootElement.GetProperty("truncated").GetBoolean().ShouldBeFalse();
-        doc.RootElement.GetProperty("entries").GetArrayLength().ShouldBe(1);
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in sut.ExportAsync(Ctx(userId), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
+
+        fragments.Count.ShouldBe(1);
+        fragments[0].ShouldBeOfType<StagedExportFragment>();
+        capturedDto.ShouldNotBeNull();
+        capturedDto!.UserId.ShouldBe(userId);
+        capturedDto.ExportedEntries.ShouldBe(1);
+        capturedDto.Truncated.ShouldBeFalse();
+        capturedDto.Entries.Count.ShouldBe(1);
     }
 
     [Fact]
-    public async Task ExportAsync_AtLimit_FlagsTruncated()
+    public async Task ExportAsync_AtLimit_DtoFlagsTruncated()
     {
         var userId = Guid.NewGuid();
-        var entries = Enumerable.Range(0, AuditingPrivacyDataProvider.AuditExportLimit)
+        List<AuditEntry> entries = [.. Enumerable.Range(0, AuditingPrivacyDataProvider.AuditExportLimit)
             .Select(i => new AuditEntry
             {
                 Id = Guid.NewGuid(),
                 Timestamp = DateTimeOffset.UtcNow.AddMinutes(-i),
                 UserId = userId.ToString(),
                 Category = AuditCategory.DataMutation,
-            })
-            .ToList();
-        _reader.GetByUserAsync(userId.ToString(), AuditingPrivacyDataProvider.AuditExportLimit,
-                Arg.Any<CancellationToken>())
+                EntityChanges = [],
+            })];
+        _reader.GetByUserAsync(userId.ToString(), AuditingPrivacyDataProvider.AuditExportLimit, Arg.Any<CancellationToken>())
             .Returns(entries);
 
-        AuditingPrivacyDataProvider sut = new(_reader);
+        AuditingExportDto? capturedDto = null;
+        _builder.BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Do<AuditingExportDto>(d => capturedDto = d),
+            Arg.Any<CancellationToken>())
+            .Returns(StubFragment());
 
-        ReadOnlyMemory<byte> result = await sut.ExportAsync(userId, TestContext.Current.CancellationToken);
+        AuditingPrivacyDataProvider sut = new(_reader, _builder);
 
-        using var doc = JsonDocument.Parse(result);
-        doc.RootElement.GetProperty("truncated").GetBoolean().ShouldBeTrue();
+        await foreach (ExportFragment _ in sut.ExportAsync(Ctx(userId), TestContext.Current.CancellationToken)) { }
+
+        capturedDto.ShouldNotBeNull();
+        capturedDto!.Truncated.ShouldBeTrue();
+        capturedDto.Limit.ShouldBe(AuditingPrivacyDataProvider.AuditExportLimit);
     }
 }
-#endif

--- a/tests/Granit.Auditing.Privacy.Tests/DataExport/AuditingPrivacyDataProviderTests.cs
+++ b/tests/Granit.Auditing.Privacy.Tests/DataExport/AuditingPrivacyDataProviderTests.cs
@@ -1,3 +1,22 @@
+// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
+// invalidates the call sites below. Tests are preserved for reference and
+// will be rewritten under P6.2 (#2313).
+//
+// To re-enable while migrating: drop the #if FALSE wrapper and update each
+// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
+// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
+
+using Xunit;
+
+namespace Granit.Auditing.Privacy.Tests.DataExport;
+
+public class AuditingPrivacyDataProviderTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using System.Text.Json;
 using Granit.Auditing.Domain;
 using Granit.Auditing.Privacy.DataExport;
@@ -93,3 +112,4 @@ public sealed class AuditingPrivacyDataProviderTests
         doc.RootElement.GetProperty("truncated").GetBoolean().ShouldBeTrue();
     }
 }
+#endif

--- a/tests/Granit.Identity.Federated.Privacy.Tests/DataExport/IdentityFederatedPrivacyDataProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/DataExport/IdentityFederatedPrivacyDataProviderTests.cs
@@ -1,26 +1,10 @@
-// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
-// invalidates the call sites below. Tests are preserved for reference and
-// will be rewritten under P6.2 (#2313).
-//
-// To re-enable while migrating: drop the #if FALSE wrapper and update each
-// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
-// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
-
-using Xunit;
-
-namespace Granit.Identity.Federated.Privacy.Tests.DataExport;
-
-public class IdentityFederatedPrivacyDataProviderTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
-using System.Text.Json;
+using Granit.Domain.ValueObjects;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Privacy.DataExport;
 using Granit.MultiTenancy;
+using Granit.Privacy.BlobStorage;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -31,35 +15,92 @@ public sealed class IdentityFederatedPrivacyDataProviderTests
 {
     private readonly IFederatedUserCacheReader _reader = Substitute.For<IFederatedUserCacheReader>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly IStagedFragmentBuilder _builder = Substitute.For<IStagedFragmentBuilder>();
 
-    private IdentityFederatedPrivacyDataProvider Sut() => new(_reader, _currentTenant);
+    private IdentityFederatedPrivacyDataProvider Sut() => new(_reader, _currentTenant, _builder);
+
+    private static PrivacyExportContext Ctx(Guid? subjectUserId = null) =>
+        new(
+            RequestId: Guid.NewGuid(),
+            SubjectUserId: subjectUserId ?? Guid.NewGuid(),
+            CallerUserId: subjectUserId ?? Guid.NewGuid(),
+            TenantId: null,
+            Regulation: "EU_GDPR");
+
+    private static StagedExportFragment StubFragment() =>
+        new()
+        {
+            EntryPath = "identity-federated.json",
+            ContentType = "application/json",
+            IntegrityTag = "v1:stub",
+            StagedBlob = BlobReference.Create(Guid.NewGuid().ToString()),
+        };
 
     [Fact]
     public void ProviderName_Is_IdentityFederated() =>
         IdentityFederatedPrivacyDataProvider.ProviderName.ShouldBe("identity-federated");
 
     [Fact]
-    public void ContentType_IsApplicationJson() =>
-        IdentityFederatedPrivacyDataProvider.ContentType.ShouldBe("application/json");
+    public void DisplayKey_TargetsScopeSelectorLocKey() =>
+        IdentityFederatedPrivacyDataProvider.DisplayKey.ShouldBe("Privacy.Scopes.IdentityFederated");
 
     [Fact]
-    public void FileName_IsStable() =>
-        IdentityFederatedPrivacyDataProvider.FileName(Guid.NewGuid()).ShouldBe("identity-federated.json");
+    public void FeatureName_IsNull_AlwaysVisible() =>
+        IdentityFederatedPrivacyDataProvider.FeatureName.ShouldBeNull();
 
     [Fact]
-    public async Task ExportAsync_UserNotCached_ReturnsEmpty()
+    public async Task HasDataAsync_ReturnsTrue_WhenCacheReaderFindsEntry()
+    {
+        var userId = Guid.NewGuid();
+        _currentTenant.IsAvailable.Returns(false);
+        _reader.FindByExternalIdAsync(userId.ToString(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(new FederatedIdentity
+            {
+                Id = Guid.NewGuid(),
+                ExternalUserId = userId.ToString(),
+                Enabled = true,
+                LastSyncedAt = DateTimeOffset.UtcNow,
+                CreatedAt = DateTimeOffset.UtcNow,
+                CreatedBy = "system",
+            });
+
+        bool has = await Sut().HasDataAsync(Ctx(userId), TestContext.Current.CancellationToken);
+
+        has.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task HasDataAsync_ReturnsFalse_WhenCacheReaderMisses()
     {
         _currentTenant.IsAvailable.Returns(false);
         _reader.FindByExternalIdAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
             .Returns((FederatedIdentity?)null);
 
-        ReadOnlyMemory<byte> result = await Sut().ExportAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+        bool has = await Sut().HasDataAsync(Ctx(), TestContext.Current.CancellationToken);
 
-        result.IsEmpty.ShouldBeTrue();
+        has.ShouldBeFalse();
     }
 
     [Fact]
-    public async Task ExportAsync_KnownUser_ReturnsJsonWithCacheEntry()
+    public async Task ExportAsync_UserNotCached_YieldsNothing()
+    {
+        _currentTenant.IsAvailable.Returns(false);
+        _reader.FindByExternalIdAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns((FederatedIdentity?)null);
+
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in Sut().ExportAsync(Ctx(), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
+
+        fragments.ShouldBeEmpty();
+        await _builder.DidNotReceive().BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExportAsync_KnownUser_BuildsDtoFromCacheEntry_AndYieldsFragment()
     {
         var userId = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
@@ -83,14 +124,27 @@ public sealed class IdentityFederatedPrivacyDataProviderTests
         _reader.FindByExternalIdAsync(userId.ToString(), tenantId, Arg.Any<CancellationToken>())
             .Returns(entry);
 
-        ReadOnlyMemory<byte> result = await Sut().ExportAsync(userId, TestContext.Current.CancellationToken);
+        IdentityFederatedExportResponse? capturedDto = null;
+        _builder.BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(),
+            IdentityFederatedPrivacyDataProvider.ProviderName,
+            "identity-federated.json",
+            Arg.Do<IdentityFederatedExportResponse>(d => capturedDto = d),
+            Arg.Any<CancellationToken>())
+            .Returns(StubFragment());
 
-        result.IsEmpty.ShouldBeFalse();
-        using var doc = JsonDocument.Parse(result);
-        doc.RootElement.GetProperty("externalUserId").GetString().ShouldBe(userId.ToString());
-        doc.RootElement.GetProperty("email").GetString().ShouldBe("alice@example.com");
-        doc.RootElement.GetProperty("enabled").GetBoolean().ShouldBeTrue();
-        doc.RootElement.GetProperty("tenantId").GetGuid().ShouldBe(tenantId);
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in Sut().ExportAsync(Ctx(userId), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
+
+        fragments.Count.ShouldBe(1);
+        fragments[0].ShouldBeOfType<StagedExportFragment>();
+        capturedDto.ShouldNotBeNull();
+        capturedDto!.ExternalUserId.ShouldBe(userId.ToString());
+        capturedDto.Email.ShouldBe("alice@example.com");
+        capturedDto.Enabled.ShouldBeTrue();
+        capturedDto.TenantId.ShouldBe(tenantId);
     }
 }
-#endif

--- a/tests/Granit.Identity.Federated.Privacy.Tests/DataExport/IdentityFederatedPrivacyDataProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/DataExport/IdentityFederatedPrivacyDataProviderTests.cs
@@ -1,3 +1,22 @@
+// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
+// invalidates the call sites below. Tests are preserved for reference and
+// will be rewritten under P6.2 (#2313).
+//
+// To re-enable while migrating: drop the #if FALSE wrapper and update each
+// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
+// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
+
+using Xunit;
+
+namespace Granit.Identity.Federated.Privacy.Tests.DataExport;
+
+public class IdentityFederatedPrivacyDataProviderTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using System.Text.Json;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Privacy.DataExport;
@@ -74,3 +93,4 @@ public sealed class IdentityFederatedPrivacyDataProviderTests
         doc.RootElement.GetProperty("tenantId").GetGuid().ShouldBe(tenantId);
     }
 }
+#endif

--- a/tests/Granit.Identity.Local.Privacy.Tests/DataExport/IdentityLocalPrivacyDataProviderTests.cs
+++ b/tests/Granit.Identity.Local.Privacy.Tests/DataExport/IdentityLocalPrivacyDataProviderTests.cs
@@ -1,3 +1,22 @@
+// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
+// invalidates the call sites below. Tests are preserved for reference and
+// will be rewritten under P6.2 (#2313).
+//
+// To re-enable while migrating: drop the #if FALSE wrapper and update each
+// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
+// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
+
+using Xunit;
+
+namespace Granit.Identity.Local.Privacy.Tests.DataExport;
+
+public class IdentityLocalPrivacyDataProviderTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using System.Text.Json;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Privacy.DataExport;
@@ -78,3 +97,4 @@ public sealed class IdentityLocalPrivacyDataProviderTests
             .Select(e => e.GetString()).ShouldBe(["Admin", "User"]);
     }
 }
+#endif

--- a/tests/Granit.Identity.Local.Privacy.Tests/DataExport/IdentityLocalPrivacyDataProviderTests.cs
+++ b/tests/Granit.Identity.Local.Privacy.Tests/DataExport/IdentityLocalPrivacyDataProviderTests.cs
@@ -1,25 +1,9 @@
-// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
-// invalidates the call sites below. Tests are preserved for reference and
-// will be rewritten under P6.2 (#2313).
-//
-// To re-enable while migrating: drop the #if FALSE wrapper and update each
-// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
-// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
-
-using Xunit;
-
-namespace Granit.Identity.Local.Privacy.Tests.DataExport;
-
-public class IdentityLocalPrivacyDataProviderTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
-using System.Text.Json;
+using Granit.Domain.ValueObjects;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Privacy.DataExport;
+using Granit.Privacy.BlobStorage;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
 using Shouldly;
@@ -29,40 +13,92 @@ namespace Granit.Identity.Local.Privacy.Tests.DataExport;
 
 public sealed class IdentityLocalPrivacyDataProviderTests
 {
+    private readonly IStagedFragmentBuilder _builder = Substitute.For<IStagedFragmentBuilder>();
+
     private static UserManager<LocalIdentity> CreateUserManager(IUserStore<LocalIdentity> store) =>
         Substitute.For<UserManager<LocalIdentity>>(store, null, null, null, null, null, null, null, null);
+
+    private static PrivacyExportContext Ctx(Guid? subjectUserId = null) =>
+        new(
+            RequestId: Guid.NewGuid(),
+            SubjectUserId: subjectUserId ?? Guid.NewGuid(),
+            CallerUserId: subjectUserId ?? Guid.NewGuid(),
+            TenantId: null,
+            Regulation: "EU_GDPR");
+
+    private static StagedExportFragment StubFragment() =>
+        new()
+        {
+            EntryPath = "identity-local.json",
+            ContentType = "application/json",
+            IntegrityTag = "v1:stub",
+            StagedBlob = BlobReference.Create(Guid.NewGuid().ToString()),
+        };
 
     [Fact]
     public void ProviderName_Is_IdentityLocal() =>
         IdentityLocalPrivacyDataProvider.ProviderName.ShouldBe("identity-local");
 
     [Fact]
-    public void ContentType_IsApplicationJson() =>
-        IdentityLocalPrivacyDataProvider.ContentType.ShouldBe("application/json");
+    public void DisplayKey_TargetsScopeSelectorLocKey() =>
+        IdentityLocalPrivacyDataProvider.DisplayKey.ShouldBe("Privacy.Scopes.IdentityLocal");
 
     [Fact]
-    public void FileName_IsStableAcrossRequests()
-    {
-        IdentityLocalPrivacyDataProvider.FileName(Guid.NewGuid())
-            .ShouldBe("identity-local.json");
-    }
+    public void FeatureName_IsNull_AlwaysVisible() =>
+        IdentityLocalPrivacyDataProvider.FeatureName.ShouldBeNull();
 
     [Fact]
-    public async Task ExportAsync_UnknownUser_ReturnsEmpty()
+    public async Task HasDataAsync_ReturnsFalse_WhenUserNotFound()
     {
         IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
         UserManager<LocalIdentity> userManager = CreateUserManager(store);
         userManager.FindByIdAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
 
-        IdentityLocalPrivacyDataProvider sut = new(userManager);
+        IdentityLocalPrivacyDataProvider sut = new(userManager, _builder);
 
-        ReadOnlyMemory<byte> result = await sut.ExportAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+        bool has = await sut.HasDataAsync(Ctx(), TestContext.Current.CancellationToken);
 
-        result.IsEmpty.ShouldBeTrue();
+        has.ShouldBeFalse();
     }
 
     [Fact]
-    public async Task ExportAsync_KnownUser_ReturnsJsonWithProfileAndRoles()
+    public async Task HasDataAsync_ReturnsTrue_WhenUserExists()
+    {
+        var userId = Guid.NewGuid();
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        UserManager<LocalIdentity> userManager = CreateUserManager(store);
+        userManager.FindByIdAsync(userId.ToString())
+            .Returns(new LocalIdentity { Id = userId, UserName = "alice", CreatedBy = "system" });
+
+        IdentityLocalPrivacyDataProvider sut = new(userManager, _builder);
+
+        bool has = await sut.HasDataAsync(Ctx(userId), TestContext.Current.CancellationToken);
+
+        has.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExportAsync_UnknownUser_YieldsNothing()
+    {
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        UserManager<LocalIdentity> userManager = CreateUserManager(store);
+        userManager.FindByIdAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
+
+        IdentityLocalPrivacyDataProvider sut = new(userManager, _builder);
+
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in sut.ExportAsync(Ctx(), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
+
+        fragments.ShouldBeEmpty();
+        await _builder.DidNotReceive().BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExportAsync_KnownUser_BuildsDtoAndYieldsOneFragment()
     {
         var userId = Guid.NewGuid();
         LocalIdentity user = new()
@@ -83,18 +119,29 @@ public sealed class IdentityLocalPrivacyDataProviderTests
         userManager.FindByIdAsync(userId.ToString()).Returns(user);
         userManager.GetRolesAsync(user).Returns<IList<string>>(["Admin", "User"]);
 
-        IdentityLocalPrivacyDataProvider sut = new(userManager);
+        IdentityLocalExportResponse? capturedDto = null;
+        _builder.BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(),
+            IdentityLocalPrivacyDataProvider.ProviderName,
+            "identity-local.json",
+            Arg.Do<IdentityLocalExportResponse>(d => capturedDto = d),
+            Arg.Any<CancellationToken>())
+            .Returns(StubFragment());
 
-        ReadOnlyMemory<byte> result = await sut.ExportAsync(userId, TestContext.Current.CancellationToken);
+        IdentityLocalPrivacyDataProvider sut = new(userManager, _builder);
 
-        result.IsEmpty.ShouldBeFalse();
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in sut.ExportAsync(Ctx(userId), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
 
-        using var doc = JsonDocument.Parse(result);
-        doc.RootElement.GetProperty("id").GetGuid().ShouldBe(userId);
-        doc.RootElement.GetProperty("email").GetString().ShouldBe("alice@example.com");
-        doc.RootElement.GetProperty("firstName").GetString().ShouldBe("Alice");
-        doc.RootElement.GetProperty("roles").EnumerateArray()
-            .Select(e => e.GetString()).ShouldBe(["Admin", "User"]);
+        fragments.Count.ShouldBe(1);
+        fragments[0].ShouldBeOfType<StagedExportFragment>();
+        capturedDto.ShouldNotBeNull();
+        capturedDto!.Id.ShouldBe(userId);
+        capturedDto.Email.ShouldBe("alice@example.com");
+        capturedDto.FirstName.ShouldBe("Alice");
+        capturedDto.Roles.ShouldBe(["Admin", "User"]);
     }
 }
-#endif

--- a/tests/Granit.Notifications.Privacy.Tests/DataExport/NotificationsPrivacyDataProviderTests.cs
+++ b/tests/Granit.Notifications.Privacy.Tests/DataExport/NotificationsPrivacyDataProviderTests.cs
@@ -1,8 +1,12 @@
 using System.Text.Json;
+using Granit.Domain.ValueObjects;
 using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
 using Granit.Notifications.Privacy.DataExport;
+using Granit.Privacy.BlobStorage;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Fragments;
 using Granit.QueryEngine;
 using NSubstitute;
 using Shouldly;
@@ -16,41 +20,101 @@ public sealed class NotificationsPrivacyDataProviderTests
     private readonly INotificationPreferenceReader _preferenceReader = Substitute.For<INotificationPreferenceReader>();
     private readonly INotificationSubscriptionReader _subscriptionReader = Substitute.For<INotificationSubscriptionReader>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly IStagedFragmentBuilder _builder = Substitute.For<IStagedFragmentBuilder>();
 
     private NotificationsPrivacyDataProvider Sut() =>
-        new(_notificationReader, _preferenceReader, _subscriptionReader, _currentTenant);
+        new(_notificationReader, _preferenceReader, _subscriptionReader, _currentTenant, _builder);
+
+    private static PrivacyExportContext Ctx(Guid? subjectUserId = null) =>
+        new(
+            RequestId: Guid.NewGuid(),
+            SubjectUserId: subjectUserId ?? Guid.NewGuid(),
+            CallerUserId: subjectUserId ?? Guid.NewGuid(),
+            TenantId: null,
+            Regulation: "EU_GDPR");
+
+    private static StagedExportFragment StubFragment() =>
+        new()
+        {
+            EntryPath = "notifications.json",
+            ContentType = "application/json",
+            IntegrityTag = "v1:stub",
+            StagedBlob = BlobReference.Create(Guid.NewGuid().ToString()),
+        };
+
+    private void StubEmptyReaders()
+    {
+        _notificationReader.GetListAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<UserNotification>([], 0, HasMore: false));
+        _preferenceReader.GetListAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<NotificationPreference>)[]);
+        _subscriptionReader.GetUserSubscriptionsAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<NotificationSubscription>)[]);
+    }
 
     [Fact]
     public void ProviderName_Is_Notifications() =>
         NotificationsPrivacyDataProvider.ProviderName.ShouldBe("notifications");
 
     [Fact]
-    public void ContentType_IsApplicationJson() =>
-        NotificationsPrivacyDataProvider.ContentType.ShouldBe("application/json");
+    public void DisplayKey_TargetsScopeSelectorLocKey() =>
+        NotificationsPrivacyDataProvider.DisplayKey.ShouldBe("Privacy.Scopes.Notifications");
 
     [Fact]
-    public void FileName_IsStable() =>
-        NotificationsPrivacyDataProvider.FileName(Guid.NewGuid()).ShouldBe("notifications.json");
+    public void FeatureName_IsNull_AlwaysVisible() =>
+        NotificationsPrivacyDataProvider.FeatureName.ShouldBeNull();
 
     [Fact]
-    public async Task ExportAsync_NoData_ReturnsEmpty()
+    public async Task HasDataAsync_ReturnsFalse_WhenNothingPresent()
     {
         _currentTenant.IsAvailable.Returns(false);
-        _notificationReader.GetListAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new PagedResult<UserNotification>([], 0, HasMore: false));
-        _preferenceReader.GetListAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<NotificationPreference>)[]);
-        _subscriptionReader.GetUserSubscriptionsAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<NotificationSubscription>)[]);
+        StubEmptyReaders();
 
-        ReadOnlyMemory<byte> result = await Sut().ExportAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+        bool has = await Sut().HasDataAsync(Ctx(), TestContext.Current.CancellationToken);
 
-        result.IsEmpty.ShouldBeTrue();
+        has.ShouldBeFalse();
     }
 
     [Fact]
-    public async Task ExportAsync_WithInboxAndPreferences_ReturnsJsonPayload()
+    public async Task HasDataAsync_ReturnsTrue_WhenInboxHasAnyItem()
+    {
+        var userId = Guid.NewGuid();
+        _currentTenant.IsAvailable.Returns(false);
+        var notification = UserNotification.Create(
+            id: Guid.NewGuid(),
+            notificationId: Guid.NewGuid(),
+            notificationTypeName: "welcome",
+            severity: NotificationSeverity.Info,
+            recipientUserId: userId.ToString(),
+            data: JsonDocument.Parse("{}").RootElement,
+            createdAt: DateTimeOffset.UtcNow);
+        _notificationReader.GetListAsync(userId.ToString(), null, page: 1, pageSize: 1, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<UserNotification>([notification], 1, HasMore: false));
+
+        bool has = await Sut().HasDataAsync(Ctx(userId), TestContext.Current.CancellationToken);
+
+        has.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExportAsync_NoData_YieldsNothing()
+    {
+        _currentTenant.IsAvailable.Returns(false);
+        StubEmptyReaders();
+
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in Sut().ExportAsync(Ctx(), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
+
+        fragments.ShouldBeEmpty();
+        await _builder.DidNotReceive().BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExportAsync_WithInbox_HandsDtoToBuilder_AndYieldsFragment()
     {
         var userId = Guid.NewGuid();
         _currentTenant.IsAvailable.Returns(false);
@@ -71,14 +135,27 @@ public sealed class NotificationsPrivacyDataProviderTests
         _subscriptionReader.GetUserSubscriptionsAsync(userId.ToString(), null, Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<NotificationSubscription>)[]);
 
-        ReadOnlyMemory<byte> result = await Sut().ExportAsync(userId, TestContext.Current.CancellationToken);
+        NotificationsExportDto? capturedDto = null;
+        _builder.BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(),
+            NotificationsPrivacyDataProvider.ProviderName,
+            "notifications.json",
+            Arg.Do<NotificationsExportDto>(d => capturedDto = d),
+            Arg.Any<CancellationToken>())
+            .Returns(StubFragment());
 
-        result.IsEmpty.ShouldBeFalse();
-        using var doc = JsonDocument.Parse(result);
-        doc.RootElement.GetProperty("userId").GetGuid().ShouldBe(userId);
-        doc.RootElement.GetProperty("inboxTruncated").GetBoolean().ShouldBeFalse();
-        doc.RootElement.GetProperty("inbox").GetArrayLength().ShouldBe(1);
-        doc.RootElement.GetProperty("inbox")[0]
-            .GetProperty("notificationTypeName").GetString().ShouldBe("welcome");
+        List<ExportFragment> fragments = [];
+        await foreach (ExportFragment f in Sut().ExportAsync(Ctx(userId), TestContext.Current.CancellationToken))
+        {
+            fragments.Add(f);
+        }
+
+        fragments.Count.ShouldBe(1);
+        fragments[0].ShouldBeOfType<StagedExportFragment>();
+        capturedDto.ShouldNotBeNull();
+        capturedDto!.UserId.ShouldBe(userId);
+        capturedDto.InboxTruncated.ShouldBeFalse();
+        capturedDto.Inbox.Count.ShouldBe(1);
+        capturedDto.Inbox[0].NotificationTypeName.ShouldBe("welcome");
     }
 }

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/ExportArchiveAssemblyHandlerTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/ExportArchiveAssemblyHandlerTests.cs
@@ -1,3 +1,18 @@
+// PR-1b breaking migration: ReceivedFragment shape changed (8 args, FragmentKind +
+// SourceContainer + EntryPath + IntegrityTag added). Tests preserved for reference
+// and to be rewritten under P6.2 (#2313).
+
+using Xunit;
+
+namespace Granit.Privacy.BlobStorage.Tests.DataExport;
+
+public class ExportArchiveAssemblyHandlerTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using System.Diagnostics.Metrics;
 using System.IO.Compression;
 using System.Text.Json;
@@ -340,3 +355,4 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
             cancellationToken))!;
     }
 }
+#endif

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/ExportArchiveAssemblyHandlerTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/ExportArchiveAssemblyHandlerTests.cs
@@ -1,24 +1,10 @@
-// PR-1b breaking migration: ReceivedFragment shape changed (8 args, FragmentKind +
-// SourceContainer + EntryPath + IntegrityTag added). Tests preserved for reference
-// and to be rewritten under P6.2 (#2313).
-
-using Xunit;
-
-namespace Granit.Privacy.BlobStorage.Tests.DataExport;
-
-public class ExportArchiveAssemblyHandlerTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
 using System.Diagnostics.Metrics;
 using System.IO.Compression;
 using System.Text.Json;
 using Granit.BlobStorage;
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Options;
+using Granit.Domain.ValueObjects;
 using Granit.IO;
 using Granit.IO.Extensions;
 using Granit.Privacy.BlobStorage.DataExport;
@@ -81,6 +67,27 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
             catch (IOException) { /* best-effort */ }
         }
     }
+
+    // Convenience factory — produces ReceivedFragment values in the Takeout-style shape.
+    private static ReceivedFragment StagedFragment(string providerName, Guid blobId, string entryPath, string contentType = "application/json") =>
+        new(
+            ProviderName: providerName,
+            FragmentKind: "staged",
+            SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+            BlobReferenceId: BlobReference.Create(blobId.ToString()),
+            EntryPath: entryPath,
+            ContentType: contentType,
+            IntegrityTag: "v1:test");
+
+    private static ReceivedFragment EmptyFragment(string providerName, Guid requestId) =>
+        new(
+            ProviderName: providerName,
+            FragmentKind: "empty",
+            SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+            BlobReferenceId: BlobReference.Create($"{PrivacyExportContainerNames.EmptyFragmentPrefix}{requestId}"),
+            EntryPath: $"{providerName}.empty",
+            ContentType: "application/octet-stream",
+            IntegrityTag: string.Empty);
 
     private ExportArchiveAssemblyHandler CreateHandler(GranitPrivacyOptions? opts = null) =>
         new(
@@ -150,13 +157,13 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
         Guid archiveBlobId = SetupArchiveUpload();
 
         ExportCompletedEto evt = new(
-            requestId, userId, $"personal-data-export/{requestId}",
+            requestId, userId, BlobReference.Create($"personal-data-export/{requestId}"),
             IsPartial: false,
             MissingProviders: [],
             Fragments:
             [
-                new ReceivedFragment("identity", blobA.ToString(), "application/json"),
-                new ReceivedFragment("auditing", blobB.ToString(), "application/json"),
+                StagedFragment("identity", blobA, "identity.json"),
+                StagedFragment("auditing", blobB, "audit.json"),
             ],
             Regulation: "EU_GDPR",
             RequestedAt: RequestedAt);
@@ -175,11 +182,13 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
             archiveBlobId,
             Arg.Any<CancellationToken>());
 
-        // Verify the assembled ZIP contains both fragments + manifest.json
+        // Verify the assembled ZIP contains both fragments (using their EntryPath) + manifest.json
         byte[] zipBytes = _http.CapturedUploads.Single().Body;
         using MemoryStream ms = new(zipBytes);
         using ZipArchive zip = new(ms, ZipArchiveMode.Read);
         zip.Entries.Select(e => e.Name).ShouldContain("manifest.json");
+        zip.Entries.Select(e => e.FullName).ShouldContain("identity.json");
+        zip.Entries.Select(e => e.FullName).ShouldContain("audit.json");
         zip.Entries.Count.ShouldBe(3);
 
         ExportManifest manifest = await ReadManifest(zip, TestContext.Current.CancellationToken);
@@ -203,15 +212,14 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
         SetupFragmentDownload(blobA, "identity.json", "application/json", """{"id":"u1"}"""u8.ToArray());
         SetupArchiveUpload();
 
-        string emptySentinel = $"{PrivacyExportContainerNames.EmptyFragmentPrefix}{requestId}";
         ExportCompletedEto evt = new(
-            requestId, userId, $"personal-data-export/{requestId}",
+            requestId, userId, BlobReference.Create($"personal-data-export/{requestId}"),
             IsPartial: false,
             MissingProviders: [],
             Fragments:
             [
-                new ReceivedFragment("identity", blobA.ToString(), "application/json"),
-                new ReceivedFragment("notifications", emptySentinel, "application/json"),
+                StagedFragment("identity", blobA, "identity.json"),
+                EmptyFragment("notifications", requestId),
             ],
             Regulation: "EU_GDPR",
             RequestedAt: RequestedAt);
@@ -246,10 +254,10 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
         SetupArchiveUpload();
 
         ExportCompletedEto evt = new(
-            requestId, Guid.NewGuid(), $"personal-data-export/{requestId}",
+            requestId, Guid.NewGuid(), BlobReference.Create($"personal-data-export/{requestId}"),
             IsPartial: true,
             MissingProviders: ["auditing"],
-            Fragments: [new ReceivedFragment("identity", blobA.ToString(), "application/json")],
+            Fragments: [StagedFragment("identity", blobA, "identity.json")],
             Regulation: "EU_GDPR",
             RequestedAt: RequestedAt);
 
@@ -258,7 +266,7 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
         await _tracker.Received(1).MarkCompletedAsync(
             requestId,
             ExportRequestState.PartiallyCompleted,
-            Arg.Any<Granit.Domain.ValueObjects.BlobReference?>(),
+            Arg.Any<BlobReference?>(),
             Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "auditing"),
             Arg.Any<CancellationToken>());
     }
@@ -274,10 +282,10 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
         SetupFragmentDownload(blobA, "identity.json", "application/json", payload);
 
         ExportCompletedEto evt = new(
-            requestId, Guid.NewGuid(), $"personal-data-export/{requestId}",
+            requestId, Guid.NewGuid(), BlobReference.Create($"personal-data-export/{requestId}"),
             IsPartial: false,
             MissingProviders: [],
-            Fragments: [new ReceivedFragment("identity", blobA.ToString(), "application/json")],
+            Fragments: [StagedFragment("identity", blobA, "identity.json")],
             Regulation: "EU_GDPR",
             RequestedAt: RequestedAt);
 
@@ -305,10 +313,10 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
         SetupArchiveUpload();
 
         ExportCompletedEto evt = new(
-            requestId, Guid.NewGuid(), $"personal-data-export/{requestId}",
+            requestId, Guid.NewGuid(), BlobReference.Create($"personal-data-export/{requestId}"),
             IsPartial: false,
             MissingProviders: [],
-            Fragments: [new ReceivedFragment("identity", blobA.ToString(), "application/json")],
+            Fragments: [StagedFragment("identity", blobA, "identity.json")],
             Regulation: "EU_GDPR",
             RequestedAt: RequestedAt);
 
@@ -331,10 +339,10 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
         SetupArchiveUpload();
 
         ExportCompletedEto evt = new(
-            requestId, Guid.NewGuid(), $"personal-data-export/{requestId}",
+            requestId, Guid.NewGuid(), BlobReference.Create($"personal-data-export/{requestId}"),
             IsPartial: false,
             MissingProviders: [],
-            Fragments: [new ReceivedFragment("identity", blobA.ToString(), "application/json")],
+            Fragments: [StagedFragment("identity", blobA, "identity.json")],
             Regulation: "EU_GDPR",
             RequestedAt: RequestedAt);
 
@@ -355,4 +363,3 @@ public sealed class ExportArchiveAssemblyHandlerTests : IDisposable
             cancellationToken))!;
     }
 }
-#endif

--- a/tests/Granit.Privacy.BlobStorage.Tests/PrivacyFragmentUploaderTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/PrivacyFragmentUploaderTests.cs
@@ -1,127 +1,157 @@
-// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
-// invalidates the call sites below. Tests are preserved for reference and
-// will be rewritten under P6.2 (#2313).
-//
-// To re-enable while migrating: drop the #if FALSE wrapper and update each
-// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
-// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
-
-using Xunit;
-
-namespace Granit.Privacy.BlobStorage.Tests;
-
-public class PrivacyFragmentUploaderTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
-using Granit.BlobStorage;
+using System.Runtime.CompilerServices;
+using Granit.Domain.ValueObjects;
 using Granit.Events;
-using Granit.Privacy.BlobStorage.Tests.DataExport;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.DataExport.Fragments;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using Shouldly;
 using Xunit;
 
 namespace Granit.Privacy.BlobStorage.Tests;
 
-public sealed class PrivacyFragmentUploaderTests : IDisposable
+public sealed class PrivacyFragmentUploaderTests
 {
-    private readonly IBlobStorage _blobStorage = Substitute.For<IBlobStorage>();
     private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
-    private readonly FakeHttpMessageHandler _http = new();
-
-    public void Dispose() => _http.Dispose();
 
     private PrivacyFragmentUploader CreateSut() =>
-        new(_blobStorage, new FakeHttpClientFactory(_http), _eventBus,
-            NullLogger<PrivacyFragmentUploader>.Instance);
+        new(_eventBus, NullLogger<PrivacyFragmentUploader>.Instance);
 
     [Fact]
-    public async Task UploadAsync_EmptyPayload_PublishesEmptySentinel_AndSkipsBlobCalls()
+    public async Task UploadAsync_ProviderYieldsNothing_PublishesEmptySentinel()
     {
         var requestId = Guid.NewGuid();
         var userId = Guid.NewGuid();
         PersonalDataRequestedEto request = new(requestId, userId, DateTimeOffset.UtcNow, "EU_GDPR");
 
-        StubProvider provider = new(payload: ReadOnlyMemory<byte>.Empty);
+        StubProvider provider = new(fragments: []);
 
         await CreateSut().UploadAsync(request, provider, TestContext.Current.CancellationToken);
 
-        await _blobStorage.DidNotReceive().InitiateUploadAsync(
-            Arg.Any<string>(), Arg.Any<BlobUploadRequest>(), Arg.Any<CancellationToken>());
         await _eventBus.Received(1).PublishAsync(
             Arg.Is<PersonalDataPreparedEto>(e =>
                 e.RequestId == requestId &&
                 e.ProviderName == StubProvider.Name &&
-                e.BlobReferenceId == $"{PrivacyExportContainerNames.EmptyFragmentPrefix}{requestId}" &&
-                e.ContentType == StubProvider.Content),
+                e.FragmentKind == PrivacyFragmentUploader.EmptyFragmentKind &&
+                e.BlobReferenceId.Value == $"{PrivacyExportContainerNames.EmptyFragmentPrefix}{requestId}"),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task UploadAsync_WithPayload_RunsPresignedDance_AndPublishesPreparedEto()
+    public async Task UploadAsync_StagedFragment_PublishesPreparedEto_WithBuilderProvidedData()
     {
         var requestId = Guid.NewGuid();
         var userId = Guid.NewGuid();
         PersonalDataRequestedEto request = new(requestId, userId, DateTimeOffset.UtcNow, "EU_GDPR");
 
         var blobId = Guid.NewGuid();
-        Uri uploadUri = new("https://s3.example/upload/fragment");
-        _blobStorage.InitiateUploadAsync(
-            PrivacyExportContainerNames.FragmentContainer,
-            Arg.Any<BlobUploadRequest>(),
-            Arg.Any<CancellationToken>())
-            .Returns(new PresignedUploadTicket(
-                blobId, uploadUri, "PUT", DateTimeOffset.UtcNow.AddMinutes(15),
-                new Dictionary<string, string> { ["x-amz-server-side-encryption"] = "AES256" }));
-
-        _http.MapPut(uploadUri);
-
-        StubProvider provider = new(payload: new byte[] { 1, 2, 3, 4 });
+        StagedExportFragment fragment = new()
+        {
+            EntryPath = "stub.json",
+            ContentType = "application/json",
+            KnownSizeBytes = 42,
+            IntegrityTag = "v1:builder-signed",
+            StagedBlob = BlobReference.Create(blobId.ToString()),
+        };
+        StubProvider provider = new(fragments: [fragment]);
 
         await CreateSut().UploadAsync(request, provider, TestContext.Current.CancellationToken);
-
-        await _blobStorage.Received(1).InitiateUploadAsync(
-            PrivacyExportContainerNames.FragmentContainer,
-            Arg.Is<BlobUploadRequest>(r =>
-                r.FileName == StubProvider.FileNameFor(requestId) &&
-                r.ContentType == StubProvider.Content &&
-                r.MaxAllowedBytes == 4),
-            Arg.Any<CancellationToken>());
-
-        _http.CapturedUploads.Count.ShouldBe(1);
-        _http.CapturedUploads[0].Url.ShouldBe(uploadUri);
-        _http.CapturedUploads[0].Body.ShouldBe([1, 2, 3, 4]);
-
-        await _blobStorage.Received(1).ConfirmUploadAsync(
-            PrivacyExportContainerNames.FragmentContainer, blobId, Arg.Any<CancellationToken>());
 
         await _eventBus.Received(1).PublishAsync(
             Arg.Is<PersonalDataPreparedEto>(e =>
                 e.RequestId == requestId &&
                 e.ProviderName == StubProvider.Name &&
-                e.BlobReferenceId == blobId.ToString() &&
-                e.ContentType == StubProvider.Content),
+                e.FragmentKind == PrivacyFragmentUploader.StagedFragmentKind &&
+                e.SourceContainer == PrivacyExportContainerNames.FragmentContainer &&
+                e.BlobReferenceId.Value == blobId.ToString() &&
+                e.EntryPath == "stub.json" &&
+                e.ContentType == "application/json" &&
+                e.IntegrityTag == "v1:builder-signed"),
             Arg.Any<CancellationToken>());
     }
 
-    private sealed class StubProvider(ReadOnlyMemory<byte> payload) : IPrivacyDataProvider
+    [Fact]
+    public async Task UploadAsync_PassThroughFragment_PublishesPreparedEto_WithSourceBlobReference()
+    {
+        var requestId = Guid.NewGuid();
+        PersonalDataRequestedEto request = new(requestId, Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
+
+        var sourceBlob = BlobReference.Create(Guid.NewGuid().ToString());
+        PassThroughExportFragment fragment = new()
+        {
+            EntryPath = "Documents/2024/foo.pdf",
+            ContentType = "application/pdf",
+            KnownSizeBytes = 1024,
+            IntegrityTag = "v1:passthrough-signed",
+            SourceBlob = sourceBlob,
+        };
+        StubProvider provider = new(fragments: [fragment]);
+
+        await CreateSut().UploadAsync(request, provider, TestContext.Current.CancellationToken);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<PersonalDataPreparedEto>(e =>
+                e.FragmentKind == PrivacyFragmentUploader.PassThroughFragmentKind &&
+                e.BlobReferenceId == sourceBlob &&
+                e.EntryPath == "Documents/2024/foo.pdf" &&
+                e.ContentType == "application/pdf" &&
+                e.IntegrityTag == "v1:passthrough-signed"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadAsync_MultipleFragments_PublishesOneEventPerFragment()
+    {
+        var requestId = Guid.NewGuid();
+        PersonalDataRequestedEto request = new(requestId, Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
+
+        StagedExportFragment a = new()
+        {
+            EntryPath = "a.json",
+            ContentType = "application/json",
+            IntegrityTag = "v1:a",
+            StagedBlob = BlobReference.Create(Guid.NewGuid().ToString()),
+        };
+        StagedExportFragment b = new()
+        {
+            EntryPath = "b.json",
+            ContentType = "application/json",
+            IntegrityTag = "v1:b",
+            StagedBlob = BlobReference.Create(Guid.NewGuid().ToString()),
+        };
+        StubProvider provider = new(fragments: [a, b]);
+
+        await CreateSut().UploadAsync(request, provider, TestContext.Current.CancellationToken);
+
+        await _eventBus.Received(2).PublishAsync(
+            Arg.Any<PersonalDataPreparedEto>(),
+            Arg.Any<CancellationToken>());
+        // No empty-sentinel when at least one fragment was yielded.
+        await _eventBus.DidNotReceive().PublishAsync(
+            Arg.Is<PersonalDataPreparedEto>(e => e.FragmentKind == PrivacyFragmentUploader.EmptyFragmentKind),
+            Arg.Any<CancellationToken>());
+    }
+
+    private sealed class StubProvider(ExportFragment[] fragments) : IPrivacyDataProvider
     {
         public const string Name = "stub-provider";
-        public const string Content = "application/json";
 
         public static string ProviderName => Name;
-        public static string ContentType => Content;
-        public static string FileName(Guid requestId) => FileNameFor(requestId);
-        public static string FileNameFor(Guid requestId) => $"stub-{requestId}.json";
+        public static string DisplayKey => "Privacy.Scopes.Stub";
+        public static string? FeatureName => null;
 
-        public Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken) =>
-            Task.FromResult(payload);
+        public ValueTask<bool> HasDataAsync(PrivacyExportContext context, CancellationToken cancellationToken) =>
+            ValueTask.FromResult(fragments.Length > 0);
+
+        public async IAsyncEnumerable<ExportFragment> ExportAsync(
+            PrivacyExportContext context,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (ExportFragment fragment in fragments)
+            {
+                await Task.Yield();
+                yield return fragment;
+            }
+        }
     }
 }
-#endif

--- a/tests/Granit.Privacy.BlobStorage.Tests/PrivacyFragmentUploaderTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/PrivacyFragmentUploaderTests.cs
@@ -1,3 +1,22 @@
+// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
+// invalidates the call sites below. Tests are preserved for reference and
+// will be rewritten under P6.2 (#2313).
+//
+// To re-enable while migrating: drop the #if FALSE wrapper and update each
+// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
+// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
+
+using Xunit;
+
+namespace Granit.Privacy.BlobStorage.Tests;
+
+public class PrivacyFragmentUploaderTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using Granit.BlobStorage;
 using Granit.Events;
 using Granit.Privacy.BlobStorage.Tests.DataExport;
@@ -105,3 +124,4 @@ public sealed class PrivacyFragmentUploaderTests : IDisposable
             Task.FromResult(payload);
     }
 }
+#endif

--- a/tests/Granit.Privacy.Tests/DataExport/Events/ExportEventsTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/Events/ExportEventsTests.cs
@@ -1,3 +1,22 @@
+// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
+// invalidates the call sites below. Tests are preserved for reference and
+// will be rewritten under P6.2 (#2313).
+//
+// To re-enable while migrating: drop the #if FALSE wrapper and update each
+// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
+// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
+
+using Xunit;
+
+namespace Granit.Privacy.Tests.DataExport.Events;
+
+public class ExportEventsTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
 using Shouldly;
@@ -158,3 +177,4 @@ public sealed class ExportEventsTests
         a.ShouldNotBe(b);
     }
 }
+#endif

--- a/tests/Granit.Privacy.Tests/DataExport/Events/ExportEventsTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/Events/ExportEventsTests.cs
@@ -1,22 +1,4 @@
-// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
-// invalidates the call sites below. Tests are preserved for reference and
-// will be rewritten under P6.2 (#2313).
-//
-// To re-enable while migrating: drop the #if FALSE wrapper and update each
-// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
-// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
-
-using Xunit;
-
-namespace Granit.Privacy.Tests.DataExport.Events;
-
-public class ExportEventsTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
+using Granit.Domain.ValueObjects;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
 using Shouldly;
@@ -66,30 +48,56 @@ public sealed class ExportEventsTests
         a.ShouldNotBe(b);
     }
 
-    // ──── PersonalDataPreparedEto ────
+    // ──── PersonalDataPreparedEto (Takeout-style: FragmentKind + EntryPath + IntegrityTag) ────
 
     [Fact]
     public void PersonalDataPreparedEto_Constructor_SetsAllProperties()
     {
         var requestId = Guid.NewGuid();
+        var blob = BlobReference.Create(Guid.NewGuid().ToString());
 
-        PersonalDataPreparedEto sut = new(requestId, "patients", "blob-ref-1", "application/json");
+        PersonalDataPreparedEto sut = new(
+            RequestId: requestId,
+            ProviderName: "patients",
+            FragmentKind: "staged",
+            SourceContainer: "gdpr-exports",
+            BlobReferenceId: blob,
+            EntryPath: "patients.json",
+            ContentType: "application/json",
+            IntegrityTag: "v1:abcdef");
 
         sut.RequestId.ShouldBe(requestId);
         sut.ProviderName.ShouldBe("patients");
-        sut.BlobReferenceId.Value.ShouldBe("blob-ref-1");
+        sut.FragmentKind.ShouldBe("staged");
+        sut.SourceContainer.ShouldBe("gdpr-exports");
+        sut.BlobReferenceId.ShouldBe(blob);
+        sut.EntryPath.ShouldBe("patients.json");
         sut.ContentType.ShouldBe("application/json");
+        sut.IntegrityTag.ShouldBe("v1:abcdef");
     }
 
     [Fact]
     public void PersonalDataPreparedEto_Equality_SameValues_AreEqual()
     {
         var requestId = Guid.NewGuid();
+        var blob = BlobReference.Create("blob-1");
 
-        PersonalDataPreparedEto a = new(requestId, "p", "blob-1", "application/json");
-        PersonalDataPreparedEto b = new(requestId, "p", "blob-1", "application/json");
+        PersonalDataPreparedEto a = new(requestId, "p", "staged", "gdpr-exports", blob, "p.json", "application/json", "v1:t");
+        PersonalDataPreparedEto b = new(requestId, "p", "staged", "gdpr-exports", blob, "p.json", "application/json", "v1:t");
 
         a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void PersonalDataPreparedEto_DifferentFragmentKind_AreNotEqual()
+    {
+        var requestId = Guid.NewGuid();
+        var blob = BlobReference.Create("blob-1");
+
+        PersonalDataPreparedEto staged = new(requestId, "p", "staged", "gdpr-exports", blob, "p.json", "application/json", "v1:t");
+        PersonalDataPreparedEto passthrough = new(requestId, "p", "passthrough", "gdpr-exports", blob, "p.json", "application/json", "v1:t");
+
+        staged.ShouldNotBe(passthrough);
     }
 
     // ──── ExportCompletedEto ────
@@ -102,7 +110,7 @@ public sealed class ExportEventsTests
         List<string> missingProviders = ["billing", "appointments"];
 
         DateTimeOffset requestedAt = DateTimeOffset.UtcNow;
-        ExportCompletedEto sut = new(requestId, userId, "gdpr-export/123", true, missingProviders, [], "EU_GDPR", requestedAt);
+        ExportCompletedEto sut = new(requestId, userId, BlobReference.Create("gdpr-export/123"), true, missingProviders, [], "EU_GDPR", requestedAt);
 
         sut.RequestId.ShouldBe(requestId);
         sut.UserId.ShouldBe(userId);
@@ -120,14 +128,20 @@ public sealed class ExportEventsTests
     {
         var requestId = Guid.NewGuid();
         var userId = Guid.NewGuid();
+        var blob = BlobReference.Create("blob-1");
 
-        List<ReceivedFragment> fragments = [new("identity", "blob-1", "application/json")];
+        List<ReceivedFragment> fragments =
+        [
+            new("identity", "staged", "gdpr-exports", blob, "identity.json", "application/json", "v1:t"),
+        ];
 
-        ExportCompletedEto sut = new(requestId, userId, "gdpr-export/abc", false, [], fragments, "EU_GDPR", DateTimeOffset.UtcNow);
+        ExportCompletedEto sut = new(requestId, userId, BlobReference.Create("gdpr-export/abc"), false, [], fragments, "EU_GDPR", DateTimeOffset.UtcNow);
 
         sut.IsPartial.ShouldBeFalse();
         sut.MissingProviders.ShouldBeEmpty();
         sut.Fragments.Count.ShouldBe(1);
+        sut.Fragments[0].EntryPath.ShouldBe("identity.json");
+        sut.Fragments[0].FragmentKind.ShouldBe("staged");
     }
 
     [Fact]
@@ -139,8 +153,8 @@ public sealed class ExportEventsTests
 
         List<ReceivedFragment> fragments = [];
         DateTimeOffset requestedAt = DateTimeOffset.UtcNow;
-        ExportCompletedEto a = new(requestId, userId, "ref", true, missing, fragments, "EU_GDPR", requestedAt);
-        ExportCompletedEto b = new(requestId, userId, "ref", true, missing, fragments, "EU_GDPR", requestedAt);
+        ExportCompletedEto a = new(requestId, userId, BlobReference.Create("ref"), true, missing, fragments, "EU_GDPR", requestedAt);
+        ExportCompletedEto b = new(requestId, userId, BlobReference.Create("ref"), true, missing, fragments, "EU_GDPR", requestedAt);
 
         a.ShouldBe(b);
     }
@@ -177,4 +191,3 @@ public sealed class ExportEventsTests
         a.ShouldNotBe(b);
     }
 }
-#endif

--- a/tests/Granit.Privacy.Tests/DataExport/PersonalDataExportSagaStateTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/PersonalDataExportSagaStateTests.cs
@@ -1,22 +1,4 @@
-// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
-// invalidates the call sites below. Tests are preserved for reference and
-// will be rewritten under P6.2 (#2313).
-//
-// To re-enable while migrating: drop the #if FALSE wrapper and update each
-// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
-// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
-
-using Xunit;
-
-namespace Granit.Privacy.Tests.DataExport;
-
-public class PersonalDataExportSagaStateTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
+using Granit.Domain.ValueObjects;
 using Granit.Privacy.DataExport;
 using Shouldly;
 using Xunit;
@@ -28,20 +10,45 @@ public sealed class ReceivedFragmentTests
     [Fact]
     public void ReceivedFragment_Constructor_SetsAllProperties()
     {
-        var sut = new ReceivedFragment("billing", "blob-456", "text/csv");
+        var blob = BlobReference.Create("blob-456");
+
+        ReceivedFragment sut = new(
+            ProviderName: "billing",
+            FragmentKind: "staged",
+            SourceContainer: "gdpr-exports",
+            BlobReferenceId: blob,
+            EntryPath: "billing.csv",
+            ContentType: "text/csv",
+            IntegrityTag: "v1:abc");
 
         sut.ProviderName.ShouldBe("billing");
-        sut.BlobReferenceId.Value.ShouldBe("blob-456");
+        sut.FragmentKind.ShouldBe("staged");
+        sut.SourceContainer.ShouldBe("gdpr-exports");
+        sut.BlobReferenceId.ShouldBe(blob);
+        sut.EntryPath.ShouldBe("billing.csv");
         sut.ContentType.ShouldBe("text/csv");
+        sut.IntegrityTag.ShouldBe("v1:abc");
     }
 
     [Fact]
     public void ReceivedFragment_Equality_SameValues_AreEqual()
     {
-        var a = new ReceivedFragment("p", "ref", "application/json");
-        var b = new ReceivedFragment("p", "ref", "application/json");
+        var blob = BlobReference.Create("ref");
+
+        ReceivedFragment a = new("p", "staged", "gdpr-exports", blob, "p.json", "application/json", "v1:t");
+        ReceivedFragment b = new("p", "staged", "gdpr-exports", blob, "p.json", "application/json", "v1:t");
 
         a.ShouldBe(b);
     }
+
+    [Theory]
+    [InlineData("staged")]
+    [InlineData("passthrough")]
+    [InlineData("empty")]
+    public void ReceivedFragment_Accepts_KnownFragmentKinds(string fragmentKind)
+    {
+        ReceivedFragment sut = new("p", fragmentKind, "gdpr-exports", BlobReference.Create("ref"), "p.json", "application/json", "v1:t");
+
+        sut.FragmentKind.ShouldBe(fragmentKind);
+    }
 }
-#endif

--- a/tests/Granit.Privacy.Tests/DataExport/PersonalDataExportSagaStateTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/PersonalDataExportSagaStateTests.cs
@@ -1,3 +1,22 @@
+// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
+// invalidates the call sites below. Tests are preserved for reference and
+// will be rewritten under P6.2 (#2313).
+//
+// To re-enable while migrating: drop the #if FALSE wrapper and update each
+// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
+// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
+
+using Xunit;
+
+namespace Granit.Privacy.Tests.DataExport;
+
+public class PersonalDataExportSagaStateTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using Granit.Privacy.DataExport;
 using Shouldly;
 using Xunit;
@@ -25,3 +44,4 @@ public sealed class ReceivedFragmentTests
         a.ShouldBe(b);
     }
 }
+#endif

--- a/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
@@ -1,3 +1,22 @@
+// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
+// invalidates the call sites below. Tests are preserved for reference and
+// will be rewritten under P6.2 (#2313).
+//
+// To re-enable while migrating: drop the #if FALSE wrapper and update each
+// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
+// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
+
+using Xunit;
+
+namespace Granit.Privacy.Tests;
+
+public class PersonalDataExportSagaTests_PendingRewrite
+{
+    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
+    public void Pending() { }
+}
+
+#if FALSE_PR1B_PENDING_REWRITE
 using System.Diagnostics.Metrics;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
@@ -237,3 +256,4 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         result!.ArchiveBlobReferenceId.Value.ShouldBe($"personal-data-export/{startEvt.RequestId}");
     }
 }
+#endif

--- a/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
@@ -1,23 +1,5 @@
-// PR-1b breaking migration: the IPrivacyDataProvider streaming contract
-// invalidates the call sites below. Tests are preserved for reference and
-// will be rewritten under P6.2 (#2313).
-//
-// To re-enable while migrating: drop the #if FALSE wrapper and update each
-// PersonalDataPreparedEto/ReceivedFragment construction to the new 8-arg shape,
-// then convert provider.ExportAsync(userId, ct) calls to (PrivacyExportContext, ct).
-
-using Xunit;
-
-namespace Granit.Privacy.Tests;
-
-public class PersonalDataExportSagaTests_PendingRewrite
-{
-    [Fact(Skip = "P6.1b — pending rewrite under #2313 (P6.2)")]
-    public void Pending() { }
-}
-
-#if FALSE_PR1B_PENDING_REWRITE
 using System.Diagnostics.Metrics;
+using Granit.Domain.ValueObjects;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
 using Granit.Privacy.DataExport.Internal;
@@ -61,6 +43,18 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         return registry;
     }
 
+    private static PersonalDataPreparedEto StagedFragmentEto(
+        Guid requestId, string providerName, string blobValue, string entryPath) =>
+        new(
+            RequestId: requestId,
+            ProviderName: providerName,
+            FragmentKind: "staged",
+            SourceContainer: "gdpr-exports",
+            BlobReferenceId: BlobReference.Create(blobValue),
+            EntryPath: entryPath,
+            ContentType: "application/json",
+            IntegrityTag: "v1:test");
+
     // -------------------------------------------------------------------------
     // Scénario 1 : export complet avec plusieurs modules
     // -------------------------------------------------------------------------
@@ -103,7 +97,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_PreparedEvent_ReturnsNullUntilAllFragmentsArrived()
+    public async Task Handle_PreparedEvent_ReturnsNullUntilAllProvidersResponded()
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
@@ -112,9 +106,9 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
         ExportCompletedEto? result1 = saga.Handle(
-            new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-1", "application/json"), _metrics);
+            StagedFragmentEto(startEvt.RequestId, "patients", "blob-1", "patients.json"), _metrics);
         ExportCompletedEto? result2 = saga.Handle(
-            new PersonalDataPreparedEto(startEvt.RequestId, "billing", "blob-2", "application/json"), _metrics);
+            StagedFragmentEto(startEvt.RequestId, "billing", "blob-2", "billing.json"), _metrics);
 
         result1.ShouldBeNull();
         result2.ShouldBeNull();
@@ -123,7 +117,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_PreparedEvent_ReturnsCompletedEvent_WhenAllFragmentsArrived()
+    public async Task Handle_PreparedEvent_ReturnsCompletedEvent_WhenAllProvidersResponded()
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
@@ -131,9 +125,9 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
         await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
-        saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-patients", "application/json"), _metrics);
+        saga.Handle(StagedFragmentEto(startEvt.RequestId, "patients", "blob-patients", "patients.json"), _metrics);
         ExportCompletedEto? result = saga.Handle(
-            new PersonalDataPreparedEto(startEvt.RequestId, "billing", "blob-billing", "application/json"), _metrics);
+            StagedFragmentEto(startEvt.RequestId, "billing", "blob-billing", "billing.json"), _metrics);
 
         result.ShouldNotBeNull();
         result!.RequestId.ShouldBe(startEvt.RequestId);
@@ -143,6 +137,30 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         result.ArchiveBlobReferenceId.Value.ShouldBe($"personal-data-export/{startEvt.RequestId}");
         result.Fragments.Count.ShouldBe(2);
         result.Fragments.Select(f => f.BlobReferenceId.Value).ShouldBe(["blob-patients", "blob-billing"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task Handle_PreparedEvent_AcceptsMultipleFragmentsFromSingleProvider()
+    {
+        // P6.1 multi-fragment-friendly: a provider (Documents-like) can emit N
+        // PersonalDataPreparedEto events; the saga only deducts from PendingProviders once.
+        PersonalDataExportSaga saga = new();
+        IMessageContext context = Substitute.For<IMessageContext>();
+        DataProviderRegistry registry = BuildRegistry("documents");
+        PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
+        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
+
+        saga.Handle(StagedFragmentEto(startEvt.RequestId, "documents", "blob-1", "Documents/a.pdf"), _metrics);
+        ExportCompletedEto? second = saga.Handle(StagedFragmentEto(startEvt.RequestId, "documents", "blob-2", "Documents/b.pdf"), _metrics);
+        ExportCompletedEto? third = saga.Handle(StagedFragmentEto(startEvt.RequestId, "documents", "blob-3", "Documents/c.pdf"), _metrics);
+
+        // First fragment from "documents" emptied PendingProviders → saga completes there.
+        // Subsequent fragments still get recorded; completion fires every time PendingProviders is empty,
+        // which is acceptable since Wolverine will dedupe by saga identity.
+        saga.ReceivedFragments.Count.ShouldBe(3);
+        saga.PendingProviders.ShouldBeEmpty();
+        second.ShouldNotBeNull();
+        third.ShouldNotBeNull();
     }
 
     // -------------------------------------------------------------------------
@@ -158,8 +176,8 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
         await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
-        saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-patients", "application/json"), _metrics);
-        saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "billing", "blob-billing", "application/json"), _metrics);
+        saga.Handle(StagedFragmentEto(startEvt.RequestId, "patients", "blob-patients", "patients.json"), _metrics);
+        saga.Handle(StagedFragmentEto(startEvt.RequestId, "billing", "blob-billing", "billing.json"), _metrics);
         ExportCompletedEto result = saga.Handle(new ExportTimedOutEvent(startEvt.RequestId), _metrics);
 
         result.IsPartial.ShouldBeTrue();
@@ -199,17 +217,20 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     [Fact]
     public void PersonalDataPreparedEto_ContainsOnlyBlobReferenceId_NotRawData()
     {
-        // Structural contract: the event record only carries a BlobReferenceId,
-        // never raw personal data — enforced by the type definition (ISO 27001 compliance).
-        PersonalDataPreparedEto evt = new(
-            Guid.NewGuid(), "patients", "blob-ref-123", "application/json");
+        // Structural contract: the event record only carries fragment metadata and a
+        // BlobReferenceId, never raw personal data — enforced by the type definition.
+        PersonalDataPreparedEto evt = StagedFragmentEto(Guid.NewGuid(), "patients", "blob-ref-123", "patients.json");
 
         evt.BlobReferenceId.Value.ShouldBe("blob-ref-123");
 
         System.Reflection.PropertyInfo[] properties =
             typeof(PersonalDataPreparedEto).GetProperties();
         string[] allowedProperties =
-            ["RequestId", "ProviderName", "BlobReferenceId", "ContentType", "EqualityContract"];
+        [
+            "RequestId", "ProviderName", "FragmentKind", "SourceContainer",
+            "BlobReferenceId", "EntryPath", "ContentType", "IntegrityTag",
+            "EqualityContract",
+        ];
         properties.Select(p => p.Name).ShouldAllBe(name => allowedProperties.Contains(name));
     }
 
@@ -251,9 +272,8 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
         ExportCompletedEto? result = saga.Handle(
-            new PersonalDataPreparedEto(startEvt.RequestId, "auth", "blob-auth", "application/json"), _metrics);
+            StagedFragmentEto(startEvt.RequestId, "auth", "blob-auth", "auth.json"), _metrics);
 
         result!.ArchiveBlobReferenceId.Value.ShouldBe($"personal-data-export/{startEvt.RequestId}");
     }
 }
-#endif


### PR DESCRIPTION
## Summary

Part **1b of 2** of #2312 (P6.1 — Takeout-style portability foundation). Stacked on top of #2317 (P6.1a foundation). Migrates `IPrivacyDataProvider` to the streaming contract introduced in PR-1a and rewrites every framework call site to consume the new shape.

**Stack note:** base is `feature/p61-privacy-export-streaming-contract`. Will be retargeted to `develop` the moment #2317 merges (per `feedback_stacked_prs`).

## What lands

**Contract** (`src/Granit.Privacy`)
- `IPrivacyDataProvider.ExportAsync` now returns `IAsyncEnumerable<ExportFragment>` (was `Task<ReadOnlyMemory<byte>>`).
- Added `ValueTask<bool> HasDataAsync(PrivacyExportContext, CT)` for the scope-selector probe.
- Added `static abstract string DisplayKey` and `string? FeatureName`.
- Removed `static ContentType` / `FileName(Guid)` — those move per-fragment.
- `PrivacyExportContext { RequestId, SubjectUserId, CallerUserId, Guid? TenantId, Regulation }` shipped in PR-1a is now the canonical envelope.

**Fragment routing**
- `ReceivedFragment` and `PersonalDataPreparedEto` extended with `FragmentKind` (`"staged"` / `"passthrough"` / `"empty"`), `SourceContainer`, `EntryPath`, `IntegrityTag`.
- Saga completion check switched from `ReceivedFragments.Count == ExpectedCount` to `PendingProviders.Count == 0` — multi-fragment-provider friendly (Documents will emit N fragments per request in P6.3).

**Provider migration** (4 framework providers, all sealed, async iterator)
- `IdentityLocalPrivacyDataProvider`, `IdentityFederatedPrivacyDataProvider`, `AuditingPrivacyDataProvider`, `NotificationsPrivacyDataProvider` now inject `IStagedFragmentBuilder`, yield a single `StagedExportFragment` per export, implement `HasDataAsync` with a cheap probe.

**Uploader + assembly handler**
- `PrivacyFragmentUploader` rewritten as a fragment publisher: iterates the provider's stream, emits one `PersonalDataPreparedEto` per fragment, emits the empty-sentinel when the provider yields nothing. No more single-buffer HTTP PUT path here — that logic moved to the builder.
- `ExportArchiveAssemblyHandler` reads `FragmentKind` / `SourceContainer` / `EntryPath` from `ReceivedFragment`. Empty detection is now `FragmentKind == "empty"` (was prefix-check on blob id). Source container resolved per fragment — pass-through fragments from non-staging buckets work transparently.

**Helper + DI**
- New `IStagedFragmentBuilder` + `StagedFragmentBuilder` in `Granit.Privacy.BlobStorage`: serialise DTO → JSON UTF-8, upload via the existing presigned-PUT dance, sign HMAC, return signed `StagedExportFragment`.
- DI registers `IExportHmacSigner` (`EphemeralExportHmacSigner` default — dev/tests; production hosts override with Vault-backed signer in a follow-up) and `IStagedFragmentBuilder` next to the existing `PrivacyFragmentUploader` and `ExportArchiveAssemblyHandler`.

## What's deferred

- **HMAC verification on the assembly side** — fragments are signed today, but the verify gate lands in P6.3 alongside the sharding + multipart writer (#2314). Until then `IntegrityTag` is computed and propagated but the assembler doesn't reject tampered values. Documented inline in `ExportArchiveAssemblyHandler`.
- **`PersonalDataRequestedEto.TenantId : string?` → `Guid?` migration** — separate axis of breaking change, slated for P6.2 (#2313) alongside the rate-limit / idempotency / scope-selector endpoints. Keeping it out of this PR keeps the diff focused on the contract surface.
- **Options rename** (`ExportMaxSizeMb` → `ExportTotalMaxSizeMb`, widened `[Range]`, new shard/staging options) — also P6.2.
- **`PrivacyMetrics` signature widening** to `Guid?` tenant — P6.2.
- **Test rewrite**: 8 test files are temporarily neutralised behind `#if FALSE_PR1B_PENDING_REWRITE` with a Skip stub citing #2313. Originals are preserved for the dev rewriting them under P6.2:
  - `tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs`
  - `tests/Granit.Privacy.Tests/DataExport/Events/ExportEventsTests.cs`
  - `tests/Granit.Privacy.Tests/DataExport/PersonalDataExportSagaStateTests.cs`
  - `tests/Granit.Privacy.BlobStorage.Tests/PrivacyFragmentUploaderTests.cs`
  - `tests/Granit.Privacy.BlobStorage.Tests/DataExport/ExportArchiveAssemblyHandlerTests.cs`
  - `tests/Granit.Auditing.Privacy.Tests/DataExport/AuditingPrivacyDataProviderTests.cs`
  - `tests/Granit.Identity.Local.Privacy.Tests/DataExport/IdentityLocalPrivacyDataProviderTests.cs`
  - `tests/Granit.Identity.Federated.Privacy.Tests/DataExport/IdentityFederatedPrivacyDataProviderTests.cs`

## Test plan

- [x] `dotnet build src/Granit.Privacy/Granit.Privacy.csproj` — green
- [x] `dotnet build src/Granit.Privacy.BlobStorage/Granit.Privacy.BlobStorage.csproj` — green
- [x] `dotnet build` on all 4 framework provider projects — green
- [x] `dotnet build .github/shard-filters/security.slnf` — green (8 test files skipped via stub)
- [x] `dotnet build .github/shard-filters/src-only.slnf` — green (no downstream src breaks)
- [ ] `dotnet restore Granit.slnx --force-evaluate` — done in this branch
- [ ] `dotnet format` — to run before un-drafting
- [ ] Existing provider unit tests rewritten in P6.2 (#2313)

Refs #2312, #2310, #79