### PR TITLE
feat(text-extraction-office): pin MC mode + archi-test SSRF guard (TE-F2.2.1)

### DIFF
--- a/src/Granit.TextExtraction.Office/Internal/OpenXmlExtraction.cs
+++ b/src/Granit.TextExtraction.Office/Internal/OpenXmlExtraction.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using Granit.TextExtraction.Options;
 
@@ -9,6 +10,17 @@ namespace Granit.TextExtraction.Office.Internal;
 /// </summary>
 internal static class OpenXmlExtraction
 {
+    /// <remarks>
+    /// We deliberately don't strip external relationships
+    /// (<c>&lt;Relationship Target="http://..."&gt;</c>) from the <c>.rels</c> parts
+    /// before opening: OpenXml's reader never dereferences an external relationship
+    /// target on its own, so a strip pass would cost CPU on every document for zero
+    /// behaviour change. The defence is structural instead — the architecture test
+    /// <c>Office_assembly_must_not_reference_HTTP_or_external_URI_APIs</c> enforces
+    /// that the Office assembly cannot reference <see cref="System.Net.Http.HttpClient"/> /
+    /// <c>System.Net.WebRequest</c> / <c>System.Net.Sockets</c> at build time, so even
+    /// a future code path that tried to follow an external target would fail to link.
+    /// </remarks>
     public static OpenSettings BuildOpenSettings(GranitTextExtractionOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
@@ -18,6 +30,14 @@ internal static class OpenXmlExtraction
             // honours this by throwing FileFormatException so the host stays bounded.
             MaxCharactersInPart = options.MaxExtractedCharLength,
             AutoSave = false,
+            // Pin Markup Compatibility processing to the Office 2010 schema set and
+            // walk only loaded parts. Future Office versions introducing new MC choice
+            // branches degrade gracefully (the parser ignores the unknown extension)
+            // instead of triggering OpenXml's "best effort" fallback — which has a
+            // history of opening attack surface for crafted alternate-content blocks.
+            MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(
+                MarkupCompatibilityProcessMode.ProcessLoadedPartsOnly,
+                FileFormatVersions.Office2010),
         };
     }
 

--- a/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Shouldly;
 using Xunit;
@@ -167,6 +168,91 @@ public sealed class TextExtractionArchitectureTests
             $"{projectName} must declare [DependsOn(... typeof(GranitTextExtractionModule) ...)] " +
             "on its module so the pipeline/options/metrics are registered when only this " +
             "provider is wired in.");
