### PR TITLE
feat(blob-storage): P6.3a MultipartWriteStream + IBlobStoreProvider.OpenWriteMultipartAsync

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10621,6 +10621,34 @@
       ]
     },
     {
+      "name": "MultipartWriteStream",
+      "fqn": "Granit.BlobStorage.MultipartWriteStream",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/MultipartWriteStream.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "CompleteAsync",
+          "kind": "method",
+          "signature": "CompleteAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "AbortAsync",
+          "kind": "method",
+          "signature": "AbortAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DisposeAsync",
+          "kind": "method",
+          "signature": "DisposeAsync()",
+          "returnType": "ValueTask"
+        }
+      ]
+    },
+    {
       "name": "BlobStorageOptions",
       "fqn": "Granit.BlobStorage.Options.BlobStorageOptions",
       "kind": "class",

--- a/src/Granit.BlobStorage/Granit.BlobStorage.csproj
+++ b/src/Granit.BlobStorage/Granit.BlobStorage.csproj
@@ -24,6 +24,8 @@
     <InternalsVisibleTo Include="Granit.BlobStorage.Proxy.Tests" />
     <InternalsVisibleTo Include="Granit.DataExchange.BlobStorage" />
     <InternalsVisibleTo Include="Granit.DataExchange.BlobStorage.Tests" />
+    <InternalsVisibleTo Include="Granit.Privacy.BlobStorage" />
+    <InternalsVisibleTo Include="Granit.Privacy.BlobStorage.Tests" />
     <!-- Required by NSubstitute (Castle.DynamicProxy) to mock internal interfaces in tests -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Granit.BlobStorage/Internal/BufferedMultipartWriteStream.cs
+++ b/src/Granit.BlobStorage/Internal/BufferedMultipartWriteStream.cs
@@ -1,0 +1,192 @@
+namespace Granit.BlobStorage.Internal;
+
+/// <summary>
+/// Default <see cref="MultipartWriteStream"/> — buffers writes to a temp file
+/// (FileOptions.DeleteOnClose) and ships the whole content via a single
+/// <see cref="IBlobStoreProvider.SaveAsync"/> call on
+/// <see cref="MultipartWriteStream.CompleteAsync"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Correct for every provider — used as the default implementation behind the
+/// default interface method on <see cref="IBlobStoreProvider"/>. Providers with
+/// native multipart support (S3 InitiateMultipartUpload, Azure Block Blob
+/// StageBlock, GCS resumable upload) override
+/// <see cref="IBlobStoreProvider.OpenWriteMultipartAsync"/> for memory-efficient
+/// streaming on multi-GB blobs — the temp file shifts to host disk pressure
+/// but never touches RAM beyond the FileStream buffer.
+/// </para>
+/// <para>
+/// <b>Disposal contract:</b> calling <see cref="DisposeAsync"/> (or sync
+/// <c>Dispose</c>) without first calling
+/// <see cref="MultipartWriteStream.CompleteAsync"/> implicitly aborts —
+/// partial bytes never reach the blob.
+/// </para>
+/// </remarks>
+internal sealed class BufferedMultipartWriteStream : MultipartWriteStream
+{
+    private readonly IBlobStoreProvider _provider;
+    private readonly string _bucket;
+    private readonly string _objectKey;
+    private readonly string _contentType;
+    private readonly FileStream _buffer;
+    private bool _completed;
+    private bool _aborted;
+
+    public BufferedMultipartWriteStream(
+        IBlobStoreProvider provider,
+        string bucket,
+        string objectKey,
+        string contentType)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentException.ThrowIfNullOrEmpty(bucket);
+        ArgumentException.ThrowIfNullOrEmpty(objectKey);
+        ArgumentException.ThrowIfNullOrEmpty(contentType);
+
+        _provider = provider;
+        _bucket = bucket;
+        _objectKey = objectKey;
+        _contentType = contentType;
+
+        // Guid.NewGuid (not Granit.Guids.IGuidGenerator) is intentional here: the
+        // temp filename is local-only and short-lived, not a database key — no
+        // clustered-index ordering concern applies. Suppress GRSEC002.
+#pragma warning disable GRSEC002
+        string tempPath = Path.Combine(
+            Path.GetTempPath(),
+            $"granit-blobstorage-mpw-{Guid.NewGuid():N}.tmp");
+#pragma warning restore GRSEC002
+        _buffer = new FileStream(
+            tempPath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None,
+            bufferSize: 81920,
+            FileOptions.DeleteOnClose | FileOptions.Asynchronous);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Stream surface — forwarded to the temp-file buffer (write-only client view).
+    // ────────────────────────────────────────────────────────────────────────
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => !_aborted && !_completed;
+    public override long Length => _buffer.Length;
+
+    public override long Position
+    {
+        get => _buffer.Position;
+        set => throw new NotSupportedException("Multipart write stream is forward-only.");
+    }
+
+    public override void Flush() => _buffer.Flush();
+
+    public override Task FlushAsync(CancellationToken cancellationToken) =>
+        _buffer.FlushAsync(cancellationToken);
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException("Multipart write stream is write-only.");
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new NotSupportedException("Multipart write stream is forward-only.");
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException("Multipart write stream is forward-only.");
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        ThrowIfCompletedOrAborted();
+        _buffer.Write(buffer, offset, count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        ThrowIfCompletedOrAborted();
+        _buffer.Write(buffer);
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        ThrowIfCompletedOrAborted();
+        return _buffer.WriteAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        ThrowIfCompletedOrAborted();
+        return _buffer.WriteAsync(buffer, cancellationToken);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Multipart lifecycle.
+    // ────────────────────────────────────────────────────────────────────────
+
+    public override async Task CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        if (_aborted)
+        {
+            throw new InvalidOperationException(
+                "Cannot complete a multipart write stream that has already been aborted.");
+        }
+
+        await _buffer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        _buffer.Position = 0;
+        await _provider
+            .SaveAsync(_bucket, _objectKey, _buffer, _contentType, cancellationToken)
+            .ConfigureAwait(false);
+        _completed = true;
+    }
+
+    public override Task AbortAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_completed)
+        {
+            _aborted = true;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (!_completed && !_aborted)
+        {
+            await AbortAsync().ConfigureAwait(false);
+        }
+
+        await _buffer.DisposeAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (!_completed && !_aborted)
+            {
+                _aborted = true;
+            }
+
+            _buffer.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void ThrowIfCompletedOrAborted()
+    {
+        ObjectDisposedException.ThrowIf(_aborted, this);
+        if (_completed)
+        {
+            throw new InvalidOperationException(
+                "Cannot write to a multipart write stream after CompleteAsync.");
+        }
+    }
+}

--- a/src/Granit.BlobStorage/Internal/IBlobStoreProvider.cs
+++ b/src/Granit.BlobStorage/Internal/IBlobStoreProvider.cs
@@ -55,4 +55,41 @@ internal interface IBlobStoreProvider
         string objectKey,
         int byteCount,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Opens a streaming write surface whose final size is not known in advance —
+    /// used by content producers that write incrementally (ZIP shards, archive
+    /// builders) and cannot buffer the entire payload in memory.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The caller writes bytes via the returned <see cref="MultipartWriteStream"/>
+    /// and finalises with either
+    /// <see cref="MultipartWriteStream.CompleteAsync"/> (commit the blob) or
+    /// <see cref="MultipartWriteStream.AbortAsync"/> (discard). Disposing without
+    /// calling either is treated as an abort — partial bytes never reach the blob.
+    /// </para>
+    /// <para>
+    /// The default implementation buffers writes to a
+    /// <c>FileOptions.DeleteOnClose</c> temp file and ships the whole content via
+    /// a single <see cref="SaveAsync"/> on
+    /// <see cref="MultipartWriteStream.CompleteAsync"/>. Correct for every
+    /// provider but not memory-optimal — providers with native multipart support
+    /// (S3 InitiateMultipartUpload, Azure StageBlock, GCS resumable upload)
+    /// override this method to stream parts directly without the temp-file hop.
+    /// </para>
+    /// </remarks>
+    Task<MultipartWriteStream> OpenWriteMultipartAsync(
+        string bucket,
+        string objectKey,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(bucket);
+        ArgumentException.ThrowIfNullOrEmpty(objectKey);
+        ArgumentException.ThrowIfNullOrEmpty(contentType);
+
+        return Task.FromResult<MultipartWriteStream>(
+            new BufferedMultipartWriteStream(this, bucket, objectKey, contentType));
+    }
 }

