### PR TITLE
feat(privacy-export): EF export-assembly checkpoint store (P6.3c.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -38162,6 +38162,28 @@
       ]
     },
     {
+      "name": "ExportAssemblyCheckpointRow",
+      "fqn": "Granit.Privacy.EntityFrameworkCore.Entities.ExportAssemblyCheckpointRow",
+      "kind": "class",
+      "project": "Granit.Privacy.EntityFrameworkCore",
+      "file": "src/Granit.Privacy.EntityFrameworkCore/Entities/ExportAssemblyCheckpointRow.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "RequestId",
+          "kind": "property",
+          "signature": "Guid RequestId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "UpdatedAt",
+          "kind": "property",
+          "signature": "DateTimeOffset UpdatedAt",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
       "name": "ExportRequestEntity",
       "fqn": "Granit.Privacy.EntityFrameworkCore.Entities.ExportRequestEntity",
       "kind": "class",
@@ -38199,7 +38221,7 @@
       "kind": "class",
       "project": "Granit.Privacy.EntityFrameworkCore",
       "file": "src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitPrivacyEntityFrameworkCore",

--- a/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/EfExportAssemblyCheckpointStore.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/EfExportAssemblyCheckpointStore.cs
@@ -1,0 +1,122 @@
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.EntityFrameworkCore.Entities;
+using Granit.Privacy.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
+
+/// <summary>
+/// EF-backed <see cref="IExportAssemblyCheckpointStore"/>. Persists one row per
+/// <c>(RequestId, TenantId)</c> tuple so a crashed assembly worker can resume past
+/// the last committed shard on re-dispatch.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Multi-tenant filter bypass.</b> Every query calls
+/// <c>.IgnoreQueryFilters([MultiTenant])</c> because the job's target
+/// <c>tenantId</c> is dictated by the message payload, which may differ from the
+/// ambient <see cref="Granit.MultiTenancy.ICurrentTenant"/>. Isolation rests on the
+/// explicit <c>r.TenantId == tenantId</c> equality predicate on every read/write —
+/// DO NOT remove or relax it. The integration test
+/// <c>EfExportAssemblyCheckpointStoreCrossTenantIsolationTests</c> locks this
+/// invariant.
+/// </para>
+/// <para>
+/// <b>Concurrency.</b> The row implements <see cref="Granit.Domain.IConcurrencyAware"/>;
+/// a duplicate dispatcher racing on the same tuple loses on
+/// <see cref="DbContext.SaveChangesAsync(CancellationToken)"/> with
+/// <see cref="DbUpdateConcurrencyException"/>. This store currently rethrows the
+/// EF exception — Wolverine's retry-with-cooldown surface wraps it for DLQ
+/// (lands in P6.3c.5).
+/// </para>
+/// </remarks>
+internal sealed class EfExportAssemblyCheckpointStore(
+    IDbContextFactory<PrivacyDbContext> factory,
+    TimeProvider timeProvider) : IExportAssemblyCheckpointStore
+{
+    public async Task<ExportAssemblyCheckpoint?> GetAsync(
+        Guid requestId,
+        Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using PrivacyDbContext db = await factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // Tenant filter bypass — see class remarks. Isolation rests on the explicit
+        // equality below; do not remove `r.TenantId == tenantId`.
+        ExportAssemblyCheckpointRow? row = await db.Set<ExportAssemblyCheckpointRow>()
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RequestId == requestId && r.TenantId == tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (row is null)
+        {
+            return null;
+        }
+
+        return new ExportAssemblyCheckpoint(
+            LastCompletedShardIndex: row.LastCompletedShardIndex,
+            NextFragmentIndex: row.NextFragmentIndex,
+            CompletedShardObjectKeys: row.CompletedShardObjectKeys.AsReadOnly());
+    }
+
+    public async Task SetAsync(
+        Guid requestId,
+        Guid? tenantId,
+        ExportAssemblyCheckpoint checkpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+
+        await using PrivacyDbContext db = await factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        DbSet<ExportAssemblyCheckpointRow> set = db.Set<ExportAssemblyCheckpointRow>();
+
+        // Tenant filter bypass — see class remarks.
+        ExportAssemblyCheckpointRow? existing = await set
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .FirstOrDefaultAsync(r => r.RequestId == requestId && r.TenantId == tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        if (existing is null)
+        {
+            set.Add(new ExportAssemblyCheckpointRow
+            {
+                RequestId = requestId,
+                TenantId = tenantId,
+                LastCompletedShardIndex = checkpoint.LastCompletedShardIndex,
+                NextFragmentIndex = checkpoint.NextFragmentIndex,
+                CompletedShardObjectKeys = [.. checkpoint.CompletedShardObjectKeys],
+                UpdatedAt = now,
+            });
+        }
+        else
+        {
+            existing.LastCompletedShardIndex = checkpoint.LastCompletedShardIndex;
+            existing.NextFragmentIndex = checkpoint.NextFragmentIndex;
+            existing.CompletedShardObjectKeys = [.. checkpoint.CompletedShardObjectKeys];
+            existing.UpdatedAt = now;
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task ClearAsync(
+        Guid requestId,
+        Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using PrivacyDbContext db = await factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // Tenant filter bypass — see class remarks. The `r.TenantId == tenantId`
+        // predicate is the sole guard against `ExecuteDelete` wiping rows belonging
+        // to other tenants.
+        await db.Set<ExportAssemblyCheckpointRow>()
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(r => r.RequestId == requestId && r.TenantId == tenantId)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/ExportAssemblyCheckpointRowConfiguration.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/ExportAssemblyCheckpointRowConfiguration.cs
@@ -1,0 +1,31 @@
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Privacy.EntityFrameworkCore.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
+
+internal sealed class ExportAssemblyCheckpointRowConfiguration : IEntityTypeConfiguration<ExportAssemblyCheckpointRow>
+{
+    public void Configure(EntityTypeBuilder<ExportAssemblyCheckpointRow> builder)
+    {
+        builder.ToTable(
+            GranitPrivacyDbProperties.DbTablePrefix + "export_assembly_checkpoints",
+            GranitPrivacyDbProperties.DbSchema);
+
+        // (RequestId, TenantId) is the natural key — one in-flight assembly per
+        // (request, tenant). No surrogate Id.
+        builder.HasKey(e => new { e.RequestId, e.TenantId });
+
+        builder.Property(e => e.LastCompletedShardIndex).IsRequired();
+        builder.Property(e => e.NextFragmentIndex).IsRequired();
+        builder.Property(e => e.UpdatedAt).IsRequired();
+
+        builder.Property(e => e.CompletedShardObjectKeys)
+            .HasJsonConversion()
+            .IsRequired();
+
+        // ConcurrencyStamp is auto-wired by ApplyGranitConventions; pin the column shape.
+        builder.Property(e => e.ConcurrencyStamp).IsRequired().HasMaxLength(36);
+    }
+}

--- a/src/Granit.Privacy.EntityFrameworkCore/Entities/ExportAssemblyCheckpointRow.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Entities/ExportAssemblyCheckpointRow.cs
@@ -1,0 +1,60 @@
+using Granit.Domain;
+
+namespace Granit.Privacy.EntityFrameworkCore.Entities;
+
+/// <summary>
+/// Persistent checkpoint row for the <c>Granit.Privacy.BackgroundJobs</c> export
+/// assembly service. One row per <c>(RequestId, TenantId)</c> tuple; carries the
+/// resumable shard-level state so a crashed worker can pick up after the last
+/// fully-committed shard.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Multi-tenant.</b> Persisted under <see cref="IMultiTenant.TenantId"/> so the
+/// row lives behind the standard Privacy tenant filter. The store deliberately
+/// bypasses the filter on every query and uses an explicit <c>r.TenantId == tenantId</c>
+/// equality predicate — see <c>EfExportAssemblyCheckpointStore</c>'s class remarks.
+/// </para>
+/// <para>
+/// <b>Concurrency.</b> Implements <see cref="IConcurrencyAware"/> so a duplicate
+/// dispatcher racing on the same <c>(RequestId, TenantId)</c> tuple loses on
+/// <c>SaveChangesAsync</c> with <c>DbUpdateConcurrencyException</c> rather than
+/// silently clobbering progress.
+/// </para>
+/// </remarks>
+public sealed class ExportAssemblyCheckpointRow : IMultiTenant, IConcurrencyAware
+{
+    /// <summary>Saga / export-request correlation id.</summary>
+    public Guid RequestId { get; set; }
+
+    /// <inheritdoc/>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>
+    /// Index of the last shard whose multipart upload was confirmed. <c>-1</c> when
+    /// the run started fresh — the next dispatch resumes from fragment 0.
+    /// </summary>
+    public int LastCompletedShardIndex { get; set; }
+
+    /// <summary>
+    /// Fragment-list index where the next shard should resume. Always points past
+    /// the last fragment successfully appended to a committed shard.
+    /// </summary>
+    public int NextFragmentIndex { get; set; }
+
+    /// <summary>
+    /// Object keys of the shards already committed to blob storage, in shard-index
+    /// order, JSON-encoded. Carried forward so the next run can rebuild the
+    /// manifest without rescanning the bucket.
+    /// </summary>
+    public List<string> CompletedShardObjectKeys { get; set; } = [];
+
+    /// <summary>UTC timestamp of the last checkpoint write — informational.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Optimistic-concurrency token (auto-managed by <c>ConcurrencyStampInterceptor</c>
+    /// and wired by <c>ApplyGranitConventions</c>).
+    /// </summary>
+    public string ConcurrencyStamp { get; set; } = string.Empty;
+}

--- a/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
 using Granit.Privacy.EntityFrameworkCore.Internal;
 using Granit.Privacy.LegalAgreements;
 using Microsoft.EntityFrameworkCore;
@@ -54,6 +56,10 @@ public static class PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.TryAddScoped<ILegalDocumentWriter>(sp => sp.GetRequiredService<EfLegalDocumentStore>());
 
         builder.Services.TryAddScoped<ILegalDocumentPublicationService, LegalDocumentPublicationService>();
+
+        // Swap the BlobStorage in-memory default with the durable EF impl.
+        // Replace (not TryAdd) so the EF impl wins regardless of registration order.
+        builder.Services.Replace(ServiceDescriptor.Scoped<IExportAssemblyCheckpointStore, EfExportAssemblyCheckpointStore>());
 
         return builder;
     }

--- a/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyModelBuilderExtensions.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyModelBuilderExtensions.cs
@@ -13,6 +13,7 @@ public static class PrivacyModelBuilderExtensions
     {
         modelBuilder.ApplyConfiguration(new LegalDocumentConfiguration());
         modelBuilder.ApplyConfiguration(new ExportRequestEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new ExportAssemblyCheckpointRowConfiguration());
         modelBuilder.ApplyConfiguration(new DeletionRequestEntityConfiguration());
         return modelBuilder;
     }

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyDbContext.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyDbContext.cs
@@ -23,6 +23,8 @@ internal sealed class PrivacyDbContext(
 
     public DbSet<ExportRequestEntity> ExportRequests { get; set; } = null!;
 
+    public DbSet<ExportAssemblyCheckpointRow> ExportAssemblyCheckpoints { get; set; } = null!;
+
     public DbSet<DeletionRequestEntity> DeletionRequests { get; set; } = null!;
 
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportAssemblyCheckpointStoreCrossTenantIsolationTests.cs
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportAssemblyCheckpointStoreCrossTenantIsolationTests.cs
@@ -1,0 +1,220 @@
+// EF1001 noise suppressed at the project level — these tests intentionally
+// instantiate the internal store via InternalsVisibleTo.
+using Granit.Encryption;
+using Granit.MultiTenancy;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
+using Granit.Privacy.EntityFrameworkCore.Entities;
+using Granit.Privacy.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Locks the cross-tenant isolation invariant for <see cref="EfExportAssemblyCheckpointStore"/>.
+/// The store deliberately bypasses <c>GranitFilterNames.MultiTenant</c> on every
+/// read/write because the export assembly job's target tenant id is dictated by the
+/// message payload, which may differ from the ambient <c>ICurrentTenant</c>. Isolation
+/// rests entirely on the explicit <c>r.TenantId == tenantId</c> predicate — these tests
+/// fail loudly if a future refactor drops it.
+/// </summary>
+public sealed class EfExportAssemblyCheckpointStoreCrossTenantIsolationTests
+{
+    private static readonly Guid TenantA = new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = new("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public async Task GetAsync_DoesNotReturnAnotherTenantsRow_WithSameRequestId()
+    {
+        // Same request id under two tenants — reading tenant A MUST return tenant
+        // A's checkpoint, never tenant B's or the ambient tenant's.
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken);
+
+        var sut = new EfExportAssemblyCheckpointStore(h.Factory, TimeProvider.System);
+        var requestId = Guid.NewGuid();
+        ExportAssemblyCheckpoint a = new(LastCompletedShardIndex: 1, NextFragmentIndex: 5, CompletedShardObjectKeys: ["a-000.zip", "a-001.zip"]);
+        ExportAssemblyCheckpoint b = new(LastCompletedShardIndex: 2, NextFragmentIndex: 9, CompletedShardObjectKeys: ["b-000.zip", "b-001.zip", "b-002.zip"]);
+
+        await sut.SetAsync(requestId, TenantA, a, TestContext.Current.CancellationToken);
+        await sut.SetAsync(requestId, TenantB, b, TestContext.Current.CancellationToken);
+
+        ExportAssemblyCheckpoint? readA = await sut.GetAsync(requestId, TenantA, TestContext.Current.CancellationToken);
+        ExportAssemblyCheckpoint? readB = await sut.GetAsync(requestId, TenantB, TestContext.Current.CancellationToken);
+
+        readA.ShouldNotBeNull();
+        readA.LastCompletedShardIndex.ShouldBe(1);
+        readA.CompletedShardObjectKeys.ShouldBe(["a-000.zip", "a-001.zip"]);
+
+        readB.ShouldNotBeNull();
+        readB.LastCompletedShardIndex.ShouldBe(2);
+        readB.CompletedShardObjectKeys.ShouldBe(["b-000.zip", "b-001.zip", "b-002.zip"]);
+    }
+
+    [Fact]
+    public async Task ClearAsync_DoesNotDeleteAnotherTenantsRow()
+    {
+        // ExecuteDelete bypasses change tracking — a missing predicate would wipe
+        // every row matching RequestId across all tenants.
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken);
+
+        var sut = new EfExportAssemblyCheckpointStore(h.Factory, TimeProvider.System);
+        var requestId = Guid.NewGuid();
+        ExportAssemblyCheckpoint a = new(0, 1, ["a-000.zip"]);
+        ExportAssemblyCheckpoint b = new(0, 1, ["b-000.zip"]);
+
+        await sut.SetAsync(requestId, TenantA, a, TestContext.Current.CancellationToken);
+        await sut.SetAsync(requestId, TenantB, b, TestContext.Current.CancellationToken);
+
+        await sut.ClearAsync(requestId, TenantA, TestContext.Current.CancellationToken);
+
+        (await sut.GetAsync(requestId, TenantA, TestContext.Current.CancellationToken)).ShouldBeNull();
+        // Tenant B's row must survive.
+        ExportAssemblyCheckpoint? readB = await sut.GetAsync(requestId, TenantB, TestContext.Current.CancellationToken);
+        readB.ShouldNotBeNull();
+        readB.CompletedShardObjectKeys.ShouldBe(["b-000.zip"]);
+    }
+
+    [Fact]
+    public async Task SetAsync_ForAmbientTenantA_CanWriteForADifferentTenantB()
+    {
+        // Background workers run under their own tenant scope (set by the job
+        // handler). The store bypasses the ambient tenant filter so a worker
+        // dispatched for tenant B can checkpoint against tenant B even if the
+        // ambient ICurrentTenant happens to point elsewhere.
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken);
+
+        var sut = new EfExportAssemblyCheckpointStore(h.Factory, TimeProvider.System);
+        var requestId = Guid.NewGuid();
+        ExportAssemblyCheckpoint cp = new(0, 1, ["b-000.zip"]);
+
+        await sut.SetAsync(requestId, TenantB, cp, TestContext.Current.CancellationToken);
+
+        (await sut.GetAsync(requestId, TenantB, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+        (await sut.GetAsync(requestId, TenantA, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_RoundTripsAllCheckpointFields()
+    {
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken);
+
+        var sut = new EfExportAssemblyCheckpointStore(h.Factory, TimeProvider.System);
+        var requestId = Guid.NewGuid();
+        ExportAssemblyCheckpoint cp = new(
+            LastCompletedShardIndex: 3,
+            NextFragmentIndex: 17,
+            CompletedShardObjectKeys: ["personal-data-export/x-000.zip", "personal-data-export/x-001.zip", "personal-data-export/x-002.zip", "personal-data-export/x-003.zip"]);
+
+        await sut.SetAsync(requestId, TenantA, cp, TestContext.Current.CancellationToken);
+        ExportAssemblyCheckpoint? read = await sut.GetAsync(requestId, TenantA, TestContext.Current.CancellationToken);
+
+        read.ShouldNotBeNull();
+        read.LastCompletedShardIndex.ShouldBe(3);
+        read.NextFragmentIndex.ShouldBe(17);
+        read.CompletedShardObjectKeys.Count.ShouldBe(4);
+        read.CompletedShardObjectKeys[^1].ShouldBe("personal-data-export/x-003.zip");
+    }
+
+    [Fact]
+    public async Task SetAsync_TwiceUpdatesInPlace_DoesNotInsertDuplicate()
+    {
+        await using SqliteHarness h = await SqliteHarness.CreateAsync(
+            new MutableTenant { Id = TenantA }, TestContext.Current.CancellationToken);
+
+        var sut = new EfExportAssemblyCheckpointStore(h.Factory, TimeProvider.System);
+        var requestId = Guid.NewGuid();
+
+        await sut.SetAsync(requestId, TenantA, new ExportAssemblyCheckpoint(0, 1, ["a-000.zip"]), TestContext.Current.CancellationToken);
+        await sut.SetAsync(requestId, TenantA, new ExportAssemblyCheckpoint(1, 4, ["a-000.zip", "a-001.zip"]), TestContext.Current.CancellationToken);
+
+        await using PrivacyDbContext db = await h.Factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        int rowCount = await db.Set<ExportAssemblyCheckpointRow>()
+            .IgnoreQueryFilters([Granit.Persistence.EntityFrameworkCore.GranitFilterNames.MultiTenant])
+            .CountAsync(r => r.RequestId == requestId && r.TenantId == TenantA, TestContext.Current.CancellationToken);
+
+        rowCount.ShouldBe(1);
+
+        ExportAssemblyCheckpoint? read = await sut.GetAsync(requestId, TenantA, TestContext.Current.CancellationToken);
+        read.ShouldNotBeNull();
+        read.LastCompletedShardIndex.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// In-memory SQLite harness — gives us real SQL translation (the InMemory provider
+    /// lies about query filters) without a Postgres container.
+    /// </summary>
+    private sealed class SqliteHarness : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        public IDbContextFactory<PrivacyDbContext> Factory { get; }
+
+        private SqliteHarness(SqliteConnection connection, IDbContextFactory<PrivacyDbContext> factory)
+        {
+            _connection = connection;
+            Factory = factory;
+        }
+
+        public static async Task<SqliteHarness> CreateAsync(MutableTenant tenant, CancellationToken ct)
+        {
+            SqliteConnection connection = new("DataSource=:memory:");
+            await connection.OpenAsync(ct);
+
+            DbContextOptions<PrivacyDbContext> options = new DbContextOptionsBuilder<PrivacyDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            IStringEncryptionService encryption = new PassthroughEncryption();
+            var factory = new FixedFactory(options, encryption, tenant);
+
+            await using (PrivacyDbContext db = await factory.CreateDbContextAsync(ct))
+            {
+                await db.Database.EnsureCreatedAsync(ct);
+            }
+
+            return new SqliteHarness(connection, factory);
+        }
+
+        public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+        private sealed class FixedFactory(
+            DbContextOptions<PrivacyDbContext> options,
+            IStringEncryptionService encryption,
+            ICurrentTenant tenant) : IDbContextFactory<PrivacyDbContext>
+        {
+            public PrivacyDbContext CreateDbContext() => new(options, encryption, tenant);
+            public Task<PrivacyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+                Task.FromResult(new PrivacyDbContext(options, encryption, tenant));
+        }
+
+        private sealed class PassthroughEncryption : IStringEncryptionService
+        {
+            public string Encrypt(string plainText) => plainText;
+            public string? Decrypt(string cipherText) => cipherText;
+        }
+    }
+
+    private sealed class MutableTenant : ICurrentTenant
+    {
+        public Guid? Id { get; set; }
+        public bool IsAvailable => Id is not null;
+        public string? Name => null;
+        public IDisposable Change(Guid? id, string? name = null)
+        {
+            Guid? prev = Id;
+            Id = id;
+            return new Restore(this, prev);
+        }
+
+        private sealed class Restore(MutableTenant t, Guid? prev) : IDisposable
+        {
+            public void Dispose() => t.Id = prev;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`EfExportAssemblyCheckpointStore` persists the resumable shard-level state of
in-flight export assembly runs so a crashed worker can pick up past the last
fully-committed shard on re-dispatch. The `AddGranitPrivacyEntityFrameworkCore`
registration replaces the BlobStorage in-memory default; hosts wiring the EF
persistence module automatically get durable checkpoints without further opt-in.

### What ships

- `ExportAssemblyCheckpointRow` — `IMultiTenant` + `IConcurrencyAware`. Composite key
  `(RequestId, TenantId)`. `CompletedShardObjectKeys` persisted as JSON via
  `HasJsonConversion` (same pattern as `ExportRequestEntity.MissingProviders`).
- `ExportAssemblyCheckpointRowConfiguration` — table `pri_export_assembly_checkpoints`,
  36-char `ConcurrencyStamp` pinned.
- `EfExportAssemblyCheckpointStore` (internal sealed). Mirrors the
  `EfRebuildCheckpointStore` discipline: every read/write bypasses the multi-tenant
  query filter and relies on an explicit `r.TenantId == tenantId` equality predicate.
  The `ExecuteDelete` in `ClearAsync` MUST keep that predicate or it would wipe rows
  across tenants — the cross-tenant test locks the invariant.
- `PrivacyDbContext.ExportAssemblyCheckpoints` `DbSet` + configuration applied via
  `ConfigurePrivacyModule`.
- `AddGranitPrivacyEntityFrameworkCore` replaces the in-memory store via
  `ServiceDescriptor.Scoped` (Replace, not TryAdd — EF wins regardless of registration
  order).

### Tests (5 new, real SQLite)

The EF InMemory provider lies about query filter translation, so the cross-tenant
suite runs against `Microsoft.Data.Sqlite`:

- Same `RequestId` across two tenants stays segregated on read.
- `ClearAsync`'s `ExecuteDelete` does not touch other tenants' rows.
- A worker dispatched for tenant B writes against tenant B even when `ICurrentTenant`
  points to A.
- All checkpoint fields round-trip through the JSON column.
- A double `SetAsync` updates in place — no duplicate row inserted.

### Test plan

- [x] `dotnet build src/Granit.Privacy.EntityFrameworkCore` clean
- [x] `dotnet test tests/Granit.Privacy.EntityFrameworkCore.Tests` — 27/27 pass
- [x] `dotnet test .github/shard-filters/security.slnf` — full shard green
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 235/235 pass
- [x] `dotnet format` clean on touched projects

### Still queued

- Mid-flight per-shard checkpoint writes inside `PrivacyExportAssemblyService` (the
  store is in place; the upgrade is a localised change).
- Wolverine retry policy + DLQ PII redaction.
- P6.3d native multipart overrides for S3 / Azure / GCS.