### PR TITLE
fix(text-extraction-ocr-tesseract): route LibrarySearchPath to InteropDotNet loader

### DIFF
--- a/src/Granit.TextExtraction.Ocr.Tesseract/Internal/DefaultTesseractRecognizer.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/Internal/DefaultTesseractRecognizer.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Granit.TextExtraction.Ocr.Tesseract.Options;
 using Microsoft.Extensions.Options;
 using Tesseract;
@@ -36,15 +37,48 @@ internal sealed class DefaultTesseractRecognizer : ITesseractRecognizer, IDispos
 
             ObjectDisposedException.ThrowIf(_disposed, this);
 
-            _engine ??= new TesseractEngine(
-                _options.DataPath ?? throw new InvalidOperationException(
-                    "TesseractOcrOptions.DataPath is required — set it to the tessdata directory."),
-                _options.Language,
-                EngineMode.Default);
+            if (_engine is null)
+            {
+                ApplyLibrarySearchPath();
+                _engine = new TesseractEngine(
+                    _options.DataPath ?? throw new InvalidOperationException(
+                        "TesseractOcrOptions.DataPath is required — set it to the tessdata directory."),
+                    _options.Language,
+                    EngineMode.Default);
+            }
 
             using var pix = Pix.LoadFromMemory(imageBytes);
             using Page page = _engine.Process(pix);
             return Task.FromResult(page.GetText() ?? string.Empty);
+        }
+    }
+
+    private void ApplyLibrarySearchPath()
+    {
+        // The Charlesw `Tesseract` NuGet's InteropDotNet.LibraryLoader does NOT honour
+        // LD_LIBRARY_PATH or the standard dlopen system paths on Linux — it only
+        // probes the app's bin/ directory and `TesseractEnviornment.CustomSearchPath`
+        // (the wrapper's typo, not ours). Hosts that install libtesseract system-wide
+        // via apt (the common Linux production shape) would hit DllNotFoundException
+        // on the first OCR call. Route the option to the wrapper's API; auto-detect
+        // the Debian/Ubuntu canonical path when no explicit value is set.
+        string? searchPath = _options.LibrarySearchPath;
+        if (searchPath is null && OperatingSystem.IsLinux())
+        {
+            searchPath = RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64 => "/usr/lib/x86_64-linux-gnu",
+                Architecture.Arm64 => "/usr/lib/aarch64-linux-gnu",
+                _ => null,
+            };
+        }
+
+        // Empty string is the opt-out sentinel — leave the existing wrapper default
+        // alone (the wrapper falls back to its own auto-detection logic, useful for
+        // Windows hosts shipping the bundled DLLs).
+        if (!string.IsNullOrEmpty(searchPath))
+        {
+            TesseractEnviornment.CustomSearchPath = searchPath;
         }
     }
 

--- a/src/Granit.TextExtraction.Ocr.Tesseract/Options/TesseractOcrOptions.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/Options/TesseractOcrOptions.cs
@@ -51,4 +51,26 @@ public sealed class TesseractOcrOptions
         "image/tiff",
         "image/bmp",
     ];
+
+    /// <summary>
+    /// Filesystem directory the Charlesw <c>Tesseract</c> NuGet should probe for the
+    /// native <c>libleptonica</c> / <c>libtesseract</c> binaries.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The NuGet uses its own <c>InteropDotNet.LibraryLoader</c> on Linux which does
+    /// NOT honour <c>LD_LIBRARY_PATH</c> or the standard <c>dlopen</c> search paths.
+    /// It only checks the app's <c>bin/</c> folder and a <c>CustomSearchPath</c>.
+    /// Without this option set, hosts that install <c>libtesseract</c> system-wide
+    /// (the common Linux production case) get <c>DllNotFoundException</c> at the
+    /// first OCR call.
+    /// </para>
+    /// <para>
+    /// Defaults to <see langword="null"/>: the recognizer auto-detects the standard
+    /// Debian/Ubuntu path on Linux (<c>/usr/lib/x86_64-linux-gnu</c> on amd64,
+    /// <c>/usr/lib/aarch64-linux-gnu</c> on arm64). Set explicitly to point at a
+    /// non-standard install path; set to empty string to opt out of auto-detection.
+    /// </para>
+    /// </remarks>
+    public string? LibrarySearchPath { get; set; }
 }

