### PR TITLE
feat(privacy)!: widen PrivacyMetrics + DataDeletion + OptOut TenantId Guid?

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37228,7 +37228,7 @@
           "name": "Start",
           "kind": "method",
           "signature": "Start(DeletionDeferredEto @event, IOptions<GranitPrivacyOptions> options, IMessageContext context, IDeletionRequestTrackerWriter tracker, PrivacyMetrics metrics)",
-          "returnType": "string? TenantId { get; set; } public bool ReminderSent { get; set; } public Task"
+          "returnType": "Guid? TenantId { get; set; } public bool ReminderSent { get; set; } public Task"
         }
       ]
     },
@@ -37598,55 +37598,55 @@
         {
           "name": "RecordFragmentReceived",
           "kind": "method",
-          "signature": "RecordFragmentReceived(string? tenantId, string provider, string? regulation = null)",
+          "signature": "RecordFragmentReceived(Guid? tenantId, string provider, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordDeletionRequested",
           "kind": "method",
-          "signature": "RecordDeletionRequested(string? tenantId, string? regulation = null)",
+          "signature": "RecordDeletionRequested(Guid? tenantId, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordDeletionDeferred",
           "kind": "method",
-          "signature": "RecordDeletionDeferred(string? tenantId, string? regulation = null)",
+          "signature": "RecordDeletionDeferred(Guid? tenantId, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordDeletionCancelled",
           "kind": "method",
-          "signature": "RecordDeletionCancelled(string? tenantId, string? regulation = null)",
+          "signature": "RecordDeletionCancelled(Guid? tenantId, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordDeletionExecuted",
           "kind": "method",
-          "signature": "RecordDeletionExecuted(string? tenantId, string? regulation = null)",
+          "signature": "RecordDeletionExecuted(Guid? tenantId, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordDeletionReminderSent",
           "kind": "method",
-          "signature": "RecordDeletionReminderSent(string? tenantId, string? regulation = null)",
+          "signature": "RecordDeletionReminderSent(Guid? tenantId, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordExportCompleted",
           "kind": "method",
-          "signature": "RecordExportCompleted(string? tenantId, string status, TimeSpan duration, string? regulation = null)",
+          "signature": "RecordExportCompleted(Guid? tenantId, string status, TimeSpan duration, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordArchiveAssembled",
           "kind": "method",
-          "signature": "RecordArchiveAssembled(string? tenantId, string status, bool isPartial, TimeSpan duration, string? regulation = null)",
+          "signature": "RecordArchiveAssembled(Guid? tenantId, string status, bool isPartial, TimeSpan duration, string? regulation = null)",
           "returnType": "void"
         },
         {
           "name": "RecordOptOutRevoked",
           "kind": "method",
-          "signature": "RecordOptOutRevoked(string? tenantId, string? regulation = null)",
+          "signature": "RecordOptOutRevoked(Guid? tenantId, string? regulation = null)",
           "returnType": "void"
         },
         {

--- a/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
@@ -137,7 +137,7 @@ public sealed partial class ExportArchiveAssemblyHandler(
 
             TimeSpan duration = Stopwatch.GetElapsedTime(startTimestamp);
             metrics.RecordArchiveAssembled(
-                tenantId: @event.TenantId?.ToString(), status: finalState.ToString(), @event.IsPartial, duration, @event.Regulation);
+                tenantId: @event.TenantId, status: finalState.ToString(), @event.IsPartial, duration, @event.Regulation);
             LogArchiveAssembled(logger, @event.RequestId, @event.Fragments.Count, emptyProviders.Count, (long)duration.TotalMilliseconds);
         }
         catch (PrivacyExportSizeLimitExceededException ex)
@@ -151,7 +151,7 @@ public sealed partial class ExportArchiveAssemblyHandler(
                 cancellationToken).ConfigureAwait(false);
             TimeSpan duration = Stopwatch.GetElapsedTime(startTimestamp);
             metrics.RecordArchiveAssembled(
-                tenantId: @event.TenantId?.ToString(),
+                tenantId: @event.TenantId,
                 status: ExportRequestState.SizeLimitExceeded.ToString(),
                 @event.IsPartial,
                 duration,

--- a/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
@@ -196,7 +196,7 @@ public static class PrivacyEndpointRouteBuilderExtensions
         Guid recordId = guidGenerator.Create();
         DateTimeOffset now = timeProvider.GetUtcNow();
         string regulation = await ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
-        string? tenantId = ResolveTenantId(currentTenant);
+        Guid? tenantId = ResolveTenantId(currentTenant);
 
         // Determine identity — authenticated user or anonymous visitor
         Guid? userId = TryGetUserIdOrNull(httpContext);
@@ -475,7 +475,7 @@ public static class PrivacyEndpointRouteBuilderExtensions
                 cancellationToken)
             .ConfigureAwait(false);
 
