### PR TITLE
feat(privacy-export): emit remaining ROPA events (P6.4.5 follow-up)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36946,6 +36946,24 @@
           "returnType": "Task"
         },
         {
+          "name": "WriteFragmentPreparedAsync",
+          "kind": "method",
+          "signature": "WriteFragmentPreparedAsync(PrivacyExportFragmentPreparedAudit data, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "WriteAssemblyStartedAsync",
+          "kind": "method",
+          "signature": "WriteAssemblyStartedAsync(PrivacyExportAssemblyStartedAudit data, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "WriteShardCompletedAsync",
+          "kind": "method",
+          "signature": "WriteShardCompletedAsync(PrivacyExportShardCompletedAudit data, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
           "name": "WriteExportCompletedAsync",
           "kind": "method",
           "signature": "WriteExportCompletedAsync(PrivacyExportCompletedAudit data, CancellationToken cancellationToken)",
@@ -37157,7 +37175,7 @@
       "kind": "record",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs",
-      "line": 500,
+      "line": 579,
       "members": []
     },
     {
@@ -37223,7 +37241,7 @@
       "kind": "class",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/PrivacyFragmentUploader.cs",
-      "line": 23,
+      "line": 26,
       "members": []
     },
     {
@@ -37479,6 +37497,24 @@
           "returnType": "Task"
         },
         {
+          "name": "WriteFragmentPreparedAsync",
+          "kind": "method",
+          "signature": "WriteFragmentPreparedAsync(PrivacyExportFragmentPreparedAudit data, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "WriteAssemblyStartedAsync",
+          "kind": "method",
+          "signature": "WriteAssemblyStartedAsync(PrivacyExportAssemblyStartedAudit data, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "WriteShardCompletedAsync",
+          "kind": "method",
+          "signature": "WriteShardCompletedAsync(PrivacyExportShardCompletedAudit data, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
           "name": "WriteExportCompletedAsync",
           "kind": "method",
           "signature": "WriteExportCompletedAsync(PrivacyExportCompletedAudit data, CancellationToken cancellationToken)",
@@ -37499,12 +37535,21 @@
       ]
     },
     {
+      "name": "PrivacyExportAssemblyStartedAudit",
+      "fqn": "Granit.Privacy.DataExport.Audit.PrivacyExportAssemblyStartedAudit",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs",
+      "line": 162,
+      "members": []
+    },
+    {
       "name": "PrivacyExportCompletedAudit",
       "fqn": "Granit.Privacy.DataExport.Audit.PrivacyExportCompletedAudit",
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs",
-      "line": 75,
+      "line": 88,
       "members": []
     },
     {
@@ -37513,7 +37558,16 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs",
-      "line": 119,
+      "line": 207,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportFragmentPreparedAudit",
+      "fqn": "Granit.Privacy.DataExport.Audit.PrivacyExportFragmentPreparedAudit",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs",
+      "line": 137,
       "members": []
     },
     {
@@ -37522,7 +37576,16 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs",
-      "line": 51,
+      "line": 64,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportShardCompletedAudit",
+      "fqn": "Granit.Privacy.DataExport.Audit.PrivacyExportShardCompletedAudit",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs",
+      "line": 187,
       "members": []
     },
     {
@@ -37531,7 +37594,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs",
-      "line": 98,
+      "line": 111,
       "members": []
     },
     {

--- a/src/Granit.Privacy.Auditing/AuditingPrivacyExportAuditWriter.cs
+++ b/src/Granit.Privacy.Auditing/AuditingPrivacyExportAuditWriter.cs
@@ -47,6 +47,62 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 ])],
         }, cancellationToken);
 
