### PR TITLE
feat(webhooks): expose Stripe-style signing-secret hint on subscriptions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -48515,7 +48515,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, HttpsUrl targetUrl, string eventType, Guid signingKeyId, string protectedSecret, DateTimeOffset createdAt, Guid? tenantId = null)",
+          "signature": "Create(Guid id, HttpsUrl targetUrl, string eventType, Guid signingKeyId, string protectedSecret, DateTimeOffset createdAt, Guid? tenantId = null, string? signingSecretHint = null)",
           "returnType": "WebhookSubscription"
         },
         {
@@ -48546,7 +48546,7 @@
           "name": "RecordSuccess",
           "kind": "method",
           "signature": "RecordSuccess(DateTimeOffset at)",
-          "returnType": "string? DeactivationReason { get; private set; } public int ConsecutiveFailureCount { get; private set; } public DateTimeOffset? LastSuccessAt { get; private set; } public DateTimeOffset? SuspendedAt { get; private set; } public string? SuspendedBy { get; private set; } internal void"
+          "returnType": "string? SigningSecretHint { get; private set; } public string? DeactivationReason { get; private set; } public int ConsecutiveFailureCount { get; private set; } public DateTimeOffset? LastSuccessAt { get; private set; } public DateTimeOffset? SuspendedAt { get; private set; } public string? SuspendedBy { get; private set; } internal void"
         }
       ]
     },
@@ -48628,7 +48628,7 @@
       "kind": "record",
       "project": "Granit.Webhooks.Endpoints",
       "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionResponse.cs",
-      "line": 8,
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionResponse.cs
+++ b/src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionResponse.cs
@@ -5,6 +5,21 @@ namespace Granit.Webhooks.Endpoints.Dtos;
 /// <summary>
 /// Response representing a webhook subscription.
 /// </summary>
+/// <param name="Id">Unique subscription identifier.</param>
+/// <param name="TargetUrl">HTTPS endpoint that receives webhook POSTs.</param>
+/// <param name="EventType">Logical event type the subscription listens for.</param>
+/// <param name="Status">Current lifecycle status.</param>
+/// <param name="ConsecutiveFailureCount">Number of consecutive delivery failures since the last success.</param>
+/// <param name="LastSuccessAt">UTC timestamp of the last successful delivery, if any.</param>
+/// <param name="CreatedAt">UTC creation timestamp.</param>
+/// <param name="ModifiedAt">UTC last-modified timestamp, if any.</param>
+/// <param name="SigningSecretHint">
+/// Stripe-style masked preview of the active signing secret
+/// (e.g. <c>whsec_b46a****************5182</c>) for admin UIs to display on the
+/// detail/edit view without ever re-exposing the plaintext. Refreshed on every
+/// signing-key rotation. <c>null</c> for subscriptions created before the hint
+/// was introduced — UIs should fall back to a static placeholder in that case.
+/// </param>
 public sealed record WebhookSubscriptionResponse(
     Guid Id,
     string TargetUrl,
@@ -13,4 +28,5 @@ public sealed record WebhookSubscriptionResponse(
     int ConsecutiveFailureCount,
     DateTimeOffset? LastSuccessAt,
     DateTimeOffset CreatedAt,
-    DateTimeOffset? ModifiedAt);
+    DateTimeOffset? ModifiedAt,
+    string? SigningSecretHint);

--- a/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionReadEndpoints.cs
+++ b/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionReadEndpoints.cs
@@ -53,5 +53,6 @@ internal static class WebhookSubscriptionReadEndpoints
             subscription.ConsecutiveFailureCount,
             subscription.LastSuccessAt,
             subscription.CreatedAt,
-            subscription.ModifiedAt);
+            subscription.ModifiedAt,
+            subscription.SigningSecretHint);
 }

