### PR TITLE
feat(privacy-export): P6.2 scope visibility resolver + scopes endpoint + filter

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37265,7 +37265,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs",
-      "line": 10,
+      "line": 25,
       "members": []
     },
     {
@@ -37319,7 +37319,7 @@
       "kind": "interface",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/IDataProviderRegistry.cs",
-      "line": 8,
+      "line": 10,
       "members": [
         {
           "name": "Register",
@@ -37328,10 +37328,22 @@
           "returnType": "void"
         },
         {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(ProviderRegistration registration)",
+          "returnType": "void"
+        },
+        {
           "name": "GetAll",
           "kind": "method",
           "signature": "GetAll()",
           "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetAllRegistrations",
+          "kind": "method",
+          "signature": "GetAllRegistrations()",
+          "returnType": "IReadOnlyList<ProviderRegistration>"
         }
       ]
     },
@@ -37402,6 +37414,38 @@
       ]
     },
     {
+      "name": "IPrivacyScopeResolver",
+      "fqn": "Granit.Privacy.DataExport.IPrivacyScopeResolver",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyScopeResolver.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ListVisibleAsync",
+          "kind": "method",
+          "signature": "ListVisibleAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlyList<ProviderDescriptor>>"
+        }
+      ]
+    },
+    {
+      "name": "IPrivacyScopeVisibilityPolicy",
+      "fqn": "Granit.Privacy.DataExport.IPrivacyScopeVisibilityPolicy",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyScopeVisibilityPolicy.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "IsVisibleAsync",
+          "kind": "method",
+          "signature": "IsVisibleAsync(ProviderDescriptor descriptor, PrivacyExportContext context, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<bool>"
+        }
+      ]
+    },
+    {
       "name": "PersonalDataExportSaga",
       "fqn": "Granit.Privacy.DataExport.PersonalDataExportSaga",
       "kind": "class",
@@ -37430,7 +37474,7 @@
         {
           "name": "Start",
           "kind": "method",
-          "signature": "Start(PersonalDataRequestedEto @event, IDataProviderRegistry registry, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics)",
+          "signature": "Start(PersonalDataRequestedEto @event, IPrivacyScopeResolver scopeResolver, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics, CancellationToken cancellationToken)",
           "returnType": "string? TenantId { get; set; } public DateTimeOffset RequestedAt { get; set; } public Task<ExportCompletedEto?>"
         }
       ]
@@ -37457,6 +37501,24 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/PrivacyExportContext.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ProviderDescriptor",
+      "fqn": "Granit.Privacy.DataExport.ProviderDescriptor",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/ProviderDescriptor.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ProviderRegistration",
+      "fqn": "Granit.Privacy.DataExport.ProviderRegistration",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/ProviderRegistration.cs",
       "line": 17,
       "members": []
     },
@@ -37586,6 +37648,12 @@
           "kind": "method",
           "signature": "RecordOptOutRevoked(string? tenantId, string? regulation = null)",
           "returnType": "void"
+        },
+        {
+          "name": "RecordScopeProbeDuration",
+          "kind": "method",
+          "signature": "RecordScopeProbeDuration(Guid? tenantId, string providerName, TimeSpan duration)",
+          "returnType": "void"
         }
       ]
     },