--- a/src/Granit.TextExtraction.Ocr.Tesseract/README.md
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/README.md
@@ -48,6 +48,31 @@ adds ~10–30 MB.
   pipeline never throws on OCR failure so a broken image doesn't tank the rest of
   the document.
 
+## Native-library search path
+
+The Charlesw `Tesseract` NuGet uses its own `InteropDotNet.LibraryLoader` on
+Linux which does **not** honour `LD_LIBRARY_PATH` or the standard `dlopen`
+search paths — it only probes the app's `bin/` directory and a
+`TesseractEnviornment.CustomSearchPath` (typo in the upstream API). Hosts
+that install `libtesseract` system-wide via apt would otherwise hit
+`DllNotFoundException` on the first OCR call.
+
+`DefaultTesseractRecognizer` routes `TesseractOcrOptions.LibrarySearchPath`
+into the wrapper's API automatically. Left unset, it auto-detects the
+Debian/Ubuntu canonical path on Linux (`/usr/lib/x86_64-linux-gnu` on amd64,
+`/usr/lib/aarch64-linux-gnu` on arm64). Override for non-standard installs:
+
+```csharp
+services.AddTesseractOcrExtractor(o =>
+{
+    o.DataPath = "/opt/myapp/tessdata";
+    o.LibrarySearchPath = "/opt/myapp/native";
+});
+```
+
+Set to the empty string to opt out of auto-detection (e.g. Windows hosts
+shipping the bundled DLLs in `bin/`).
+
 ## Threading
 
 `DefaultTesseractRecognizer` serialises all calls through one locked


### PR DESCRIPTION
Genuine root cause of the integration-shard OCR failures that survived #2322 + #2323 + #2328 + #2332.

## What's actually broken

The Charlesw \`Tesseract\` NuGet uses its own \`InteropDotNet.LibraryLoader\` on Linux. That loader does NOT call \`dlopen\` with system paths in scope — it builds an absolute path itself and just runs \`File.Exists\` against:

1. the app's \`bin/\` directory + \`/x64/\` subdirectory
2. \`AppDomain.CurrentDomain.BaseDirectory + /x64/\`
3. \`Tesseract.TesseractEnviornment.CustomSearchPath\` (typo official — yes, really)

So \`LD_LIBRARY_PATH\` was the wrong knob from the start. \`ldconfig\`-cache state was equally irrelevant. The symlinks at \`/usr/lib/x86_64-linux-gnu/libleptonica-1.82.0.so\` exist, but the wrapper never looks there.

## Fix

- New option \`TesseractOcrOptions.LibrarySearchPath\` (default \`null\` = auto-detect).
- \`DefaultTesseractRecognizer\` sets \`TesseractEnviornment.CustomSearchPath\` on first engine construction.
- Auto-detect resolves to \`/usr/lib/x86_64-linux-gnu\` on amd64 Linux, \`/usr/lib/aarch64-linux-gnu\` on arm64 Linux.
- Empty string opts out (Windows hosts shipping the bundled DLLs).

The existing CI install step (symlinks + ldconfig + LD_LIBRARY_PATH) stays as-is — symlinks are still required because the wrapper appends \`libleptonica-1.82.0.so\` to the search path; ldconfig + LD_LIBRARY_PATH don't hurt and help any other native lib (SkiaSharp, etc.) that DOES use the standard loader.

## Test plan

- [x] Unit suite 19/19 green.
- [x] Format + markdownlint clean.
- [ ] CI integration shard's live OCR suite goes green.

Once green this also unblocks the parallel showcase work on Indexing/Pdf.Ocr — they cohabit on the integration shard and were getting collateral noise.