### PR TITLE
feat(blob-storage-azure-blob): native multipart override via StageBlock (P6.3d.2)

### DIFF
--- a/src/Granit.BlobStorage.AzureBlob/Internal/AzureBlobClient.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Internal/AzureBlobClient.cs
@@ -4,6 +4,7 @@ using Azure;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
 using Granit.BlobStorage.AzureBlob.Diagnostics;
 using Granit.BlobStorage.AzureBlob.Options;
@@ -226,6 +227,29 @@ internal sealed class AzureBlobClient : IBlobStoreProvider, IPresignedUrlProvide
         await stream.DisposeAsync().ConfigureAwait(false);
 
         return buffer;
+    }
+
+    /// <inheritdoc/>
+    public Task<MultipartWriteStream> OpenWriteMultipartAsync(
+        string bucket,
+        string objectKey,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(bucket);
+        ArgumentException.ThrowIfNullOrEmpty(objectKey);
+        ArgumentException.ThrowIfNullOrEmpty(contentType);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        BlockBlobClient blockClient = _serviceClient
+            .GetBlobContainerClient(bucket)
+            .GetBlockBlobClient(objectKey);
+
+        // Unlike S3, Azure has no separate "initiate" call — block ids are
+        // client-generated and the upload only exists once the first block stages.
+        AzureBlockBlobOperations operations = new(blockClient);
+        return Task.FromResult<MultipartWriteStream>(
+            new AzureBlockBlobMultipartWriteStream(operations, contentType));
     }
 
     // ── SAS generation helpers ────────────────────────────────────────────────

