### PR TITLE
feat(persistence): SetConcurrencyStampOriginalValue helper for disconnected updates (ADR-061)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -15561,7 +15561,7 @@
       "kind": "interface",
       "project": "Granit",
       "file": "src/Granit/Domain/IConcurrencyAware.cs",
-      "line": 26,
+      "line": 28,
       "members": []
     },
     {
@@ -15570,7 +15570,7 @@
       "kind": "interface",
       "project": "Granit",
       "file": "src/Granit/Domain/IConcurrencyStampRequest.cs",
-      "line": 26,
+      "line": 27,
       "members": []
     },
     {
@@ -34947,6 +34947,15 @@
           "returnType": "bool"
         }
       ]
+    },
+    {
+      "name": "ConcurrencyStampExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.ConcurrencyStampExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/ConcurrencyStampExtensions.cs",
+      "line": 26,
+      "members": []
     },
     {
       "name": "DbContextOptionsBuilderExtensions",

--- a/src/Granit.Identity.EntityFrameworkCore/EntityConfigurations/UserConfiguration.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/EntityConfigurations/UserConfiguration.cs
@@ -58,6 +58,8 @@ internal sealed class UserConfiguration : IEntityTypeConfiguration<User>
 
         // Audit columns inherited from AuditedAggregateRoot — already configured
         // by ApplyGranitConventions (CreatedAt, CreatedBy, ModifiedAt, ModifiedBy
-        // dimensions, plus IConcurrencyAware token). Nothing to declare here.
+        // dimensions). User does not implement IConcurrencyAware; auth concurrency
+        // is handled by LocalIdentity via ASP.NET Identity's own ConcurrencyStamp.
+        // Nothing to declare here.
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ConcurrencyStampExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ConcurrencyStampExtensions.cs
@@ -1,0 +1,67 @@
+using Granit.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Persistence.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Helpers for applying a client-supplied concurrency stamp to an
+/// <see cref="IConcurrencyAware"/> entity in disconnected (CQRS) update scenarios.
+/// </summary>
+/// <remarks>
+/// <para>
+/// In the <b>connected</b> scenario — the entity was loaded from the same
+/// <see cref="DbContext"/> that saves it — EF Core already tracks the original
+/// stamp and no helper is needed.
+/// </para>
+/// <para>
+/// In the <b>disconnected</b> scenario — a command handler receives the stamp from
+/// the client and applies it to a freshly-attached entity — the original value must
+/// be set explicitly so EF Core emits it in the <c>WHERE</c> clause on update.
+/// These helpers replace the hand-written
+/// <c>context.Entry(entity).Property(e =&gt; e.ConcurrencyStamp).OriginalValue = stamp;</c>
+/// expression. A mismatch with the stored value raises
+/// <see cref="DbUpdateConcurrencyException"/> (HTTP 409 via the framework exception mapper).
+/// </para>
+/// </remarks>
+public static class ConcurrencyStampExtensions
+{
+    /// <summary>
+    /// Sets the original concurrency stamp for <paramref name="entity"/> so EF Core
+    /// validates it against the stored value on the next save (disconnected update).
+    /// </summary>
+    /// <typeparam name="TEntity">The <see cref="IConcurrencyAware"/> entity type.</typeparam>
+    /// <param name="context">The tracking context the entity is (or will be) attached to.</param>
+    /// <param name="entity">The entity whose original stamp is being set.</param>
+    /// <param name="originalStamp">The stamp the client last read; must match the stored value.</param>
+    public static void SetConcurrencyStampOriginalValue<TEntity>(
+        this DbContext context,
+        TEntity entity,
+        string originalStamp)
+        where TEntity : class, IConcurrencyAware
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(entity);
+        ArgumentException.ThrowIfNullOrEmpty(originalStamp);
+
+        context.Entry(entity).Property(e => e.ConcurrencyStamp).OriginalValue = originalStamp;
+    }
+
+    /// <summary>
+    /// Sets the original concurrency stamp for <paramref name="entity"/> from a request DTO
+    /// implementing <see cref="IConcurrencyStampRequest"/> (disconnected update).
+    /// </summary>
+    /// <typeparam name="TEntity">The <see cref="IConcurrencyAware"/> entity type.</typeparam>
+    /// <param name="context">The tracking context the entity is (or will be) attached to.</param>
+    /// <param name="entity">The entity whose original stamp is being set.</param>
+    /// <param name="request">The request carrying the client-supplied stamp.</param>
+    public static void SetConcurrencyStampOriginalValue<TEntity>(
+        this DbContext context,
+        TEntity entity,
+        IConcurrencyStampRequest request)
+        where TEntity : class, IConcurrencyAware
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        context.SetConcurrencyStampOriginalValue(entity, request.ConcurrencyStamp);
+    }
+}