+    public Task WriteFragmentPreparedAsync(PrivacyExportFragmentPreparedAudit data, CancellationToken cancellationToken) =>
+        auditingWriter.WriteAsync(new AuditEntry
+        {
+            Timestamp = data.Timestamp,
+            UserId = data.SubjectUserId.ToString("D", CultureInfo.InvariantCulture),
+            Category = AuditCategory.DataAccess,
+            TenantId = data.TenantId,
+            EntityChanges = [BuildLifecycleChange(
+                data.RequestId,
+                AuditChangeType.Modified,
+                [
+                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "fragment-prepared" },
+                    new AuditPropertyChange { PropertyName = "ProviderName", NewValue = data.ProviderName },
+                    new AuditPropertyChange { PropertyName = "FragmentKind", NewValue = data.FragmentKind },
+                    new AuditPropertyChange { PropertyName = "EntryPathHash", NewValue = data.EntryPathHash },
+                    new AuditPropertyChange { PropertyName = "SizeBytes", NewValue = (data.SizeBytes ?? -1).ToString(CultureInfo.InvariantCulture) },
+                ])],
+        }, cancellationToken);
+
+    public Task WriteAssemblyStartedAsync(PrivacyExportAssemblyStartedAudit data, CancellationToken cancellationToken) =>
+        auditingWriter.WriteAsync(new AuditEntry
+        {
+            Timestamp = data.Timestamp,
+            UserId = data.SubjectUserId.ToString("D", CultureInfo.InvariantCulture),
+            Category = AuditCategory.DataAccess,
+            TenantId = data.TenantId,
+            EntityChanges = [BuildLifecycleChange(
+                data.RequestId,
+                AuditChangeType.Modified,
+                [
+                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "assembly-started" },
+                    new AuditPropertyChange { PropertyName = "Regulation", NewValue = data.Regulation },
+                    new AuditPropertyChange { PropertyName = "ExpectedFragmentCount", NewValue = data.ExpectedFragmentCount.ToString(CultureInfo.InvariantCulture) },
+                    new AuditPropertyChange { PropertyName = "IsResumed", NewValue = data.IsResumed ? "true" : "false" },
+                ])],
+        }, cancellationToken);
+
+    public Task WriteShardCompletedAsync(PrivacyExportShardCompletedAudit data, CancellationToken cancellationToken) =>
+        auditingWriter.WriteAsync(new AuditEntry
+        {
+            Timestamp = data.Timestamp,
+            UserId = data.SubjectUserId.ToString("D", CultureInfo.InvariantCulture),
+            Category = AuditCategory.DataAccess,
+            TenantId = data.TenantId,
+            EntityChanges = [BuildLifecycleChange(
+                data.RequestId,
+                AuditChangeType.Modified,
+                [
+                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "shard-completed" },
+                    new AuditPropertyChange { PropertyName = "ShardIndex", NewValue = data.ShardIndex.ToString(CultureInfo.InvariantCulture) },
+                    new AuditPropertyChange { PropertyName = "SizeBytes", NewValue = data.SizeBytes.ToString(CultureInfo.InvariantCulture) },
+                    new AuditPropertyChange { PropertyName = "Sha256", NewValue = data.Sha256Hex },
+                    new AuditPropertyChange { PropertyName = "DurationMs", NewValue = data.DurationMs.ToString(CultureInfo.InvariantCulture) },
+                ])],
+        }, cancellationToken);
+
     public Task WriteExportCompletedAsync(PrivacyExportCompletedAudit data, CancellationToken cancellationToken) =>
         auditingWriter.WriteAsync(new AuditEntry
         {

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
@@ -121,9 +121,24 @@ internal sealed partial class PrivacyExportAssemblyService(
                 cancellationToken).ConfigureAwait(false);
         }
 
+        await auditWriter.WriteAssemblyStartedAsync(
+            new PrivacyExportAssemblyStartedAudit(
+                RequestId: completion.RequestId,
+                SubjectUserId: completion.UserId,
+                TenantId: completion.TenantId,
+                Regulation: completion.Regulation,
+                ExpectedFragmentCount: completion.Fragments.Count,
+                IsResumed: resumeFrom is not null,
+                Timestamp: timeProvider.GetUtcNow()),
+            cancellationToken).ConfigureAwait(false);
+
         HttpClient httpClient = httpClientFactory.CreateClient(HttpClientName);
         List<string> emptyProviders = [];
         List<ExportManifestFragment> manifestFragments = [];
+
+        // Wall-clock anchor for per-shard duration audit. Reset on every rollover so
+        // each ShardCompleted entry records the time spent on that shard alone.
+        long shardStartTimestamp = Stopwatch.GetTimestamp();
 
         string objectKeyPrefix = BuildObjectKeyPrefix(completion.RequestId);
         await using ShardingArchiveWriter writer = new(
@@ -199,10 +214,22 @@ internal sealed partial class PrivacyExportAssemblyService(
                             NextFragmentIndex: i,
                             CompletedShardObjectKeys: [.. writer.Shards.Select(s => s.ObjectKey)]),
                         cancellationToken).ConfigureAwait(false);
+
+                    await EmitShardCompletedAuditAsync(completion, writer.Shards[^1], shardStartTimestamp, cancellationToken)
+                        .ConfigureAwait(false);
+                    shardStartTimestamp = Stopwatch.GetTimestamp();
                 }
             }
 
