### PR TITLE
fix(webhooks): fail-fast on dual-scope integration mistakes (#2021 follow-up)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13562,6 +13562,15 @@
       "members": []
     },
     {
+      "name": "ImportDefinitionServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.Extensions.ImportDefinitionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Extensions/ImportDefinitionServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
       "name": "ServiceCollectionExtensions",
       "fqn": "Granit.DataExchange.Extensions.ServiceCollectionExtensions",
       "kind": "class",
@@ -13583,7 +13592,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.Abstractions",
       "file": "src/Granit.DataExchange.Abstractions/GranitDataExchangeAbstractionsModule.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -13900,8 +13909,8 @@
       "name": "ChildCollectionBuilder",
       "fqn": "Granit.DataExchange.Import.Mapping.ChildCollectionBuilder",
       "kind": "class",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Import/Mapping/ChildCollectionBuilder.cs",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ChildCollectionBuilder.cs",
       "line": 9,
       "members": []
     },
@@ -13925,8 +13934,8 @@
       "name": "IImportDefinitionDescriptor",
       "fqn": "Granit.DataExchange.Import.Mapping.IImportDefinitionDescriptor",
       "kind": "interface",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Import/Mapping/IImportDefinitionDescriptor.cs",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/IImportDefinitionDescriptor.cs",
       "line": 12,
       "members": [
         {
@@ -14019,8 +14028,8 @@
       "name": "ImportDefinition",
       "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinition",
       "kind": "class",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Import/Mapping/ImportDefinition.cs",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ImportDefinition.cs",
       "line": 31,
       "members": [
         {
@@ -14077,8 +14086,8 @@
       "name": "ImportDefinitionBuilder",
       "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinitionBuilder",
       "kind": "class",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Import/Mapping/ImportDefinitionBuilder.cs",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ImportDefinitionBuilder.cs",
       "line": 10,
       "members": []
     },
@@ -14086,8 +14095,8 @@
       "name": "ImportFieldMetadata",
       "fqn": "Granit.DataExchange.Import.Mapping.ImportFieldMetadata",
       "kind": "record",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Import/Mapping/ImportFieldMetadata.cs",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ImportFieldMetadata.cs",
       "line": 12,
       "members": []
     },
@@ -14126,8 +14135,8 @@
       "name": "PropertyMapping",
       "fqn": "Granit.DataExchange.Import.Mapping.PropertyMapping",
       "kind": "class",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Import/Mapping/PropertyMapping.cs",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/PropertyMapping.cs",
       "line": 6,
       "members": [
         {
@@ -14148,8 +14157,8 @@
       "name": "PropertyMappingBuilder",
       "fqn": "Granit.DataExchange.Import.Mapping.PropertyMappingBuilder",
       "kind": "class",
-      "project": "Granit.DataExchange",
-      "file": "src/Granit.DataExchange/Import/Mapping/PropertyMappingBuilder.cs",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/PropertyMappingBuilder.cs",
       "line": 6,
       "members": []
     },
@@ -23292,7 +23301,7 @@
       "kind": "class",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/GranitIdentityModule.cs",
-      "line": 27,
+      "line": 28,
       "members": [
         {
           "name": "ConfigureServices",
@@ -23705,6 +23714,22 @@
           "kind": "method",
           "signature": "PseudonymizeByIdAsync(string userId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "UserImportDefinition",
+      "fqn": "Granit.Identity.Imports.UserImportDefinition",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Imports/UserImportDefinition.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
         }
       ]
     },

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
 using Granit.Webhooks.Abstractions;
@@ -20,13 +21,44 @@ public static class WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
     /// backed by a PostgreSQL database.
     /// </summary>
     /// <remarks>
-    /// Must be called after <c>AddGranitWebhooks()</c>.
-    /// Registers:
+    /// <para>
+    /// Must be called after <c>AddGranitWebhooks()</c>. Registers:
+    /// </para>
     /// <list type="bullet">
     ///   <item><see cref="EfWebhookSubscriptionStore"/> — replaces <c>InMemoryWebhookSubscriptionStore</c> for both <see cref="IWebhookSubscriptionReader"/> and <see cref="IWebhookSubscriptionWriter"/>.</item>
     ///   <item><see cref="EfWebhookDeliveryStore"/> — replaces <c>NullWebhookDeliveryWriter</c> (enables ISO 27001 audit trail).</item>
     ///   <item><see cref="Internal.WebhooksDbContext"/> — registered via <c>IDbContextFactory</c> for thread-safe usage in Wolverine handlers.</item>
     /// </list>
+    /// <para>
+    /// <b>Integration requirement — host-scoped DbContext only.</b> Webhooks is a
+    /// <b>dual-scope</b> module: platform-managed subscriptions (<c>TenantId == null</c>)
+    /// coexist with tenant-managed subscriptions (<c>TenantId == &lt;tenant&gt;</c>) in the
+    /// same physical table. Tenant isolation is enforced by the row-level <c>MultiTenant</c>
+    /// query filter — host admin reads bypass the filter via
+    /// <see cref="Internal.EfWebhookSubscriptionQueryableSource"/>. To support this contract
+    /// the tables live in <see cref="GranitDbDefaults.HostDbSchema"/>
+    /// (see <see cref="GranitWebhooksDbProperties.DbSchema"/>).
+    /// </para>
+    /// <para>
+    /// <b>When folding the model into the consuming app's own <see cref="DbContext"/></b>,
+    /// call <see cref="WebhooksModelBuilderExtensions.ConfigureWebhooksModule"/> on a
+    /// <b>host-scoped</b> DbContext (one registered via <c>AddGranitDbContext&lt;T&gt;</c>) —
+    /// never on a tenant-isolated DbContext (one registered via
+    /// <c>AddGranitIsolatedDbContext&lt;T&gt;</c>). Folding into an isolated DbContext under
+    /// the <c>SchemaPerTenant</c> or <c>DatabasePerTenant</c> strategy creates the table in
+    /// each tenant's schema (e.g. <c>acme.webhooks_subscriptions</c>) while
+    /// <see cref="Internal.WebhooksDbContext"/> still qualifies queries against
+    /// <c>host.webhooks_subscriptions</c>, leading to a <c>42P01 relation does not exist</c>
+    /// error at the first request. The internal
+    /// <c>WebhooksDualScopeIntegrationValidator</c> fails fast at host startup if this
+    /// misconfiguration is detected.
+    /// </para>
+    /// <para>
+    /// If your deployment genuinely needs <i>physically isolated</i> webhook tables per
+    /// tenant (e.g. for <c>DROP SCHEMA</c> tenant lessivage under GDPR), see the dedicated
+    /// Epic — this requires a second host DbContext for platform subscriptions and is not
+    /// supported by the current <c>AddGranitWebhooksEntityFrameworkCore</c> extension.
+    /// </para>
     /// </remarks>
     /// <param name="builder">The host application builder.</param>
     /// <param name="configure">EF Core <see cref="DbContextOptionsBuilder"/> configuration (provider + connection string).</param>
@@ -36,6 +68,7 @@ public static class WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
         Action<DbContextOptionsBuilder> configure)
     {
         builder.Services.AddGranitDbContext<WebhooksDbContext>(configure);
+        builder.Services.AddHostedService<WebhooksDualScopeIntegrationValidator>();
 
         builder.Services.AddScoped<EfWebhookSubscriptionStore>();
         builder.Services.Replace(

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDualScopeIntegrationValidator.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDualScopeIntegrationValidator.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Webhooks.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Fail-fast guard that detects when a tenant-isolated <see cref="DbContext"/> folds the
+/// Webhooks model via <see cref="Extensions.WebhooksModelBuilderExtensions.ConfigureWebhooksModule"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Webhooks is a dual-scope module: tables live in the <i>host</i> schema and tenant
+/// isolation is enforced via the <c>MultiTenant</c> row-level query filter. Folding
+/// <c>ConfigureWebhooksModule()</c> into an isolated DbContext under <c>SchemaPerTenant</c>
+/// or <c>DatabasePerTenant</c> creates the table in the wrong place — runtime queries
+/// then fail with PostgreSQL 42P01 (<i>relation does not exist</i>).
+/// </para>
+/// <para>
+/// Runs once at <c>host.StartAsync()</c>. For each <see cref="IsolatedDbContextMarker"/>,
+/// resolves the always-registered <see cref="TenantIsolationStrategy.SharedDatabase"/>
+/// keyed factory (cheap — no real DB I/O, only model compilation), inspects the model's
+/// entity types, and throws if any Webhooks aggregate is configured.
+/// </para>
+/// </remarks>
+internal sealed partial class WebhooksDualScopeIntegrationValidator(
+    IEnumerable<IsolatedDbContextMarker> markers,
+    IServiceProvider serviceProvider,
+    ILogger<WebhooksDualScopeIntegrationValidator> logger) : IHostedService
+{
+    private static readonly HashSet<Type> WebhooksAggregates =
+    [
+        typeof(WebhookSubscription),
+        typeof(WebhookSigningKey),
+        typeof(WebhookDeliveryAttempt),
+    ];
+
+    /// <inheritdoc/>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        List<(Type DbContextType, List<string> Entities)> offenders = [];
+
+        foreach (IsolatedDbContextMarker marker in markers)
+        {
+            List<string>? folded = TryFindFoldedWebhooksEntities(marker.DbContextType);
+            if (folded is { Count: > 0 })
+            {
+                offenders.Add((marker.DbContextType, folded));
+            }
+        }
+
+        if (offenders.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        StringBuilder sb = new();
+        sb.AppendLine(
+            "Webhooks is a dual-scope module: its tables live in the host schema and tenant " +
+            "isolation is enforced by the MultiTenant row-level query filter. " +
+            "ConfigureWebhooksModule() must be folded into a host-scoped DbContext " +
+            "(registered via AddGranitDbContext<T>), never into a tenant-isolated DbContext " +
+            "(registered via AddGranitIsolatedDbContext<T>) — otherwise the migration creates " +
+            "the table in the tenant schema while runtime queries target the host schema, " +
+            "causing PostgreSQL 42P01 at the first request.");
+        sb.AppendLine();
+        sb.AppendLine("The following isolated DbContexts incorrectly fold Webhooks entities:");
+        foreach ((Type type, List<string> entities) in offenders)
+        {
+            sb.Append("  - ").Append(type.FullName ?? type.Name)
+              .Append(" → ").AppendLine(string.Join(", ", entities));
+        }
+        sb.AppendLine();
+        sb.Append("Move ConfigureWebhooksModule() to a host-scoped DbContext, or open the ");
+        sb.Append("fully-isolated Webhooks Epic if you need physically separate tables per tenant.");
+
+        throw new InvalidOperationException(sb.ToString());
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private List<string>? TryFindFoldedWebhooksEntities(Type dbContextType)
+    {
+        // Resolve the SharedDatabase keyed factory — always registered by
+        // AddGranitIsolatedDbContext, and the cheapest path (no search_path / no tenant
+        // dispatch). The factory builds DbContextOptions from the configureShared delegate;
+        // we never open a connection, only compile the model.
+        Type factoryType = typeof(IDbContextFactory<>).MakeGenericType(dbContextType);
+        object? factory = serviceProvider.GetKeyedService(factoryType, TenantIsolationStrategy.SharedDatabase);
+        if (factory is null)
+        {
+            LogNoSharedFactory(dbContextType.Name);
+            return null;
+        }
+
+        try
+        {
+            var context = (DbContext)factoryType
+                .GetMethod(nameof(IDbContextFactory<DbContext>.CreateDbContext))!
+                .Invoke(factory, parameters: null)!;
+
+            try
+            {
+                List<string> matches = [];
+                foreach (IEntityType entityType in context.Model.GetEntityTypes())
+                {
+                    if (WebhooksAggregates.Contains(entityType.ClrType))
+                    {
+                        matches.Add(entityType.ClrType.Name);
+                    }
+                }
+                return matches;
+            }
+            finally
+            {
+                context.Dispose();
+            }
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            // Best-effort: a DbContext that throws at model-compile time is already broken
+            // elsewhere — let the real validator handle it. Don't mask unrelated startup
+            // failures behind a Webhooks-specific message.
+            LogValidationSkipped(dbContextType.Name, ex.GetType().Name, ex.Message);
+            return null;
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping Webhooks dual-scope validation for {ContextType}: no SharedDatabase keyed factory registered.")]
+    private partial void LogNoSharedFactory(string contextType);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping Webhooks dual-scope validation for {ContextType}: model inspection failed with {ExceptionType}: {Message}.")]
+    private partial void LogValidationSkipped(string contextType, string exceptionType, string message);
+}

--- a/src/Granit.Webhooks.EntityFrameworkCore/README.md
+++ b/src/Granit.Webhooks.EntityFrameworkCore/README.md
@@ -15,6 +15,56 @@ dotnet add package Granit.Webhooks.EntityFrameworkCore
 - `Granit.Persistence`
 - `Granit.Webhooks`
 
+## Integration
+
+Webhooks is a **dual-scope** module: platform-managed subscriptions (`TenantId == null`)
+and tenant-managed subscriptions (`TenantId == <tenant>`) coexist in the same physical
+table. Tenant isolation is enforced by the row-level `MultiTenant` query filter; host
+admin endpoints bypass the filter through `EfWebhookSubscriptionQueryableSource`.
+
+To support this contract the tables live in `GranitDbDefaults.HostDbSchema` (default
+`host`) — never per-tenant. When folding the entity configurations into your own
+`DbContext`, call `ConfigureWebhooksModule()` on a **host-scoped** DbContext:
+
+```csharp
+public sealed class AppHostDbContext(
+    DbContextOptions<AppHostDbContext> options,
+    ICurrentTenant currentTenant,
+    IDataFilter? dataFilter = null) : GranitDbContext(options, currentTenant, dataFilter)
+{
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ConfigureWebhooksModule(); // host DbContext owns the tables
+    }
+}
+```
+
+```csharp
+// Program.cs — host DbContext registered via AddGranitDbContext (non-isolated)
+builder.Services.AddGranitDbContext<AppHostDbContext>(opts => opts.UseNpgsql(cs));
+builder.AddGranitWebhooksEntityFrameworkCore(opts => opts.UseNpgsql(cs));
+```
+
+**Never** fold `ConfigureWebhooksModule()` into a tenant-isolated DbContext
+(`AddGranitIsolatedDbContext<T>`). Under `SchemaPerTenant` or `DatabasePerTenant` this
+creates the table in each tenant's schema (e.g. `acme.webhooks_subscriptions`) while
+the internal `WebhooksDbContext` still qualifies queries against `host.webhooks_subscriptions`,
+producing PostgreSQL `42P01 relation does not exist` at the first request.
+
+`WebhooksDualScopeIntegrationValidator` fails fast at host startup when this
+misconfiguration is detected.
+
+### Why not per-tenant tables?
+
+The row-level filter already gives tenants logical isolation: a subscription written by
+`user@acme.local` carries `TenantId = <acme-guid>` and is invisible to `beta` tenant
+queries. The single shared table also lets host admins observe events cross-tenant
+(e.g. SIEM forwarding) without duplicating the schema.
+
+If your deployment needs **physical** isolation (e.g. `DROP SCHEMA` tenant lessivage
+under GDPR), this is a separate Epic — the framework currently does not ship a
+fully-isolated mode for Webhooks.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionQueryableSourceTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionQueryableSourceTests.cs
@@ -1,0 +1,119 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.Webhooks.Domain;
+using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Behavioural tests for <see cref="EfWebhookSubscriptionQueryableSource"/> — the
+/// host-bypass piece of the dual-scope contract documented in #2021. These tests pin
+/// the row-level filter semantics so a future refactor can't silently drop the bypass
+/// (which would force host admin reads through the tenant filter and hide cross-tenant
+/// rows).
+/// </summary>
+public sealed class EfWebhookSubscriptionQueryableSourceTests
+{
+    private readonly Guid _tenantA = Guid.NewGuid();
+    private readonly Guid _tenantB = Guid.NewGuid();
+    private readonly DbContextOptions<WebhooksDbContext> _options;
+    private readonly DataFilter _filter = new();
+
+    public EfWebhookSubscriptionQueryableSourceTests()
+    {
+        _options = new DbContextOptionsBuilder<WebhooksDbContext>()
+            .UseInMemoryDatabase(databaseName: $"webhooks-qs-{Guid.NewGuid()}")
+            .Options;
+    }
+
+    [Fact]
+    public async Task GetQueryable_TenantContext_ReturnsTenantRows()
+    {
+        // Arrange — seed tenant A, tenant B, and a platform (null) subscription with the
+        // MultiTenant filter temporarily disabled so we can write across tenants.
+        await SeedAcrossTenantsAsync(
+            CreateSubscription("doc.uploaded", _tenantA),
+            CreateSubscription("doc.uploaded", _tenantB),
+            CreateSubscription("doc.uploaded", tenantId: null));
+
+        // Tenant A is active — both at the DbContext level (filter parameter) and at the
+        // QueryableSource level (no bypass).
+        ICurrentTenant tenantA = TenantStub(_tenantA, isAvailable: true);
+        var sut = new EfWebhookSubscriptionQueryableSource(
+            new TenantScopedDbContextFactory(_options, tenantA, _filter),
+            tenantA);
+
+        // Act
+        WebhookSubscription[] result = [.. sut.GetQueryable()];
+
+        // Assert — tenant B's row is gone; tenant A's row remains.
+        result.ShouldHaveSingleItem();
+        result[0].TenantId.ShouldBe(_tenantA);
+    }
+
+    [Fact]
+    public async Task GetQueryable_HostContext_ReturnsAllTenants()
+    {
+        // Arrange
+        await SeedAcrossTenantsAsync(
+            CreateSubscription("doc.uploaded", _tenantA),
+            CreateSubscription("doc.uploaded", _tenantB),
+            CreateSubscription("doc.uploaded", tenantId: null));
+
+        // No tenant — host admin path. IgnoreQueryFilters([MultiTenant]) bypasses the
+        // row-level filter and returns every subscription.
+        ICurrentTenant host = TenantStub(tenantId: null, isAvailable: false);
+        var sut = new EfWebhookSubscriptionQueryableSource(
+            new TenantScopedDbContextFactory(_options, host, _filter),
+            host);
+
+        // Act
+        WebhookSubscription[] result = [.. sut.GetQueryable()];
+
+        // Assert — all three rows visible to the host context.
+        result.Length.ShouldBe(3);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private async Task SeedAcrossTenantsAsync(params WebhookSubscription[] subscriptions)
+    {
+        using IDisposable _ = _filter.Disable<IMultiTenant>();
+        await using WebhooksDbContext context = new(_options, TenantStub(tenantId: null, isAvailable: false), _filter);
+        context.WebhookSubscriptions.AddRange(subscriptions);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static ICurrentTenant TenantStub(Guid? tenantId, bool isAvailable)
+    {
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(isAvailable);
+        tenant.Id.Returns(tenantId);
+        return tenant;
+    }
+
+    private static WebhookSubscription CreateSubscription(string eventType, Guid? tenantId) =>
+        WebhookSubscription.Create(
+            Guid.NewGuid(),
+            $"https://example.com/{Guid.NewGuid()}",
+            eventType,
+            signingKeyId: Guid.NewGuid(),
+            protectedSecret: "protected-secret",
+            createdAt: DateTimeOffset.UtcNow,
+            tenantId: tenantId);
+
+    private sealed class TenantScopedDbContextFactory(
+        DbContextOptions<WebhooksDbContext> options,
+        ICurrentTenant currentTenant,
+        IDataFilter dataFilter) : IDbContextFactory<WebhooksDbContext>
+    {
+        public WebhooksDbContext CreateDbContext() => new(options, currentTenant, dataFilter);
+    }
+}

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDualScopeIntegrationValidatorTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDualScopeIntegrationValidatorTests.cs
@@ -1,0 +1,125 @@
+using Granit.DataFiltering;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Webhooks.EntityFrameworkCore.Extensions;
+using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Verifies that <see cref="WebhooksDualScopeIntegrationValidator"/> fails fast at
+/// host startup when a tenant-isolated DbContext folds the Webhooks model — the
+/// integration mistake that produced the 42P01 in the showcase #2021 follow-up.
+/// </summary>
+public sealed class WebhooksDualScopeIntegrationValidatorTests
+{
+    [Fact]
+    public async Task StartAsync_NoIsolatedMarkers_DoesNotThrow()
+    {
+        ServiceProvider sp = new ServiceCollection().BuildServiceProvider();
+        var sut = new WebhooksDualScopeIntegrationValidator(
+            markers: [],
+            serviceProvider: sp,
+            logger: NullLogger<WebhooksDualScopeIntegrationValidator>.Instance);
+
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_IsolatedDbContextWithoutWebhooks_DoesNotThrow()
+    {
+        ServiceProvider sp = BuildProvider<CleanIsolatedDbContext>();
+        var sut = new WebhooksDualScopeIntegrationValidator(
+            markers: sp.GetServices<IsolatedDbContextMarker>(),
+            serviceProvider: sp,
+            logger: NullLogger<WebhooksDualScopeIntegrationValidator>.Instance);
+
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_IsolatedDbContextFoldsWebhooks_Throws()
+    {
+        ServiceProvider sp = BuildProvider<OffendingIsolatedDbContext>();
+        var sut = new WebhooksDualScopeIntegrationValidator(
+            markers: sp.GetServices<IsolatedDbContextMarker>(),
+            serviceProvider: sp,
+            logger: NullLogger<WebhooksDualScopeIntegrationValidator>.Instance);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.StartAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("dual-scope");
+        ex.Message.ShouldContain(nameof(OffendingIsolatedDbContext));
+        ex.Message.ShouldContain("WebhookSubscription");
+    }
+
+    private static ServiceProvider BuildProvider<TContext>()
+        where TContext : DbContext
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        // Minimal isolated registration: a SharedDatabase keyed factory the validator
+        // can resolve, plus the marker the validator enumerates. We bypass
+        // AddGranitIsolatedDbContext so the test stays a true unit test (no
+        // configuration binding, no ValidateOnStart side effects).
+        services.AddKeyedScoped<IDbContextFactory<TContext>>(
+            TenantIsolationStrategy.SharedDatabase,
+            (sp, _) => new InMemoryDbContextFactory<TContext>());
+
+        services.AddSingleton(new IsolatedDbContextMarker(
+            typeof(TContext),
+            new HashSet<TenantIsolationStrategy> { TenantIsolationStrategy.SharedDatabase }));
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class InMemoryDbContextFactory<TContext> : IDbContextFactory<TContext>
+        where TContext : DbContext
+    {
+        public TContext CreateDbContext()
+        {
+            DbContextOptionsBuilder<TContext> builder = new DbContextOptionsBuilder<TContext>()
+                .UseInMemoryDatabase($"validator-{Guid.NewGuid()}");
+            return (TContext)Activator.CreateInstance(
+                typeof(TContext),
+                builder.Options,
+                GranitDesignTime.CurrentTenant,
+                NullDataFilter.Instance)!;
+        }
+
+        public Task<TContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+    }
+
+    // -------------------------------------------------------------------------
+    // Test DbContexts — both inherit from GranitDbContext so the SingleValueObject
+    // converters from ApplyGranitConventions are wired and the Webhooks aggregates
+    // can compile their model under the InMemory provider.
+    // -------------------------------------------------------------------------
+
+    internal sealed class CleanIsolatedDbContext(
+        DbContextOptions<CleanIsolatedDbContext> options,
+        ICurrentTenant currentTenant,
+        IDataFilter? dataFilter = null) : GranitDbContext(options, currentTenant, dataFilter)
+    {
+        // No Webhooks fold — validator should pass.
+        protected override void OnGranitModelCreating(ModelBuilder modelBuilder) { }
+    }
+
+    internal sealed class OffendingIsolatedDbContext(
+        DbContextOptions<OffendingIsolatedDbContext> options,
+        ICurrentTenant currentTenant,
+        IDataFilter? dataFilter = null) : GranitDbContext(options, currentTenant, dataFilter)
+    {
+        // The integration mistake: folding Webhooks into an isolated DbContext.
+        protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ConfigureWebhooksModule();
+    }
+}


### PR DESCRIPTION
## Summary

Webhooks was explicitly designed as a **dual-scope** module in #2021: platform-managed
subscriptions (`TenantId == null`) and tenant-managed subscriptions (`TenantId == <tenant>`)
coexist in a single host-schema table, with row-level `MultiTenant` filtering and an
`EfWebhookSubscriptionQueryableSource` bypass for host admin reads. The contract requires
consuming apps to fold `ConfigureWebhooksModule()` into a **host-scoped** DbContext (one
registered via `AddGranitDbContext<T>`).

The showcase regression (`GET /api/v1/webhooks/subscriptions` returning a Postgres
`42P01 relation "host.webhooks_subscriptions" does not exist`) traced back to folding
the module into `ShowcaseTenantDbContext` (registered via `AddGranitIsolatedDbContext<T>`),
which under `SchemaPerTenant` creates the table in each tenant's schema while the
internal `WebhooksDbContext` keeps qualifying queries against `host.*`.

This PR makes that integration mistake fail loudly at host startup instead of silently
at the first request.

### Framework changes

- New `WebhooksDualScopeIntegrationValidator` (`IHostedService`) registered by
  `AddGranitWebhooksEntityFrameworkCore`. Enumerates `IsolatedDbContextMarker`
  singletons, resolves their always-registered `SharedDatabase` keyed factory,
  compiles the model in-memory (no DB I/O), and throws `InvalidOperationException`
  if any of `WebhookSubscription` / `WebhookSigningKey` / `WebhookDeliveryAttempt`
  is folded into an isolated DbContext. Model-compile failures are logged at
  Debug and left for the real validator to surface.
- `AddGranitWebhooksEntityFrameworkCore` XmlDoc rewritten to spell out the
  host-scoped DbContext requirement, the 42P01 failure mode, and a pointer to
  the fully-isolated Webhooks Epic.
- `Granit.Webhooks.EntityFrameworkCore/README.md` gains an Integration section
  with a working host-DbContext sample and a "Why not per-tenant tables?" note
  covering the row-level filter rationale.

### Tests

- `WebhooksDualScopeIntegrationValidatorTests` — no-markers no-op, clean
  isolated DbContext no-op, offending isolated DbContext throws with a message
  naming the offender and the entity.
- `EfWebhookSubscriptionQueryableSourceTests` — `TenantContext_ReturnsTenantRows`
  (filter honored, returns only the active tenant's row), `HostContext_ReturnsAllTenants`
  (`IgnoreQueryFilters([MultiTenant])` returns every row including the platform
  subscription). Pins the host-vs-tenant bypass behavior so a future refactor
  cannot silently drop it.

Postgres testcontainers coverage of `search_path` interactions is deferred to
the fully-isolated Webhooks Epic.

## Follow-ups (out of scope)

- Showcase: move `ConfigureWebhooksModule()` from `ShowcaseTenantDbContext` to
  `ShowcaseHostDbContext`.
- Dedicated Epic for fully-isolated per-tenant Webhooks tables (GDPR
  `DROP SCHEMA` use case).

## Test plan

- [x] `dotnet build src/Granit.Webhooks.EntityFrameworkCore` — green.
- [x] `dotnet build tests/Granit.Webhooks.EntityFrameworkCore.Tests` — green.
- [x] `Granit.Webhooks.EntityFrameworkCore.Tests` — 31/31 green (includes the
      5 new tests).
- [ ] Showcase smoke test under SchemaPerTenant (deferred — separate showcase PR
      will move the `ConfigureWebhooksModule()` call).