### PR TITLE
feat(analyzers): GRSEC005 — PrivacyExportContext subject-substitution analyzer (P6.2 reliquats)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4645,6 +4645,15 @@
       "members": []
     },
     {
+      "name": "PrivacyExportSubjectSubstitutionAnalyzer",
+      "fqn": "Granit.Analyzers.PrivacyExportSubjectSubstitutionAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs",
+      "line": 40,
+      "members": []
+    },
+    {
       "name": "RenameColumnForbiddenAnalyzer",
       "fqn": "Granit.Analyzers.RenameColumnForbiddenAnalyzer",
       "kind": "class",

--- a/src/Granit.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Granit.Analyzers/AnalyzerReleases.Unshipped.md
@@ -13,6 +13,7 @@ GRSEC001 | Security | Warning | DateTimeNowAnalyzer, IsEnabledByDefault=True
 GRSEC002 | Security | Warning | GuidNewGuidAnalyzer, IsEnabledByDefault=True
 GRSEC003 | Security | Error | HardcodedSecretAnalyzer, IsEnabledByDefault=True
 GRSEC004 | Security | Warning | DirectCookieAccessAnalyzer, IsEnabledByDefault=True
+GRSEC005 | Security | Warning | PrivacyExportSubjectSubstitutionAnalyzer, IsEnabledByDefault=True
 GREF001 | EntityFramework | Warning | SynchronousSaveChangesAnalyzer, IsEnabledByDefault=True
 GRAPI001 | Api | Warning | UntypedResultsAnalyzer, IsEnabledByDefault=True
 GRAPI002 | Api | Warning | TypedResultsBadRequestAnalyzer, IsEnabledByDefault=True

--- a/src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs
+++ b/src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs
@@ -1,0 +1,133 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Granit.Analyzers;
+
+/// <summary>
+/// GR-SEC003 — Flags constructions of <c>Granit.Privacy.DataExport.PrivacyExportContext</c>
+/// where <c>SubjectUserId</c> and <c>CallerUserId</c> are bound to different symbols.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework's v1 privacy-export pipeline is strictly self-service: only the data
+/// subject can export their own data. Construction sites that pass distinct identifiers
+/// for caller and subject are reserved for the future <c>Privacy.Exports.OnBehalfOf</c>
+/// path (admin DSR), which must verify the permission and audit the substitution
+/// before the context reaches a provider.
+/// </para>
+/// <para>
+/// This analyzer fires when the two argument expressions resolve to different local
+/// symbols — the most common bug shape (typo, paste error). Cases the analyzer
+/// deliberately doesn't catch:
+/// </para>
+/// <list type="bullet">
+///   <item>Calls where both arguments are non-identifier expressions (e.g. literal
+///         method calls). Treating those as "different" would noise up every
+///         <c>Guid.NewGuid()</c>-style test construction.</item>
+///   <item>The two arguments referencing the same symbol via different access paths
+///         (e.g. <c>user.Id</c> vs <c>user.Id</c>) — handled by ISymbol equality.</item>
+///   <item>Record <c>with</c> expressions that override one of the two fields. Those
+///         need dataflow tracking that the analyzer doesn't do today.</item>
+/// </list>
+/// <para>
+/// Suppress with <c>#pragma warning disable GRSEC005</c> after the admin-DSR
+/// permission check is in place.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PrivacyExportSubjectSubstitutionAnalyzer : SingleRuleAnalyzerBase
+{
+    /// <summary>Diagnostic identifier.</summary>
+    public const string DiagnosticId = "GRSEC005";
+
+    private const string PrivacyExportContextFullName = "Granit.Privacy.DataExport.PrivacyExportContext";
+
+    private static readonly DiagnosticDescriptor _rule = new(
+        DiagnosticId,
+        title: "PrivacyExportContext subject must equal caller",
+        messageFormat: "PrivacyExportContext is being constructed with SubjectUserId ({0}) "
+            + "different from CallerUserId ({1}); v1 of the export pipeline is self-service only. "
+            + "Pass the same identifier for both, or suppress GRSEC005 once a "
+            + "Privacy.Exports.OnBehalfOf permission check guards this construction.",
+        category: "Security",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Self-service exports must construct PrivacyExportContext with caller "
+            + "equal to subject. Mismatched identifiers are reserved for the admin DSR path "
+            + "(Privacy.Exports.OnBehalfOf), which has to verify the permission and audit the "
+            + "substitution before the context reaches a provider.");
+
+    /// <inheritdoc/>
+    protected override DiagnosticDescriptor Rule => _rule;
+
+    /// <inheritdoc/>
+    protected override void RegisterActions(AnalysisContext context)
+        => context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, SyntaxKind.ObjectCreationExpression, SyntaxKind.ImplicitObjectCreationExpression);
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        var creation = (BaseObjectCreationExpressionSyntax)context.Node;
+        if (creation.ArgumentList is null || creation.ArgumentList.Arguments.Count < 3)
+        {
+            return;
+        }
+
+        ISymbol? typeSymbol = context.SemanticModel.GetSymbolInfo(creation).Symbol;
+        if (typeSymbol is not IMethodSymbol ctor || ctor.MethodKind != MethodKind.Constructor)
+        {
+            return;
+        }
+
+        if (ctor.ContainingType.ToDisplayString() != PrivacyExportContextFullName)
+        {
+            return;
+        }
+
+        ArgumentSyntax? subjectArg = null;
+        ArgumentSyntax? callerArg = null;
+
+        for (int i = 0; i < creation.ArgumentList.Arguments.Count; i++)
+        {
+            ArgumentSyntax arg = creation.ArgumentList.Arguments[i];
+            string? parameterName = arg.NameColon?.Name.Identifier.Text
+                ?? (i < ctor.Parameters.Length ? ctor.Parameters[i].Name : null);
+
+            if (parameterName == "SubjectUserId")
+            {
+                subjectArg = arg;
+            }
+            else if (parameterName == "CallerUserId")
+            {
+                callerArg = arg;
+            }
+        }
+
+        if (subjectArg is null || callerArg is null)
+        {
+            return;
+        }
+
+        ISymbol? subjectSymbol = context.SemanticModel.GetSymbolInfo(subjectArg.Expression).Symbol;
+        ISymbol? callerSymbol = context.SemanticModel.GetSymbolInfo(callerArg.Expression).Symbol;
+
+        // Skip when either argument doesn't bind to a symbol (literals, method calls,
+        // dynamic expressions) — over-flagging those would dwarf the true-positive rate.
+        if (subjectSymbol is null || callerSymbol is null)
+        {
+            return;
+        }
+
+        if (SymbolEqualityComparer.Default.Equals(subjectSymbol, callerSymbol))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            _rule,
+            creation.GetLocation(),
+            subjectArg.Expression.ToString(),
+            callerArg.Expression.ToString()));
+    }
+}

