### PR TITLE
fix(indexing-privacy): drop string ParseTenantId after Guid? widening

### DIFF
--- a/src/Granit.Indexing.Privacy/PersonalDataDeletionHandler.cs
+++ b/src/Granit.Indexing.Privacy/PersonalDataDeletionHandler.cs
@@ -35,14 +35,11 @@ public class PersonalDataDeletionHandler
         ArgumentNullException.ThrowIfNull(erasers);
         ArgumentNullException.ThrowIfNull(currentTenant);
 
-        Guid? tenantId = ParseTenantId(@event.TenantId) ?? currentTenant.Id;
+        Guid? tenantId = @event.TenantId ?? currentTenant.Id;
 
         foreach (IIndexedDataEraser eraser in erasers)
         {
             await eraser.EraseAsync(tenantId, @event.UserId, cancellationToken).ConfigureAwait(false);
         }
     }
-
-    private static Guid? ParseTenantId(string? raw) =>
-        Guid.TryParse(raw, out Guid id) ? id : null;
 }

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PersonalDataDeletionCascadeTests.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PersonalDataDeletionCascadeTests.cs
@@ -61,7 +61,7 @@ public sealed class PersonalDataDeletionCascadeTests(PostgresFixture fixture)
             RequestedAt: DateTimeOffset.UtcNow,
             Reason: "GDPR Art. 17",
             Regulation: "GDPR",
-            TenantId: tenantA.ToString());
+            TenantId: tenantA);
 
         await PersonalDataDeletionHandler.Handle(
             @event,

--- a/tests/Granit.Indexing.Privacy.Tests/PersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Indexing.Privacy.Tests/PersonalDataDeletionHandlerTests.cs
@@ -22,7 +22,7 @@ public sealed class PersonalDataDeletionHandlerTests
             RequestedAt: DateTimeOffset.UtcNow,
             Reason: "GDPR",
             Regulation: "GDPR",
-            TenantId: tenantId.ToString());
+            TenantId: tenantId);
 
         await PersonalDataDeletionHandler.Handle(
             @event,
@@ -35,7 +35,7 @@ public sealed class PersonalDataDeletionHandlerTests
     }
 
     [Fact]
-    public async Task Falls_back_to_current_tenant_when_event_tenant_id_is_invalid()
+    public async Task Falls_back_to_current_tenant_when_event_tenant_id_is_null()
     {
         var currentTenantId = Guid.NewGuid();
         StubCurrentTenant tenant = new(currentTenantId);
@@ -48,7 +48,7 @@ public sealed class PersonalDataDeletionHandlerTests
             RequestedAt: DateTimeOffset.UtcNow,
             Reason: "r",
             Regulation: "GDPR",
-            TenantId: "not-a-guid");
+            TenantId: null);
 
         await PersonalDataDeletionHandler.Handle(@event, [ef], tenant, TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
## Summary

- PR #2324 widened `PersonalDataDeletionRequestedEto.TenantId` from `string?` to `Guid?`, but `PersonalDataDeletionHandler` still routed it through a `ParseTenantId(string?)` helper — develop is currently red.
- Drop the obsolete helper and use the `Guid?` value directly.
- Update the unit test ("falls back to current tenant when invalid GUID" → "when null") + the EF integration test fixture that constructed the event with `.ToString()`.

## Test plan

- [x] `dotnet build src/Granit.Indexing.Privacy` clean
- [x] `dotnet test tests/Granit.Indexing.Privacy.Tests` — 3/3 pass
- [x] `dotnet format` clean on the three projects