### PR TITLE
fix(webhooks): scope-resolve keyed IDbContextFactory in DualScopeIntegrationValidator

### DIFF
--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDualScopeIntegrationValidator.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDualScopeIntegrationValidator.cs
@@ -87,12 +87,14 @@ internal sealed partial class WebhooksDualScopeIntegrationValidator(
 
     private List<string>? TryFindFoldedWebhooksEntities(Type dbContextType)
     {
-        // Resolve the SharedDatabase keyed factory — always registered by
-        // AddGranitIsolatedDbContext, and the cheapest path (no search_path / no tenant
-        // dispatch). The factory builds DbContextOptions from the configureShared delegate;
-        // we never open a connection, only compile the model.
+        // The keyed IDbContextFactory<T> registered by AddGranitIsolatedDbContext is scoped
+        // (EF Core default). Resolving it through the root provider trips CallSiteValidator
+        // when the host enables ValidateScopes (default in dev). Open a per-call scope so
+        // the resolution is legal regardless of the consumer's ServiceProviderOptions.
+        using IServiceScope scope = serviceProvider.CreateScope();
+
         Type factoryType = typeof(IDbContextFactory<>).MakeGenericType(dbContextType);
-        object? factory = serviceProvider.GetKeyedService(factoryType, TenantIsolationStrategy.SharedDatabase);
+        object? factory = scope.ServiceProvider.GetKeyedService(factoryType, TenantIsolationStrategy.SharedDatabase);
         if (factory is null)
         {
             LogNoSharedFactory(dbContextType.Name);

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDualScopeIntegrationValidatorTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDualScopeIntegrationValidatorTests.cs
@@ -60,7 +60,25 @@ public sealed class WebhooksDualScopeIntegrationValidatorTests
         ex.Message.ShouldContain("WebhookSubscription");
     }
 
-    private static ServiceProvider BuildProvider<TContext>()
+    /// <summary>
+    /// Reproduces the dev-host boot path: the validator is registered as a hosted
+    /// service and runs against the root provider, which has <c>ValidateScopes = true</c>
+    /// by default. Resolving the scoped keyed <see cref="IDbContextFactory{TContext}"/>
+    /// directly used to throw "Cannot resolve scoped service ... from root provider".
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_RootProviderWithValidateScopes_DoesNotThrow()
+    {
+        ServiceProvider sp = BuildProvider<CleanIsolatedDbContext>(validateScopes: true);
+        var sut = new WebhooksDualScopeIntegrationValidator(
+            markers: sp.GetServices<IsolatedDbContextMarker>(),
+            serviceProvider: sp,
+            logger: NullLogger<WebhooksDualScopeIntegrationValidator>.Instance);
+
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static ServiceProvider BuildProvider<TContext>(bool validateScopes = false)
         where TContext : DbContext
     {
         IServiceCollection services = new ServiceCollection();
@@ -77,7 +95,10 @@ public sealed class WebhooksDualScopeIntegrationValidatorTests
             typeof(TContext),
             new HashSet<TenantIsolationStrategy> { TenantIsolationStrategy.SharedDatabase }));
 
-        return services.BuildServiceProvider();
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = validateScopes,
+        });
     }
 
     private sealed class InMemoryDbContextFactory<TContext> : IDbContextFactory<TContext>


### PR DESCRIPTION
## Summary

- `WebhooksDualScopeIntegrationValidator` (introduced in #2376) runs as an `IHostedService` and resolved the keyed `IDbContextFactory<T>` directly from the root provider. `AddGranitIsolatedDbContext` registers those factories as scoped (EF Core default), so dev hosts with `ValidateScopes = true` failed at boot with `Cannot resolve scoped service '…IDbContextFactory…' from root provider`.
- Fix: wrap the keyed resolution and the model inspection in a per-call `IServiceScope`. Ctor signature unchanged — minimal 1-line diff in `TryFindFoldedWebhooksEntities`.
- Adds a regression test that builds the `ServiceProvider` with `ValidateScopes = true` and asserts `StartAsync` does not throw.

Follow-up to #2376. Unblocks granit-showcase-dotnet MR !22 (`fix/webhooks-host-scoped-integration`).

## Test plan

- [x] `dotnet build tests/Granit.Webhooks.EntityFrameworkCore.Tests` — clean
- [x] `dotnet test tests/Granit.Webhooks.EntityFrameworkCore.Tests --filter WebhooksDualScopeIntegrationValidatorTests` — 4/4 pass
- [x] Verified the new regression test fails on pre-fix code with the exact `Cannot resolve scoped service` repro
- [ ] Showcase host boots in dev once a dev-package is published (validated downstream on MR !22)