+            // Capture the shard count before CompleteAsync to detect whether a final
+            // open shard closes inside it (last shard never rolled over mid-loop).
+            int shardsBeforeFinal = writer.Shards.Count;
             IReadOnlyList<ShardManifest> shards = await writer.CompleteAsync(cancellationToken).ConfigureAwait(false);
+            if (shards.Count > shardsBeforeFinal)
+            {
+                await EmitShardCompletedAuditAsync(completion, shards[^1], shardStartTimestamp, cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
             BlobReference manifestBlobReference = await UploadManifestAsync(
                 completion, emptyProviders, manifestFragments, shards, httpClient, cancellationToken)
@@ -270,6 +297,7 @@ internal sealed partial class PrivacyExportAssemblyService(
                 completion.IsPartial,
                 duration,
                 completion.Regulation);
+            await EmitFailedAuditAsync(completion, ex, cancellationToken).ConfigureAwait(false);
             throw new PrivacyExportAssemblyException(
                 completion.RequestId,
                 $"Privacy export {completion.RequestId} assembly failed: {ex.Message}",
@@ -287,7 +315,58 @@ internal sealed partial class PrivacyExportAssemblyService(
                 completion.IsPartial,
                 duration,
                 completion.Regulation);
+            await EmitFailedAuditAsync(completion, ex, cancellationToken).ConfigureAwait(false);
             throw;
+        }
+    }
+
+    private Task EmitShardCompletedAuditAsync(
+        ExportCompletedEto completion,
+        ShardManifest shard,
+        long shardStartTimestamp,
+        CancellationToken cancellationToken)
+    {
+        long durationMs = (long)Stopwatch.GetElapsedTime(shardStartTimestamp).TotalMilliseconds;
+        // Resumed shards arrive with empty sha256 (re-streaming to recompute would
+        // defeat the checkpoint). Emit an empty digest in that case so the audit row
+        // still pins the shard's identity by index + size.
+        string sha256Hex = shard.Sha256.Length == 0 ? "" : Convert.ToHexStringLower(shard.Sha256);
+        return auditWriter.WriteShardCompletedAsync(
+            new PrivacyExportShardCompletedAudit(
+                RequestId: completion.RequestId,
+                SubjectUserId: completion.UserId,
+                TenantId: completion.TenantId,
+                ShardIndex: shard.Index,
+                SizeBytes: shard.CompressedSizeBytes,
+                Sha256Hex: sha256Hex,
+                DurationMs: durationMs,
+                Timestamp: timeProvider.GetUtcNow()),
+            cancellationToken);
+    }
+
+    private async Task EmitFailedAuditAsync(
+        ExportCompletedEto completion,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // The audit writer must not mask the original assembly failure, so swallow
+            // any audit-side exception here and let the rethrow above surface the real
+            // cause. The audit row is best-effort on the failure path.
+            await auditWriter.WriteExportFailedAsync(
+                new PrivacyExportFailedAudit(
+                    RequestId: completion.RequestId,
+                    SubjectUserId: completion.UserId,
+                    TenantId: completion.TenantId,
+                    ExceptionType: exception.GetType().Name,
+                    RetryCount: 0,
+                    Timestamp: timeProvider.GetUtcNow()),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort — see remark above.
         }
     }
 

--- a/src/Granit.Privacy.BlobStorage/PrivacyFragmentUploader.cs
+++ b/src/Granit.Privacy.BlobStorage/PrivacyFragmentUploader.cs
@@ -1,6 +1,9 @@
+using System.Security.Cryptography;
+using System.Text;
 using Granit.Domain.ValueObjects;
 using Granit.Events;
 using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Audit;
 using Granit.Privacy.DataExport.Events;
 using Granit.Privacy.DataExport.Fragments;
 using Microsoft.Extensions.Logging;
@@ -22,6 +25,8 @@ namespace Granit.Privacy.BlobStorage;
 /// </remarks>
 public sealed partial class PrivacyFragmentUploader(
     IDistributedEventBus eventBus,
+    IPrivacyExportAuditWriter auditWriter,
+    TimeProvider timeProvider,
     ILogger<PrivacyFragmentUploader> logger)
 {
     /// <summary>FragmentKind sentinel value for providers with no data for the subject.</summary>
@@ -78,6 +83,19 @@ public sealed partial class PrivacyFragmentUploader(
                 cancellationToken).ConfigureAwait(false);
 
             LogFragmentPrepared(logger, TProvider.ProviderName, request.UserId, request.RequestId, fragment.EntryPath, kind);
+
+            await auditWriter.WriteFragmentPreparedAsync(
+                new PrivacyExportFragmentPreparedAudit(
+                    RequestId: request.RequestId,
+                    SubjectUserId: request.UserId,
+                    TenantId: request.TenantId,
+                    ProviderName: TProvider.ProviderName,
+                    FragmentKind: kind,
+                    EntryPathHash: HashEntryPath(fragment.EntryPath),
+                    SizeBytes: fragment.KnownSizeBytes,
+                    Timestamp: timeProvider.GetUtcNow()),
+                cancellationToken).ConfigureAwait(false);
+
             published++;
         }
 
@@ -96,7 +114,25 @@ public sealed partial class PrivacyFragmentUploader(
                     IntegrityTag: string.Empty,
                     TenantId: request.TenantId),
                 cancellationToken).ConfigureAwait(false);