+    }
+
+    /// <summary>
+    /// <c>Granit.TextExtraction.Office</c> opens user-supplied OOXML packages with the
+    /// OpenXml SDK. Those packages can declare <c>&lt;Relationship Target="http://..."&gt;</c>
+    /// entries pointing at attacker-controlled URLs. The OpenXml reader does not
+    /// dereference them on its own, but a code path that wired in
+    /// <c>HttpClient</c> / <c>WebRequest</c> / <c>Socket</c> by mistake would turn the
+    /// extractor into an SSRF gadget.
+    /// </summary>
+    /// <remarks>
+    /// We anchor the invariant on a source scan: if a file in the Office package
+    /// references one of the forbidden APIs, the test fails. Strips line and block
+    /// comments first so xml-doc mentions don't trip the check — same pattern as the
+    /// VULN-300 <c>WithDefaultLoader</c> archi test in <c>Granit.Html.AngleSharp.Tests</c>.
+    /// </remarks>
+    [Fact]
+    public void Office_assembly_must_not_reference_HTTP_or_external_URI_APIs()
+    {
+        string officeDir = Path.Join(SrcRoot, "Granit.TextExtraction.Office");
+        Directory.Exists(officeDir).ShouldBeTrue($"Expected {officeDir} to exist.");
+
+        List<string> violations = [];
+
+        foreach (string csFile in Directory
+            .EnumerateFiles(officeDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)))
+        {
+            string code = StripCommentsAndStrings(File.ReadAllText(csFile));
+            string relativePath = Path.GetRelativePath(SrcRoot, csFile);
+
+            foreach (Regex forbidden in ForbiddenNetworkingApiRegexes)
+            {
+                Match match = forbidden.Match(code);
+                if (match.Success)
+                {
+                    violations.Add($"{relativePath}: {match.Value}");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Granit.TextExtraction.Office must not reference HTTP / external-URI APIs " +
+            "(HttpClient, WebRequest, WebClient, System.Net.Sockets.*). " +
+            "OpenXml packages can declare external relationship targets — any networking " +
+            "API in this assembly is a latent SSRF path. " +
+            "If a code path genuinely needs networking, raise the requirement first; this " +
+            "invariant only flips intentionally. Violations: " + string.Join(" | ", violations));
+    }
+
+    private static readonly Regex[] ForbiddenNetworkingApiRegexes =
+    [
+        new(@"\busing\s+System\.Net\.Http\b", RegexOptions.Compiled),
+        new(@"\busing\s+System\.Net\.Sockets\b", RegexOptions.Compiled),
+        new(@"\busing\s+System\.Net\s*;", RegexOptions.Compiled),
+        new(@"\bSystem\.Net\.Http\.", RegexOptions.Compiled),
+        new(@"\bSystem\.Net\.Sockets\.", RegexOptions.Compiled),
+        new(@"\bSystem\.Net\.(WebRequest|WebClient)\b", RegexOptions.Compiled),
+        new(@"\bHttpClient\b", RegexOptions.Compiled),
+        new(@"\bWebRequest\b", RegexOptions.Compiled),
+        new(@"\bWebClient\b", RegexOptions.Compiled),
+    ];
+
+    private static readonly Regex LineCommentRegex =
+        new(@"//.*?$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    private static readonly Regex BlockCommentRegex =
+        new(@"/\*.*?\*/", RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex VerbatimStringRegex =
+        new(@"@""(?:""""|[^""])*""", RegexOptions.Compiled);
+
+    private static readonly Regex RegularStringRegex =
+        new(@"""(?:\\.|[^""\\])*""", RegexOptions.Compiled);
+
+    private static string StripCommentsAndStrings(string source)
+    {
+        // Comments first so a `// HttpClient is forbidden` xml-doc note doesn't trip
+        // the scan, then strings so `"HttpClient.cs"` literals don't either.
+        string s = BlockCommentRegex.Replace(source, string.Empty);
+        s = LineCommentRegex.Replace(s, string.Empty);
+        s = VerbatimStringRegex.Replace(s, "\"\"");
+        s = RegularStringRegex.Replace(s, "\"\"");
+        return s;
     }
 
     private static IEnumerable<string> EnumerateExtractorPackages()


### PR DESCRIPTION
Closes #2271.

Two compile-time defence-in-depth gates for the Office extractors, deferred from #2270 review.

## 1. Pin Markup Compatibility processing

`BuildOpenSettings` now sets:

```csharp
MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(
    MarkupCompatibilityProcessMode.ProcessLoadedPartsOnly,
    FileFormatVersions.Office2010)
```

Future Office versions introducing new MC choice branches degrade gracefully (the parser ignores the unknown extension) instead of triggering OpenXml's "best effort" path — which has a history of opening attack surface for crafted alternate-content blocks. Doc comment in `OpenXmlExtraction.cs` explains why we don't strip external relationships from `.rels` parts before opening (OpenXml's reader never dereferences external relationship targets, so the strip would cost CPU for zero behaviour change).

## 2. Architecture test: forbid HTTP / external-URI APIs

New `Office_assembly_must_not_reference_HTTP_or_external_URI_APIs` in `tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs` source-scans every `.cs` file under `src/Granit.TextExtraction.Office/` and fails if any references:

- `HttpClient` (incl. `using System.Net.Http`)
- `WebRequest` / `WebClient`
- `System.Net.Sockets.*` (incl. `using System.Net.Sockets`)

OOXML packages can declare `<Relationship Target="http://...">` entries pointing at attacker-controlled URLs. A code path that wired in networking by mistake would turn the extractor into an SSRF gadget. The build now refuses to compile such a regression in.

Implementation strips line/block comments AND string literals first so xml-doc and doc-comment mentions don't trip the check — same shape as the `WithDefaultLoader` archi test in `Granit.Html.AngleSharp.Tests`.

## Acceptance from the story

- [x] `MarkupCompatibilityProcessSettings` line added.
- [x] Existing Office tests stay green (33/33).
- [x] New archi test asserts no HTTP / external-URI API in `Granit.TextExtraction.Office`.
- [x] Doc comment in `OpenXmlExtraction.cs` explains the relationship-strip non-decision.
- [x] Zero change to public surface or behaviour.

## Test plan

- [x] `dotnet test tests/Granit.TextExtraction.Office.Tests --no-build` — 33/33 green.
- [x] `dotnet test tests/Granit.ArchitectureTests --filter TextExtractionArchitectureTests --no-build` — 26/26 green (was 25; +1 new test).
- [x] `dotnet format src/Granit.TextExtraction.Office --verify-no-changes` clean.
- [x] `dotnet format tests/Granit.ArchitectureTests --verify-no-changes` clean.