### PR TITLE
feat(privacy-export): signed manifest with sha256-per-shard + HMAC envelope (P6.4.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37080,7 +37080,7 @@
       "kind": "record",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs",
-      "line": 437,
+      "line": 469,
       "members": []
     },
     {
@@ -37834,6 +37834,28 @@
       "file": "src/Granit.Privacy/DataExport/Security/EphemeralExportHmacSigner.cs",
       "line": 21,
       "members": []
+    },
+    {
+      "name": "IExportContentSigner",
+      "fqn": "Granit.Privacy.DataExport.Security.IExportContentSigner",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Security/IExportContentSigner.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "SignBytes",
+          "kind": "method",
+          "signature": "SignBytes(ReadOnlySpan<byte> payload)",
+          "returnType": "string"
+        },
+        {
+          "name": "VerifyBytes",
+          "kind": "method",
+          "signature": "VerifyBytes(ReadOnlySpan<byte> payload, string tag)",
+          "returnType": "bool"
+        }
+      ]
     },
     {
       "name": "IExportHmacSigner",

--- a/src/Granit.Privacy.BlobStorage/DataExport/BlobBackedPrivacyExportDownloadResolver.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/BlobBackedPrivacyExportDownloadResolver.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using Granit.BlobStorage;
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Internal;
-using Granit.Domain.ValueObjects;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Exceptions;
 
@@ -31,9 +30,12 @@ internal sealed class BlobBackedPrivacyExportDownloadResolver(
         Guid requestId,
         CancellationToken cancellationToken)
     {
-        ManifestLookup lookup = await ReadManifestAsync(requestId, cancellationToken).ConfigureAwait(false);
+        // Skip the JSON parse — we don't need shard metadata to return the manifest
+        // stream itself, only the descriptor's object key. Saves one blob read per
+        // manifest download vs routing through ReadManifestAsync.
+        BlobDescriptor descriptor = await ResolveManifestDescriptorAsync(requestId, cancellationToken).ConfigureAwait(false);
         Stream stream = await blobStoreProvider
-            .OpenReadAsync(PrivacyExportContainerNames.FragmentContainer, lookup.ManifestObjectKey, cancellationToken)
+            .OpenReadAsync(PrivacyExportContainerNames.FragmentContainer, descriptor.ObjectKey, cancellationToken)
             .ConfigureAwait(false);
 
         return new PrivacyExportDownloadPayload(
@@ -68,16 +70,11 @@ internal sealed class BlobBackedPrivacyExportDownloadResolver(
             LengthBytes: shard.CompressedSizeBytes > 0 ? shard.CompressedSizeBytes : null);
     }
 
-    private async Task<ManifestLookup> ReadManifestAsync(Guid requestId, CancellationToken cancellationToken)
+    private async Task<BlobDescriptor> ResolveManifestDescriptorAsync(Guid requestId, CancellationToken cancellationToken)
     {
         ExportRequestStatus? status = await trackerReader.GetStatusAsync(requestId, cancellationToken).ConfigureAwait(false);
-        if (status?.ArchiveBlobReferenceId is null)
-        {
-            throw new PrivacyExportNotReadyException(requestId);
-        }
-
-        BlobReference manifestRef = status.ArchiveBlobReferenceId;
-        if (!Guid.TryParse(manifestRef.Value, out Guid manifestBlobId))
+        if (status?.ArchiveBlobReferenceId is null
+            || !Guid.TryParse(status.ArchiveBlobReferenceId.Value, out Guid manifestBlobId))
         {
             throw new PrivacyExportNotReadyException(requestId);
         }
@@ -86,26 +83,34 @@ internal sealed class BlobBackedPrivacyExportDownloadResolver(
             .GetDescriptorAsync(PrivacyExportContainerNames.FragmentContainer, manifestBlobId, cancellationToken)
             .ConfigureAwait(false);
 
-        if (descriptor is null)
-        {
-            throw new PrivacyExportNotReadyException(requestId);
-        }
+        return descriptor ?? throw new PrivacyExportNotReadyException(requestId);
+    }
+
+    private async Task<ManifestLookup> ReadManifestAsync(Guid requestId, CancellationToken cancellationToken)
+    {
+        BlobDescriptor descriptor = await ResolveManifestDescriptorAsync(requestId, cancellationToken).ConfigureAwait(false);
 
         await using Stream manifestStream = await blobStoreProvider
             .OpenReadAsync(PrivacyExportContainerNames.FragmentContainer, descriptor.ObjectKey, cancellationToken)
             .ConfigureAwait(false);
 
-        ManifestPayload payload = await JsonSerializer
-            .DeserializeAsync<ManifestPayload>(manifestStream, ManifestJsonOptions, cancellationToken)
+        ManifestEnvelope envelope = await JsonSerializer
+            .DeserializeAsync<ManifestEnvelope>(manifestStream, ManifestJsonOptions, cancellationToken)
             .ConfigureAwait(false)
             ?? throw new PrivacyExportNotReadyException(requestId);
 
-        return new ManifestLookup(descriptor.ObjectKey, payload.Shards ?? []);
+        return new ManifestLookup(descriptor.ObjectKey, envelope.Payload?.Shards ?? []);
     }
 
     private static readonly JsonSerializerOptions ManifestJsonOptions = new(JsonSerializerDefaults.Web);
 
     private sealed record ManifestLookup(string ManifestObjectKey, IReadOnlyList<ManifestShard> Shards);
+
+    // Signed-manifest envelope: { "payload": { schemaVersion, ..., shards: [...] }, "integrityTag": "v1:..." }.
+    // The resolver only needs `shards` from inside the payload — it doesn't re-verify the
+    // HMAC, that's the verifier's job (a future endpoint or client-side CLI). All we
+    // care about here is routing shardIndex → objectKey.
+    private sealed record ManifestEnvelope(ManifestPayload? Payload);
 
     private sealed record ManifestPayload(IReadOnlyList<ManifestShard>? Shards);
 

--- a/src/Granit.Privacy.BlobStorage/DataExport/Internal/Sha256ComputingStream.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/Internal/Sha256ComputingStream.cs
@@ -1,0 +1,124 @@
+using System.Security.Cryptography;
+
+namespace Granit.Privacy.BlobStorage.DataExport.Internal;
+
+/// <summary>
+/// Forward-only write-through SHA-256 digest. Mirrors
+/// <see cref="WriteCountingStream"/>: every byte handed to the wrapped stream is
+/// also fed into an <see cref="IncrementalHash"/>, so the shard's content
+/// digest is available at close time without a second pass over the bytes.
+/// </summary>
+/// <remarks>
+/// The shard pipeline layers the streams as
+/// <c>ZipArchive → Sha256ComputingStream → WriteCountingStream → MultipartWriteStream</c>,
+/// so the sha256 covers exactly the bytes that land in blob storage (post-ZIP
+/// framing including the central directory). The digest is finalised by
+/// <see cref="ComputeHashAndReset"/> just before the multipart upload is
+/// committed.
+/// </remarks>
+internal sealed class Sha256ComputingStream(Stream inner, bool leaveOpen) : Stream
+{
+    private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+    private bool _disposed;
+
+    public override bool CanRead => false;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => inner.CanWrite;
+
+    public override long Length => inner.Length;
+
+    public override long Position
+    {
+        get => inner.Position;
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() => inner.Flush();
+
+    public override Task FlushAsync(CancellationToken cancellationToken) => inner.FlushAsync(cancellationToken);
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _hash.AppendData(buffer, offset, count);
+        inner.Write(buffer, offset, count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        _hash.AppendData(buffer);
+        inner.Write(buffer);
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        _hash.AppendData(buffer, offset, count);
+        await inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        _hash.AppendData(buffer.Span);
+        await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override void WriteByte(byte value)
+    {
+        Span<byte> single = [value];
+        _hash.AppendData(single);
+        inner.WriteByte(value);
+    }
+
+    /// <summary>
+    /// Finalises the running digest and returns its 32-byte SHA-256 result. Resets
+    /// the hash so the same stream cannot be re-used for a second digest — call
+    /// exactly once per shard, immediately before the multipart upload commits.
+    /// </summary>
+    public byte[] ComputeHashAndReset() => _hash.GetHashAndReset();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            base.Dispose(disposing);
+            return;
+        }
+        _disposed = true;
+
+        if (disposing)
+        {
+            _hash.Dispose();
+            if (!leaveOpen)
+            {
+                inner.Dispose();
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+        _disposed = true;
+
+        _hash.Dispose();
+        if (!leaveOpen)
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
@@ -53,6 +53,7 @@ internal sealed partial class PrivacyExportAssemblyService(
     IBlobStorage blobStorage,
     IBlobStoreProvider blobStoreProvider,
     IExportHmacSigner hmacSigner,
+    IExportContentSigner contentSigner,
     IExportAssemblyCheckpointStore checkpointStore,
     IExportRequestTrackerWriter trackerWriter,
     IHttpClientFactory httpClientFactory,
@@ -95,7 +96,10 @@ internal sealed partial class PrivacyExportAssemblyService(
         int startShardIndex = (resumeFrom?.LastCompletedShardIndex ?? -1) + 1;
         IReadOnlyList<ShardManifest> priorShards = resumeFrom is null
             ? []
-            : [.. resumeFrom.CompletedShardObjectKeys.Select((key, idx) => new ShardManifest(idx, key, CompressedSizeBytes: 0))];
+            // Sha256 is empty for resumed shards — re-streaming to recompute the digest
+            // would defeat the point of checkpointing. The manifest serialiser writes an
+            // empty string for these so downstream verifiers can flag and re-download.
+            : [.. resumeFrom.CompletedShardObjectKeys.Select((key, idx) => new ShardManifest(idx, key, CompressedSizeBytes: 0, Sha256: []))];
 
         if (resumeFrom is not null)
         {
@@ -333,7 +337,14 @@ internal sealed partial class PrivacyExportAssemblyService(
         HttpClient httpClient,
         CancellationToken cancellationToken)
     {
-        var manifest = new
+        // The signed-manifest envelope is a two-property object: `payload` carries
+        // the canonical manifest content, `integrityTag` carries the HMAC over the
+        // payload's UTF-8 bytes. Verifiers extract `payload`'s raw JSON text (via
+        // JsonDocument.GetRawText / Utf8JsonReader) to recompute the HMAC — that's
+        // why we serialise the payload separately and splice it in with
+        // Utf8JsonWriter.WriteRawValue (no re-parse, byte-identical to what was
+        // signed).
+        var manifestPayload = new
         {
             schemaVersion = 1,
             requestId = completion.RequestId,
@@ -349,11 +360,15 @@ internal sealed partial class PrivacyExportAssemblyService(
                 index = s.Index,
                 objectKey = s.ObjectKey,
                 compressedSizeBytes = s.CompressedSizeBytes,
+                sha256 = s.Sha256.Length == 0 ? "" : Convert.ToHexStringLower(s.Sha256),
             }).ToArray(),
             fragments = manifestFragments,
         };
 
-        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(manifest, ManifestJsonOptions);
+        byte[] payloadBytes = JsonSerializer.SerializeToUtf8Bytes(manifestPayload, ManifestJsonOptions);
+        string integrityTag = contentSigner.SignBytes(payloadBytes);
+
+        byte[] payload = BuildSignedEnvelope(payloadBytes, integrityTag);
 
         PresignedUploadTicket ticket = await blobStorage.InitiateUploadAsync(
             PrivacyExportContainerNames.FragmentContainer,
@@ -382,6 +397,23 @@ internal sealed partial class PrivacyExportAssemblyService(
             PrivacyExportContainerNames.FragmentContainer, ticket.BlobId, cancellationToken).ConfigureAwait(false);
 
         return BlobReference.Create(ticket.BlobId.ToString());
+    }
+
+    private static byte[] BuildSignedEnvelope(byte[] payloadBytes, string integrityTag)
+    {
+        using MemoryStream ms = new(payloadBytes.Length + 128);
+        using (Utf8JsonWriter writer = new(ms, new JsonWriterOptions { Indented = true }))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("payload");
+            // WriteRawValue writes payloadBytes verbatim — byte-identical to what
+            // contentSigner.SignBytes saw. Without this, a re-parse + re-emit could
+            // change whitespace or numeric formatting and break verification.
+            writer.WriteRawValue(payloadBytes);
+            writer.WriteString("integrityTag", integrityTag);
+            writer.WriteEndObject();
+        }
+        return ms.ToArray();
     }
 
     private static string BuildObjectKeyPrefix(Guid requestId) =>

--- a/src/Granit.Privacy.BlobStorage/DataExport/ShardingArchiveWriter.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/ShardingArchiveWriter.cs
@@ -57,6 +57,7 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
     private int _nextShardIndex;
     private MultipartWriteStream? _multipart;
     private WriteCountingStream? _counter;
+    private Sha256ComputingStream? _hasher;
     private ZipArchive? _zip;
     private bool _completed;
     private bool _disposed;
@@ -178,6 +179,12 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
             _multipart = null;
         }
 
+        if (_hasher is not null)
+        {
+            await _hasher.DisposeAsync().ConfigureAwait(false);
+            _hasher = null;
+        }
+
         if (_counter is not null)
         {
             await _counter.DisposeAsync().ConfigureAwait(false);
@@ -190,11 +197,15 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
         string objectKey = $"{_objectKeyPrefix}-{_nextShardIndex:D3}.zip";
         _multipart = await _provider.OpenWriteMultipartAsync(
             _bucket, objectKey, "application/zip", cancellationToken).ConfigureAwait(false);
+        // ZipArchive → Sha256ComputingStream → WriteCountingStream → MultipartWriteStream.
+        // The hash + counter both observe post-ZIP-framing bytes (including the central
+        // directory written on Dispose), which is exactly what a downloading client sees.
         _counter = new WriteCountingStream(_multipart, leaveOpen: true);
+        _hasher = new Sha256ComputingStream(_counter, leaveOpen: true);
         // leaveOpen on the ZipArchive so disposing it writes the central directory
-        // through the counter without closing the multipart stream — we still need
-        // to call CompleteAsync on it explicitly.
-        _zip = new ZipArchive(_counter, ZipArchiveMode.Create, leaveOpen: true);
+        // through the hash + counter without closing the multipart stream — we still
+        // need to call CompleteAsync on it explicitly.
+        _zip = new ZipArchive(_hasher, ZipArchiveMode.Create, leaveOpen: true);
     }
 
     private async Task CloseCurrentShardAsync(CancellationToken cancellationToken)
@@ -207,22 +218,26 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
         int shardIndex = _nextShardIndex;
         string objectKey = $"{_objectKeyPrefix}-{shardIndex:D3}.zip";
 
-        // Disposing ZipArchive writes the central directory bytes into the counter +
-        // multipart stream. Must precede CompleteAsync on the multipart so the upload
-        // captures the directory.
+        // Disposing ZipArchive writes the central directory bytes through the hasher +
+        // counter into the multipart stream. Must precede CompleteAsync on the multipart
+        // so the upload captures the directory — and ComputeHashAndReset must happen
+        // after the dispose so the central directory is included in the digest.
         _zip.Dispose();
         _zip = null;
 
+        byte[] sha256 = _hasher!.ComputeHashAndReset();
         long bytes = _counter!.BytesWritten;
         await _counter.FlushAsync(cancellationToken).ConfigureAwait(false);
         await _multipart!.CompleteAsync(cancellationToken).ConfigureAwait(false);
 
+        await _hasher.DisposeAsync().ConfigureAwait(false);
+        _hasher = null;
         await _counter.DisposeAsync().ConfigureAwait(false);
         _counter = null;
         await _multipart.DisposeAsync().ConfigureAwait(false);
         _multipart = null;
 
-        _completedShards.Add(new ShardManifest(shardIndex, objectKey, bytes));
+        _completedShards.Add(new ShardManifest(shardIndex, objectKey, bytes, sha256));
         _nextShardIndex++;
     }
 
@@ -274,4 +289,6 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
 /// <param name="Index">Zero-based shard index in write order.</param>
 /// <param name="ObjectKey">Blob-storage object key of the shard ZIP.</param>
 /// <param name="CompressedSizeBytes">Total bytes written to the shard (post-ZIP framing).</param>
-internal sealed record ShardManifest(int Index, string ObjectKey, long CompressedSizeBytes);
+/// <param name="Sha256">SHA-256 digest of the shard's bytes — empty for shards rehydrated
+/// from a checkpoint (re-streaming would be the only way to recompute, deliberately skipped).</param>
+internal sealed record ShardManifest(int Index, string ObjectKey, long CompressedSizeBytes, byte[] Sha256);

--- a/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy.BlobStorage/Extensions/ServiceCollectionExtensions.cs
@@ -33,7 +33,9 @@ public static class ServiceCollectionExtensions
     {
         services.AddHttpClient(StagedFragmentBuilder.HttpClientName);
         services.AddHttpClient(PrivacyExportAssemblyService.HttpClientName);
-        services.TryAddSingleton<IExportHmacSigner, EphemeralExportHmacSigner>();
+        services.TryAddSingleton<EphemeralExportHmacSigner>();
+        services.TryAddSingleton<IExportHmacSigner>(sp => sp.GetRequiredService<EphemeralExportHmacSigner>());
+        services.TryAddSingleton<IExportContentSigner>(sp => sp.GetRequiredService<EphemeralExportHmacSigner>());
         services.TryAddSingleton<IExportAssemblyCheckpointStore, InMemoryExportAssemblyCheckpointStore>();
         services.TryAddScoped<IStagedFragmentBuilder, StagedFragmentBuilder>();
         services.TryAddScoped<IBlobBackedExportSource, BlobBackedExportSource>();

--- a/src/Granit.Privacy/DataExport/Security/EphemeralExportHmacSigner.cs
+++ b/src/Granit.Privacy/DataExport/Security/EphemeralExportHmacSigner.cs
@@ -18,7 +18,7 @@ namespace Granit.Privacy.DataExport.Security;
 /// legacy tags during a rotation window.
 /// </para>
 /// </remarks>
-public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IDisposable
+public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IExportContentSigner, IDisposable
 {
     private const string Version = "v1";
     private const int KeySizeBytes = 32;
@@ -72,6 +72,46 @@ public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IDisp
         string presented = tag[(colonIndex + 1)..];
         byte[] canonical = Canonicalize(parameters);
         byte[] expected = HMACSHA256.HashData(_key, canonical);
+        byte[] decoded;
+        try
+        {
+            decoded = Base64UrlDecode(presented);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(expected, decoded);
+    }
+
+    /// <inheritdoc />
+    public string SignBytes(ReadOnlySpan<byte> payload)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        byte[] mac = HMACSHA256.HashData(_key, payload);
+        return $"{Version}:{Base64UrlEncode(mac)}";
+    }
+
+    /// <inheritdoc />
+    public bool VerifyBytes(ReadOnlySpan<byte> payload, string tag)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrEmpty(tag);
+
+        int colonIndex = tag.IndexOf(':', StringComparison.Ordinal);
+        if (colonIndex <= 0)
+        {
+            return false;
+        }
+
+        if (!tag.AsSpan(0, colonIndex).SequenceEqual(Version))
+        {
+            return false;
+        }
+
+        string presented = tag[(colonIndex + 1)..];
+        byte[] expected = HMACSHA256.HashData(_key, payload);
         byte[] decoded;
         try
         {

--- a/src/Granit.Privacy/DataExport/Security/IExportContentSigner.cs
+++ b/src/Granit.Privacy/DataExport/Security/IExportContentSigner.cs
@@ -1,0 +1,32 @@
+namespace Granit.Privacy.DataExport.Security;
+
+/// <summary>
+/// Signs and verifies arbitrary byte payloads with the export HMAC key — companion
+/// to <see cref="IExportHmacSigner"/> which signs fragment identity tuples. Used
+/// by the assembly job to seal the manifest sidecar (sha256-per-shard + schema
+/// version), and by hosts to detect tampering before trusting a downloaded
+/// manifest.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Same key material as <see cref="IExportHmacSigner"/> but a distinct signing
+/// surface: fragment tags bind identity tuples, manifest tags bind whole JSON
+/// payloads. Keeping the two methods on separate interfaces prevents accidental
+/// cross-domain verification (a fragment tag never validates against manifest
+/// bytes and vice versa, even when the underlying key is shared).
+/// </para>
+/// <para>
+/// <b>Tag format:</b> identical to fragment tags — <c>v{version}:{Base64Url(HMAC-SHA256(K, payload))}</c>.
+/// </para>
+/// </remarks>
+public interface IExportContentSigner
+{
+    /// <summary>Produces an integrity tag over the canonical byte payload.</summary>
+    string SignBytes(ReadOnlySpan<byte> payload);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="tag"/> verifies against
+    /// <paramref name="payload"/> under any key version known to the signer.
+    /// </summary>
+    bool VerifyBytes(ReadOnlySpan<byte> payload, string tag);
+}

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/BlobBackedPrivacyExportDownloadResolverTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/BlobBackedPrivacyExportDownloadResolverTests.cs
@@ -163,8 +163,14 @@ public sealed class BlobBackedPrivacyExportDownloadResolverTests
             index = i,
             objectKey = $"personal-data-export/abc-{i:D3}.zip",
             compressedSizeBytes = 1024 * (i + 1),
+            sha256 = "00".PadRight(64, '0'),
         });
-        return JsonSerializer.Serialize(new { shards });
+        // Signed-envelope shape: { payload: { shards: [...] }, integrityTag: "..." }
+        return JsonSerializer.Serialize(new
+        {
+            payload = new { shards },
+            integrityTag = "v1:stub",
+        });
     }
 
     private sealed record Setup(BlobBackedPrivacyExportDownloadResolver Resolver, IBlobStoreProvider Provider);

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/Sha256ComputingStreamTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/Sha256ComputingStreamTests.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+using Granit.Privacy.BlobStorage.DataExport.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.BlobStorage.Tests.DataExport.Internal;
+
+public sealed class Sha256ComputingStreamTests
+{
+    [Fact]
+    public async Task WriteAsync_AccumulatesHash_MatchingSha256OverInnerBytes()
+    {
+        byte[] payload = [.. Enumerable.Range(0, 1024).Select(i => (byte)(i % 256))];
+        byte[] expected = SHA256.HashData(payload);
+
+        using MemoryStream inner = new();
+        await using (Sha256ComputingStream sut = new(inner, leaveOpen: true))
+        {
+            // Write in three uneven chunks to exercise the memory + span + offset overloads.
+            await sut.WriteAsync(payload.AsMemory(0, 300), TestContext.Current.CancellationToken);
+            await sut.WriteAsync(payload.AsMemory(300, 500), TestContext.Current.CancellationToken);
+            sut.Write(payload, 800, 224); // sync byte[] overload
+
+            byte[] computed = sut.ComputeHashAndReset();
+            computed.ShouldBe(expected);
+        }
+
+        inner.ToArray().ShouldBe(payload);
+    }
+
+    [Fact]
+    public async Task WriteByte_IsIncludedInDigest()
+    {
+        byte[] expected = SHA256.HashData([0xAB]);
+
+        using MemoryStream inner = new();
+        await using Sha256ComputingStream sut = new(inner, leaveOpen: true);
+        sut.WriteByte(0xAB);
+
+        sut.ComputeHashAndReset().ShouldBe(expected);
+        inner.ToArray().ShouldBe([0xAB]);
+    }
+}

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.Metrics;
 using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
 using Granit.BlobStorage;
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Internal;
@@ -93,6 +95,46 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         (await _checkpoints.GetAsync(requestId, tenantId: null, TestContext.Current.CancellationToken))
             .ShouldBeNull("checkpoint should be cleared after successful assembly");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_ManifestIsSigned_AndHmacRoundTrips_Over_PayloadRawBytes()
+    {
+        var requestId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var blobA = Guid.NewGuid();
+        SetupFragmentDownload(blobA, """{"id":"u1"}"""u8.ToArray());
+        SetupManifestUpload();
+
+        ExportCompletedEto evt = BuildEvent(
+            requestId, userId,
+            [BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json")]);
+
+        await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
+
+        // The manifest is the only application/json PUT body captured by the fake HTTP handler.
+        CapturedUpload manifestUpload = _http.CapturedUploads
+            .Single(u => u.Url.AbsoluteUri.StartsWith("https://s3.example/upload/", StringComparison.Ordinal));
+
+        using var envelope = JsonDocument.Parse(manifestUpload.Body);
+        JsonElement payloadElement = envelope.RootElement.GetProperty("payload");
+        JsonElement tagElement = envelope.RootElement.GetProperty("integrityTag");
+
+        string tag = tagElement.GetString().ShouldNotBeNull();
+        tag.ShouldStartWith("v1:");
+
+        // Verify the HMAC by feeding the payload's UTF-8 raw text back through the signer.
+        byte[] payloadBytes = Encoding.UTF8.GetBytes(payloadElement.GetRawText());
+        _hmacSigner.VerifyBytes(payloadBytes, tag).ShouldBeTrue("the assembly service must sign over the payload's raw bytes");
+
+        // schemaVersion stamp is mandatory — verifiers branch on it.
+        payloadElement.GetProperty("schemaVersion").GetInt32().ShouldBe(1);
+
+        // sha256 hex digest is emitted per shard (64 hex chars = 32 bytes).
+        foreach (JsonElement shard in payloadElement.GetProperty("shards").EnumerateArray())
+        {
+            shard.GetProperty("sha256").GetString()!.Length.ShouldBe(64);
+        }
     }
 
     [Fact]
@@ -276,7 +318,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         GranitPrivacyOptions opts = new() { ExportShardMaxSizeMb = 1 };
         PrivacyExportAssemblyService sut = new(
-            _blobStorage, _blobStoreProvider, _hmacSigner, spy, _tracker,
+            _blobStorage, _blobStoreProvider, _hmacSigner, _hmacSigner, spy, _tracker,
             new FakeHttpClientFactory(_http), ConfigOptions.Create(opts),
             _timeProvider, _metrics, NullLogger<PrivacyExportAssemblyService>.Instance);
 
@@ -360,6 +402,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         new(
             _blobStorage,
             _blobStoreProvider,
+            _hmacSigner,
             _hmacSigner,
             _checkpoints,
             _tracker,

--- a/tests/Granit.Privacy.Tests/DataExport/Security/EphemeralExportContentSignerTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/Security/EphemeralExportContentSignerTests.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using Granit.Privacy.DataExport.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Tests.DataExport.Security;
+
+public sealed class EphemeralExportContentSignerTests
+{
+    private static EphemeralExportHmacSigner CreateSigner() =>
+        new(NullLogger<EphemeralExportHmacSigner>.Instance);
+
+    [Fact]
+    public void SignBytes_then_VerifyBytes_returns_true()
+    {
+        using EphemeralExportHmacSigner signer = CreateSigner();
+        byte[] payload = Encoding.UTF8.GetBytes("""{"schemaVersion":1,"shards":[]}""");
+
+        string tag = signer.SignBytes(payload);
+        signer.VerifyBytes(payload, tag).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void VerifyBytes_returns_false_when_payload_tampered_with()
+    {
+        using EphemeralExportHmacSigner signer = CreateSigner();
+        byte[] original = Encoding.UTF8.GetBytes("""{"shardCount":3}""");
+        string tag = signer.SignBytes(original);
+
+        byte[] tampered = Encoding.UTF8.GetBytes("""{"shardCount":4}""");
+        signer.VerifyBytes(tampered, tag).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void VerifyBytes_returns_false_for_unknown_version()
+    {
+        using EphemeralExportHmacSigner signer = CreateSigner();
+        byte[] payload = Encoding.UTF8.GetBytes("anything");
+        string realTag = signer.SignBytes(payload);
+
+        // Swap version prefix to v99 — even if the MAC happens to be valid for v1,
+        // the version mismatch must reject.
+        string forged = "v99" + realTag[realTag.IndexOf(':')..];
+        signer.VerifyBytes(payload, forged).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void VerifyBytes_returns_false_on_malformed_tag()
+    {
+        using EphemeralExportHmacSigner signer = CreateSigner();
+        byte[] payload = Encoding.UTF8.GetBytes("data");
+
+        signer.VerifyBytes(payload, "no-colon").ShouldBeFalse();
+        signer.VerifyBytes(payload, "v1:%%%bad-base64%%%").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FragmentTag_and_ContentTag_dont_cross_verify()
+    {
+        // Even though both interfaces share the same key, a fragment-identity tag
+        // must not validate against a content payload of the same bytes (the
+        // canonicalisations are different domains).
+        using EphemeralExportHmacSigner signer = CreateSigner();
+
+        ExportHmacParameters fragmentParams = new(
+            RequestId: Guid.NewGuid(),
+            SubjectUserId: Guid.NewGuid(),
+            ProviderName: "identity-local",
+            FragmentKind: "staged",
+            SourceContainer: "gdpr-exports",
+            SourceBlobId: Guid.NewGuid(),
+            EntryPath: "identity-local.json",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(30));
+
+        string fragmentTag = signer.Sign(fragmentParams);
+        byte[] fragmentCanonicalBytes = Encoding.UTF8.GetBytes(fragmentParams.RequestId.ToString());
+
+        // Fragment tag should NOT verify when treated as a content tag over arbitrary bytes.
+        signer.VerifyBytes(fragmentCanonicalBytes, fragmentTag).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Adds tamper-evidence to the personal-data-export manifest sidecar. Two layered integrity signals:

1. **sha256 per shard** — computed in-flight via a new `Sha256ComputingStream` layered into the shard write pipeline as `ZipArchive → Sha256ComputingStream → WriteCountingStream → MultipartWriteStream`. The digest covers exactly the bytes that land in storage (post-ZIP framing including the central directory).
2. **HMAC envelope** — the manifest is wrapped in `{ payload: {...}, integrityTag: \"v1:...\" }`. The HMAC is computed over the canonical UTF-8 bytes of `payload` and spliced in via `Utf8JsonWriter.WriteRawValue` so byte-identity is preserved end-to-end. Verifiers extract `payload`'s raw text via `JsonDocument.GetRawText()` to recompute.

## New abstractions

- `IExportContentSigner` — companion to `IExportHmacSigner`, signs arbitrary byte payloads. Distinct surface prevents accidental cross-domain verification.
- `EphemeralExportHmacSigner` now implements both interfaces from a single instance with shared key material.
- `Sha256ComputingStream` — mirror of `WriteCountingStream`, finalises via `ComputeHashAndReset` just before the multipart upload commits.

## Manifest format

The payload now stamps `schemaVersion: 1` so future format changes can be rejected without ambiguity. The `BlobBackedPrivacyExportDownloadResolver` reads through the new envelope (parsing `payload.shards[]` for shard-index routing) and skips the redundant manifest parse on `OpenManifestAsync` (one blob read instead of two for manifest downloads).

Shards rehydrated from a crash-resume checkpoint carry an empty `sha256` in the manifest — re-streaming to recompute the digest would defeat the point of checkpointing.

## Test plan
- [x] `dotnet test tests/Granit.Privacy.BlobStorage.Tests` — 64/64 (61 existing + 3 new: round-trip HMAC verify, sha256 stream invariants)
- [x] `dotnet test tests/Granit.Privacy.Tests` — 279/279 (4 new content-signer tests)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 235/235
- [x] `dotnet format` clean across all modified projects
- [ ] CI green on full shard matrix