@@ -37694,12 +37762,30 @@
       "members": []
     },
     {
+      "name": "PrivacyExportRequest",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyExportRequest",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyExportRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "PrivacyExportRequestResponse",
       "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyExportRequestResponse",
       "kind": "record",
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyExportRequestResponse.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportScopeResponse",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyExportScopeResponse",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyExportScopeResponse.cs",
+      "line": 15,
       "members": []
     },
     {

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportRequest.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportRequest.cs
@@ -1,0 +1,10 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// Optional body for <c>POST /privacy/exports</c>. All fields are optional —
+/// posting an empty body (or no body at all) defaults to "everything visible to me".
+/// </summary>
+/// <param name="Scopes">Subset of provider names the subject wants in the archive.
+/// Unknown / hidden entries are silently dropped server-side (VULN-202: no enumeration
+/// leak). <see langword="null"/> or empty means "all visible scopes" — Takeout default.</param>
+public sealed record PrivacyExportRequest(IReadOnlyList<string>? Scopes = null);

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportScopeResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportScopeResponse.cs
@@ -1,0 +1,20 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// One entry returned by <c>GET /privacy/exports/scopes</c> — describes a single
+/// provider scope the data subject can include in an export request.
+/// </summary>
+/// <param name="ProviderName">Stable identifier (used in the POST body's
+/// <c>Scopes</c> list).</param>
+/// <param name="DisplayKey">Localisation key — the BFF / front resolves it.</param>
+/// <param name="FeatureName">Optional feature flag tagging this scope (informational —
+/// gating already applied server-side by the visibility policy).</param>
+/// <param name="DefaultSelected">Whether the UI should pre-check this scope.</param>
+/// <param name="EstimatedSizeBytes">Best-effort size hint, when the provider can answer
+/// cheaply.</param>
+public sealed record PrivacyExportScopeResponse(
+    string ProviderName,
+    string DisplayKey,
+    string? FeatureName,
+    bool DefaultSelected,
+    long? EstimatedSizeBytes);

--- a/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
@@ -278,6 +278,18 @@ public static class PrivacyEndpointRouteBuilderExtensions
 
     private static void MapExportEndpoints(RouteGroupBuilder group)
     {
+        group.MapGet("/exports/scopes", HandleListExportScopesAsync)
+             .RequireAuthorization(PrivacyPermissions.Export.Execute)
+             .WithName("ListPrivacyExportScopes")
+             .WithSummary("Lists the export scopes visible to the current user.")
+             .WithDescription(
+                 "Returns one entry per IPrivacyDataProvider the subject can include in an export, after applying "
+                 + "the framework visibility gates: module loaded, HasDataAsync probe (Takeout-style "
+                 + "\"if you never used it, it doesn't appear\"), and the host IPrivacyScopeVisibilityPolicy. "
+                 + "Use the returned ProviderName values to populate the POST /privacy/exports `Scopes` field; "
+                 + "unknown / hidden scopes in that POST are silently skipped.")
+             .Produces<IReadOnlyList<PrivacyExportScopeResponse>>();
+
         group.MapPost("/exports", HandleRequestExportAsync)
              .RequireAuthorization(PrivacyPermissions.Export.Execute)
              .WithName("RequestPrivacyExport")
@@ -285,9 +297,10 @@ public static class PrivacyEndpointRouteBuilderExtensions
              .WithDescription(
                  "Triggers the scatter-gather export saga (GDPR Art. 15/20). Each registered data provider "
                  + "prepares its fragment asynchronously. The saga assembles fragments into a downloadable archive. "
-                 + "Poll GET /export/{requestId} for status, or wire a Granit.Notifications handler on "
-                 + "ExportCompletedEto to notify the user when the archive is ready. "
-                 + "Use the ArchiveBlobReferenceId with the BlobStorage download endpoint to obtain a pre-signed URL.")
+                 + "The optional `Scopes` array narrows the export to a subset of provider scopes (see "
+                 + "GET /privacy/exports/scopes); omitting it exports everything visible to the subject. "
+                 + "Poll GET /exports/{requestId} for status, or wire a Granit.Notifications handler on "
+                 + "ExportCompletedEto to notify the user when the archive is ready.")
              .Produces<PrivacyExportRequestResponse>(StatusCodes.Status202Accepted);
 
         group.MapGet("/exports/{requestId:guid}", HandleGetExportStatusAsync)
@@ -421,6 +434,7 @@ public static class PrivacyEndpointRouteBuilderExtensions
     // -------------------------------------------------------------------------
 
     private static async Task<Results<Accepted<PrivacyExportRequestResponse>, ProblemHttpResult>> HandleRequestExportAsync(
+        [FromBody] PrivacyExportRequest? body,
         [FromServices] ICurrentUserService currentUser,
         [FromServices] IDistributedEventBus eventBus,
         [FromServices] IExportRequestTrackerWriter tracker,
@@ -441,12 +455,24 @@ public static class PrivacyEndpointRouteBuilderExtensions
         string? tenantId = ResolveTenantId(currentTenant);
         string regulation = await ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
 
+        // Null / empty Scopes → "everything visible" (Takeout default). Unknown / hidden
+        // entries are silently dropped by the saga via the visibility resolver (VULN-202).
+        IReadOnlyList<string>? requestedScopes = body?.Scopes is { Count: > 0 } scopes ? scopes : null;
+
         await tracker
             .RecordRequestAsync(requestId, userId, now, cancellationToken)
             .ConfigureAwait(false);
 
         await eventBus
-            .PublishAsync(new PersonalDataRequestedEto(requestId, userId, now, regulation, tenantId), cancellationToken)
+            .PublishAsync(
+                new PersonalDataRequestedEto(
+                    RequestId: requestId,
+                    UserId: userId,
+                    RequestedAt: now,
+                    Regulation: regulation,
+                    TenantId: tenantId,
+                    RequestedScopes: requestedScopes),
+                cancellationToken)
             .ConfigureAwait(false);
 
         metrics.RecordExportRequested(tenantId, regulation);
@@ -454,6 +480,45 @@ public static class PrivacyEndpointRouteBuilderExtensions
         return TypedResults.Accepted(
             $"/privacy/export/{requestId}",
             new PrivacyExportRequestResponse(requestId, now));
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<PrivacyExportScopeResponse>>, ProblemHttpResult>> HandleListExportScopesAsync(
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IPrivacyScopeResolver scopeResolver,
+        [FromServices] ICurrentTenant currentTenant,
+        [FromServices] IPrivacyRegulationResolver? regulationResolver,
+        [FromServices] IGuidGenerator guidGenerator,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(currentUser, out Guid userId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        Guid? tenantGuid = currentTenant.IsAvailable ? currentTenant.Id : null;
+        string regulation = await ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
+
+        // RequestId is synthetic here — we're not actually starting an export, just probing
+        // visibility. Subject == Caller (self-service); admin "on behalf of" flows are deferred.
+        PrivacyExportContext probeContext = new(
+            RequestId: guidGenerator.Create(),
+            SubjectUserId: userId,
+            CallerUserId: userId,
+            TenantId: tenantGuid,
+            Regulation: regulation);
+
+        IReadOnlyList<ProviderDescriptor> visible = await scopeResolver
+            .ListVisibleAsync(probeContext, cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<PrivacyExportScopeResponse> response = [.. visible.Select(d => new PrivacyExportScopeResponse(
+            ProviderName: d.ProviderName,
+            DisplayKey: d.DisplayKey,
+            FeatureName: d.FeatureName,
+            DefaultSelected: d.DefaultSelected,
+            EstimatedSizeBytes: d.EstimatedSizeBytes))];
+
+        return TypedResults.Ok(response);
     }
 
     private static async Task<Results<Ok<PrivacyExportStatusResponse>, ProblemHttpResult>> HandleGetExportStatusAsync(

--- a/src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs
+++ b/src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs
@@ -4,13 +4,29 @@ using Wolverine.Persistence.Sagas;
 namespace Granit.Privacy.DataExport.Events;
 
 /// <summary>
-/// Published when a data subject requests export of their personal data (GDPR Art. 15/20, LGPD Art. 18, CCPA).
-/// Each registered data provider handles this event and prepares its fragment.
+/// Published when a data subject requests export of their personal data (GDPR Art. 15/20,
+/// LGPD Art. 18, CCPA). Each registered data provider handles this event and prepares
+/// its fragment when its scope is in <see cref="RequestedScopes"/> (or when
+/// <see cref="RequestedScopes"/> is <see langword="null"/> — Takeout-style "all visible").
 /// </summary>
+/// <param name="RequestId">Saga correlation id.</param>
+/// <param name="UserId">Data subject whose data is being exported.</param>
+/// <param name="RequestedAt">When the subject filed the request.</param>
+/// <param name="Regulation">Regulation code under which the request is processed.</param>
+/// <param name="TenantId">Tenant scope, as currently typed in this Eto
+/// (<see cref="string"/>?). Will widen to <see cref="Guid"/>? in a follow-up alongside
+/// the metrics-signature migration.</param>
+/// <param name="RequestedFormat">Wire format requested by the subject (default JSON).</param>
+/// <param name="RequestedScopes">Subset of provider names the subject asked for.
+/// <see langword="null"/> means "all scopes visible to me" (Takeout-style default).
+/// The saga intersects this list with the visibility resolver's output — unknown or
+/// hidden scopes are silently skipped and recorded in the audit trail (VULN-202: no
+/// echo back to the caller, no enumeration leak).</param>
 public sealed record PersonalDataRequestedEto(
     [property: SagaIdentity] Guid RequestId,
     Guid UserId,
     DateTimeOffset RequestedAt,
     string Regulation,
     string? TenantId = null,
-    string RequestedFormat = "JSON") : IIntegrationEvent;
+    string RequestedFormat = "JSON",
+    IReadOnlyList<string>? RequestedScopes = null) : IIntegrationEvent;

--- a/src/Granit.Privacy/DataExport/IDataProviderRegistry.cs
+++ b/src/Granit.Privacy/DataExport/IDataProviderRegistry.cs
@@ -2,16 +2,41 @@ namespace Granit.Privacy.DataExport;
 
 /// <summary>
 /// Declarative registry of modules participating in data subject export/deletion.
-/// Each module registers its provider name at startup.
-/// The Saga uses <see cref="Count"/> to know how many fragments to expect.
+/// Each module registers its provider name (and optional Takeout-style metadata) at
+/// startup. The saga uses <see cref="Count"/> to know how many fragments to expect;
+/// <see cref="IPrivacyScopeResolver"/> uses <see cref="GetAllRegistrations"/> to evaluate
+/// visibility gates.
 /// </summary>
 public interface IDataProviderRegistry
 {
-    /// <summary>Registers a data provider. Throws if the name is already registered.</summary>
+    /// <summary>
+    /// Registers a data provider by name only — minimal metadata, no scope-selector
+    /// visibility. Used for legacy registrations (e.g. tests).
+    /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="Register(ProviderRegistration)"/> when the typed provider is
+    /// available (it propagates <c>DisplayKey</c>, <c>FeatureName</c>, and the
+    /// <c>HasData</c> probe used by the scope selector).
+    /// </remarks>
     void Register(string providerName);
+
+    /// <summary>
+    /// Registers a fully-described data provider. Captures the static metadata
+    /// (display key, feature name) and the probe delegate used by the scope selector.
+    /// </summary>
+    void Register(ProviderRegistration registration);
 
     /// <summary>Returns all registered provider names.</summary>
     IReadOnlyList<string> GetAll();
+
+    /// <summary>
+    /// Returns the full registration records for every provider that registered with
+    /// <see cref="Register(ProviderRegistration)"/>. Providers registered name-only
+    /// (legacy path) are returned with a default registration: <c>DisplayKey</c> equal
+    /// to the provider name, <c>FeatureName</c> null, <c>HasDataProbe</c> returning
+    /// <see langword="true"/>.
+    /// </summary>
+    IReadOnlyList<ProviderRegistration> GetAllRegistrations();
 
     /// <summary>Returns the number of registered providers.</summary>
     int Count { get; }

--- a/src/Granit.Privacy/DataExport/IPrivacyScopeResolver.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyScopeResolver.cs
@@ -1,0 +1,31 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Resolves which provider scopes are visible to a data subject for a given export
+/// request, by composing three gates over the
+/// <see cref="IDataProviderRegistry"/>:
+/// <list type="number">
+///   <item><b>Module loaded</b> — only providers registered via
+///   <c>AddDataProvider&lt;TProvider&gt;()</c>.</item>
+///   <item><b>HasData probe</b> — <see cref="IPrivacyDataProvider.HasDataAsync"/>;
+///   providers with no data for this subject are hidden (Takeout-style UX).</item>
+///   <item><b>Visibility policy</b> — host-supplied
+///   <see cref="IPrivacyScopeVisibilityPolicy"/> for feature-flag /
+///   per-tenant filtering.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// The saga calls this resolver when the export starts so it knows which providers to
+/// expect fragments from (<c>ExpectedCount</c> + <c>PendingProviders</c>). The scopes
+/// endpoint calls it to populate the UI selector.
+/// </remarks>
+public interface IPrivacyScopeResolver
+{
+    /// <summary>
+    /// Returns the <see cref="ProviderDescriptor"/>s visible to the subject for this
+    /// request, after applying all gates in registration order.
+    /// </summary>
+    Task<IReadOnlyList<ProviderDescriptor>> ListVisibleAsync(
+        PrivacyExportContext context,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Privacy/DataExport/IPrivacyScopeVisibilityPolicy.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyScopeVisibilityPolicy.cs
@@ -1,0 +1,56 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Host extension point that gates which provider scopes the data subject can see in
+/// the export selector (<c>GET /privacy/exports/scopes</c>) and request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework runs three gates before consulting this policy:
+/// <list type="number">
+///   <item>Module loaded — only providers registered with
+///   <c>AddDataProvider&lt;TProvider&gt;()</c> participate.</item>
+///   <item><see cref="IPrivacyDataProvider.HasDataAsync"/> — providers with no data for
+///   the subject are hidden (UX: Google Takeout-style "if you never used Photos, Photos
+///   doesn't appear").</item>
+///   <item>This policy — host decides whether to additionally filter by feature flags,
+///   per-tenant configuration, custom permissions, etc.</item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>GDPR Art. 15/20 reminder:</b> Article 20 portability is a personal right, not a
+/// usage right. A "reader" of Documents must still be able to export her own documents
+/// even without an admin permission. Hosts overriding this policy should think hard
+/// before denying a scope to a subject who has data in it — denying GDPR Art. 15 access
+/// generally requires a documented legal basis.
+/// </para>
+/// <para>
+/// The default implementation (<see cref="AllowAllPrivacyScopeVisibilityPolicy"/>) is
+/// fail-open. Hosts wire a custom policy via DI to layer feature-flag or fine-grained
+/// permission checks on top.
+/// </para>
+/// </remarks>
+public interface IPrivacyScopeVisibilityPolicy
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the scope should be visible to the subject for
+    /// this request.
+    /// </summary>
+    ValueTask<bool> IsVisibleAsync(
+        ProviderDescriptor descriptor,
+        PrivacyExportContext context,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Default fail-open <see cref="IPrivacyScopeVisibilityPolicy"/> — every provider that
+/// passes the module-loaded and HasData gates stays visible. Production hosts that need
+/// feature-flag or permission-based filtering replace this via DI.
+/// </summary>
+internal sealed class AllowAllPrivacyScopeVisibilityPolicy : IPrivacyScopeVisibilityPolicy
+{
+    public ValueTask<bool> IsVisibleAsync(
+        ProviderDescriptor descriptor,
+        PrivacyExportContext context,
+        CancellationToken cancellationToken) => ValueTask.FromResult(true);
+}

--- a/src/Granit.Privacy/DataExport/Internal/DataProviderRegistry.cs
+++ b/src/Granit.Privacy/DataExport/Internal/DataProviderRegistry.cs
@@ -7,22 +7,43 @@ namespace Granit.Privacy.DataExport.Internal;
 /// </summary>
 internal sealed class DataProviderRegistry : IDataProviderRegistry
 {
-    private readonly ConcurrentDictionary<string, byte> _providers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, ProviderRegistration> _providers =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public void Register(string providerName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
 
-        if (!_providers.TryAdd(providerName, 0))
+        ProviderRegistration legacyRegistration = new(
+            ProviderName: providerName,
+            DisplayKey: providerName,
+            FeatureName: null,
+            HasDataProbe: static (_, _, _) => ValueTask.FromResult(true));
+
+        if (!_providers.TryAdd(providerName, legacyRegistration))
         {
             throw new InvalidOperationException($"Data provider '{providerName}' is already registered.");
         }
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<string> GetAll() =>
-        _providers.Keys.ToList();
+    public void Register(ProviderRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(registration.ProviderName);
+
+        if (!_providers.TryAdd(registration.ProviderName, registration))
+        {
+            throw new InvalidOperationException($"Data provider '{registration.ProviderName}' is already registered.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> GetAll() => [.. _providers.Keys];
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ProviderRegistration> GetAllRegistrations() => [.. _providers.Values];
 
     /// <inheritdoc/>
     public int Count => _providers.Count;

--- a/src/Granit.Privacy/DataExport/Internal/PrivacyScopeResolver.cs
+++ b/src/Granit.Privacy/DataExport/Internal/PrivacyScopeResolver.cs
@@ -1,0 +1,66 @@
+using Granit.Privacy.Diagnostics;
+
+namespace Granit.Privacy.DataExport.Internal;
+
+/// <summary>
+/// Default <see cref="IPrivacyScopeResolver"/> — applies the three visibility gates in
+/// registration order. Scoped lifetime so it can resolve scoped
+/// <see cref="IPrivacyDataProvider"/> instances via <see cref="IServiceProvider"/>.
+/// </summary>
+internal sealed class PrivacyScopeResolver(
+    IDataProviderRegistry registry,
+    IPrivacyScopeVisibilityPolicy visibilityPolicy,
+    IServiceProvider serviceProvider,
+    PrivacyMetrics metrics) : IPrivacyScopeResolver
+{
+    public async Task<IReadOnlyList<ProviderDescriptor>> ListVisibleAsync(
+        PrivacyExportContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        IReadOnlyList<ProviderRegistration> registrations = registry.GetAllRegistrations();
+        List<ProviderDescriptor> visible = new(registrations.Count);
+
+        foreach (ProviderRegistration registration in registrations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ProviderDescriptor descriptor = new(
+                ProviderName: registration.ProviderName,
+                DisplayKey: registration.DisplayKey,
+                FeatureName: registration.FeatureName);
+
+            long startTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+            bool hasData;
+            try
+            {
+                hasData = await registration.HasDataProbe(serviceProvider, context, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                TimeSpan elapsed = System.Diagnostics.Stopwatch.GetElapsedTime(startTimestamp);
+                metrics.RecordScopeProbeDuration(
+                    context.TenantId, registration.ProviderName, elapsed);
+            }
+
+            if (!hasData)
+            {
+                continue;
+            }
+
+            bool allowedByPolicy = await visibilityPolicy
+                .IsVisibleAsync(descriptor, context, cancellationToken)
+                .ConfigureAwait(false);
+            if (!allowedByPolicy)
+            {
+                continue;
+            }
+
+            visible.Add(descriptor);
+        }
+
+        return visible;
+    }
+}

--- a/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
+++ b/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
@@ -69,19 +69,40 @@ public sealed class PersonalDataExportSaga : Saga
     // handler discovery. An `Async`-suffixed name compiles to a silent no-op handler.
     public async Task<ExportCompletedEto?> Start(
         PersonalDataRequestedEto @event,
-        IDataProviderRegistry registry,
+        IPrivacyScopeResolver scopeResolver,
         IOptions<GranitPrivacyOptions> options,
         IMessageContext context,
-        PrivacyMetrics metrics)
+        PrivacyMetrics metrics,
+        CancellationToken cancellationToken)
     {
         Id = @event.RequestId;
         UserId = @event.UserId;
         Regulation = @event.Regulation;
         TenantId = @event.TenantId;
         RequestedAt = @event.RequestedAt;
-        ExpectedCount = registry.Count;
         metrics.RecordExportRequested(TenantId, Regulation);
-        PendingProviders = [.. registry.GetAll()];
+
+        // Apply visibility gates + intersect with the subject's RequestedScopes list.
+        // RequestedScopes naming an unknown / hidden provider is silently dropped (VULN-202:
+        // never echo unknown scope names back). Null means "all visible to me" — Takeout default.
+        PrivacyExportContext exportContext = new(
+            RequestId: @event.RequestId,
+            SubjectUserId: @event.UserId,
+            CallerUserId: @event.UserId,
+            TenantId: TryParseTenantId(@event.TenantId),
+            Regulation: @event.Regulation);
+
+        IReadOnlyList<ProviderDescriptor> visible = await scopeResolver
+            .ListVisibleAsync(exportContext, cancellationToken)
+            .ConfigureAwait(false);
+
+        IEnumerable<string> selected = @event.RequestedScopes is null
+            ? visible.Select(d => d.ProviderName)
+            : visible.Select(d => d.ProviderName)
+                .Intersect(@event.RequestedScopes, StringComparer.OrdinalIgnoreCase);
+
+        PendingProviders = [.. selected];
+        ExpectedCount = PendingProviders.Count;
 
         if (ExpectedCount == 0)
         {
@@ -160,4 +181,9 @@ public sealed class PersonalDataExportSaga : Saga
             Regulation,
             RequestedAt);
     }
+
+    // Eto-side TenantId is still typed as string? (legacy schema). The Guid? migration
+    // ships as a separate breaking pass alongside metrics widening; until then we try-parse.
+    private static Guid? TryParseTenantId(string? value) =>
+        Guid.TryParse(value, out Guid parsed) ? parsed : null;
 }

--- a/src/Granit.Privacy/DataExport/ProviderDescriptor.cs
+++ b/src/Granit.Privacy/DataExport/ProviderDescriptor.cs
@@ -1,0 +1,25 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Public-facing metadata for a single privacy data provider, as surfaced by
+/// <see cref="IPrivacyScopeResolver.ListVisibleAsync"/> to the scope selector
+/// (<c>GET /privacy/exports/scopes</c>).
+/// </summary>
+/// <param name="ProviderName">Stable identifier — matches
+/// <see cref="IPrivacyDataProvider.ProviderName"/>.</param>
+/// <param name="DisplayKey">Localisation key for the human-readable label.
+/// Resolved client-side or by the BFF.</param>
+/// <param name="FeatureName">Optional feature flag controlling the scope. When non-null
+/// the host can hide the scope via an <see cref="IPrivacyScopeVisibilityPolicy"/>
+/// that consults <c>Granit.Features</c>.</param>
+/// <param name="DefaultSelected">Whether the scope should be pre-checked in the UI.
+/// Defaults to <see langword="true"/> — Takeout-style "everything by default".</param>
+/// <param name="EstimatedSizeBytes">Optional best-effort size hint for the UI. Providers
+/// that can answer cheaply (e.g. document count × average size) populate this; others
+/// leave it <see langword="null"/>.</param>
+public sealed record ProviderDescriptor(
+    string ProviderName,
+    string DisplayKey,
+    string? FeatureName,
+    bool DefaultSelected = true,
+    long? EstimatedSizeBytes = null);

--- a/src/Granit.Privacy/DataExport/ProviderRegistration.cs
+++ b/src/Granit.Privacy/DataExport/ProviderRegistration.cs
@@ -1,0 +1,21 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Captured registration record for a single <see cref="IPrivacyDataProvider"/>.
+/// Built by <c>GranitPrivacyBuilder.AddDataProvider&lt;TProvider&gt;()</c> at startup;
+/// consumed by <see cref="IPrivacyScopeResolver"/> to evaluate the visibility gates
+/// without taking a hard dep on the typed provider.
+/// </summary>
+/// <param name="ProviderName">Stable identifier (e.g. <c>"identity-local"</c>).</param>
+/// <param name="DisplayKey">Localisation key for the scope selector UI.</param>
+/// <param name="FeatureName">Optional feature flag controlling visibility — interpreted
+/// by the host's <see cref="IPrivacyScopeVisibilityPolicy"/>.</param>
+/// <param name="HasDataProbe">Resolves the typed provider from
+/// <see cref="IServiceProvider"/> at scope-evaluation time and calls
+/// <see cref="IPrivacyDataProvider.HasDataAsync"/>. Captured by the builder so callers
+/// of <see cref="IPrivacyScopeResolver"/> don't need to know the concrete provider type.</param>
+public sealed record ProviderRegistration(
+    string ProviderName,
+    string DisplayKey,
+    string? FeatureName,
+    Func<IServiceProvider, PrivacyExportContext, CancellationToken, ValueTask<bool>> HasDataProbe);

--- a/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
+++ b/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
@@ -28,6 +28,7 @@ public sealed class PrivacyMetrics
     private readonly Counter<long> _archivesAssembled;
     private readonly Histogram<double> _exportDuration;
     private readonly Histogram<double> _archiveAssemblyDuration;
+    private readonly Histogram<double> _scopeProbeDuration;
 
     public PrivacyMetrics(IMeterFactory meterFactory)
     {
@@ -82,6 +83,11 @@ public sealed class PrivacyMetrics
             "granit.privacy.export.archive.duration",
             unit: "s",
             description: "Duration of export archive assembly in seconds.");
+
+        _scopeProbeDuration = meter.CreateHistogram<double>(
+            "granit.privacy.scope.probe.duration",
+            unit: "ms",
+            description: "Duration of IPrivacyDataProvider.HasDataAsync probes during scope visibility resolution.");
     }
 
     /// <summary>Records an export request.</summary>
@@ -147,6 +153,18 @@ public sealed class PrivacyMetrics
     /// <summary>Records an opt-out revocation.</summary>
     public void RecordOptOutRevoked(string? tenantId, string? regulation = null) =>
         _optOutRevocations.Add(1, CreateTags(tenantId, regulation));
+
+    /// <summary>
+    /// Records the duration of a single <see cref="DataExport.IPrivacyDataProvider.HasDataAsync"/>
+    /// probe during scope visibility resolution. Tagged by <c>provider_name</c> +
+    /// <c>tenant_id</c> only — never by request id (unbounded cardinality, VULN-204).
+    /// </summary>
+    public void RecordScopeProbeDuration(Guid? tenantId, string providerName, TimeSpan duration) =>
+        _scopeProbeDuration.Record(duration.TotalMilliseconds, new TagList
+        {
+            { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
+            { "provider_name", providerName },
+        });
 
     private static TagList CreateTags(string? tenantId, string? regulation) => new()
     {

--- a/src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs
@@ -47,6 +47,11 @@ public static class PrivacyServiceCollectionExtensions
             dataProviderRegistry.Register(providerName);
         }
 
+        foreach (ProviderRegistration registration in builder.DataProviderRegistrations)
+        {
+            dataProviderRegistry.Register(registration);
+        }
+
         foreach (LegalDocumentDefinition document in builder.LegalDocuments)
         {
             legalDocumentRegistry.Register(document);
@@ -57,6 +62,11 @@ public static class PrivacyServiceCollectionExtensions
         services.TryAddSingleton<IDataProviderRegistry>(dataProviderRegistry);
         services.TryAddSingleton(legalDocumentRegistry);
         services.TryAddSingleton<IProcessingPurposeRegistry>(purposeRegistry);
+
+        // Scope-visibility infrastructure. Default policy is fail-open (every provider that
+        // has data stays visible) — hosts override via services.AddSingleton<IPrivacyScopeVisibilityPolicy, ...>.
+        services.TryAddSingleton<IPrivacyScopeVisibilityPolicy, AllowAllPrivacyScopeVisibilityPolicy>();
+        services.TryAddScoped<IPrivacyScopeResolver, PrivacyScopeResolver>();
 
         // When Granit.Privacy.EntityFrameworkCore is wired (ILegalDocumentReader registered),
         // use the composite registry (DB-first, static-fallback with distributed cache).

--- a/src/Granit.Privacy/GranitPrivacyBuilder.cs
+++ b/src/Granit.Privacy/GranitPrivacyBuilder.cs
@@ -22,8 +22,14 @@ public sealed class GranitPrivacyBuilder(IServiceCollection services)
     /// </remarks>
     public IServiceCollection Services { get; } = services;
 
-    /// <summary>Data provider names to register at startup.</summary>
+    /// <summary>Data provider names registered name-only (legacy / minimal metadata).</summary>
     internal List<string> DataProviderNames { get; } = [];
+
+    /// <summary>
+    /// Fully-described data provider registrations captured by
+    /// <see cref="AddDataProvider{TProvider}"/>. Drive the scope selector visibility gates.
+    /// </summary>
+    internal List<DataExport.ProviderRegistration> DataProviderRegistrations { get; } = [];
 
     /// <summary>Legal document definitions to register at startup.</summary>
     internal List<LegalDocumentDefinition> LegalDocuments { get; } = [];
@@ -54,8 +60,13 @@ public sealed class GranitPrivacyBuilder(IServiceCollection services)
     public GranitPrivacyBuilder AddDataProvider<TProvider>()
         where TProvider : class, IPrivacyDataProvider
     {
-        RegisterDataProvider(TProvider.ProviderName);
         Services.AddScoped<TProvider>();
+        DataProviderRegistrations.Add(new DataExport.ProviderRegistration(
+            ProviderName: TProvider.ProviderName,
+            DisplayKey: TProvider.DisplayKey,
+            FeatureName: TProvider.FeatureName,
+            HasDataProbe: static (sp, ctx, ct) =>
+                sp.GetRequiredService<TProvider>().HasDataAsync(ctx, ct)));
         return this;
     }
 

--- a/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsTestServer.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsTestServer.cs
@@ -51,6 +51,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
     public ICurrentUserService CurrentUser { get; }
     public IExportRequestTrackerWriter ExportWriter { get; }
     public IExportRequestTrackerReader ExportReader { get; }
+    public IPrivacyScopeResolver ScopeResolver { get; }
     public IDeletionRequestTrackerWriter DeletionWriter { get; }
     public IDeletionRequestTrackerReader DeletionReader { get; }
     public ILegalDocumentRegistry DocumentRegistry { get; }
@@ -75,6 +76,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         ICurrentUserService currentUser,
         IExportRequestTrackerWriter exportWriter,
         IExportRequestTrackerReader exportReader,
+        IPrivacyScopeResolver scopeResolver,
         IDeletionRequestTrackerWriter deletionWriter,
         IDeletionRequestTrackerReader deletionReader,
         ILegalDocumentRegistry documentRegistry,
@@ -98,6 +100,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         CurrentUser = currentUser;
         ExportWriter = exportWriter;
         ExportReader = exportReader;
+        ScopeResolver = scopeResolver;
         DeletionWriter = deletionWriter;
         DeletionReader = deletionReader;
         DocumentRegistry = documentRegistry;
@@ -125,6 +128,9 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
 
         IExportRequestTrackerWriter exportWriter = Substitute.For<IExportRequestTrackerWriter>();
         IExportRequestTrackerReader exportReader = Substitute.For<IExportRequestTrackerReader>();
+        IPrivacyScopeResolver scopeResolver = Substitute.For<IPrivacyScopeResolver>();
+        scopeResolver.ListVisibleAsync(Arg.Any<PrivacyExportContext>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<ProviderDescriptor>)[]);
         IDeletionRequestTrackerWriter deletionWriter = Substitute.For<IDeletionRequestTrackerWriter>();
         IDeletionRequestTrackerReader deletionReader = Substitute.For<IDeletionRequestTrackerReader>();
         ILegalDocumentRegistry documentRegistry = Substitute.For<ILegalDocumentRegistry>();
@@ -193,6 +199,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         builder.Services.AddSingleton(currentUser);
         builder.Services.AddSingleton(exportWriter);
         builder.Services.AddSingleton(exportReader);
+        builder.Services.AddSingleton(scopeResolver);
         builder.Services.AddSingleton(deletionWriter);
         builder.Services.AddSingleton(deletionReader);
         builder.Services.AddSingleton(documentRegistry);
@@ -237,7 +244,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
 
         return new PrivacyEndpointsTestServer(
             app, authenticatedClient, anonymousClient,
-            currentUser, exportWriter, exportReader,
+            currentUser, exportWriter, exportReader, scopeResolver,
             deletionWriter, deletionReader,
             documentRegistry, agreementChecker, agreementStoreReader, agreementStoreWriter,
             regulationResolver, optOutWriter, optOutReader, purposeRegistry,

--- a/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyExportScopesEndpointTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyExportScopesEndpointTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.Endpoints.Dtos;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Integration;
+
+public sealed class PrivacyExportScopesEndpointTests
+{
+    [Fact]
+    public async Task GetScopes_ReturnsResolverDescriptorsAsPrivacyExportScopeResponses()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+        server.ScopeResolver.ListVisibleAsync(Arg.Any<PrivacyExportContext>(), Arg.Any<CancellationToken>())
+            .Returns([
+                new ProviderDescriptor("identity-local", "Privacy.Scopes.IdentityLocal", null),
+                new ProviderDescriptor("documents", "Privacy.Scopes.Documents", "Documents.Privacy", DefaultSelected: false, EstimatedSizeBytes: 12_345),
+            ]);
+
+        HttpResponseMessage response = await server.AuthenticatedClient.GetAsync(
+            "/privacy/exports/scopes", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        IReadOnlyList<PrivacyExportScopeResponse>? body = await response.Content.ReadFromJsonAsync<IReadOnlyList<PrivacyExportScopeResponse>>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body!.Count.ShouldBe(2);
+        body[0].ProviderName.ShouldBe("identity-local");
+        body[0].DisplayKey.ShouldBe("Privacy.Scopes.IdentityLocal");
+        body[0].DefaultSelected.ShouldBeTrue();
+        body[0].EstimatedSizeBytes.ShouldBeNull();
+        body[1].ProviderName.ShouldBe("documents");
+        body[1].FeatureName.ShouldBe("Documents.Privacy");
+        body[1].DefaultSelected.ShouldBeFalse();
+        body[1].EstimatedSizeBytes.ShouldBe(12_345);
+    }
+
+    [Fact]
+    public async Task GetScopes_AnonymousClient_Returns401()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AnonymousClient.GetAsync(
+            "/privacy/exports/scopes", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task PostExports_WithoutScopes_PublishesEtoWithNullRequestedScopes()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AuthenticatedClient.PostAsync(
+            "/privacy/exports", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        await server.EventBus.Received(1).PublishAsync(
+            Arg.Is<PersonalDataRequestedEto>(e => e.RequestedScopes == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostExports_WithScopes_PublishesEtoCarryingTheScopes()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AuthenticatedClient.PostAsJsonAsync(
+            "/privacy/exports",
+            new PrivacyExportRequest(Scopes: ["identity-local", "documents"]),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        await server.EventBus.Received(1).PublishAsync(
+            Arg.Is<PersonalDataRequestedEto>(e =>
+                e.RequestedScopes != null &&
+                e.RequestedScopes.Count == 2 &&
+                e.RequestedScopes.Contains("identity-local") &&
+                e.RequestedScopes.Contains("documents")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostExports_WithEmptyScopesArray_TreatedAsAllVisible()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AuthenticatedClient.PostAsJsonAsync(
+            "/privacy/exports",
+            new PrivacyExportRequest(Scopes: []),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        // Empty array is normalised to null (Takeout default: "everything visible").
+        await server.EventBus.Received(1).PublishAsync(
+            Arg.Is<PersonalDataRequestedEto>(e => e.RequestedScopes == null),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Privacy.Tests/DataExport/Internal/PrivacyScopeResolverTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/Internal/PrivacyScopeResolverTests.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics.Metrics;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Internal;
+using Granit.Privacy.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Tests.DataExport.Internal;
+
+public sealed class PrivacyScopeResolverTests : IDisposable
+{
+    private readonly ServiceProvider _sp;
+    private readonly PrivacyMetrics _metrics;
+
+    public PrivacyScopeResolverTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _metrics = new PrivacyMetrics(_sp.GetRequiredService<IMeterFactory>());
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private static PrivacyExportContext Ctx() =>
+        new(
+            RequestId: Guid.NewGuid(),
+            SubjectUserId: Guid.NewGuid(),
+            CallerUserId: Guid.NewGuid(),
+            TenantId: null,
+            Regulation: "EU_GDPR");
+
+    private static ProviderRegistration Registration(
+        string name,
+        bool hasData = true,
+        string? featureName = null) =>
+        new(
+            ProviderName: name,
+            DisplayKey: $"Privacy.Scopes.{name}",
+            FeatureName: featureName,
+            HasDataProbe: (_, _, _) => ValueTask.FromResult(hasData));
+
+    [Fact]
+    public async Task ListVisibleAsync_ReturnsEveryRegisteredProvider_WhenAllGatesPass()
+    {
+        DataProviderRegistry registry = new();
+        registry.Register(Registration("identity-local"));
+        registry.Register(Registration("auditing"));
+        registry.Register(Registration("documents"));
+
+        PrivacyScopeResolver sut = new(registry, new AllowAllPrivacyScopeVisibilityPolicy(), _sp, _metrics);
+
+        IReadOnlyList<ProviderDescriptor> result = await sut.ListVisibleAsync(Ctx(), TestContext.Current.CancellationToken);
+
+        result.Select(d => d.ProviderName).ShouldBe(["identity-local", "auditing", "documents"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ListVisibleAsync_HidesProvider_WhenHasDataIsFalse()
+    {
+        DataProviderRegistry registry = new();
+        registry.Register(Registration("identity-local", hasData: true));
+        registry.Register(Registration("documents", hasData: false));
+
+        PrivacyScopeResolver sut = new(registry, new AllowAllPrivacyScopeVisibilityPolicy(), _sp, _metrics);
+
+        IReadOnlyList<ProviderDescriptor> result = await sut.ListVisibleAsync(Ctx(), TestContext.Current.CancellationToken);
+
+        result.Select(d => d.ProviderName).ShouldBe(["identity-local"]);
+    }
+
+    [Fact]
+    public async Task ListVisibleAsync_HidesProvider_WhenPolicyDenies()
+    {
+        DataProviderRegistry registry = new();
+        registry.Register(Registration("identity-local"));
+        registry.Register(Registration("documents"));
+
+        DenyingPolicy policy = new("documents");
+
+        PrivacyScopeResolver sut = new(registry, policy, _sp, _metrics);
+
+        IReadOnlyList<ProviderDescriptor> result = await sut.ListVisibleAsync(Ctx(), TestContext.Current.CancellationToken);
+
+        result.Select(d => d.ProviderName).ShouldBe(["identity-local"]);
+    }
+
+    private sealed class DenyingPolicy(string deniedProviderName) : IPrivacyScopeVisibilityPolicy
+    {
+        public ValueTask<bool> IsVisibleAsync(
+            ProviderDescriptor descriptor,
+            PrivacyExportContext context,
+            CancellationToken cancellationToken) =>
+            ValueTask.FromResult(descriptor.ProviderName != deniedProviderName);
+    }
+
+    [Fact]
+    public async Task ListVisibleAsync_ReturnsEmpty_WhenNoProvidersRegistered()
+    {
+        DataProviderRegistry registry = new();
+        PrivacyScopeResolver sut = new(registry, new AllowAllPrivacyScopeVisibilityPolicy(), _sp, _metrics);
+
+        IReadOnlyList<ProviderDescriptor> result = await sut.ListVisibleAsync(Ctx(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListVisibleAsync_PreservesFeatureNameOnDescriptor()
+    {
+        DataProviderRegistry registry = new();
+        registry.Register(Registration("documents", featureName: "Documents.Privacy"));
+
+        PrivacyScopeResolver sut = new(registry, new AllowAllPrivacyScopeVisibilityPolicy(), _sp, _metrics);
+
+        IReadOnlyList<ProviderDescriptor> result = await sut.ListVisibleAsync(Ctx(), TestContext.Current.CancellationToken);
+
+        result.Single().FeatureName.ShouldBe("Documents.Privacy");
+        result.Single().DisplayKey.ShouldBe("Privacy.Scopes.documents");
+    }
+
+    [Fact]
+    public async Task ListVisibleAsync_LegacyNameOnlyRegistration_IsVisibleByDefault()
+    {
+        // Registering by name only (legacy / test path) should still produce a visible scope
+        // — the registry fills in a fail-open HasData probe.
+        DataProviderRegistry registry = new();
+        registry.Register("legacy-provider");
+
+        PrivacyScopeResolver sut = new(registry, new AllowAllPrivacyScopeVisibilityPolicy(), _sp, _metrics);
+
+        IReadOnlyList<ProviderDescriptor> result = await sut.ListVisibleAsync(Ctx(), TestContext.Current.CancellationToken);
+
+        ProviderDescriptor descriptor = result.ShouldHaveSingleItem();
+        descriptor.ProviderName.ShouldBe("legacy-provider");
+        descriptor.DisplayKey.ShouldBe("legacy-provider");
+        descriptor.FeatureName.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ListVisibleAsync_PassesProbeArgumentsThrough()
+    {
+        PrivacyExportContext probedContext = null!;
+        ProviderRegistration probing = new(
+            ProviderName: "probe",
+            DisplayKey: "Privacy.Scopes.probe",
+            FeatureName: null,
+            HasDataProbe: (sp, ctx, _) =>
+            {
+                probedContext = ctx;
+                sp.ShouldNotBeNull();
+                return ValueTask.FromResult(true);
+            });
+
+        DataProviderRegistry registry = new();
+        registry.Register(probing);
+
+        PrivacyScopeResolver sut = new(registry, new AllowAllPrivacyScopeVisibilityPolicy(), _sp, _metrics);
+
+        PrivacyExportContext given = Ctx();
+        await sut.ListVisibleAsync(given, TestContext.Current.CancellationToken);
+
+        probedContext.ShouldBeEquivalentTo(given);
+    }
+}

--- a/tests/Granit.Privacy.Tests/DataProviderRegistryTests.cs
+++ b/tests/Granit.Privacy.Tests/DataProviderRegistryTests.cs
@@ -40,7 +40,7 @@ public sealed class DataProviderRegistryTests
     [Fact]
     public void Register_NullOrWhitespace_ThrowsArgumentException()
     {
-        Action actNull = () => _sut.Register(null!);
+        Action actNull = () => _sut.Register((string)null!);
         Action actEmpty = () => _sut.Register("");
         Action actWhitespace = () => _sut.Register("   ");
 

--- a/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.Metrics;
 using Granit.Domain.ValueObjects;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
-using Granit.Privacy.DataExport.Internal;
 using Granit.Privacy.Diagnostics;
 using Granit.Privacy.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,15 +31,18 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     private static IOptions<GranitPrivacyOptions> DefaultOptions() =>
         Microsoft.Extensions.Options.Options.Create(new GranitPrivacyOptions { ExportTimeoutMinutes = 5 });
 
-    private static DataProviderRegistry BuildRegistry(params string[] providers)
+    private static IPrivacyScopeResolver BuildScopeResolver(params string[] providers)
     {
-        DataProviderRegistry registry = new();
-        foreach (string p in providers)
-        {
-            registry.Register(p);
-        }
+        IReadOnlyList<ProviderDescriptor> descriptors = [.. providers.Select(name =>
+            new ProviderDescriptor(
+                ProviderName: name,
+                DisplayKey: $"Privacy.Scopes.{name}",
+                FeatureName: null))];
 
-        return registry;
+        IPrivacyScopeResolver resolver = Substitute.For<IPrivacyScopeResolver>();
+        resolver.ListVisibleAsync(Arg.Any<PrivacyExportContext>(), Arg.Any<CancellationToken>())
+            .Returns(descriptors);
+        return resolver;
     }
 
     private static PersonalDataPreparedEto StagedFragmentEto(
@@ -64,12 +66,12 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry registry = BuildRegistry("patients", "billing");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing");
         var requestId = Guid.NewGuid();
         var userId = Guid.NewGuid();
         PersonalDataRequestedEto evt = new(requestId, userId, DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.Start(evt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(evt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Id.ShouldBe(requestId);
         saga.UserId.ShouldBe(userId);
@@ -83,11 +85,11 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry registry = BuildRegistry("patients", "billing");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing");
         var requestId = Guid.NewGuid();
         PersonalDataRequestedEto evt = new(requestId, Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.Start(evt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(evt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         // ScheduleAsync is an extension method that calls PublishAsync with DeliveryOptions.
         // NSubstitute cannot intercept extension methods, so we verify the underlying PublishAsync call.
@@ -101,9 +103,9 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry registry = BuildRegistry("patients", "billing", "appointments");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing", "appointments");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         ExportCompletedEto? result1 = saga.Handle(
             StagedFragmentEto(startEvt.RequestId, "patients", "blob-1", "patients.json"), _metrics);
@@ -121,9 +123,9 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry registry = BuildRegistry("patients", "billing");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "patients", "blob-patients", "patients.json"), _metrics);
         ExportCompletedEto? result = saga.Handle(
@@ -146,9 +148,9 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         // PersonalDataPreparedEto events; the saga only deducts from PendingProviders once.
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry registry = BuildRegistry("documents");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("documents");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "documents", "blob-1", "Documents/a.pdf"), _metrics);
         ExportCompletedEto? second = saga.Handle(StagedFragmentEto(startEvt.RequestId, "documents", "blob-2", "Documents/b.pdf"), _metrics);
@@ -172,9 +174,9 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry registry = BuildRegistry("patients", "billing", "appointments");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing", "appointments");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "patients", "blob-patients", "patients.json"), _metrics);
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "billing", "blob-billing", "billing.json"), _metrics);
@@ -195,10 +197,10 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry emptyRegistry = new();
         PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        ExportCompletedEto? result = await saga.Start(evt, emptyRegistry, DefaultOptions(), context, _metrics);
+        // No providers registered → resolver returns empty list, saga completes immediately.
+        ExportCompletedEto? result = await saga.Start(evt, BuildScopeResolver(), DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.IsPartial.ShouldBeFalse();
@@ -245,10 +247,10 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         IOptions<GranitPrivacyOptions> options = Microsoft.Extensions.Options.Options.Create(
             new GranitPrivacyOptions { ExportTimeoutMinutes = 10 });
-        DataProviderRegistry registry = BuildRegistry("auth");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("auth");
         PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.Start(evt, registry, options, context, _metrics);
+        await saga.Start(evt, scopeResolver, options, context, _metrics, TestContext.Current.CancellationToken);
 
         // ScheduleAsync(message, TimeSpan) sets ScheduleDelay (relative), not ScheduledTime (absolute).
         await context.Received(1).PublishAsync(
@@ -267,9 +269,9 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     {
         PersonalDataExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        DataProviderRegistry registry = BuildRegistry("auth");
+        IPrivacyScopeResolver scopeResolver = BuildScopeResolver("auth");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         ExportCompletedEto? result = saga.Handle(
             StagedFragmentEto(startEvt.RequestId, "auth", "blob-auth", "auth.json"), _metrics);

--- a/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
+++ b/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
@@ -75,6 +75,7 @@ public sealed class PrivacySagaWolverineCodegenTests
             .ConfigureServices(services =>
             {
                 services.AddSingleton<IDataProviderRegistry>(new DataProviderRegistry());
+                services.AddSingleton(Substitute.For<IPrivacyScopeResolver>());
                 services.AddSingleton(Substitute.For<IDeletionRequestTrackerWriter>());
                 services.AddSingleton(TimeProvider.System);
                 services.AddSingleton(Substitute.For<ILegalDocumentRegistry>());


### PR DESCRIPTION
## Summary

Implements the **scope-selector surface** of #2313 (P6.2). The subject can now see which provider scopes carry their data (`GET /privacy/exports/scopes`) and narrow an export to a subset (`POST /privacy/exports { Scopes }`). The saga intersects `RequestedScopes` with the visibility resolver's output before fanning out.

## Visibility gates

`IPrivacyScopeResolver` composes three gates in registration order:

1. **Module loaded** — only providers registered via `AddDataProvider<T>()`.
2. **`HasDataAsync` probe** — providers with no data for the subject are hidden (Takeout-style "if you never used it, it doesn't appear").
3. **`IPrivacyScopeVisibilityPolicy`** — host extension point. Default `AllowAllPrivacyScopeVisibilityPolicy` is fail-open. Hosts wire feature-flag / per-tenant policies on top.

> **GDPR Art. 15/20 reminder** baked into the policy doc: portability is a personal right, not a usage right. Denying a scope to a subject who has data in it generally requires a documented legal basis. The default refuses to make that decision for the host.

## What lands

**`Granit.Privacy/DataExport/`**

- `ProviderDescriptor` + `ProviderRegistration` records.
- `IPrivacyScopeResolver` + `PrivacyScopeResolver` (scoped impl).
- `IPrivacyScopeVisibilityPolicy` + `AllowAllPrivacyScopeVisibilityPolicy`.
- `IDataProviderRegistry.Register(ProviderRegistration)` overload + `GetAllRegistrations()`. The legacy `Register(string)` keeps fail-open visibility.
- `GranitPrivacyBuilder.AddDataProvider<T>()` captures `TProvider.DisplayKey` / `FeatureName` statics + a closure on `HasDataAsync`.
- `PersonalDataExportSaga.Start` now consumes `IPrivacyScopeResolver` to compute `ExpectedCount` / `PendingProviders`. `RequestedScopes` (null = "all visible", Takeout default) is intersected with the visible set; unknown / hidden entries are silently dropped (**VULN-202**: never echo unknown scope names back).
- `PersonalDataRequestedEto.RequestedScopes` field (optional, defaults `null`).
- `PrivacyMetrics.RecordScopeProbeDuration` — `granit.privacy.scope.probe.duration` histogram, tagged by `provider_name` + `tenant_id` only (**VULN-204**: never `request_id`, cardinality).

**`Granit.Privacy.Endpoints`**

- `GET /privacy/exports/scopes` — returns the visible-to-me descriptors.
- `POST /privacy/exports` body extended with optional `Scopes[]` (empty array normalised to `null` = Takeout default).
- `PrivacyExportRequest` + `PrivacyExportScopeResponse` DTOs.

## Out of scope (follow-ups)

These were listed as P6.2 deliverables in #2313 but are deferred to focused follow-up PRs to keep this review manageable:

- **Rate-limit + Idempotency-Key** on `POST /privacy/exports` (`privacy-export-create` 1/24h sliding window + `Idempotency-Key` header). Plan §15, VULN-105.
- **Permission split**: `Privacy.Exports.Execute` (self) vs `Privacy.Exports.OnBehalfOf` (admin DSR, code in v1.1). VULN-201.
- **Subject-substitution Roslyn analyzer** (VULN-200).
- **FluentValidation server-side rejection** of unknown scopes — currently silent-skip via the saga. Both behaviours are GDPR-safe; the explicit reject is purely defense-in-depth and adds tests + 400 wiring.
- **`PersonalDataRequestedEto.TenantId` migration** from `string?` to `Guid?` + `PrivacyMetrics` signature widening.

## Test plan

- [x] `dotnet build .github/shard-filters/security.slnf` — green
- [x] `dotnet build .github/shard-filters/infrastructure.slnf` — green
- [x] `Granit.Privacy.Tests` — 269 tests green (was 262, +7 `PrivacyScopeResolverTests`)
- [x] `Granit.Privacy.Endpoints.Tests` — 123 tests green (was 118, +5 `PrivacyExportScopesEndpointTests`)
- [x] `dotnet format --verify-no-changes` clean on the 4 modified projects
- [x] `Granit.Privacy.BlobStorage.Tests` (23), `Granit.Identity.Local.Privacy.Tests` (8), `Granit.Identity.Federated.Privacy.Tests` (8), `Granit.Auditing.Privacy.Tests` (9), `Granit.Notifications.Privacy.Tests` (8) — all green, no regression from the saga signature change

Refs #2313, #2310, #79