-        metrics.RecordExportRequested(tenantId?.ToString(), regulation);
+        metrics.RecordExportRequested(tenantId, regulation);
 
         return TypedResults.Accepted(
             $"/privacy/export/{requestId}",
@@ -603,7 +603,7 @@ public static class PrivacyEndpointRouteBuilderExtensions
 
         Guid requestId = guidGenerator.Create();
         DateTimeOffset now = timeProvider.GetUtcNow();
-        string? tenantId = ResolveTenantId(currentTenant);
+        Guid? tenantId = ResolveTenantId(currentTenant);
         string requestedBy = currentUser.Email ?? "unknown";
         string regulation = await ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
 
@@ -902,8 +902,8 @@ public static class PrivacyEndpointRouteBuilderExtensions
             detail: "User is not authenticated or has no valid user ID.",
             statusCode: StatusCodes.Status401Unauthorized);
 
-    internal static string? ResolveTenantId(ICurrentTenant currentTenant) =>
-        currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null;
+    internal static Guid? ResolveTenantId(ICurrentTenant currentTenant) =>
+        currentTenant.IsAvailable ? currentTenant.Id : null;
 
     internal static void RegisterOptOutCookie(ICookieRegistry registry) =>
         registry.Register(new CookieDefinition(

--- a/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/EfDeletionRequestTracker.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/EfDeletionRequestTracker.cs
@@ -120,5 +120,5 @@ internal sealed class EfDeletionRequestTracker<TContext>(
             entity.CancelledAt,
             entity.ExecutedAt,
             entity.Regulation,
-            entity.TenantId?.ToString());
+            entity.TenantId);
 }

--- a/src/Granit.Privacy/DataDeletion/DeletionRequestStatus.cs
+++ b/src/Granit.Privacy/DataDeletion/DeletionRequestStatus.cs
@@ -16,4 +16,4 @@ public sealed record DeletionRequestStatus(
     DateTimeOffset? CancelledAt,
     DateTimeOffset? ExecutedAt,
     string? Regulation = null,
-    string? TenantId = null);
+    Guid? TenantId = null);

--- a/src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs
@@ -19,4 +19,4 @@ public sealed record DeletionDeferredEto(
     string Reason,
     DateTimeOffset ScheduledDeletionAt,
     string Regulation,
-    string? TenantId = null) : IIntegrationEvent;
+    Guid? TenantId = null) : IIntegrationEvent;

--- a/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs
@@ -17,4 +17,4 @@ public sealed record PersonalDataDeletionRequestedEto(
     [property: SensitiveData(Level = Sensitivity.Confidential), Encrypted]
     string Reason,
     string Regulation,
-    string? TenantId = null) : IIntegrationEvent;
+    Guid? TenantId = null) : IIntegrationEvent;

--- a/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
+++ b/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
@@ -58,7 +58,7 @@ public sealed class PersonalDataDeletionSaga : Saga
     public string Regulation { get; set; } = string.Empty;
 
     /// <summary>Tenant identifier propagated from the starting event for metrics tagging.</summary>
-    public string? TenantId { get; set; }
+    public Guid? TenantId { get; set; }
 
     /// <summary>Whether the reminder notification has been sent.</summary>
     public bool ReminderSent { get; set; }

--- a/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
+++ b/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
@@ -83,7 +83,7 @@ public sealed class PersonalDataExportSaga : Saga
         Regulation = @event.Regulation;
         TenantId = @event.TenantId;
         RequestedAt = @event.RequestedAt;
-        metrics.RecordExportRequested(TenantId?.ToString(), Regulation);
+        metrics.RecordExportRequested(TenantId, Regulation);
 
         // Apply visibility gates + intersect with the subject's RequestedScopes list.
         // RequestedScopes naming an unknown / hidden provider is silently dropped (VULN-202:
@@ -144,7 +144,7 @@ public sealed class PersonalDataExportSaga : Saga
             @event.ContentType,
             @event.IntegrityTag));
         bool expected = PendingProviders.Remove(@event.ProviderName);
