### PR TITLE
test(text-extraction-ocr-tesseract-integration): add live libtesseract suite (TE-F3.1c)

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -64,6 +64,8 @@
       "src/Granit.RateLimiting/Granit.RateLimiting.csproj",
       "src/Granit.Settings/Granit.Settings.csproj",
       "src/Granit.Testing/Granit.Testing.csproj",
+      "src/Granit.TextExtraction.Ocr.Tesseract/Granit.TextExtraction.Ocr.Tesseract.csproj",
+      "src/Granit.TextExtraction/Granit.TextExtraction.csproj",
       "src/Granit.Timing/Granit.Timing.csproj",
       "src/Granit.Validation/Granit.Validation.csproj",
       "src/Granit.Wolverine.Postgresql/Granit.Wolverine.Postgresql.csproj",
@@ -85,6 +87,7 @@
       "tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/Granit.Indexing.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.OpenIddict.Tests.Integration/Granit.OpenIddict.Tests.Integration.csproj",
       "tests/Granit.QueryEngine.AspNetCore.Tests.Integration/Granit.QueryEngine.AspNetCore.Tests.Integration.csproj",
+      "tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj",
       "tests/Granit.Wolverine.Postgresql.Tests.Integration/Granit.Wolverine.Postgresql.Tests.Integration.csproj",
       "tests/Granit.Wolverine.SqlServer.Tests.Integration/Granit.Wolverine.SqlServer.Tests.Integration.csproj"
     ]

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -338,6 +338,7 @@
         "tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration",
         "tests/Granit.OpenIddict.Tests.Integration",
         "tests/Granit.QueryEngine.AspNetCore.Tests.Integration",
+        "tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration",
         "tests/Granit.Wolverine.Postgresql.Tests.Integration",
         "tests/Granit.Wolverine.SqlServer.Tests.Integration"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,26 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
           restore-keys: nuget-${{ runner.os }}-
 
+      # libtesseract is a runtime native dep for Granit.TextExtraction.Ocr.Tesseract's
+      # integration suite. Without TESSDATA_PREFIX set the live OCR tests skip
+      # themselves — dev machines that lack the system package still run the unit
+      # suite; the integration shard installs them and flips the switch.
+      #
+      # The Charlesw `Tesseract` NuGet (5.x) hard-codes the names
+      # `libleptonica-1.82.0` and `libtesseract50` when probing the loader path.
+      # apt ships `liblept.so.5` / `libtesseract.so.5` so we symlink the canonical
+      # names into place — without it, P/Invoke throws DllNotFoundException at the
+      # first OCR call.
+      - name: Install libtesseract (integration shard only)
+        if: matrix.shard.name == 'integration'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libtesseract5 tesseract-ocr-eng tesseract-ocr-fra
+          sudo ln -sf /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.82.0.so
+          sudo ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract50.so
+          echo "TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata" >> "$GITHUB_ENV"
+
       - name: Build shard
         run: >
           dotnet build .github/shard-filters/${{ matrix.shard.name }}.slnf

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -333,6 +333,7 @@
       "tests/Granit.Tests/Granit.Tests.csproj",
       "tests/Granit.TextExtraction.Email.Tests/Granit.TextExtraction.Email.Tests.csproj",
       "tests/Granit.TextExtraction.Ocr.AI.Tests/Granit.TextExtraction.Ocr.AI.Tests.csproj",
+      "tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj",
       "tests/Granit.TextExtraction.Ocr.Tesseract.Tests/Granit.TextExtraction.Ocr.Tesseract.Tests.csproj",
       "tests/Granit.TextExtraction.Office.Tests/Granit.TextExtraction.Office.Tests.csproj",
       "tests/Granit.TextExtraction.Pdf.Tests/Granit.TextExtraction.Pdf.Tests.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -206,6 +206,7 @@
       "tests/Granit.Tests/Granit.Tests.csproj",
       "tests/Granit.TextExtraction.Email.Tests/Granit.TextExtraction.Email.Tests.csproj",
       "tests/Granit.TextExtraction.Ocr.AI.Tests/Granit.TextExtraction.Ocr.AI.Tests.csproj",
