### PR TITLE
Scoped* wrappers direct tests + BuildGuardDescriptor helper

### DIFF
--- a/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
+++ b/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
@@ -104,42 +104,43 @@ public static class AIServiceCollectionExtensions
             return;
         }
 
-        if (existing.ImplementationType is not null)
+        Func<IServiceProvider, ISettingManager>? resolveInner = null;
+        ServiceLifetime guardLifetime = existing.Lifetime;
+
+        if (existing.ImplementationType is { } implType)
         {
             // Re-register the underlying implementation under its concrete type so the guard
             // can pull it via DI.
-            services.Add(new ServiceDescriptor(
-                existing.ImplementationType,
-                existing.ImplementationType,
-                existing.Lifetime));
+            services.Add(new ServiceDescriptor(implType, implType, existing.Lifetime));
+            resolveInner = sp => (ISettingManager)sp.GetRequiredService(implType);
+        }
+        else if (existing.ImplementationFactory is { } factory)
+        {
+            resolveInner = sp => (ISettingManager)factory(sp);
+        }
+        else if (existing.ImplementationInstance is ISettingManager instance)
+        {
+            resolveInner = _ => instance;
+            guardLifetime = ServiceLifetime.Singleton;
+        }
 
-            services.Add(new ServiceDescriptor(
-                typeof(ISettingManager),
-                sp => new AISettingsCredentialsGuard(
-                    (ISettingManager)sp.GetRequiredService(existing.ImplementationType),
-                    ResolvePermissionChecker(sp, existing.Lifetime)),
-                existing.Lifetime));
+        if (resolveInner is null)
+        {
             return;
         }
 
-        if (existing.ImplementationFactory is not null)
-        {
-            services.Add(new ServiceDescriptor(
-                typeof(ISettingManager),
-                sp => new AISettingsCredentialsGuard(
-                    (ISettingManager)existing.ImplementationFactory(sp),
-                    ResolvePermissionChecker(sp, existing.Lifetime)),
-                existing.Lifetime));
-            return;
-        }
-
-        if (existing.ImplementationInstance is ISettingManager instance)
-        {
-            services.AddSingleton<ISettingManager>(sp => new AISettingsCredentialsGuard(
-                instance,
-                ResolvePermissionChecker(sp, ServiceLifetime.Singleton)));
-        }
+        services.Add(BuildGuardDescriptor(resolveInner, guardLifetime));
     }
+
+    private static ServiceDescriptor BuildGuardDescriptor(
+        Func<IServiceProvider, ISettingManager> resolveInner,
+        ServiceLifetime lifetime) =>
+        new(
+            typeof(ISettingManager),
+            sp => new AISettingsCredentialsGuard(
+                resolveInner(sp),
+                ResolvePermissionChecker(sp, lifetime)),
+            lifetime);
 
     /// <summary>
     /// Returns an <see cref="IPermissionChecker"/> safe to capture in a constructor whose