--- a/src/Granit.Webhooks.Endpoints/Internal/WebhooksSchemaExampleProvider.cs
+++ b/src/Granit.Webhooks.Endpoints/Internal/WebhooksSchemaExampleProvider.cs
@@ -36,6 +36,7 @@ internal sealed class WebhooksSchemaExampleProvider : ISchemaExampleProvider
                 ["lastSuccessAt"] = "2026-04-20T13:45:12+00:00",
                 ["createdAt"] = "2026-03-15T09:00:00+00:00",
                 ["modifiedAt"] = null,
+                ["signingSecretHint"] = "whsec_b46a****************5182",
             },
         };
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
@@ -58,6 +58,14 @@ internal sealed class WebhookSubscriptionConfiguration : IEntityTypeConfiguratio
         builder.Property(e => e.SuspendedBy)
             .HasMaxLength(450);
 
+        // Non-sensitive masked preview (e.g. "whsec_b46a****************5182") shown
+        // in admin UIs. Refreshed on every signing-key rotation. Nullable for rows
+        // created before the hint was introduced. Current format is exactly 30 chars
+        // (6 prefix + 4 + 16 mask + 4); 32 leaves a small headroom for minor format
+        // tweaks without bloating the column.
+        builder.Property(e => e.SigningSecretHint)
+            .HasMaxLength(32);
+
         // Audit fields from AuditedEntity / CreationAuditedEntity.
         builder.Property(e => e.CreatedAt).IsRequired();
         builder.Property(e => e.CreatedBy).HasMaxLength(450);

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
@@ -7,6 +7,7 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
+using Granit.Webhooks.Internal;
 using Granit.Webhooks.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -101,7 +102,8 @@ internal sealed class EfWebhookSubscriptionStore(
             guidGenerator.Create(),
             protectedSecret,
             clock.Now,
-            tenantId);
+            tenantId,
+            signingSecretHint: WebhookSecretHint.From(plainSecret));
 
         await AddAsync(subscription, cancellationToken).ConfigureAwait(false);
 