-        metrics.RecordFragmentReceived(TenantId?.ToString(), expected ? @event.ProviderName : "unknown", Regulation);
+        metrics.RecordFragmentReceived(TenantId, expected ? @event.ProviderName : "unknown", Regulation);
 
         // Multi-fragment providers (Documents, attachments) emit one Prepared event per
         // fragment but only count once against ExpectedCount via PendingProviders.Remove.
@@ -174,7 +174,7 @@ public sealed class PersonalDataExportSaga : Saga
     /// </summary>
     public ExportCompletedEto Handle(ExportTimedOutEvent @event, PrivacyMetrics metrics)
     {
-        metrics.RecordExportCompleted(TenantId?.ToString(), "timeout", TimeSpan.Zero, Regulation);
+        metrics.RecordExportCompleted(TenantId, "timeout", TimeSpan.Zero, Regulation);
         MarkCompleted();
         return new ExportCompletedEto(
             RequestId: Id,

--- a/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
+++ b/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
@@ -91,53 +91,53 @@ public sealed class PrivacyMetrics
     }
 
     /// <summary>Records an export request.</summary>
-    public void RecordExportRequested(string? tenantId, string? regulation = null) =>
+    public void RecordExportRequested(Guid? tenantId, string? regulation = null) =>
         _exportRequests.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>Records a fragment received from a data provider.</summary>
-    public void RecordFragmentReceived(string? tenantId, string provider, string? regulation = null) =>
+    public void RecordFragmentReceived(Guid? tenantId, string provider, string? regulation = null) =>
         _fragmentsReceived.Add(1, new TagList
         {
-            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
             { TagRegulation, regulation ?? DefaultRegulation },
             { "provider", provider },
         });
 
     /// <summary>Records a deletion request.</summary>
-    public void RecordDeletionRequested(string? tenantId, string? regulation = null) =>
+    public void RecordDeletionRequested(Guid? tenantId, string? regulation = null) =>
         _deletionRequests.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>Records a deferred deletion request.</summary>
-    public void RecordDeletionDeferred(string? tenantId, string? regulation = null) =>
+    public void RecordDeletionDeferred(Guid? tenantId, string? regulation = null) =>
         _deletionDeferred.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>Records a cancelled deferred deletion.</summary>
-    public void RecordDeletionCancelled(string? tenantId, string? regulation = null) =>
+    public void RecordDeletionCancelled(Guid? tenantId, string? regulation = null) =>
         _deletionCancelled.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>Records an executed deletion.</summary>
-    public void RecordDeletionExecuted(string? tenantId, string? regulation = null) =>
+    public void RecordDeletionExecuted(Guid? tenantId, string? regulation = null) =>
         _deletionExecuted.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>Records a deletion reminder notification sent.</summary>
-    public void RecordDeletionReminderSent(string? tenantId, string? regulation = null) =>
+    public void RecordDeletionReminderSent(Guid? tenantId, string? regulation = null) =>
         _deletionReminders.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>Records the duration and status of a completed export.</summary>
-    public void RecordExportCompleted(string? tenantId, string status, TimeSpan duration, string? regulation = null) =>
+    public void RecordExportCompleted(Guid? tenantId, string status, TimeSpan duration, string? regulation = null) =>
         _exportDuration.Record(duration.TotalSeconds, new TagList
         {
-            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
             { TagRegulation, regulation ?? DefaultRegulation },
             { "status", status },
         });
 
     /// <summary>Records a completed archive assembly (success or <c>SizeLimitExceeded</c>).</summary>
-    public void RecordArchiveAssembled(string? tenantId, string status, bool isPartial, TimeSpan duration, string? regulation = null)
+    public void RecordArchiveAssembled(Guid? tenantId, string status, bool isPartial, TimeSpan duration, string? regulation = null)
     {
         TagList tags = new()
         {
-            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
             { TagRegulation, regulation ?? DefaultRegulation },
             { "status", status },
             { "is_partial", isPartial ? "true" : "false" },
@@ -147,11 +147,11 @@ public sealed class PrivacyMetrics
     }
 
     /// <summary>Records an opt-out request.</summary>
-    public void RecordOptOutRequested(string? tenantId, string? regulation = null) =>
+    public void RecordOptOutRequested(Guid? tenantId, string? regulation = null) =>
         _optOutRequests.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>Records an opt-out revocation.</summary>
-    public void RecordOptOutRevoked(string? tenantId, string? regulation = null) =>
+    public void RecordOptOutRevoked(Guid? tenantId, string? regulation = null) =>
         _optOutRevocations.Add(1, CreateTags(tenantId, regulation));
 
     /// <summary>
@@ -166,9 +166,9 @@ public sealed class PrivacyMetrics
             { "provider_name", providerName },
         });
 