--- a/tests/Granit.Authorization.Tests/ScopedPermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/ScopedPermissionCheckerTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.Tests;
+
+public sealed class ScopedPermissionCheckerTests
+{
+    private const string SamplePermission = "Invoices.Read";
+
+    // --- TryCreate ---
+
+    [Fact]
+    public void TryCreate_ReturnsNull_WhenScopeFactoryIsNull()
+    {
+        ScopedPermissionChecker.TryCreate(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryCreate_ReturnsNull_WhenInnerCheckerNotRegistered()
+    {
+        await using ServiceProvider sp = new ServiceCollection().BuildServiceProvider();
+
+        var wrapper = ScopedPermissionChecker.TryCreate(
+            sp.GetRequiredService<IServiceScopeFactory>());
+
+        wrapper.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryCreate_ReturnsWrapper_WhenInnerCheckerIsRegistered()
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => Substitute.For<IPermissionChecker>());
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        var wrapper = ScopedPermissionChecker.TryCreate(
+            sp.GetRequiredService<IServiceScopeFactory>());
+
+        wrapper.ShouldNotBeNull();
+    }
+
+    // --- IsGrantedAsync ---
+
+    [Fact]
+    public async Task IsGrantedAsync_ReturnsTrue_WhenInnerGrants()
+    {
+        IPermissionChecker inner = Substitute.For<IPermissionChecker>();
+        inner.IsGrantedAsync(SamplePermission, Arg.Any<CancellationToken>()).Returns(true);
+        await using ServiceProvider sp = BuildProvider(inner);
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        bool granted = await wrapper.IsGrantedAsync(SamplePermission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeTrue();
+        await inner.Received(1).IsGrantedAsync(SamplePermission, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task IsGrantedAsync_ReturnsFalse_WhenInnerDenies()
+    {
+        IPermissionChecker inner = Substitute.For<IPermissionChecker>();
+        inner.IsGrantedAsync(SamplePermission, Arg.Any<CancellationToken>()).Returns(false);
+        await using ServiceProvider sp = BuildProvider(inner);
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        bool granted = await wrapper.IsGrantedAsync(SamplePermission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsGrantedAsync_DeniesByDefault_WhenInnerUnregisteredAfterConstruction()
+    {
+        // Defensive least-privilege path: if the registration disappears after TryCreate
+        // (caller built the wrapper directly), deny rather than fail-open.
+        await using ServiceProvider sp = new ServiceCollection().BuildServiceProvider();
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        bool granted = await wrapper.IsGrantedAsync(SamplePermission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsGrantedAsync_PropagatesCancellationToken()
+    {
+        IPermissionChecker inner = Substitute.For<IPermissionChecker>();
+        await using ServiceProvider sp = BuildProvider(inner);
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+        using CancellationTokenSource cts = new();
+
+        await wrapper.IsGrantedAsync(SamplePermission, cts.Token);
+
+        await inner.Received(1).IsGrantedAsync(SamplePermission, cts.Token);
+    }
+
+    [Fact]
+    public async Task IsGrantedAsync_PropagatesInnerException()
+    {
+        IPermissionChecker inner = Substitute.For<IPermissionChecker>();
+        inner.IsGrantedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .ThrowsAsync(new InvalidOperationException("boom"));
+        await using ServiceProvider sp = BuildProvider(inner);
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => wrapper.IsGrantedAsync(SamplePermission, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldBe("boom");
+    }
+
+    // --- GetGrantedAsync ---
+
+    [Fact]
+    public async Task GetGrantedAsync_ReturnsInnerSubset()
+    {
+        IPermissionChecker inner = Substitute.For<IPermissionChecker>();
+        string[] requested = ["A", "B", "C"];
+        inner.GetGrantedAsync(requested, Arg.Any<CancellationToken>())
+             .Returns(new[] { "A", "C" });
+        await using ServiceProvider sp = BuildProvider(inner);
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        IReadOnlyList<string> granted = await wrapper.GetGrantedAsync(
+            requested, TestContext.Current.CancellationToken);
+
+        granted.ShouldBe(["A", "C"]);
+    }
+
+    [Fact]
+    public async Task GetGrantedAsync_ReturnsEmpty_WhenInnerUnregisteredAfterConstruction()
+    {
+        await using ServiceProvider sp = new ServiceCollection().BuildServiceProvider();
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        IReadOnlyList<string> granted = await wrapper.GetGrantedAsync(
+            ["A"], TestContext.Current.CancellationToken);
+
+        granted.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetGrantedAsync_PropagatesInnerException()
+    {
+        IPermissionChecker inner = Substitute.For<IPermissionChecker>();
+        inner.GetGrantedAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+             .ThrowsAsync(new InvalidOperationException("boom"));
+        await using ServiceProvider sp = BuildProvider(inner);
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => wrapper.GetGrantedAsync(["A"], TestContext.Current.CancellationToken));
+    }
+
+    // --- Scope lifecycle ---
+
+    [Fact]
+    public async Task EachCall_CreatesAFreshScope()
+    {
+        int created = 0;
+        ServiceCollection services = new();
+        services.AddScoped(_ =>
+        {
+            created++;
+            return Substitute.For<IPermissionChecker>();
+        });
+        await using ServiceProvider sp = services.BuildServiceProvider();
+        ScopedPermissionChecker wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await wrapper.IsGrantedAsync(SamplePermission, TestContext.Current.CancellationToken);
+        await wrapper.GetGrantedAsync(["A"], TestContext.Current.CancellationToken);
+
+        created.ShouldBe(2);
+    }
+
+    private static ServiceProvider BuildProvider(IPermissionChecker inner)
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => inner);
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Granit.Tests/Events/ScopedLocalEventBusTests.cs
+++ b/tests/Granit.Tests/Events/ScopedLocalEventBusTests.cs
@@ -1,0 +1,123 @@
+using Granit.Events;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Events;
+
+public sealed class ScopedLocalEventBusTests
+{
+    private sealed record SampleEvent(string Value);
+
+    [Fact]
+    public async Task TryCreate_ReturnsNull_WhenScopeFactoryIsNull()
+    {
+        ScopedLocalEventBus.TryCreate(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryCreate_ReturnsNull_WhenInnerBusNotRegistered()
+    {
+        await using ServiceProvider sp = new ServiceCollection().BuildServiceProvider();
+
+        var wrapper = ScopedLocalEventBus.TryCreate(
+            sp.GetRequiredService<IServiceScopeFactory>());
+
+        wrapper.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryCreate_ReturnsWrapper_WhenInnerBusIsRegistered()
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => Substitute.For<ILocalEventBus>());
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        var wrapper = ScopedLocalEventBus.TryCreate(
+            sp.GetRequiredService<IServiceScopeFactory>());
+
+        wrapper.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task PublishAsync_ResolvesInnerBusAndForwardsEvent()
+    {
+        ILocalEventBus inner = Substitute.For<ILocalEventBus>();
+        ServiceCollection services = new();
+        services.AddScoped(_ => inner);
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        ScopedLocalEventBus wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+        SampleEvent evt = new("hello");
+
+        await wrapper.PublishAsync(evt, TestContext.Current.CancellationToken);
+
+        await inner.Received(1).PublishAsync(evt, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PublishAsync_IsNoOp_WhenInnerBusUnregisteredAfterConstruction()
+    {
+        // Wrapper resolves the bus lazily per call; if DI evolves to drop the registration
+        // (rare but possible in tests), publish should be a silent no-op rather than throw.
+        await using ServiceProvider sp = new ServiceCollection().BuildServiceProvider();
+        ScopedLocalEventBus wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await Should.NotThrowAsync(
+            () => wrapper.PublishAsync(new SampleEvent("x"), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task PublishAsync_CreatesAFreshScopePerCall()
+    {
+        int created = 0;
+        ServiceCollection services = new();
+        services.AddScoped(_ =>
+        {
+            created++;
+            return Substitute.For<ILocalEventBus>();
+        });
+        await using ServiceProvider sp = services.BuildServiceProvider();
+        ScopedLocalEventBus wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await wrapper.PublishAsync(new SampleEvent("a"), TestContext.Current.CancellationToken);
+        await wrapper.PublishAsync(new SampleEvent("b"), TestContext.Current.CancellationToken);
+
+        created.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task PublishAsync_PropagatesCancellationToken()
+    {
+        ILocalEventBus inner = Substitute.For<ILocalEventBus>();
+        ServiceCollection services = new();
+        services.AddScoped(_ => inner);
+        await using ServiceProvider sp = services.BuildServiceProvider();
+        ScopedLocalEventBus wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        using CancellationTokenSource cts = new();
+
+        await wrapper.PublishAsync(new SampleEvent("c"), cts.Token);
+
+        await inner.Received(1).PublishAsync(Arg.Any<SampleEvent>(), cts.Token);
+    }
+
+    [Fact]
+    public async Task PublishAsync_PropagatesInnerException()
+    {
+        ILocalEventBus inner = Substitute.For<ILocalEventBus>();
+        inner.PublishAsync(Arg.Any<SampleEvent>(), Arg.Any<CancellationToken>())
+             .ThrowsAsync(new InvalidOperationException("boom"));
+        ServiceCollection services = new();
+        services.AddScoped(_ => inner);
+        await using ServiceProvider sp = services.BuildServiceProvider();
+        ScopedLocalEventBus wrapper = new(sp.GetRequiredService<IServiceScopeFactory>());
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => wrapper.PublishAsync(new SampleEvent("err"), TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldBe("boom");
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2372 addressing two SonarQube gates that came back below
threshold on that PR:

- **Coverage 55.4% (threshold 80%)** — the `ScopedLocalEventBus` and
  `ScopedPermissionChecker` wrappers were only covered indirectly through
  `AIScopeValidationTests`. Added direct unit tests for both:
  - `tests/Granit.Tests/Events/ScopedLocalEventBusTests.cs` (8 cases)
  - `tests/Granit.Authorization.Tests/ScopedPermissionCheckerTests.cs` (12 cases)
- **Duplicated lines density 9.6% (threshold 3%)** — the three branches of
  `DecorateSettingManagerWithCredentialsGuard` (ImplementationType /
  ImplementationFactory / ImplementationInstance) shared the same
  `new ServiceDescriptor(..., sp => new AISettingsCredentialsGuard(...), lifetime)`
  shape. Extracted `BuildGuardDescriptor` and reduced the branches to a
  single `Func<IServiceProvider, ISettingManager>` selection.

## Test plan

- [x] `dotnet test tests/Granit.Tests/Granit.Tests.csproj` — 482/482
- [x] `dotnet test tests/Granit.Authorization.Tests/Granit.Authorization.Tests.csproj` — 258/258
- [x] `dotnet test tests/Granit.AI.Tests/Granit.AI.Tests.csproj` — 44/44 (incl. `AIScopeValidationTests` covering the singleton-ISettingManager → guard path through the new helper)