@@ -172,6 +174,8 @@ internal sealed class EfWebhookSubscriptionStore(
         TimeSpan grace = retiredKeyGracePeriod ?? options.Value.RetiredKeyGracePeriod;
         Guid newKeyId = guidGenerator.Create();
 
+        string hint = WebhookSecretHint.From(plainSecret);
+
         await WriteAsync(async db =>
         {
             WebhookSubscription subscription = await db.WebhookSubscriptions
@@ -180,7 +184,7 @@ internal sealed class EfWebhookSubscriptionStore(
                 .ConfigureAwait(false)
                 ?? throw new EntityNotFoundException(typeof(WebhookSubscription), subscriptionId);
 
-            subscription.RotateSigningKey(newKeyId, protectedSecret, clock.Now, grace);
+            subscription.RotateSigningKey(newKeyId, protectedSecret, clock.Now, grace, newSigningSecretHint: hint);
         }, cancellationToken).ConfigureAwait(false);
 
         return new WebhookSigningKeyRotatedResult(newKeyId, plainSecret);

--- a/src/Granit.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscription.cs
@@ -29,6 +29,20 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
     /// Creates a new active <see cref="WebhookSubscription"/> with an initial
     /// <see cref="WebhookSigningKeyStatus.Active"/> signing key.
     /// </summary>
+    /// <param name="id">Identifier for the new subscription.</param>
+    /// <param name="targetUrl">HTTPS endpoint that will receive webhook POST requests.</param>
+    /// <param name="eventType">Logical event type the subscription listens for.</param>
+    /// <param name="signingKeyId">Identifier for the initial signing key.</param>
+    /// <param name="protectedSecret">Opaque protected signing secret (format defined by <see cref="Abstractions.IWebhookSecretProtector"/>).</param>
+    /// <param name="createdAt">Creation timestamp (provided by an <see cref="Granit.Timing.IClock"/>).</param>
+    /// <param name="tenantId">Tenant the subscription belongs to, or <c>null</c> for global.</param>
+    /// <param name="signingSecretHint">
+    /// Optional Stripe-style masked preview of the plaintext signing secret
+    /// (e.g. <c>whsec_b46a****************5182</c>). Computed from the plaintext
+    /// at the call site and persisted as non-sensitive metadata so admin UIs can
+    /// render a stable hint after creation. <c>null</c> for legacy callers that
+    /// don't surface the hint.
+    /// </param>
     public static WebhookSubscription Create(
         Guid id,
         HttpsUrl targetUrl,
@@ -36,7 +50,8 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
         Guid signingKeyId,
         string protectedSecret,
         DateTimeOffset createdAt,
-        Guid? tenantId = null)
+        Guid? tenantId = null,
+        string? signingSecretHint = null)
     {
         var subscription = new WebhookSubscription
         {
@@ -45,6 +60,7 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
             EventType = eventType,
             TenantId = tenantId,
             Status = WebhookSubscriptionStatus.Active,
+            SigningSecretHint = signingSecretHint,
         };
 
         subscription._signingKeys.Add(WebhookSigningKey.Create(
@@ -87,6 +103,16 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
 
     /// <summary>Current lifecycle status of the subscription.</summary>
     public WebhookSubscriptionStatus Status { get; private set; } = WebhookSubscriptionStatus.Active;
+
+    /// <summary>
+    /// Stripe-style masked preview of the plaintext signing secret currently in
+    /// effect (e.g. <c>whsec_b46a****************5182</c>). Refreshed on every
+    /// <see cref="RotateSigningKey"/> to match the new active key. Non-sensitive
+    /// metadata: exposes ~32 bits out of the secret's 256 bits of entropy. <c>null</c>
+    /// for subscriptions created before the hint was introduced.
+    /// Current format is exactly 30 characters; column allows up to 32.
+    /// </summary>
+    public string? SigningSecretHint { get; private set; }
 
     /// <summary>
     /// Human-readable reason for suspension or deactivation.
@@ -219,12 +245,18 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
     /// <param name="newProtectedSecret">Opaque protected secret for the new key.</param>
     /// <param name="now">Current timestamp (provided by an <see cref="Granit.Timing.IClock"/>).</param>
     /// <param name="retiredKeyGracePeriod">Grace period during which the previously-active key remains accepted in verification.</param>
+    /// <param name="newSigningSecretHint">
+    /// Optional masked preview of the new plaintext secret. Refreshed on the
+    /// subscription so admin UIs surface the most recent active hint. Pass
+    /// <c>null</c> to leave the existing hint untouched (legacy callers).
+    /// </param>
     /// <returns>The newly-created active key.</returns>
     internal WebhookSigningKey RotateSigningKey(
         Guid newKeyId,
         string newProtectedSecret,
         DateTimeOffset now,
-        TimeSpan retiredKeyGracePeriod)
+        TimeSpan retiredKeyGracePeriod,
+        string? newSigningSecretHint = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(newProtectedSecret);
 
@@ -240,6 +272,11 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
             now);
 
         _signingKeys.Add(newKey);
+
+        if (newSigningSecretHint is not null)
+        {
+            SigningSecretHint = newSigningSecretHint;
+        }
 
         return newKey;
     }

--- a/src/Granit.Webhooks/Internal/InMemoryWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks/Internal/InMemoryWebhookSubscriptionStore.cs
@@ -77,7 +77,8 @@ internal sealed class InMemoryWebhookSubscriptionStore(
             _guidGenerator.Create(),
             protectedSecret,
             _clock.Now,
-            tenantId);
+            tenantId,
+            signingSecretHint: WebhookSecretHint.From(plainSecret));
 
         _subscriptions[subscription.Id] = subscription;
 
@@ -181,7 +182,8 @@ internal sealed class InMemoryWebhookSubscriptionStore(
             newKeyId,
             protectedSecret,
             _clock.Now,
-            grace);
+            grace,
+            newSigningSecretHint: WebhookSecretHint.From(plainSecret));
 
         return new WebhookSigningKeyRotatedResult(newKey.Id, plainSecret);
     }

