### PR TITLE
fix(wolverine): quiet per-envelope success logs to unblock Aspire dashboard

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -48761,7 +48761,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.EntityFrameworkCore",
       "file": "src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitWebhooksEntityFrameworkCore",
@@ -49461,7 +49461,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs",
-      "line": 25,
+      "line": 26,
       "members": [
         {
           "name": "AddGranitWolverine",

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Wolverine;
 using Wolverine.ErrorHandling;
@@ -160,6 +161,15 @@ public static class WolverineHostApplicationBuilderExtensions
             opts.Policies.AddMiddleware<TenantContextBehavior>();
             opts.Policies.AddMiddleware<UserContextBehavior>();
             opts.Policies.AddMiddleware<TraceContextBehavior>();
+
+            // Wolverine's default `MessageSuccessLogLevel` is Information — one line per
+            // handled envelope. Fan-out flows (privacy export scatter-gather, bulk
+            // notification dispatch) push hundreds of those into Aspire's Logs/Structured
+            // view in a few seconds and the dashboard's virtualized renderer chokes the
+            // browser. Demote to Debug so the per-envelope success traces stay opt-in via
+            // `"Wolverine": "Debug"` in appsettings; warnings, errors and retries still
+            // surface at their original levels.
+            opts.Policies.MessageSuccessLogLevel(LogLevel.Debug);
 
             configure?.Invoke(opts);
 


### PR DESCRIPTION
## Summary
- Set `opts.Policies.MessageSuccessLogLevel(LogLevel.Debug)` in `AddGranitWolverine` so every handled envelope no longer emits an `Information` log line.
- Symptom triggering this: a self-service Privacy data export fans out 1 × `PersonalDataRequestedEto` → N × `PersonalDataPreparedEto` (Identity Local/Federated, Notifications, Auditing, Blob Storage, AI, Documents…) → `ExportCompletedEto` → background assembly job → shard + manifest + signing + audit ETOs. Wolverine's default per-envelope success trace at `Information` produces hundreds of lines in a couple of seconds, which freezes the Aspire dashboard's virtualized Logs/Structured view (browser-side, not server-side).
- Warnings, errors, retries and DLQ moves keep their original log levels — visibility on actual problems is unchanged. Re-enable verbose tracing per-environment with `"Wolverine": "Debug"` in `appsettings`.

## Test plan
- [x] `dotnet build src/Granit.Wolverine`
- [x] `dotnet test tests/Granit.Wolverine.Tests` (158/158)
- [x] `dotnet format src/Granit.Wolverine/Granit.Wolverine.csproj --verify-no-changes`
- [ ] CI shards green
- [ ] Manual: trigger a privacy export and confirm Aspire Logs view stays responsive