--- a/src/Granit.BlobStorage/MultipartWriteStream.cs
+++ b/src/Granit.BlobStorage/MultipartWriteStream.cs
@@ -1,0 +1,51 @@
+namespace Granit.BlobStorage;
+
+/// <summary>
+/// Streaming write surface for a blob whose final size is not known in advance —
+/// used by callers that produce content incrementally (ZIP shards, archive
+/// builders) and cannot buffer the entire payload in memory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Callers write bytes via the inherited <see cref="Stream"/> API and finalise
+/// the blob by calling either <see cref="CompleteAsync"/> (commit the written
+/// bytes to the blob) or <see cref="AbortAsync"/> (discard them). Disposing
+/// the stream without calling either is treated as an abort — partial bytes
+/// are never silently committed.
+/// </para>
+/// <para>
+/// The default implementation
+/// (<c>Internal.BufferedMultipartWriteStream</c>) buffers writes to a
+/// FileOptions.DeleteOnClose temp file and performs a single
+/// <see cref="Internal.IBlobStoreProvider.SaveAsync"/> on
+/// <see cref="CompleteAsync"/>. Native multipart implementations (S3
+/// InitiateMultipartUpload, Azure Block Blob StageBlock, GCS resumable upload)
+/// override the contract for memory-efficiency on multi-GB blobs.
+/// </para>
+/// </remarks>
+public abstract class MultipartWriteStream : Stream, IAsyncDisposable
+{
+    /// <summary>
+    /// Finalises the multipart write. After this call returns, the blob is
+    /// readable via the standard <see cref="IBlobStorage"/> APIs. Calling
+    /// <see cref="CompleteAsync"/> twice is a no-op; calling it after
+    /// <see cref="AbortAsync"/> throws.
+    /// </summary>
+    public abstract Task CompleteAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Discards every byte written so far. Idempotent; safe to call after
+    /// <see cref="CompleteAsync"/> (in which case it's a no-op — the blob has
+    /// already been committed). Implementations clean up provider-side state
+    /// (S3 AbortMultipartUpload, temp files, …).
+    /// </summary>
+    public abstract Task AbortAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously releases resources held by the stream. Implementations
+    /// that have not been committed via <see cref="CompleteAsync"/> or
+    /// explicitly aborted via <see cref="AbortAsync"/> MUST abort here so
+    /// partial bytes never reach the blob.
+    /// </summary>
+    public override abstract ValueTask DisposeAsync();
+}

