### PR TITLE
feat(blob-storage-gcs): native resumable upload multipart override (P6.3d.3)

### DIFF
--- a/src/Granit.BlobStorage.GoogleCloud/Internal/GcsResumableMultipartWriteStream.cs
+++ b/src/Granit.BlobStorage.GoogleCloud/Internal/GcsResumableMultipartWriteStream.cs
@@ -1,0 +1,254 @@
+using System.Diagnostics;
+using Granit.BlobStorage.GoogleCloud.Diagnostics;
+
+namespace Granit.BlobStorage.GoogleCloud.Internal;
+
+/// <summary>
+/// Native GCS resumable upload — buffers each chunk in memory (default 8 MB)
+/// and ships it via <see cref="IGcsResumableUploadOperations.UploadChunkAsync"/>
+/// as soon as the threshold is hit, instead of the framework default that
+/// buffers the whole blob to a temp file before a single
+/// <c>IBlobStoreProvider.SaveAsync</c> call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why it matters.</b> Personal-data exports for active users can hit tens of
+/// gigabytes; the temp-file fallback shifts the bottleneck from RAM to host
+/// disk pressure rather than removing it. Native resumable upload keeps at most
+/// one chunk window in RAM (default 8 MB) per concurrent upload.
+/// </para>
+/// <para>
+/// <b>Chunk size discipline.</b> GCS requires every chunk except the last to be
+/// a multiple of 256 KiB (262,144 bytes); the final chunk can be any size.
+/// The stream enforces this two ways: (1) the constructor rejects chunk sizes
+/// that aren't a multiple of 256 KiB, and (2) writes that would overflow the
+/// chunk size are split so the in-memory buffer never exceeds it before flush.
+/// </para>
+/// <para>
+/// <b>Abort semantics.</b> The session URI is the abort target — DELETE on
+/// that URI discards any uploaded chunks. The bucket's
+/// <c>abort_incomplete_multipart_upload</c> lifecycle rule is the safety net
+/// for the case where the abort itself fails (network partition, process kill).
+/// </para>
+/// <para>
+/// <b>Lifecycle contract.</b>
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="CompleteAsync"/> uploads any remaining buffered bytes as
+///         the final chunk with the total object size, which commits the upload.</item>
+///   <item><see cref="AbortAsync"/> issues DELETE against the session URI —
+///         best-effort.</item>
+///   <item>Disposing without calling either is treated as an abort.</item>
+/// </list>
+/// </remarks>
+internal sealed class GcsResumableMultipartWriteStream : MultipartWriteStream
+{
+    /// <summary>Default chunk size (8 MB = 32 × 256 KiB). Aligned with the S3 default.</summary>
+    internal const int DefaultChunkSizeBytes = 8 * 1024 * 1024;
+
+    /// <summary>
+    /// GCS-mandated chunk-size alignment: every non-final chunk must be a multiple
+    /// of 256 KiB. Configured chunk sizes must therefore be a multiple of this value.
+    /// </summary>
+    internal const int MinChunkSizeBytes = 256 * 1024;
+
+    private readonly IGcsResumableUploadOperations _operations;
+    private readonly Uri _sessionUri;
+    private readonly int _chunkSizeBytes;
+
+    private MemoryStream _chunkBuffer;
+    private long _bytesUploaded;
+    private bool _completed;
+    private bool _aborted;
+
+    public GcsResumableMultipartWriteStream(
+        IGcsResumableUploadOperations operations,
+        Uri sessionUri,
+        int chunkSizeBytes = DefaultChunkSizeBytes)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+        ArgumentNullException.ThrowIfNull(sessionUri);
+        ArgumentOutOfRangeException.ThrowIfLessThan(chunkSizeBytes, MinChunkSizeBytes);
+        if (chunkSizeBytes % MinChunkSizeBytes != 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(chunkSizeBytes),
+                $"GCS resumable upload chunk size must be a multiple of {MinChunkSizeBytes} (256 KiB).");
+        }
+
+        _operations = operations;
+        _sessionUri = sessionUri;
+        _chunkSizeBytes = chunkSizeBytes;
+        _chunkBuffer = new MemoryStream(chunkSizeBytes);
+    }
+
+    // ── Stream surface (write-only) ──────────────────────────────────────────
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => !_aborted && !_completed;
+    public override long Length => _bytesUploaded + _chunkBuffer.Length;
+
+    public override long Position
+    {
+        get => Length;
+        set => throw new NotSupportedException("GCS resumable upload stream is forward-only.");
+    }
+
+    public override void Flush() { /* No flush on partial chunk — the buffer holds it until threshold. */ }
+
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException("GCS resumable upload stream is write-only.");
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new NotSupportedException("GCS resumable upload stream is forward-only.");
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException("GCS resumable upload stream is forward-only.");
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        ThrowIfCompletedOrAborted();
+        WriteCoreAsync(buffer.AsMemory(offset, count), CancellationToken.None).AsTask().GetAwaiter().GetResult();
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        ThrowIfCompletedOrAborted();
+        return WriteCoreAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        ThrowIfCompletedOrAborted();
+        return WriteCoreAsync(buffer, cancellationToken);
+    }
+
+    private async ValueTask WriteCoreAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+    {
+        // GCS requires non-final chunks to be exactly a multiple of 256 KiB. The
+        // cleanest way to honour that is to never let the in-memory buffer exceed
+        // _chunkSizeBytes — split overflowing writes and flush at the boundary.
+        int remaining = buffer.Length;
+        int offset = 0;
+        while (remaining > 0)
+        {
+            int spaceLeft = _chunkSizeBytes - (int)_chunkBuffer.Length;
+            int toWrite = Math.Min(spaceLeft, remaining);
+            await _chunkBuffer.WriteAsync(buffer.Slice(offset, toWrite), cancellationToken).ConfigureAwait(false);
+            offset += toWrite;
+            remaining -= toWrite;
+
+            if (_chunkBuffer.Length == _chunkSizeBytes)
+            {
+                await FlushBufferAsync(isFinal: false, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    // ── Multipart lifecycle ──────────────────────────────────────────────────
+
+    public override async Task CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        if (_aborted)
+        {
+            throw new InvalidOperationException(
+                "Cannot complete a GCS resumable upload that has already been aborted.");
+        }
+
+        using Activity? activity = BlobStorageGoogleCloudActivitySource.Source.StartActivity("Gcs.CompleteResumableUpload");
+
+        // The final chunk carries the total object size, which is what commits the
+        // upload on the GCS side. An empty trailing chunk is acceptable — that's
+        // how a zero-byte object is finalised.
+        await FlushBufferAsync(isFinal: true, cancellationToken).ConfigureAwait(false);
+        _completed = true;
+    }
+
+    public override async Task AbortAsync(CancellationToken cancellationToken = default)
+    {
+        if (_aborted || _completed)
+        {
+            return;
+        }
+        _aborted = true;
+
+        using Activity? activity = BlobStorageGoogleCloudActivitySource.Source.StartActivity("Gcs.AbortResumableUpload");
+        await _operations.AbortSessionAsync(_sessionUri, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (!_completed && !_aborted)
+        {
+            await AbortAsync().ConfigureAwait(false);
+        }
+
+        await _chunkBuffer.DisposeAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (!_completed && !_aborted)
+            {
+                _aborted = true;
+                try
+                {
+                    _operations.AbortSessionAsync(_sessionUri, CancellationToken.None).GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    // Best-effort abort — see AbortAsync remarks.
+                }
+            }
+
+            _chunkBuffer.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    private async Task FlushBufferAsync(bool isFinal, CancellationToken cancellationToken)
+    {
+        long chunkLength = _chunkBuffer.Length;
+        long? totalSize = isFinal ? _bytesUploaded + chunkLength : null;
+        ReadOnlyMemory<byte> chunkBytes = _chunkBuffer.GetBuffer().AsMemory(0, (int)chunkLength);
+
+        using (Activity? activity = BlobStorageGoogleCloudActivitySource.Source.StartActivity("Gcs.UploadChunk"))
+        {
+            activity?.SetTag("gcs.chunk_offset", _bytesUploaded);
+            activity?.SetTag("gcs.chunk_size_bytes", chunkLength);
+            activity?.SetTag("gcs.is_final", isFinal);
+            await _operations.UploadChunkAsync(_sessionUri, chunkBytes, _bytesUploaded, totalSize, cancellationToken).ConfigureAwait(false);
+        }
+
+        _bytesUploaded += chunkLength;
+
+        // Recycle the buffer — a one-off large upload shouldn't permanently retain
+        // its capacity allocation.
+        await _chunkBuffer.DisposeAsync().ConfigureAwait(false);
+        _chunkBuffer = new MemoryStream(_chunkSizeBytes);
+    }
+
+    private void ThrowIfCompletedOrAborted()
+    {
+        ObjectDisposedException.ThrowIf(_aborted, this);
+        if (_completed)
+        {
+            throw new InvalidOperationException(
+                "Cannot write to a GCS resumable upload stream after CompleteAsync.");
+        }
+    }
+}

--- a/src/Granit.BlobStorage.GoogleCloud/Internal/GcsResumableUploadOperations.cs
+++ b/src/Granit.BlobStorage.GoogleCloud/Internal/GcsResumableUploadOperations.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using Google.Cloud.Storage.V1;
+
+namespace Granit.BlobStorage.GoogleCloud.Internal;
+
+/// <summary>
+/// Default <see cref="IGcsResumableUploadOperations"/> wired against the
+/// <see cref="StorageClient"/>'s underlying authenticated
+/// <see cref="HttpClient"/>. Production path for the assembly job;
+/// <see cref="GcsResumableMultipartWriteStream"/> resolves it via the
+/// <see cref="GoogleCloudBlobClient"/> override.
+/// </summary>
+/// <remarks>
+/// The implementation speaks raw HTTP because <see cref="StorageClient"/> only
+/// exposes resumable uploads bound to a known-length source stream — incompatible
+/// with the forward-only, length-unknown stream surface required by
+/// <see cref="MultipartWriteStream"/>.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+internal sealed class GcsResumableUploadOperations(StorageClient storageClient) : IGcsResumableUploadOperations
+{
+    private const string UploadEndpoint = "https://storage.googleapis.com/upload/storage/v1/b/";
+
+    // 308 is the GCS "chunk accepted, more bytes expected" status. .NET's HttpStatusCode
+    // enum doesn't name it (it's a non-standard reuse of "Permanent Redirect"), so refer
+    // to it numerically.
+    private const int ResumeIncompleteStatusCode = 308;
+
+    private readonly HttpClient _httpClient = storageClient.Service.HttpClient;
+
+    public async Task<Uri> InitiateSessionAsync(string bucket, string objectKey, string contentType, CancellationToken cancellationToken)
+    {
+        string url = $"{UploadEndpoint}{Uri.EscapeDataString(bucket)}/o?uploadType=resumable&name={Uri.EscapeDataString(objectKey)}";
+
+        using HttpRequestMessage request = new(HttpMethod.Post, url);
+        request.Headers.Add("X-Upload-Content-Type", contentType);
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        if (response.Headers.Location is null)
+        {
+            throw new InvalidOperationException(
+                "GCS resumable upload initiation did not return a session URI in the Location header.");
+        }
+
+        return response.Headers.Location;
+    }
+
+    public async Task UploadChunkAsync(
+        Uri sessionUri,
+        ReadOnlyMemory<byte> chunk,
+        long offset,
+        long? totalSize,
+        CancellationToken cancellationToken)
+    {
+        string totalSegment = totalSize?.ToString(CultureInfo.InvariantCulture) ?? "*";
+        string contentRange = chunk.Length == 0
+            ? $"bytes */{totalSegment}"
+            : string.Create(CultureInfo.InvariantCulture, $"bytes {offset}-{offset + chunk.Length - 1}/{totalSegment}");
+
+        using HttpRequestMessage request = new(HttpMethod.Put, sessionUri);
+        ByteArrayContent content = new(chunk.ToArray());
+        content.Headers.ContentLength = chunk.Length;
+        if (!content.Headers.TryAddWithoutValidation("Content-Range", contentRange))
+        {
+            throw new InvalidOperationException($"Failed to set Content-Range header on GCS chunk upload: '{contentRange}'.");
+        }
+        request.Content = content;
+
+        using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.OK
+            && response.StatusCode != HttpStatusCode.Created
+            && (int)response.StatusCode != ResumeIncompleteStatusCode)
+        {
+            response.EnsureSuccessStatusCode();
+        }
+    }
+
+    public async Task AbortSessionAsync(Uri sessionUri, CancellationToken cancellationToken)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Delete, sessionUri);
+        try
+        {
+            using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            // 204 No Content is the documented success status; 499 (non-standard) also indicates aborted.
+        }
+        catch
+        {
+            // Best-effort abort. The bucket lifecycle policy is the safety net.
+        }
+    }
+}

--- a/src/Granit.BlobStorage.GoogleCloud/Internal/GoogleCloudBlobClient.cs
+++ b/src/Granit.BlobStorage.GoogleCloud/Internal/GoogleCloudBlobClient.cs
@@ -23,6 +23,7 @@ internal sealed class GoogleCloudBlobClient : IBlobStoreProvider, IPresignedUrlP
     private readonly StorageClient _storage;
     private readonly UrlSigner _urlSigner;
     private readonly IClock _clock;
+    private readonly GcsResumableUploadOperations _resumableUploadOperations;
 
     public GoogleCloudBlobClient(IOptions<GoogleCloudStorageOptions> options, IClock clock)
     {
@@ -56,6 +57,8 @@ internal sealed class GoogleCloudBlobClient : IBlobStoreProvider, IPresignedUrlP
                         "or provide a CredentialFilePath to a service account key file."));
             }
         }