--- a/src/Granit.Webhooks/Internal/WebhookSecretHint.cs
+++ b/src/Granit.Webhooks/Internal/WebhookSecretHint.cs
@@ -1,0 +1,46 @@
+namespace Granit.Webhooks.Internal;
+
+/// <summary>
+/// Produces a Stripe-style masked preview of a signing secret (e.g.
+/// <c>whsec_b46a****************5182</c>) for admin UIs. Computed once from the
+/// plaintext at creation / rotation time and persisted alongside the protected
+/// secret — never derived from the hashed value (impossible by design).
+/// </summary>
+internal static class WebhookSecretHint
+{
+    /// <summary>Fixed visual length of the masked middle section.</summary>
+    private const int MiddleStars = 16;
+
+    /// <summary>Number of plaintext characters kept on each edge.</summary>
+    private const int EdgeChars = 4;
+
+    /// <summary>Recognised secret prefix produced by the signing-secret generator.</summary>
+    private const string KnownPrefix = "whsec_";
+
+    /// <summary>
+    /// Returns a masked preview of <paramref name="plaintext"/>. The known
+    /// <c>whsec_</c> prefix is preserved; the next 4 hex characters and the last 4
+    /// are kept, with a 16-character mask in between. For unusually short inputs
+    /// (≤ 8 body characters after the prefix), the entire body is replaced by
+    /// asterisks so no two adjacent plaintext chunks leak.
+    /// </summary>
+    public static string From(string plaintext)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(plaintext);
+
+        bool hasPrefix = plaintext.StartsWith(KnownPrefix, StringComparison.Ordinal);
+        string head = hasPrefix ? KnownPrefix : string.Empty;
+        ReadOnlySpan<char> body = plaintext.AsSpan(head.Length);
+
+        if (body.Length <= 2 * EdgeChars)
+        {
+            return string.Concat(head, new string('*', body.Length));
+        }
+
+        return string.Concat(
+            head,
+            body[..EdgeChars],
+            new string('*', MiddleStars),
+            body[^EdgeChars..]);
+    }
+}

--- a/tests/Granit.Webhooks.Endpoints.Tests/Dtos/WebhookSubscriptionResponseTests.cs
+++ b/tests/Granit.Webhooks.Endpoints.Tests/Dtos/WebhookSubscriptionResponseTests.cs
@@ -18,6 +18,7 @@ public sealed class WebhookSubscriptionResponseTests
         DateTimeOffset lastSuccessAt = DateTimeOffset.UtcNow.AddHours(-1);
         DateTimeOffset createdAt = DateTimeOffset.UtcNow.AddDays(-7);
         DateTimeOffset modifiedAt = DateTimeOffset.UtcNow;
+        string hint = "whsec_b46a****************5182";
 
         var response = new WebhookSubscriptionResponse(
             id,
@@ -27,7 +28,8 @@ public sealed class WebhookSubscriptionResponseTests
             failureCount,
             lastSuccessAt,
             createdAt,
-            modifiedAt);
+            modifiedAt,
+            hint);
 
         response.Id.ShouldBe(id);
         response.TargetUrl.ShouldBe(targetUrl);
@@ -37,6 +39,7 @@ public sealed class WebhookSubscriptionResponseTests
         response.LastSuccessAt.ShouldBe(lastSuccessAt);
         response.CreatedAt.ShouldBe(createdAt);
         response.ModifiedAt.ShouldBe(modifiedAt);
+        response.SigningSecretHint.ShouldBe(hint);
     }
 
     [Fact]
@@ -50,9 +53,11 @@ public sealed class WebhookSubscriptionResponseTests
             0,
             null,
             DateTimeOffset.UtcNow,
+            null,
             null);
 
         response.LastSuccessAt.ShouldBeNull();
         response.ModifiedAt.ShouldBeNull();