+      "tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj",
       "tests/Granit.TextExtraction.Ocr.Tesseract.Tests/Granit.TextExtraction.Ocr.Tesseract.Tests.csproj",
       "tests/Granit.TextExtraction.Office.Tests/Granit.TextExtraction.Office.Tests.csproj",
       "tests/Granit.TextExtraction.Pdf.Tests/Granit.TextExtraction.Pdf.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -540,6 +540,7 @@
     <Project Path="tests/Granit.TextExtraction.Email.Tests/Granit.TextExtraction.Email.Tests.csproj" />
     <Project Path="tests/Granit.TextExtraction.Ocr.AI.Tests/Granit.TextExtraction.Ocr.AI.Tests.csproj" />
     <Project Path="tests/Granit.TextExtraction.Ocr.Tesseract.Tests/Granit.TextExtraction.Ocr.Tesseract.Tests.csproj" />
+    <Project Path="tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj" />
     <Project Path="tests/Granit.TextExtraction.Office.Tests/Granit.TextExtraction.Office.Tests.csproj" />
     <Project Path="tests/Granit.TextExtraction.Pdf.Tests/Granit.TextExtraction.Pdf.Tests.csproj" />
     <Project Path="tests/Granit.TextExtraction.Tests/Granit.TextExtraction.Tests.csproj" />

--- a/src/Granit.TextExtraction.Ocr.Tesseract/README.md
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/README.md
@@ -24,6 +24,11 @@ Linux (Debian / Ubuntu):
 
 ```bash
 apt-get install -y libtesseract5 tesseract-ocr-eng tesseract-ocr-fra
+# The Charlesw Tesseract NuGet probes for "libleptonica-1.82.0" and
+# "libtesseract50" by name — the apt packages ship liblept.so.5 and
+# libtesseract.so.5 instead, so symlink the canonical names:
+ln -sf /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.82.0.so
+ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract50.so
 ```
 
 The traineddata path is then `/usr/share/tesseract-ocr/5/tessdata/`. Each language
@@ -46,3 +51,20 @@ adds ~10–30 MB.
 `TesseractEngine` (Tesseract is not thread-safe). For high-throughput workloads,
 register a custom `ITesseractRecognizer` that pools multiple engines before
 calling `AddTesseractOcrExtractor`.
