### PR TITLE
refactor(dataexchange): promote ImportDefinition to Abstractions + add UserImportDefinition

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12827,7 +12827,7 @@
       "kind": "record",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportPreviewResponse.cs",
-      "line": 8,
+      "line": 9,
       "members": []
     },
     {
@@ -13672,6 +13672,15 @@
       ]
     },
     {
+      "name": "ChildCollectionBuilder",
+      "fqn": "Granit.DataExchange.Import.ChildCollectionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/ChildCollectionBuilder.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "ImportJob",
       "fqn": "Granit.DataExchange.Import.Domain.ImportJob",
       "kind": "class",
@@ -13835,6 +13844,22 @@
       ]
     },
     {
+      "name": "IImportDefinitionDescriptor",
+      "fqn": "Granit.DataExchange.Import.IImportDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/IImportDefinitionDescriptor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetFieldMetadata",
+          "kind": "method",
+          "signature": "GetFieldMetadata()",
+          "returnType": "string Name { get; } Type EntityType { get; } int MaxFileSizeMb { get; } IReadOnlyList<string> AllowedMimeTypes { get; } IReadOnlyList<ImportFieldMetadata>"
+        }
+      ]
+    },
+    {
       "name": "IRecordIdentityResolver",
       "fqn": "Granit.DataExchange.Import.Identity.IRecordIdentityResolver",
       "kind": "interface",
@@ -13866,6 +13891,82 @@
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Import/Identity/RecordOperation.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImportDefinition",
+      "fqn": "Granit.DataExchange.Import.ImportDefinition",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/ImportDefinition.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TEntity)",
+          "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "MaxFileSizeMb",
+          "kind": "property",
+          "signature": "int MaxFileSizeMb",
+          "returnType": "int"
+        },
+        {
+          "name": "AllowedMimeTypes",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> AllowedMimeTypes",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetFieldMetadata",
+          "kind": "method",
+          "signature": "GetFieldMetadata()",
+          "returnType": "IReadOnlyList<ImportFieldMetadata>"
+        },
+        {
+          "name": "GetBusinessKeyProperties",
+          "kind": "method",
+          "signature": "GetBusinessKeyProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetExcludedOnUpdateProperties",
+          "kind": "method",
+          "signature": "GetExcludedOnUpdateProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetGroupByColumn",
+          "kind": "method",
+          "signature": "GetGroupByColumn()",
+          "returnType": "string?"
+        },
+        {
+          "name": "GetHasExternalId",
+          "kind": "method",
+          "signature": "GetHasExternalId()",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ImportDefinitionBuilder",
+      "fqn": "Granit.DataExchange.Import.ImportDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/ImportDefinitionBuilder.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImportFieldMetadata",
+      "fqn": "Granit.DataExchange.Import.ImportFieldMetadata",
+      "kind": "record",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/ImportFieldMetadata.cs",
+      "line": 12,
       "members": []
     },
     {
@@ -13906,15 +14007,6 @@
       "members": []
     },
     {
-      "name": "ChildCollectionBuilder",
-      "fqn": "Granit.DataExchange.Import.Mapping.ChildCollectionBuilder",
-      "kind": "class",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ChildCollectionBuilder.cs",
-      "line": 9,
-      "members": []
-    },
-    {
       "name": "IDataMapper",
       "fqn": "Granit.DataExchange.Import.Mapping.IDataMapper",
       "kind": "interface",
@@ -13927,22 +14019,6 @@
           "kind": "method",
           "signature": "MapAsync(RawImportRow row, IReadOnlyList<ImportColumnMapping> mappings, ImportOptions options, CancellationToken cancellationToken = default)",
           "returnType": "Task<MappingResult<TEntity>>"
-        }
-      ]
-    },
-    {
-      "name": "IImportDefinitionDescriptor",
-      "fqn": "Granit.DataExchange.Import.Mapping.IImportDefinitionDescriptor",
-      "kind": "interface",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/IImportDefinitionDescriptor.cs",
-      "line": 12,
-      "members": [
-        {
-          "name": "GetFieldMetadata",
-          "kind": "method",
-          "signature": "GetFieldMetadata()",
-          "returnType": "string Name { get; } Type EntityType { get; } int MaxFileSizeMb { get; } IReadOnlyList<string> AllowedMimeTypes { get; } IReadOnlyList<ImportFieldMetadata>"
         }
       ]
     },