+        response.SigningSecretHint.ShouldBeNull();
     }
 }

--- a/tests/Granit.Webhooks.Endpoints.Tests/Endpoints/WebhookSubscriptionReadEndpointsTests.cs
+++ b/tests/Granit.Webhooks.Endpoints.Tests/Endpoints/WebhookSubscriptionReadEndpointsTests.cs
@@ -1,0 +1,45 @@
+using Granit.Webhooks.Domain;
+using Granit.Webhooks.Endpoints.Dtos;
+using Granit.Webhooks.Endpoints.Endpoints;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Endpoints.Tests.Endpoints;
+
+public sealed class WebhookSubscriptionReadEndpointsTests
+{
+    [Fact]
+    public void MapToResponse_PropagatesSigningSecretHint()
+    {
+        const string Hint = "whsec_b46a****************5182";
+        var subscription = WebhookSubscription.Create(
+            id: Guid.NewGuid(),
+            targetUrl: "https://example.com/hook",
+            eventType: "test.event",
+            signingKeyId: Guid.NewGuid(),
+            protectedSecret: "protected-secret",
+            createdAt: DateTimeOffset.UtcNow,
+            tenantId: null,
+            signingSecretHint: Hint);
+
+        WebhookSubscriptionResponse response = WebhookSubscriptionReadEndpoints.MapToResponse(subscription);
+
+        response.SigningSecretHint.ShouldBe(Hint);
+    }
+
+    [Fact]
+    public void MapToResponse_NullHint_IsForwardedAsNull()
+    {
+        var subscription = WebhookSubscription.Create(
+            id: Guid.NewGuid(),
+            targetUrl: "https://example.com/hook",
+            eventType: "test.event",
+            signingKeyId: Guid.NewGuid(),
+            protectedSecret: "protected-secret",
+            createdAt: DateTimeOffset.UtcNow);
+
+        WebhookSubscriptionResponse response = WebhookSubscriptionReadEndpoints.MapToResponse(subscription);
+
+        response.SigningSecretHint.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
@@ -5,6 +5,7 @@ using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Granit.Webhooks.Internal;
 using Granit.Webhooks.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -171,6 +172,22 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
         await Should.ThrowAsync<Granit.Exceptions.EntityNotFoundException>(async () =>
             await _sut.DeactivateAsync(Guid.NewGuid(), "reason", TestContext.Current.CancellationToken));
     }
+
+    [Fact]
+    public async Task CreateAsync_persists_signing_secret_hint()
+    {
+        WebhookSubscriptionCreatedResult created = await _sut.CreateAsync(
+            "https://example.com/hook", "doc.uploaded", null, TestContext.Current.CancellationToken);
+
+        // Loaded back from the store to prove the hint round-trips through EF.
+        WebhookSubscription? roundTripped = await _sut.FindByIdAsync(
+            created.Subscription.Id, TestContext.Current.CancellationToken);
+
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.SigningSecretHint.ShouldNotBeNull();
+        roundTripped.SigningSecretHint.ShouldBe(WebhookSecretHint.From(created.PlainSecret));
+    }
+
 
     // -------------------------------------------------------------------------
     // Helpers

--- a/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
@@ -141,6 +141,34 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         result.PlainSecret.ShouldStartWith("whsec_");
     }
 