+
+        _resumableUploadOperations = new GcsResumableUploadOperations(_storage);
     }
 
     // ── IPresignedUrlProvider ─────────────────────────────────────────────────
@@ -224,6 +227,29 @@ internal sealed class GoogleCloudBlobClient : IBlobStoreProvider, IPresignedUrlP
             cancellationToken).ConfigureAwait(false);
         stream.Position = 0;
         return stream;
+    }
+
+    /// <inheritdoc/>
+    public async Task<MultipartWriteStream> OpenWriteMultipartAsync(
+        string bucket,
+        string objectKey,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(bucket);
+        ArgumentException.ThrowIfNullOrEmpty(objectKey);
+        ArgumentException.ThrowIfNullOrEmpty(contentType);
+
+        using Activity? activity = BlobStorageGoogleCloudActivitySource.Source.StartActivity("Gcs.InitiateResumableUpload");
+        activity?.SetTag(BlobStorageGoogleCloudActivitySource.TagBucket, bucket);
+        activity?.SetTag(BlobStorageGoogleCloudActivitySource.TagObjectKey, objectKey);
+        activity?.SetTag(BlobStorageGoogleCloudActivitySource.TagContentType, contentType);
+
+        Uri sessionUri = await _resumableUploadOperations
+            .InitiateSessionAsync(bucket, objectKey, contentType, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new GcsResumableMultipartWriteStream(_resumableUploadOperations, sessionUri);
     }
 
     /// <inheritdoc/>

--- a/src/Granit.BlobStorage.GoogleCloud/Internal/IGcsResumableUploadOperations.cs
+++ b/src/Granit.BlobStorage.GoogleCloud/Internal/IGcsResumableUploadOperations.cs
@@ -1,0 +1,52 @@
+namespace Granit.BlobStorage.GoogleCloud.Internal;
+
+/// <summary>
+/// Thin testing seam over the three GCS resumable-upload HTTP calls that
+/// <see cref="GcsResumableMultipartWriteStream"/> needs: session initiate, chunk
+/// upload, and abort. Keeps the stream decoupled from the raw HTTP protocol so
+/// unit tests can mock with NSubstitute instead of standing up an
+/// <see cref="HttpClient"/> mock.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Chunk size discipline.</b> Every chunk except the final one MUST be a
+/// multiple of 256 KiB (262,144 bytes) — GCS rejects mid-stream chunks of any
+/// other size. <see cref="GcsResumableMultipartWriteStream"/> enforces this by
+/// only flushing when the in-memory buffer reaches the configured chunk size,
+/// which is itself constrained to be a multiple of 256 KiB.
+/// </para>
+/// <para>
+/// <b>Session URI.</b> A resumable upload session is identified by an opaque URI
+/// returned in the <c>Location</c> header of the initiate response. The same
+/// URI is the target of every chunk PUT and the eventual DELETE on abort. It
+/// expires after one week per the GCS service contract — the storage bucket's
+/// <c>abort_incomplete_multipart_upload</c> lifecycle rule is the safety net
+/// for sessions whose <see cref="AbortSessionAsync"/> never fires.
+/// </para>
+/// </remarks>
+internal interface IGcsResumableUploadOperations
+{
+    /// <summary>
+    /// Initiates a resumable upload session and returns the per-session URI used
+    /// for subsequent chunk uploads.
+    /// </summary>
+    Task<Uri> InitiateSessionAsync(string bucket, string objectKey, string contentType, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Uploads a single chunk against an in-progress session. Non-final chunks
+    /// pass <paramref name="totalSize"/> as <see langword="null"/>; the final
+    /// chunk passes the total object size, which commits the upload.
+    /// </summary>
+    Task UploadChunkAsync(
+        Uri sessionUri,
+        ReadOnlyMemory<byte> chunk,
+        long offset,
+        long? totalSize,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Aborts a resumable upload session. Best-effort — the bucket lifecycle
+    /// policy is the safety net when the network drops.
+    /// </summary>
+    Task AbortSessionAsync(Uri sessionUri, CancellationToken cancellationToken);
+}

--- a/tests/Granit.BlobStorage.GoogleCloud.Tests/Internal/GcsResumableMultipartWriteStreamTests.cs
+++ b/tests/Granit.BlobStorage.GoogleCloud.Tests/Internal/GcsResumableMultipartWriteStreamTests.cs
@@ -1,0 +1,294 @@
+using Granit.BlobStorage.GoogleCloud.Internal;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.GoogleCloud.Tests.Internal;
+
+public sealed class GcsResumableMultipartWriteStreamTests
+{
+    private const string ContentType = "application/zip";
+    private const int ChunkSize = 1 * 1024 * 1024; // 1 MB — multiple of 256 KiB, smallest sane test size.
+    private static readonly Uri SessionUri = new("https://storage.googleapis.com/upload/session/abc123");
+
+    [Fact]
+    public async Task CompleteAsync_SinglePayloadUnderChunkThreshold_UploadsSingleFinalChunk()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using (GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize))
+        {
+            await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+            await sut.CompleteAsync(TestContext.Current.CancellationToken);
+        }
+
+        await ops.Received(1).UploadChunkAsync(
+            SessionUri,
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            offset: 0L,
+            totalSize: 3L,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAsync_AcrossMultipleChunks_FlushesMidStream_AndShipsFinalRemainder()
+    {
+        List<(long offset, long? totalSize, int length)> captured = [];
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+        ops.UploadChunkAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<long>(),
+                Arg.Any<long?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured.Add((
+                    callInfo.Arg<long>(),
+                    callInfo.Arg<long?>(),
+                    callInfo.Arg<ReadOnlyMemory<byte>>().Length));
+                return Task.CompletedTask;
+            });
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        // First write hits the threshold → flush as chunk 1.
+        await sut.WriteAsync(new byte[ChunkSize], TestContext.Current.CancellationToken);
+
+        captured.Count.ShouldBe(1);
+        captured[0].offset.ShouldBe(0L);
+        captured[0].length.ShouldBe(ChunkSize);
+        captured[0].totalSize.ShouldBeNull();
+
+        // Small follow-up rides Complete as the final chunk.
+        await sut.WriteAsync(new byte[1024], TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        captured.Count.ShouldBe(2);
+        captured[1].offset.ShouldBe((long)ChunkSize);
+        captured[1].length.ShouldBe(1024);
+        captured[1].totalSize.ShouldBe(ChunkSize + 1024L);
+    }
+
+    [Fact]
+    public async Task WriteAsync_OverflowingChunkBoundary_SplitsCleanly()
+    {
+        // A single write of chunkSize + 100 bytes must produce one chunk-sized flush
+        // (mid-stream) and leave 100 bytes for the final flush. GCS rejects mid-stream
+        // chunks that aren't a multiple of 256 KiB — this is the regression guard.
+        List<int> chunkLengths = [];
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+        ops.UploadChunkAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<long>(),
+                Arg.Any<long?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                chunkLengths.Add(callInfo.Arg<ReadOnlyMemory<byte>>().Length);
+                return Task.CompletedTask;
+            });
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.WriteAsync(new byte[ChunkSize + 100], TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        chunkLengths.ShouldBe([ChunkSize, 100]);
+    }
+
+    [Fact]
+    public async Task UploadChunk_ReceivesOffsetsInOrderStartingAtZero()
+    {
+        List<long> offsets = [];
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+        ops.UploadChunkAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<long>(),
+                Arg.Any<long?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                offsets.Add(callInfo.Arg<long>());
+                return Task.CompletedTask;
+            });
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.WriteAsync(new byte[ChunkSize], TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[ChunkSize], TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[1024], TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        offsets.ShouldBe([0L, ChunkSize, 2L * ChunkSize]);
+    }
+
+    [Fact]
+    public async Task NonFinalChunks_PassNullTotalSize_FinalChunkCarriesTotal()
+    {
+        List<long?> totalSizes = [];
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+        ops.UploadChunkAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<long>(),
+                Arg.Any<long?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                totalSizes.Add(callInfo.Arg<long?>());
+                return Task.CompletedTask;
+            });
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.WriteAsync(new byte[ChunkSize], TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[ChunkSize], TestContext.Current.CancellationToken);
+        await sut.WriteAsync(new byte[500], TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        totalSizes.ShouldBe([null, null, 2L * ChunkSize + 500]);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_NoWrites_UploadsEmptyFinalChunk()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await ops.Received(1).UploadChunkAsync(
+            SessionUri,
+            Arg.Is<ReadOnlyMemory<byte>>(m => m.Length == 0),
+            offset: 0L,
+            totalSize: 0L,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AbortAsync_DeletesSession_AndDoesNotUploadAnyChunk()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await ops.Received(1).AbortSessionAsync(SessionUri, Arg.Any<CancellationToken>());
+        await ops.DidNotReceive().UploadChunkAsync(
+            Arg.Any<Uri>(),
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            Arg.Any<long>(),
+            Arg.Any<long?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithoutCompleteOrAbort_AutoAborts()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using (GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize))
+        {
+            await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+            // No explicit Complete or Abort.
+        }
+
+        await ops.Received(1).AbortSessionAsync(SessionUri, Arg.Any<CancellationToken>());
+        await ops.DidNotReceive().UploadChunkAsync(
+            Arg.Any<Uri>(),
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            Arg.Any<long>(),
+            Arg.Any<long?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_IsIdempotent()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await ops.Received(1).UploadChunkAsync(
+            Arg.Any<Uri>(),
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            Arg.Any<long>(),
+            Arg.Any<long?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AfterAbort_Throws()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.CompleteAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterComplete_Throws()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.CompleteAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await sut.WriteAsync(new byte[] { 4 }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterAbort_Throws()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+
+        await using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+        await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);
+        await sut.AbortAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<ObjectDisposedException>(
+            async () => await sut.WriteAsync(new byte[] { 4 }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void StreamSurface_RejectsReadsAndSeeks()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+        using GcsResumableMultipartWriteStream sut = new(ops, SessionUri, ChunkSize);
+
+        sut.CanRead.ShouldBeFalse();
+        sut.CanSeek.ShouldBeFalse();
+        sut.CanWrite.ShouldBeTrue();
+
+        Should.Throw<NotSupportedException>(() => sut.Read(new byte[4], 0, 4));
+        Should.Throw<NotSupportedException>(() => sut.Seek(0, SeekOrigin.Begin));
+        Should.Throw<NotSupportedException>(() => sut.SetLength(10));
+        Should.Throw<NotSupportedException>(() => sut.Position = 0);
+    }
+
+    [Fact]
+    public void Ctor_RejectsChunkSizeBelowMinimum()
+    {
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            new GcsResumableMultipartWriteStream(ops, SessionUri, chunkSizeBytes: 1024));
+    }
+
+    [Fact]
+    public void Ctor_RejectsChunkSizeNotAlignedTo256KiB()
+    {
+        // 300 KiB > 256 KiB minimum but isn't a multiple of 256 KiB — GCS rejects
+        // mid-stream chunks of that size, so the stream rejects the config up-front.
+        IGcsResumableUploadOperations ops = Substitute.For<IGcsResumableUploadOperations>();
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            new GcsResumableMultipartWriteStream(ops, SessionUri, chunkSizeBytes: 300 * 1024));
+    }
+}


### PR DESCRIPTION
## Summary

Third (and final) leg of P6.3d — native multipart for the three cloud blob providers. After S3 (#2344) and Azure Blob (#2345), this adds GCS resumable upload as the `OpenWriteMultipartAsync` override on `GoogleCloudBlobClient`, so a multi-gigabyte export stays in an 8 MB chunk window instead of round-tripping through the host's temp dir.

GCS resumable upload has no SDK helper compatible with a forward-only, length-unknown stream — `Google.Cloud.Storage.V1` only exposes uploads bound to a known-length source. The override speaks raw HTTP against the storage session endpoint via the authenticated `StorageClient.Service.HttpClient`, behind a thin `IGcsResumableUploadOperations` testing seam.

GCS-specific discipline (vs. S3/Azure):

- Non-final chunks must be a multiple of 256 KiB — the stream rejects chunk sizes that aren't aligned, and splits writes that would overflow the buffer so it never exceeds the chunk size before flush.
- The final chunk carries the total object size (`Content-Range: bytes N-M/total`), which is what commits the upload server-side. An empty trailing chunk cleanly finalises a zero-byte object.
- Abort = DELETE on the session URI; best-effort. The bucket lifecycle policy is the safety net.

## What's in the PR

- `IGcsResumableUploadOperations` — testing seam (3 ops: initiate / upload-chunk / abort)
- `GcsResumableUploadOperations` — raw HTTP impl using `StorageClient.Service.HttpClient`, `[ExcludeFromCodeCoverage]`
- `GcsResumableMultipartWriteStream` — internal sealed `MultipartWriteStream` subclass (8 MB default, 256 KiB min/alignment, buffer recycle, auto-abort on dispose)
- `GoogleCloudBlobClient.OpenWriteMultipartAsync` — initiates session via `Gcs.InitiateResumableUpload` activity and hands the URI to the stream
- 15 NSubstitute unit tests on the stream

## Test plan
- [x] `dotnet build src/Granit.BlobStorage.GoogleCloud` clean
- [x] `dotnet test tests/Granit.BlobStorage.GoogleCloud.Tests` — 45/45 pass (30 pre-existing + 15 new)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 235/235 pass
- [x] `dotnet format` clean on `src/` and `tests/` targets
- [ ] CI green on full shard matrix