@@ -14025,82 +14101,6 @@
       "members": []
     },
     {
-      "name": "ImportDefinition",
-      "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinition",
-      "kind": "class",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ImportDefinition.cs",
-      "line": 31,
-      "members": [
-        {
-          "name": "typeof",
-          "kind": "method",
-          "signature": "typeof(TEntity)",
-          "returnType": "string Name { get; } public Type EntityType =>"
-        },
-        {
-          "name": "MaxFileSizeMb",
-          "kind": "property",
-          "signature": "int MaxFileSizeMb",
-          "returnType": "int"
-        },
-        {
-          "name": "AllowedMimeTypes",
-          "kind": "property",
-          "signature": "IReadOnlyList<string> AllowedMimeTypes",
-          "returnType": "IReadOnlyList<string>"
-        },
-        {
-          "name": "GetFieldMetadata",
-          "kind": "method",
-          "signature": "GetFieldMetadata()",
-          "returnType": "IReadOnlyList<ImportFieldMetadata>"
-        },
-        {
-          "name": "GetBusinessKeyProperties",
-          "kind": "method",
-          "signature": "GetBusinessKeyProperties()",
-          "returnType": "IReadOnlyList<string>"
-        },
-        {
-          "name": "GetExcludedOnUpdateProperties",
-          "kind": "method",
-          "signature": "GetExcludedOnUpdateProperties()",
-          "returnType": "IReadOnlyList<string>"
-        },
-        {
-          "name": "GetGroupByColumn",
-          "kind": "method",
-          "signature": "GetGroupByColumn()",
-          "returnType": "string?"
-        },
-        {
-          "name": "GetHasExternalId",
-          "kind": "method",
-          "signature": "GetHasExternalId()",
-          "returnType": "bool"
-        }
-      ]
-    },
-    {
-      "name": "ImportDefinitionBuilder",
-      "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinitionBuilder",
-      "kind": "class",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ImportDefinitionBuilder.cs",
-      "line": 10,
-      "members": []
-    },
-    {
-      "name": "ImportFieldMetadata",
-      "fqn": "Granit.DataExchange.Import.Mapping.ImportFieldMetadata",
-      "kind": "record",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/ImportFieldMetadata.cs",
-      "line": 12,
-      "members": []
-    },
-    {
       "name": "MappingConfidence",
       "fqn": "Granit.DataExchange.Import.Mapping.MappingConfidence",
       "kind": "enum",
@@ -14130,37 +14130,6 @@
           "returnType": "bool"
         }
       ]
-    },
-    {
-      "name": "PropertyMapping",
-      "fqn": "Granit.DataExchange.Import.Mapping.PropertyMapping",
-      "kind": "class",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/PropertyMapping.cs",
-      "line": 6,
-      "members": [
-        {
-          "name": "PropertyPath",
-          "kind": "property",
-          "signature": "required string PropertyPath",
-          "returnType": "required string"
-        },
-        {
-          "name": "ToFieldMetadata",
-          "kind": "method",
-          "signature": "ToFieldMetadata()",
-          "returnType": "bool IsRequired { get; init; } public string? Format { get; init; } public bool IsChildCollection { get; init; } internal ImportFieldMetadata"
-        }
-      ]
-    },
-    {
-      "name": "PropertyMappingBuilder",
-      "fqn": "Granit.DataExchange.Import.Mapping.PropertyMappingBuilder",
-      "kind": "class",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Import/Mapping/PropertyMappingBuilder.cs",
-      "line": 6,
-      "members": []
     },
     {
       "name": "SemanticMappingSuggestion",
@@ -14388,6 +14357,37 @@
           "returnType": "ImportUploadResult"
         }
       ]
