### PR TITLE
feat(privacy-export): step-up auth + multi-shard download endpoints (P6.4.1+P6.4.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37440,6 +37440,15 @@
       ]
     },
     {
+      "name": "PrivacyExportNotReadyException",
+      "fqn": "Granit.Privacy.DataExport.Exceptions.PrivacyExportNotReadyException",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Exceptions/PrivacyExportNotReadyException.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "ExportAssemblyCheckpoint",
       "fqn": "Granit.Privacy.DataExport.ExportAssemblyCheckpoint",
       "kind": "record",
@@ -37638,6 +37647,34 @@
       ]
     },
     {
+      "name": "IPrivacyExportDownloadResolver",
+      "fqn": "Granit.Privacy.DataExport.IPrivacyExportDownloadResolver",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportDownloadResolver.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ReadManifestSummaryAsync",
+          "kind": "method",
+          "signature": "ReadManifestSummaryAsync(Guid requestId, CancellationToken cancellationToken)",
+          "returnType": "Task<PrivacyExportManifestSummary>"
+        },
+        {
+          "name": "OpenManifestAsync",
+          "kind": "method",
+          "signature": "OpenManifestAsync(Guid requestId, CancellationToken cancellationToken)",
+          "returnType": "Task<PrivacyExportDownloadPayload>"
+        },
+        {
+          "name": "OpenShardAsync",
+          "kind": "method",
+          "signature": "OpenShardAsync(Guid requestId, int shardIndex, CancellationToken cancellationToken)",
+          "returnType": "Task<PrivacyExportDownloadPayload>"
+        }
+      ]
+    },
+    {
       "name": "IPrivacyScopeResolver",
       "fqn": "Granit.Privacy.DataExport.IPrivacyScopeResolver",
       "kind": "interface",
@@ -37726,6 +37763,24 @@
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/PrivacyExportContext.cs",
       "line": 17,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportDownloadPayload",
+      "fqn": "Granit.Privacy.DataExport.PrivacyExportDownloadPayload",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportDownloadResolver.cs",
+      "line": 60,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportManifestSummary",
+      "fqn": "Granit.Privacy.DataExport.PrivacyExportManifestSummary",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportDownloadResolver.cs",
+      "line": 50,
       "members": []
     },
     {
@@ -38117,6 +38172,18 @@
           "kind": "property",
           "signature": "string TagName",
           "returnType": "string"
+        },
+        {
+          "name": "RateLimitingPolicy",
+          "kind": "property",
+          "signature": "string? RateLimitingPolicy",
+          "returnType": "string?"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan DownloadStepUpMaxAge { get; set; } = TimeSpan."
         }
       ]
     },

