### PR TITLE
feat(privacy): POST /privacy/exports/on-behalf-of (admin DSR endpoint)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -38298,6 +38298,15 @@
       "members": []
     },
     {
+      "name": "PrivacyExportOnBehalfOfRequest",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyExportOnBehalfOfRequest",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyExportOnBehalfOfRequest.cs",
+      "line": 27,
+      "members": []
+    },
+    {
       "name": "PrivacyExportRequest",
       "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyExportRequest",
       "kind": "record",

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportOnBehalfOfRequest.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportOnBehalfOfRequest.cs
@@ -1,0 +1,29 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// Body for <c>POST /privacy/exports/on-behalf-of</c> — the admin DSR
+/// (Data Subject Request) path where an authenticated administrator triggers
+/// an export for a different data subject.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Gated by the dedicated <c>Privacy.Exports.OnBehalfOf</c> permission — distinct
+/// from the self-service <c>Privacy.Exports.Execute</c> so RBAC policies can
+/// grant the admin path to a narrow operator role without unlocking it for
+/// every authenticated user.
+/// </para>
+/// <para>
+/// The audit trail records both <c>CallerUserId</c> (the administrator) and
+/// <c>SubjectUserId</c> (the data subject) so the substitution is fully
+/// reconstructable — this is the GDPR Art. 30 ROPA-relevant signal that the
+/// access was an admin DSR, not a self-service one.
+/// </para>
+/// </remarks>
+/// <param name="SubjectUserId">Identifier of the data subject the export targets.
+/// MUST be a real account known to the host — there's no anonymous-subject path.</param>
+/// <param name="Scopes">Subset of provider names to include in the archive.
+/// Same semantics as the self-service endpoint: <see langword="null"/> / empty
+/// means "all visible scopes".</param>
+public sealed record PrivacyExportOnBehalfOfRequest(
+    Guid SubjectUserId,
+    IReadOnlyList<string>? Scopes = null);

--- a/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
@@ -293,6 +293,24 @@ public static class PrivacyEndpointRouteBuilderExtensions
                  + "unknown / hidden scopes in that POST are silently skipped.")
              .Produces<IReadOnlyList<PrivacyExportScopeResponse>>();
 
+        group.MapPost("/exports/on-behalf-of", HandleRequestExportOnBehalfOfAsync)
+             .RequireAuthorization(PrivacyPermissions.Exports.OnBehalfOf)
+             .RequireGranitRateLimiting(PrivacyExportRateLimitPolicies.ExportCreate)
+             .WithMetadata(new IdempotentAttribute { Required = false })
+             .WithName("RequestPrivacyExportOnBehalfOf")
+             .WithSummary("Requests a personal data export on behalf of another data subject (admin DSR).")
+             .WithDescription(
+                 "Admin-driven counterpart to POST /privacy/exports — gated by the dedicated "
+                 + "Privacy.Exports.OnBehalfOf permission so RBAC can hand it to a narrow operator "
+                 + "role without unlocking it for every authenticated user. The body's SubjectUserId "
+                 + "identifies the data subject; the authenticated caller is recorded separately on "
+                 + "the audit row so the substitution is fully reconstructable for GDPR Art. 30 ROPA. "
+                 + "Shares the privacy-export-create rate-limit policy (partitioned by the caller).")
+             .Produces<PrivacyExportRequestResponse>(StatusCodes.Status202Accepted)
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
+             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+             .ProducesProblem(StatusCodes.Status429TooManyRequests);
+
         group.MapPost("/exports", HandleRequestExportAsync)
              .RequireAuthorization(PrivacyPermissions.Exports.Execute)
              .RequireGranitRateLimiting(PrivacyExportRateLimitPolicies.ExportCreate)
@@ -496,6 +514,78 @@ public static class PrivacyEndpointRouteBuilderExtensions
                 RequestId: requestId,
                 CallerUserId: userId,
                 SubjectUserId: userId,