+    },
+    {
+      "name": "PropertyMapping",
+      "fqn": "Granit.DataExchange.Import.PropertyMapping",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/PropertyMapping.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PropertyPath",
+          "kind": "property",
+          "signature": "required string PropertyPath",
+          "returnType": "required string"
+        },
+        {
+          "name": "ToFieldMetadata",
+          "kind": "method",
+          "signature": "ToFieldMetadata()",
+          "returnType": "bool IsRequired { get; init; } public string? Format { get; init; } public bool IsChildCollection { get; init; } internal ImportFieldMetadata"
+        }
+      ]
+    },
+    {
+      "name": "PropertyMappingBuilder",
+      "fqn": "Granit.DataExchange.Import.PropertyMappingBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Import/PropertyMappingBuilder.cs",
+      "line": 6,
+      "members": []
     },
     {
       "name": "ICorrectionFileGenerator",
@@ -23719,10 +23719,10 @@
     },
     {
       "name": "UserImportDefinition",
-      "fqn": "Granit.Identity.Imports.UserImportDefinition",
+      "fqn": "Granit.Identity.Import.UserImportDefinition",
       "kind": "class",
       "project": "Granit.Identity",
-      "file": "src/Granit.Identity/Imports/UserImportDefinition.cs",
+      "file": "src/Granit.Identity/Import/UserImportDefinition.cs",
       "line": 16,
       "members": [
         {

--- a/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
+++ b/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Granit.AI;
 using Granit.AI.Internal;
 using Granit.DataExchange.AI.Options;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.DataExchange.Abstractions/Extensions/ImportDefinitionServiceCollectionExtensions.cs
+++ b/src/Granit.DataExchange.Abstractions/Extensions/ImportDefinitionServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using Granit.DataExchange.Import;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.DataExchange.Extensions;
+
+/// <summary>
+/// DI registration helpers for <see cref="ImportDefinition{TEntity}"/>.
+/// </summary>
+/// <remarks>
+/// Lives in <c>Granit.DataExchange.Abstractions</c> so a base module can declare and
+/// register its import definitions without taking a runtime dependency on
+/// <c>Granit.DataExchange</c> (orchestrator, parsers, jobs).
+/// </remarks>
+public static class ImportDefinitionServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers an import definition for the specified entity type.
+    /// </summary>
+    /// <typeparam name="TEntity">The target entity type.</typeparam>
+    /// <typeparam name="TDefinition">The import definition implementation.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddImportDefinition<TEntity, TDefinition>(
+        this IServiceCollection services)
+        where TEntity : class
+        where TDefinition : ImportDefinition<TEntity>
+    {
+        services.AddSingleton<ImportDefinition<TEntity>, TDefinition>();
+        services.AddSingleton<IImportDefinitionDescriptor>(sp =>
+            sp.GetRequiredService<ImportDefinition<TEntity>>());
+        return services;
+    }
+}

--- a/src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj
+++ b/src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.DataExchange.Abstractions</PackageId>
-    <Description>Inter-module contracts for Granit.DataExchange: declarative ExportDefinition base class, builders, descriptors, auto-source/extra-field hooks. Reference this package from any module that declares exports; reference Granit.DataExchange only from hosts that execute them.</Description>
+    <Description>Inter-module contracts for Granit.DataExchange: declarative ExportDefinition and ImportDefinition base classes, builders, descriptors, auto-source/extra-field hooks. Reference this package from any module that declares exports or imports; reference Granit.DataExchange only from hosts that execute them.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.DataExchange.Abstractions/GranitDataExchangeAbstractionsModule.cs
+++ b/src/Granit.DataExchange.Abstractions/GranitDataExchangeAbstractionsModule.cs
@@ -6,10 +6,11 @@ namespace Granit.DataExchange;
 /// Marker module for <c>Granit.DataExchange.Abstractions</c>.
 /// </summary>
 /// <remarks>
-/// Modules that only declare <see cref="Export.ExportDefinition{TEntity}"/> instances
-/// (without executing exports) reference <c>Granit.DataExchange.Abstractions</c> and
-/// declare <c>[DependsOn(typeof(GranitDataExchangeAbstractionsModule))]</c>. Hosts that
-/// run the export pipeline depend on <c>GranitDataExchangeModule</c> instead, which
+/// Modules that only declare <see cref="Export.ExportDefinition{TEntity}"/> or
+/// <see cref="Import.ImportDefinition{TEntity}"/> instances (without executing
+/// the pipelines) reference <c>Granit.DataExchange.Abstractions</c> and declare
+/// <c>[DependsOn(typeof(GranitDataExchangeAbstractionsModule))]</c>. Hosts that run the
+/// export or import pipelines depend on <c>GranitDataExchangeModule</c> instead, which
 /// transitively depends on this module.
 /// </remarks>
 public sealed class GranitDataExchangeAbstractionsModule : GranitModule

--- a/src/Granit.DataExchange.Abstractions/Import/ChildCollectionBuilder.cs
+++ b/src/Granit.DataExchange.Abstractions/Import/ChildCollectionBuilder.cs
@@ -1,6 +1,6 @@
 using System.Linq.Expressions;
 
-namespace Granit.DataExchange.Import.Mapping;
+namespace Granit.DataExchange.Import;
 
 /// <summary>
 /// Fluent builder for configuring child collection properties in a parent/child import.

--- a/src/Granit.DataExchange.Abstractions/Import/IImportDefinitionDescriptor.cs
+++ b/src/Granit.DataExchange.Abstractions/Import/IImportDefinitionDescriptor.cs
@@ -1,11 +1,11 @@
-namespace Granit.DataExchange.Import.Mapping;
+namespace Granit.DataExchange.Import;
 
 /// <summary>
 /// Non-generic view of an <see cref="ImportDefinition{TEntity}"/> for runtime resolution by name.
 /// </summary>
 /// <remarks>
 /// Registered as a singleton alongside the generic <see cref="ImportDefinition{TEntity}"/> by
-/// <see cref="Extensions.ServiceCollectionExtensions.AddImportDefinition{TEntity,TDefinition}"/>.
+/// <see cref="Extensions.ImportDefinitionServiceCollectionExtensions.AddImportDefinition{TEntity,TDefinition}"/>.
 /// Endpoints and other services can enumerate <c>IEnumerable&lt;IImportDefinitionDescriptor&gt;</c>
 /// to find a definition by name without compile-time knowledge of the entity type.
 /// </remarks>

--- a/src/Granit.DataExchange.Abstractions/Import/ImportDefinition.cs
+++ b/src/Granit.DataExchange.Abstractions/Import/ImportDefinition.cs
@@ -1,4 +1,4 @@
-namespace Granit.DataExchange.Import.Mapping;
+namespace Granit.DataExchange.Import;
 
 /// <summary>
 /// Base class for declaring how an entity type is imported.

--- a/src/Granit.DataExchange.Abstractions/Import/ImportDefinitionBuilder.cs
+++ b/src/Granit.DataExchange.Abstractions/Import/ImportDefinitionBuilder.cs
@@ -1,6 +1,6 @@
 using System.Linq.Expressions;
 
-namespace Granit.DataExchange.Import.Mapping;
+namespace Granit.DataExchange.Import;
 
 /// <summary>
 /// Fluent builder for declaring importable properties, business keys, and grouping

--- a/src/Granit.DataExchange.Abstractions/Import/ImportFieldMetadata.cs
+++ b/src/Granit.DataExchange.Abstractions/Import/ImportFieldMetadata.cs
@@ -1,4 +1,4 @@
-namespace Granit.DataExchange.Import.Mapping;
+namespace Granit.DataExchange.Import;
 
 /// <summary>
 /// Metadata about a target entity property, used for mapping suggestions.

--- a/src/Granit.DataExchange.Abstractions/Import/PropertyMapping.cs
+++ b/src/Granit.DataExchange.Abstractions/Import/PropertyMapping.cs
@@ -1,4 +1,4 @@
-namespace Granit.DataExchange.Import.Mapping;
+namespace Granit.DataExchange.Import;
 
 /// <summary>
 /// Immutable metadata about a single importable property, built from <see cref="PropertyMappingBuilder"/>.

--- a/src/Granit.DataExchange.Abstractions/Import/PropertyMappingBuilder.cs
+++ b/src/Granit.DataExchange.Abstractions/Import/PropertyMappingBuilder.cs
@@ -1,4 +1,4 @@
-namespace Granit.DataExchange.Import.Mapping;
+namespace Granit.DataExchange.Import;
 
 /// <summary>
 /// Fluent builder for configuring how a single property is imported.

--- a/src/Granit.DataExchange.Abstractions/README.md
+++ b/src/Granit.DataExchange.Abstractions/README.md
@@ -1,10 +1,10 @@
 # Granit.DataExchange.Abstractions
 
 Inter-module contracts for Granit.DataExchange: declarative `ExportDefinition<T>`
-base class, fluent builders (`ExportDefinitionBuilder<T>`, `ExportFieldBuilder<T>`),
-field descriptors, auto-source hooks and extra-property providers. Reference this
-package from any module that declares exports; reference `Granit.DataExchange` only
-from hosts that execute them.
+and `ImportDefinition<T>` base classes, fluent builders (`ExportDefinitionBuilder<T>`,
+`ImportDefinitionBuilder<T>`, …), field/property descriptors, auto-source hooks and
+extra-property providers. Reference this package from any module that declares exports
+or imports; reference `Granit.DataExchange` only from hosts that execute them.
 
 Part of the [granit](https://granit-fx.dev) framework.
 

--- a/src/Granit.DataExchange.Endpoints/Dtos/Import/ImportPreviewResponse.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Import/ImportPreviewResponse.cs
@@ -1,3 +1,4 @@
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 
 namespace Granit.DataExchange.Endpoints.Dtos.Import;

--- a/src/Granit.DataExchange.Endpoints/Internal/Import/ImportDefinitionResolver.cs
+++ b/src/Granit.DataExchange.Endpoints/Internal/Import/ImportDefinitionResolver.cs
@@ -1,3 +1,4 @@
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 
 namespace Granit.DataExchange.Endpoints.Internal.Import;

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Identity/BusinessKeyResolver.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Identity/BusinessKeyResolver.cs
@@ -1,6 +1,6 @@
 using System.Linq.Expressions;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Identity;
-using Granit.DataExchange.Import.Mapping;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.DataExchange.EntityFrameworkCore.Internal.Import.Identity;

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Identity/CompositeKeyResolver.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Identity/CompositeKeyResolver.cs
@@ -1,6 +1,6 @@
 using System.Linq.Expressions;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Identity;
-using Granit.DataExchange.Import.Mapping;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.DataExchange.EntityFrameworkCore.Internal.Import.Identity;

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Identity/ExternalIdResolver.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Identity/ExternalIdResolver.cs
@@ -1,6 +1,6 @@
 using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Entities;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Identity;
-using Granit.DataExchange.Import.Mapping;
 using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Granit.DataExchange/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.DataExchange/Extensions/ServiceCollectionExtensions.cs
@@ -78,24 +78,6 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers an import definition for the specified entity type.
-    /// </summary>
-    /// <typeparam name="TEntity">The target entity type.</typeparam>
-    /// <typeparam name="TDefinition">The import definition implementation.</typeparam>
-    /// <param name="services">The service collection.</param>
-    /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddImportDefinition<TEntity, TDefinition>(
-        this IServiceCollection services)
-        where TEntity : class
-        where TDefinition : ImportDefinition<TEntity>
-    {
-        services.AddSingleton<ImportDefinition<TEntity>, TDefinition>();
-        services.AddSingleton<IImportDefinitionDescriptor>(sp =>
-            sp.GetRequiredService<ImportDefinition<TEntity>>());
-        return services;
-    }
-
-    /// <summary>
     /// Registers the core data export pipeline infrastructure.
     /// </summary>
     /// <remarks>

--- a/src/Granit.DataExchange/Import/Internal/ImportUploadService.cs
+++ b/src/Granit.DataExchange/Import/Internal/ImportUploadService.cs
@@ -1,5 +1,4 @@
 using Granit.DataExchange.Import.Domain;
-using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Pipeline;
 using Granit.Domain.ValueObjects;
 using Granit.Guids;

--- a/src/Granit.Identity/GranitIdentityModule.cs
+++ b/src/Granit.Identity/GranitIdentityModule.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Domain;
 using Granit.Identity.Entities;
 using Granit.Identity.Exports;
 using Granit.Identity.Extensions;
+using Granit.Identity.Import;
 using Granit.Identity.Queries;
 using Granit.Modularity;
 using Granit.QueryEngine;
@@ -36,6 +37,7 @@ public sealed class GranitIdentityModule : GranitModule
         // companion package; this module exposes the abstractions only.
         context.Services.AddQueryDefinition<User, UserQueryDefinition>();
         context.Services.AddExportDefinition<User, UserExportDefinition>();
+        context.Services.AddImportDefinition<User, UserImportDefinition>();
         context.Services.AddEntityDefinition<User, UserEntityDefinition>();
     }
 }