-    private static TagList CreateTags(string? tenantId, string? regulation) => new()
+    private static TagList CreateTags(Guid? tenantId, string? regulation) => new()
     {
-        { TagTenantId, tenantId ?? DefaultTenant },
+        { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
         { TagRegulation, regulation ?? DefaultRegulation },
     };
 }

--- a/src/Granit.Privacy/OptOut/Events/OptOutRequestedEto.cs
+++ b/src/Granit.Privacy/OptOut/Events/OptOutRequestedEto.cs
@@ -13,4 +13,4 @@ public sealed record OptOutRequestedEto(
     string? AnonymousTrackId,
     DateTimeOffset RequestedAt,
     string Regulation,
-    string? TenantId) : IIntegrationEvent;
+    Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Privacy/OptOut/Events/OptOutRevokedEto.cs
+++ b/src/Granit.Privacy/OptOut/Events/OptOutRevokedEto.cs
@@ -13,4 +13,4 @@ public sealed record OptOutRevokedEto(
     string? AnonymousTrackId,
     DateTimeOffset RevokedAt,
     string Regulation,
-    string? TenantId) : IIntegrationEvent;
+    Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Privacy/OptOut/OptOutRecord.cs
+++ b/src/Granit.Privacy/OptOut/OptOutRecord.cs
@@ -19,5 +19,5 @@ public sealed record OptOutRecord(
     OptOutState State,
     DateTimeOffset RequestedAt,
     DateTimeOffset? RevokedAt,
-    string? TenantId,
+    Guid? TenantId,
     string Regulation);

--- a/tests/Granit.Privacy.Endpoints.Tests/Extensions/PrivacyHelperMethodTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Extensions/PrivacyHelperMethodTests.cs
@@ -163,16 +163,16 @@ public sealed class PrivacyHelperMethodTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void ResolveTenantId_TenantAvailable_ReturnsIdString()
+    public void ResolveTenantId_TenantAvailable_ReturnsId()
     {
         var tenantId = Guid.NewGuid();
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         currentTenant.IsAvailable.Returns(true);
         currentTenant.Id.Returns(tenantId);
 
-        string? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
+        Guid? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
 
-        result.ShouldBe(tenantId.ToString());
+        result.ShouldBe(tenantId);
     }
 
     [Fact]
@@ -181,7 +181,7 @@ public sealed class PrivacyHelperMethodTests
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         currentTenant.IsAvailable.Returns(false);
 
-        string? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
+        Guid? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
 
         result.ShouldBeNull();
     }
@@ -193,7 +193,7 @@ public sealed class PrivacyHelperMethodTests
         currentTenant.IsAvailable.Returns(true);
         currentTenant.Id.Returns((Guid?)null);
 
-        string? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
+        Guid? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
 
         result.ShouldBeNull();
     }

--- a/tests/Granit.Privacy.Tests/Diagnostics/PrivacyMetricsTests.cs
+++ b/tests/Granit.Privacy.Tests/Diagnostics/PrivacyMetricsTests.cs
@@ -9,6 +9,10 @@ namespace Granit.Privacy.Tests.Diagnostics;
 
 public sealed class PrivacyMetricsTests : IDisposable
 {
+    // Fixed tenant ids so the expected tag strings are stable across runs.
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TenantB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
     private readonly ServiceProvider _sp;
     private readonly IMeterFactory _meterFactory;
     private readonly PrivacyMetrics _metrics;
@@ -30,12 +34,12 @@ public sealed class PrivacyMetricsTests : IDisposable
         using var collector = new MetricCollector<long>(
             _meterFactory, PrivacyMetrics.MeterName, "granit.privacy.export.requests");
 
-        _metrics.RecordExportRequested("tenant-123");
+        _metrics.RecordExportRequested(TenantA);
 
         IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
         snapshot.ShouldHaveSingleItem();
         snapshot[0].Value.ShouldBe(1);
-        snapshot[0].Tags["tenant_id"].ShouldBe("tenant-123");
+        snapshot[0].Tags["tenant_id"].ShouldBe(TenantA.ToString());
     }
 
     [Fact]
@@ -57,12 +61,12 @@ public sealed class PrivacyMetricsTests : IDisposable
         using var collector = new MetricCollector<long>(
             _meterFactory, PrivacyMetrics.MeterName, "granit.privacy.export.fragments.received");
 
-        _metrics.RecordFragmentReceived("t1", "identity-provider");
+        _metrics.RecordFragmentReceived(TenantA, "identity-provider");
 
         IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
         snapshot.ShouldHaveSingleItem();
         snapshot[0].Value.ShouldBe(1);
