### PR TITLE
ci(publish): bump dotnet nuget push --timeout to 900s for GitLab feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,10 +526,13 @@ jobs:
           dotnet nuget add source \
             "https://gitlab.digitaldynamics.be/api/v4/projects/11/packages/nuget/index.json" \
             --name gitlab_granit_business
+          # GitLab's NuGet endpoint is sometimes slow on large packages — bump from
+          # the 300s default to 900s so transient PUT stalls don't fail the publish.
           dotnet nuget push "nupkgs/*.nupkg" \
             --source gitlab_granit_business \
             --api-key "$GITLAB_NUGET_TOKEN" \
-            --skip-duplicate
+            --skip-duplicate \
+            --timeout 900
 
   # nuget.org — release packages on version tags
   publish-nuget:


### PR DESCRIPTION
## Summary

The default 300s timeout was tripping on larger packages when publishing dev-feed nupkgs to the GitLab Package Registry:

```
Pushing Granit.Identity.Federated.Cognito.0.1.0-dev.3112.nupkg to
  'https://gitlab.digitaldynamics.be/api/v4/projects/11/packages/nuget'...
  PUT https://gitlab.digitaldynamics.be/api/v4/projects/11/packages/nuget/
error: The operation was canceled.
error:   Pushing took too long. You can change the default timeout
  of 300 seconds by using the --timeout <seconds> option with the
  push command.
```

Bump `--timeout` to **900s** (15 min) on the GitLab push step so transient PUT stalls don't fail the publish.

Only touches the GitLab feed step; nuget.org publish (tag-gated) is left alone — nuget.org doesn't show the same pattern and the 300s default is fine there.

## Test plan

- [ ] Next `develop` merge runs the publish job and the push completes under the new timeout