--- a/tests/Granit.BlobStorage.Tests/Internal/BufferedMultipartWriteStreamTests.cs
+++ b/tests/Granit.BlobStorage.Tests/Internal/BufferedMultipartWriteStreamTests.cs
@@ -1,0 +1,183 @@
+using Granit.BlobStorage.Internal;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Tests.Internal;
+
+public sealed class BufferedMultipartWriteStreamTests
+{
+    private const string Bucket = "exports";
+    private const string ObjectKey = "tenant-a/shard-001.zip";
+    private const string ContentType = "application/zip";
+
+    private static BufferedMultipartWriteStream CreateSut(IBlobStoreProvider provider) =>
+        new(provider, Bucket, ObjectKey, ContentType);
+
+    [Fact]
+    public async Task CompleteAsync_ShipsAllBufferedBytesToTheProvider()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+        byte[] payload = [1, 2, 3, 4, 5, 6, 7, 8];
+
+        CapturedBytes captured = CaptureSavedBytes(provider);
+
+        await using (BufferedMultipartWriteStream sut = CreateSut(provider))
+        {
+            await sut.WriteAsync(payload, TestContext.Current.CancellationToken);
+            await sut.CompleteAsync(TestContext.Current.CancellationToken);
+        }
+
+        await provider.Received(1).SaveAsync(
+            Bucket, ObjectKey, Arg.Any<Stream>(), ContentType, Arg.Any<CancellationToken>());
+        captured.Value.ShouldBe(payload);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_IsIdempotent()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+
+        await using BufferedMultipartWriteStream sut = CreateSut(provider);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await provider.Received(1).SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AbortAsync_DoesNotShipBytes()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+
+        await using BufferedMultipartWriteStream sut = CreateSut(provider);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await provider.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AbortAsync_IsIdempotent()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+
+        await using BufferedMultipartWriteStream sut = CreateSut(provider);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        // No throw. SaveAsync still uncalled.
+        await provider.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithoutCompleteOrAbort_DoesNotShipBytes()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+
+        await using (BufferedMultipartWriteStream sut = CreateSut(provider))
+        {
+            await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+            // No explicit Complete or Abort.
+        }
+
+        await provider.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AfterAbort_Throws()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+
+        await using BufferedMultipartWriteStream sut = CreateSut(provider);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.CompleteAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterComplete_Throws()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+
+        await using BufferedMultipartWriteStream sut = CreateSut(provider);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await sut.WriteAsync(new byte[] { 4 }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterAbort_Throws()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+
+        await using BufferedMultipartWriteStream sut = CreateSut(provider);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<ObjectDisposedException>(
+            async () => await sut.WriteAsync(new byte[] { 4 }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void StreamSurface_RejectsReadsAndSeeks()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+        using BufferedMultipartWriteStream sut = CreateSut(provider);
+
+        sut.CanRead.ShouldBeFalse();
+        sut.CanSeek.ShouldBeFalse();
+        sut.CanWrite.ShouldBeTrue();
+
+        Should.Throw<NotSupportedException>(() => sut.Read(new byte[4], 0, 4));
+        Should.Throw<NotSupportedException>(() => sut.Seek(0, SeekOrigin.Begin));
+        Should.Throw<NotSupportedException>(() => sut.SetLength(10));
+        Should.Throw<NotSupportedException>(() => sut.Position = 0);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_ShipsExactByteSequence_ForMultipleWrites()
+    {
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+        CapturedBytes captured = CaptureSavedBytes(provider);
+
+        await using BufferedMultipartWriteStream sut = CreateSut(provider);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[] { 4, 5, 6 }, TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[] { 7, 8 }, TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        captured.Value.ShouldBe([1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    // Reference-type holder so the lambda's assignment is observable from the test
+    // after the SUT (and its temp-file buffer) has been disposed.
+    private sealed class CapturedBytes
+    {
+        public byte[] Value { get; set; } = [];
+    }
+
+    private static CapturedBytes CaptureSavedBytes(IBlobStoreProvider provider)
+    {
+        CapturedBytes captured = new();
+        provider.SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                Stream s = callInfo.Arg<Stream>();
+                using MemoryStream ms = new();
+                s.CopyTo(ms);
+                captured.Value = ms.ToArray();
+                return Task.CompletedTask;
+            });
+        return captured;
+    }
+}


### PR DESCRIPTION
## Summary

First brick of P6.3 (#2314). Gives every blob-store provider a streaming-write surface whose final size isn't known in advance — required by the upcoming `ShardingArchiveWriter`: a ZIP archive's Central Directory is only emitted when the archive is closed, so the writer can't stage bytes behind a single PUT.

Split as a focused first PR to keep the rest of P6.3 (sharding writer, background job, checkpoint store) reviewable on its own.

## Contract

**`Granit.BlobStorage`** (public surface):

```csharp
public abstract class MultipartWriteStream : Stream, IAsyncDisposable
{
    public abstract Task CompleteAsync(CancellationToken cancellationToken = default);
    public abstract Task AbortAsync(CancellationToken cancellationToken = default);
}
```

**`Granit.BlobStorage.Internal`** (internal):

- `IBlobStoreProvider.OpenWriteMultipartAsync(bucket, objectKey, contentType, ct)` — added as a **default interface method**, backward-compatible with the 5 existing implementations (S3, Azure, FileSystem, Database, GoogleCloud) which inherit the default without recompilation.
- `BufferedMultipartWriteStream` — default impl buffering writes to a `FileOptions.DeleteOnClose` temp file, shipping the full content via a single `SaveAsync` on `CompleteAsync`. Correct for every provider but not memory-optimal; providers with native multipart support (S3 `InitiateMultipartUpload`, Azure `StageBlock`, GCS resumable upload) will override in follow-up PRs.

**Disposal contract**: disposing without `CompleteAsync` or `AbortAsync` is treated as an abort — partial bytes never reach the blob.

## IVT

`Granit.Privacy.BlobStorage{,.Tests}` added to the `InternalsVisibleTo` list. The upcoming `ShardingArchiveWriter` consumes `IBlobStoreProvider` directly (higher-level `IBlobStorage` is presigned-URL-shaped — wrong abstraction for server-side streaming writes).

## Tests

10 new tests on `BufferedMultipartWriteStream`:

- `CompleteAsync` ships every buffered byte via a single `SaveAsync` call.
- `CompleteAsync` is idempotent.
- `AbortAsync` prevents `SaveAsync`, is idempotent.
- `DisposeAsync` without `Complete`/`Abort` acts as `Abort`.
- `CompleteAsync` after `Abort` throws `InvalidOperationException`.
- `WriteAsync` after `Complete` throws `InvalidOperationException`, after `Abort` throws `ObjectDisposedException`.
- Stream surface rejects reads/seeks/SetLength/Position-set.
- Multi-write byte sequence preserved end-to-end (3 writes of 3+3+2 → 8 bytes in order).

## Test plan

- [x] `dotnet build src/Granit.BlobStorage/Granit.BlobStorage.csproj` — green
- [x] All 5 store providers build unchanged (default interface method) — green
- [x] `dotnet build .github/shard-filters/security.slnf` + `infrastructure.slnf` + `architecture.slnf` — green
- [x] `Granit.BlobStorage.Tests` — 10 new tests green
- [x] `dotnet format --verify-no-changes` clean on the 2 modified projects

## Out of scope (next P6.3 bricks)

- **P6.3b**: `ShardingArchiveWriter` + `IBlobBackedExportSource` — consumes `OpenWriteMultipartAsync`.
- **P6.3c**: `PrivacyExportAssemblyJob` + handler + tenant-aware `IExportAssemblyCheckpointStore` + EF impl + saga wiring.
- **P6.3d**: Native multipart overrides on S3 / Azure / GCS for memory-efficient multi-GB streaming (the temp-file default is correct but disk-heavy on large blobs).

Refs #2314, #2310, #79