+    [Fact]
+    public async Task CreateAsync_PersistsSigningSecretHint_DerivedFromPlainSecret()
+    {
+        WebhookSubscriptionCreatedResult result = await _store.CreateAsync(
+            "https://example.com/hook", "test.event", null, TestContext.Current.CancellationToken);
+
+        result.Subscription.SigningSecretHint.ShouldNotBeNull();
+        result.Subscription.SigningSecretHint.ShouldBe(WebhookSecretHint.From(result.PlainSecret));
+        // Never expose the plaintext through the hint.
+        result.Subscription.SigningSecretHint.ShouldNotContain(result.PlainSecret[10..30]);
+    }
+
+    [Fact]
+    public async Task RotateSigningKeyAsync_RefreshesSigningSecretHintOnSubscription()
+    {
+        WebhookSubscriptionCreatedResult created = await _store.CreateAsync(
+            "https://example.com/hook", "test.event", null, TestContext.Current.CancellationToken);
+        string initialHint = created.Subscription.SigningSecretHint!;
+
+        WebhookSigningKeyRotatedResult rotated = await ((IWebhookSigningKeyWriter)_store)
+            .RotateSigningKeyAsync(created.Subscription.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
+
+        WebhookSubscription? updated = await _store.FindByIdAsync(created.Subscription.Id, TestContext.Current.CancellationToken);
+        updated!.SigningSecretHint.ShouldNotBeNull();
+        updated.SigningSecretHint.ShouldBe(WebhookSecretHint.From(rotated.PlainSecret));
+        updated.SigningSecretHint.ShouldNotBe(initialHint);
+    }
+
     // -------------------------------------------------------------------------
     // DeactivateAsync
     // -------------------------------------------------------------------------

--- a/tests/Granit.Webhooks.Tests/WebhookSecretHintTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSecretHintTests.cs
@@ -1,0 +1,78 @@
+using Granit.Webhooks.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Tests;
+
+public sealed class WebhookSecretHintTests
+{
+    [Fact]
+    public void From_PreservesKnownPrefix_AndMasksBody()
+    {
+        // 64 hex chars after the prefix → standard whsec_ output.
+        string plaintext = "whsec_b46a0123456789abcdef0123456789abcdef0123456789abcdef0123455182";
+
+        string hint = WebhookSecretHint.From(plaintext);
+
+        hint.ShouldStartWith("whsec_b46a");
+        hint.ShouldEndWith("5182");
+        hint.Length.ShouldBe(6 + 4 + 16 + 4); // prefix + first4 + 16 stars + last4
+        hint.ShouldBe("whsec_b46a****************5182");
+    }
+
+    [Fact]
+    public void From_IsIdempotentInShape_AcrossDifferentInputs()
+    {
+        string a = WebhookSecretHint.From("whsec_" + new string('a', 64));
+        string b = WebhookSecretHint.From("whsec_" + new string('b', 64));
+
+        a.Length.ShouldBe(b.Length);
+        a.ShouldBe("whsec_aaaa****************aaaa");
+        b.ShouldBe("whsec_bbbb****************bbbb");
+    }
+
+    [Fact]
+    public void From_WithoutKnownPrefix_DoesNotInventOne()
+    {
+        string plaintext = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+        string hint = WebhookSecretHint.From(plaintext);
+
+        hint.ShouldNotStartWith("whsec_");
+        hint.ShouldStartWith("0123");
+        hint.ShouldEndWith("cdef");
+        hint.Length.ShouldBe(4 + 16 + 4);
+    }
+
+    [Fact]
+    public void From_ShortBody_MasksEntireBody_NoLeak()
+    {
+        // 8 body chars or fewer → entire body becomes asterisks so first/last don't overlap.
+        string hint = WebhookSecretHint.From("whsec_abcd");
+
+        hint.ShouldBe("whsec_****");
+    }
+
+    [Fact]
+    public void From_ExactlyEightBodyChars_MasksEverything()
+    {
+        string hint = WebhookSecretHint.From("whsec_12345678");
+
+        hint.ShouldBe("whsec_********");
+    }
+
+    [Fact]
+    public void From_NineBodyChars_KeepsEdgesAndMasksMiddle()
+    {
+        string hint = WebhookSecretHint.From("whsec_123456789");
+
+        hint.ShouldBe("whsec_1234****************6789");
+    }
+
+    [Fact]
+    public void From_NullOrEmpty_Throws()
+    {
+        Should.Throw<ArgumentException>(() => WebhookSecretHint.From(null!));
+        Should.Throw<ArgumentException>(() => WebhookSecretHint.From(string.Empty));
+    }
+}

--- a/tests/Granit.Webhooks.Tests/WebhookSigningKeyTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSigningKeyTests.cs
@@ -105,6 +105,47 @@ public sealed class WebhookSigningKeyTests
     }
 
     [Fact]
