### PR TITLE
feat(domain): adopt IConcurrencyAware on race-prone aggregates (ADR-061)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7697,6 +7697,12 @@
           "returnType": "string? Description { get; private set; } public bool IsSystem { get; private set; } public bool IsOrphaned { get; private set; } public DateTimeOffset? OrphanedAt { get; private set; } private"
         },
         {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string name, MultiTenancySides multiTenancySide, Guid? tenantId, string? clientId = null, string? description = null, bool isSystem = false)",
+          "returnType": "RoleMetadata"
+        },
+        {
           "name": "MarkAsOrphaned",
           "kind": "method",
           "signature": "MarkAsOrphaned(DateTimeOffset now)",
@@ -13017,6 +13023,12 @@
           "kind": "property",
           "signature": "BlobReference? BlobReference",
           "returnType": "BlobReference?"
+        },
+        {
+          "name": "ConcurrencyStamp",
+          "kind": "property",
+          "signature": "string ConcurrencyStamp",
+          "returnType": "string"
         }
       ]
     },
@@ -13658,6 +13670,12 @@
           "kind": "property",
           "signature": "IReadOnlyList<ImportColumnMapping>? Mappings",
           "returnType": "IReadOnlyList<ImportColumnMapping>?"
+        },
+        {
+          "name": "ConcurrencyStamp",
+          "kind": "property",
+          "signature": "string ConcurrencyStamp",
+          "returnType": "string"
         }
       ]
     },
@@ -29361,6 +29379,12 @@
           "kind": "property",
           "signature": "string? CustomDomain",
           "returnType": "string?"
