### PR TITLE
feat(indexing-ef): expose ConfigureIndexingModule() folding extension

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -26561,8 +26561,15 @@
       "kind": "class",
       "project": "Granit.Indexing.EntityFrameworkCore",
       "file": "src/Granit.Indexing.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
-      "line": 14,
-      "members": []
+      "line": 15,
+      "members": [
+        {
+          "name": "ConfigureIndexingModule",
+          "kind": "method",
+          "signature": "ConfigureIndexingModule(this ModelBuilder modelBuilder, IEnumerable<Type> indexedKeyTypes, string defaultDictionary = \"english\", int? embeddingDimensions = null, bool isPostgres = true)",
+          "returnType": "ModelBuilder"
+        }
+      ]
     },
     {
       "name": "ServiceCollectionExtensions",
@@ -26630,7 +26637,7 @@
       "kind": "class",
       "project": "Granit.Indexing.EntityFrameworkCore",
       "file": "src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs",
-      "line": 26,
+      "line": 34,
       "members": []
     },
     {
@@ -26639,7 +26646,7 @@
       "kind": "record",
       "project": "Granit.Indexing.EntityFrameworkCore",
       "file": "src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs",
-      "line": 135,
+      "line": 74,
       "members": []
     },
     {

--- a/src/Granit.Indexing.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -13,6 +14,149 @@ namespace Granit.Indexing.EntityFrameworkCore.Extensions;
 /// </remarks>
 public static class ModelBuilderExtensions
 {
+    /// <summary>
+    /// Applies the Granit Indexing module's entity configurations to a host-owned
+    /// <see cref="ModelBuilder"/> — the <c>IndexedEntryRow&lt;TKey&gt;</c> table for each
+    /// registered key type, plus the rebuild-job checkpoint table. Use this when the
+    /// host wants the indexing entities folded into its consolidated DbContext instead
+    /// of running the isolated <c>IndexingDbContext</c>. Both code paths are supported.
+    /// </summary>
+    /// <param name="modelBuilder">EF Core model builder.</param>
+    /// <param name="indexedKeyTypes">
+    /// CLR types of the indexed-entry keys (e.g. <c>typeof(Guid)</c>). One table is
+    /// created per registered type. Must contain at least one type.
+    /// </param>
+    /// <param name="defaultDictionary">
+    /// Postgres text-search dictionary for the generated <c>tsvector</c> column. Defaults
+    /// to <c>english</c> — override per-deployment for other corpora. Ignored on
+    /// non-Postgres providers (the column is unmapped).
+    /// </param>
+    /// <param name="embeddingDimensions">
+    /// Vector dimensionality when the host opts into <c>Granit.Indexing.Embeddings</c>.
+    /// When <see langword="null"/>, the embedding column is unmapped. On Postgres, the
+    /// <c>vector</c> extension is also registered (<c>HasPostgresExtension("vector")</c>).
+    /// </param>
+    /// <param name="isPostgres">
+    /// Whether the host DbContext targets Npgsql. Controls whether the Postgres-specific
+    /// generated columns (<c>tsvector</c>, <c>vector(N)</c>) are emitted. Default
+    /// <see langword="true"/>; pass <see langword="false"/> for SQLite / in-memory test
+    /// rigs where the generated columns can't be translated.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Mirrors the pattern in <c>Granit.Auditing.EntityFrameworkCore.ConfigureAuditingModule</c>,
+    /// <c>Granit.Presence.EntityFrameworkCore.ConfigurePresenceModule</c>, etc. The
+    /// isolated <c>IndexingDbContext</c> calls this internally — single source of truth.
+    /// </para>
+    /// <para>
+    /// <b>Caller responsibilities</b> when using this in a folded host DbContext:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>Add <c>options.UseNpgsql(cs, npg =&gt; npg.UseVector())</c> if embeddings are
+    /// active — without it Npgsql throws on the <c>vector</c> column type.</item>
+    /// <item>Pair the EF tenant filter wiring (<c>ApplyGranitConventions</c>) as usual.</item>
+    /// <item>Migrations live in the host's migration project; the isolated DbContext's
+    /// migrations are NOT run when this method is used.</item>
+    /// </list>
+    /// </remarks>
+    public static ModelBuilder ConfigureIndexingModule(
+        this ModelBuilder modelBuilder,
+        IEnumerable<Type> indexedKeyTypes,
+        string defaultDictionary = "english",
+        int? embeddingDimensions = null,
+        bool isPostgres = true)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+        ArgumentNullException.ThrowIfNull(indexedKeyTypes);
+        ArgumentException.ThrowIfNullOrEmpty(defaultDictionary);
+
+        Type[] keys = [.. indexedKeyTypes];
+        if (keys.Length == 0)
+        {
+            throw new ArgumentException(
+                "At least one TKey must be supplied — Granit.Indexing maps one table per key type.",
+                nameof(indexedKeyTypes));
+        }
+
+        if (isPostgres && embeddingDimensions.HasValue)
+        {
+            modelBuilder.HasPostgresExtension("vector");
+        }
+
+        modelBuilder.ApplyConfiguration(new Configurations.IndexingRebuildCheckpointRowConfiguration());
+
+        foreach (Type keyType in keys)
+        {
+            ApplyConfigurationMethod
+                .MakeGenericMethod(typeof(IndexedEntryRow<>).MakeGenericType(keyType))
+                .Invoke(modelBuilder, [Activator.CreateInstance(typeof(Configurations.IndexedEntryRowConfiguration<>).MakeGenericType(keyType))!]);
+
+            if (isPostgres)
+            {
+                HasGeneratedTsVectorColumnMethod
+                    .MakeGenericMethod(keyType)
+                    .Invoke(null, [modelBuilder, defaultDictionary]);
+
+                if (embeddingDimensions.HasValue)
+                {
+                    HasEmbeddingColumnMethod
+                        .MakeGenericMethod(keyType)
+                        .Invoke(null, [modelBuilder, embeddingDimensions.Value]);
+                }
+                else
+                {
+                    IgnoreEmbeddingColumnMethod
+                        .MakeGenericMethod(keyType)
+                        .Invoke(null, [modelBuilder]);
+                }
+            }
+            else
+            {
+                IgnoreSearchVectorMethod
+                    .MakeGenericMethod(keyType)
+                    .Invoke(null, [modelBuilder]);
+                IgnoreEmbeddingColumnMethod
+                    .MakeGenericMethod(keyType)
+                    .Invoke(null, [modelBuilder]);
+            }
+        }
+
+        return modelBuilder;
+    }
+
+    private static readonly MethodInfo ApplyConfigurationMethod = typeof(ModelBuilder)
+        .GetMethods()
+        .Single(m => m.Name == nameof(ModelBuilder.ApplyConfiguration) && m.IsGenericMethod && m.GetParameters().Length == 1);
+
+    private static readonly MethodInfo HasGeneratedTsVectorColumnMethod =
+        typeof(ModelBuilderExtensions).GetMethod(
+            nameof(HasGeneratedTsVectorColumn),
+            BindingFlags.Static | BindingFlags.Public)!;
+
+    private static readonly MethodInfo HasEmbeddingColumnMethod =
+        typeof(ModelBuilderExtensions).GetMethod(
+            nameof(HasEmbeddingColumn),
+            BindingFlags.Static | BindingFlags.Public)!;
+
+    private static readonly MethodInfo IgnoreEmbeddingColumnMethod =
+        typeof(ModelBuilderExtensions).GetMethod(
+            nameof(IgnoreEmbeddingColumn),
+            BindingFlags.Static | BindingFlags.Public)!;
+
+    private static readonly MethodInfo IgnoreSearchVectorMethod =
+        typeof(ModelBuilderExtensions).GetMethod(
+            nameof(IgnoreSearchVector),
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    internal static EntityTypeBuilder<IndexedEntryRow<TKey>> IgnoreSearchVector<TKey>(
+        this ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+        EntityTypeBuilder<IndexedEntryRow<TKey>> entity = modelBuilder.Entity<IndexedEntryRow<TKey>>();
+        entity.Ignore(e => e.SearchVector);
+        return entity;
+    }
+
     /// <summary>
     /// Configures <see cref="IndexedEntryRow{TKey}.SearchVector"/> as a Postgres
     /// <c>tsvector</c> column generated from <see cref="IndexedEntryRow{TKey}.Content"/>

--- a/src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs
@@ -1,5 +1,5 @@
-using System.Reflection;
 using Granit.DataFiltering;
+using Granit.Indexing.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -20,7 +20,15 @@ namespace Granit.Indexing.EntityFrameworkCore;
 /// <b>Per-key-type shape.</b> Consumers pass every key type they index to
 /// <c>AddGranitIndexingEntityFrameworkCore</c>; the DbContext enumerates registrations
 /// from <see cref="IndexingDbContextSchema"/> at <see cref="OnGranitModelCreating"/>
-/// time and maps one <see cref="IndexedEntryRow{TKey}"/> per registered key type.
+/// time and delegates the model-building to
+/// <c>ModelBuilderExtensions.ConfigureIndexingModule</c>.
+/// </para>
+/// <para>
+/// <b>Alternative folding path.</b> Hosts that prefer a single consolidated DbContext
+/// (single migration tree, single connection scope) can skip
+/// <c>AddGranitIndexingEntityFrameworkCore</c> entirely and call
+/// <c>modelBuilder.ConfigureIndexingModule([typeof(Guid), ...])</c> directly from
+/// their own <see cref="DbContext.OnModelCreating"/>.
 /// </para>
 /// </remarks>
 public sealed class IndexingDbContext : GranitDbContext
@@ -47,83 +55,14 @@ public sealed class IndexingDbContext : GranitDbContext
     {
         bool isPostgres = string.Equals(Database.ProviderName, GranitDbProviders.Postgres, StringComparison.Ordinal);
 
-        if (isPostgres && EmbeddingDimensions.HasValue)
-        {
-            modelBuilder.HasPostgresExtension("vector");
-        }
-
-        // Rebuild-job checkpoint table — always mapped so the
-        // EfRebuildCheckpointStore impl works without a separate DbContext.
-        modelBuilder.ApplyConfiguration(new Configurations.IndexingRebuildCheckpointRowConfiguration());
-
-        foreach (Type keyType in IndexedKeyTypes)
-        {
-            ApplyConfigurationMethod
-                .MakeGenericMethod(typeof(IndexedEntryRow<>).MakeGenericType(keyType))
-                .Invoke(modelBuilder, [Activator.CreateInstance(typeof(Configurations.IndexedEntryRowConfiguration<>).MakeGenericType(keyType))!]);
-
-            if (isPostgres)
-            {
-                HasGeneratedTsVectorColumnMethod
-                    .MakeGenericMethod(keyType)
-                    .Invoke(null, [modelBuilder, DefaultDictionary]);
-
-                if (EmbeddingDimensions.HasValue)
-                {
-                    HasEmbeddingColumnMethod
-                        .MakeGenericMethod(keyType)
-                        .Invoke(null, [modelBuilder, EmbeddingDimensions.Value]);
-                }
-                else
-                {
-                    IgnoreEmbeddingColumnMethod
-                        .MakeGenericMethod(keyType)
-                        .Invoke(null, [modelBuilder]);
-                }
-            }
-            else
-            {
-                // Non-Postgres providers (in-memory / SQLite test rigs) don't have tsvector
-                // or pgvector; unmap both so EF Core's relational provider doesn't try to
-                // emit columns it cannot translate.
-                IgnoreSearchVectorMethod
-                    .MakeGenericMethod(keyType)
-                    .Invoke(null, [modelBuilder]);
-                IgnoreEmbeddingColumnMethod
-                    .MakeGenericMethod(keyType)
-                    .Invoke(null, [modelBuilder]);
-            }
-        }
+        modelBuilder.ConfigureIndexingModule(
+            IndexedKeyTypes,
+            DefaultDictionary,
+            EmbeddingDimensions,
+            isPostgres);
 
         modelBuilder.ApplyGranitConventions(currentTenant: null, dataFilter: null);
     }
-
-    private static readonly MethodInfo ApplyConfigurationMethod = typeof(ModelBuilder)
-        .GetMethods()
-        .Single(m => m.Name == nameof(ModelBuilder.ApplyConfiguration) && m.IsGenericMethod && m.GetParameters().Length == 1);
-
-    private static readonly MethodInfo HasGeneratedTsVectorColumnMethod =
-        typeof(Extensions.ModelBuilderExtensions).GetMethod(
-            nameof(Extensions.ModelBuilderExtensions.HasGeneratedTsVectorColumn),
-            BindingFlags.Static | BindingFlags.Public)!;
-
-    private static readonly MethodInfo HasEmbeddingColumnMethod =
-        typeof(Extensions.ModelBuilderExtensions).GetMethod(
-            nameof(Extensions.ModelBuilderExtensions.HasEmbeddingColumn),
-            BindingFlags.Static | BindingFlags.Public)!;
-
-    private static readonly MethodInfo IgnoreEmbeddingColumnMethod =
-        typeof(Extensions.ModelBuilderExtensions).GetMethod(
-            nameof(Extensions.ModelBuilderExtensions.IgnoreEmbeddingColumn),
-            BindingFlags.Static | BindingFlags.Public)!;
-
-    private static readonly MethodInfo IgnoreSearchVectorMethod =
-        typeof(IndexingDbContext).GetMethod(
-            nameof(IgnoreSearchVector),
-            BindingFlags.Static | BindingFlags.NonPublic)!;
-
-    private static void IgnoreSearchVector<TKey>(ModelBuilder modelBuilder) =>
-        modelBuilder.Entity<IndexedEntryRow<TKey>>().Ignore(e => e.SearchVector);
 }
 
 /// <summary>

--- a/src/Granit.Indexing.EntityFrameworkCore/README.md
+++ b/src/Granit.Indexing.EntityFrameworkCore/README.md
@@ -37,6 +37,36 @@ builder.Services.AddGranitIndexingBackend<Guid, MyHitResponse>(
     row => new MyHitResponse(row.Key, row.Summary ?? string.Empty, row.Tags));
 ```
 
+## Alternative: fold into a host-owned DbContext
+
+Hosts that prefer one consolidated DbContext (single migration tree, single
+connection scope) can skip `AddGranitIndexingEntityFrameworkCore` and call
+`modelBuilder.ConfigureIndexingModule(...)` from their own `OnModelCreating`:
+
+```csharp
+public sealed class AppDbContext(
+    DbContextOptions<AppDbContext> options,
+    ICurrentTenant currentTenant,
+    IDataFilter? dataFilter = null)
+    : GranitDbContext(options, currentTenant, dataFilter)
+{
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+    {
+        // ... host entities ...
+        modelBuilder.ConfigureIndexingModule(
+            indexedKeyTypes: [typeof(Guid)],
+            defaultDictionary: "english",
+            embeddingDimensions: 1536, // null when not using Granit.Indexing.Embeddings
+            isPostgres: true);
+    }
+}
+```
+
+The folded path applies the same conventions (audit fields, soft delete, tenant
+filter) via the host's `ApplyGranitConventions` — no extra wiring required. The
+isolated `IndexingDbContext` path remains supported in parallel; pick the one
+that matches your migration strategy.
+
 ## Migrations
 
 This package ships no EF migrations. Consumer hosts own them.

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests/ConfigureIndexingModuleTests.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests/ConfigureIndexingModuleTests.cs
@@ -1,0 +1,92 @@
+using Granit.DataFiltering;
+using Granit.Indexing.EntityFrameworkCore.Extensions;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Indexing.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Folding-path tests for the new <c>ConfigureIndexingModule</c> extension — proves a
+/// host-owned DbContext can map IndexedEntryRow tables WITHOUT the isolated
+/// IndexingDbContext + AddGranitIndexingEntityFrameworkCore wiring.
+/// </summary>
+public sealed class ConfigureIndexingModuleTests
+{
+    [Fact]
+    public async Task Host_DbContext_can_fold_indexing_tables_via_ConfigureIndexingModule()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        MutableTenant tenant = new() { Id = Guid.NewGuid() };
+        DbContextOptions<HostFoldedDbContext> options = new DbContextOptionsBuilder<HostFoldedDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using HostFoldedDbContext db = new(options, tenant);
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        // IndexedEntryRow<Guid> table was mapped by the extension.
+        IEntityType? entryType = db.Model.FindEntityType(typeof(IndexedEntryRow<Guid>));
+        entryType.ShouldNotBeNull();
+
+        // Rebuild-checkpoint table is also mapped — same single-source-of-truth as the
+        // isolated DbContext.
+        IEntityType? checkpointType = db.Model.FindEntityType(
+            "Granit.Indexing.EntityFrameworkCore.IndexingRebuildCheckpointRow");
+        checkpointType.ShouldNotBeNull();
+
+        // Index + insert via the host context, prove the table is fully wired.
+        IndexedEntryRow<Guid> row = new()
+        {
+            Key = Guid.NewGuid(),
+            TenantId = tenant.Id,
+            Content = "hello folded host context",
+            Language = "en",
+            CharCount = 25,
+        };
+        db.Set<IndexedEntryRow<Guid>>().Add(row);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        IndexedEntryRow<Guid>? roundTripped = await db.Set<IndexedEntryRow<Guid>>()
+            .SingleOrDefaultAsync(r => r.Key == row.Key, TestContext.Current.CancellationToken);
+        roundTripped.ShouldNotBeNull();
+        roundTripped.Content.ShouldBe("hello folded host context");
+
+        await connection.DisposeAsync();
+    }
+
+    [Fact]
+    public void ConfigureIndexingModule_throws_when_no_key_type_supplied()
+    {
+        ModelBuilder mb = new();
+        Should.Throw<ArgumentException>(() =>
+            mb.ConfigureIndexingModule([]))
+            .ParamName.ShouldBe("indexedKeyTypes");
+    }
+
+    /// <summary>
+    /// Host-owned DbContext that demonstrates the folding pattern. Pretends to be the
+    /// consumer's app context — declares its own DbSets PLUS the indexing tables.
+    /// </summary>
+    private sealed class HostFoldedDbContext(
+        DbContextOptions<HostFoldedDbContext> options,
+        ICurrentTenant currentTenant,
+        IDataFilter? dataFilter = null)
+        : GranitDbContext(options, currentTenant, dataFilter)
+    {
+        protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ConfigureIndexingModule(
+                indexedKeyTypes: [typeof(Guid)],
+                defaultDictionary: "simple",
+                embeddingDimensions: null,
+                isPostgres: false);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2335.

`Granit.Indexing.EntityFrameworkCore` was the only Granit module with an isolated DbContext that didn't ship a `ConfigureXxxModule()` extension hosts can fold into their consolidated DbContext. Convention precedent: Auditing, Presence, Documents (granit-business), Taxonomy (granit-business).

## What changed

Adds `ModelBuilderExtensions.ConfigureIndexingModule(modelBuilder, indexedKeyTypes, defaultDictionary, embeddingDimensions, isPostgres)`:

- `indexedKeyTypes` — one table per TKey, same shape as `AddGranitIndexingEntityFrameworkCore(typeof(Guid))`.
- `defaultDictionary` — Postgres tsvector dictionary, defaults `english`.
- `embeddingDimensions` — opt-in pgvector column + HNSW index + `vector` extension registration.
- `isPostgres` — toggles Postgres-specific generated columns vs the SQLite/in-memory ignore path.

`IndexingDbContext.OnGranitModelCreating` now delegates to the extension — single source of truth. Both deployment paths (isolated DbContext / folded host DbContext) are supported and tested.

## Why this matters

Reported by the showcase session (`granit-showcase-dotnet` MR !20 prep) when wiring Indexing into the host's consolidated DbContext. Without this extension, the host has to either:

A. Run a dedicated migration project for `IndexingDbContext` (heavy)
B. Hand-copy the reflection-based per-TKey wiring from `OnGranitModelCreating` (fragile)

Both anti-patterns. The extension makes folding a 5-line addition.

## Test plan

- [x] `dotnet test tests/Granit.Indexing.EntityFrameworkCore.Tests --no-build` — 13/13 (11 existing + 2 new).
- [x] New `ConfigureIndexingModuleTests` proves a host-owned DbContext on SQLite can map `IndexedEntryRow<Guid>` + index + roundtrip through it.
- [x] `dotnet format src/Granit.Indexing.EntityFrameworkCore --verify-no-changes` clean.
- [x] `dotnet format tests/Granit.Indexing.EntityFrameworkCore.Tests --verify-no-changes` clean.
- [x] `markdownlint` clean on README.
- [x] No public API surface change to the isolated path — `AddGranitIndexingEntityFrameworkCore` callers are unaffected.

## README

Adds an "Alternative: fold into a host-owned DbContext" section showing the new usage pattern.

## Next up

Issue #2336 (`Granit.Indexing.Embeddings` consume `Granit.AI` factory instead of singleton `IEmbeddingGenerator`) is the other framework gap the showcase reported. Separate PR — breaking, larger scope.