### PR TITLE
feat(privacy-export): mid-flight per-shard crash-resume (P6.3c.4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37042,7 +37042,7 @@
       "kind": "record",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs",
-      "line": 350,
+      "line": 412,
       "members": []
     },
     {

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
@@ -82,15 +82,35 @@ internal sealed partial class PrivacyExportAssemblyService(
         activity?.SetTag("privacy.export.request_id", completion.RequestId);
         activity?.SetTag("privacy.export.is_partial", completion.IsPartial);
 
-        // Mark the checkpoint slot — a future sub-PR will write per-shard progress here.
-        await checkpointStore.SetAsync(
-            completion.RequestId,
-            completion.TenantId,
-            new ExportAssemblyCheckpoint(
-                LastCompletedShardIndex: -1,
-                NextFragmentIndex: 0,
-                CompletedShardObjectKeys: []),
-            cancellationToken).ConfigureAwait(false);
+        // Resume from a prior crashed run, or start fresh. The checkpoint granularity
+        // is the closed shard — a half-written ZIP or an open multipart upload is not
+        // recoverable, so resume skips fragments already absorbed into a fully-committed
+        // shard and reopens the writer at the next shard index.
+        ExportAssemblyCheckpoint? resumeFrom = await checkpointStore
+            .GetAsync(completion.RequestId, completion.TenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        int startFragmentIndex = resumeFrom?.NextFragmentIndex ?? 0;
+        int startShardIndex = (resumeFrom?.LastCompletedShardIndex ?? -1) + 1;
+        IReadOnlyList<ShardManifest> priorShards = resumeFrom is null
+            ? []
+            : [.. resumeFrom.CompletedShardObjectKeys.Select((key, idx) => new ShardManifest(idx, key, CompressedSizeBytes: 0))];
+
+        if (resumeFrom is not null)
+        {
+            LogResumingAssembly(logger, completion.RequestId, startFragmentIndex, startShardIndex);
+        }
+        else
+        {
+            await checkpointStore.SetAsync(
+                completion.RequestId,
+                completion.TenantId,
+                new ExportAssemblyCheckpoint(
+                    LastCompletedShardIndex: -1,
+                    NextFragmentIndex: 0,
+                    CompletedShardObjectKeys: []),
+                cancellationToken).ConfigureAwait(false);
+        }
 
         HttpClient httpClient = httpClientFactory.CreateClient(HttpClientName);
         List<string> emptyProviders = [];
@@ -98,15 +118,24 @@ internal sealed partial class PrivacyExportAssemblyService(
 
         string objectKeyPrefix = BuildObjectKeyPrefix(completion.RequestId);
         await using ShardingArchiveWriter writer = new(
-            blobStoreProvider, PrivacyExportContainerBucket(opts), objectKeyPrefix, shardMaxBytes);
+            blobStoreProvider, PrivacyExportContainerBucket(opts), objectKeyPrefix, shardMaxBytes,
+            startShardIndex: startShardIndex,
+            priorShards: priorShards);
 
         DateTimeOffset hmacExpiryWindow = timeProvider.GetUtcNow()
             + TimeSpan.FromMinutes(opts.ExportTimeoutMinutes * 4);
 
         try
         {
-            foreach (ReceivedFragment fragment in completion.Fragments)
+            // The fragment list in the saga's completion event is deterministic per
+            // RequestId, so a resumed run sees the same order. We iterate every fragment
+            // to keep the manifest's emptyProviders / manifestFragments lists complete
+            // (covering pre-resume work too), but only stream non-empty fragments at or
+            // past startFragmentIndex into the writer.
+            for (int i = 0; i < completion.Fragments.Count; i++)
             {
+                ReceivedFragment fragment = completion.Fragments[i];
+
                 if (string.Equals(fragment.FragmentKind, PrivacyFragmentUploader.EmptyFragmentKind, StringComparison.Ordinal))
                 {
                     emptyProviders.Add(fragment.ProviderName);
@@ -119,6 +148,16 @@ internal sealed partial class PrivacyExportAssemblyService(
                     continue;
                 }
 
+                if (i < startFragmentIndex)
+                {
+                    // Re-build manifest metadata for the fragment without re-streaming
+                    // its bytes — the shard it lived in is already committed.
+                    string priorEntryName = await ResolveEntryNameAsync(fragment, blobId, cancellationToken).ConfigureAwait(false);
+                    manifestFragments.Add(new ExportManifestFragment(
+                        fragment.ProviderName, priorEntryName, fragment.ContentType, fragment.BlobReferenceId));
+                    continue;
+                }
+
                 if (!VerifyFragmentTag(completion, fragment, blobId, hmacExpiryWindow))
                 {
                     LogIntegrityTagRejected(logger, fragment.ProviderName, completion.RequestId);
@@ -126,13 +165,32 @@ internal sealed partial class PrivacyExportAssemblyService(
                         $"HMAC integrity tag verification failed for provider '{fragment.ProviderName}' on request {completion.RequestId}.");
                 }
 
+                int shardsBefore = writer.Shards.Count;
+
                 string entryName = await ResolveEntryNameAsync(fragment, blobId, cancellationToken).ConfigureAwait(false);
                 await CopyFragmentToWriterAsync(writer, entryName, fragment, blobId, downloadTtl, httpClient, cancellationToken)
                     .ConfigureAwait(false);
 
                 manifestFragments.Add(new ExportManifestFragment(
                     fragment.ProviderName, entryName, fragment.ContentType, fragment.BlobReferenceId));
-                // ExportManifestFragment.FileName carries the resolved entry name.
+
+                // AppendAsync rolls over BEFORE writing when the prior shard hit the cap,
+                // so a growth in Shards.Count means the rolled-over shard is fully
+                // committed to storage. Persist a checkpoint pointing at the fragment
+                // currently in flight (this one): a re-dispatch will re-do this fragment
+                // into a fresh shard, which is fine because the committed shards stay
+                // addressable individually.
+                if (writer.Shards.Count > shardsBefore)
+                {
+                    await checkpointStore.SetAsync(
+                        completion.RequestId,
+                        completion.TenantId,
+                        new ExportAssemblyCheckpoint(
+                            LastCompletedShardIndex: writer.Shards[^1].Index,
+                            NextFragmentIndex: i,
+                            CompletedShardObjectKeys: [.. writer.Shards.Select(s => s.ObjectKey)]),
+                        cancellationToken).ConfigureAwait(false);
+                }
             }
 
             IReadOnlyList<ShardManifest> shards = await writer.CompleteAsync(cancellationToken).ConfigureAwait(false);
@@ -324,6 +382,10 @@ internal sealed partial class PrivacyExportAssemblyService(
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Privacy export {RequestId}: assembled into {ShardCount} shard(s) ({FragmentCount} fragment(s), {EmptyCount} empty) in {ElapsedMs} ms")]
     private static partial void LogArchiveAssembled(ILogger logger, Guid requestId, int shardCount, int fragmentCount, int emptyCount, long elapsedMs);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Privacy export {RequestId}: resuming after a prior crashed run — skipping {SkipCount} fragments already committed, next shard index {NextShardIndex}")]
+    private static partial void LogResumingAssembly(ILogger logger, Guid requestId, int skipCount, int nextShardIndex);
 
     [LoggerMessage(Level = LogLevel.Warning,
         Message = "Privacy export {RequestId}: provider {Provider} returned unparseable BlobReferenceId '{BlobReferenceId}' — skipping")]

--- a/src/Granit.Privacy.BlobStorage/DataExport/ShardingArchiveWriter.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/ShardingArchiveWriter.cs
@@ -65,17 +65,28 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
         IBlobStoreProvider provider,
         string bucket,
         string objectKeyPrefix,
-        long shardMaxBytes)
+        long shardMaxBytes,
+        int startShardIndex = 0,
+        IReadOnlyList<ShardManifest>? priorShards = null)
     {
         ArgumentNullException.ThrowIfNull(provider);
         ArgumentException.ThrowIfNullOrEmpty(bucket);
         ArgumentException.ThrowIfNullOrEmpty(objectKeyPrefix);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(shardMaxBytes);
+        ArgumentOutOfRangeException.ThrowIfNegative(startShardIndex);
 
         _provider = provider;
         _bucket = bucket;
         _objectKeyPrefix = objectKeyPrefix;
         _shardMaxBytes = shardMaxBytes;
+        _nextShardIndex = startShardIndex;
+
+        // Resume seeds — previously committed shards re-surfaced in the final
+        // manifest returned by CompleteAsync without re-uploading their bytes.
+        if (priorShards is { Count: > 0 })
+        {
+            _completedShards.AddRange(priorShards);
+        }
     }
 
     /// <summary>Shards finalised by <see cref="CompleteAsync"/>, in write order.</summary>

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
@@ -174,7 +174,151 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
             Arg.Any<CancellationToken>());
     }
 
-    private PrivacyExportAssemblyService CreateSut() =>
+    [Fact]
+    public async Task AssembleAsync_WritesCheckpoint_OnEveryShardRollover()
+    {
+        // Three large incompressible payloads with a 1 MB shard cap force one
+        // rollover (shard 0 closes when fragment 2 is appended). Verify the
+        // checkpoint snapshots that rollover: shard 0 committed, next fragment
+        // index points at fragment 2 (currently in flight in shard 1).
+        var requestId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        Guid[] blobs = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        byte[] big = new byte[700 * 1024];
+        Random.Shared.NextBytes(big);
+        foreach (Guid b in blobs)
+        {
+            SetupFragmentDownload(b, big, "application/octet-stream");
+        }
+        SetupManifestUpload();
+
+        ExportCompletedEto evt = BuildEvent(
+            requestId, userId,
+            [
+                BuildSignedFragment(requestId, userId, "p0", blobs[0], "p0.bin", "application/octet-stream"),
+                BuildSignedFragment(requestId, userId, "p1", blobs[1], "p1.bin", "application/octet-stream"),
+                BuildSignedFragment(requestId, userId, "p2", blobs[2], "p2.bin", "application/octet-stream"),
+            ]);
+
+        GranitPrivacyOptions opts = new() { ExportShardMaxSizeMb = 1 };
+        await CreateSut(opts).AssembleAsync(evt, TestContext.Current.CancellationToken);
+
+        _blobStoreProvider.SavedBlobs.Keys.Count(k => k.EndsWith(".zip", StringComparison.Ordinal)).ShouldBe(2);
+
+        // After clean completion the checkpoint is cleared — but along the way the
+        // mid-flight one was observed. We assert the latter via a fresh harness so
+        // we can capture the in-flight state.
+    }
+
+    [Fact]
+    public async Task AssembleAsync_MidFlightCheckpoint_RecordsCommittedShardAndCurrentFragmentIndex()
+    {
+        // Spy on the checkpoint store to capture every SetAsync between the start
+        // marker and the final ClearAsync. The mid-flight snapshot must point at
+        // the fragment that triggered the rollover (= fragment 2 here).
+        var requestId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        Guid[] blobs = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        byte[] big = new byte[700 * 1024];
+        Random.Shared.NextBytes(big);
+        foreach (Guid b in blobs)
+        {
+            SetupFragmentDownload(b, big, "application/octet-stream");
+        }
+        SetupManifestUpload();
+
+        var spy = new RecordingCheckpointStore();
+        ExportCompletedEto evt = BuildEvent(
+            requestId, userId,
+            [
+                BuildSignedFragment(requestId, userId, "p0", blobs[0], "p0.bin", "application/octet-stream"),
+                BuildSignedFragment(requestId, userId, "p1", blobs[1], "p1.bin", "application/octet-stream"),
+                BuildSignedFragment(requestId, userId, "p2", blobs[2], "p2.bin", "application/octet-stream"),
+            ]);
+
+        GranitPrivacyOptions opts = new() { ExportShardMaxSizeMb = 1 };
+        PrivacyExportAssemblyService sut = new(
+            _blobStorage, _blobStoreProvider, _hmacSigner, spy, _tracker,
+            new FakeHttpClientFactory(_http), ConfigOptions.Create(opts),
+            _timeProvider, _metrics, NullLogger<PrivacyExportAssemblyService>.Instance);
+
+        await sut.AssembleAsync(evt, TestContext.Current.CancellationToken);
+
+        // First Set: fresh-run marker (LastCompletedShardIndex = -1, NextFragmentIndex = 0).
+        spy.Sets[0].Checkpoint.LastCompletedShardIndex.ShouldBe(-1);
+        spy.Sets[0].Checkpoint.NextFragmentIndex.ShouldBe(0);
+
+        // Mid-flight Set: shard 0 committed, fragment 2 in flight.
+        ExportAssemblyCheckpoint midflight = spy.Sets[1].Checkpoint;
+        midflight.LastCompletedShardIndex.ShouldBe(0);
+        midflight.NextFragmentIndex.ShouldBe(2);
+        midflight.CompletedShardObjectKeys.Count.ShouldBe(1);
+
+        // Clear fired after successful completion.
+        spy.Cleared.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task AssembleAsync_ResumesFromCheckpoint_SkipsCommittedFragments_AndStartsAtNextShardIndex()
+    {
+        // Pre-seed a checkpoint pointing at "shard 0 committed, fragment 2 ready
+        // to resume". The service must skip fragments 0+1 (no blob read, no
+        // re-streaming), continue with fragment 2 into shard 1, and surface the
+        // pre-existing shard 0 in the final manifest.
+        var requestId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        Guid[] blobs = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        // Only fragment 2 will be re-streamed — but the resume path still calls
+        // ResolveEntryNameAsync for fragments 0+1 (manifest rebuild), so we stub
+        // those descriptors too.
+        foreach (Guid b in blobs)
+        {
+            SetupFragmentDownload(b, "{}"u8.ToArray());
+        }
+        SetupManifestUpload();
+
+        string priorShardKey = $"personal-data-export/{requestId}-000.zip";
+        await _checkpoints.SetAsync(
+            requestId,
+            tenantId: null,
+            new ExportAssemblyCheckpoint(
+                LastCompletedShardIndex: 0,
+                NextFragmentIndex: 2,
+                CompletedShardObjectKeys: [priorShardKey]),
+            TestContext.Current.CancellationToken);
+
+        ExportCompletedEto evt = BuildEvent(
+            requestId, userId,
+            [
+                BuildSignedFragment(requestId, userId, "p0", blobs[0], "p0.json", "application/json"),
+                BuildSignedFragment(requestId, userId, "p1", blobs[1], "p1.json", "application/json"),
+                BuildSignedFragment(requestId, userId, "p2", blobs[2], "p2.json", "application/json"),
+            ]);
+
+        await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
+
+        // Only one NEW shard was uploaded (shard 001), even though the final manifest
+        // covers two shards (000 and 001).
+        _blobStoreProvider.SavedBlobs.Keys.Count(k => k.EndsWith(".zip", StringComparison.Ordinal)).ShouldBe(1);
+        _blobStoreProvider.SavedBlobs.Keys.ShouldContain($"personal-data-export/{requestId}-001.zip");
+
+        // The new shard contains only the third fragment.
+        byte[] shardBytes = _blobStoreProvider.SavedBlobs[$"personal-data-export/{requestId}-001.zip"];
+        using MemoryStream zipStream = new(shardBytes);
+        using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
+        zip.Entries.Select(e => e.FullName).ShouldBe(["p2.json"]);
+
+        // Fragments 0 and 1 were re-fetched only for descriptor lookup, NOT for
+        // bytes (no presigned-download URL request fired).
+        int downloadCalls = _http.Requests.Count(r => r.Method == HttpMethod.Get);
+        downloadCalls.ShouldBe(1, "only fragment 2 should re-stream bytes on resume");
+
+        // Checkpoint cleared after the clean run.
+        (await _checkpoints.GetAsync(requestId, tenantId: null, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    private PrivacyExportAssemblyService CreateSut(GranitPrivacyOptions? opts = null) =>
         new(
             _blobStorage,
             _blobStoreProvider,
@@ -182,12 +326,12 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
             _checkpoints,
             _tracker,
             new FakeHttpClientFactory(_http),
-            ConfigOptions.Create(new GranitPrivacyOptions()),
+            ConfigOptions.Create(opts ?? new GranitPrivacyOptions()),
             _timeProvider,
             _metrics,
             NullLogger<PrivacyExportAssemblyService>.Instance);
 
-    private void SetupFragmentDownload(Guid blobId, byte[] payload)
+    private void SetupFragmentDownload(Guid blobId, byte[] payload, string contentType = "application/json")
     {
         Uri downloadUri = new($"https://s3.example/{blobId}");
         _blobStorage.CreateDownloadUrlAsync(
@@ -201,7 +345,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
             blobId,
             Arg.Any<CancellationToken>())
             .Returns((BlobDescriptor?)null);
-        _http.MapGet(downloadUri, payload, "application/json");
+        _http.MapGet(downloadUri, payload, contentType);
     }
 
     private Guid SetupManifestUpload()
@@ -255,6 +399,34 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
             Fragments: fragments,
             Regulation: "EU_GDPR",
             RequestedAt: RequestedAt);
+
+    /// <summary>
+    /// Records every <see cref="IExportAssemblyCheckpointStore"/> call so the test
+    /// can assert the mid-flight snapshot taken at a shard rollover.
+    /// </summary>
+    private sealed class RecordingCheckpointStore : IExportAssemblyCheckpointStore
+    {
+        public List<(Guid RequestId, Guid? TenantId, ExportAssemblyCheckpoint Checkpoint)> Sets { get; } = [];
+        public int Cleared { get; private set; }
+        private ExportAssemblyCheckpoint? _latest;
+
+        public Task<ExportAssemblyCheckpoint?> GetAsync(Guid requestId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_latest);
+
+        public Task SetAsync(Guid requestId, Guid? tenantId, ExportAssemblyCheckpoint checkpoint, CancellationToken cancellationToken = default)
+        {
+            Sets.Add((requestId, tenantId, checkpoint));
+            _latest = checkpoint;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(Guid requestId, Guid? tenantId, CancellationToken cancellationToken = default)
+        {
+            Cleared++;
+            _latest = null;
+            return Task.CompletedTask;
+        }
+    }
 
     /// <summary>
     /// In-memory <see cref="IBlobStoreProvider"/> — exercises the default interface


### PR DESCRIPTION
## Summary

`PrivacyExportAssemblyService` now writes a checkpoint after every shard rollover and
resumes past it on re-dispatch. A worker that crashes after shard N is committed picks
up at shard N+1 on the next dispatch instead of replaying the entire fragment list —
the EF checkpoint store landed in #2338 already provides the durable backing.

### Writer changes

`ShardingArchiveWriter` constructor gains two optional parameters:

- `startShardIndex` — seeds the rolling shard counter so a resumed writer produces
  object keys past the last committed shard's index instead of re-starting at `-000`.
- `priorShards` — re-surfaces previously committed shards in the `Shards` property
  without re-uploading their bytes, so `CompleteAsync` returns the full manifest
  across the original and resumed runs.

### Service flow

1. Read the checkpoint at start. If present, derive `startFragmentIndex` /
   `startShardIndex` / `priorShards` and log the resume.
2. Iterate every fragment to keep `emptyProviders` / `manifestFragments` complete
   (covering pre-resume work too) but only stream non-empty fragments at or past
   `startFragmentIndex` into the writer.
3. After every `AppendAsync`, compare `writer.Shards.Count` to its pre-append snapshot.
   A growth means the prior shard's multipart upload was confirmed during the rollover
   that triggered this append — snapshot it:
   `{ LastCompletedShardIndex = writer.Shards[^1].Index, NextFragmentIndex = i (current
   in-flight fragment), CompletedShardObjectKeys = writer.Shards.Select(s => s.ObjectKey) }`.
4. After `CompleteAsync`, upload manifest, mark tracker, clear checkpoint.

### Tests (3 new)

- `AssembleAsync_WritesCheckpoint_OnEveryShardRollover` — three 700 KB payloads with a
  1 MB shard cap force exactly one rollover; two shards land in storage.
- `AssembleAsync_MidFlightCheckpoint_RecordsCommittedShardAndCurrentFragmentIndex` — spy
  store captures the fresh-run marker AND the mid-flight snapshot pointing at the
  fragment that triggered the rollover, plus the final `Clear` after success.
- `AssembleAsync_ResumesFromCheckpoint_SkipsCommittedFragments_AndStartsAtNextShardIndex`
  — pre-seed a checkpoint, run `AssembleAsync`, verify only one new shard is uploaded
  (shard `001`), the new shard contains only the resumed fragment, and the http
  handler sees exactly one GET (no re-streaming of already-committed fragments).

### Test plan

- [x] `dotnet build src/Granit.Privacy.BlobStorage` clean
- [x] `dotnet test tests/Granit.Privacy.BlobStorage.Tests` — 55/55 pass
- [x] Security shard green (66 assemblies, 0 failures)
- [x] `dotnet format` clean on touched projects

### Still queued

- Wolverine retry policy + DLQ PII redaction (P6.3c.5).
- P6.3d native multipart overrides for S3 / Azure / GCS.
- P6.4 download UX + security (step-up auth, multi-shard endpoints, signed manifest,
  ROPA audit, lifecycle IaC).