+    public void RotateSigningKey_WithHint_UpdatesSubscriptionSigningSecretHint()
+    {
+        var subscription = WebhookSubscription.Create(
+            Guid.NewGuid(),
+            "https://example.com/webhook",
+            "test.event",
+            Guid.NewGuid(),
+            "first-protected",
+            Now,
+            tenantId: null,
+            signingSecretHint: "whsec_aaaa****************aaaa");
+
+        subscription.RotateSigningKey(
+            Guid.NewGuid(),
+            "new-protected",
+            Now,
+            Grace,
+            newSigningSecretHint: "whsec_bbbb****************bbbb");
+
+        subscription.SigningSecretHint.ShouldBe("whsec_bbbb****************bbbb");
+    }
+
+    [Fact]
+    public void RotateSigningKey_WithoutHint_LeavesExistingSigningSecretHintUntouched()
+    {
+        var subscription = WebhookSubscription.Create(
+            Guid.NewGuid(),
+            "https://example.com/webhook",
+            "test.event",
+            Guid.NewGuid(),
+            "first-protected",
+            Now,
+            tenantId: null,
+            signingSecretHint: "whsec_aaaa****************aaaa");
+
+        subscription.RotateSigningKey(Guid.NewGuid(), "new-protected", Now, Grace);
+
+        subscription.SigningSecretHint.ShouldBe("whsec_aaaa****************aaaa");
+    }
+
+    [Fact]
     public void StampRotationNotification_RecordsTimestamp()
     {
         WebhookSubscription subscription = WithSigningKey(out _);


### PR DESCRIPTION
## Summary

Admin UIs need a stable, masked preview of a webhook's signing secret
(e.g. `whsec_b46a****************5182`) on the detail / edit view —
the plaintext is only returned at creation and rotation, so the hint
must be computed at those call sites and persisted as non-sensitive
metadata.

- `WebhookSecretHint.From(plaintext)` — pure helper, preserves the
  `whsec_` prefix, keeps 4 chars on each edge, 16-char mask in between,
  degrades safely on short inputs.
- `WebhookSubscription.SigningSecretHint` (nullable) refreshed on
  `Create` and `RotateSigningKey`. EF column capped at 32 chars
  (current format is exactly 30).
- Both stores (InMemory + EF) compute the hint from the plaintext at
  create / rotate time — never derived from the protected value.
- `WebhookSubscriptionResponse` exposes `SigningSecretHint`; OpenAPI
  example updated. Legacy rows stay `null` — UI falls back to a static
  placeholder.

No EF migration shipped: consuming apps own webhook schema migrations
(framework convention).

## Security note

Exposing 8 of 64 hex characters leaks ~32 of 256 bits of entropy —
non-exploitable, same pattern as Stripe / GitHub / Slack secret hints.

## Test plan

- [x] `WebhookSecretHintTests` — formatting, prefix preservation,
      short-input fallback, null/empty guard
- [x] `WebhookSigningKeyTests` — domain `RotateSigningKey` updates
      `SigningSecretHint` when a new hint is provided; leaves it
      untouched otherwise
- [x] `InMemoryWebhookSubscriptionStoreTests` — hint derived from
      plaintext on create, refreshed on rotate, differs after rotation
- [x] `EfWebhookSubscriptionStoreTests` — hint round-trips through EF
      (create + find)
- [x] `WebhookSubscriptionReadEndpointsTests` — hint propagates to the
      response DTO from the read endpoint
- [x] `WebhookSubscriptionResponseTests` — updated for the new
      positional record argument
- [x] All 321 webhook tests green; `dotnet format --verify-no-changes`
      clean on touched projects