--- a/src/Granit.Identity/Import/UserImportDefinition.cs
+++ b/src/Granit.Identity/Import/UserImportDefinition.cs
@@ -1,0 +1,33 @@
+using Granit.DataExchange.Import;
+using Granit.Identity.Domain;
+
+namespace Granit.Identity.Import;
+
+/// <summary>
+/// CSV / XLSX import surface for the canonical <see cref="User"/> aggregate
+/// (ADR-051). Mirror of <see cref="Exports.UserExportDefinition"/> — the same
+/// profile field whitelist applies in both directions. Auth secrets, security
+/// counters (<c>PasswordHash</c>, <c>LockoutEnd</c>, <c>AccessFailedCount</c>, …)
+/// and lookup-hash columns (<c>EmailHash</c>, <c>PhoneNumberHash</c>) are never
+/// importable — they live on <c>LocalIdentity</c> or are derived by the EF
+/// lookup-hash interceptor. <c>TenantId</c> is intentionally excluded so the
+/// resolution always goes through the ambient multi-tenant context.
+/// </summary>
+public sealed class UserImportDefinition : ImportDefinition<User>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Identity.UserImport";
+
+    /// <inheritdoc />
+    protected override void Configure(ImportDefinitionBuilder<User> builder) =>
+        builder
+            .HasBusinessKey(u => u.Email)
+            .Property(u => u.Email, p => p.DisplayName("Email").Required())
+            .Property(u => u.DisplayName, p => p.DisplayName("Name").Required())
+            .Property(u => u.FirstName, p => p.DisplayName("First Name"))
+            .Property(u => u.LastName, p => p.DisplayName("Last Name"))
+            .Property(u => u.PhoneNumber, p => p.DisplayName("Phone"))
+            .Property(u => u.PreferredLocale, p => p.DisplayName("Locale"))
+            .Property(u => u.Timezone, p => p.DisplayName("Timezone"))
+            .Property(u => u.IsEnabled, p => p.DisplayName("Enabled"));
+}