--- a/src/Granit.BlobStorage.AzureBlob/Internal/AzureBlockBlobMultipartWriteStream.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Internal/AzureBlockBlobMultipartWriteStream.cs
@@ -1,0 +1,241 @@
+using System.Diagnostics;
+using Granit.BlobStorage.AzureBlob.Diagnostics;
+
+namespace Granit.BlobStorage.AzureBlob.Internal;
+
+/// <summary>
+/// Native Azure Block Blob multipart upload — buffers each block in memory
+/// (default 8 MB) and stages it via <see cref="IAzureBlockBlobOperations.StageBlockAsync"/>
+/// as soon as the threshold is hit, instead of the framework default that
+/// buffers the whole blob to a temp file before a single
+/// <c>IBlobStoreProvider.SaveAsync</c> call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why it matters.</b> Personal-data exports for active users can hit tens of
+/// gigabytes; the temp-file fallback shifts the bottleneck from RAM to host
+/// disk pressure rather than removing it. Native StageBlock keeps at most one
+/// block window in RAM (default 8 MB) per concurrent upload.
+/// </para>
+/// <para>
+/// <b>Block-id discipline.</b> Azure requires every block id committed in a
+/// single <c>CommitBlockList</c> to share the same byte length. The stream
+/// generates ids from <see cref="Guid.NewGuid"/> base64-encoded (24 chars
+/// each) so the uniformity rule holds without per-call validation.
+/// </para>
+/// <para>
+/// <b>No native abort.</b> Azure block blobs don't expose an abort call —
+/// uncommitted blocks expire automatically after 7 days per the service
+/// contract. <see cref="AbortAsync"/> simply skips
+/// <c>CommitBlockListAsync</c>; the storage account's lifecycle policy is
+/// the safety net for stuck stages.
+/// </para>
+/// <para>
+/// <b>Lifecycle contract.</b>
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="CompleteAsync"/> stages any remaining bytes as the final
+///         block then issues <c>CommitBlockList</c>.</item>
+///   <item><see cref="AbortAsync"/> is a no-op except for the in-process flag
+///         flip — staged blocks expire on the service side.</item>
+///   <item>Disposing without calling either is treated as an abort.</item>
+/// </list>
+/// </remarks>
+internal sealed class AzureBlockBlobMultipartWriteStream : MultipartWriteStream
+{
+    /// <summary>Default block size (8 MB). Aligned with the S3 default.</summary>
+    internal const int DefaultBlockSizeBytes = 8 * 1024 * 1024;
+
+    /// <summary>
+    /// Practical minimum block size. Azure has no hard minimum like S3 but
+    /// going below 1 MB blows the 50 000-block ceiling on multi-GB uploads.
+    /// </summary>
+    internal const int MinBlockSizeBytes = 1 * 1024 * 1024;
+
+    private readonly IAzureBlockBlobOperations _operations;
+    private readonly string _contentType;
+    private readonly int _blockSizeBytes;
+    private readonly List<string> _blockIds = [];
+
+    private MemoryStream _blockBuffer;
+    private bool _completed;
+    private bool _aborted;
+
+    public AzureBlockBlobMultipartWriteStream(
+        IAzureBlockBlobOperations operations,
+        string contentType,
+        int blockSizeBytes = DefaultBlockSizeBytes)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+        ArgumentException.ThrowIfNullOrEmpty(contentType);
+        ArgumentOutOfRangeException.ThrowIfLessThan(blockSizeBytes, MinBlockSizeBytes);
+
+        _operations = operations;
+        _contentType = contentType;
+        _blockSizeBytes = blockSizeBytes;
+        _blockBuffer = new MemoryStream(blockSizeBytes);
+    }
+
+    // ── Stream surface (write-only) ──────────────────────────────────────────
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => !_aborted && !_completed;
+    public override long Length => _blockBuffer.Length;
+
+    public override long Position
+    {
+        get => _blockBuffer.Position;
+        set => throw new NotSupportedException("Azure block-blob multipart write stream is forward-only.");
+    }
+
+    public override void Flush() { /* No flush on partial block — the buffer holds it until threshold. */ }
+
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException("Azure block-blob multipart write stream is write-only.");
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new NotSupportedException("Azure block-blob multipart write stream is forward-only.");
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException("Azure block-blob multipart write stream is forward-only.");
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        ThrowIfCompletedOrAborted();
+        _blockBuffer.Write(buffer, offset, count);
+        if (_blockBuffer.Length >= _blockSizeBytes)
+        {
+            // Sync path: StageBlock is an HTTP call and the stream API requires it
+            // to run synchronously here. Most production callers use WriteAsync.
+            FlushBufferAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        ThrowIfCompletedOrAborted();
+        await _blockBuffer.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+        if (_blockBuffer.Length >= _blockSizeBytes)
+        {
+            await FlushBufferAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        ThrowIfCompletedOrAborted();
+        await _blockBuffer.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        if (_blockBuffer.Length >= _blockSizeBytes)
+        {
+            await FlushBufferAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    // ── Multipart lifecycle ──────────────────────────────────────────────────
+
+    public override async Task CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        if (_aborted)
+        {
+            throw new InvalidOperationException(
+                "Cannot complete an Azure block-blob multipart upload that has already been aborted.");
+        }
+
+        using Activity? activity = BlobStorageAzureActivitySource.Source.StartActivity("Azure.CommitBlockList");
+
+        // Stage any remaining bytes as the final block. Azure requires at least one
+        // block committed; a zero-byte trailing block is acceptable.
+        if (_blockBuffer.Length > 0 || _blockIds.Count == 0)
+        {
+            await FlushBufferAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await _operations.CommitBlockListAsync(_blockIds, _contentType, cancellationToken).ConfigureAwait(false);
+        _completed = true;
+    }
+
+    public override Task AbortAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_completed)
+        {
+            _aborted = true;
+        }
+        // Azure has no native abort. Staged blocks expire after 7 days by service
+        // contract; the storage account lifecycle policy is the safety net.
+        return Task.CompletedTask;
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (!_completed && !_aborted)
+        {
+            await AbortAsync().ConfigureAwait(false);
+        }
+
+        await _blockBuffer.DisposeAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (!_completed && !_aborted)
+            {
+                _aborted = true;
+            }
+
+            _blockBuffer.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    private async Task FlushBufferAsync(CancellationToken cancellationToken)
+    {
+        // Guid.NewGuid (not Granit.Guids.IGuidGenerator) is intentional here: the
+        // block id is a per-upload local-only multipart token, not a database key —
+        // no clustered-index ordering concern applies. Suppress GRSEC002.
+        // Block ids must share the same byte length across a CommitBlockList call.
+        // A Guid base64-encoded is always 24 chars — pinned uniformity, trivially unique.
+#pragma warning disable GRSEC002
+        string blockId = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+#pragma warning restore GRSEC002
+        _blockBuffer.Position = 0;
+        long blockLength = _blockBuffer.Length;
+
+        using (Activity? activity = BlobStorageAzureActivitySource.Source.StartActivity("Azure.StageBlock"))
+        {
+            activity?.SetTag("azure.block_id", blockId);
+            activity?.SetTag("azure.block_size_bytes", blockLength);
+            await _operations.StageBlockAsync(blockId, _blockBuffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        _blockIds.Add(blockId);
+
+        // Recycle the buffer — a one-off large upload shouldn't permanently retain
+        // its capacity allocation.
+        await _blockBuffer.DisposeAsync().ConfigureAwait(false);
+        _blockBuffer = new MemoryStream(_blockSizeBytes);
+    }
+
+    private void ThrowIfCompletedOrAborted()
+    {
+        ObjectDisposedException.ThrowIf(_aborted, this);
+        if (_completed)
+        {
+            throw new InvalidOperationException(
+                "Cannot write to an Azure block-blob multipart write stream after CompleteAsync.");
+        }
+    }
+}

--- a/src/Granit.BlobStorage.AzureBlob/Internal/AzureBlockBlobOperations.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Internal/AzureBlockBlobOperations.cs
@@ -1,0 +1,25 @@
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+
+namespace Granit.BlobStorage.AzureBlob.Internal;
+
+/// <summary>
+/// Default <see cref="IAzureBlockBlobOperations"/> backed by a real
+/// <see cref="BlockBlobClient"/>. Production path for the assembly job;
+/// <see cref="AzureBlockBlobMultipartWriteStream"/> resolves it via the
+/// <see cref="AzureBlobClient"/> override.
+/// </summary>
+internal sealed class AzureBlockBlobOperations(BlockBlobClient client) : IAzureBlockBlobOperations
+{
+    public Task StageBlockAsync(string blockId, Stream content, CancellationToken cancellationToken) =>
+        client.StageBlockAsync(blockId, content, cancellationToken: cancellationToken);
+
+    public async Task CommitBlockListAsync(IReadOnlyList<string> blockIds, string contentType, CancellationToken cancellationToken)
+    {
+        CommitBlockListOptions options = new()
+        {
+            HttpHeaders = new BlobHttpHeaders { ContentType = contentType },
+        };
+        await client.CommitBlockListAsync(blockIds, options, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.BlobStorage.AzureBlob/Internal/IAzureBlockBlobOperations.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Internal/IAzureBlockBlobOperations.cs
@@ -1,0 +1,35 @@
+namespace Granit.BlobStorage.AzureBlob.Internal;
+
+/// <summary>
+/// Thin testing seam over the two Azure block-blob calls that
+/// <see cref="AzureBlockBlobMultipartWriteStream"/> needs:
+/// <see cref="StageBlockAsync"/> + <see cref="CommitBlockListAsync"/>. Lets the
+/// stream stay decoupled from <c>Azure.Storage.Blobs.Specialized.BlockBlobClient</c>
+/// (which has no Granit-style interface) so unit tests can mock with NSubstitute
+/// instead of standing up a transport mock.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Block IDs.</b> Azure requires all block IDs on a given commit to share the
+/// same byte length (the SDK rejects mixed-length IDs at <c>CommitBlockList</c>
+/// time). Callers MUST therefore generate IDs from a fixed-length source — a
+/// 16-byte Guid base64-encoded yields 24 chars, well under the 64-byte limit and
+/// trivially uniform.
+/// </para>
+/// <para>
+/// <b>No explicit abort.</b> Azure block blobs have no equivalent to S3's
+/// <c>AbortMultipartUpload</c>: staged-but-uncommitted blocks expire after 7 days
+/// per the service contract. Abort paths therefore simply skip
+/// <see cref="CommitBlockListAsync"/> — there are no resources to clean up
+/// synchronously.
+/// </para>
+/// </remarks>
+internal interface IAzureBlockBlobOperations
+{
+    /// <summary>Stages a single block by id; the bytes become committed only once
+    /// <see cref="CommitBlockListAsync"/> includes the same id in its list.</summary>
+    Task StageBlockAsync(string blockId, Stream content, CancellationToken cancellationToken);
+
+    /// <summary>Commits the given block ids — in order — as the final block-blob content.</summary>
+    Task CommitBlockListAsync(IReadOnlyList<string> blockIds, string contentType, CancellationToken cancellationToken);
+}

--- a/tests/Granit.BlobStorage.AzureBlob.Tests/Internal/AzureBlockBlobMultipartWriteStreamTests.cs
+++ b/tests/Granit.BlobStorage.AzureBlob.Tests/Internal/AzureBlockBlobMultipartWriteStreamTests.cs
@@ -1,0 +1,211 @@
+using Granit.BlobStorage.AzureBlob.Internal;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.AzureBlob.Tests.Internal;
+
+public sealed class AzureBlockBlobMultipartWriteStreamTests
+{
+    private const string ContentType = "application/zip";
+    private const int OneMb = 1 * 1024 * 1024;
+
+    [Fact]
+    public async Task CompleteAsync_SinglePayloadUnderBlockThreshold_StagesOneBlock_AndCommits()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using (AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb))
+        {
+            await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+            await sut.CompleteAsync(TestContext.Current.CancellationToken);
+        }
+
+        await ops.Received(1).StageBlockAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+        await ops.Received(1).CommitBlockListAsync(
+            Arg.Is<IReadOnlyList<string>>(ids => ids.Count == 1),
+            ContentType,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAsync_AcrossMultipleBlocks_StagesMidStream_AndShipsFinalRemainder()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        // First write hits the threshold → stage as block 1.
+        await sut.WriteAsync(new byte[OneMb], TestContext.Current.CancellationToken);
+
+        await ops.Received(1).StageBlockAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+
+        // Small follow-up rides Complete as block 2.
+        await sut.WriteAsync(new byte[1024], TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await ops.Received(2).StageBlockAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+        await ops.Received(1).CommitBlockListAsync(
+            Arg.Is<IReadOnlyList<string>>(ids => ids.Count == 2),
+            ContentType,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CommitBlockList_ReceivesBlockIdsInStageOrder()
+    {
+        List<string> stagedOrder = [];
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+        ops.StageBlockAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                stagedOrder.Add(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        IReadOnlyList<string>? committed = null;
+        ops.CommitBlockListAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                committed = callInfo.Arg<IReadOnlyList<string>>();
+                return Task.CompletedTask;
+            });
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        await sut.WriteAsync(new byte[OneMb], TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[OneMb], TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[1024], TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        committed.ShouldNotBeNull();
+        committed.ShouldBe(stagedOrder, "CommitBlockList must order block ids exactly as StageBlock saw them");
+        committed.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task BlockIds_AreFixedLength()
+    {
+        // Azure rejects mixed-length block ids at CommitBlockList time. Pin the
+        // 24-char base64-of-Guid uniformity.
+        List<string> staged = [];
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+        ops.StageBlockAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                staged.Add(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        await sut.WriteAsync(new byte[OneMb], TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[OneMb], TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        staged.Count.ShouldBeGreaterThan(1);
+        staged.Select(id => id.Length).Distinct().Count().ShouldBe(1);
+        staged[0].Length.ShouldBe(24); // 16-byte Guid → 24 base64 chars.
+    }
+
+    [Fact]
+    public async Task AbortAsync_DoesNotCommit()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await ops.DidNotReceive().CommitBlockListAsync(
+            Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithoutCompleteOrAbort_DoesNotCommit()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using (AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb))
+        {
+            await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+            // No explicit Complete or Abort.
+        }
+
+        await ops.DidNotReceive().CommitBlockListAsync(
+            Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_IsIdempotent()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await ops.Received(1).CommitBlockListAsync(
+            Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AfterAbort_Throws()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.CompleteAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterComplete_Throws()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await sut.WriteAsync(new byte[] { 4 }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterAbort_Throws()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+
+        await using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<ObjectDisposedException>(
+            async () => await sut.WriteAsync(new byte[] { 4 }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void StreamSurface_RejectsReadsAndSeeks()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+        using AzureBlockBlobMultipartWriteStream sut = new(ops, ContentType, blockSizeBytes: OneMb);
+
+        sut.CanRead.ShouldBeFalse();
+        sut.CanSeek.ShouldBeFalse();
+        sut.CanWrite.ShouldBeTrue();
+
+        Should.Throw<NotSupportedException>(() => sut.Read(new byte[4], 0, 4));
+        Should.Throw<NotSupportedException>(() => sut.Seek(0, SeekOrigin.Begin));
+        Should.Throw<NotSupportedException>(() => sut.SetLength(10));
+        Should.Throw<NotSupportedException>(() => sut.Position = 0);
+    }
+
+    [Fact]
+    public void Ctor_RejectsBlockSizeBelowMinimum()
+    {
+        IAzureBlockBlobOperations ops = Substitute.For<IAzureBlockBlobOperations>();
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            new AzureBlockBlobMultipartWriteStream(ops, ContentType, blockSizeBytes: 1));
+    }
+}


### PR DESCRIPTION
## Summary

`AzureBlobClient` now overrides `IBlobStoreProvider.OpenWriteMultipartAsync` with an
Azure-native `StageBlock` + `CommitBlockList` chain, replacing the framework default
that buffers the whole blob to a `DeleteOnClose` temp file before a single block-blob
`Upload`. Multi-gigabyte personal-data exports stream straight to Azure with at most
one 8 MB block window in RAM at a time.

### `AzureBlockBlobMultipartWriteStream` (internal sealed)

- Buffers writes into an in-memory `MemoryStream`; when the buffer reaches the
  configurable `blockSizeBytes` (default 8 MB, practical min 1 MB so the 50 000-block
  ceiling stays a non-issue on multi-GB uploads), stages it as the next block and
  recycles the buffer.
- Block ids generated as `Convert.ToBase64String(Guid.NewGuid().ToByteArray())` →
  fixed 24 chars. Azure rejects mixed-length ids at `CommitBlockList` time; the
  uniformity is pinned by a theory test.
- `Guid.NewGuid` is intentional here (not `Granit.Guids.IGuidGenerator`): the block
  id is a per-upload local-only multipart token, not a database key — same
  suppression pattern as `BufferedMultipartWriteStream`'s temp-file naming.
- `CompleteAsync` stages any remaining bytes as the final block then commits via
  `CommitBlockList`. An empty upload still ships one zero-byte block so the commit
  doesn't fail with "no blocks".
- `AbortAsync` is a no-op except for the in-process flag flip — Azure has no native
  abort. Uncommitted blocks expire after 7 days by service contract; the storage
  account lifecycle policy is the safety net.
- Disposing without Complete or Abort is treated as Abort.

### Testing seam — `IAzureBlockBlobOperations`

Azure SDK `BlockBlobClient` has no Granit-style interface, so a thin internal
abstraction over the two calls the stream needs (`StageBlockAsync`,
`CommitBlockListAsync`) lets NSubstitute mock without a transport mock.
`AzureBlockBlobOperations` (sealed) wraps a real `BlockBlobClient`;
`AzureBlobClient.OpenWriteMultipartAsync` hands it off to the stream.

### Tests (12 new)

- Single-block happy path.
- Multi-block flush + final remainder.
- Block id stage order preserved on commit.
- Fixed-length block ids (24 chars each).
- Explicit `Abort` skips commit.
- Dispose without Complete or Abort auto-aborts (no commit).
- `CompleteAsync` idempotent.
- `CompleteAsync` after `Abort` throws.
- Write after `Complete` and write after `Abort` throw correctly.
- Stream surface rejects reads, seeks, set-length, position-set.
- Ctor enforces the 1 MB practical minimum.

### Test plan

- [x] `dotnet build src/Granit.BlobStorage.AzureBlob` clean
- [x] `dotnet test tests/Granit.BlobStorage.AzureBlob.Tests` — 39/39 pass
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 235/235 pass
- [x] `dotnet format` clean on touched projects

### Still queued

- P6.3d.3 GCS native override (resumable upload).
- P6.4 download UX + security (step-up auth, multi-shard endpoints, signed manifest,
  ROPA audit, lifecycle IaC).