### PR TITLE
fix(ci-integration): discover libtesseract / liblept .so files via glob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,10 @@ jobs:
       #
       # The Charlesw `Tesseract` NuGet (5.x) hard-codes the names
       # `libleptonica-1.82.0` and `libtesseract50` when probing the loader path.
-      # apt ships `liblept.so.5` / `libtesseract.so.5` so we symlink the canonical
-      # names into place — without it, P/Invoke throws DllNotFoundException at the
-      # first OCR call.
+      # The runtime apt packages (`liblept5`, `libtesseract5`) only ship the
+      # fully-versioned `.so.MAJOR.MINOR.PATCH` files — no `.so.MAJOR` symlinks
+      # (those come with the `-dev` packages). We discover the actual file via
+      # glob and point the canonical names at it.
       - name: Install libtesseract (integration shard only)
         if: matrix.shard.name == 'integration'
         run: |
@@ -130,8 +131,16 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libtesseract5 tesseract-ocr-eng tesseract-ocr-fra \
             fontconfig fonts-dejavu-core
-          sudo ln -sf /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.82.0.so
-          sudo ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract50.so
+          LIB_DIR=/usr/lib/x86_64-linux-gnu
+          LEPT_LIB=$(ls "$LIB_DIR"/liblept.so.5* 2>/dev/null | head -n 1)
+          TESS_LIB=$(ls "$LIB_DIR"/libtesseract.so.5* 2>/dev/null | head -n 1)
+          if [ -z "$LEPT_LIB" ] || [ -z "$TESS_LIB" ]; then
+            echo "Could not locate libtesseract / liblept under $LIB_DIR" >&2
+            ls "$LIB_DIR" | grep -E '(lept|tesseract)' >&2 || true
+            exit 1
+          fi
+          sudo ln -sf "$LEPT_LIB" "$LIB_DIR/libleptonica-1.82.0.so"
+          sudo ln -sf "$TESS_LIB" "$LIB_DIR/libtesseract50.so"
           echo "TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata" >> "$GITHUB_ENV"
 
       - name: Build shard

--- a/src/Granit.TextExtraction.Ocr.Tesseract/README.md
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/README.md
@@ -25,10 +25,13 @@ Linux (Debian / Ubuntu):
 ```bash
 apt-get install -y libtesseract5 tesseract-ocr-eng tesseract-ocr-fra
 # The Charlesw Tesseract NuGet probes for "libleptonica-1.82.0" and
-# "libtesseract50" by name — the apt packages ship liblept.so.5 and
-# libtesseract.so.5 instead, so symlink the canonical names:
-ln -sf /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.82.0.so
-ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract50.so
+# "libtesseract50" by name. The runtime apt packages only ship the fully
+# versioned `.so.MAJOR.MINOR.PATCH` files (`liblept.so.5.0.4`,
+# `libtesseract.so.5.0.3` on Ubuntu 24.04) — no `.so.MAJOR` shortcut.
+# Discover the file via glob and symlink the canonical names:
+LIB_DIR=/usr/lib/x86_64-linux-gnu
+ln -sf "$(ls $LIB_DIR/liblept.so.5* | head -n 1)" "$LIB_DIR/libleptonica-1.82.0.so"
+ln -sf "$(ls $LIB_DIR/libtesseract.so.5* | head -n 1)" "$LIB_DIR/libtesseract50.so"
 ```
 
 The traineddata path is then `/usr/share/tesseract-ocr/5/tessdata/`. Each language


### PR DESCRIPTION
Follow-up to #2322. Develop is still red on the OCR integration shard because the symlinks I added in the previous fix point at `liblept.so.5` / `libtesseract.so.5` — those don't exist on the runner. Ubuntu 24.04's runtime packages (`liblept5`, `libtesseract5`) only ship the fully-versioned shared objects (`liblept.so.5.0.4`, `libtesseract.so.5.0.3`); the `.so.MAJOR` shortcut symlinks are part of the `-dev` packages.

## Fix

Discover the actual `.so` file via a glob and link the canonical names the Charlesw `Tesseract` NuGet probes for (`libleptonica-1.82.0.so`, `libtesseract50.so`). Adds a fail-fast guard so a future apt-naming change shows in the CI log instead of producing a confusing `DllNotFoundException` downstream.

README updated with the same recipe so local developer installs match CI.

## Test plan

- [x] YAML syntax OK (`python -c yaml.safe_load`).
- [x] `markdownlint-cli2 src/Granit.TextExtraction.Ocr.Tesseract/README.md` clean.
- [ ] CI integration shard runs the live OCR suite end-to-end.