-        snapshot[0].Tags["tenant_id"].ShouldBe("t1");
+        snapshot[0].Tags["tenant_id"].ShouldBe(TenantA.ToString());
         snapshot[0].Tags["provider"].ShouldBe("identity-provider");
     }
 
@@ -72,7 +76,7 @@ public sealed class PrivacyMetricsTests : IDisposable
         using var collector = new MetricCollector<long>(
             _meterFactory, PrivacyMetrics.MeterName, "granit.privacy.deletion.requests");
 
-        _metrics.RecordDeletionRequested("t1");
+        _metrics.RecordDeletionRequested(TenantA);
 
         IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
         snapshot.ShouldHaveSingleItem();
@@ -85,13 +89,13 @@ public sealed class PrivacyMetricsTests : IDisposable
         using var collector = new MetricCollector<double>(
             _meterFactory, PrivacyMetrics.MeterName, "granit.privacy.export.duration");
 
-        _metrics.RecordExportCompleted("t1", "completed", TimeSpan.FromSeconds(3.5));
+        _metrics.RecordExportCompleted(TenantA, "completed", TimeSpan.FromSeconds(3.5));
 
         IReadOnlyList<CollectedMeasurement<double>> snapshot = collector.GetMeasurementSnapshot();
         snapshot.ShouldHaveSingleItem();
         snapshot[0].Value.ShouldBe(3.5, 0.01);
         snapshot[0].Tags["status"].ShouldBe("completed");
-        snapshot[0].Tags["tenant_id"].ShouldBe("t1");
+        snapshot[0].Tags["tenant_id"].ShouldBe(TenantA.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Finishes the Privacy module's TenantId type unification (started in #2321). Every public `TenantId` surface in `Granit.Privacy*` now uses `Guid?`, matching CLAUDE.md §IMultiTenant and the EF row type. Call sites drop the `.ToString()` plumbing — the compiler now catches argument-confusion bugs (e.g. passing a `UserId` where a `TenantId` is expected).

## Breaking surface

**`PrivacyMetrics` (11 methods)** — `string? tenantId` → `Guid? tenantId`:
- `RecordExportRequested`
- `RecordFragmentReceived`
- `RecordDeletionRequested` / `Deferred` / `Cancelled` / `Executed` / `ReminderSent`
- `RecordExportCompleted`
- `RecordArchiveAssembled`
- `RecordOptOutRequested` / `Revoked`

Internal `CreateTags` and inline `TagList` emit `tenantId?.ToString() ?? DefaultTenant` so the OTel tag value stays a string — **no behaviour change on the wire**.

**DataDeletion** (3 records):
- `PersonalDataDeletionRequestedEto.TenantId`: `string?` → `Guid?`
- `DeletionDeferredEto.TenantId`: `string?` → `Guid?`
- `DeletionRequestStatus.TenantId`: `string?` → `Guid?`
- `PersonalDataDeletionSaga.TenantId` state field: `string?` → `Guid?`

**OptOut** (3 records):
- `OptOutRecord.TenantId`: `string?` → `Guid?`
- `OptOutRequestedEto.TenantId`: `string?` → `Guid?`
- `OptOutRevokedEto.TenantId`: `string?` → `Guid?`

**Helpers & call sites**:
- `PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(ICurrentTenant)`: returns `Guid?` (was `string?`).
- `ExportArchiveAssemblyHandler`, `EfDeletionRequestTracker`, `PersonalDataExportSaga`: pass `TenantId` directly to metric calls — `.ToString()` shims removed.

## Tests

- `PrivacyMetricsTests`: replaced string literal tenants with fixed `Guid` constants (`TenantA` / `TenantB`). Null-tenant tests retained — confirm the `"global"` fallback tag survives the type change.
- `PrivacyHelperMethodTests.ResolveTenantId*` (3 tests): updated to assert `Guid?` rather than `string?` returns.

## Test plan

- [x] `dotnet build` on the 5 modified `src` projects — green
- [x] `dotnet build .github/shard-filters/security.slnf` + `infrastructure.slnf` — green
- [x] 8 Privacy test suites — **457 tests green** (Privacy: 272, BlobStorage: 23, Identity.Local: 8, Identity.Federated: 8, Auditing: 9, Notifications: 8, Endpoints: 125, BackgroundJobs: 4)
- [x] `dotnet format --verify-no-changes` clean on the 6 modified projects

Refs #2310, #2314, #79