--- a/src/Granit/Domain/IConcurrencyAware.cs
+++ b/src/Granit/Domain/IConcurrencyAware.cs
@@ -17,9 +17,11 @@ namespace Granit.Domain;
 /// </para>
 /// <para>
 /// <b>Disconnected updates (CQRS):</b> when the entity is not loaded from the same
-/// <c>DbContext</c>, set the original stamp received from the client before saving:
+/// <c>DbContext</c>, set the original stamp received from the client before saving via
+/// <c>ConcurrencyStampExtensions.SetConcurrencyStampOriginalValue</c>
+/// (in <c>Granit.Persistence.EntityFrameworkCore</c>):
 /// <code>
-/// dbContext.Entry(entity).Property(e =&gt; e.ConcurrencyStamp).OriginalValue = request.ConcurrencyStamp;
+/// dbContext.SetConcurrencyStampOriginalValue(entity, request.ConcurrencyStamp);
 /// </code>
 /// </para>
 /// </remarks>

--- a/src/Granit/Domain/IConcurrencyStampRequest.cs
+++ b/src/Granit/Domain/IConcurrencyStampRequest.cs
@@ -15,7 +15,8 @@ namespace Granit.Domain;
 /// entity.Name = request.Name; // EF Core already knows OriginalValue
 ///
 /// // Disconnected scenario (CQRS command, new DbContext):
