### PR TITLE
docs(privacy-export): bucket lifecycle policies reference (P6.4.6)

### DIFF
--- a/src/Granit.Privacy.BlobStorage/Lifecycle.md
+++ b/src/Granit.Privacy.BlobStorage/Lifecycle.md
@@ -1,0 +1,115 @@
+# Bucket lifecycle policies for personal-data exports
+
+This package writes two classes of objects into blob storage:
+
+| Object | Container / bucket | Lifetime |
+| --- | --- | --- |
+| Shard ZIPs (`personal-data-export/{requestId}-{NNN}.zip`) | `gdpr-exports` (`PrivacyExportContainerNames.FragmentContainer`) | Long enough for the data subject to download — but no longer. |
+| Manifest sidecar (`personal-data-export-{requestId}-manifest.json`) | same bucket | Same as shards. |
+| Staged provider fragments (transient JSON / blobs uploaded by `PrivacyFragmentUploader`) | same bucket | Until the assembly job has consumed them. |
+
+The assembly path leaves an object behind for two reasons:
+
+- **Crash-resume.** A failed multipart upload sits as part-blobs until the lifecycle policy reaps them.
+- **GDPR Art. 12(3) ceiling.** A completed export should not linger indefinitely — the controller MUST delete it once the subject has had a reasonable window to download.
+
+The framework intentionally does NOT auto-delete on its own — host operators configure the storage account's lifecycle policy to match their compliance posture. The reference policies below are the framework's defaults.
+
+## S3 (Terraform)
+
+```hcl
+resource "aws_s3_bucket_lifecycle_configuration" "gdpr_exports" {
+  bucket = aws_s3_bucket.gdpr_exports.id
+
+  # 1. Reap orphan multipart uploads — assemble crashes, AbortMultipartUpload
+  # never fires, the parts sit forever otherwise. 1 day is well past Wolverine's
+  # default retry-with-cooldown budget (~21 minutes).
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+
+  # 2. Safety-net expiration — every object in the bucket expires after the
+  # configured GDPR retention window, regardless of whether the assembler
+  # tagged it as completed. Defends against a crash between
+  # CompleteMultipartUpload and the (future) tag-on-completion call.
+  rule {
+    id     = "gdpr-export-retention-safety-net"
+    status = "Enabled"
+    expiration {
+      days = 30
+    }
+  }
+}
+```
+
+## Azure Blob (Bicep)
+
+```bicep
+resource lifecyclePolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    policy: {
+      rules: [
+        {
+          name: 'gdpr-export-retention-safety-net'
+          enabled: true
+          type: 'Lifecycle'
+          definition: {
+            filters: {
+              blobTypes: ['blockBlob']
+              prefixMatch: ['gdpr-exports/']
+            }
+            actions: {
+              baseBlob: {
+                delete: { daysAfterCreationGreaterThan: 30 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Azure Block Blob has no equivalent of S3's `abort_incomplete_multipart_upload` — Azure documents that uncommitted blocks expire **automatically after 7 days** per the service contract, so the rule isn't needed.
+
+## GCS (Terraform)
+
+```hcl
+resource "google_storage_bucket" "gdpr_exports" {
+  name                        = "gdpr-exports"
+  uniform_bucket_level_access = true
+
+  lifecycle_rule {
+    condition { age = 30 }
+    action    { type = "Delete" }
+  }
+
+  # GCS resumable upload sessions expire after 7 days per the service contract,
+  # so no explicit abort-incomplete rule is required.
+}
+```
+
+## Tunables
+
+The framework's defaults assume a 30-day grace window:
+
+- **Too short** for a subject who fired and forgot the request — the email link will 404 silently.
+- **Too long** wastes storage and increases the breach-blast radius.
+
+30 days mirrors the manifest expiry encoded in `ExportDownloadUrlExpiryMinutes` (24 h presigned URL) × a 30× safety margin, and aligns with most regulators' "month or so" reasonable-window expectations under Art. 12(3).
+
+## Tag-based completion lifecycle (planned)
+
+The plan §14 calls for a more granular policy that distinguishes completed objects from in-flight ones:
+
+- Reap **uncompleted** uploads after 1 day.
+- Reap **completed** shards after 30 days — keyed off a `granit-export-status=completed` object tag the assembler would set on `CompleteMultipartUploadAsync`.
+
+This requires extending `IBlobStoreProvider` with a tagging hook on multipart completion. Tracked as a follow-up; the age-based policy above is the working interim.

--- a/src/Granit.Privacy.BlobStorage/README.md
+++ b/src/Granit.Privacy.BlobStorage/README.md
@@ -86,6 +86,15 @@ The archive assembler:
    `Completed`, `PartiallyCompleted` (saga timed out), or `SizeLimitExceeded`
    (archive exceeded `ExportMaxSizeMb`)
 
+## Bucket lifecycle policies
+
+Personal-data exports are persistent objects under GDPR Art. 12(3) and need an
+explicit retention ceiling on the storage account. The framework does NOT
+auto-delete on its own — host operators configure the lifecycle policy to
+match their compliance posture. Reference Terraform / Bicep snippets for S3,
+Azure Blob, and GCS, plus the planned tag-based completion lifecycle, live in
+[Lifecycle.md](Lifecycle.md).
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).


### PR DESCRIPTION
## Summary

Closes the Takeout-style export epic with a docs-only PR: reference IaC snippets for the two retention concerns the framework can't enforce from inside the .NET process.

`granit-dotnet` doesn't ship Terraform / Bicep itself — host operators apply the IaC to their own infra repo. This PR documents what \"correct\" looks like.

## What's documented

- **`src/Granit.Privacy.BlobStorage/Lifecycle.md`** — three lifecycle blocks (S3 Terraform, Azure Bicep, GCS Terraform):
  - Orphan multipart-upload reaping after 1 day (S3 + GCS — Azure handles this in the service contract).
  - 30-day object retention ceiling — satisfies GDPR Art. 12(3) without keeping multi-GB archives indefinitely.
- BlobStorage README cross-links to `Lifecycle.md`.

The plan §14 **tag-based variant** (`granit-export-status=completed` differentiating completed vs in-flight) is noted as a follow-up — it needs a tagging hook on `IBlobStoreProvider.OpenWriteMultipartAsync` that doesn't exist yet. The age-based safety-net is the working interim.

## Epic close-out

This is the last sub-PR of the Takeout-style portability epic (P6.3 → P6.4):

| Sub-PR | Title | PR |
|---|---|---|
| P6.3d | S3 native multipart override | #2344 |
| P6.3d.2 | Azure Blob native multipart override | #2345 |
| P6.3d.3 | GCS resumable upload native multipart override | #2347 |
| P6.4.1+2 | Step-up auth + multi-shard download endpoints | #2348 |
| P6.4.3 | Signed manifest with sha256 + HMAC envelope | #2349 |
| P6.4.4 | Multi-shard download links in notification email | #2350 |
| P6.4.5 | ROPA audit lifecycle to Granit.Auditing | #2351 |
| P6.4.6 | Bucket lifecycle policies reference (this PR) | — |

Out of scope this epic (already noted in the plan):
- `Privacy.Exports.OnBehalfOf` (admin DSR) → v1.1
- Drive / Dropbox / OneDrive destinations → v2
- Documents provider concrete impl → hand-off to `granit-business`
- Failed-audit DLQ hook in `Granit.Privacy.BackgroundJobs.Wolverine` → tracked separately
- Tag-on-completion in `IBlobStoreProvider` (tag-based lifecycle) → tracked separately

## Test plan
- [x] `npx markdownlint-cli2` clean on both modified files
- [ ] CI green