+                TenantId: tenantId,
+                Regulation: regulation,
+                ResolvedScopes: requestedScopes ?? [],
+                ClientIp: PseudonymizeIpAddress(httpContext.Connection.RemoteIpAddress?.ToString()),
+                UserAgent: httpContext.Request.Headers.UserAgent.ToString(),
+                CorrelationId: httpContext.TraceIdentifier,
+                Timestamp: now),
+            cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Accepted(
+            $"/privacy/export/{requestId}",
+            new PrivacyExportRequestResponse(requestId, now));
+    }
+
+    private static async Task<Results<Accepted<PrivacyExportRequestResponse>, ProblemHttpResult>> HandleRequestExportOnBehalfOfAsync(
+        [FromBody] PrivacyExportOnBehalfOfRequest body,
+        HttpContext httpContext,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IDistributedEventBus eventBus,
+        [FromServices] IExportRequestTrackerWriter tracker,
+        [FromServices] IPrivacyExportAuditWriter auditWriter,
+        [FromServices] PrivacyMetrics metrics,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ICurrentTenant currentTenant,
+        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IPrivacyRegulationResolver? regulationResolver,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        if (!TryGetUserId(currentUser, out Guid callerUserId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        // SubjectUserId non-empty + scope bounds are enforced by
+        // PrivacyExportOnBehalfOfRequestValidator at the FluentValidation auto-filter
+        // pass — the handler is only reached on a clean body.
+
+        Guid requestId = guidGenerator.Create();
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        string regulation = await ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<string>? requestedScopes = body.Scopes is { Count: > 0 } scopes ? scopes : null;
+
+        // The saga's PersonalDataRequestedEto.UserId names the data subject — providers
+        // and the visibility resolver key off it for HasData probes etc. The caller's
+        // identity only matters for the audit row (Art. 30 ROPA).
+        await tracker
+            .RecordRequestAsync(requestId, body.SubjectUserId, now, cancellationToken)
+            .ConfigureAwait(false);
+
+        await eventBus
+            .PublishAsync(
+                new PersonalDataRequestedEto(
+                    RequestId: requestId,
+                    UserId: body.SubjectUserId,
+                    RequestedAt: now,
+                    Regulation: regulation,
+                    TenantId: tenantId,
+                    RequestedScopes: requestedScopes),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        metrics.RecordExportRequested(tenantId, regulation);
+
+        await auditWriter.WriteExportRequestedAsync(
+            new PrivacyExportRequestedAudit(
+                RequestId: requestId,
+                CallerUserId: callerUserId,
+                SubjectUserId: body.SubjectUserId,
                 TenantId: tenantId,
                 Regulation: regulation,
                 ResolvedScopes: requestedScopes ?? [],

--- a/src/Granit.Privacy.Endpoints/Validators/PrivacyExportOnBehalfOfRequestValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Validators/PrivacyExportOnBehalfOfRequestValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using Granit.Privacy.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Privacy.Endpoints.Validators;
+
+/// <summary>
+/// Validator for <see cref="PrivacyExportOnBehalfOfRequest"/>. Mirrors the
+/// scope-list bounds from <see cref="PrivacyExportRequestValidator"/> and adds
+/// the dedicated <c>SubjectUserId</c> non-empty check — the admin DSR path
+/// requires a real subject identifier, so an empty Guid is rejected at the
+/// FluentValidation pass before the handler runs.
+/// </summary>
+internal sealed class PrivacyExportOnBehalfOfRequestValidator : GranitValidator<PrivacyExportOnBehalfOfRequest>
+{
+    private const int MaxScopes = 64;
+    private const int MaxScopeNameLength = 200;
+
+    public PrivacyExportOnBehalfOfRequestValidator()
+    {
+        RuleFor(x => x.SubjectUserId)
+            .NotEqual(Guid.Empty);
+
+        RuleFor(x => x.Scopes)
+            .Must(s => s is null || s.Count <= MaxScopes)
+                .WithErrorCodeAndMessage("Granit:Validation:PrivacyExportTooManyScopes");
+
+        RuleForEach(x => x.Scopes!)
+            .NotEmpty()
+            .MaximumLength(MaxScopeNameLength)
+            .When(x => x.Scopes is { Count: > 0 });
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsTestServer.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsTestServer.cs
@@ -39,6 +39,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
 
     private const string AuthenticatedRole = "authenticated";
     private const string ExportRole = "export";
+    private const string ExportOnBehalfOfRole = "export-on-behalf-of";
     private const string DeletionRole = "deletion";
     private const string PurposesReadRole = "purposes-read";
     private const string AgreementsReadRole = "agreements-read";
@@ -52,6 +53,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
     public ICurrentUserService CurrentUser { get; }
     public IExportRequestTrackerWriter ExportWriter { get; }
     public IExportRequestTrackerReader ExportReader { get; }
+    public IPrivacyExportAuditWriter AuditWriter { get; }
     public IPrivacyScopeResolver ScopeResolver { get; }
     public IDeletionRequestTrackerWriter DeletionWriter { get; }
     public IDeletionRequestTrackerReader DeletionReader { get; }
@@ -77,6 +79,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         ICurrentUserService currentUser,
         IExportRequestTrackerWriter exportWriter,
         IExportRequestTrackerReader exportReader,
+        IPrivacyExportAuditWriter auditWriter,
         IPrivacyScopeResolver scopeResolver,
         IDeletionRequestTrackerWriter deletionWriter,
         IDeletionRequestTrackerReader deletionReader,
@@ -101,6 +104,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         CurrentUser = currentUser;
         ExportWriter = exportWriter;
         ExportReader = exportReader;
+        AuditWriter = auditWriter;
         ScopeResolver = scopeResolver;
         DeletionWriter = deletionWriter;
         DeletionReader = deletionReader;
@@ -188,6 +192,8 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         builder.Services.AddAuthorizationBuilder()
             .AddPolicy(PrivacyPermissions.Exports.Execute,
                 policy => policy.RequireRole(ExportRole))
+            .AddPolicy(PrivacyPermissions.Exports.OnBehalfOf,
+                policy => policy.RequireRole(ExportOnBehalfOfRole))
             .AddPolicy(PrivacyPermissions.Deletions.Execute,
                 policy => policy.RequireRole(DeletionRole))
             .AddPolicy(PrivacyPermissions.Purposes.Read,
@@ -247,7 +253,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         await app.StartAsync().ConfigureAwait(false);
 
         string allRoles = string.Join(",",
-            AuthenticatedRole, ExportRole, DeletionRole,
+            AuthenticatedRole, ExportRole, ExportOnBehalfOfRole, DeletionRole,
             PurposesReadRole, AgreementsReadRole, AgreementsCreateRole);
 
         HttpClient authenticatedClient = app.GetTestClient();
@@ -257,7 +263,7 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
 
         return new PrivacyEndpointsTestServer(
             app, authenticatedClient, anonymousClient,
-            currentUser, exportWriter, exportReader, scopeResolver,
+            currentUser, exportWriter, exportReader, auditWriter, scopeResolver,
             deletionWriter, deletionReader,
             documentRegistry, agreementChecker, agreementStoreReader, agreementStoreWriter,
             regulationResolver, optOutWriter, optOutReader, purposeRegistry,

--- a/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyExportOnBehalfOfEndpointTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyExportOnBehalfOfEndpointTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Privacy.DataExport.Audit;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.Endpoints.Dtos;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Integration;
+
+public sealed class PrivacyExportOnBehalfOfEndpointTests
+{
+    private static readonly Guid OtherSubjectId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public async Task PostOnBehalfOf_PublishesSagaEventWithSubjectAsUserId()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AuthenticatedClient.PostAsJsonAsync(
+            "/privacy/exports/on-behalf-of",
+            new PrivacyExportOnBehalfOfRequest(SubjectUserId: OtherSubjectId),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        await server.EventBus.Received(1).PublishAsync(
+            Arg.Is<PersonalDataRequestedEto>(e => e.UserId == OtherSubjectId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostOnBehalfOf_AuditCarriesCallerAndSubjectDistinctly()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AuthenticatedClient.PostAsJsonAsync(
+            "/privacy/exports/on-behalf-of",
+            new PrivacyExportOnBehalfOfRequest(SubjectUserId: OtherSubjectId),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        await server.AuditWriter.Received(1).WriteExportRequestedAsync(
+            Arg.Is<PrivacyExportRequestedAudit>(a =>
+                a.CallerUserId == PrivacyEndpointsTestServer.TestUserId
+                && a.SubjectUserId == OtherSubjectId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostOnBehalfOf_RecordsTrackerEntryAgainstSubjectUserId()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AuthenticatedClient.PostAsJsonAsync(
+            "/privacy/exports/on-behalf-of",
+            new PrivacyExportOnBehalfOfRequest(SubjectUserId: OtherSubjectId),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        await server.ExportWriter.Received(1).RecordRequestAsync(
+            Arg.Any<Guid>(),
+            OtherSubjectId,
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostOnBehalfOf_EmptySubjectId_Returns422ValidationProblem()
+    {
+        // FluentValidationAutoEndpointFilter surfaces validation failures as 422
+        // UnprocessableEntity — handled before the handler runs, so no saga fires.
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AuthenticatedClient.PostAsJsonAsync(
+            "/privacy/exports/on-behalf-of",
+            new PrivacyExportOnBehalfOfRequest(SubjectUserId: Guid.Empty),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        await server.EventBus.DidNotReceive().PublishAsync(
+            Arg.Any<PersonalDataRequestedEto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostOnBehalfOf_Anonymous_Returns401()
+    {
+        await using PrivacyEndpointsTestServer server = await PrivacyEndpointsTestServer.CreateAsync();
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync(
+            "/privacy/exports/on-behalf-of",
+            new PrivacyExportOnBehalfOfRequest(SubjectUserId: OtherSubjectId),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces the v1.1 admin DSR path that PR #2354 reserved by minting the `Privacy.Exports.OnBehalfOf` permission constant. An authenticated administrator can now trigger an export for a different data subject through a dedicated endpoint:

```
POST /privacy/exports/on-behalf-of
{ \"subjectUserId\": \"<guid>\", \"scopes\": [\"...\"] }
```

Distinct from the self-service `POST /privacy/exports` so RBAC can hand the admin path to a narrow operator role without unlocking it for every authenticated user.

## Audit trail

The handler captures both identifiers on the audit row:

- `CallerUserId` = the authenticated admin
- `SubjectUserId` = the data subject from the body

ROPA / Art. 30 evidence now distinguishes self-service exports from admin DSRs without having to join against logs.

## Validation

`PrivacyExportOnBehalfOfRequestValidator` adds a `NotEqual(Guid.Empty)` on `SubjectUserId` plus the same scope-list bounds (max 64 scopes, 200 chars each) as the self-service validator. FluentValidationAutoEndpointFilter surfaces violations as `422 UnprocessableEntity` before the handler runs.

## Downstream semantics (deferred)

The saga and providers continue to operate on `SubjectUserId` as their `UserId` — only the audit row carries both identifiers. Finer-grained admin-DSR semantics (e.g. suppressing sensitive scopes during an on-behalf-of run, requiring an `Idempotency-Key`, dedicated rate-limit policy partition) stay follow-ups.

## What's NOT touched
- `PrivacyExportContext` construction sites — the framework still constructs with caller==subject from the saga's perspective (the admin's identity is purely an audit concern today).
- The GRSEC005 analyzer therefore does NOT need a `#pragma warning disable` anywhere.

## Test plan
- [x] `dotnet test tests/Granit.Privacy.Endpoints.Tests` — 141/141 (5 new integration tests on the OnBehalfOf endpoint)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 235/235 (validator pairing surface satisfied)
- [x] `dotnet format` clean
- [ ] CI green