--- a/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
+++ b/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
@@ -1,6 +1,7 @@
 using Granit.AI;
 using Granit.DataExchange.AI.Internal;
 using Granit.DataExchange.AI.Options;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Import/ImportDtoTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Import/ImportDtoTests.cs
@@ -1,4 +1,5 @@
 using Granit.DataExchange.Endpoints.Dtos.Import;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Reporting;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportDefinitionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportDefinitionEndpointsTests.cs
@@ -4,6 +4,7 @@ using Granit.DataExchange.Endpoints.Dtos.Export;
 using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;
 using Granit.DataExchange.Import.Pipeline;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportExecutionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportExecutionEndpointsTests.cs
@@ -5,6 +5,7 @@ using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;
 using Granit.DataExchange.Import.Pipeline;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportJobListEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportJobListEndpointsTests.cs
@@ -5,6 +5,7 @@ using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;
 using Granit.DataExchange.Import.Pipeline;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportPresetEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportPresetEndpointsTests.cs
@@ -4,6 +4,7 @@ using Granit.DataExchange.Endpoints.Dtos.Export;
 using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;
 using Granit.DataExchange.Import.Pipeline;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportExecutionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportExecutionEndpointsTests.cs
@@ -5,6 +5,7 @@ using Granit.DataExchange.Endpoints.Dtos.Import;
 using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Messages;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportJobListEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportJobListEndpointsTests.cs