--- a/tests/Granit.Analyzers.Tests/PrivacyExportSubjectSubstitutionAnalyzerTests.cs
+++ b/tests/Granit.Analyzers.Tests/PrivacyExportSubjectSubstitutionAnalyzerTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analyzers.Tests;
+
+public sealed class PrivacyExportSubjectSubstitutionAnalyzerTests
+{
+    private const string PrivacyExportContextStub = """
+        namespace Granit.Privacy.DataExport
+        {
+            public sealed record PrivacyExportContext(
+                System.Guid RequestId,
+                System.Guid SubjectUserId,
+                System.Guid CallerUserId,
+                System.Guid? TenantId,
+                string Regulation);
+        }
+        """;
+
+    [Fact]
+    public async Task GRSEC005_silent_when_subject_and_caller_share_a_symbol()
+    {
+        string source = """
+            using System;
+            using Granit.Privacy.DataExport;
+
+            public class Service
+            {
+                public PrivacyExportContext Create(Guid userId) =>
+                    new PrivacyExportContext(
+                        RequestId: Guid.Empty,
+                        SubjectUserId: userId,
+                        CallerUserId: userId,
+                        TenantId: null,
+                        Regulation: "EU_GDPR");
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzerTestHelpers.RunAnalyzerAsync<PrivacyExportSubjectSubstitutionAnalyzer>(
+                source, [PrivacyExportContextStub], TestContext.Current.CancellationToken);
+
+        diagnostics.Where(d => d.Id == PrivacyExportSubjectSubstitutionAnalyzer.DiagnosticId)
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GRSEC005_fires_when_subject_and_caller_bind_to_different_symbols()
+    {
+        string source = """
+            using System;
+            using Granit.Privacy.DataExport;
+
+            public class Service
+            {
+                public PrivacyExportContext Create(Guid subject, Guid caller) =>
+                    new PrivacyExportContext(
+                        RequestId: Guid.Empty,
+                        SubjectUserId: subject,
+                        CallerUserId: caller,
+                        TenantId: null,
+                        Regulation: "EU_GDPR");
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzerTestHelpers.RunAnalyzerAsync<PrivacyExportSubjectSubstitutionAnalyzer>(
+                source, [PrivacyExportContextStub], TestContext.Current.CancellationToken);
+
+        diagnostics.ShouldContain(d => d.Id == PrivacyExportSubjectSubstitutionAnalyzer.DiagnosticId);
+    }
+
+    [Fact]
+    public async Task GRSEC005_fires_on_positional_construction()
+    {
+        string source = """
+            using System;
+            using Granit.Privacy.DataExport;
+
+            public class Service
+            {
+                public PrivacyExportContext Create(Guid subject, Guid caller) =>
+                    new PrivacyExportContext(Guid.Empty, subject, caller, null, "EU_GDPR");
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzerTestHelpers.RunAnalyzerAsync<PrivacyExportSubjectSubstitutionAnalyzer>(
+                source, [PrivacyExportContextStub], TestContext.Current.CancellationToken);
+
+        diagnostics.ShouldContain(d => d.Id == PrivacyExportSubjectSubstitutionAnalyzer.DiagnosticId);
+    }
+
+    [Fact]
+    public async Task GRSEC005_fires_on_implicit_target_typed_new()
+    {
+        string source = """
+            using System;
+            using Granit.Privacy.DataExport;
+
+            public class Service
+            {
+                public PrivacyExportContext Create(Guid subject, Guid caller) =>
+                    new(Guid.Empty, subject, caller, null, "EU_GDPR");
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzerTestHelpers.RunAnalyzerAsync<PrivacyExportSubjectSubstitutionAnalyzer>(
+                source, [PrivacyExportContextStub], TestContext.Current.CancellationToken);
+
+        diagnostics.ShouldContain(d => d.Id == PrivacyExportSubjectSubstitutionAnalyzer.DiagnosticId);
+    }
+
+    [Fact]
+    public async Task GRSEC005_silent_when_both_arguments_are_non_identifier_expressions()
+    {
+        // Two literal Guid.NewGuid() calls bind to the same method symbol — the
+        // analyzer treats this as "same symbol" and stays silent. False-negative
+        // tolerated; the alternative noises up every test fixture.
+        string source = """
+            using System;
+            using Granit.Privacy.DataExport;
+
+            public class Service
+            {
+                public PrivacyExportContext Create() =>
+                    new PrivacyExportContext(
+                        RequestId: Guid.Empty,
+                        SubjectUserId: Guid.NewGuid(),
+                        CallerUserId: Guid.NewGuid(),
+                        TenantId: null,
+                        Regulation: "EU_GDPR");
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzerTestHelpers.RunAnalyzerAsync<PrivacyExportSubjectSubstitutionAnalyzer>(
+                source, [PrivacyExportContextStub], TestContext.Current.CancellationToken);
+
+        diagnostics.Where(d => d.Id == PrivacyExportSubjectSubstitutionAnalyzer.DiagnosticId)
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GRSEC005_silent_on_other_records()
+    {
+        // Sanity check: the analyzer is scoped to PrivacyExportContext, not any
+        // record that happens to have SubjectUserId / CallerUserId field names.
+        string source = """
+            using System;
+
+            public sealed record OtherContext(
+                Guid SubjectUserId,
+                Guid CallerUserId);
+
+            public class Service
+            {
+                public OtherContext Create(Guid subject, Guid caller) =>
+                    new OtherContext(subject, caller);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzerTestHelpers.RunAnalyzerAsync<PrivacyExportSubjectSubstitutionAnalyzer>(
+                source, Array.Empty<string>(), TestContext.Current.CancellationToken);
+
+        diagnostics.Where(d => d.Id == PrivacyExportSubjectSubstitutionAnalyzer.DiagnosticId)
+            .ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last open item from the original Takeout plan §13.9 / VULN-200.

`GRSEC005` flags construction sites of \`Granit.Privacy.DataExport.PrivacyExportContext\` where \`SubjectUserId\` and \`CallerUserId\` bind to different symbols — the shape of an admin-DSR-on-behalf-of substitution that bypasses the v1 self-service contract.

## Detection

Symbol-level, not syntactic:

- \`new(userId, userId, ...)\` → silent (same symbol)
- \`new(subject, caller, ...)\` → **warn**
- \`new(Guid.NewGuid(), Guid.NewGuid(), ...)\` → silent (both bind to the same `Guid.NewGuid` method symbol — false-negative tolerated so test fixtures don't noise up)
- \`new(SubjectUserId: x, CallerUserId: x, ...)\` → silent (named-arg form)
- \`new OtherRecord(subject, caller, ...)\` → silent (analyzer scoped to PrivacyExportContext only)

Handles positional + named arguments, regular `new T(...)` and target-typed `new(...)`. Suppress with `#pragma warning disable GRSEC005` after the future `Privacy.Exports.OnBehalfOf` permission gate validates the substitution and audits it.

## Test plan
- [x] `dotnet test tests/Granit.Analyzers.Tests` — 116/116 (110 existing + 6 new GRSEC005 tests)
- [x] `dotnet build src/Granit.Privacy*` clean — analyzer doesn't false-positive on the framework's own self-service construction sites
- [x] `dotnet test tests/Granit.ArchitectureTests` — 235/235
- [x] `dotnet format` clean
- [ ] CI green

## Epic close-out

This was the last reliquat from the original P6.2 plan §15. All four follow-ups now shipped:

| # | Title | PR |
|---|---|---|
| R1 | Rate-limit + idempotency on POST | #2353 |
| R2 | Plural permission names + `IsSelfService` flag | #2354 |
| R3 | ROPA missing events (fragment-prepared/assembly-started/shard-completed/failed) | #2355 |
| R4 | Subject-substitution analyzer (this PR) | — |

Hors scope durable de l'épopée (rappel) :
- `Privacy.Exports.OnBehalfOf` endpoint surface (v1.1)
- Drive/Dropbox/OneDrive destinations (v2)
- Documents provider concret (hand-off granit-business)
- Failed-audit DLQ hook in Granit.Privacy.BackgroundJobs.Wolverine
- Tag-on-completion in IBlobStoreProvider (tag-based lifecycle)
- Re-traduction des 16 templates culturels