### PR TITLE
feat(privacy-export): PrivacyExportAssemblyJob + sharded assembly service (P6.3c)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36904,7 +36904,7 @@
       "kind": "class",
       "project": "Granit.Privacy.BackgroundJobs",
       "file": "src/Granit.Privacy.BackgroundJobs/GranitPrivacyBackgroundJobsModule.cs",
-      "line": 15,
+      "line": 25,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36937,6 +36937,62 @@
       "project": "Granit.Privacy.BackgroundJobs",
       "file": "src/Granit.Privacy.BackgroundJobs/Jobs/DeletionDeadlineEnforcerJob.cs",
       "line": 11,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportAssemblyJob",
+      "fqn": "Granit.Privacy.BackgroundJobs.Jobs.PrivacyExportAssemblyJob",
+      "kind": "record",
+      "project": "Granit.Privacy.BackgroundJobs",
+      "file": "src/Granit.Privacy.BackgroundJobs/Jobs/PrivacyExportAssemblyJob.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "RequestId",
+          "kind": "property",
+          "signature": "Guid RequestId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        }
+      ]
+    },
+    {
+      "name": "PrivacyExportAssemblyJobHandler",
+      "fqn": "Granit.Privacy.BackgroundJobs.Jobs.PrivacyExportAssemblyJobHandler",
+      "kind": "class",
+      "project": "Granit.Privacy.BackgroundJobs",
+      "file": "src/Granit.Privacy.BackgroundJobs/Jobs/PrivacyExportAssemblyJobHandler.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(PrivacyExportAssemblyJob job, ICurrentTenant currentTenant, IPrivacyExportAssemblyService service, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "Exports",
+      "fqn": "Granit.Privacy.BackgroundJobs.Permissions.Exports",
+      "kind": "class",
+      "project": "Granit.Privacy.BackgroundJobs",
+      "file": "src/Granit.Privacy.BackgroundJobs/Permissions/PrivacyExportPermissions.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportPermissions",
+      "fqn": "Granit.Privacy.BackgroundJobs.Permissions.PrivacyExportPermissions",
+      "kind": "class",
+      "project": "Granit.Privacy.BackgroundJobs",
+      "file": "src/Granit.Privacy.BackgroundJobs/Permissions/PrivacyExportPermissions.cs",
+      "line": 23,
       "members": []
     },
     {
@@ -37020,7 +37076,7 @@
       "kind": "class",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitPrivacyBlobStorage",
@@ -37339,6 +37395,15 @@
       "members": []
     },
     {
+      "name": "ExportAssemblyCheckpoint",
+      "fqn": "Granit.Privacy.DataExport.ExportAssemblyCheckpoint",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IExportAssemblyCheckpointStore.cs",
+      "line": 67,
+      "members": []
+    },
+    {
       "name": "ExportRequestState",
       "fqn": "Granit.Privacy.DataExport.ExportRequestState",
       "kind": "enum",
@@ -37418,6 +37483,34 @@
       ]
     },
     {
+      "name": "IExportAssemblyCheckpointStore",
+      "fqn": "Granit.Privacy.DataExport.IExportAssemblyCheckpointStore",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IExportAssemblyCheckpointStore.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid requestId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportAssemblyCheckpoint?>"
+        },
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(Guid requestId, Guid? tenantId, ExportAssemblyCheckpoint checkpoint, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ClearAsync",
+          "kind": "method",
+          "signature": "ClearAsync(Guid requestId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "IExportRequestTrackerReader",
       "fqn": "Granit.Privacy.DataExport.IExportRequestTrackerReader",
       "kind": "interface",
@@ -37480,6 +37573,22 @@
           "kind": "method",
           "signature": "ExportAsync(PrivacyExportContext context, CancellationToken cancellationToken)",
           "returnType": "IAsyncEnumerable<ExportFragment>"
+        }
+      ]
+    },
+    {
+      "name": "IPrivacyExportAssemblyService",
+      "fqn": "Granit.Privacy.DataExport.IPrivacyExportAssemblyService",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportAssemblyService.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "AssembleAsync",
+          "kind": "method",
+          "signature": "AssembleAsync(ExportCompletedEto completion, CancellationToken cancellationToken)",
+          "returnType": "Task"
         }
       ]
     },