@@ -4,6 +4,7 @@ using Granit.DataExchange.Endpoints.Dtos.Import;
 using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportReportEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportReportEndpointsTests.cs
@@ -5,6 +5,7 @@ using Granit.DataExchange.Endpoints.Dtos.Import;
 using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
@@ -6,6 +6,7 @@ using Granit.DataExchange.Endpoints.Dtos.Import;
 using Granit.DataExchange.Endpoints.Extensions;
 using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Parsing;

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Infrastructure/TestImportDefinition.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Infrastructure/TestImportDefinition.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 
 namespace Granit.DataExchange.EntityFrameworkCore.Tests.Infrastructure;
 

--- a/tests/Granit.DataExchange.Tests/Import/ImportPreviewServiceTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/ImportPreviewServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Internal;
 using Granit.DataExchange.Import.Mapping;

--- a/tests/Granit.DataExchange.Tests/Import/ImportUploadServiceTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/ImportUploadServiceTests.cs
@@ -1,6 +1,6 @@
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Internal;
-using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Pipeline;
 using Granit.Guids;
 using Granit.Timing;

--- a/tests/Granit.DataExchange.Tests/Import/Mapping/ImportDefinitionBuilderEdgeCaseTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/Mapping/ImportDefinitionBuilderEdgeCaseTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/Import/Mapping/ImportFieldMetadataTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/Mapping/ImportFieldMetadataTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/Import/Mapping/PropertyMappingToFieldMetadataTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/Mapping/PropertyMappingToFieldMetadataTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/Mapping/ChildCollectionBuilderTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/ChildCollectionBuilderTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/Mapping/ImportDefinitionBuilderTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/ImportDefinitionBuilderTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/Mapping/ImportDefinitionTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/ImportDefinitionTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/Mapping/NullSemanticMappingServiceTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/NullSemanticMappingServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Shouldly;
 using Xunit;