--- a/src/Granit.Privacy.BlobStorage/DataExport/BlobBackedPrivacyExportDownloadResolver.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/BlobBackedPrivacyExportDownloadResolver.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Internal;
+using Granit.Domain.ValueObjects;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Exceptions;
+
+namespace Granit.Privacy.BlobStorage.DataExport;
+
+/// <summary>
+/// Default <see cref="IPrivacyExportDownloadResolver"/> backed by the BlobStorage
+/// descriptor registry (for the manifest sidecar) plus
+/// <see cref="IBlobStoreProvider.OpenReadAsync"/> (for the shard archives, which
+/// the assembly job writes directly without descriptor entries).
+/// </summary>
+internal sealed class BlobBackedPrivacyExportDownloadResolver(
+    IBlobStorage blobStorage,
+    IBlobStoreProvider blobStoreProvider,
+    IExportRequestTrackerReader trackerReader) : IPrivacyExportDownloadResolver
+{
+    public async Task<PrivacyExportManifestSummary> ReadManifestSummaryAsync(
+        Guid requestId,
+        CancellationToken cancellationToken)
+    {
+        ManifestLookup lookup = await ReadManifestAsync(requestId, cancellationToken).ConfigureAwait(false);
+        return new PrivacyExportManifestSummary(lookup.Shards.Count, lookup.ManifestObjectKey);
+    }
+
+    public async Task<PrivacyExportDownloadPayload> OpenManifestAsync(
+        Guid requestId,
+        CancellationToken cancellationToken)
+    {
+        ManifestLookup lookup = await ReadManifestAsync(requestId, cancellationToken).ConfigureAwait(false);
+        Stream stream = await blobStoreProvider
+            .OpenReadAsync(PrivacyExportContainerNames.FragmentContainer, lookup.ManifestObjectKey, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new PrivacyExportDownloadPayload(
+            Content: stream,
+            ContentType: "application/json",
+            FileName: $"personal-data-export-{requestId}-manifest.json",
+            LengthBytes: null);
+    }
+
+    public async Task<PrivacyExportDownloadPayload> OpenShardAsync(
+        Guid requestId,
+        int shardIndex,
+        CancellationToken cancellationToken)
+    {
+        ManifestLookup lookup = await ReadManifestAsync(requestId, cancellationToken).ConfigureAwait(false);
+        if (shardIndex < 0 || shardIndex >= lookup.Shards.Count)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(shardIndex),
+                $"Shard index {shardIndex} is out of range for export {requestId} (manifest declares {lookup.Shards.Count} shard(s)).");
+        }
+
+        ManifestShard shard = lookup.Shards[shardIndex];
+        Stream stream = await blobStoreProvider
+            .OpenReadAsync(PrivacyExportContainerNames.FragmentContainer, shard.ObjectKey, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new PrivacyExportDownloadPayload(
+            Content: stream,
+            ContentType: "application/zip",
+            FileName: $"personal-data-export-{requestId}-{shardIndex:D3}.zip",
+            LengthBytes: shard.CompressedSizeBytes > 0 ? shard.CompressedSizeBytes : null);
+    }
+
+    private async Task<ManifestLookup> ReadManifestAsync(Guid requestId, CancellationToken cancellationToken)
+    {
+        ExportRequestStatus? status = await trackerReader.GetStatusAsync(requestId, cancellationToken).ConfigureAwait(false);
+        if (status?.ArchiveBlobReferenceId is null)
+        {
+            throw new PrivacyExportNotReadyException(requestId);
+        }
+
+        BlobReference manifestRef = status.ArchiveBlobReferenceId;
+        if (!Guid.TryParse(manifestRef.Value, out Guid manifestBlobId))
+        {
+            throw new PrivacyExportNotReadyException(requestId);
+        }
+
+        BlobDescriptor? descriptor = await blobStorage
+            .GetDescriptorAsync(PrivacyExportContainerNames.FragmentContainer, manifestBlobId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (descriptor is null)
+        {
+            throw new PrivacyExportNotReadyException(requestId);
+        }
+
+        await using Stream manifestStream = await blobStoreProvider
+            .OpenReadAsync(PrivacyExportContainerNames.FragmentContainer, descriptor.ObjectKey, cancellationToken)
+            .ConfigureAwait(false);
+
+        ManifestPayload payload = await JsonSerializer
+            .DeserializeAsync<ManifestPayload>(manifestStream, ManifestJsonOptions, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new PrivacyExportNotReadyException(requestId);
+
+        return new ManifestLookup(descriptor.ObjectKey, payload.Shards ?? []);
+    }
+
+    private static readonly JsonSerializerOptions ManifestJsonOptions = new(JsonSerializerDefaults.Web);
+
+    private sealed record ManifestLookup(string ManifestObjectKey, IReadOnlyList<ManifestShard> Shards);
+
+    private sealed record ManifestPayload(IReadOnlyList<ManifestShard>? Shards);
+
+    private sealed record ManifestShard(int Index, string ObjectKey, long CompressedSizeBytes);
+}

--- a/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IStagedFragmentBuilder, StagedFragmentBuilder>();
         services.TryAddScoped<IBlobBackedExportSource, BlobBackedExportSource>();
         services.TryAddScoped<IPrivacyExportAssemblyService, PrivacyExportAssemblyService>();
+        services.TryAddScoped<IPrivacyExportDownloadResolver, BlobBackedPrivacyExportDownloadResolver>();
         services.TryAddScoped<PrivacyFragmentUploader>();
         return services;
     }

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportDownloadEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportDownloadEndpoints.cs
@@ -1,0 +1,235 @@
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Exceptions;
+using Granit.Privacy.Endpoints.Extensions;
+using Granit.Privacy.Endpoints.Internal;
+using Granit.Privacy.Endpoints.Options;
+using Granit.Privacy.Endpoints.Permissions;
+using Granit.Users;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Privacy.Endpoints.Endpoints;
+
+/// <summary>
+/// Privacy-export download routes — manifest + per-shard streaming with
+/// step-up authentication gating. Companion to the request/status routes
+/// declared in <c>PrivacyEndpointRouteBuilderExtensions.MapExportEndpoints</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The download path streams bytes through the BFF (no presigned-URL 302)
+/// because <see cref="IPrivacyExportDownloadResolver"/> reaches into the raw
+/// <c>IBlobStoreProvider</c> to resolve shard archives — they have no
+/// <c>IBlobStorage</c> descriptor entry of their own, only the manifest does.
+/// Streaming also keeps every byte under the step-up gate and the ROPA audit
+/// trail, which a direct cloud-to-client transfer would bypass.
+/// </para>
+/// </remarks>
+internal static class PrivacyExportDownloadEndpoints
+{
+    internal static RouteGroupBuilder MapPrivacyExportDownloadEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/exports/{requestId:guid}/download", HandleDownloadAsync)
+            .RequireAuthorization(PrivacyPermissions.Export.Execute)
+            .WithName("DownloadPrivacyExport")
+            .WithSummary("Downloads the personal data export archive (compat — single-shard or manifest).")
+            .WithDescription(
+                "Convenience route that resolves to shard 0 when the export produced a single archive, "
+                + "or to the manifest sidecar when sharded into multiple ZIPs. For deterministic multi-shard "
+                + "downloads, use GET /exports/{requestId}/download/{shardIndex} per shard plus "
+                + "GET /exports/{requestId}/download/manifest to discover the shard count. "
+                + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
+            .Produces(StatusCodes.Status200OK, contentType: "application/octet-stream")
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        group.MapGet("/exports/{requestId:guid}/download/manifest", HandleDownloadManifestAsync)
+            .RequireAuthorization(PrivacyPermissions.Export.Execute)
+            .WithName("DownloadPrivacyExportManifest")
+            .WithSummary("Downloads the manifest sidecar describing the export's shards.")
+            .WithDescription(
+                "Returns the signed JSON manifest produced by the assembly job. Clients use it to discover "
+                + "the shard count and per-shard sha256/integrity tag before pulling each ZIP. "
+                + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
+            .Produces(StatusCodes.Status200OK, contentType: "application/json")
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        group.MapGet("/exports/{requestId:guid}/download/{shardIndex:int:min(0)}", HandleDownloadShardAsync)
+            .RequireAuthorization(PrivacyPermissions.Export.Execute)
+            .WithName("DownloadPrivacyExportShard")
+            .WithSummary("Downloads a single shard of a sharded personal data export.")
+            .WithDescription(
+                "Streams the shard ZIP indexed by 0..(ShardCount-1) from the export's archive set. "
+                + "Shard indices outside the manifest's bounds return 404. "
+                + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
+            .Produces(StatusCodes.Status200OK, contentType: "application/zip")
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        return group;
+    }
+
+    private static async Task<Results<FileStreamHttpResult, ProblemHttpResult>> HandleDownloadAsync(
+        Guid requestId,
+        HttpContext httpContext,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IExportRequestTrackerReader tracker,
+        [FromServices] IPrivacyExportDownloadResolver downloadResolver,
+        [FromServices] IOptions<PrivacyEndpointsOptions> options,
+        [FromServices] TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        if (!PrivacyEndpointRouteBuilderExtensions.TryGetUserId(currentUser, out Guid userId))
+        {
+            return PrivacyEndpointRouteBuilderExtensions.UserNotAuthenticated();
+        }
+
+        ExportRequestStatus? status = await tracker.GetStatusAsync(requestId, cancellationToken).ConfigureAwait(false);
+        ProblemHttpResult? gate = Gate(httpContext, options.Value, timeProvider, status, requestId, userId);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        try
+        {
+            PrivacyExportManifestSummary summary = await downloadResolver
+                .ReadManifestSummaryAsync(requestId, cancellationToken).ConfigureAwait(false);
+
+            PrivacyExportDownloadPayload payload = summary.ShardCount switch
+            {
+                1 => await downloadResolver.OpenShardAsync(requestId, 0, cancellationToken).ConfigureAwait(false),
+                _ => await downloadResolver.OpenManifestAsync(requestId, cancellationToken).ConfigureAwait(false),
+            };
+
+            return ToFileResult(payload);
+        }
+        catch (PrivacyExportNotReadyException)
+        {
+            return ExportNotReady(requestId);
+        }
+    }
+
+    private static async Task<Results<FileStreamHttpResult, ProblemHttpResult>> HandleDownloadManifestAsync(
+        Guid requestId,
+        HttpContext httpContext,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IExportRequestTrackerReader tracker,
+        [FromServices] IPrivacyExportDownloadResolver downloadResolver,
+        [FromServices] IOptions<PrivacyEndpointsOptions> options,
+        [FromServices] TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        if (!PrivacyEndpointRouteBuilderExtensions.TryGetUserId(currentUser, out Guid userId))
+        {
+            return PrivacyEndpointRouteBuilderExtensions.UserNotAuthenticated();
+        }
+
+        ExportRequestStatus? status = await tracker.GetStatusAsync(requestId, cancellationToken).ConfigureAwait(false);
+        ProblemHttpResult? gate = Gate(httpContext, options.Value, timeProvider, status, requestId, userId);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        try
+        {
+            PrivacyExportDownloadPayload payload = await downloadResolver
+                .OpenManifestAsync(requestId, cancellationToken).ConfigureAwait(false);
+            return ToFileResult(payload);
+        }
+        catch (PrivacyExportNotReadyException)
+        {
+            return ExportNotReady(requestId);
+        }
+    }
+
+    private static async Task<Results<FileStreamHttpResult, ProblemHttpResult>> HandleDownloadShardAsync(
+        Guid requestId,
+        int shardIndex,
+        HttpContext httpContext,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IExportRequestTrackerReader tracker,
+        [FromServices] IPrivacyExportDownloadResolver downloadResolver,
+        [FromServices] IOptions<PrivacyEndpointsOptions> options,
+        [FromServices] TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        if (!PrivacyEndpointRouteBuilderExtensions.TryGetUserId(currentUser, out Guid userId))
+        {
+            return PrivacyEndpointRouteBuilderExtensions.UserNotAuthenticated();
+        }
+
+        ExportRequestStatus? status = await tracker.GetStatusAsync(requestId, cancellationToken).ConfigureAwait(false);
+        ProblemHttpResult? gate = Gate(httpContext, options.Value, timeProvider, status, requestId, userId);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        try
+        {
+            PrivacyExportDownloadPayload payload = await downloadResolver
+                .OpenShardAsync(requestId, shardIndex, cancellationToken).ConfigureAwait(false);
+            return ToFileResult(payload);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return TypedResults.Problem(
+                detail: $"Shard {shardIndex} is out of range for export '{requestId}'.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+        catch (PrivacyExportNotReadyException)
+        {
+            return ExportNotReady(requestId);
+        }
+    }
+
+    // The analyzer that enforces [FromServices] on interface params keys off the
+    // method signature, not the registration path — this is a private helper, not a
+    // route handler. Pass the already-resolved status in to keep the analyzer happy
+    // and avoid hidden DI assumptions inside helpers.
+    private static ProblemHttpResult? Gate(
+        HttpContext httpContext,
+        PrivacyEndpointsOptions endpointOptions,
+        TimeProvider timeProvider,
+        ExportRequestStatus? status,
+        Guid requestId,
+        Guid callerUserId)
+    {
+        // 404 if the export doesn't exist OR belongs to another subject — the same
+        // status code keeps tenant/user enumeration through the download path closed.
+        if (status is null || status.UserId != callerUserId)
+        {
+            return TypedResults.Problem(
+                detail: $"Export request '{requestId}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (endpointOptions.DownloadStepUpRequired
+            && !PrivacyStepUpChallenge.IsAuthFresh(httpContext, endpointOptions.DownloadStepUpMaxAge, timeProvider.GetUtcNow()))
+        {
+            string detail = PrivacyStepUpChallenge.SetStepUpChallengeHeader(httpContext, endpointOptions.DownloadStepUpMaxAge);
+            return TypedResults.Problem(detail: detail, statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        return null;
+    }
+
+    private static ProblemHttpResult ExportNotReady(Guid requestId) =>
+        TypedResults.Problem(
+            detail: $"Export request '{requestId}' has no archive available yet. Poll GET /privacy/exports/{requestId} for status.",
+            statusCode: StatusCodes.Status409Conflict);
+
+    private static FileStreamHttpResult ToFileResult(PrivacyExportDownloadPayload payload) =>
+        TypedResults.Stream(payload.Content, payload.ContentType, payload.FileName);
+}
+

--- a/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
@@ -322,6 +322,8 @@ public static class PrivacyEndpointRouteBuilderExtensions
                  "Returns all export requests submitted by the current user, ordered by most recent first. "
                  + "Each entry includes the request state, timestamps, and archive reference when available.")
              .Produces<IReadOnlyList<PrivacyExportStatusResponse>>();
+
+        group.MapPrivacyExportDownloadEndpoints();
     }
 
     // -------------------------------------------------------------------------

--- a/src/Granit.Privacy.Endpoints/Internal/PrivacyStepUpChallenge.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/PrivacyStepUpChallenge.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Privacy.Endpoints.Internal;
+
+/// <summary>
+/// Helpers for the step-up authentication gate applied to privacy-export
+/// download endpoints. A long-lived session cookie is not enough to download
+/// a GDPR archive — the caller must have re-authenticated recently enough that
+/// the OIDC <c>auth_time</c> claim falls inside the configured freshness window.
+/// </summary>
+/// <remarks>
+/// <para>
+/// On failure the endpoint emits a <c>401 Unauthorized</c> with a
+/// <c>WWW-Authenticate: Bearer error="step_up", acr_values="urn:granit:step-up"</c>
+/// header so an OIDC-aware BFF can transparently redirect the user back through
+/// the identity provider for a fresh authentication before retrying the download.
+/// </para>
+/// </remarks>
+internal static class PrivacyStepUpChallenge
+{
+    /// <summary>
+    /// ACR value advertised in the <c>WWW-Authenticate</c> challenge header.
+    /// </summary>
+    internal const string StepUpAcrValue = "urn:granit:step-up";
+
+    private const string AuthTimeClaim = "auth_time";
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the caller's <c>auth_time</c> claim
+    /// is present and within <paramref name="maxAge"/> of <paramref name="now"/>.
+    /// </summary>
+    internal static bool IsAuthFresh(HttpContext httpContext, TimeSpan maxAge, DateTimeOffset now)
+    {
+        Claim? authTimeClaim = httpContext.User.FindFirst(AuthTimeClaim);
+        if (authTimeClaim is null)
+        {
+            return false;
+        }
+
+        if (!long.TryParse(authTimeClaim.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long authTimeUnix))
+        {
+            return false;
+        }
+
+        var authTime = DateTimeOffset.FromUnixTimeSeconds(authTimeUnix);
+        return now - authTime <= maxAge;
+    }
+
+    /// <summary>
+    /// Sets the <c>WWW-Authenticate</c> challenge header for a step-up retry on
+    /// <paramref name="httpContext"/>'s response and returns the standard problem
+    /// detail message — call sites then return a 401 ProblemHttpResult that picks
+    /// the header up.
+    /// </summary>
+    internal static string SetStepUpChallengeHeader(HttpContext httpContext, TimeSpan maxAge)
+    {
+        string header = $"Bearer error=\"step_up\", acr_values=\"{StepUpAcrValue}\", max_age=\"{(int)maxAge.TotalSeconds}\"";
+        httpContext.Response.Headers["WWW-Authenticate"] = header;
+        return $"Step-up authentication required: re-authenticate within the last {(int)maxAge.TotalMinutes} minute(s).";
+    }
+}

--- a/src/Granit.Privacy.Endpoints/Options/PrivacyEndpointsOptions.cs
+++ b/src/Granit.Privacy.Endpoints/Options/PrivacyEndpointsOptions.cs
@@ -27,4 +27,26 @@ public sealed class PrivacyEndpointsOptions
     /// resource exhaustion through excessive export/deletion requests (OWASP API4).
     /// </summary>
     public string? RateLimitingPolicy { get; set; }
+
+    /// <summary>
+    /// Whether the privacy-export download endpoints require a recent re-authentication
+    /// (step-up auth). When <see langword="true"/> (default), the OIDC <c>auth_time</c>
+    /// claim must be within <see cref="DownloadStepUpMaxAge"/> of the current time;
+    /// otherwise the endpoint returns <c>401</c> with a <c>WWW-Authenticate: Bearer
+    /// error="step_up"</c> header so an OIDC-aware BFF can refresh the session
+    /// transparently before retrying.
+    /// </summary>
+    /// <remarks>
+    /// A long-lived session cookie is not sufficient evidence to release a GDPR
+    /// archive — a stolen cookie alone must not let an attacker pivot to a full
+    /// personal-data export. Hosts running entirely behind a hardware token wall
+    /// can flip this off; the default is on.
+    /// </remarks>
+    public bool DownloadStepUpRequired { get; set; } = true;
+
+    /// <summary>
+    /// Maximum age of the OIDC <c>auth_time</c> claim for the privacy-export download
+    /// endpoints. Defaults to 5 minutes.
+    /// </summary>
+    public TimeSpan DownloadStepUpMaxAge { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/Granit.Privacy/DataExport/Exceptions/PrivacyExportNotReadyException.cs
+++ b/src/Granit.Privacy/DataExport/Exceptions/PrivacyExportNotReadyException.cs
@@ -1,0 +1,18 @@
+namespace Granit.Privacy.DataExport.Exceptions;
+
+/// <summary>
+/// Thrown by <see cref="IPrivacyExportDownloadResolver"/> when a download is
+/// requested for an export that hasn't completed yet (no manifest reference on
+/// the tracker, or the manifest blob is unreadable).
+/// </summary>
+/// <remarks>
+/// Distinct from a 404 — the request exists, it just isn't downloadable. The
+/// endpoint surface maps this to <c>409 Conflict</c> so clients can poll the
+/// status endpoint instead of treating the request as gone.
+/// </remarks>
+public sealed class PrivacyExportNotReadyException(Guid requestId)
+    : Exception($"Privacy export {requestId} is not ready for download.")
+{
+    /// <summary>Saga / export-request correlation id.</summary>
+    public Guid RequestId { get; } = requestId;
+}

--- a/src/Granit.Privacy/DataExport/IPrivacyExportDownloadResolver.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyExportDownloadResolver.cs
@@ -1,0 +1,64 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Resolves the bytes of a completed privacy export — both the manifest sidecar
+/// and the individual shard archives — for download endpoints. Abstracts the
+/// storage tier so endpoints stay in <c>Granit.Privacy.Endpoints</c> without
+/// depending on <c>IBlobStoreProvider</c> internals.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Shards aren't registered in the <c>IBlobStorage</c> descriptor table — they're
+/// written directly via <c>IBlobStoreProvider.OpenWriteMultipartAsync</c> from
+/// the assembly job, with object keys derived from the request ID. The
+/// resolver reads the manifest sidecar first to learn the shard count and to
+/// validate the requested <c>shardIndex</c>, then streams the raw bytes back to
+/// the caller.
+/// </para>
+/// <para>
+/// Streaming through the BFF (rather than 302-redirecting to a presigned URL)
+/// keeps every download under the step-up auth gate and the ROPA audit trail.
+/// Hosts that need direct cloud-to-client transfers can replace this resolver.
+/// </para>
+/// </remarks>
+public interface IPrivacyExportDownloadResolver
+{
+    /// <summary>Returns the manifest's shard count plus the manifest blob reference.</summary>
+    Task<PrivacyExportManifestSummary> ReadManifestSummaryAsync(
+        Guid requestId,
+        CancellationToken cancellationToken);
+
+    /// <summary>Opens a read stream over the manifest JSON sidecar.</summary>
+    Task<PrivacyExportDownloadPayload> OpenManifestAsync(
+        Guid requestId,
+        CancellationToken cancellationToken);
+
+    /// <summary>Opens a read stream over the specified shard ZIP.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Shard index is out of bounds for the request's manifest.</exception>
+    Task<PrivacyExportDownloadPayload> OpenShardAsync(
+        Guid requestId,
+        int shardIndex,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Snapshot of the manifest sidecar's downloadable surface — used by endpoints
+/// to validate shard indexes and to decide compat redirects.
+/// </summary>
+/// <param name="ShardCount">Number of shard archives the assembly produced.</param>
+/// <param name="ManifestObjectKey">Manifest sidecar object key inside the export bucket.</param>
+public sealed record PrivacyExportManifestSummary(int ShardCount, string ManifestObjectKey);
+
+/// <summary>
+/// Read-only stream of either the manifest JSON or a single shard archive,
+/// plus the metadata required to serve it as an HTTP file response.
+/// </summary>
+/// <param name="Content">The byte stream — the caller must dispose it.</param>
+/// <param name="ContentType">MIME type to set on the response (e.g. <c>application/zip</c>).</param>
+/// <param name="FileName">Suggested download filename, used in the <c>Content-Disposition</c> header.</param>
+/// <param name="LengthBytes">Total stream length when known, or <c>null</c> for streaming.</param>
+public sealed record PrivacyExportDownloadPayload(
+    Stream Content,
+    string ContentType,
+    string FileName,
+    long? LengthBytes);

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/BlobBackedPrivacyExportDownloadResolverTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/BlobBackedPrivacyExportDownloadResolverTests.cs
@@ -1,0 +1,171 @@
+using System.Text;
+using System.Text.Json;
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Internal;
+using Granit.Domain.ValueObjects;
+using Granit.Privacy.BlobStorage.DataExport;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Exceptions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.BlobStorage.Tests.DataExport;
+
+public sealed class BlobBackedPrivacyExportDownloadResolverTests
+{
+    private static readonly Guid RequestId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid UserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid ManifestBlobId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    [Fact]
+    public async Task OpenShardAsync_ReturnsStream_AndPropagatesShardObjectKeyFromManifest()
+    {
+        Setup setup = BuildSetup(shardCount: 3);
+
+        PrivacyExportDownloadPayload payload = await setup.Resolver
+            .OpenShardAsync(RequestId, shardIndex: 1, TestContext.Current.CancellationToken);
+
+        payload.ContentType.ShouldBe("application/zip");
+        payload.FileName.ShouldBe($"personal-data-export-{RequestId}-001.zip");
+
+        // Each OpenShardAsync re-reads the manifest first (own descriptor lookup),
+        // then opens the targeted shard — assert via the bucket+key tuple.
+        await setup.Provider.Received(1).OpenReadAsync(
+            "gdpr-exports",
+            "personal-data-export/abc-001.zip",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task OpenShardAsync_OutOfBounds_Throws()
+    {
+        Setup setup = BuildSetup(shardCount: 2);
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(
+            () => setup.Resolver.OpenShardAsync(RequestId, shardIndex: 5, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task OpenManifestAsync_ReturnsManifestJsonStream()
+    {
+        Setup setup = BuildSetup(shardCount: 2);
+
+        PrivacyExportDownloadPayload payload = await setup.Resolver
+            .OpenManifestAsync(RequestId, TestContext.Current.CancellationToken);
+
+        payload.ContentType.ShouldBe("application/json");
+        payload.FileName.ShouldBe($"personal-data-export-{RequestId}-manifest.json");
+    }
+
+    [Fact]
+    public async Task ReadManifestSummaryAsync_NoArchiveYet_Throws()
+    {
+        IExportRequestTrackerReader tracker = Substitute.For<IExportRequestTrackerReader>();
+        tracker.GetStatusAsync(RequestId, Arg.Any<CancellationToken>())
+            .Returns(new ExportRequestStatus(
+                RequestId,
+                UserId,
+                ExportRequestState.Pending,
+                RequestedAt: DateTimeOffset.UtcNow,
+                CompletedAt: null,
+                ArchiveBlobReferenceId: null,
+                MissingProviders: []));
+
+        BlobBackedPrivacyExportDownloadResolver resolver = new(
+            Substitute.For<IBlobStorage>(),
+            Substitute.For<IBlobStoreProvider>(),
+            tracker);
+
+        await Should.ThrowAsync<PrivacyExportNotReadyException>(
+            () => resolver.ReadManifestSummaryAsync(RequestId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ReadManifestSummaryAsync_DescriptorMissing_Throws()
+    {
+        IExportRequestTrackerReader tracker = Substitute.For<IExportRequestTrackerReader>();
+        tracker.GetStatusAsync(RequestId, Arg.Any<CancellationToken>())
+            .Returns(new ExportRequestStatus(
+                RequestId,
+                UserId,
+                ExportRequestState.Completed,
+                RequestedAt: DateTimeOffset.UtcNow,
+                CompletedAt: DateTimeOffset.UtcNow,
+                ArchiveBlobReferenceId: BlobReference.Create(ManifestBlobId.ToString()),
+                MissingProviders: []));
+
+        IBlobStorage blobStorage = Substitute.For<IBlobStorage>();
+        blobStorage.GetDescriptorAsync("gdpr-exports", ManifestBlobId, Arg.Any<CancellationToken>())
+            .Returns((BlobDescriptor?)null);
+
+        BlobBackedPrivacyExportDownloadResolver resolver = new(
+            blobStorage,
+            Substitute.For<IBlobStoreProvider>(),
+            tracker);
+
+        await Should.ThrowAsync<PrivacyExportNotReadyException>(
+            () => resolver.ReadManifestSummaryAsync(RequestId, TestContext.Current.CancellationToken));
+    }
+
+    private static Setup BuildSetup(int shardCount)
+    {
+        IExportRequestTrackerReader tracker = Substitute.For<IExportRequestTrackerReader>();
+        tracker.GetStatusAsync(RequestId, Arg.Any<CancellationToken>())
+            .Returns(new ExportRequestStatus(
+                RequestId,
+                UserId,
+                ExportRequestState.Completed,
+                RequestedAt: DateTimeOffset.UtcNow,
+                CompletedAt: DateTimeOffset.UtcNow,
+                ArchiveBlobReferenceId: BlobReference.Create(ManifestBlobId.ToString()),
+                MissingProviders: []));
+
+        var descriptor = BlobDescriptor.Create(
+            id: ManifestBlobId,
+            tenantId: null,
+            containerName: "gdpr-exports",
+            objectKey: $"personal-data-export/abc-manifest.json",
+            request: new BlobUploadRequest(
+                FileName: $"personal-data-export-{RequestId}-manifest.json",
+                ContentType: "application/json",
+                MaxAllowedBytes: 1024),
+            createdAt: DateTimeOffset.UtcNow);
+
+        IBlobStorage blobStorage = Substitute.For<IBlobStorage>();
+        blobStorage.GetDescriptorAsync("gdpr-exports", ManifestBlobId, Arg.Any<CancellationToken>())
+            .Returns(descriptor);
+
+        // Re-emit a fresh stream for each manifest read so .NET doesn't trip over
+        // a disposed stream when the resolver opens the manifest twice (once for
+        // descriptor + summary, again for the shard lookup).
+        IBlobStoreProvider provider = Substitute.For<IBlobStoreProvider>();
+        provider.OpenReadAsync("gdpr-exports", descriptor.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(_ => new MemoryStream(Encoding.UTF8.GetBytes(BuildManifestJson(shardCount))));
+
+        // Each shard read returns an empty stream — content doesn't matter for the
+        // tests, only the bucket+objectKey routing.
+        for (int i = 0; i < shardCount; i++)
+        {
+            string objectKey = $"personal-data-export/abc-{i:D3}.zip";
+            provider.OpenReadAsync("gdpr-exports", objectKey, Arg.Any<CancellationToken>())
+                .Returns(_ => new MemoryStream([]));
+        }
+
+        return new Setup(new BlobBackedPrivacyExportDownloadResolver(blobStorage, provider, tracker), provider);
+    }
+
+    private static string BuildManifestJson(int shardCount)
+    {
+        var shards = Enumerable.Range(0, shardCount).Select(i => new
+        {
+            index = i,
+            objectKey = $"personal-data-export/abc-{i:D3}.zip",
+            compressedSizeBytes = 1024 * (i + 1),
+        });
+        return JsonSerializer.Serialize(new { shards });
+    }
+
+    private sealed record Setup(BlobBackedPrivacyExportDownloadResolver Resolver, IBlobStoreProvider Provider);
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Internal/PrivacyStepUpChallengeTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Internal/PrivacyStepUpChallengeTests.cs
@@ -1,0 +1,79 @@
+using System.Security.Claims;
+using Granit.Privacy.Endpoints.Internal;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Internal;
+
+public sealed class PrivacyStepUpChallengeTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 26, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan FiveMinutes = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public void IsAuthFresh_ReturnsTrue_WhenAuthTimeIsWithinWindow()
+    {
+        long authTime = Now.AddMinutes(-3).ToUnixTimeSeconds();
+        DefaultHttpContext context = BuildContextWithAuthTimeClaim(authTime.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        PrivacyStepUpChallenge.IsAuthFresh(context, FiveMinutes, Now).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsAuthFresh_ReturnsFalse_WhenAuthTimeIsBeyondWindow()
+    {
+        long authTime = Now.AddMinutes(-10).ToUnixTimeSeconds();
+        DefaultHttpContext context = BuildContextWithAuthTimeClaim(authTime.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        PrivacyStepUpChallenge.IsAuthFresh(context, FiveMinutes, Now).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsAuthFresh_ReturnsTrue_AtExactBoundary()
+    {
+        // The check is "now - authTime <= maxAge", i.e. 5 minutes ago is still fresh.
+        long authTime = Now.AddMinutes(-5).ToUnixTimeSeconds();
+        DefaultHttpContext context = BuildContextWithAuthTimeClaim(authTime.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        PrivacyStepUpChallenge.IsAuthFresh(context, FiveMinutes, Now).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsAuthFresh_ReturnsFalse_WhenAuthTimeClaimMissing()
+    {
+        DefaultHttpContext context = new();
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(authenticationType: "test"));
+
+        PrivacyStepUpChallenge.IsAuthFresh(context, FiveMinutes, Now).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsAuthFresh_ReturnsFalse_WhenAuthTimeClaimIsNonNumeric()
+    {
+        DefaultHttpContext context = BuildContextWithAuthTimeClaim("not-a-number");
+
+        PrivacyStepUpChallenge.IsAuthFresh(context, FiveMinutes, Now).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetStepUpChallengeHeader_SetsWwwAuthenticateBearerStepUp()
+    {
+        DefaultHttpContext context = new();
+
+        string detail = PrivacyStepUpChallenge.SetStepUpChallengeHeader(context, FiveMinutes);
+
+        detail.ShouldContain("Step-up authentication required");
+        context.Response.Headers["WWW-Authenticate"].ToString()
+            .ShouldBe("Bearer error=\"step_up\", acr_values=\"urn:granit:step-up\", max_age=\"300\"");
+    }
+
+    private static DefaultHttpContext BuildContextWithAuthTimeClaim(string claimValue)
+    {
+        DefaultHttpContext context = new();
+        ClaimsIdentity identity = new(authenticationType: "test");
+        identity.AddClaim(new Claim("auth_time", claimValue));
+        context.User = new ClaimsPrincipal(identity);
+        return context;
+    }
+}


### PR DESCRIPTION
## Summary

First leg of P6.4 — the personal-data-export download surface with step-up authentication gating.

Three new endpoints under `/privacy/exports/{requestId}/download/...`:

- `download` — compat: shard 0 for single-shard exports, manifest sidecar otherwise
- `download/manifest` — JSON manifest streamed directly
- `download/{shardIndex:int:min(0)}` — individual ZIP shard

A long-lived session cookie isn't enough to release a GDPR archive — the OIDC `auth_time` claim must be within `DownloadStepUpMaxAge` (default 5 min) of now, otherwise the endpoint returns `401` with `WWW-Authenticate: Bearer error=\"step_up\", acr_values=\"urn:granit:step-up\", max_age=\"300\"` so an OIDC-aware BFF can refresh the session transparently before the client retries.

## Architecture

- `IPrivacyExportDownloadResolver` (public, in `Granit.Privacy`) keeps the endpoint package free of `IBlobStoreProvider` internals.
- `BlobBackedPrivacyExportDownloadResolver` (internal, in `Granit.Privacy.BlobStorage`) reads the manifest descriptor (logged in `IBlobStorage`) to learn the shard count, then streams the requested shard directly via `IBlobStoreProvider.OpenReadAsync` on its raw object key. Shards have no descriptor entries of their own — only the manifest does.
- `PrivacyStepUpChallenge` (internal, in `Granit.Privacy.Endpoints`) is the pure helper for both the freshness check and the `WWW-Authenticate` header emission.
- Streaming through the BFF (rather than 302-redirecting to a presigned URL) keeps every byte under the step-up gate and the future ROPA audit trail.

## What's in the PR

- `IPrivacyExportDownloadResolver` + `PrivacyExportDownloadPayload` + `PrivacyExportManifestSummary`
- `BlobBackedPrivacyExportDownloadResolver` impl + DI registration
- `PrivacyExportNotReadyException` (409 mapping for in-flight exports)
- `PrivacyStepUpChallenge` helper
- `PrivacyEndpointsOptions.DownloadStepUpRequired` / `DownloadStepUpMaxAge`
- `PrivacyExportDownloadEndpoints.cs` — 3 endpoint registrations + handlers
- Unit tests: 6 on the step-up helper, 4 on the resolver impl

## Test plan
- [x] `dotnet build` clean on `Granit.Privacy`, `Granit.Privacy.BlobStorage`, `Granit.Privacy.Endpoints`
- [x] `dotnet test tests/Granit.Privacy.Endpoints.Tests` — 131/131 pass (125 existing + 6 step-up)
- [x] `dotnet test tests/Granit.Privacy.BlobStorage.Tests` — 61/61 pass (57 existing + 4 resolver)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 235/235 pass
- [x] `dotnet format` clean on `src/Granit.Privacy{,.BlobStorage,.Endpoints}` + new test files
- [ ] CI green on full shard matrix