### PR TITLE
fix(privacy): anchor tenant scope in PersonalDataExportSaga.Start + tenant-scoped provider validator

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -38133,7 +38133,7 @@
       "kind": "interface",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs",
-      "line": 25,
+      "line": 37,
       "members": [
         {
           "name": "HasDataAsync",
@@ -38247,7 +38247,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs",
-      "line": 36,
+      "line": 37,
       "members": [
         {
           "name": "Id",
@@ -38270,7 +38270,7 @@
         {
           "name": "Start",
           "kind": "method",
-          "signature": "Start(PersonalDataRequestedEto @event, IPrivacyScopeResolver scopeResolver, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics, CancellationToken cancellationToken)",
+          "signature": "Start(PersonalDataRequestedEto @event, IPrivacyScopeResolver scopeResolver, ICurrentTenant currentTenant, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics, CancellationToken cancellationToken)",
           "returnType": "Guid? TenantId { get; set; } public DateTimeOffset RequestedAt { get; set; } public Task<ExportCompletedEto?>"
         }
       ]
@@ -38340,7 +38340,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/ProviderRegistration.cs",
-      "line": 17,
+      "line": 22,
       "members": []
     },
     {

--- a/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -51,6 +51,8 @@ public static class PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions
             configureSchemaPerTenant,
             configureTenantSchema);
 
+        builder.Services.AddHostedService<PrivacyTenantScopedProviderValidator>();
+
         builder.Services.AddScoped<EfLegalDocumentStore>();
         builder.Services.TryAddScoped<ILegalDocumentReader>(sp => sp.GetRequiredService<EfLegalDocumentStore>());
         builder.Services.TryAddScoped<ILegalDocumentWriter>(sp => sp.GetRequiredService<EfLegalDocumentStore>());

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyTenantScopedProviderValidator.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyTenantScopedProviderValidator.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Privacy.DataExport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Privacy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Fail-fast guard that detects <see cref="IPrivacyDataProvider"/> implementations
+/// depending on a tenant-isolated <see cref="DbContext"/> while
+/// <c>Granit.MultiTenancy</c> is not wired.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Companion to <c>WebhooksDualScopeIntegrationValidator</c> (#2376). The privacy
+/// equivalent of the dual-scope misconfig is subtler: there is no wrong-schema fold,
+/// but if a provider's constructor takes a tenant-isolated DbContext and
+/// <see cref="ICurrentTenant"/> resolves to <see cref="NullTenantContext"/>, the
+/// DbContext silently falls back to the <c>SharedDatabase</c> keyed factory
+/// (<see cref="Granit.Persistence.EntityFrameworkCore.Extensions.PersistenceTenantExtensions"/>
+/// scoped-fallback) and queries the host schema regardless of which tenant the
+/// envelope addresses — leading to PostgreSQL 42P01 on the first request.
+/// </para>
+/// <para>
+/// The framework saga (<c>PersonalDataExportSaga.Start</c>) opens the tenant scope
+/// from the envelope payload for the HasData probe path; the export-handler path
+/// relies on <c>TenantContextBehavior</c> restoring the X-Tenant-Id header. Both
+/// require <see cref="ICurrentTenant"/> to be a real implementation, not the null
+/// fallback. This validator throws if a tenant-isolated dependency is present but
+/// multi-tenancy isn't registered, and logs the detected dependencies otherwise as
+/// discoverability for operators auditing privacy data flow.
+/// </para>
+/// </remarks>
+internal sealed partial class PrivacyTenantScopedProviderValidator(
+    IDataProviderRegistry providerRegistry,
+    IEnumerable<IsolatedDbContextMarker> isolatedMarkers,
+    ICurrentTenant currentTenant,
+    ILogger<PrivacyTenantScopedProviderValidator> logger) : IHostedService
+{
+    /// <inheritdoc/>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        HashSet<Type> isolatedDbContextTypes = [.. isolatedMarkers.Select(m => m.DbContextType)];
+        if (isolatedDbContextTypes.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        List<(string ProviderName, Type ProviderType, IReadOnlyList<Type> IsolatedDbContexts)> dependencies = [];
+
+        foreach (ProviderRegistration registration in providerRegistry.GetAllRegistrations())
+        {
+            if (registration.ProviderType is null)
+            {
+                continue;
+            }
+
+            IReadOnlyList<Type> deps = FindIsolatedDbContextDependencies(
+                registration.ProviderType, isolatedDbContextTypes);
+            if (deps.Count > 0)
+            {
+                dependencies.Add((registration.ProviderName, registration.ProviderType, deps));
+            }
+        }
+
+        if (dependencies.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        bool multiTenancyMissing = currentTenant is NullTenantContext;
+        if (multiTenancyMissing)
+        {
+            StringBuilder sb = new();
+            sb.AppendLine(
+                "Privacy data providers depend on tenant-isolated DbContexts but " +
+                "Granit.MultiTenancy is not registered (ICurrentTenant resolves to " +
+                "NullTenantContext). Tenant-isolated DbContexts silently fall back to " +
+                "the SharedDatabase keyed factory in that configuration, so per-tenant " +
+                "tables would be queried against the host schema (PostgreSQL 42P01).");
+            sb.AppendLine();
+            sb.AppendLine("Offending providers:");
+            foreach ((string name, Type type, IReadOnlyList<Type> deps) in dependencies)
+            {
+                sb.Append("  - ").Append(name)
+                  .Append(" (").Append(type.FullName ?? type.Name).Append(')')
+                  .Append(" → ").AppendLine(string.Join(", ", deps.Select(d => d.Name)));
+            }
+            sb.AppendLine();
+            sb.Append("Call AddGranitMultiTenancy() on the host, or move the provider to a ");
+            sb.Append("host-scoped DbContext (registered via AddGranitDbContext).");
+
+            throw new InvalidOperationException(sb.ToString());
+        }
+
+        foreach ((string name, Type type, IReadOnlyList<Type> deps) in dependencies)
+        {
+            LogTenantScopedProvider(name, type.Name, string.Join(", ", deps.Select(d => d.Name)));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static IReadOnlyList<Type> FindIsolatedDbContextDependencies(
+        Type providerType, HashSet<Type> isolatedDbContextTypes)
+    {
+        // Inspect every public constructor's parameter list. Most providers expose a single
+        // primary ctor, but we don't assume — any ctor reachable by DI is a potential bind
+        // site, and a false negative here would defeat the validator's purpose.
+        HashSet<Type> matches = [];
+        foreach (System.Reflection.ConstructorInfo ctor in providerType.GetConstructors())
+        {
+            foreach (System.Reflection.ParameterInfo param in ctor.GetParameters())
+            {
+                if (isolatedDbContextTypes.Contains(param.ParameterType))
+                {
+                    matches.Add(param.ParameterType);
+                }
+            }
+        }
+        return [.. matches];
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Privacy provider {ProviderName} ({ProviderType}) depends on tenant-isolated DbContext(s) {IsolatedDbContexts}. The framework saga and TenantContextBehavior anchor the tenant scope automatically; custom orchestrators must open ICurrentTenant.Change(context.TenantId) before resolving the provider.")]
+    private partial void LogTenantScopedProvider(string providerName, string providerType, string isolatedDbContexts);
+}

--- a/src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs
@@ -21,6 +21,18 @@ namespace Granit.Privacy.DataExport;
 /// modules (Documents, attachments). Providers now stream one or more
 /// <see cref="ExportFragment"/> values via <see cref="ExportAsync"/>.
 /// </para>
+/// <para>
+/// <b>Tenant scope invariant.</b> Implementations that depend on a tenant-isolated
+/// <c>DbContext</c> (registered via <c>AddGranitIsolatedDbContext</c>) require an active
+/// <c>ICurrentTenant</c> at construction time, otherwise the DbContext silently falls
+/// back to the <c>SharedDatabase</c> keyed factory and queries the wrong schema
+/// (PostgreSQL 42P01). The framework already anchors the tenant for you on the two
+/// official orchestration paths: <c>PersonalDataExportSaga.Start</c> (HasData probe) and
+/// the per-provider Wolverine handlers (via <see cref="Events.PersonalDataRequestedEto.TenantId"/>
+/// restored on the receiving side by <c>TenantContextBehavior</c>). Custom orchestrators
+/// that resolve an <see cref="IPrivacyDataProvider"/> directly MUST do the same — open
+/// <c>currentTenant.Change(context.TenantId)</c> before resolving the provider.
+/// </para>
 /// </remarks>
 public interface IPrivacyDataProvider
 {

--- a/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
+++ b/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Privacy.DataExport.Events;
 using Granit.Privacy.Diagnostics;
 using Granit.Privacy.Options;
@@ -73,6 +74,7 @@ public sealed class PersonalDataExportSaga : Saga
     public async Task<ExportCompletedEto?> Start(
         PersonalDataRequestedEto @event,
         IPrivacyScopeResolver scopeResolver,
+        ICurrentTenant currentTenant,
         IOptions<GranitPrivacyOptions> options,
         IMessageContext context,
         PrivacyMetrics metrics,
@@ -84,6 +86,14 @@ public sealed class PersonalDataExportSaga : Saga
         TenantId = @event.TenantId;
         RequestedAt = @event.RequestedAt;
         metrics.RecordExportRequested(TenantId, Regulation);
+
+        // Anchor the tenant carried by the envelope payload before resolving any scoped
+        // service. TenantContextBehavior normally sets this from the X-Tenant-Id header,
+        // but the header can be missing on outbox replay, saga rehydration, local-queue
+        // paths, or inline tests — in which case PrivacyScopeResolver would resolve
+        // tenant-isolated DbContexts through the SharedDatabase fallback and query the
+        // wrong schema (42P01). The saga state's TenantId is the authoritative source.
+        using IDisposable _ = currentTenant.Change(@event.TenantId);
 
         // Apply visibility gates + intersect with the subject's RequestedScopes list.
         // RequestedScopes naming an unknown / hidden provider is silently dropped (VULN-202:

--- a/src/Granit.Privacy/DataExport/ProviderRegistration.cs
+++ b/src/Granit.Privacy/DataExport/ProviderRegistration.cs
@@ -14,8 +14,14 @@ namespace Granit.Privacy.DataExport;
 /// <see cref="IServiceProvider"/> at scope-evaluation time and calls
 /// <see cref="IPrivacyDataProvider.HasDataAsync"/>. Captured by the builder so callers
 /// of <see cref="IPrivacyScopeResolver"/> don't need to know the concrete provider type.</param>
+/// <param name="ProviderType">Concrete <see cref="IPrivacyDataProvider"/> implementation
+/// type. Captured so startup validators (e.g. the tenant-isolated DbContext dependency
+/// check in <c>Granit.Privacy.EntityFrameworkCore</c>) can introspect the constructor
+/// without pulling the typed provider through DI. Legacy name-only registrations carry
+/// <see langword="null"/>.</param>
 public sealed record ProviderRegistration(
     string ProviderName,
     string DisplayKey,
     string? FeatureName,
-    Func<IServiceProvider, PrivacyExportContext, CancellationToken, ValueTask<bool>> HasDataProbe);
+    Func<IServiceProvider, PrivacyExportContext, CancellationToken, ValueTask<bool>> HasDataProbe,
+    Type? ProviderType = null);

--- a/src/Granit.Privacy/GranitPrivacyBuilder.cs
+++ b/src/Granit.Privacy/GranitPrivacyBuilder.cs
@@ -66,7 +66,8 @@ public sealed class GranitPrivacyBuilder(IServiceCollection services)
             DisplayKey: TProvider.DisplayKey,
             FeatureName: TProvider.FeatureName,
             HasDataProbe: static (sp, ctx, ct) =>
-                sp.GetRequiredService<TProvider>().HasDataAsync(ctx, ct)));
+                sp.GetRequiredService<TProvider>().HasDataAsync(ctx, ct),
+            ProviderType: typeof(TProvider)));
         return this;
     }
 

--- a/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Metrics;
 using Granit.Domain.ValueObjects;
+using Granit.MultiTenancy;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;
 using Granit.Privacy.Diagnostics;
@@ -27,6 +28,8 @@ public sealed class PersonalDataExportSagaTests : IDisposable
     }
 
     public void Dispose() => _sp.Dispose();
+
+    private static readonly ICurrentTenant CurrentTenant = NullTenantContext.Instance;
 
     private static IOptions<GranitPrivacyOptions> DefaultOptions() =>
         Microsoft.Extensions.Options.Options.Create(new GranitPrivacyOptions { ExportTimeoutMinutes = 5 });
@@ -71,7 +74,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         var userId = Guid.NewGuid();
         PersonalDataRequestedEto evt = new(requestId, userId, DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.Start(evt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(evt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Id.ShouldBe(requestId);
         saga.UserId.ShouldBe(userId);
@@ -89,7 +92,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         var requestId = Guid.NewGuid();
         PersonalDataRequestedEto evt = new(requestId, Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.Start(evt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(evt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         // ScheduleAsync is an extension method that calls PublishAsync with DeliveryOptions.
         // NSubstitute cannot intercept extension methods, so we verify the underlying PublishAsync call.
@@ -105,7 +108,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing", "appointments");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(startEvt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         ExportCompletedEto? result1 = saga.Handle(
             StagedFragmentEto(startEvt.RequestId, "patients", "blob-1", "patients.json"), _metrics);
@@ -125,7 +128,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(startEvt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "patients", "blob-patients", "patients.json"), _metrics);
         ExportCompletedEto? result = saga.Handle(
@@ -150,7 +153,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         IPrivacyScopeResolver scopeResolver = BuildScopeResolver("documents");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(startEvt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "documents", "blob-1", "Documents/a.pdf"), _metrics);
         ExportCompletedEto? second = saga.Handle(StagedFragmentEto(startEvt.RequestId, "documents", "blob-2", "Documents/b.pdf"), _metrics);
@@ -176,7 +179,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         IPrivacyScopeResolver scopeResolver = BuildScopeResolver("patients", "billing", "appointments");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(startEvt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "patients", "blob-patients", "patients.json"), _metrics);
         saga.Handle(StagedFragmentEto(startEvt.RequestId, "billing", "blob-billing", "billing.json"), _metrics);
@@ -200,7 +203,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
         // No providers registered → resolver returns empty list, saga completes immediately.
-        ExportCompletedEto? result = await saga.Start(evt, BuildScopeResolver(), DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        ExportCompletedEto? result = await saga.Start(evt, BuildScopeResolver(), CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.IsPartial.ShouldBeFalse();
@@ -250,7 +253,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         PersonalDataRequestedEto evt = new(
             Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR", TenantId: tenantId);
 
-        await saga.Start(evt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(evt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         saga.TenantId.ShouldBe(tenantId);
     }
@@ -264,7 +267,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         PersonalDataRequestedEto evt = new(
             Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR", TenantId: tenantId);
 
-        ExportCompletedEto? result = await saga.Start(evt, BuildScopeResolver(), DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        ExportCompletedEto? result = await saga.Start(evt, BuildScopeResolver(), CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.TenantId.ShouldBe(tenantId);
@@ -279,7 +282,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         var tenantId = Guid.NewGuid();
         PersonalDataRequestedEto startEvt = new(
             Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR", TenantId: tenantId);
-        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(startEvt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         ExportCompletedEto result = saga.Handle(new ExportTimedOutEvent(startEvt.RequestId), _metrics);
 
@@ -300,7 +303,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IPrivacyScopeResolver scopeResolver = BuildScopeResolver("auth");
         PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.Start(evt, scopeResolver, options, context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(evt, scopeResolver, CurrentTenant, options, context, _metrics, TestContext.Current.CancellationToken);
 
         // ScheduleAsync(message, TimeSpan) sets ScheduleDelay (relative), not ScheduledTime (absolute).
         await context.Received(1).PublishAsync(
@@ -321,11 +324,76 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         IPrivacyScopeResolver scopeResolver = BuildScopeResolver("auth");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.Start(startEvt, scopeResolver, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+        await saga.Start(startEvt, scopeResolver, CurrentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
 
         ExportCompletedEto? result = saga.Handle(
             StagedFragmentEto(startEvt.RequestId, "auth", "blob-auth", "auth.json"), _metrics);
 
         result!.ArchiveBlobReferenceId.Value.ShouldBe($"personal-data-export/{startEvt.RequestId}");
+    }
+
+    // -------------------------------------------------------------------------
+    // Tenant scope anchor — regression for the 42P01 bug when the envelope reaches
+    // the saga without TenantContextBehavior having set ICurrentTenant (outbox
+    // replay, saga rehydration, local-queue path, inline test invocation).
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Start_AnchorsTenantFromEvent_BeforeResolvingProviders()
+    {
+        // Arrange: ICurrentTenant starts inactive — simulates the envelope reaching
+        // the saga without an X-Tenant-Id header restored by TenantContextBehavior.
+        RecordingCurrentTenant currentTenant = new();
+        Guid? observedDuringProbe = null;
+
+        IPrivacyScopeResolver scopeResolver = Substitute.For<IPrivacyScopeResolver>();
+        scopeResolver.ListVisibleAsync(Arg.Any<PrivacyExportContext>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                observedDuringProbe = currentTenant.Id;
+                return (IReadOnlyList<ProviderDescriptor>)[];
+            });
+
+        PersonalDataExportSaga saga = new();
+        IMessageContext context = Substitute.For<IMessageContext>();
+        var tenantId = Guid.NewGuid();
+        PersonalDataRequestedEto evt = new(
+            Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR", TenantId: tenantId);
+
+        currentTenant.Id.ShouldBeNull("baseline: no tenant active before saga.Start");
+
+        // Act
+        await saga.Start(evt, scopeResolver, currentTenant, DefaultOptions(), context, _metrics, TestContext.Current.CancellationToken);
+
+        // Assert: the scope was open during the scope-resolver invocation (i.e. before
+        // any tenant-isolated DbContext could be resolved by a provider's HasDataAsync)…
+        observedDuringProbe.ShouldBe(tenantId);
+
+        // …and restored after the saga method returns.
+        currentTenant.Id.ShouldBeNull();
+    }
+
+    private sealed class RecordingCurrentTenant : ICurrentTenant
+    {
+        public bool IsAvailable => Id.HasValue;
+        public Guid? Id { get; private set; }
+        public string? Name { get; private set; }
+
+        public IDisposable Change(Guid? id, string? name = null)
+        {
+            (Guid? previousId, string? previousName) = (Id, Name);
+            Id = id;
+            Name = name;
+            return new Restore(this, previousId, previousName);
+        }
+
+        private sealed class Restore(RecordingCurrentTenant owner, Guid? previousId, string? previousName) : IDisposable
+        {
+            public void Dispose()
+            {
+                owner.Id = previousId;
+                owner.Name = previousName;
+            }
+        }
     }
 }

--- a/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
+++ b/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 using Granit.Privacy.DataExport;
@@ -76,6 +77,7 @@ public sealed class PrivacySagaWolverineCodegenTests
             {
                 services.AddSingleton<IDataProviderRegistry>(new DataProviderRegistry());
                 services.AddSingleton(Substitute.For<IPrivacyScopeResolver>());
+                services.AddSingleton<ICurrentTenant>(NullTenantContext.Instance);
                 services.AddSingleton(Substitute.For<IDeletionRequestTrackerWriter>());
                 services.AddSingleton(TimeProvider.System);
                 services.AddSingleton(Substitute.For<ILegalDocumentRegistry>());


### PR DESCRIPTION
## Summary

- **Option 1 (saga anchor):** `PersonalDataExportSaga.Start` now opens `currentTenant.Change(@event.TenantId)` before `PrivacyScopeResolver.ListVisibleAsync` runs. Closes the gap where the envelope reaches the saga without `X-Tenant-Id` (outbox replay, saga rehydration after restart, local-queue paths, inline tests), letting tenant-isolated provider `DbContext`s silently fall back to `SharedDatabase` and query the host schema (PostgreSQL 42P01).
- **Option 3 (fail-fast validator):** new `PrivacyTenantScopedProviderValidator` hosted service in `Granit.Privacy.EntityFrameworkCore` — companion to `WebhooksDualScopeIntegrationValidator` (#2376). Enumerates registered `IPrivacyDataProvider` constructors, detects tenant-isolated `DbContext` dependencies, and throws at startup if multi-tenancy isn't wired (`ICurrentTenant` resolves to `NullTenantContext`). Otherwise logs the dependency map at Information level for operators auditing privacy data flow.
- Required adding `Type ProviderType` to `ProviderRegistration` so the validator can introspect ctors without going through DI.
- Updated `IPrivacyDataProvider` docstring with the tenant scope invariant.

## Background

Reproduced on the showcase 2026-05-28: a tenant user POSTs `/api/v1/privacy/exports`, saga starts, `PlaygroundMedicalPrivacyDataProvider.HasDataAsync` fires inside `PrivacyScopeResolver.ListVisibleAsync` → `Npgsql.PostgresException: 42P01: relation "playground_medical_records" does not exist`. The provider's `PlaygroundDbContext` is registered via `AddGranitIsolatedDbContext` (`SchemaPerTenant`); without an active tenant the scoped fallback returns a `SharedDatabase` instance pointing at `public`.

Defense in depth at the saga is the right layer because `@event.TenantId` is the authoritative tenant captured at publish time (immutable across retries) and the saga is the earliest point inside the handler scope where the scope can be opened *before* `IServiceProvider.GetRequiredService<TProvider>()` resolves the DbContext for the probe. Mirrors the existing `PrivacyExportAssemblyJobHandler` pattern.

## Test plan

- [x] `tests/Granit.Privacy.Tests` — 282/282 pass, including new regression `Start_AnchorsTenantFromEvent_BeforeResolvingProviders` that pins the contract using a `RecordingCurrentTenant` fake.
- [x] `tests/Granit.Privacy.EntityFrameworkCore.Tests` — 29/29 pass.
- [x] `tests/Granit.ArchitectureTests` — 235/235 pass (no convention regression).
- [x] Full `security` shard — all green.
- [x] `dotnet format --verify-no-changes` clean on the touched projects.
- [ ] Manual showcase rerun: POST `/api/v1/privacy/exports` as a tenant user, confirm the saga starts without 42P01 and provider fragments are uploaded.

## Out of scope (follow-ups)

- The per-provider Wolverine handler path (`PrivacyFragmentUploader.UploadAsync` invoked by handlers like `AuditingPersonalDataExportHandler`) cannot be patched the same way: the typed provider is resolved by Wolverine *before* `HandleAsync` runs, so anchoring inside the body is too late. That path remains dependent on `TenantContextBehavior` restoring the header. A Wolverine middleware that anchors from the payload `TenantId` ahead of handler scope resolution is the right fix — separate PR.
- Surface the silent fallback in `AddGranitIsolatedDbContext`'s scoped fallback (lines 265-279 of `PersistenceTenantExtensions.cs`) with a logger warning when it's taken in a multi-tenant deployment — separate PR.