+        },
+        {
+          "name": "ConcurrencyStamp",
+          "kind": "property",
+          "signature": "string ConcurrencyStamp",
+          "returnType": "string"
         },
         {
           "name": "Create",

--- a/src/Granit.Authorization/Domain/RoleMetadata.cs
+++ b/src/Granit.Authorization/Domain/RoleMetadata.cs
@@ -32,7 +32,7 @@ namespace Granit.Authorization.Domain;
 /// <c>TenantId = null</c> and <c>ClientId = null</c> cannot duplicate each other.
 /// </para>
 /// </remarks>
-public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
+public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant, IConcurrencyAware
 {
     /// <summary>Human-readable role name, e.g. <c>"TenantAdministrator"</c>. Max 256 characters.</summary>
     public string Name { get; private set; } = string.Empty;
@@ -92,6 +92,16 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
         get => TenantId;
         set => TenantId = value;
     }
+
+    /// <summary>
+    /// Optimistic-concurrency token (ADR-061). Auto-managed by <c>ConcurrencyStampInterceptor</c>
+    /// and configured as an EF Core concurrency token by <c>ApplyGranitConventions</c>. Guards
+    /// against concurrent admin edits silently overwriting one another.
+    /// </summary>
+    public string ConcurrencyStamp { get; private set; } = string.Empty;
+
+    /// <inheritdoc/>
+    string IConcurrencyAware.ConcurrencyStamp { get => ConcurrencyStamp; set => ConcurrencyStamp = value; }
 
     /// <summary>
     /// Creates a new <see cref="RoleMetadata"/> and raises a <see cref="RoleCreatedEvent"/>

--- a/src/Granit.DataExchange/Export/Domain/ExportJob.cs
+++ b/src/Granit.DataExchange/Export/Domain/ExportJob.cs
@@ -10,7 +10,7 @@ namespace Granit.DataExchange.Export.Domain;
 /// Inherits <see cref="AuditedAggregateRoot"/> for ISO 27001-compliant audit trail
 /// (CreatedAt, CreatedBy, ModifiedAt, ModifiedBy).
 /// </remarks>
-public sealed class ExportJob : AuditedAggregateRoot, IMultiTenant
+public sealed class ExportJob : AuditedAggregateRoot, IMultiTenant, IConcurrencyAware
 {
     // Parameterless constructor required by EF Core materializer.
     private ExportJob() { }
@@ -88,6 +88,16 @@ public sealed class ExportJob : AuditedAggregateRoot, IMultiTenant
 
     /// <inheritdoc />
     Guid? IMultiTenant.TenantId { get => TenantId; set => TenantId = value; }
+
+    /// <summary>
+    /// Optimistic-concurrency token (ADR-061). Auto-managed by <c>ConcurrencyStampInterceptor</c>
+    /// and configured as an EF Core concurrency token by <c>ApplyGranitConventions</c>. Guards
+    /// against a duplicate worker clobbering a concurrently-advanced job status.
+    /// </summary>
+    public string ConcurrencyStamp { get; private set; } = string.Empty;
+
+    /// <inheritdoc/>
+    string IConcurrencyAware.ConcurrencyStamp { get => ConcurrencyStamp; set => ConcurrencyStamp = value; }
 
     /// <summary>
     /// Transitions to <see cref="ExportJobStatus.Exporting"/>.

--- a/src/Granit.DataExchange/Import/Domain/ImportJob.cs
+++ b/src/Granit.DataExchange/Import/Domain/ImportJob.cs
@@ -13,7 +13,7 @@ namespace Granit.DataExchange.Import.Domain;
 /// Inherits <see cref="AuditedAggregateRoot"/> for ISO 27001-compliant audit trail
 /// (CreatedAt, CreatedBy, ModifiedAt, ModifiedBy).
 /// </remarks>
-public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant
+public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant, IConcurrencyAware
 {
     // Parameterless constructor required by EF Core materializer.
     private ImportJob() { }
@@ -102,6 +102,16 @@ public sealed class ImportJob : AuditedAggregateRoot, IMultiTenant
 
     /// <inheritdoc />
     Guid? IMultiTenant.TenantId { get => TenantId; set => TenantId = value; }
+
+    /// <summary>
+    /// Optimistic-concurrency token (ADR-061). Auto-managed by <c>ConcurrencyStampInterceptor</c>
+    /// and configured as an EF Core concurrency token by <c>ApplyGranitConventions</c>. Guards
+    /// against a duplicate worker clobbering a concurrently-advanced job status.
+    /// </summary>
+    public string ConcurrencyStamp { get; private set; } = string.Empty;
+
+    /// <inheritdoc/>
+    string IConcurrencyAware.ConcurrencyStamp { get => ConcurrencyStamp; set => ConcurrencyStamp = value; }
 
     /// <summary>
     /// Sets the column mappings after user confirmation.

--- a/src/Granit.MultiTenancy/Domain/Tenant.cs
+++ b/src/Granit.MultiTenancy/Domain/Tenant.cs
@@ -12,7 +12,7 @@ namespace Granit.MultiTenancy.Domain;
 /// All state transitions go through behavior methods that enforce invariants
 /// and raise domain events dispatched by <c>DomainEventDispatcherInterceptor</c>.
 /// </remarks>
-public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
+public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo, IConcurrencyAware
 {
     /// <summary>Display name of the tenant (max 256 characters).</summary>
     public string Name { get; private set; } = string.Empty;
@@ -39,6 +39,16 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
 
     // Explicit interface: Entity.Id is Guid, ITenantInfo.Id is Guid?
     Guid? ITenantInfo.Id => Id;
+
+    /// <summary>
+    /// Optimistic-concurrency token (ADR-061). Auto-managed by <c>ConcurrencyStampInterceptor</c>
+    /// and configured as an EF Core concurrency token by <c>ApplyGranitConventions</c>. Guards
+    /// against concurrent admin edits (details, custom domain, activation) racing on the same row.
+    /// </summary>
+    public string ConcurrencyStamp { get; private set; } = string.Empty;
+
+    /// <inheritdoc/>
+    string IConcurrencyAware.ConcurrencyStamp { get => ConcurrencyStamp; set => ConcurrencyStamp = value; }
 
     /// <summary>
     /// Private constructor for EF Core materialization.

--- a/src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs
+++ b/src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs
@@ -31,7 +31,7 @@ namespace Granit.Workflow.Domain;
 /// by implementing the static abstract member explicitly.
 /// </para>
 /// </remarks>
-public abstract class VersionedWorkflowEntity : AuditedAggregateRoot, IVersionedEntity, IWorkflowStateful
+public abstract class VersionedWorkflowEntity : AuditedAggregateRoot, IVersionedEntity, IWorkflowStateful, IConcurrencyAware
 {
     /// <summary>
     /// Initializes a new instance for EF Core materialization.
@@ -52,6 +52,13 @@ public abstract class VersionedWorkflowEntity : AuditedAggregateRoot, IVersioned
     /// <inheritdoc/>
     public bool IsPublished { get; private set; }
 
+    /// <summary>
+    /// Optimistic-concurrency token (ADR-061). Auto-managed by <c>ConcurrencyStampInterceptor</c>
+    /// and configured as an EF Core concurrency token by <c>ApplyGranitConventions</c>. Guards
+    /// every derived workflow entity against two concurrent lifecycle transitions racing.
+    /// </summary>
+    public string ConcurrencyStamp { get; private set; } = string.Empty;
+
     // Explicit interface implementations for interceptor write access.
     // VersioningInterceptor writes VersionId/Version via IVersioned cast.
     // WorkflowTransitionInterceptor writes IsPublished via IPublishable cast.
@@ -68,6 +75,9 @@ public abstract class VersionedWorkflowEntity : AuditedAggregateRoot, IVersioned
 
     /// <inheritdoc/>
     bool IPublishable.IsPublished { get => IsPublished; set => IsPublished = value; }
+
+    /// <inheritdoc/>
+    string IConcurrencyAware.ConcurrencyStamp { get => ConcurrencyStamp; set => ConcurrencyStamp = value; }
 
     /// <inheritdoc/>
     static string IWorkflowStateful.StatusPropertyName => nameof(LifecycleStatus);

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/ConcurrencyConventionTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/ConcurrencyConventionTests.cs
@@ -1,0 +1,36 @@
+using Granit.DataExchange.EntityFrameworkCore.Internal;
+using Granit.DataExchange.EntityFrameworkCore.Tests.Infrastructure;
+using Granit.DataExchange.Export.Domain;
+using Granit.DataExchange.Import.Domain;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.DataExchange.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Locks the ADR-061 adoption: the <see cref="Granit.Domain.IConcurrencyAware"/> job
+/// aggregates must be configured as EF Core concurrency tokens by
+/// <c>ApplyGranitConventions</c> in the real <c>DataExchangeDbContext</c> model — not just
+/// in the generic convention unit tests. Catches an accidental removal of the interface.
+/// </summary>
+public sealed class ConcurrencyConventionTests
+{
+    [Theory]
+    [InlineData(typeof(ExportJob))]
+    [InlineData(typeof(ImportJob))]
+    public void Job_aggregates_expose_ConcurrencyStamp_as_a_concurrency_token(Type entityType)
+    {
+        using DataExchangeDbContext context =
+            new InMemoryDataExchangeContextFactory(Guid.NewGuid().ToString()).CreateDbContext();
+
+        IProperty property = context.Model
+            .FindEntityType(entityType)
+            .ShouldNotBeNull()
+            .FindProperty("ConcurrencyStamp")
+            .ShouldNotBeNull();
+
+        property.IsConcurrencyToken.ShouldBeTrue();
+        property.GetMaxLength().ShouldBe(36);
+    }
+}


### PR DESCRIPTION
## What

Adopts the framework optimistic-concurrency primitive (`IConcurrencyAware` + auto-managed `ConcurrencyStamp`, see **ADR-061**) on five mutable, concurrently-written aggregates that lacked it:

| Aggregate | Rationale |
|---|---|
| `ExportJob`, `ImportJob` | Worker state machines saved via the change tracker with **no DB-level claim** — a duplicate dispatch could clobber a concurrently-advanced status. |
| `VersionedWorkflowEntity` (abstract base) | Protects **every** derived workflow entity against two concurrent lifecycle transitions racing. |
| `RoleMetadata`, `Tenant` | Admin-edited configuration updated in place. |

## How

Uses the framework idiom already established by `VersionedWorkflowEntity` for `IVersioned`/`IPublishable`: a public `{ get; private set; }` read property plus an **explicit-interface write accessor** for the interceptor. The private-setter `DomainConvention` rule stays green — **no architecture-rule change**. `ApplyGranitConventions` auto-wires `.IsConcurrencyToken()` + `VARCHAR(36)`; no per-entity Fluent config. No migrations (framework ships none; consuming apps regenerate).

## Evaluated and deliberately excluded

- **`PermissionGrant`** — insert/delete model (grant guarded by a unique constraint, revoke is a delete), never updated in place → a stamp adds nothing.
- **`ScheduledAction`** — already has an atomic `ExecuteUpdateAsync ... WHERE Status=Pending` claim; the better mechanism for a claim.
- **`User`** — auth concurrency already lives on `LocalIdentity` via ASP.NET Identity's own `ConcurrencyStamp`; the canonical `User` is profile-only (low harm).
- **`UserPresence` / `TimelineEntry` / `UserNotification`** — last-write-wins / append-only by design; a stamp would cause spurious 409s.

## DoD

- ✅ Build clean (4 modules)
- ✅ `ArchitectureTests` / `DomainConventionTests` 8/8 (private-setter rule green)
- ✅ Module unit tests: DataExchange 353, Workflow 118, Authorization 246, MultiTenancy 113
- ✅ New model-metadata regression test locking `ExportJob`/`ImportJob` token wiring (2/2)
- ✅ `dotnet format --verify-no-changes` clean

## Related

- ADR-061 + docs page ship as a separate `granit-docs` PR.
- Independent of #2361 (helper) — no stacking.