### PR TITLE
feat(privacy-export): multi-shard download links in notification email (P6.4.4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37080,7 +37080,7 @@
       "kind": "record",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs",
-      "line": 469,
+      "line": 486,
       "members": []
     },
     {
@@ -37386,6 +37386,15 @@
           "returnType": "Guid? TenantId { get; set; } public bool ReminderSent { get; set; } public Task"
         }
       ]
+    },
+    {
+      "name": "ExportArchiveAssembledEto",
+      "fqn": "Granit.Privacy.DataExport.Events.ExportArchiveAssembledEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/ExportArchiveAssembledEto.cs",
+      "line": 27,
+      "members": []
     },
     {
       "name": "ExportCompletedEto",
@@ -38847,7 +38856,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Notifications",
       "file": "src/Granit.Privacy.Notifications/Handlers/ExportCompletedNotificationHandler.cs",
-      "line": 15,
+      "line": 19,
       "members": [
         {
           "name": "HandleAsync",
@@ -39084,15 +39093,8 @@
       "kind": "record",
       "project": "Granit.Privacy.Notifications",
       "file": "src/Granit.Privacy.Notifications/PrivacyExportReadyNotificationType.cs",
-      "line": 44,
-      "members": [
-        {
-          "name": "ArchiveBlobReferenceDisplay",
-          "kind": "property",
-          "signature": "string ArchiveBlobReferenceDisplay",
-          "returnType": "string"
-        }
-      ]
+      "line": 45,
+      "members": []
     },
     {
       "name": "PrivacyExportReadyNotificationType",

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
@@ -6,6 +6,7 @@ using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Internal;
 using Granit.BlobStorage.Options;
 using Granit.Domain.ValueObjects;
+using Granit.Events;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
 using Granit.Privacy.DataExport.Exceptions;
@@ -56,6 +57,7 @@ internal sealed partial class PrivacyExportAssemblyService(
     IExportContentSigner contentSigner,
     IExportAssemblyCheckpointStore checkpointStore,
     IExportRequestTrackerWriter trackerWriter,
+    IDistributedEventBus eventBus,
     IHttpClientFactory httpClientFactory,
     IOptions<GranitPrivacyOptions> options,
     TimeProvider timeProvider,
@@ -213,6 +215,21 @@ internal sealed partial class PrivacyExportAssemblyService(
                 finalState,
                 manifestBlobReference,
                 completion.MissingProviders,
+                cancellationToken).ConfigureAwait(false);
+
+            // The notification handler subscribes to this event (not the saga's
+            // ExportCompletedEto) so the download links it embeds can be trusted —
+            // the shards are committed before the email goes out.
+            await eventBus.PublishAsync(
+                new ExportArchiveAssembledEto(
+                    RequestId: completion.RequestId,
+                    UserId: completion.UserId,
+                    ManifestBlobReferenceId: manifestBlobReference,
+                    ShardCount: shards.Count,
+                    IsPartial: completion.IsPartial,
+                    Regulation: completion.Regulation,
+                    RequestedAt: completion.RequestedAt,
+                    TenantId: completion.TenantId),
                 cancellationToken).ConfigureAwait(false);
 
             await checkpointStore.ClearAsync(completion.RequestId, completion.TenantId, cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Privacy.Notifications/Handlers/ExportCompletedNotificationHandler.cs
+++ b/src/Granit.Privacy.Notifications/Handlers/ExportCompletedNotificationHandler.cs
@@ -4,13 +4,17 @@ using Granit.Privacy.DataExport.Events;
 namespace Granit.Privacy.Notifications.Handlers;
 
 /// <summary>
-/// Handles <see cref="ExportCompletedEto"/> by routing to the right user-facing
-/// notification depending on whether the saga produced a complete or partial archive.
+/// Routes export-lifecycle events to the right user-facing notification:
+/// the failure email keys off the saga's <see cref="ExportCompletedEto"/>
+/// (the saga is the only place that knows about timeouts / partial results),
+/// while the success email keys off <see cref="ExportArchiveAssembledEto"/>
+/// (published by the assembly job once every shard is persisted, so the
+/// embedded download links can be trusted).
 /// </summary>
 /// <remarks>
-/// Branching at the handler level (rather than registering two competing handlers on
-/// the same event) avoids having both the "ready" and "failed" notifications
-/// dispatched for a single completion — the user sees exactly one outcome email.
+/// Splitting the subscription this way prevents the previous race window in
+/// which the "ready" email could fire before any shard reached storage — the
+/// user would have followed the link and seen a not-yet-available archive.
 /// </remarks>
 public class ExportCompletedNotificationHandler
 {
@@ -19,19 +23,37 @@ public class ExportCompletedNotificationHandler
         INotificationPublisher publisher,
         CancellationToken cancellationToken)
     {
+        // Only the partial-completion branch fires here — the assembly job emits a
+        // dedicated ExportArchiveAssembledEto on success that the second handler
+        // below picks up. Complete sagas with no missing providers are intentionally
+        // a no-op on this path.
+        if (!evt.IsPartial)
+        {
+            return;
+        }
+
+        await publisher.PublishAsync(
+            PrivacyExportFailedNotificationType.Instance,
+            new PrivacyExportFailedNotificationData(
+                evt.RequestId,
+                evt.ArchiveBlobReferenceId,
+                evt.MissingProviders,
+                string.Join(", ", evt.MissingProviders),
+                evt.RequestedAt,
+                evt.Regulation),
+            [evt.UserId.ToString()],
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task HandleAsync(
+        ExportArchiveAssembledEto evt,
+        INotificationPublisher publisher,
+        CancellationToken cancellationToken)
+    {
+        // Partial completions already fired the failure email from the saga's
+        // ExportCompletedEto — skip the success email so the user sees one outcome.
         if (evt.IsPartial)
         {
-            await publisher.PublishAsync(
-                PrivacyExportFailedNotificationType.Instance,
-                new PrivacyExportFailedNotificationData(
-                    evt.RequestId,
-                    evt.ArchiveBlobReferenceId,
-                    evt.MissingProviders,
-                    string.Join(", ", evt.MissingProviders),
-                    evt.RequestedAt,
-                    evt.Regulation),
-                [evt.UserId.ToString()],
-                cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -39,7 +61,7 @@ public class ExportCompletedNotificationHandler
             PrivacyExportReadyNotificationType.Instance,
             new PrivacyExportReadyNotificationData(
                 evt.RequestId,
-                evt.ArchiveBlobReferenceId,
+                evt.ShardCount,
                 evt.RequestedAt,
                 evt.Regulation),
             [evt.UserId.ToString()],

--- a/src/Granit.Privacy.Notifications/PrivacyExportReadyNotificationType.cs
+++ b/src/Granit.Privacy.Notifications/PrivacyExportReadyNotificationType.cs
@@ -1,13 +1,13 @@
-using Granit.Domain.ValueObjects;
 using Granit.Notifications;
 
 namespace Granit.Privacy.Notifications;
 
 /// <summary>
 /// Notification type for a personal data export that completed successfully —
-/// sent to the data subject after the export saga finished without timeouts.
-/// Carries the blob reference of the assembled archive so the email template can
-/// render a pre-signed download link.
+/// sent to the data subject after the archive assembly job persisted every shard.
+/// Carries the shard count so the email template can render one BFF download
+/// link per shard (no direct presigned URLs in the email body — every download
+/// stays under the step-up authentication gate).
 /// </summary>
 /// <remarks>
 /// Channel: Email only by default — the archive must reach the user as a transactional
@@ -35,22 +35,15 @@ public sealed class PrivacyExportReadyNotificationType
 /// Data payload for an export-ready notification.
 /// </summary>
 /// <param name="RequestId">Correlation id of the originating export request.</param>
-/// <param name="ArchiveBlobReferenceId">
-/// Logical blob reference of the assembled archive — the email template resolves
-/// this to a pre-signed download URL via the BlobStorage download endpoint.
-/// </param>
+/// <param name="ShardCount">Number of shard ZIPs the assembly job produced.
+/// Templates iterate <c>0..(ShardCount - 1)</c> to render one BFF download
+/// link per shard via <c>{{ app.base_url }}/privacy/exports/{{ model.request_id }}/download/{{ index }}</c>.</param>
 /// <param name="RequestedAt">When the data subject filed the request.</param>
-/// <param name="Regulation">Privacy regulation code the request was filed under (e.g. <c>EU_GDPR</c>).</param>
+/// <param name="Regulation">Privacy regulation code the request was filed under
+/// (e.g. <c>EU_GDPR</c>). Templates pick the localised display form (RGPD / DSGVO
+/// / RODO / GDPR) via the surrounding copy, not from this raw code.</param>
 public sealed record PrivacyExportReadyNotificationData(
     Guid RequestId,
-    BlobReference ArchiveBlobReferenceId,
+    int ShardCount,
     DateTimeOffset RequestedAt,
-    string Regulation)
-{
-    /// <summary>
-    /// String form of <see cref="ArchiveBlobReferenceId"/> exposed for Scriban templates.
-    /// Email templates render <c>{{ model.archive_blob_reference_display }}</c> to avoid
-    /// reaching through the value object's <c>.value</c> indirection in template syntax.
-    /// </summary>
-    public string ArchiveBlobReferenceDisplay => ArchiveBlobReferenceId.Value;
-}
+    string Regulation);

--- a/src/Granit.Privacy.Notifications/Templates/privacy.export_ready.fr.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.export_ready.fr.html
@@ -1,11 +1,24 @@
 <title>Votre export de données personnelles est prêt</title>
 <p>Bonjour,</p>
 <p>Votre export de données personnelles, demandé le <strong>{{ model.requested_at | date.to_string '%d %B %Y' }}</strong>{{ if model.regulation }} au titre de la réglementation <code>{{ model.regulation }}</code>{{ end }}, est désormais prêt à être téléchargé.</p>
+{{ if model.shard_count > 1 }}
+<p>Votre archive a été répartie sur <strong>{{ model.shard_count }} fichiers</strong>. Téléchargez chacun d'eux — ils peuvent être ouverts indépendamment :</p>
+<ul style="padding-left: 18px;">
+  {{ for i in 0..(model.shard_count - 1) }}
+  <li style="margin: 6px 0;">
+    <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}/download/{{ i }}">Fichier {{ i + 1 }} sur {{ model.shard_count }}</a>
+  </li>
+  {{ end }}
+</ul>
+<p>Vous pouvez aussi télécharger le manifeste d'intégrité pour vérifier chaque fichier :</p>
+<p><a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}/download/manifest">Télécharger le manifeste</a></p>
+{{ else }}
 <p>Vous pouvez télécharger votre archive depuis votre espace de confidentialité :</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Télécharger mon archive</a>
+  <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}/download/0" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Télécharger mon archive</a>
 </p>
-<p>Le lien de téléchargement a une durée de validité limitée pour votre sécurité. S'il expire, vous pouvez en générer un nouveau depuis cette même page.</p>
+{{ end }}
+<p>Pour votre sécurité, chaque lien de téléchargement déclenche une brève ré-authentification. Si vous n'êtes pas à l'origine de cette demande, contactez-nous immédiatement.</p>
 <p>Référence : <code>{{ model.request_id }}</code></p>
 {{ if privacy.dpo_email }}
 <p style="font-size: 13px; color: #4b5563;">Une question sur vos données ? Contactez notre Délégué à la Protection des Données : <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.export_ready.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.export_ready.html
@@ -1,11 +1,24 @@
 <title>Your personal data export is ready</title>
 <p>Hi,</p>
 <p>Your personal data export, requested on <strong>{{ model.requested_at | date.to_string '%B %d, %Y' }}</strong>{{ if model.regulation }} under regulation <code>{{ model.regulation }}</code>{{ end }}, is now ready for download.</p>
+{{ if model.shard_count > 1 }}
+<p>Your archive was split across <strong>{{ model.shard_count }} files</strong>. Download each one — they can be opened independently:</p>
+<ul style="padding-left: 18px;">
+  {{ for i in 0..(model.shard_count - 1) }}
+  <li style="margin: 6px 0;">
+    <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}/download/{{ i }}">Shard {{ i + 1 }} of {{ model.shard_count }}</a>
+  </li>
+  {{ end }}
+</ul>
+<p>You can also download the integrity manifest to verify each shard:</p>
+<p><a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}/download/manifest">Download manifest</a></p>
+{{ else }}
 <p>You can download your archive from your privacy dashboard:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Download my archive</a>
+  <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}/download/0" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Download my archive</a>
 </p>
-<p>The download link is time-limited for your security. If it expires, you can request a new one from the same page.</p>
+{{ end }}
+<p>For your security, each download link triggers a brief re-authentication. If you don't recognise this request, contact us immediately.</p>
 <p>Reference: <code>{{ model.request_id }}</code></p>
 {{ if privacy.dpo_email }}
 <p style="font-size: 13px; color: #4b5563;">Questions about your data? Contact our Data Protection Officer at <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>

--- a/src/Granit.Privacy/DataExport/Events/ExportArchiveAssembledEto.cs
+++ b/src/Granit.Privacy/DataExport/Events/ExportArchiveAssembledEto.cs
@@ -1,0 +1,35 @@
+using Granit.Domain.ValueObjects;
+using Granit.Events;
+
+namespace Granit.Privacy.DataExport.Events;
+
+/// <summary>
+/// Published by the archive-assembly background job once every shard plus the signed
+/// manifest sidecar are persisted. Distinct from <see cref="ExportCompletedEto"/> —
+/// that event fires when the saga finishes gathering fragments, well before the
+/// shards exist in storage. Notification handlers (and any downstream consumer that
+/// needs to link to the actual archive bytes) MUST subscribe to this event, not the
+/// saga's completion event, otherwise the user receives a download link before the
+/// shards are uploaded.
+/// </summary>
+/// <param name="RequestId">Correlation id of the originating export request.</param>
+/// <param name="UserId">Data subject whose archive is now downloadable.</param>
+/// <param name="ManifestBlobReferenceId">Blob reference of the signed manifest
+/// sidecar (the addressable artifact on the tracker).</param>
+/// <param name="ShardCount">Number of shard ZIPs the assembler produced — drives the
+/// per-shard link list rendered in the notification email.</param>
+/// <param name="IsPartial"><c>true</c> when the saga reported a partial completion;
+/// passed through so notification handlers can preserve the partial-vs-complete
+/// distinction without re-reading the tracker.</param>
+/// <param name="Regulation">Privacy regulation code the request was filed under.</param>
+/// <param name="RequestedAt">When the data subject filed the request.</param>
+/// <param name="TenantId">Tenant scope propagated from the originating request.</param>
+public sealed record ExportArchiveAssembledEto(
+    Guid RequestId,
+    Guid UserId,
+    BlobReference ManifestBlobReferenceId,
+    int ShardCount,
+    bool IsPartial,
+    string Regulation,
+    DateTimeOffset RequestedAt,
+    Guid? TenantId = null) : IIntegrationEvent;

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
@@ -7,6 +7,7 @@ using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Internal;
 using Granit.BlobStorage.Options;
 using Granit.Domain.ValueObjects;
+using Granit.Events;
 using Granit.Privacy.BlobStorage.DataExport;
 using Granit.Privacy.BlobStorage.DataExport.Internal;
 using Granit.Privacy.DataExport;
@@ -35,6 +36,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
     private readonly IExportRequestTrackerWriter _tracker = Substitute.For<IExportRequestTrackerWriter>();
     private readonly InMemoryExportAssemblyCheckpointStore _checkpoints = new();
     private readonly EphemeralExportHmacSigner _hmacSigner = new(NullLogger<EphemeralExportHmacSigner>.Instance);
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
     private readonly FakeHttpMessageHandler _http = new();
     private readonly ServiceProvider _sp;
     private readonly PrivacyMetrics _metrics;
@@ -319,7 +321,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         GranitPrivacyOptions opts = new() { ExportShardMaxSizeMb = 1 };
         PrivacyExportAssemblyService sut = new(
             _blobStorage, _blobStoreProvider, _hmacSigner, _hmacSigner, spy, _tracker,
-            new FakeHttpClientFactory(_http), ConfigOptions.Create(opts),
+            _eventBus, new FakeHttpClientFactory(_http), ConfigOptions.Create(opts),
             _timeProvider, _metrics, NullLogger<PrivacyExportAssemblyService>.Instance);
 
         await sut.AssembleAsync(evt, TestContext.Current.CancellationToken);
@@ -406,6 +408,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
             _hmacSigner,
             _checkpoints,
             _tracker,
+            _eventBus,
             new FakeHttpClientFactory(_http),
             ConfigOptions.Create(opts ?? new GranitPrivacyOptions()),
             _timeProvider,

--- a/tests/Granit.Privacy.Notifications.Tests/Handlers/ExportCompletedNotificationHandlerTests.cs
+++ b/tests/Granit.Privacy.Notifications.Tests/Handlers/ExportCompletedNotificationHandlerTests.cs
@@ -9,34 +9,81 @@ namespace Granit.Privacy.Notifications.Tests.Handlers;
 public sealed class ExportCompletedNotificationHandlerTests
 {
     [Fact]
-    public async Task HandleAsync_CompleteExport_PublishesReadyNotification()
+    public async Task HandleAsync_CompleteAssembly_PublishesReadyNotificationWithShardCount()
     {
         INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
         var userId = Guid.NewGuid();
         var requestId = Guid.NewGuid();
         DateTimeOffset requestedAt = DateTimeOffset.UtcNow.AddMinutes(-3);
-        ExportCompletedEto evt = new(
+        ExportArchiveAssembledEto evt = new(
             RequestId: requestId,
             UserId: userId,
-            ArchiveBlobReferenceId: "personal-data-export/abc",
+            ManifestBlobReferenceId: "abc-manifest",
+            ShardCount: 3,
             IsPartial: false,
-            MissingProviders: [],
-            Fragments: [],
             Regulation: "EU_GDPR",
             RequestedAt: requestedAt);
 
-        await ExportCompletedNotificationHandler.HandleAsync(evt, publisher, CancellationToken.None);
+        await ExportCompletedNotificationHandler.HandleAsync(evt, publisher, TestContext.Current.CancellationToken);
 
         await publisher.Received(1).PublishAsync(
             PrivacyExportReadyNotificationType.Instance,
             Arg.Is<PrivacyExportReadyNotificationData>(d =>
                 d.RequestId == requestId &&
-                d.ArchiveBlobReferenceId == "personal-data-export/abc" &&
+                d.ShardCount == 3 &&
                 d.RequestedAt == requestedAt &&
                 d.Regulation == "EU_GDPR"),
             Arg.Is<IReadOnlyList<string>>(ids => ids.Count == 1 && ids[0] == userId.ToString()),
             Arg.Any<CancellationToken>());
+    }
 
+    [Fact]
+    public async Task HandleAsync_AssembledButFlaggedPartial_SkipsReadyNotification()
+    {
+        // The saga's ExportCompletedEto (handled below) is the only place that emits
+        // the failure email — the assembled-event handler must not double-fire.
+        INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
+        ExportArchiveAssembledEto evt = new(
+            RequestId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
+            ManifestBlobReferenceId: "abc",
+            ShardCount: 1,
+            IsPartial: true,
+            Regulation: "EU_GDPR",
+            RequestedAt: DateTimeOffset.UtcNow);
+
+        await ExportCompletedNotificationHandler.HandleAsync(evt, publisher, TestContext.Current.CancellationToken);
+
+        await publisher.DidNotReceive().PublishAsync(
+            PrivacyExportReadyNotificationType.Instance,
+            Arg.Any<PrivacyExportReadyNotificationData>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_CompleteSaga_SkipsFailureNotification()
+    {
+        // The success path used to ride ExportCompletedEto; it now defers to
+        // ExportArchiveAssembledEto so the email links point at committed shards.
+        INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
+        ExportCompletedEto evt = new(
+            RequestId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
+            ArchiveBlobReferenceId: "personal-data-export/abc",
+            IsPartial: false,
+            MissingProviders: [],
+            Fragments: [],
+            Regulation: "EU_GDPR",
+            RequestedAt: DateTimeOffset.UtcNow);
+
+        await ExportCompletedNotificationHandler.HandleAsync(evt, publisher, TestContext.Current.CancellationToken);
+
+        await publisher.DidNotReceive().PublishAsync(
+            PrivacyExportReadyNotificationType.Instance,
+            Arg.Any<PrivacyExportReadyNotificationData>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>());
         await publisher.DidNotReceive().PublishAsync(
             PrivacyExportFailedNotificationType.Instance,
             Arg.Any<PrivacyExportFailedNotificationData>(),
@@ -45,7 +92,7 @@ public sealed class ExportCompletedNotificationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_PartialExport_PublishesFailedNotificationWithMissingProviders()
+    public async Task HandleAsync_PartialSaga_PublishesFailureNotification()
     {
         INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
         var userId = Guid.NewGuid();
@@ -62,7 +109,7 @@ public sealed class ExportCompletedNotificationHandlerTests
             Regulation: "EU_GDPR",
             RequestedAt: requestedAt);
 
-        await ExportCompletedNotificationHandler.HandleAsync(evt, publisher, CancellationToken.None);
+        await ExportCompletedNotificationHandler.HandleAsync(evt, publisher, TestContext.Current.CancellationToken);
 
         await publisher.Received(1).PublishAsync(
             PrivacyExportFailedNotificationType.Instance,
@@ -74,12 +121,6 @@ public sealed class ExportCompletedNotificationHandlerTests
                 d.RequestedAt == requestedAt &&
                 d.Regulation == "EU_GDPR"),
             Arg.Is<IReadOnlyList<string>>(ids => ids.Count == 1 && ids[0] == userId.ToString()),
-            Arg.Any<CancellationToken>());
-
-        await publisher.DidNotReceive().PublishAsync(
-            PrivacyExportReadyNotificationType.Instance,
-            Arg.Any<PrivacyExportReadyNotificationData>(),
-            Arg.Any<IReadOnlyList<string>>(),
             Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary

Closes the race where the \"export ready\" email could fire before the assembly job had persisted any shard. The success notification now subscribes to a new `ExportArchiveAssembledEto` emitted by the assembly service AFTER `MarkCompletedAsync`, so every download link in the email body points to bytes that already exist in storage.

The saga's `ExportCompletedEto` continues to drive only the partial / failure path — that's where missing-provider data lives. Splitting the two events along the success/failure axis keeps the user receiving exactly one outcome email.

## Email template

EN + FR rewritten to iterate `0..(ShardCount - 1)` and emit one BFF download link per shard, plus a manifest link when `ShardCount > 1`. Single-shard exports keep the centred CTA layout. No presigned URLs are embedded anywhere — every download stays behind the step-up gate from #2348.

## Breaking changes

- `ExportArchiveAssembledEto` — new event, published by `PrivacyExportAssemblyService` after the manifest is persisted.
- `PrivacyExportReadyNotificationData`:
  - removed `ArchiveBlobReferenceId` / `ArchiveBlobReferenceDisplay`
  - added `ShardCount: int`
- `ExportCompletedNotificationHandler.HandleAsync(ExportCompletedEto, ...)` now only handles the partial-completion branch; success is a separate overload on `ExportArchiveAssembledEto`.
- `PrivacyExportAssemblyService` constructor takes a new `IDistributedEventBus` dependency.

## Follow-up

The 16 auto-translated cultures keep their existing single-download-link copy (pointing at the BFF dashboard) — re-translation via `scripts/translate-templates.py` is tracked separately. Functionality is unaffected: stale templates degrade to the dashboard URL, which already lists shards.

## Test plan
- [x] `dotnet test tests/Granit.Privacy.BlobStorage.Tests` — 64/64
- [x] `dotnet test tests/Granit.Privacy.Notifications.Tests` — 274/274 (rewritten handler tests for the dual-event topology)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 235/235
- [x] `dotnet format` clean across all modified projects
- [ ] CI green on full shard matrix