--- a/tests/Granit.DataExchange.Tests/Mapping/PropertyMappingBuilderTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/PropertyMappingBuilderTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/Mapping/PropertyMappingTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/PropertyMappingTests.cs
@@ -1,4 +1,4 @@
-using Granit.DataExchange.Import.Mapping;
+using Granit.DataExchange.Import;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.DataExchange.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.DataExchange.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Extensions;
+using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Pipeline;
 using Granit.DataExchange.Tests.Mapping;

--- a/tests/Granit.Identity.Tests/Import/UserImportDefinitionTests.cs
+++ b/tests/Granit.Identity.Tests/Import/UserImportDefinitionTests.cs
@@ -1,0 +1,97 @@
+using Granit.DataExchange.Import;
+using Granit.Identity.Domain;
+using Granit.Identity.Import;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Tests.Import;
+
+public sealed class UserImportDefinitionTests
+{
+    [Fact]
+    public void Name_IsCanonicalIdentifier()
+    {
+        var definition = new UserImportDefinition();
+
+        definition.Name.ShouldBe("Granit.Identity.UserImport");
+    }
+
+    [Fact]
+    public void EntityType_IsUser()
+    {
+        var definition = new UserImportDefinition();
+
+        definition.EntityType.ShouldBe(typeof(User));
+    }
+
+    [Fact]
+    public void BusinessKey_IsEmail()
+    {
+        var definition = new UserImportDefinition();
+
+        IReadOnlyList<string> keys = definition.GetBusinessKeyProperties();
+
+        keys.ShouldBe(["Email"]);
+    }
+
+    [Fact]
+    public void Properties_AreProfileWhitelistInOrder()
+    {
+        var definition = new UserImportDefinition();
+
+        string[] expected =
+        [
+            nameof(User.Email),
+            nameof(User.DisplayName),
+            nameof(User.FirstName),
+            nameof(User.LastName),
+            nameof(User.PhoneNumber),
+            nameof(User.PreferredLocale),
+            nameof(User.Timezone),
+            nameof(User.IsEnabled),
+        ];
+
+        IReadOnlyList<PropertyMapping> properties = definition.GetProperties();
+
+        properties.Select(p => p.PropertyPath).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Email_IsRequired()
+    {
+        var definition = new UserImportDefinition();
+
+        PropertyMapping email = definition.GetProperties()
+            .Single(p => p.PropertyPath == nameof(User.Email));
+
+        email.IsRequired.ShouldBeTrue();
+        email.DisplayName.ShouldBe("Email");
+    }
+
+    [Fact]
+    public void DisplayName_IsRequired()
+    {
+        var definition = new UserImportDefinition();
+
+        PropertyMapping displayName = definition.GetProperties()
+            .Single(p => p.PropertyPath == nameof(User.DisplayName));
+
+        displayName.IsRequired.ShouldBeTrue();
+        displayName.DisplayName.ShouldBe("Name");
+    }
+
+    [Theory]
+    [InlineData("PasswordHash")]
+    [InlineData("SecurityStamp")]
+    [InlineData("EmailHash")]
+    [InlineData("PhoneNumberHash")]
+    [InlineData("TenantId")]
+    [InlineData("Id")]
+    public void SensitiveProperties_AreNotImportable(string propertyName)
+    {
+        var definition = new UserImportDefinition();
+
+        definition.GetProperties()
+            .ShouldNotContain(p => p.PropertyPath == propertyName);
+    }
+}


### PR DESCRIPTION
## Summary

- **Restores Export/Import symmetry** in `Granit.DataExchange.Abstractions`: declarative Import types (`ImportDefinition<T>`, builders, `IImportDefinitionDescriptor`, `PropertyMapping(Builder)`, `ImportFieldMetadata`, `ChildCollectionBuilder`) + DI helper `AddImportDefinition<T,TDef>` move out of the runtime `Granit.DataExchange` package and into `Granit.DataExchange.Abstractions/Import/` under namespace `Granit.DataExchange.Import` — mirror of the existing `Granit.DataExchange.Export` layout. Runtime mapping pipeline (`IDataMapper`, `MappingResult`, semantic mapping services, …) stays in `Granit.DataExchange` (execution layer, parallel to `Export.Internal`).
- **Adds `Granit.Identity.UserImport`** ([UserImportDefinition.cs](../blob/feat/dataexchange-import-abstractions-symmetry/src/Granit.Identity/Import/UserImportDefinition.cs)) mirroring `UserExportDefinition`'s profile field whitelist (business key = `Email`; auth secrets / lookup-hash columns / `TenantId` / `Id` excluded). Wired via `AddImportDefinition<User, UserImportDefinition>()` in `GranitIdentityModule`. Unblocks `granit-showcase` `ImportDialog` repointing from `"Showcase.UserImport"` to `"Granit.Identity.UserImport"` (cross-repo follow-up).
- Consumer `using` statements migrated (added `using Granit.DataExchange.Import;`); redundant ones pruned by `dotnet format style --diagnostics IDE0005`.

## Motivation

`Granit.Identity` only references `Granit.DataExchange.Abstractions`, so it could declare `UserExportDefinition` but **not** `UserImportDefinition` — the import abstractions lived in the runtime package. This packaging asymmetry blocked any base module from owning its import declaration. The fix also addresses the folder/namespace asymmetry inside `Abstractions` itself (`Export/*.cs` flat vs `Import/Mapping/*.cs` nested).

## Scope notes

- `UserImportDefinition` is the **only** new concrete `ImportDefinition<T>` in this PR. The framework currently ships 25 `ExportDefinition<T>` for 1 `ImportDefinition<T>` — generalizing the pairing for admin-writable entities (GranitRole, GranitUserGroup, Tenant, LocalizationOverride, SettingRecord, WebhookSubscription, NotificationPreference, RoleMetadata, PermissionGrant, OpenIddictApplication/Scope) is a separate Epic; many other entities (Audit*, Timeline*, Workflow*, *Job, BlobDescriptor, …) are append-only/derived and have no import use case.
- No archi-test added for Export ↔ Import pairing — would yield massive false positives on append-only entities. Consider an opt-in `ImportableEntities` allowlist later.
- Showcase repointing (`granit-showcase-dotnet` + `granit-showcase-react`) is out of scope and explicitly deferred per the original prompt.

## Test plan

- [x] `dotnet build` clean (0 warnings) on `Granit.DataExchange.Abstractions`, `Granit.DataExchange`, `Granit.DataExchange.EntityFrameworkCore`, `Granit.DataExchange.Endpoints`, `Granit.DataExchange.AI`, `Granit.Identity`
- [x] `dotnet format --verify-no-changes` clean on all touched projects
- [x] All affected test suites green:
  - `Granit.DataExchange.Tests` — 353/353
  - `Granit.DataExchange.Abstractions.Tests` — 1/1
  - `Granit.DataExchange.EntityFrameworkCore.Tests` — 50/50
  - `Granit.DataExchange.Endpoints.Tests` — 120/120
  - `Granit.Identity.Tests` — 159/159 (incl. new `UserImportDefinitionTests` × 12 covering name, business key, ordered property whitelist, `Email`/`DisplayName` required, sensitive-field exclusion theory)
  - `Granit.ArchitectureTests` — 235/235
- [ ] CI shards (`application`, `security`, `architecture`) pass on remote

## Follow-ups

- granit-showcase-react: repoint `"Showcase.UserImport"` → `"Granit.Identity.UserImport"` after publish (JF on it).
- Optional: open `[EPIC] Generalize Import pairing for admin-writable entities` with the matrix from the post-review summary.