### PR TITLE
fix(text-extraction-ocr-tesseract): bridge libdl lookup for glibc ≥ 2.34

### DIFF
--- a/src/Granit.TextExtraction.Ocr.Tesseract/Internal/DefaultTesseractRecognizer.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/Internal/DefaultTesseractRecognizer.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Granit.TextExtraction.Ocr.Tesseract.Options;
 using Microsoft.Extensions.Options;
 using Tesseract;
@@ -11,6 +13,8 @@ namespace Granit.TextExtraction.Ocr.Tesseract.Internal;
 /// </summary>
 internal sealed class DefaultTesseractRecognizer : ITesseractRecognizer, IDisposable
 {
+    private static int _nativeResolverInstalled;
+
     private readonly TesseractOcrOptions _options;
     private readonly Lock _gate = new();
     private TesseractEngine? _engine;
@@ -38,6 +42,7 @@ internal sealed class DefaultTesseractRecognizer : ITesseractRecognizer, IDispos
 
             if (_engine is null)
             {
+                InstallNativeResolverOnce();
                 ApplyLibrarySearchPath();
                 _engine = new TesseractEngine(
                     _options.DataPath ?? throw new InvalidOperationException(
@@ -68,6 +73,49 @@ internal sealed class DefaultTesseractRecognizer : ITesseractRecognizer, IDispos
         {
             TesseractEnviornment.CustomSearchPath = _options.LibrarySearchPath;
         }
+    }
+
+    private static void InstallNativeResolverOnce()
+    {
+        // Modern Linux (Ubuntu 24.04 / Debian 13 with glibc ≥ 2.34) merged libdl into
+        // libc — the standalone `libdl.so` symlink no longer ships with libc6, only
+        // with libc6-dev. The Charlesw NuGet's `[DllImport("libdl")]` therefore fails
+        // to resolve at runtime, and InteropDotNet's loader probes path-after-path
+        // for `libdl[.so]` / `liblibdl[.so]` before throwing DllNotFoundException.
+        // Bridge via a per-assembly DllImportResolver that points the bare name at
+        // the versioned ABI which is always present in libc6.
+        //
+        // No-op on Windows / macOS — their loaders handle libdl differently or not
+        // at all (Windows uses Kernel32, macOS dyld is bundled).
+        if (Interlocked.CompareExchange(ref _nativeResolverInstalled, 1, 0) != 0)
+        {
+            return;
+        }
+
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        try
+        {
+            NativeLibrary.SetDllImportResolver(typeof(TesseractEngine).Assembly, ResolveTesseractNative);
+        }
+        catch (InvalidOperationException)
+        {
+            // Another caller in the same process installed a resolver first — accept
+            // their wiring and skip ours. Setting the flag above prevents a retry loop.
+        }
+    }
+
+    private static IntPtr ResolveTesseractNative(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (string.Equals(libraryName, "libdl", StringComparison.Ordinal)
+            && NativeLibrary.TryLoad("libdl.so.2", assembly, searchPath, out IntPtr handle))
+        {
+            return handle;
+        }
+        return IntPtr.Zero;
     }
 
     public void Dispose()

--- a/src/Granit.TextExtraction.Ocr.Tesseract/README.md
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/README.md
@@ -63,6 +63,19 @@ services.AddTesseractOcrExtractor(o =>
   pipeline never throws on OCR failure so a broken image doesn't tank the rest of
   the document.
 
+## Modern Linux + libdl
+
+On Ubuntu 24.04 / Debian 13 (glibc ≥ 2.34) `libdl` was merged into `libc` —
+the standalone `libdl.so` symlink only ships with `libc6-dev`. The Charlesw
+NuGet declares `[DllImport("libdl")]` with the bare name, so without a fix
+P/Invoke fails to resolve and the loader throws `DllNotFoundException`
+listing a dozen probed paths. `DefaultTesseractRecognizer` installs a
+`NativeLibrary.SetDllImportResolver` on the Tesseract assembly the first
+time it builds an engine — it rewrites the bare `libdl` lookup to
+`libdl.so.2` (always present in `libc6`). Hosts that ship a custom
+`ITesseractRecognizer` should mirror that call site if they target modern
+Linux.
+
 ## Native-library search path
 
 The Charlesw `Tesseract` NuGet uses its own `InteropDotNet.LibraryLoader` on


### PR DESCRIPTION
After #2337 + #2343 fixed the InteropDotNet path layout, CI surfaced ANOTHER class of native-load failure:

\`\`\`
Unable to load shared library 'libdl' or one of its dependencies.
/.../libdl.so: cannot open shared object file: No such file or directory
/.../liblibdl.so: cannot open shared object file: No such file or directory
... (12 probed paths total)
\`\`\`

## Why

Ubuntu 24.04 / Debian 13 (glibc ≥ 2.34) merged libdl into libc. The standalone `libdl.so` symlink only ships with `libc6-dev`; the runtime `libc6` package only carries `libdl.so.2`. The Charlesw \`Tesseract\` NuGet declares \`[DllImport("libdl")]\` with the bare name — P/Invoke can't find a match.

## Fix

Per-assembly \`NativeLibrary.SetDllImportResolver\` on the Tesseract assembly, installed lazily on first engine build, idempotent under contention via \`Interlocked.CompareExchange\`. Resolver rewrites the bare \`libdl\` lookup to \`libdl.so.2\` (always in \`libc6\`).

\`\`\`csharp
private static IntPtr ResolveTesseractNative(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
{
    if (string.Equals(libraryName, "libdl", StringComparison.Ordinal)
        && NativeLibrary.TryLoad("libdl.so.2", assembly, searchPath, out IntPtr handle))
    {
        return handle;
    }
    return IntPtr.Zero;
}
\`\`\`

No-op on Windows / macOS — their loaders don't go through libdl.

This fixes **every Linux host on glibc ≥ 2.34**, not just CI. The framework shouldn't ask consumers to install \`libc6-dev\` just to OCR.

## Test plan

- [x] \`dotnet test tests/Granit.TextExtraction.Ocr.Tesseract.Tests --no-build\` — 19/19 green (unit suite untouched, resolver no-ops in mocked paths).
- [x] \`dotnet format src/Granit.TextExtraction.Ocr.Tesseract --verify-no-changes\` clean.
- [x] \`markdownlint-cli2\` clean — README gains a "Modern Linux + libdl" section.
- [ ] CI integration shard's live OCR suite finally — *finally* — green.