+
+            await auditWriter.WriteFragmentPreparedAsync(
+                new PrivacyExportFragmentPreparedAudit(
+                    RequestId: request.RequestId,
+                    SubjectUserId: request.UserId,
+                    TenantId: request.TenantId,
+                    ProviderName: TProvider.ProviderName,
+                    FragmentKind: EmptyFragmentKind,
+                    EntryPathHash: HashEntryPath($"{TProvider.ProviderName}.empty"),
+                    SizeBytes: null,
+                    Timestamp: timeProvider.GetUtcNow()),
+                cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static string HashEntryPath(string entryPath)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(entryPath));
+        return Convert.ToHexStringLower(hash);
     }
 
     [LoggerMessage(Level = LogLevel.Information,

--- a/src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs
+++ b/src/Granit.Privacy/DataExport/Audit/IPrivacyExportAuditWriter.cs
@@ -20,6 +20,19 @@ public interface IPrivacyExportAuditWriter
     /// <summary>Records that a data subject filed an export request.</summary>
     Task WriteExportRequestedAsync(PrivacyExportRequestedAudit data, CancellationToken cancellationToken);
 
+    /// <summary>Records that a provider prepared a fragment ready for assembly.</summary>
+    Task WriteFragmentPreparedAsync(PrivacyExportFragmentPreparedAudit data, CancellationToken cancellationToken);
+
+    /// <summary>Records the start of the archive-assembly job — emitted before the
+    /// first shard streams so an investigator can see "the assembler picked it up"
+    /// distinct from "the assembler finished it".</summary>
+    Task WriteAssemblyStartedAsync(PrivacyExportAssemblyStartedAudit data, CancellationToken cancellationToken);
+
+    /// <summary>Records that a single shard finished its multipart upload — emitted
+    /// after each shard's <c>CompleteMultipartUpload</c> so the audit trail captures
+    /// the per-shard sha256 + duration without waiting for the whole assembly to land.</summary>
+    Task WriteShardCompletedAsync(PrivacyExportShardCompletedAudit data, CancellationToken cancellationToken);
+
     /// <summary>Records that the archive assembly job persisted every shard plus the manifest.</summary>
     Task WriteExportCompletedAsync(PrivacyExportCompletedAudit data, CancellationToken cancellationToken);
 
@@ -104,6 +117,81 @@ public sealed record PrivacyExportShardDownloadedAudit(
     string? UserAgent,
     string? AuthMethod,
     string? CorrelationId,
+    DateTimeOffset Timestamp);
+
+/// <summary>
+/// Audit payload for a provider fragment that completed its upload step.
+/// </summary>
+/// <param name="RequestId">Saga / tracker correlation id.</param>
+/// <param name="SubjectUserId">Data subject the fragment belongs to.</param>
+/// <param name="TenantId">Tenant context.</param>
+/// <param name="ProviderName">Originating <c>IPrivacyDataProvider.ProviderName</c>.</param>
+/// <param name="FragmentKind">Fragment kind — <c>"staged"</c>, <c>"passthrough"</c>, or
+/// <c>"empty"</c> (sentinel for providers with no data).</param>
+/// <param name="EntryPathHash">SHA-256 hex digest of the entry path. The raw path
+/// can encode subject-visible filenames; the hash gives an investigator something
+/// to correlate by without leaking the original string into the audit row.</param>
+/// <param name="SizeBytes">Declared / measured payload size where known,
+/// <see langword="null"/> for empty-sentinel fragments.</param>
+/// <param name="Timestamp">When the fragment finished uploading (UTC).</param>
+public sealed record PrivacyExportFragmentPreparedAudit(
+    Guid RequestId,
+    Guid SubjectUserId,
+    Guid? TenantId,
+    string ProviderName,
+    string FragmentKind,
+    string EntryPathHash,
+    long? SizeBytes,
+    DateTimeOffset Timestamp);
+
+/// <summary>
+/// Audit payload for the moment the assembly background job picks the request up
+/// — distinct from <see cref="PrivacyExportRequestedAudit"/> (which records the
+/// HTTP request) and <see cref="PrivacyExportCompletedAudit"/> (which records the
+/// terminal state).
+/// </summary>
+/// <param name="RequestId">Saga / tracker correlation id.</param>
+/// <param name="SubjectUserId">Data subject.</param>
+/// <param name="TenantId">Tenant context.</param>
+/// <param name="Regulation">Regulation code.</param>
+/// <param name="ExpectedFragmentCount">Fragments the saga collected from providers —
+/// the assembler iterates over these.</param>
+/// <param name="IsResumed"><see langword="true"/> when the assembler picked up a
+/// prior crashed run via the checkpoint store.</param>
+/// <param name="Timestamp">Assembly start timestamp (UTC).</param>
+public sealed record PrivacyExportAssemblyStartedAudit(
+    Guid RequestId,
+    Guid SubjectUserId,
+    Guid? TenantId,
+    string Regulation,
+    int ExpectedFragmentCount,
+    bool IsResumed,
+    DateTimeOffset Timestamp);
+
+/// <summary>
+/// Audit payload for a single shard's multipart upload completion. Emitted as soon
+/// as <c>CompleteMultipartUpload</c> returns, before subsequent shards or the
+/// manifest, so the per-shard sha256 + duration is on the audit trail even if a
+/// later shard or the manifest write fails.
+/// </summary>
+/// <param name="RequestId">Saga / tracker correlation id.</param>
+/// <param name="SubjectUserId">Data subject.</param>
+/// <param name="TenantId">Tenant context.</param>
+/// <param name="ShardIndex">Zero-based shard index in write order.</param>
+/// <param name="SizeBytes">Total bytes the multipart upload committed.</param>
+/// <param name="Sha256Hex">Lowercase hex SHA-256 digest of the shard's bytes
+/// (matches the manifest's per-shard sha256).</param>
+/// <param name="DurationMs">Wall-clock time from the shard's open to its
+/// <c>CompleteMultipartUpload</c> return.</param>
+/// <param name="Timestamp">Completion timestamp (UTC).</param>
+public sealed record PrivacyExportShardCompletedAudit(
+    Guid RequestId,
+    Guid SubjectUserId,
+    Guid? TenantId,
+    int ShardIndex,
+    long SizeBytes,
+    string Sha256Hex,
+    long DurationMs,
     DateTimeOffset Timestamp);
 
 /// <summary>

--- a/src/Granit.Privacy/DataExport/Audit/NullPrivacyExportAuditWriter.cs
+++ b/src/Granit.Privacy/DataExport/Audit/NullPrivacyExportAuditWriter.cs
@@ -10,6 +10,9 @@ namespace Granit.Privacy.DataExport.Audit;
 internal sealed class NullPrivacyExportAuditWriter : IPrivacyExportAuditWriter
 {
     public Task WriteExportRequestedAsync(PrivacyExportRequestedAudit data, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task WriteFragmentPreparedAsync(PrivacyExportFragmentPreparedAudit data, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task WriteAssemblyStartedAsync(PrivacyExportAssemblyStartedAudit data, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task WriteShardCompletedAsync(PrivacyExportShardCompletedAudit data, CancellationToken cancellationToken) => Task.CompletedTask;
     public Task WriteExportCompletedAsync(PrivacyExportCompletedAudit data, CancellationToken cancellationToken) => Task.CompletedTask;
     public Task WriteShardDownloadedAsync(PrivacyExportShardDownloadedAudit data, CancellationToken cancellationToken) => Task.CompletedTask;
     public Task WriteExportFailedAsync(PrivacyExportFailedAudit data, CancellationToken cancellationToken) => Task.CompletedTask;

--- a/tests/Granit.Privacy.Auditing.Tests/AuditingPrivacyExportAuditWriterTests.cs
+++ b/tests/Granit.Privacy.Auditing.Tests/AuditingPrivacyExportAuditWriterTests.cs
@@ -87,6 +87,70 @@ public sealed class AuditingPrivacyExportAuditWriterTests
     }
 
     [Fact]
+    public async Task WriteFragmentPreparedAsync_PersistsFragmentPhaseWithHashedEntryPath()
+    {
+        IAuditingWriter writer = Substitute.For<IAuditingWriter>();
+        AuditingPrivacyExportAuditWriter sut = new(writer);
+
+        await sut.WriteFragmentPreparedAsync(new PrivacyExportFragmentPreparedAudit(
+            RequestId, SubjectId, TenantId,
+            ProviderName: "identity-local",
+            FragmentKind: "staged",
+            EntryPathHash: "abc123",
+            SizeBytes: 4096,
+            Timestamp: Now), TestContext.Current.CancellationToken);
+
+        await writer.Received(1).WriteAsync(Arg.Is<AuditEntry>(e =>
+            e.Category == AuditCategory.DataAccess
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "Phase" && p.NewValue == "fragment-prepared")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "ProviderName" && p.NewValue == "identity-local")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "EntryPathHash" && p.NewValue == "abc123")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "SizeBytes" && p.NewValue == "4096")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAssemblyStartedAsync_PersistsAssemblyStartedPhase()
+    {
+        IAuditingWriter writer = Substitute.For<IAuditingWriter>();
+        AuditingPrivacyExportAuditWriter sut = new(writer);
+
+        await sut.WriteAssemblyStartedAsync(new PrivacyExportAssemblyStartedAudit(
+            RequestId, SubjectId, TenantId, "EU_GDPR",
+            ExpectedFragmentCount: 5,
+            IsResumed: true,
+            Timestamp: Now), TestContext.Current.CancellationToken);
+
+        await writer.Received(1).WriteAsync(Arg.Is<AuditEntry>(e =>
+            e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "Phase" && p.NewValue == "assembly-started")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "ExpectedFragmentCount" && p.NewValue == "5")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "IsResumed" && p.NewValue == "true")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteShardCompletedAsync_PersistsShardCompletedPhaseWithSha256()
+    {
+        IAuditingWriter writer = Substitute.For<IAuditingWriter>();
+        AuditingPrivacyExportAuditWriter sut = new(writer);
+
+        await sut.WriteShardCompletedAsync(new PrivacyExportShardCompletedAudit(
+            RequestId, SubjectId, TenantId,
+            ShardIndex: 1,
+            SizeBytes: 1024 * 1024,
+            Sha256Hex: "deadbeef",
+            DurationMs: 9876,
+            Timestamp: Now), TestContext.Current.CancellationToken);
+
+        await writer.Received(1).WriteAsync(Arg.Is<AuditEntry>(e =>
+            e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "Phase" && p.NewValue == "shard-completed")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "ShardIndex" && p.NewValue == "1")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "Sha256" && p.NewValue == "deadbeef")
+            && e.EntityChanges.First().PropertyChanges.Any(p => p.PropertyName == "DurationMs" && p.NewValue == "9876")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task WriteExportFailedAsync_PersistsFailedPhaseWithoutPii()
     {
         IAuditingWriter writer = Substitute.For<IAuditingWriter>();

--- a/tests/Granit.Privacy.BlobStorage.Tests/PrivacyFragmentUploaderTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/PrivacyFragmentUploaderTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Granit.Domain.ValueObjects;
 using Granit.Events;
 using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Audit;
 using Granit.Privacy.DataExport.Events;
 using Granit.Privacy.DataExport.Fragments;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,9 +14,11 @@ namespace Granit.Privacy.BlobStorage.Tests;
 public sealed class PrivacyFragmentUploaderTests
 {
     private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly IPrivacyExportAuditWriter _auditWriter = Substitute.For<IPrivacyExportAuditWriter>();
+    private readonly TimeProvider _timeProvider = TimeProvider.System;
 
     private PrivacyFragmentUploader CreateSut() =>
-        new(_eventBus, NullLogger<PrivacyFragmentUploader>.Instance);
+        new(_eventBus, _auditWriter, _timeProvider, NullLogger<PrivacyFragmentUploader>.Instance);
 
     [Fact]
     public async Task UploadAsync_ProviderYieldsNothing_PublishesEmptySentinel()


### PR DESCRIPTION
## Summary

Completes the §16 ROPA contract from the Takeout plan — four lifecycle events that PR #2351 plumbed through the interface but never emitted.

| Event | Trigger | Notes |
|---|---|---|
| \`fragment-prepared\` | \`PrivacyFragmentUploader.UploadAsync\` per fragment (incl. empty sentinel) | EntryPath sha256-hashed before the row is written — no subject-visible filenames in the trail |
| \`assembly-started\` | \`PrivacyExportAssemblyService.AssembleAsync\` after checkpoint seed | Carries \`IsResumed\` so a crash-recovery run is distinguishable from a fresh dispatch |
| \`shard-completed\` | After each shard rollover + the final shard closed in \`CompleteAsync\` | Per-shard sha256 + duration land before next shard / manifest — mid-run crash still surfaces work-done-so-far |
| \`failed\` | Both catch arms in \`AssembleAsync\` (transient wrap + InvOp passthrough) | Best-effort emit in a try/swallow — the audit failure can't mask the original assembly exception |

## Interface surface

`IPrivacyExportAuditWriter` gains three new methods + payload records. `AuditingPrivacyExportAuditWriter` persists each under the same synthetic `PrivacyExport` entity, so all seven lifecycle phases for a request correlate by `EntityId` (= request id). `NullPrivacyExportAuditWriter` no-ops them.

## Per-shard duration

`shardStartTimestamp` resets on every rollover — each `ShardCompleted` row records time spent on its own shard, not from the assembly start. Resumed shards carry an empty sha256 (the checkpoint store doesn't retain digests by design); the audit row emits the empty string in that case so a verifier can flag and re-download.

## Test plan
- [x] `dotnet test tests/Granit.Privacy.Auditing.Tests` — 7/7 (3 new + 4 existing)
- [x] `dotnet test tests/Granit.Privacy.BlobStorage.Tests` — 64/64 (PrivacyFragmentUploader ctor now takes IPrivacyExportAuditWriter + TimeProvider)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 235/235
- [x] `dotnet format` clean across all modified projects
- [ ] CI green

Last reliquat after this lands: subject-substitution Roslyn analyzer (VULN-200).