### PR TITLE
fix(ci-integration): drop ldconfig-grep ⇒ readlink-e for libtesseract symlink check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,18 +142,20 @@ jobs:
           sudo ln -sf "$LEPT_LIB" "$LIB_DIR/libleptonica-1.82.0.so"
           sudo ln -sf "$TESS_LIB" "$LIB_DIR/libtesseract50.so"
           # Refresh the loader cache — fresh symlinks aren't in /etc/ld.so.cache
-          # until ldconfig runs, and the Charlesw NuGet's InteropDotNet loader uses
-          # dlopen which consults the cache before falling through to a path scan.
-          # Belt-and-suspenders: also push $LIB_DIR onto LD_LIBRARY_PATH in case the
-          # cache refresh races the test step.
+          # until ldconfig runs. Belt-and-suspenders: also push $LIB_DIR onto
+          # LD_LIBRARY_PATH so dlopen finds the canonical names even if the cache
+          # refresh races the test step.
           sudo ldconfig
           echo "LD_LIBRARY_PATH=$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
           echo "TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata" >> "$GITHUB_ENV"
-          # Smoke-check — fail the step (with diagnostics) if dlopen still won't
-          # resolve the canonical names. Catches a symlink target gone wrong faster
-          # than waiting for the .NET P/Invoke to throw later.
-          ldconfig -p | grep -E '(libleptonica|libtesseract50)' || {
-            echo "ldconfig cache does not contain the canonical names" >&2
+          # Smoke-check the symlinks resolve. readlink -e follows the chain and
+          # fails if any link in the chain is broken — catches a target-gone-wrong
+          # faster than waiting for the .NET P/Invoke to throw later. ldconfig
+          # indexes shared objects by ELF SONAME, not filesystem name, so a cache
+          # grep on the aliased names would be a false negative.
+          readlink -e "$LIB_DIR/libleptonica-1.82.0.so" >/dev/null && \
+          readlink -e "$LIB_DIR/libtesseract50.so" >/dev/null || {
+            echo "libleptonica / libtesseract50 symlinks did not resolve" >&2
             ls -l "$LIB_DIR/libleptonica-1.82.0.so" "$LIB_DIR/libtesseract50.so" >&2 || true
             exit 1
           }


### PR DESCRIPTION
Follow-up to #2328. The smoke check I added fails on a valid CI run because the assumption (\"ldconfig -p lists libraries by filesystem name\") is wrong — ldconfig indexes by ELF SONAME (\`liblept.so.5\` / \`libtesseract.so.5\`), not by the aliased names (\`libleptonica-1.82.0.so\` / \`libtesseract50.so\`) the Charlesw NuGet probes for.

CI output from develop's last run:

\`\`\`
ldconfig cache does not contain the canonical names
lrwxrwxrwx 1 root root 38 /usr/lib/x86_64-linux-gnu/libleptonica-1.82.0.so -> /usr/lib/x86_64-linux-gnu/liblept.so.5
lrwxrwxrwx 1 root root 43 /usr/lib/x86_64-linux-gnu/libtesseract50.so -> /usr/lib/x86_64-linux-gnu/libtesseract.so.5
\`\`\`

Symlinks were created correctly — the check was wrong.

## Fix

Replace \`ldconfig -p | grep ...\` with \`readlink -e\`. That follows the symlink chain and only exits zero if every link in the chain resolves to an existing file — which is the actual invariant we want to assert. dlopen with \`LD_LIBRARY_PATH\` set then handles the load.

## Test plan

- [x] \`yaml.safe_load\` clean.
- [ ] CI integration shard's libtesseract install step goes green.
- [ ] CI integration shard's live OCR suite runs (not skipped).