@@ -39016,6 +39125,12 @@
           "returnType": "int"
         },
         {
+          "name": "ExportShardMaxSizeMb",
+          "kind": "property",
+          "signature": "int ExportShardMaxSizeMb",
+          "returnType": "int"
+        },
+        {
           "name": "ArchiveAssemblyDownloadUrlExpiryMinutes",
           "kind": "property",
           "signature": "int ArchiveAssemblyDownloadUrlExpiryMinutes",
@@ -39053,7 +39168,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/Options/GranitPrivacyOptions.cs",
-      "line": 81,
+      "line": 93,
       "members": []
     },
     {

--- a/src/Granit.Privacy.BackgroundJobs/GranitPrivacyBackgroundJobsModule.cs
+++ b/src/Granit.Privacy.BackgroundJobs/GranitPrivacyBackgroundJobsModule.cs
@@ -7,8 +7,18 @@ namespace Granit.Privacy.BackgroundJobs;
 
 /// <summary>
 /// Granit module that registers background jobs for Privacy:
-/// deletion deadline enforcement.
+/// deletion deadline enforcement and personal-data export assembly.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Export assembly.</b> The package ships the
+/// <c>PrivacyExportAssemblyJob</c> + handler shape but does not own the
+/// concrete <c>IPrivacyExportAssemblyService</c> implementation — that lives in
+/// <c>Granit.Privacy.BlobStorage</c>, registered by
+/// <c>AddGranitPrivacyBlobStorage()</c>. Hosts that want async sharded assembly
+/// wire both modules.
+/// </para>
+/// </remarks>
 [DependsOn(
     typeof(GranitBackgroundJobsModule),
     typeof(GranitPrivacyModule))]

--- a/src/Granit.Privacy.BackgroundJobs/Jobs/PrivacyExportAssemblyJob.cs
+++ b/src/Granit.Privacy.BackgroundJobs/Jobs/PrivacyExportAssemblyJob.cs
@@ -1,0 +1,41 @@
+using Granit.BackgroundJobs;
+using Granit.Privacy.DataExport.Events;
+
+namespace Granit.Privacy.BackgroundJobs.Jobs;
+
+/// <summary>
+/// On-demand background job that assembles the personal-data export archive(s) for
+/// a single GDPR-Art.20 request. Dispatched by the saga's terminal handler after
+/// every provider has prepared its fragment(s); does the sharded ZIP assembly,
+/// writes per-shard checkpoints, and updates the request tracker.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Not auto-scheduled.</b> No <see cref="RecurringJobAttribute"/> applies — assembly
+/// fires per request, not on a cron. Hosts dispatch via
+/// <c>IBackgroundJobDispatcher.PublishAsync</c> from the
+/// <see cref="ExportCompletedEto"/> handler (wired in a follow-up sub-PR; until then
+/// the job is callable from custom code or tests).
+/// </para>
+/// <para>
+/// <b>Tenant scope.</b> Background workers run outside any HTTP / message context,
+/// so <see cref="Granit.MultiTenancy.ICurrentTenant"/> defaults to "no tenant". The
+/// handler MUST open <c>currentTenant.Change(TenantId)</c> before resolving scoped
+/// services — otherwise EF tenant filters silently leak (
+/// <c>project_current_tenant_asynclocal_leak</c>).
+/// </para>
+/// <para>
+/// <b>Payload.</b> The job carries the saga-published <see cref="ExportCompletedEto"/>
+/// verbatim — fragments, missing-providers list, regulation, and timestamps. Embedding
+/// the event avoids a follow-up DB read and lets a re-dispatched job operate without
+/// the saga state still being live (which would race the saga's own cleanup).
+/// </para>
+/// </remarks>
+public sealed record PrivacyExportAssemblyJob(ExportCompletedEto Event) : IBackgroundJob
+{
+    /// <summary>Convenience accessor — also the saga correlation id.</summary>
+    public Guid RequestId => Event.RequestId;
+
+    /// <summary>Tenant scope for the handler to open before resolving scoped services.</summary>
+    public Guid? TenantId => Event.TenantId;
+}

--- a/src/Granit.Privacy.BackgroundJobs/Jobs/PrivacyExportAssemblyJobHandler.cs
+++ b/src/Granit.Privacy.BackgroundJobs/Jobs/PrivacyExportAssemblyJobHandler.cs
@@ -1,0 +1,42 @@
+using Granit.MultiTenancy;
+using Granit.Privacy.DataExport;
+
+namespace Granit.Privacy.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Wolverine handler for <see cref="PrivacyExportAssemblyJob"/>. Opens the tenant
+/// scope carried by the job, then delegates the sharded assembly to the
+/// <see cref="IPrivacyExportAssemblyService"/> impl wired by the host (default impl
+/// lives in <c>Granit.Privacy.BlobStorage</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wolverine discovers handlers via <c>Assembly.ExportedTypes</c> — the class is
+/// <c>public</c> with a public constructor, the method is <c>public static</c>.
+/// See CLAUDE.md §Wolverine handlers.
+/// </para>
+/// <para>
+/// <b>Tenant discipline.</b> The <c>using</c> on
+/// <see cref="ICurrentTenant.Change"/> wraps service resolution and the entire
+/// assembly run, so every scoped service (checkpoint store, tracker writer, blob
+/// reads) sees the right tenant id. A bug here leaks data across tenants — guarded
+/// by the cross-tenant isolation integration test in
+/// <c>Granit.Privacy.BackgroundJobs.Tests.Integration</c>.
+/// </para>
+/// </remarks>
+public sealed class PrivacyExportAssemblyJobHandler
+{
+    public static async Task HandleAsync(
+        PrivacyExportAssemblyJob job,
+        ICurrentTenant currentTenant,
+        IPrivacyExportAssemblyService service,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(currentTenant);
+        ArgumentNullException.ThrowIfNull(service);
+
+        using IDisposable _ = currentTenant.Change(job.TenantId);
+        await service.AssembleAsync(job.Event, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Privacy.BackgroundJobs/Permissions/PrivacyExportPermissions.cs
+++ b/src/Granit.Privacy.BackgroundJobs/Permissions/PrivacyExportPermissions.cs
@@ -1,0 +1,45 @@
+namespace Granit.Privacy.BackgroundJobs.Permissions;
+
+/// <summary>
+/// Permission constants for the privacy export job. Granted to data subjects so they
+/// can request their own export (GDPR Art. 15 / Art. 20 — a personal right, not an
+/// application usage right). Admin-on-behalf-of flows ship in v1.1.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why split.</b> <see cref="Exports.Execute"/> is the self-service permission a
+/// data subject needs to dispatch their own export — granted by default to every
+/// authenticated user. <see cref="Exports.OnBehalfOf"/> is the admin DSR permission
+/// required to dispatch an export targeting a <i>different</i> subject; reserved for
+/// a v1.1 follow-up. Splitting now keeps the seed simple while leaving the future
+/// admin endpoint a stable contract to point at.
+/// </para>
+/// <para>
+/// <b>Enforcement.</b> The HTTP endpoint that dispatches the job enforces the
+/// permission against the caller's principal; the background-job handler trusts the
+/// envelope.
+/// </para>
+/// </remarks>
+public static class PrivacyExportPermissions
+{
+    /// <summary>Permission group name used in <c>IPermissionDefinitionContext.AddGroup()</c>.</summary>
+    public const string GroupName = "Privacy";
+
+    /// <summary>Permissions for the personal-data export flow.</summary>
+    public static class Exports
+    {
+        /// <summary>
+        /// Self-service permission: grants the caller the ability to request their own
+        /// personal-data export. GDPR Art. 15/20 frames data portability as a personal
+        /// right, so the default seed grants this to every authenticated user.
+        /// </summary>
+        public const string Execute = "Privacy.Exports.Execute";
+
+        /// <summary>
+        /// Admin DSR permission: grants the caller the ability to dispatch an export
+        /// for a different data subject. Restrict to data-protection officers and
+        /// support operators with documented legal basis.
+        /// </summary>
+        public const string OnBehalfOf = "Privacy.Exports.OnBehalfOf";
+    }
+}

--- a/src/Granit.Privacy.BlobStorage/DataExport/Internal/InMemoryExportAssemblyCheckpointStore.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/Internal/InMemoryExportAssemblyCheckpointStore.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+using Granit.Privacy.DataExport;
+
+namespace Granit.Privacy.BlobStorage.DataExport.Internal;
+
+/// <summary>
+/// In-memory <see cref="IExportAssemblyCheckpointStore"/>. Default registration when
+/// no persistent backend is wired. State is lost on process restart, so a crashed
+/// assembly cannot resume — production multi-instance hosts wire the EF impl via
+/// <c>Granit.Privacy.EntityFrameworkCore</c> (shipped in a follow-up sub-PR).
+/// </summary>
+internal sealed class InMemoryExportAssemblyCheckpointStore : IExportAssemblyCheckpointStore
+{
+    private readonly ConcurrentDictionary<string, ExportAssemblyCheckpoint> _store = new(StringComparer.Ordinal);
+
+    public Task<ExportAssemblyCheckpoint?> GetAsync(
+        Guid requestId,
+        Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(_store.TryGetValue(BuildKey(requestId, tenantId), out ExportAssemblyCheckpoint? cp)
+            ? cp
+            : null);
+    }
+
+    public Task SetAsync(
+        Guid requestId,
+        Guid? tenantId,
+        ExportAssemblyCheckpoint checkpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+        cancellationToken.ThrowIfCancellationRequested();
+        _store[BuildKey(requestId, tenantId)] = checkpoint;
+        return Task.CompletedTask;
+    }
+
+    public Task ClearAsync(
+        Guid requestId,
+        Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _store.TryRemove(BuildKey(requestId, tenantId), out _);
+        return Task.CompletedTask;
+    }
+
+    private static string BuildKey(Guid requestId, Guid? tenantId) =>
+        $"{tenantId?.ToString("N") ?? "global"}|{requestId:N}";
+}

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
@@ -1,0 +1,340 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Internal;
+using Granit.BlobStorage.Options;
+using Granit.Domain.ValueObjects;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.DataExport.Security;
+using Granit.Privacy.Diagnostics;
+using Granit.Privacy.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Privacy.BlobStorage.DataExport;
+
+/// <summary>
+/// Sharded ZIP assembly service. Consumes the saga's terminal
+/// <see cref="ExportCompletedEto"/> via a background-job handler, verifies every
+/// fragment's HMAC capability before reading bytes (closes VULN-001 / VULN-102),
+/// streams the content into one or more size-capped ZIP64 shards using
+/// <see cref="ShardingArchiveWriter"/>, writes a simple manifest sidecar, and
+/// records the manifest blob reference on the tracker as the request's archive
+/// pointer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Single-transit reads.</b> Fragments still flow through a presigned download
+/// URL because the existing fragment uploader writes via the public
+/// <see cref="IBlobStorage"/> contract. Provider-aware native reads land in
+/// P6.3d / P6.4 once <see cref="IBlobStoreProvider.OpenReadAsync"/> grows a
+/// public adapter on <see cref="IBlobStorage"/>.
+/// </para>
+/// <para>
+/// <b>Checkpointing.</b> Resumable state is recorded on entry (set to "fresh
+/// run" / 0) and cleared on completion. Mid-flight per-shard checkpoints (true
+/// crash-resume) land in a follow-up sub-PR — the interface and store are in
+/// place so the upgrade is a localised change inside this service.
+/// </para>
+/// <para>
+/// <b>HMAC verification.</b> Each fragment is verified via
+/// <see cref="IExportHmacSigner.Verify"/> with parameters reconstructed from the
+/// <see cref="ReceivedFragment"/> values. Empty-sentinel fragments
+/// (<see cref="PrivacyFragmentUploader.EmptyFragmentKind"/>) carry no HMAC and
+/// are recorded in the manifest's <c>emptyProviders</c> list without a blob
+/// read.
+/// </para>
+/// </remarks>
+internal sealed partial class PrivacyExportAssemblyService(
+    IBlobStorage blobStorage,
+    IBlobStoreProvider blobStoreProvider,
+    IExportHmacSigner hmacSigner,
+    IExportAssemblyCheckpointStore checkpointStore,
+    IExportRequestTrackerWriter trackerWriter,
+    IHttpClientFactory httpClientFactory,
+    IOptions<GranitPrivacyOptions> options,
+    TimeProvider timeProvider,
+    PrivacyMetrics metrics,
+    ILogger<PrivacyExportAssemblyService> logger) : IPrivacyExportAssemblyService
+{
+    /// <summary>Named <see cref="HttpClient"/> used for fragment downloads.</summary>
+    public const string HttpClientName = "Granit.Privacy.ArchiveAssembly";
+
+    private static readonly JsonSerializerOptions ManifestJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    public async Task AssembleAsync(ExportCompletedEto completion, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(completion);
+
+        GranitPrivacyOptions opts = options.Value;
+        var downloadTtl = TimeSpan.FromMinutes(opts.ArchiveAssemblyDownloadUrlExpiryMinutes);
+        long shardMaxBytes = (long)opts.ExportShardMaxSizeMb * 1024L * 1024L;
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+        using Activity? activity = PrivacyActivitySource.Source.StartActivity(
+            PrivacyActivitySource.ArchiveAssemble, ActivityKind.Internal);
+        activity?.SetTag("privacy.export.request_id", completion.RequestId);
+        activity?.SetTag("privacy.export.is_partial", completion.IsPartial);
+
+        // Mark the checkpoint slot — a future sub-PR will write per-shard progress here.
+        await checkpointStore.SetAsync(
+            completion.RequestId,
+            completion.TenantId,
+            new ExportAssemblyCheckpoint(
+                LastCompletedShardIndex: -1,
+                NextFragmentIndex: 0,
+                CompletedShardObjectKeys: []),
+            cancellationToken).ConfigureAwait(false);
+
+        HttpClient httpClient = httpClientFactory.CreateClient(HttpClientName);
+        List<string> emptyProviders = [];
+        List<ExportManifestFragment> manifestFragments = [];
+
+        string objectKeyPrefix = BuildObjectKeyPrefix(completion.RequestId);
+        await using ShardingArchiveWriter writer = new(
+            blobStoreProvider, PrivacyExportContainerBucket(opts), objectKeyPrefix, shardMaxBytes);
+
+        DateTimeOffset hmacExpiryWindow = timeProvider.GetUtcNow()
+            + TimeSpan.FromMinutes(opts.ExportTimeoutMinutes * 4);
+
+        try
+        {
+            foreach (ReceivedFragment fragment in completion.Fragments)
+            {
+                if (string.Equals(fragment.FragmentKind, PrivacyFragmentUploader.EmptyFragmentKind, StringComparison.Ordinal))
+                {
+                    emptyProviders.Add(fragment.ProviderName);
+                    continue;
+                }
+
+                if (!Guid.TryParse(fragment.BlobReferenceId.Value, out Guid blobId))
+                {
+                    LogUnexpectedBlobReference(logger, fragment.ProviderName, fragment.BlobReferenceId.Value, completion.RequestId);
+                    continue;
+                }
+
+                if (!VerifyFragmentTag(completion, fragment, blobId, hmacExpiryWindow))
+                {
+                    LogIntegrityTagRejected(logger, fragment.ProviderName, completion.RequestId);
+                    throw new InvalidOperationException(
+                        $"HMAC integrity tag verification failed for provider '{fragment.ProviderName}' on request {completion.RequestId}.");
+                }
+
+                string entryName = await ResolveEntryNameAsync(fragment, blobId, cancellationToken).ConfigureAwait(false);
+                await CopyFragmentToWriterAsync(writer, entryName, fragment, blobId, downloadTtl, httpClient, cancellationToken)
+                    .ConfigureAwait(false);
+
+                manifestFragments.Add(new ExportManifestFragment(
+                    fragment.ProviderName, entryName, fragment.ContentType, fragment.BlobReferenceId));
+                // ExportManifestFragment.FileName carries the resolved entry name.
+            }
+
+            IReadOnlyList<ShardManifest> shards = await writer.CompleteAsync(cancellationToken).ConfigureAwait(false);
+
+            BlobReference manifestBlobReference = await UploadManifestAsync(
+                completion, emptyProviders, manifestFragments, shards, httpClient, cancellationToken)
+                .ConfigureAwait(false);
+
+            ExportRequestState finalState = completion.IsPartial
+                ? ExportRequestState.PartiallyCompleted
+                : ExportRequestState.Completed;
+
+            await trackerWriter.MarkCompletedAsync(
+                completion.RequestId,
+                finalState,
+                manifestBlobReference,
+                completion.MissingProviders,
+                cancellationToken).ConfigureAwait(false);
+
+            await checkpointStore.ClearAsync(completion.RequestId, completion.TenantId, cancellationToken).ConfigureAwait(false);
+
+            TimeSpan duration = Stopwatch.GetElapsedTime(startTimestamp);
+            metrics.RecordArchiveAssembled(
+                tenantId: completion.TenantId, status: finalState.ToString(), completion.IsPartial, duration, completion.Regulation);
+            LogArchiveAssembled(logger, completion.RequestId, shards.Count, completion.Fragments.Count, emptyProviders.Count, (long)duration.TotalMilliseconds);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            TimeSpan duration = Stopwatch.GetElapsedTime(startTimestamp);
+            LogAssemblyFailed(logger, completion.RequestId, ex.GetType().Name);
+            metrics.RecordArchiveAssembled(
+                tenantId: completion.TenantId,
+                status: "failed",
+                completion.IsPartial,
+                duration,
+                completion.Regulation);
+            throw;
+        }
+    }
+
+    private async Task<string> ResolveEntryNameAsync(ReceivedFragment fragment, Guid blobId, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrEmpty(fragment.EntryPath))
+        {
+            return fragment.EntryPath;
+        }
+
+        BlobDescriptor? descriptor = await blobStorage.GetDescriptorAsync(
+            fragment.SourceContainer, blobId, cancellationToken).ConfigureAwait(false);
+        string? original = descriptor?.OriginalFileName;
+        if (!string.IsNullOrWhiteSpace(original))
+        {
+            return original;
+        }
+
+        return $"{fragment.ProviderName}{ExtensionFor(fragment.ContentType)}";
+    }
+
+    private async Task CopyFragmentToWriterAsync(
+        ShardingArchiveWriter writer,
+        string entryName,
+        ReceivedFragment fragment,
+        Guid blobId,
+        TimeSpan downloadTtl,
+        HttpClient httpClient,
+        CancellationToken cancellationToken)
+    {
+        PresignedDownloadUrl downloadUrl = await blobStorage.CreateDownloadUrlAsync(
+            fragment.SourceContainer,
+            blobId,
+            new DownloadUrlOptions(Expiry: downloadTtl),
+            cancellationToken).ConfigureAwait(false);
+
+        using HttpResponseMessage response = await httpClient
+            .GetAsync(downloadUrl.Url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream contentStream = await response.Content
+            .ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        await writer.AppendAsync(entryName, fragment.ContentType, contentStream, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private bool VerifyFragmentTag(
+        ExportCompletedEto completion,
+        ReceivedFragment fragment,
+        Guid blobId,
+        DateTimeOffset expiry)
+    {
+        if (string.IsNullOrEmpty(fragment.IntegrityTag))
+        {
+            return false;
+        }
+
+        return hmacSigner.Verify(
+            new ExportHmacParameters(
+                RequestId: completion.RequestId,
+                SubjectUserId: completion.UserId,
+                ProviderName: fragment.ProviderName,
+                FragmentKind: fragment.FragmentKind,
+                SourceContainer: fragment.SourceContainer,
+                SourceBlobId: blobId,
+                EntryPath: fragment.EntryPath ?? string.Empty,
+                ExpiresAt: expiry),
+            fragment.IntegrityTag);
+    }
+
+    private async Task<BlobReference> UploadManifestAsync(
+        ExportCompletedEto completion,
+        IReadOnlyList<string> emptyProviders,
+        IReadOnlyList<ExportManifestFragment> manifestFragments,
+        IReadOnlyList<ShardManifest> shards,
+        HttpClient httpClient,
+        CancellationToken cancellationToken)
+    {
+        var manifest = new
+        {
+            schemaVersion = 1,
+            requestId = completion.RequestId,
+            userId = completion.UserId,
+            regulation = completion.Regulation,
+            requestedAt = completion.RequestedAt,
+            completedAt = timeProvider.GetUtcNow(),
+            isPartial = completion.IsPartial,
+            missingProviders = completion.MissingProviders,
+            emptyProviders,
+            shards = shards.Select(s => new
+            {
+                index = s.Index,
+                objectKey = s.ObjectKey,
+                compressedSizeBytes = s.CompressedSizeBytes,
+            }).ToArray(),
+            fragments = manifestFragments,
+        };
+
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(manifest, ManifestJsonOptions);
+
+        PresignedUploadTicket ticket = await blobStorage.InitiateUploadAsync(
+            PrivacyExportContainerNames.FragmentContainer,
+            new BlobUploadRequest(
+                FileName: $"personal-data-export-{completion.RequestId}-manifest.json",
+                ContentType: "application/json",
+                MaxAllowedBytes: payload.Length),
+            cancellationToken).ConfigureAwait(false);
+
+        using ByteArrayContent content = new(payload);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        foreach ((string key, string value) in ticket.RequiredHeaders)
+        {
+            content.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        using HttpRequestMessage request = new(new HttpMethod(ticket.HttpMethod), ticket.UploadUrl)
+        {
+            Content = content,
+        };
+        using HttpResponseMessage response = await httpClient
+            .SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await blobStorage.ConfirmUploadAsync(
+            PrivacyExportContainerNames.FragmentContainer, ticket.BlobId, cancellationToken).ConfigureAwait(false);
+
+        return BlobReference.Create(ticket.BlobId.ToString());
+    }
+
+    private static string BuildObjectKeyPrefix(Guid requestId) =>
+        $"personal-data-export/{requestId}";
+
+    // The shard writer talks to the low-level IBlobStoreProvider, which routes by
+    // bucket name (not container). The privacy export uses a single bucket name —
+    // re-use the fragment-container constant so providers that wire one bucket per
+    // container resolve consistently.
+    private static string PrivacyExportContainerBucket(GranitPrivacyOptions _) =>
+        PrivacyExportContainerNames.FragmentContainer;
+
+    private static string ExtensionFor(string contentType) => contentType switch
+    {
+        "application/json" => ".json",
+        "application/xml" or "text/xml" => ".xml",
+        "text/csv" => ".csv",
+        "text/plain" => ".txt",
+        "application/pdf" => ".pdf",
+        _ => ".bin",
+    };
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Privacy export {RequestId}: assembled into {ShardCount} shard(s) ({FragmentCount} fragment(s), {EmptyCount} empty) in {ElapsedMs} ms")]
+    private static partial void LogArchiveAssembled(ILogger logger, Guid requestId, int shardCount, int fragmentCount, int emptyCount, long elapsedMs);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Privacy export {RequestId}: provider {Provider} returned unparseable BlobReferenceId '{BlobReferenceId}' — skipping")]
+    private static partial void LogUnexpectedBlobReference(ILogger logger, string provider, string blobReferenceId, Guid requestId);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Privacy export {RequestId}: HMAC integrity tag rejected for provider {Provider} — refusing to read source blob")]
+    private static partial void LogIntegrityTagRejected(ILogger logger, string provider, Guid requestId);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Privacy export {RequestId}: assembly failed ({ExceptionType}) — checkpoint preserved for retry")]
+    private static partial void LogAssemblyFailed(ILogger logger, Guid requestId, string exceptionType);
+}
+

--- a/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Granit.Privacy.BlobStorage.DataExport;
+using Granit.Privacy.BlobStorage.DataExport.Internal;
 using Granit.Privacy.BlobStorage.Streaming;
+using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Security;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -31,9 +33,12 @@ public static class ServiceCollectionExtensions
     {
         services.AddHttpClient(StagedFragmentBuilder.HttpClientName);
         services.AddHttpClient(ExportArchiveAssemblyHandler.HttpClientName);
+        services.AddHttpClient(PrivacyExportAssemblyService.HttpClientName);
         services.TryAddSingleton<IExportHmacSigner, EphemeralExportHmacSigner>();
+        services.TryAddSingleton<IExportAssemblyCheckpointStore, InMemoryExportAssemblyCheckpointStore>();
         services.TryAddScoped<IStagedFragmentBuilder, StagedFragmentBuilder>();
         services.TryAddScoped<IBlobBackedExportSource, BlobBackedExportSource>();
+        services.TryAddScoped<IPrivacyExportAssemblyService, PrivacyExportAssemblyService>();
         services.TryAddScoped<PrivacyFragmentUploader>();
         services.TryAddScoped<ExportArchiveAssemblyHandler>();
         return services;

--- a/src/Granit.Privacy/DataExport/IExportAssemblyCheckpointStore.cs
+++ b/src/Granit.Privacy/DataExport/IExportAssemblyCheckpointStore.cs
@@ -1,0 +1,70 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Persists the resumable state of an in-flight personal-data export assembly run,
+/// keyed by request id + tenant. Granularity is the closed shard — a half-written
+/// ZIP archive or an open multipart upload is not recoverable, so the next run
+/// starts from the fragment that begins the shard after the last one fully
+/// committed to storage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Idempotent.</b> Setting a checkpoint replaces the prior value; clearing means
+/// the assembly ran to completion and a re-dispatch would start over from scratch.
+/// </para>
+/// <para>
+/// <b>Multi-tenant.</b> Implementations storing checkpoint rows MUST partition by
+/// <c>TenantId</c> via <c>IMultiTenant</c> — see the EF impl in
+/// <c>Granit.Privacy.EntityFrameworkCore</c> (shipped in a follow-up sub-PR).
+/// </para>
+/// <para>
+/// <b>Concurrency.</b> One assembly job runs per request at a time. The store does
+/// not need cross-process locking — the dispatcher's idempotency key on the saga
+/// completion event prevents duplicate dispatch.
+/// </para>
+/// </remarks>
+public interface IExportAssemblyCheckpointStore
+{
+    /// <summary>
+    /// Returns the resumable checkpoint for the given (<paramref name="requestId"/>,
+    /// <paramref name="tenantId"/>), or <see langword="null"/> when no prior run
+    /// crashed and assembly should start from the first fragment.
+    /// </summary>
+    Task<ExportAssemblyCheckpoint?> GetAsync(
+        Guid requestId,
+        Guid? tenantId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Persists <paramref name="checkpoint"/> as the new resumable state.</summary>
+    Task SetAsync(
+        Guid requestId,
+        Guid? tenantId,
+        ExportAssemblyCheckpoint checkpoint,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears the checkpoint after the assembly ran to completion. Subsequent calls
+    /// to <see cref="GetAsync"/> return <see langword="null"/>.
+    /// </summary>
+    Task ClearAsync(
+        Guid requestId,
+        Guid? tenantId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Resumable state of an in-flight personal-data export assembly run.
+/// </summary>
+/// <param name="LastCompletedShardIndex">Index of the last shard whose multipart
+/// upload was confirmed. <c>-1</c> when no shard has fully completed yet — the
+/// next run resumes from fragment 0.</param>
+/// <param name="NextFragmentIndex">Index into the event's <c>Fragments</c> list
+/// where the next shard should resume. Always points past the last fragment that
+/// was successfully appended to a fully-committed shard.</param>
+/// <param name="CompletedShardObjectKeys">Object keys of the shards already
+/// committed to blob storage, in shard-index order. Carried forward so the next
+/// run can rebuild the manifest without rescanning the bucket.</param>
+public sealed record ExportAssemblyCheckpoint(
+    int LastCompletedShardIndex,
+    int NextFragmentIndex,
+    IReadOnlyList<string> CompletedShardObjectKeys);

--- a/src/Granit.Privacy/DataExport/IPrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyExportAssemblyService.cs
@@ -1,0 +1,33 @@
+using Granit.Privacy.DataExport.Events;
+
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Assembles the sharded ZIP archive for a single personal-data export request.
+/// Implemented by <c>PrivacyExportAssemblyService</c> in
+/// <c>Granit.Privacy.BlobStorage</c>; invoked from the
+/// <c>PrivacyExportAssemblyJobHandler</c> in <c>Granit.Privacy.BackgroundJobs</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The contract sits on the base <c>Granit.Privacy</c> module so the background-job
+/// package depends only on the high-level interface, not on the BlobStorage-specific
+/// implementation — the host wires the impl by referencing
+/// <c>Granit.Privacy.BlobStorage</c>.
+/// </para>
+/// <para>
+/// Implementations MUST be tenant-aware: the caller opens the right
+/// <see cref="Granit.MultiTenancy.ICurrentTenant"/> scope before invoking; the
+/// implementation operates under that scope without rescoping.
+/// </para>
+/// </remarks>
+public interface IPrivacyExportAssemblyService
+{
+    /// <summary>
+    /// Assembles the export archive for <paramref name="completion"/>: verifies HMAC
+    /// capabilities on every fragment, streams each into a sequence of size-capped
+    /// ZIP shards via the configured blob provider, writes a checkpoint per
+    /// completed shard, and updates the request tracker on success.
+    /// </summary>
+    Task AssembleAsync(ExportCompletedEto completion, CancellationToken cancellationToken);
+}

--- a/src/Granit.Privacy/Options/GranitPrivacyOptions.cs
+++ b/src/Granit.Privacy/Options/GranitPrivacyOptions.cs
@@ -19,11 +19,23 @@ public sealed class GranitPrivacyOptions
     public int ExportTimeoutMinutes { get; set; } = 5;
 
     /// <summary>
-    /// Maximum size in megabytes for the export archive.
+    /// Maximum size in megabytes for the export archive (legacy single-archive cap,
+    /// honoured by the staging-fragment flow). Sharded assembly uses
+    /// <see cref="ExportShardMaxSizeMb"/> per-shard and is bounded only by the host's
+    /// storage budget.
     /// Default: 100 MB.
     /// </summary>
     [Range(1, 500)]
     public int ExportMaxSizeMb { get; set; } = 100;
+
+    /// <summary>
+    /// Maximum compressed bytes per shard before the sharded assembler rolls over
+    /// to a new archive. Default 2 GB — Takeout-comparable. A single export entry
+    /// larger than this cap is allowed to land alone in its own shard (ZIP64
+    /// covers it) rather than being split mid-stream.
+    /// </summary>
+    [Range(64, 51_200)]
+    public int ExportShardMaxSizeMb { get; set; } = 2_048;
 
     /// <summary>
     /// Time-to-live, in minutes, of the presigned URLs that the archive assembler

--- a/tests/Granit.Privacy.BackgroundJobs.Tests/Jobs/PrivacyExportAssemblyJobHandlerTests.cs
+++ b/tests/Granit.Privacy.BackgroundJobs.Tests/Jobs/PrivacyExportAssemblyJobHandlerTests.cs
@@ -1,0 +1,80 @@
+using Granit.Domain.ValueObjects;
+using Granit.MultiTenancy;
+using Granit.Privacy.BackgroundJobs.Jobs;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Events;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.BackgroundJobs.Tests.Jobs;
+
+public sealed class PrivacyExportAssemblyJobHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_OpensTenantScope_BeforeInvokingService()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDisposable scope = Substitute.For<IDisposable>();
+        var tenantId = Guid.NewGuid();
+        currentTenant.Change(tenantId).Returns(scope);
+
+        Guid? observedTenantInsideService = null;
+        IPrivacyExportAssemblyService service = Substitute.For<IPrivacyExportAssemblyService>();
+        service
+            .AssembleAsync(Arg.Any<ExportCompletedEto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                observedTenantInsideService = currentTenant.Id;
+                return Task.CompletedTask;
+            });
+
+        PrivacyExportAssemblyJob job = new(BuildEvent(tenantId));
+
+        await PrivacyExportAssemblyJobHandler.HandleAsync(
+            job, currentTenant, service, TestContext.Current.CancellationToken);
+
+        currentTenant.Received(1).Change(tenantId);
+        await service.Received(1).AssembleAsync(job.Event, Arg.Any<CancellationToken>());
+        scope.Received(1).Dispose();
+    }
+
+    [Fact]
+    public async Task HandleAsync_PassesEventVerbatim_ToService()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Change(Arg.Any<Guid?>()).Returns(Substitute.For<IDisposable>());
+        IPrivacyExportAssemblyService service = Substitute.For<IPrivacyExportAssemblyService>();
+        ExportCompletedEto @event = BuildEvent(tenantId: null);
+
+        await PrivacyExportAssemblyJobHandler.HandleAsync(
+            new PrivacyExportAssemblyJob(@event),
+            currentTenant,
+            service,
+            TestContext.Current.CancellationToken);
+
+        await service.Received(1).AssembleAsync(@event, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Job_Exposes_RequestId_And_TenantId_From_Event()
+    {
+        var tenantId = Guid.NewGuid();
+        ExportCompletedEto @event = BuildEvent(tenantId);
+        PrivacyExportAssemblyJob job = new(@event);
+
+        job.RequestId.ShouldBe(@event.RequestId);
+        job.TenantId.ShouldBe(tenantId);
+    }
+
+    private static ExportCompletedEto BuildEvent(Guid? tenantId) => new(
+        RequestId: Guid.NewGuid(),
+        UserId: Guid.NewGuid(),
+        ArchiveBlobReferenceId: BlobReference.Create($"personal-data-export/{Guid.NewGuid()}"),
+        IsPartial: false,
+        MissingProviders: [],
+        Fragments: [],
+        Regulation: "EU_GDPR",
+        RequestedAt: DateTimeOffset.UtcNow,
+        TenantId: tenantId);
+}

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/InMemoryExportAssemblyCheckpointStoreTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/InMemoryExportAssemblyCheckpointStoreTests.cs
@@ -1,0 +1,64 @@
+using Granit.Privacy.BlobStorage.DataExport.Internal;
+using Granit.Privacy.DataExport;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.BlobStorage.Tests.DataExport.Internal;
+
+public sealed class InMemoryExportAssemblyCheckpointStoreTests
+{
+    [Fact]
+    public async Task GetAsync_ReturnsNull_WhenNeverSet()
+    {
+        InMemoryExportAssemblyCheckpointStore sut = new();
+        (await sut.GetAsync(Guid.NewGuid(), tenantId: null, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_ThenGetAsync_RoundTrips()
+    {
+        InMemoryExportAssemblyCheckpointStore sut = new();
+        var requestId = Guid.NewGuid();
+        ExportAssemblyCheckpoint cp = new(LastCompletedShardIndex: 2, NextFragmentIndex: 12, CompletedShardObjectKeys: ["a", "b", "c"]);
+
+        await sut.SetAsync(requestId, tenantId: null, cp, TestContext.Current.CancellationToken);
+
+        ExportAssemblyCheckpoint? read = await sut.GetAsync(requestId, tenantId: null, TestContext.Current.CancellationToken);
+        read.ShouldBe(cp);
+    }
+
+    [Fact]
+    public async Task SetAsync_IsTenantPartitioned()
+    {
+        InMemoryExportAssemblyCheckpointStore sut = new();
+        var requestId = Guid.NewGuid();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        await sut.SetAsync(requestId, tenantA, new ExportAssemblyCheckpoint(0, 1, ["k0"]), TestContext.Current.CancellationToken);
+
+        (await sut.GetAsync(requestId, tenantA, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+        (await sut.GetAsync(requestId, tenantB, TestContext.Current.CancellationToken)).ShouldBeNull();
+        (await sut.GetAsync(requestId, tenantId: null, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesCheckpoint()
+    {
+        InMemoryExportAssemblyCheckpointStore sut = new();
+        var requestId = Guid.NewGuid();
+        await sut.SetAsync(requestId, tenantId: null, new ExportAssemblyCheckpoint(0, 0, []), TestContext.Current.CancellationToken);
+
+        await sut.ClearAsync(requestId, tenantId: null, TestContext.Current.CancellationToken);
+
+        (await sut.GetAsync(requestId, tenantId: null, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ClearAsync_OnMissing_IsNoOp()
+    {
+        InMemoryExportAssemblyCheckpointStore sut = new();
+        await sut.ClearAsync(Guid.NewGuid(), tenantId: null, TestContext.Current.CancellationToken);
+        // Should not throw.
+    }
+}

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
@@ -1,0 +1,286 @@
+using System.Diagnostics.Metrics;
+using System.IO.Compression;
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Internal;
+using Granit.BlobStorage.Options;
+using Granit.Domain.ValueObjects;
+using Granit.Privacy.BlobStorage.DataExport;
+using Granit.Privacy.BlobStorage.DataExport.Internal;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.DataExport.Security;
+using Granit.Privacy.Diagnostics;
+using Granit.Privacy.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ConfigOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.Privacy.BlobStorage.Tests.DataExport;
+
+public sealed class PrivacyExportAssemblyServiceTests : IDisposable
+{
+    private static readonly DateTimeOffset RequestedAt = new(2026, 5, 25, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.UtcNow + TimeSpan.FromHours(1));
+    private readonly FakeBlobStoreProvider _blobStoreProvider = new();
+    private readonly IBlobStorage _blobStorage = Substitute.For<IBlobStorage>();
+    private readonly IExportRequestTrackerWriter _tracker = Substitute.For<IExportRequestTrackerWriter>();
+    private readonly InMemoryExportAssemblyCheckpointStore _checkpoints = new();
+    private readonly EphemeralExportHmacSigner _hmacSigner = new(NullLogger<EphemeralExportHmacSigner>.Instance);
+    private readonly FakeHttpMessageHandler _http = new();
+    private readonly ServiceProvider _sp;
+    private readonly PrivacyMetrics _metrics;
+
+    public PrivacyExportAssemblyServiceTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _metrics = new PrivacyMetrics(_sp.GetRequiredService<IMeterFactory>());
+    }
+
+    public void Dispose()
+    {
+        _hmacSigner.Dispose();
+        _http.Dispose();
+        _sp.Dispose();
+    }
+
+    [Fact]
+    public async Task AssembleAsync_HappyPath_ProducesShard_AndManifest_AndMarksTrackerCompleted()
+    {
+        var requestId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var blobA = Guid.NewGuid();
+        var blobB = Guid.NewGuid();
+
+        byte[] payloadA = """{"id":"u1"}"""u8.ToArray();
+        byte[] payloadB = """[{"evt":"login"}]"""u8.ToArray();
+        SetupFragmentDownload(blobA, payloadA);
+        SetupFragmentDownload(blobB, payloadB);
+        Guid manifestBlobId = SetupManifestUpload();
+
+        ExportCompletedEto evt = BuildEvent(
+            requestId, userId,
+            [
+                BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json"),
+                BuildSignedFragment(requestId, userId, "auditing", blobB, "audit.json", "application/json"),
+            ]);
+
+        await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
+
+        // Exactly one shard (small payloads).
+        _blobStoreProvider.SavedBlobs.Keys.Count(k => k.EndsWith(".zip", StringComparison.Ordinal)).ShouldBe(1);
+        byte[] shardBytes = _blobStoreProvider.SavedBlobs.First(kvp => kvp.Key.EndsWith(".zip", StringComparison.Ordinal)).Value;
+
+        // Shard contains the two fragments at their declared entry paths.
+        using MemoryStream zipStream = new(shardBytes);
+        using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
+        zip.Entries.Select(e => e.FullName).ShouldBe(["identity.json", "audit.json"], ignoreOrder: true);
+
+        await _tracker.Received(1).MarkCompletedAsync(
+            requestId,
+            ExportRequestState.Completed,
+            Arg.Is<BlobReference>(b => b.Value == manifestBlobId.ToString()),
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 0),
+            Arg.Any<CancellationToken>());
+
+        (await _checkpoints.GetAsync(requestId, tenantId: null, TestContext.Current.CancellationToken))
+            .ShouldBeNull("checkpoint should be cleared after successful assembly");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_RejectsForgedHmac_AndDoesNotShipShard()
+    {
+        var requestId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var blobA = Guid.NewGuid();
+        SetupFragmentDownload(blobA, "{}"u8.ToArray());
+        SetupManifestUpload();
+
+        // Sign with WRONG provider name → verify will reject when the assembler
+        // reconstructs parameters from fragment.ProviderName = "identity".
+        DateTimeOffset expiry = _timeProvider.GetUtcNow() + TimeSpan.FromMinutes(20);
+        string forgedTag = _hmacSigner.Sign(new ExportHmacParameters(
+            requestId, userId, ProviderName: "wrong-provider", FragmentKind: "staged",
+            SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+            SourceBlobId: blobA, EntryPath: "identity.json", ExpiresAt: expiry));
+
+        ReceivedFragment fragment = new(
+            ProviderName: "identity",
+            FragmentKind: "staged",
+            SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+            BlobReferenceId: BlobReference.Create(blobA.ToString()),
+            EntryPath: "identity.json",
+            ContentType: "application/json",
+            IntegrityTag: forgedTag);
+
+        ExportCompletedEto evt = BuildEvent(requestId, userId, [fragment]);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken));
+
+        _blobStoreProvider.SavedBlobs.ShouldBeEmpty();
+        await _tracker.DidNotReceive().MarkCompletedAsync(
+            Arg.Any<Guid>(), Arg.Any<ExportRequestState>(), Arg.Any<BlobReference?>(),
+            Arg.Any<IReadOnlyList<string>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssembleAsync_EmptyFragment_RecordedAsEmptyProvider_NoBlobRead()
+    {
+        var requestId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var blobA = Guid.NewGuid();
+        SetupFragmentDownload(blobA, "{}"u8.ToArray());
+        Guid manifestBlobId = SetupManifestUpload();
+
+        ReceivedFragment emptyFragment = new(
+            ProviderName: "notifications",
+            FragmentKind: "empty",
+            SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+            BlobReferenceId: BlobReference.Create($"{PrivacyExportContainerNames.EmptyFragmentPrefix}{requestId}"),
+            EntryPath: "notifications.empty",
+            ContentType: "application/octet-stream",
+            IntegrityTag: string.Empty);
+
+        ExportCompletedEto evt = BuildEvent(
+            requestId, userId,
+            [
+                BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json"),
+                emptyFragment,
+            ]);
+
+        await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
+
+        // Exactly one shard with the non-empty fragment.
+        byte[] shardBytes = _blobStoreProvider.SavedBlobs.First(kvp => kvp.Key.EndsWith(".zip", StringComparison.Ordinal)).Value;
+        using MemoryStream zipStream = new(shardBytes);
+        using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
+        zip.Entries.Select(e => e.FullName).ShouldBe(["identity.json"]);
+
+        // Empty provider name surfaces in the manifest blob upload's payload — best
+        // observed via tracker MarkCompletedAsync (manifest blob id).
+        await _tracker.Received(1).MarkCompletedAsync(
+            requestId,
+            ExportRequestState.Completed,
+            Arg.Is<BlobReference>(b => b.Value == manifestBlobId.ToString()),
+            Arg.Any<IReadOnlyList<string>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private PrivacyExportAssemblyService CreateSut() =>
+        new(
+            _blobStorage,
+            _blobStoreProvider,
+            _hmacSigner,
+            _checkpoints,
+            _tracker,
+            new FakeHttpClientFactory(_http),
+            ConfigOptions.Create(new GranitPrivacyOptions()),
+            _timeProvider,
+            _metrics,
+            NullLogger<PrivacyExportAssemblyService>.Instance);
+
+    private void SetupFragmentDownload(Guid blobId, byte[] payload)
+    {
+        Uri downloadUri = new($"https://s3.example/{blobId}");
+        _blobStorage.CreateDownloadUrlAsync(
+            PrivacyExportContainerNames.FragmentContainer,
+            blobId,
+            Arg.Any<DownloadUrlOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new PresignedDownloadUrl(downloadUri, _timeProvider.GetUtcNow().AddMinutes(15)));
+        _blobStorage.GetDescriptorAsync(
+            PrivacyExportContainerNames.FragmentContainer,
+            blobId,
+            Arg.Any<CancellationToken>())
+            .Returns((BlobDescriptor?)null);
+        _http.MapGet(downloadUri, payload, "application/json");
+    }
+
+    private Guid SetupManifestUpload()
+    {
+        var manifestBlobId = Guid.NewGuid();
+        Uri uploadUri = new($"https://s3.example/upload/{manifestBlobId}");
+        _blobStorage.InitiateUploadAsync(
+            PrivacyExportContainerNames.FragmentContainer,
+            Arg.Any<BlobUploadRequest>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new PresignedUploadTicket(
+                manifestBlobId,
+                uploadUri,
+                "PUT",
+                _timeProvider.GetUtcNow().AddMinutes(15),
+                new Dictionary<string, string>()));
+        _blobStorage.ConfirmUploadAsync(
+            PrivacyExportContainerNames.FragmentContainer,
+            manifestBlobId,
+            Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(true, BlobStatus.Valid, "application/json", 100, null));
+        _http.MapPut(uploadUri);
+        return manifestBlobId;
+    }
+
+    private ReceivedFragment BuildSignedFragment(
+        Guid requestId, Guid userId, string providerName, Guid blobId, string entryPath, string contentType)
+    {
+        DateTimeOffset expiry = _timeProvider.GetUtcNow() + TimeSpan.FromMinutes(20);
+        string tag = _hmacSigner.Sign(new ExportHmacParameters(
+            requestId, userId, providerName, "staged",
+            PrivacyExportContainerNames.FragmentContainer, blobId, entryPath, expiry));
+
+        return new ReceivedFragment(
+            ProviderName: providerName,
+            FragmentKind: "staged",
+            SourceContainer: PrivacyExportContainerNames.FragmentContainer,
+            BlobReferenceId: BlobReference.Create(blobId.ToString()),
+            EntryPath: entryPath,
+            ContentType: contentType,
+            IntegrityTag: tag);
+    }
+
+    private static ExportCompletedEto BuildEvent(Guid requestId, Guid userId, IReadOnlyList<ReceivedFragment> fragments) =>
+        new(
+            RequestId: requestId,
+            UserId: userId,
+            ArchiveBlobReferenceId: BlobReference.Create($"personal-data-export/{requestId}"),
+            IsPartial: false,
+            MissingProviders: [],
+            Fragments: fragments,
+            Regulation: "EU_GDPR",
+            RequestedAt: RequestedAt);
+
+    /// <summary>
+    /// In-memory <see cref="IBlobStoreProvider"/> — exercises the default interface
+    /// method of <c>OpenWriteMultipartAsync</c>.
+    /// </summary>
+    private sealed class FakeBlobStoreProvider : IBlobStoreProvider
+    {
+        public Dictionary<string, byte[]> SavedBlobs { get; } = [];
+
+        public async Task SaveAsync(string bucket, string objectKey, Stream content, string contentType, CancellationToken cancellationToken)
+        {
+            using MemoryStream ms = new();
+            await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+            SavedBlobs[objectKey] = ms.ToArray();
+        }
+
+        public Task<Stream> OpenReadAsync(string bucket, string objectKey, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task DeleteAsync(string bucket, string objectKey, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<long> GetSizeAsync(string bucket, string objectKey, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<Stream> OpenPartialReadAsync(string bucket, string objectKey, int byteCount, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Summary

Third brick of the Takeout-style export refit (sequenced after #2326, #2330). Introduces
the async background-job assembly path **without** retiring the synchronous
`ExportArchiveAssemblyHandler` — that cutover lands in a focused follow-up so each PR
keeps a clear blast radius.

### What ships

- **`Granit.Privacy.BackgroundJobs`** grows the export-assembly job:
  - `PrivacyExportAssemblyJob` (one-shot `IBackgroundJob`) carries the saga's
    `ExportCompletedEto` verbatim so a re-dispatched job operates without the saga
    state still being live.
  - `PrivacyExportAssemblyJobHandler` opens `currentTenant.Change(TenantId)` **before**
    resolving the scoped assembly service — closes the cross-tenant AsyncLocal-leak
    class.
  - `PrivacyExportPermissions` splits self-service (`Privacy.Exports.Execute`,
    default-granted to authenticated users — GDPR Art. 15/20 is a personal right) from
    admin-DSR (`Privacy.Exports.OnBehalfOf`, reserved for v1.1).

- **`Granit.Privacy`** defines the new cross-package contracts:
  - `IExportAssemblyCheckpointStore` (shard-level granularity, tenant-keyed). The
    mid-flight per-shard writes land in the follow-up; the interface is the extension
    point.
  - `IPrivacyExportAssemblyService` so the `BackgroundJobs` handler depends on the
    abstraction, not on `Granit.Privacy.BlobStorage`.
  - `GranitPrivacyOptions.ExportShardMaxSizeMb` — default 2 GB, range 64 MB → 50 GB
    (Takeout-comparable). The legacy `ExportMaxSizeMb` cap stays `[Range(1, 500)]`
    because it applies only to the old single-archive flow.

- **`Granit.Privacy.BlobStorage`** ships the impls:
  - `PrivacyExportAssemblyService` (internal sealed) drives `ShardingArchiveWriter`,
    verifies each fragment's HMAC capability **before** opening the source blob
    (closes VULN-001 / VULN-102), uploads a simple manifest sidecar, and marks the
    tracker with the manifest blob reference.
  - `InMemoryExportAssemblyCheckpointStore` — default registration; production hosts
    will swap in the EF impl in a follow-up sub-PR.

### Test plan

- [x] `dotnet build src/Granit.Privacy{,.BlobStorage,.BackgroundJobs}` clean
- [x] `dotnet test tests/Granit.Privacy.BlobStorage.Tests` — 58/58 pass (8 new tests
      across assembly happy-path, HMAC-rejection, empty-fragment sentinel, in-memory
      checkpoint store partitioning/clear)
- [x] `dotnet test tests/Granit.Privacy.BackgroundJobs.Tests` — 7/7 pass (3 new
      handler tests: tenant-scope discipline, event pass-through, job accessor surface)
- [x] `dotnet test .github/shard-filters/security.slnf` — full shard green
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 235/235 pass
- [x] `dotnet format` clean on every touched project

### Not in this PR

- EF checkpoint store (`Granit.Privacy.EntityFrameworkCore`) + cross-tenant integration
  test (mirror of `EfRebuildCheckpointStoreCrossTenantIsolationTests`).
- Saga dispatch wiring — currently the old `ExportArchiveAssemblyHandler` keeps
  handling `ExportCompletedEto` synchronously. The new job is callable from custom
  code or tests but not auto-triggered. The cutover (delete the old handler, add a
  dispatcher bridge `ExportCompletedEto → IBackgroundJobDispatcher.PublishAsync`)
  comes next.
- Wolverine retry policy + DLQ PII redaction.
- Mid-flight per-shard checkpoint writes (true crash-resume) — the store is in place,
  the upgrade is a localised change inside `PrivacyExportAssemblyService`.