-/// dbContext.Entry(entity).Property(e =&gt; e.ConcurrencyStamp).OriginalValue = request.ConcurrencyStamp;
+/// // dbContext.SetConcurrencyStampOriginalValue(entity, request);
+/// // (ConcurrencyStampExtensions in Granit.Persistence.EntityFrameworkCore)
 /// </code>
 /// <para>
 /// If the stamp in the database differs from the original value, EF Core throws

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ConcurrencyStampInterceptorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ConcurrencyStampInterceptorTests.cs
@@ -1,4 +1,5 @@
 using Granit.Domain;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -188,6 +189,86 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
         // Assert — EF Core detects mismatch between OriginalValue and DB value
         await Should.ThrowAsync<DbUpdateConcurrencyException>(
             () => context2.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    // ========================================================================
+    // Disconnected update — via SetConcurrencyStampOriginalValue helper
+    // ========================================================================
+
+    [Fact]
+    public async Task SetConcurrencyStampOriginalValue_WithStaleStamp_ThrowsDbUpdateConcurrencyException()
+    {
+        // Arrange — create entity, rotate its stamp so the captured one is stale
+        var entityId = Guid.NewGuid();
+        using TestDbContext context1 = CreateContext();
+        TestConcurrencyEntity entity = new()
+        {
+            Id = entityId,
+            Name = "Original",
+        };
+        context1.Entities.Add(entity);
+        await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        string staleStamp = entity.ConcurrencyStamp;
+
+        entity.Name = "Updated once";
+        await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
+        entity.ConcurrencyStamp.ShouldNotBe(staleStamp, "stamp must have rotated");
+
+        // Disconnected update via the helper instead of the raw Entry(...).OriginalValue expression
+        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        TestConcurrencyEntity disconnected = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
+
+        context2.SetConcurrencyStampOriginalValue(disconnected, staleStamp);
+
+        // Act
+        disconnected.Name = "Disconnected update";
+
+        // Assert
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(
+            () => context2.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SetConcurrencyStampOriginalValue_WithCurrentStamp_Succeeds()
+    {
+        // Arrange
+        var entityId = Guid.NewGuid();
+        using TestDbContext context1 = CreateContext();
+        TestConcurrencyEntity entity = new()
+        {
+            Id = entityId,
+            Name = "Original",
+        };
+        context1.Entities.Add(entity);
+        await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        string currentStamp = entity.ConcurrencyStamp;
+
+        // Disconnected update carrying the up-to-date stamp
+        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        TestConcurrencyEntity disconnected = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
+
+        context2.SetConcurrencyStampOriginalValue(disconnected, currentStamp);
+        disconnected.Name = "Disconnected update";
+
+        // Act — matching stamp → no conflict
+        await context2.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Assert — saved and stamp rotated by the interceptor
+        disconnected.Name.ShouldBe("Disconnected update");
+        disconnected.ConcurrencyStamp.ShouldNotBe(currentStamp);
+    }
+
+    [Fact]
+    public void SetConcurrencyStampOriginalValue_NullOrEmptyStamp_Throws()
+    {
+        using TestDbContext context = CreateContext();
+        TestConcurrencyEntity entity = new() { Id = Guid.NewGuid(), Name = "x" };
+        context.Entities.Add(entity);
+
+        Should.Throw<ArgumentException>(() =>
+            context.SetConcurrencyStampOriginalValue(entity, string.Empty));
     }
 
     // ========================================================================


### PR DESCRIPTION
## What

Completes the framework optimistic-concurrency story formalised in **ADR-061** (IConcurrencyAware + auto-managed opaque `ConcurrencyStamp` is *the* concurrency primitive).

- **New:** `ConcurrencyStampExtensions.SetConcurrencyStampOriginalValue` on `DbContext` (two overloads, one taking `IConcurrencyStampRequest`). Replaces the hand-written `context.Entry(entity).Property(e => e.ConcurrencyStamp).OriginalValue = stamp` expression for disconnected (CQRS) updates, and gives the previously **zero-consumer** `IConcurrencyStampRequest` contract an actual use.
- Updated `IConcurrencyAware` / `IConcurrencyStampRequest` docstrings to point at the helper.
- **Fix:** stale comment in `UserConfiguration` that wrongly claimed `User`/`AuditedAggregateRoot` carries an `IConcurrencyAware` token — it does not; auth concurrency lives on `LocalIdentity` via ASP.NET Identity's own `ConcurrencyStamp`.
- Added disconnected-update tests: stale stamp → 409, current stamp → ok, empty stamp → `ArgumentException`.

## Why

A consumer repo (`granit-business`) independently hand-rolled a `uint RowVersion` token instead of reusing this primitive — a discoverability/convention failure, not a deficiency in the token. ADR-061 sets `IConcurrencyAware` as the single primitive; this PR makes its disconnected/HTTP path first-class instead of copy-paste.

## Scope notes

- **Additive, no breaking change.** Token type, interceptor and convention unchanged → SemVer minor.
- ADR-061 + the reference doc page ship as **separate `granit-docs` PRs** (decoupled doc-PR rule).
- The `granit-business` migration off `uint RowVersion` is tracked separately (app-side).

## DoD

- ✅ Build clean (0 warnings)
- ✅ `Granit.Persistence.EntityFrameworkCore.Tests` 9/9 green (3 new)
- ✅ `dotnet format --verify-no-changes` clean on touched projects
- ✅ No dependency change → no THIRD-PARTY-NOTICES update