### PR TITLE
feat(persistence): DualScopeStorageMode primitive (ADR-063 V1, Epic #2382)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36075,6 +36075,22 @@
       ]
     },
     {
+      "name": "DualScopeValidation",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.MultiTenancy.DualScopeValidation",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/DualScopeValidation.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "ValidateStorageMode",
+          "kind": "method",
+          "signature": "ValidateStorageMode(DualScopeStorageMode storageMode, TenantIsolationStrategy strategy, string moduleName)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "ITenantConnectionStringProvider",
       "fqn": "Granit.Persistence.EntityFrameworkCore.MultiTenancy.ITenantConnectionStringProvider",
       "kind": "interface",
@@ -36466,6 +36482,15 @@
           "returnType": "InlineSpecification<T>"
         }
       ]
+    },
+    {
+      "name": "DualScopeStorageMode",
+      "fqn": "Granit.Persistence.MultiTenancy.DualScopeStorageMode",
+      "kind": "enum",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/DualScopeStorageMode.cs",
+      "line": 30,
+      "members": []
     },
     {
       "name": "SortExpression",

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/DualScopeValidation.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/DualScopeValidation.cs
@@ -1,0 +1,51 @@
+using Granit.Persistence.MultiTenancy;
+
+namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+
+/// <summary>
+/// Validates a dual-scope module's chosen <see cref="DualScopeStorageMode"/> against the
+/// host's active <see cref="TenantIsolationStrategy"/>.
+/// </summary>
+/// <remarks>
+/// Per ADR-063, <see cref="DualScopeStorageMode.Segregated"/> combined with
+/// <see cref="TenantIsolationStrategy.SharedDatabase"/> is rejected: the segregated mode
+/// exists to provide physical isolation between host and tenant rows, which a shared-database
+/// strategy fundamentally cannot deliver. Callers — typically a module's startup-time
+/// <c>IValidateOptions&lt;T&gt;</c> implementation or a host configuration check — invoke
+/// <see cref="ValidateStorageMode"/> to surface the misconfiguration before any request is served.
+/// </remarks>
+public static class DualScopeValidation
+{
+    /// <summary>
+    /// Throws when the combination of <paramref name="storageMode"/> and
+    /// <paramref name="strategy"/> is rejected by ADR-063.
+    /// </summary>
+    /// <param name="storageMode">The dual-scope storage mode declared by the module's options.</param>
+    /// <param name="strategy">The host-wide tenant isolation strategy in effect.</param>
+    /// <param name="moduleName">
+    /// Name of the calling module (e.g. <c>"Webhooks"</c>), used in the error message to
+    /// help the operator locate the misconfigured registration.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="storageMode"/> is <see cref="DualScopeStorageMode.Segregated"/>
+    /// and <paramref name="strategy"/> is <see cref="TenantIsolationStrategy.SharedDatabase"/>.
+    /// </exception>
+    public static void ValidateStorageMode(
+        DualScopeStorageMode storageMode,
+        TenantIsolationStrategy strategy,
+        string moduleName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(moduleName);
+
+        if (storageMode == DualScopeStorageMode.Segregated && strategy == TenantIsolationStrategy.SharedDatabase)
+        {
+            throw new InvalidOperationException(
+                $"{moduleName}: DualScopeStorageMode.Segregated is incompatible with " +
+                "TenantIsolationStrategy.SharedDatabase. Segregated mode requires physical separation " +
+                "between host and tenant rows, which SharedDatabase cannot provide. Either set " +
+                "StorageMode to DualScopeStorageMode.Shared (single host table with row-level filter), " +
+                "or change MultiTenancy:TenantIsolation:Strategy to SchemaPerTenant or DatabasePerTenant. " +
+                "See ADR-063 for the storage-mode taxonomy.");
+        }
+    }
+}

--- a/src/Granit.Persistence/MultiTenancy/DualScopeStorageMode.cs
+++ b/src/Granit.Persistence/MultiTenancy/DualScopeStorageMode.cs
@@ -1,0 +1,57 @@
+namespace Granit.Persistence.MultiTenancy;
+
+/// <summary>
+/// Physical storage layout choice for entities whose semantic applicability is
+/// <c>MultiTenancySides.Both</c> — i.e. dual-scope modules where the same entity shape
+/// holds both host-owned and tenant-owned rows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Complements <c>Granit.MultiTenancy.MultiTenancySides</c>, which describes the
+/// applicability semantics of a capability or entity (Host-only, Tenant-only, or Both).
+/// When applicability is <c>Both</c>, this enum picks the physical layout — a single
+/// shared host table with a row-level filter, or two physically separated tables.
+/// </para>
+/// <para>
+/// <see cref="Shared"/> is the framework default and reproduces the pre-ADR-063 behaviour
+/// across all dual-scope modules. <see cref="Segregated"/> opts the module into a
+/// two-context shape where host rows live in the host schema and tenant rows live in the
+/// tenant schema (or per-tenant database) for defense-in-depth against row-level filter
+/// regressions and to make <c>DROP SCHEMA &lt;tenant&gt; CASCADE</c> lessivage natively
+/// work for RGPD Art. 17.
+/// </para>
+/// <para>
+/// Per ADR-063, this enum is the single framework-level vocabulary for the choice; each
+/// dual-scope module exposes it through its <c>*EntityFrameworkCoreOptions.StorageMode</c>
+/// property, defaulting to <see cref="Shared"/>. <see cref="Segregated"/> support is rolled
+/// out module-by-module starting with <c>Granit.Webhooks</c> (Epic #2377).
+/// </para>
+/// </remarks>
+public enum DualScopeStorageMode
+{
+    /// <summary>
+    /// Single physical table in the host schema; <c>TenantId</c> is nullable. Host rows have
+    /// <c>TenantId == null</c>, tenant rows carry the owning tenant's identifier. Scoping is
+    /// enforced per-request by an EF Named Query Filter on <c>TenantId</c>.
+    /// </summary>
+    /// <remarks>
+    /// Lowest infrastructure cost and lowest provisioning ceremony — host and tenant data
+    /// live in the same table and migrations apply uniformly. This is the framework default.
+    /// </remarks>
+    Shared = 0,
+
+    /// <summary>
+    /// Two physical tables: a host-pinned table for host-scope rows, plus a per-tenant table
+    /// (in the tenant schema or per-tenant database) for tenant-scope rows. No row-level
+    /// filter — separation is physical. The module's store dispatches reads and writes to
+    /// the appropriate context based on the active scope.
+    /// </summary>
+    /// <remarks>
+    /// Provides defense-in-depth against row-level filter regressions and enables native
+    /// per-tenant data lessivage via schema or database drop. Requires either
+    /// <c>SchemaPerTenant</c> or <c>DatabasePerTenant</c> tenant isolation; combining
+    /// <see cref="Segregated"/> with <c>SharedDatabase</c> is rejected at startup because it
+    /// provides no physical isolation despite advertising it.
+    /// </remarks>
+    Segregated = 1,
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/DualScopeValidationTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/DualScopeValidationTests.cs
@@ -1,0 +1,65 @@
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Persistence.MultiTenancy;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests.MultiTenancy;
+
+public sealed class DualScopeValidationTests
+{
+    [Theory]
+    [InlineData(TenantIsolationStrategy.SharedDatabase)]
+    [InlineData(TenantIsolationStrategy.SchemaPerTenant)]
+    [InlineData(TenantIsolationStrategy.DatabasePerTenant)]
+    public void ValidateStorageMode_Shared_AlwaysSucceeds(TenantIsolationStrategy strategy)
+    {
+        Should.NotThrow(() => DualScopeValidation.ValidateStorageMode(
+            DualScopeStorageMode.Shared,
+            strategy,
+            "Webhooks"));
+    }
+
+    [Theory]
+    [InlineData(TenantIsolationStrategy.SchemaPerTenant)]
+    [InlineData(TenantIsolationStrategy.DatabasePerTenant)]
+    public void ValidateStorageMode_Segregated_AcceptsPhysicalIsolationStrategies(TenantIsolationStrategy strategy)
+    {
+        Should.NotThrow(() => DualScopeValidation.ValidateStorageMode(
+            DualScopeStorageMode.Segregated,
+            strategy,
+            "Webhooks"));
+    }
+
+    [Fact]
+    public void ValidateStorageMode_Segregated_RejectsSharedDatabase()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(
+            () => DualScopeValidation.ValidateStorageMode(
+                DualScopeStorageMode.Segregated,
+                TenantIsolationStrategy.SharedDatabase,
+                "Webhooks"));
+
+        ex.Message.ShouldContain("Webhooks");
+        ex.Message.ShouldContain("Segregated");
+        ex.Message.ShouldContain("SharedDatabase");
+        ex.Message.ShouldContain("ADR-063");
+    }
+
+    [Fact]
+    public void ValidateStorageMode_NullModuleName_Throws()
+    {
+        Should.Throw<ArgumentException>(() => DualScopeValidation.ValidateStorageMode(
+            DualScopeStorageMode.Shared,
+            TenantIsolationStrategy.SharedDatabase,
+            moduleName: null!));
+    }
+
+    [Fact]
+    public void ValidateStorageMode_EmptyModuleName_Throws()
+    {
+        Should.Throw<ArgumentException>(() => DualScopeValidation.ValidateStorageMode(
+            DualScopeStorageMode.Shared,
+            TenantIsolationStrategy.SharedDatabase,
+            moduleName: string.Empty));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of Epic #2382 (DualScopeMode generalisation) — ships the framework primitive every dual-scope module will reuse to expose the storage-mode choice introduced by ADR-063, before any consumer wires it.

- `Granit.Persistence.MultiTenancy.DualScopeStorageMode { Shared, Segregated }` enum, placed in `Granit.Persistence/MultiTenancy/` to mirror `Granit/MultiTenancy/MultiTenancySides.cs`.
- `Granit.Persistence.EntityFrameworkCore.MultiTenancy.DualScopeValidation.ValidateStorageMode` — fails fast when `Segregated` is combined with `TenantIsolationStrategy.SharedDatabase` (a contradiction: physical isolation advertised without delivery).
- 8 unit tests covering both modes × all three isolation strategies + arg-null guards.

## Vocabulary alignment

`DualScopeStorageMode` complements the existing `MultiTenancySides { Host, Tenant, Both }`:

- `MultiTenancySides` describes the **semantic applicability** of a capability or entity (used today by Settings, ApiKeys, MCP permission providers).
- `DualScopeStorageMode` describes the **physical storage layout** for entities whose applicability is `Both`.

Per ADR-063, these are Axis 1 and Axis 2 of the storage-mode taxonomy. The enum naming makes the relationship discoverable via xmldoc cross-references.

## Why ship the primitive alone

Epic #2377 (Webhooks) is the first consumer and will be a separate PR — this Phase 1 establishes the public API contract before the refactor lands, so the same enum can be reused for V2/V3/V4 modules without going through a rename cycle. The validation helper is small enough to ship and test standalone via Theory cases over `TenantIsolationStrategy`.

## Follow-ups

- granit-docs: ADR-063 enum reference update (`DualScopeMode` → `DualScopeStorageMode`) — small docs PR, decoupled per CLAUDE.md.
- #2377: refactor Webhooks to consume the primitive (Phase 2 of V1).

## Test plan

- [x] `dotnet build` green on `Granit.Persistence`, `Granit.Persistence.EntityFrameworkCore`, `Granit.Persistence.EntityFrameworkCore.Tests`
- [x] `dotnet test --filter DualScopeValidationTests` — 8/8 passing
- [x] `dotnet format --verify-no-changes` clean