+
+## Running the live OCR test suite locally
+
+The unit suite (`tests/Granit.TextExtraction.Ocr.Tesseract.Tests`) mocks the
+recognizer and runs everywhere. The live suite
+(`tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration`) drives the real
+native engine and is opt-in via the `TESSDATA_PREFIX` env var — without it the
+tests skip themselves so a missing system package doesn't block the unit run:
+
+```bash
+sudo apt-get install -y libtesseract5 tesseract-ocr-eng
+export TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata
+dotnet test tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration
+```
+
+CI installs the deps on the `integration` shard automatically; see
+`.github/workflows/ci.yml`.

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- Excluded from CI unit-test jobs; requires the native libtesseract library
+         (apt-get install libtesseract5 tesseract-ocr-eng) and the matching
+         traineddata. Local opt-in via the TESSDATA_PREFIX environment variable. -->
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.TextExtraction.Ocr.Tesseract\Granit.TextExtraction.Ocr.Tesseract.csproj" />
+    <ProjectReference Include="..\..\src\Granit.TextExtraction\Granit.TextExtraction.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
@@ -1,0 +1,101 @@
+using Granit.TextExtraction.Ocr.Tesseract.Extensions;
+using ImageMagick;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.TextExtraction.Ocr.Tesseract.Tests.Integration;
+
+/// <summary>
+/// End-to-end OCR round-trip against the real native libtesseract. The unit-test suite
+/// in Granit.TextExtraction.Ocr.Tesseract.Tests mocks <see cref="ITesseractRecognizer"/>;
+/// without these tests, <c>DefaultTesseractRecognizer</c> is exercised in zero pipelines
+/// — Pix loader / traineddata-path / locale-mismatch regressions would slip through.
+/// </summary>
+/// <remarks>
+/// Opt-in: set <c>TESSDATA_PREFIX</c> to the directory containing
+/// <c>eng.traineddata</c> (typically <c>/usr/share/tesseract-ocr/5/tessdata</c> on
+/// Debian/Ubuntu). Without it the suite skips so developer machines without
+/// libtesseract still run the unit suite.
+/// </remarks>
+[Trait("Category", "Integration")]
+public sealed class LiveTesseractRecognizerTests
+{
+    private static readonly string? TessdataPath = Environment.GetEnvironmentVariable("TESSDATA_PREFIX");
+
+    public static bool LibTesseractAvailable => !string.IsNullOrWhiteSpace(TessdataPath);
+
+    [Fact(SkipUnless = nameof(LibTesseractAvailable),
+        Skip = "TESSDATA_PREFIX is not set; libtesseract integration tests are opt-in. Install libtesseract + a traineddata package and export TESSDATA_PREFIX to enable.")]
+    public async Task RecognizeAsync_decodes_rendered_text_through_the_default_recognizer()
+    {
+        byte[] png = RenderPngWithText("GRANIT OCR");
+
+        await using ServiceProvider sp = BuildHost();
+        ITesseractRecognizer recognizer = sp.GetRequiredService<ITesseractRecognizer>();
+
+        string text = await recognizer.RecognizeAsync(png, TestContext.Current.CancellationToken);
+
+        // Tesseract often emits trailing whitespace / newline characters; assert on the
+        // payload only. The first character can also be flaky on some font/render
+        // combos so we settle for a stable substring.
+        text.ShouldContain("GRANIT", Case.Insensitive);
+    }
+
+    [Fact(SkipUnless = nameof(LibTesseractAvailable),
+        Skip = "TESSDATA_PREFIX is not set; libtesseract integration tests are opt-in. Install libtesseract + a traineddata package and export TESSDATA_PREFIX to enable.")]
+    public async Task TesseractOcrExtractor_round_trip_returns_recognised_text()
+    {
+        byte[] png = RenderPngWithText("HELLO OCR");
+
+        await using ServiceProvider sp = BuildHost();
+        TesseractOcrExtractor extractor = sp.GetServices<ITextExtractor>()
+            .OfType<TesseractOcrExtractor>()
+            .Single();
+
+        using MemoryStream stream = new(png);
+        TextExtractionResult result = await extractor.ExtractAsync(
+            stream,
+            contentType: "image/png",
+            maxCharLength: 4096,
+            TestContext.Current.CancellationToken);
+
+        result.Content.ShouldNotBeNullOrWhiteSpace();
+        result.Content.ShouldContain("HELLO", Case.Insensitive);
+        result.ExtractorName.ShouldBe(TesseractOcrExtractor.ExtractorName);
+    }
+
+    private static ServiceProvider BuildHost()
+    {
+        ServiceCollection services = [];
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddTesseractOcrExtractor(o =>
+        {
+            o.DataPath = TessdataPath;
+            o.Language = "eng";
+        });
+        return services.BuildServiceProvider();
+    }
+
+    private static byte[] RenderPngWithText(string text)
+    {
+        // Magick.NET (Apache-2.0, native deps bundled in the Q8-AnyCPU package) renders
+        // the caption to a PNG without requiring a system-font lookup — IM picks a built-in
+        // font, sized to fit. The output resolution is intentionally generous so Tesseract
+        // has clean glyph edges to work with.
+        MagickReadSettings settings = new()
+        {
+            Width = 600,
+            Height = 200,
+            BackgroundColor = MagickColors.White,
+            FillColor = MagickColors.Black,
+            FontPointsize = 64,
+        };
+        using MagickImage image = new($"label:{text}", settings);
+        image.BorderColor = MagickColors.White;
+        image.Border(20);
+        return image.ToByteArray(MagickFormat.Png);
+    }
+}

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
@@ -1,0 +1,371 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Magick.NET-Q8-AnyCPU": {
+        "type": "Direct",
+        "requested": "[14.*, )",
+        "resolved": "14.13.1",
+        "contentHash": "Naw4lYw9Mv+Tnd67H2Un+joZsZTWmbo7A4kycoosM6JnclMXb+ZNRbCqgvMRA6wAEJfybFDiP5NauLgL4xkyXA==",
+        "dependencies": {
+          "Magick.NET.Core": "14.13.1"
+        }
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Magick.NET.Core": {
+        "type": "Transitive",
+        "resolved": "14.13.1",
+        "contentHash": "BhqOKCLixvj/Ofwe+aRPHqoGdWekvKavsQrivBSuUq0zzzijnIF/OxqVA+GCd6WP46C4PaIfGhR65BPi2M0cKg=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "U+oquaPxFdY8lYeEIWO/AD7jDIl9sPW6aVWMQRHU/pZ/SWpLcOrAj2fcLe1HwXl4sYw1ONI56K/eELT3xr4RRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.textextraction": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.textextraction.ocr.tesseract": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.TextExtraction": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "SixLabors.ImageSharp": "[2.*, )",
+          "Tesseract": "[5.*, )"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.1.13",
+        "contentHash": "zmVHZR13XE477TBAVXE71VcMhqhiv1PbzMWIfuIDytVdBPl3KZlvYYBkqcuQSDdszVY2XHanW98VmDffoNzSSw=="
+      },
+      "Tesseract": {
+        "type": "CentralTransitive",
+        "requested": "[5.*, )",
+        "resolved": "5.2.0",
+        "contentHash": "YB7feJlrTWSXtK8+WaCcseGSPK/1r2d2FWeKGyndlrPwYClrzTlCoHD4/oQEUjKafmpkWlhTZZ7pxiRJYZgj6w=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #2279.

## Summary

- Adds `tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/` driving the real native `libtesseract` via the public `ITesseractRecognizer` / `TesseractOcrExtractor` paths.
- Renders the input PNG dynamically with Magick.NET (Apache-2.0, native deps bundled in `Magick.NET-Q8-AnyCPU`) so no binary fixture lands in the repo.
- Opt-in via the `TESSDATA_PREFIX` env var (xunit.v3 `[Fact(SkipUnless = ...)]`) — dev machines without libtesseract keep getting a green unit suite.
- Project is registered in the `integration` shard; CI auto-installs `libtesseract5` + `tesseract-ocr-eng`/`-fra` and symlinks the names the Charlesw NuGet probes for (`libleptonica-1.82.0.so`, `libtesseract50.so`) — without the symlinks the wrapper throws `DllNotFoundException`.
- README documents the env-var convention for local opt-in + the symlink dance.

Before this PR `DefaultTesseractRecognizer` was exercised in zero pipelines (unit suite mocks `ITesseractRecognizer`), so Pix loader / traineddata-path / locale-mismatch regressions would have slipped through. This closes that gap.

## Test plan

- [x] `dotnet test tests/Granit.TextExtraction.Ocr.Tesseract.Tests --no-build` — 19/19 green (unit suite untouched).
- [x] `dotnet test tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration --no-build` without `TESSDATA_PREFIX` — both tests skip with the documented reason.
- [x] `dotnet format tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration --verify-no-changes` clean.
- [x] `markdownlint-cli2 src/Granit.TextExtraction.Ocr.Tesseract/README.md` clean.
- [ ] CI integration shard runs the live suite end-to-end against the apt-installed engine.