### PR TITLE
fix(privacy-endpoints,text-extraction-ocr-integration): unblock develop CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libtesseract5 tesseract-ocr-eng tesseract-ocr-fra
+            libtesseract5 tesseract-ocr-eng tesseract-ocr-fra \
+            fontconfig fonts-dejavu-core
           sudo ln -sf /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.82.0.so
           sudo ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract50.so
           echo "TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata" >> "$GITHUB_ENV"

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
@@ -1,6 +1,7 @@
 {
   "culture": "cs",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "V jednom exportu bylo požádáno o příliš mnoho oborů (limit: 64).",
     "Permission:Privacy.Agreements.Create": "Přijmout právní smlouvu",
     "Permission:Privacy.Agreements.Read": "Zobrazit právní dokumenty a stav souhlasu",
     "Permission:Privacy.Deletion.Execute": "Požádat o smazání osobních údajů",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
@@ -1,6 +1,7 @@
 {
   "culture": "de",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Zu viele Scopes in einem einzigen Export angefordert. Das Limit liegt bei 64.",
     "Permission:Privacy.Agreements.Create": "Einer rechtlichen Vereinbarung zustimmen",
     "Permission:Privacy.Agreements.Read": "Rechtliche Dokumente und Einwilligungsstatus anzeigen",
     "Permission:Privacy.Deletion.Execute": "Löschung personenbezogener Daten anfordern",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en-GB.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en-GB.json
@@ -1,6 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Too many scopes requested in a single export. The limit is 64.",
     "PrivacyEndpoints:Workspace.Agreements": "Agreements",
     "PrivacyEndpoints:Workspace.Purposes": "Purposes",
     "PrivacyEndpoints:Workspace.Section": "Privacy"

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
@@ -1,6 +1,7 @@
 {
   "culture": "en",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Too many scopes requested in a single export. The limit is 64.",
     "Permission:Privacy.Agreements.Create": "Accept a legal agreement",
     "Permission:Privacy.Agreements.Read": "View legal documents and consent status",
     "Permission:Privacy.Deletion.Execute": "Request personal data deletion",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
@@ -1,6 +1,7 @@
 {
   "culture": "es",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Se han solicitado demasiados ámbitos en una sola exportación. El límite es 64.",
     "Permission:Privacy.Agreements.Create": "Aceptar un acuerdo legal",
     "Permission:Privacy.Agreements.Read": "Ver documentos legales y estado de consentimiento",
     "Permission:Privacy.Deletion.Execute": "Solicitar eliminación de datos personales",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr-CA.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr-CA.json
@@ -1,6 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Trop de portées demandées dans un même export (limite : 64).",
     "PrivacyEndpoints:Workspace.Agreements": "Consentements",
     "PrivacyEndpoints:Workspace.Purposes": "Finalités",
     "PrivacyEndpoints:Workspace.Section": "Confidentialité"

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
@@ -1,6 +1,7 @@
 {
   "culture": "fr",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Trop de portées demandées dans un même export (limite : 64).",
     "Permission:Privacy.Agreements.Create": "Accepter un accord légal",
     "Permission:Privacy.Agreements.Read": "Consulter les documents légaux et le statut de consentement",
     "Permission:Privacy.Deletion.Execute": "Demander la suppression des données personnelles",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/hi.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/hi.json
@@ -1,6 +1,7 @@
 {
   "culture": "hi",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "एक ही एक्सपोर्ट में बहुत अधिक स्कोप मांगे गए हैं (सीमा: 64)।",
     "Permission:Privacy.Agreements.Create": "कानूनी समझौता स्वीकार करें",
     "Permission:Privacy.Agreements.Read": "कानूनी दस्तावेज़ और सहमति स्थिति देखें",
     "Permission:Privacy.Deletion.Execute": "व्यक्तिगत डेटा हटाने का अनुरोध करें",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
@@ -1,6 +1,7 @@
 {
   "culture": "it",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Sono stati richiesti troppi scope in una singola esportazione. Il limite è 64.",
     "Permission:Privacy.Agreements.Create": "Accettare un accordo legale",
     "Permission:Privacy.Agreements.Read": "Visualizzare documenti legali e stato del consenso",
     "Permission:Privacy.Deletion.Execute": "Richiedere la cancellazione dei dati personali",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
@@ -1,6 +1,7 @@
 {
   "culture": "ja",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "1 回のエクスポートで要求されたスコープが多すぎます (上限は 64 です)。",
     "Permission:Privacy.Agreements.Create": "法的合意に同意",
     "Permission:Privacy.Agreements.Read": "法的文書と同意ステータスを表示",
     "Permission:Privacy.Deletion.Execute": "個人データの削除を要求",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
@@ -1,6 +1,7 @@
 {
   "culture": "ko",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "단일 내보내기 요청에 너무 많은 스코프가 포함되어 있습니다 (최대 64개).",
     "Permission:Privacy.Agreements.Create": "법적 계약 수락",
     "Permission:Privacy.Agreements.Read": "법적 문서 및 동의 상태 조회",
     "Permission:Privacy.Deletion.Execute": "개인 데이터 삭제 요청",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
@@ -1,6 +1,7 @@
 {
   "culture": "nl",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Te veel scopes opgevraagd in één export. De limiet is 64.",
     "Permission:Privacy.Agreements.Create": "Een juridische overeenkomst accepteren",
     "Permission:Privacy.Agreements.Read": "Juridische documenten en toestemmingsstatus bekijken",
     "Permission:Privacy.Deletion.Execute": "Verwijdering van persoonsgegevens aanvragen",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
@@ -1,6 +1,7 @@
 {
   "culture": "pl",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Zbyt wiele zakresów w jednym żądaniu eksportu (limit: 64).",
     "Permission:Privacy.Agreements.Create": "Zaakceptowanie umowy prawnej",
     "Permission:Privacy.Agreements.Read": "Wyświetlanie dokumentów prawnych i statusu zgody",
     "Permission:Privacy.Deletion.Execute": "Żądanie usunięcia danych osobowych",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt-BR.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt-BR.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Muitos escopos solicitados em uma única exportação. O limite é 64.",
     "PrivacyEndpoints:Workspace.Agreements": "Agreements",
     "PrivacyEndpoints:Workspace.Purposes": "Purposes",
     "PrivacyEndpoints:Workspace.Section": "Privacy"

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Demasiados âmbitos pedidos numa única exportação. O limite é 64.",
     "Permission:Privacy.Agreements.Create": "Aceitar um acordo legal",
     "Permission:Privacy.Agreements.Read": "Ver documentos legais e estado de consentimento",
     "Permission:Privacy.Deletion.Execute": "Solicitar eliminação de dados pessoais",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
@@ -1,6 +1,7 @@
 {
   "culture": "sv",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "För många scopes begärda i en enskild export. Gränsen är 64.",
     "Permission:Privacy.Agreements.Create": "Acceptera ett juridiskt avtal",
     "Permission:Privacy.Agreements.Read": "Visa juridiska dokument och samtycksstatus",
     "Permission:Privacy.Deletion.Execute": "Begär radering av personuppgifter",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
@@ -1,6 +1,7 @@
 {
   "culture": "tr",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "Tek bir dışa aktarmada çok fazla kapsam istendi (sınır: 64).",
     "Permission:Privacy.Agreements.Create": "Yasal sözleşmeyi kabul et",
     "Permission:Privacy.Agreements.Read": "Yasal belgeleri ve onay durumunu görüntüle",
     "Permission:Privacy.Deletion.Execute": "Kişisel veri silme talep et",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
@@ -1,6 +1,7 @@
 {
   "culture": "zh",
   "texts": {
+    "Granit:Validation:PrivacyExportTooManyScopes": "单次导出请求的范围过多,上限为 64。",
     "Permission:Privacy.Agreements.Create": "接受法律协议",
     "Permission:Privacy.Agreements.Read": "查看法律文件和同意状态",
     "Permission:Privacy.Deletion.Execute": "请求删除个人数据",

--- a/src/Granit.Privacy.Endpoints/Validators/PrivacyExportRequestValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Validators/PrivacyExportRequestValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+using Granit.Privacy.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Privacy.Endpoints.Validators;
+
+/// <summary>
+/// Validator for <see cref="PrivacyExportRequest"/>. Caps the requested-scopes
+/// list size and per-entry length so the export request handler can't be used as
+/// a DoS vector. Scope NAMES are deliberately NOT validated against a known set —
+/// unknown / hidden entries are dropped server-side by the visibility resolver to
+/// avoid enumerating the provider catalogue.
+/// </summary>
+internal sealed class PrivacyExportRequestValidator : GranitValidator<PrivacyExportRequest>
+{
+    private const int MaxScopes = 64;
+    private const int MaxScopeNameLength = 200;
+
+    public PrivacyExportRequestValidator()
+    {
+        RuleFor(x => x.Scopes)
+            .Must(s => s is null || s.Count <= MaxScopes)
+                .WithErrorCodeAndMessage("Granit:Validation:PrivacyExportTooManyScopes");
+
+        RuleForEach(x => x.Scopes!)
+            .NotEmpty()
+            .MaximumLength(MaxScopeNameLength)
+            .When(x => x.Scopes is { Count: > 0 });
+    }
+}

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
@@ -82,9 +82,12 @@ public sealed class LiveTesseractRecognizerTests
     private static byte[] RenderPngWithText(string text)
     {
         // Magick.NET (Apache-2.0, native deps bundled in the Q8-AnyCPU package) renders
-        // the caption to a PNG without requiring a system-font lookup — IM picks a built-in
-        // font, sized to fit. The output resolution is intentionally generous so Tesseract
-        // has clean glyph edges to work with.
+        // the caption to a PNG. We pin a font file path explicitly because the bundled
+        // libfreetype probes via fontconfig — on bare Ubuntu CI images without
+        // `fontconfig` + `fonts-dejavu-core` the probe returns `(null)` and IM throws
+        // MagickTypeErrorException. The CI integration shard installs both deps; the
+        // path resolution falls through to a known-good Linux location.
+        string fontPath = ResolveFontPath();
         MagickReadSettings settings = new()
         {
             Width = 600,
@@ -92,10 +95,30 @@ public sealed class LiveTesseractRecognizerTests
             BackgroundColor = MagickColors.White,
             FillColor = MagickColors.Black,
             FontPointsize = 64,
+            Font = fontPath,
         };
         using MagickImage image = new($"label:{text}", settings);
         image.BorderColor = MagickColors.White;
         image.Border(20);
         return image.ToByteArray(MagickFormat.Png);
+    }
+
+    private static string ResolveFontPath()
+    {
+        // Candidate list, ordered by what the CI integration shard installs first
+        // (`fonts-dejavu-core`). Other entries are fallbacks for developer machines.
+        string[] candidates =
+        [
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/TTF/DejaVuSans.ttf",
+            "/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        ];
+        return Array.Find(candidates, File.Exists)
+            ?? throw new FileNotFoundException(
+                "No usable system font (DejaVu Sans / Liberation Sans) was found. " +
+                "Install fonts-dejavu-core on Debian/Ubuntu or set TESSDATA_PREFIX " +
+                "only on a machine that has a known TrueType font installed.");
     }
 }


### PR DESCRIPTION
Develop CI is red on two unrelated regressions; this PR unblocks both.

## Regression 1 — Architecture test (added by #2318)

`Granit.ArchitectureTests.ValidationConventionTests.Request_types_in_Endpoints_should_have_validators` fails because `Granit.Privacy.Endpoints.PrivacyExportRequest` (introduced in P6.1 — privacy export streaming) has no `IValidator<T>`.

Adds `PrivacyExportRequestValidator` capping:

- `Scopes.Count` ≤ 64 (DoS guard against giant scope lists)
- per-scope `MaxLength = 200`
- per-scope `NotEmpty`

Scope **names** are deliberately not validated against a known set — the visibility resolver drops unknown / hidden entries server-side to avoid enumerating the provider catalogue. The validator's role is purely DoS containment, not catalogue enforcement.

Localized error message `Granit:Validation:PrivacyExportTooManyScopes` added for all 18 cultures (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi + fr-CA, en-GB, pt-BR).

## Regression 2 — Live OCR integration test (added by #2319)

`Granit.TextExtraction.Ocr.Tesseract.Tests.Integration` failed on the runner with `MagickTypeErrorException : UnableToReadFont '(null)' @ error/annotate.c/RenderFreetype/1747`. The GitHub Ubuntu image ships no system font and no fontconfig config, so Magick.NET's `label:` operator can't probe a default.

- CI `integration` shard now also installs `fontconfig` + `fonts-dejavu-core`.
- The test pins an explicit font path via `MagickReadSettings.Font` instead of relying on default-font discovery — `DejaVu Sans` first, with Liberation Sans fallbacks for dev machines that have other font packages.

## Test plan

- [x] `dotnet test tests/Granit.ArchitectureTests --filter ValidationConventionTests --no-build` — 3/3 green.
- [x] `dotnet test tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration --no-build` without `TESSDATA_PREFIX` — 2/2 SKIP (skip path intact).
- [x] `dotnet format src/Granit.Privacy.Endpoints --verify-no-changes` clean.
- [x] `dotnet format tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration --verify-no-changes` clean.
- [x] All 18 culture JSON files contain the new key (verified with `python -c json.load`).
- [ ] CI integration shard runs the live suite end-to-end with the new font setup.
- [ ] CI architecture shard goes green.