### PR TITLE
feat(webhooks): WebhooksEntityFrameworkCoreOptions + StorageMode (Phase 2A of #2377)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -48811,12 +48811,12 @@
       "kind": "class",
       "project": "Granit.Webhooks.EntityFrameworkCore",
       "file": "src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 17,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitWebhooksEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitWebhooksEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitWebhooksEntityFrameworkCore(this IHostApplicationBuilder builder, Action<WebhooksEntityFrameworkCoreOptions> configure)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -48859,8 +48859,24 @@
       "kind": "class",
       "project": "Granit.Webhooks.EntityFrameworkCore",
       "file": "src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs",
-      "line": 17,
+      "line": 20,
       "members": []
+    },
+    {
+      "name": "WebhooksEntityFrameworkCoreOptions",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.WebhooksEntityFrameworkCoreOptions",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/WebhooksEntityFrameworkCoreOptions.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "StorageMode",
+          "kind": "property",
+          "signature": "DualScopeStorageMode StorageMode",
+          "returnType": "DualScopeStorageMode"
+        }
+      ]
     },
     {
       "name": "WebhookDeliveryFailureThresholdExceededEto",

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,10 +1,13 @@
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Persistence.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -17,8 +20,7 @@ namespace Granit.Webhooks.EntityFrameworkCore.Extensions;
 public static class WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
 {
     /// <summary>
-    /// Replaces the default InMemory/no-op stores with durable EF Core implementations
-    /// backed by a PostgreSQL database.
+    /// Replaces the default InMemory/no-op stores with durable EF Core implementations.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -30,44 +32,108 @@ public static class WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
     ///   <item><see cref="Internal.WebhooksDbContext"/> — registered via <c>IDbContextFactory</c> for thread-safe usage in Wolverine handlers.</item>
     /// </list>
     /// <para>
-    /// <b>Integration requirement — host-scoped DbContext only.</b> Webhooks is a
-    /// <b>dual-scope</b> module: platform-managed subscriptions (<c>TenantId == null</c>)
-    /// coexist with tenant-managed subscriptions (<c>TenantId == &lt;tenant&gt;</c>) in the
-    /// same physical table. Tenant isolation is enforced by the row-level <c>MultiTenant</c>
-    /// query filter — host admin reads bypass the filter via
-    /// <see cref="Internal.EfWebhookSubscriptionQueryableSource"/>. To support this contract
-    /// the tables live in <see cref="GranitDbDefaults.HostDbSchema"/>
-    /// (see <see cref="GranitWebhooksDbProperties.DbSchema"/>).
+    /// <b>Storage mode (ADR-063).</b> Webhooks is a dual-scope module: platform-managed
+    /// subscriptions (<c>TenantId == null</c>) and tenant-managed subscriptions
+    /// (<c>TenantId == &lt;tenant&gt;</c>) are functionally distinct but share the same
+    /// entity shape. <see cref="WebhooksEntityFrameworkCoreOptions.StorageMode"/> selects
+    /// the physical layout:
     /// </para>
+    /// <list type="bullet">
+    ///   <item>
+    ///     <see cref="DualScopeStorageMode.Shared"/> (default) — single host table, row-level
+    ///     filter on <c>TenantId</c>. Tables live in <see cref="GranitDbDefaults.HostDbSchema"/>
+    ///     (see <see cref="GranitWebhooksDbProperties.DbSchema"/>). Backwards compatible with
+    ///     deployments that existed before ADR-063 shipped.
+    ///   </item>
+    ///   <item>
+    ///     <see cref="DualScopeStorageMode.Segregated"/> — host rows in a host-pinned context,
+    ///     tenant rows in an isolated context (per-tenant schema or per-tenant database).
+    ///     <b>Implementation pending — Phase 2B of Epic #2377.</b> Requested today,
+    ///     registration throws <see cref="NotSupportedException"/>.
+    ///   </item>
+    /// </list>
     /// <para>
-    /// <b>When folding the model into the consuming app's own <see cref="DbContext"/></b>,
-    /// call <see cref="WebhooksModelBuilderExtensions.ConfigureWebhooksModule"/> on a
-    /// <b>host-scoped</b> DbContext (one registered via <c>AddGranitDbContext&lt;T&gt;</c>) —
-    /// never on a tenant-isolated DbContext (one registered via
-    /// <c>AddGranitIsolatedDbContext&lt;T&gt;</c>). Folding into an isolated DbContext under
-    /// the <c>SchemaPerTenant</c> or <c>DatabasePerTenant</c> strategy creates the table in
-    /// each tenant's schema (e.g. <c>acme.webhooks_subscriptions</c>) while
+    /// <b>Folding into the consuming app's own <see cref="DbContext"/></b> (under
+    /// <see cref="DualScopeStorageMode.Shared"/>): call
+    /// <see cref="WebhooksModelBuilderExtensions.ConfigureWebhooksModule"/> on a
+    /// <b>host-scoped</b> DbContext (registered via <c>AddGranitDbContext&lt;T&gt;</c>) —
+    /// never on a tenant-isolated DbContext (<c>AddGranitIsolatedDbContext&lt;T&gt;</c>).
+    /// Folding into an isolated DbContext under <c>SchemaPerTenant</c> or
+    /// <c>DatabasePerTenant</c> creates the table in each tenant's schema while
     /// <see cref="Internal.WebhooksDbContext"/> still qualifies queries against
     /// <c>host.webhooks_subscriptions</c>, leading to a <c>42P01 relation does not exist</c>
     /// error at the first request. The internal
     /// <c>WebhooksDualScopeIntegrationValidator</c> fails fast at host startup if this
     /// misconfiguration is detected.
     /// </para>
-    /// <para>
-    /// If your deployment genuinely needs <i>physically isolated</i> webhook tables per
-    /// tenant (e.g. for <c>DROP SCHEMA</c> tenant lessivage under GDPR), see the dedicated
-    /// Epic — this requires a second host DbContext for platform subscriptions and is not
-    /// supported by the current <c>AddGranitWebhooksEntityFrameworkCore</c> extension.
-    /// </para>
     /// </remarks>
     /// <param name="builder">The host application builder.</param>
-    /// <param name="configure">EF Core <see cref="DbContextOptionsBuilder"/> configuration (provider + connection string).</param>
+    /// <param name="configure">
+    /// Configuration callback for the <see cref="WebhooksEntityFrameworkCoreOptions"/>.
+    /// </param>
     /// <returns>The builder for chaining.</returns>
+    /// <exception cref="ArgumentNullException">When <paramref name="configure"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// When <see cref="WebhooksEntityFrameworkCoreOptions.StorageMode"/> is
+    /// <see cref="DualScopeStorageMode.Shared"/> and
+    /// <see cref="WebhooksEntityFrameworkCoreOptions.Configure"/> is <c>null</c>, or when
+    /// <see cref="DualScopeStorageMode.Segregated"/> is combined with
+    /// <see cref="TenantIsolationStrategy.SharedDatabase"/> (rejected by ADR-063).
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// When <see cref="WebhooksEntityFrameworkCoreOptions.StorageMode"/> is
+    /// <see cref="DualScopeStorageMode.Segregated"/> — implementation lands in Phase 2B
+    /// of Epic #2377.
+    /// </exception>
     public static IHostApplicationBuilder AddGranitWebhooksEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<WebhooksEntityFrameworkCoreOptions> configure)
     {
-        builder.Services.AddGranitDbContext<WebhooksDbContext>(configure);
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        WebhooksEntityFrameworkCoreOptions options = new();
+        configure(options);
+
+        TenantIsolationStrategy strategy = ResolveTenantIsolationStrategy(builder.Configuration);
+        DualScopeValidation.ValidateStorageMode(options.StorageMode, strategy, moduleName: "Webhooks");
+
+        switch (options.StorageMode)
+        {
+            case DualScopeStorageMode.Shared:
+                RegisterSharedMode(builder, options);
+                break;
+
+            case DualScopeStorageMode.Segregated:
+                throw new NotSupportedException(
+                    "WebhooksEntityFrameworkCoreOptions.StorageMode = DualScopeStorageMode.Segregated " +
+                    "is not yet implemented. The framework primitive shipped in granit-dotnet #2386; " +
+                    "the Webhooks context split lands in Phase 2B of Epic #2377. " +
+                    "Set StorageMode to DualScopeStorageMode.Shared (the default) to keep the current behaviour.");
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(configure),
+                    options.StorageMode,
+                    "Unknown DualScopeStorageMode value.");
+        }
+
+        return builder;
+    }
+
+    private static void RegisterSharedMode(
+        IHostApplicationBuilder builder,
+        WebhooksEntityFrameworkCoreOptions options)
+    {
+        if (options.Configure is null)
+        {
+            throw new InvalidOperationException(
+                "WebhooksEntityFrameworkCoreOptions.Configure must be set when StorageMode is " +
+                "DualScopeStorageMode.Shared (the default). Provide an Action<DbContextOptionsBuilder> " +
+                "that configures the EF Core provider and connection string for the shared host context.");
+        }
+
+        builder.Services.AddGranitDbContext<WebhooksDbContext>(options.Configure);
         builder.Services.AddHostedService<WebhooksDualScopeIntegrationValidator>();
 
         builder.Services.AddScoped<EfWebhookSubscriptionStore>();
@@ -89,7 +155,14 @@ public static class WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
             ServiceDescriptor.Scoped<IWebhookStatsReader, EfWebhookStatsReader>());
         builder.Services.AddScoped<IQueryableSource<WebhookSubscription>, EfWebhookSubscriptionQueryableSource>();
         builder.Services.AddScoped<IQueryableSource<WebhookDeliveryAttempt>, EfWebhookDeliveryAttemptQueryableSource>();
+    }
 
-        return builder;
+    private static TenantIsolationStrategy ResolveTenantIsolationStrategy(IConfiguration configuration)
+    {
+        TenantIsolationOptions? bound = configuration
+            .GetSection("MultiTenancy:TenantIsolation")
+            .Get<TenantIsolationOptions>();
+
+        return bound?.Strategy ?? TenantIsolationStrategy.SharedDatabase;
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
@@ -9,7 +9,10 @@ namespace Granit.Webhooks.EntityFrameworkCore;
 /// <remarks>
 /// Replaces the default InMemory/no-op stores with durable PostgreSQL implementations.
 /// The application must configure the DbContext via
-/// <c>AddGranitWebhooksEntityFrameworkCore(opts => opts.UseNpgsql(connectionString))</c>.
+/// <c>AddGranitWebhooksEntityFrameworkCore(opts => opts.Configure = b => b.UseNpgsql(connectionString))</c>
+/// (Shared mode, default). Per ADR-063 the <c>StorageMode</c> option also accepts
+/// <c>DualScopeStorageMode.Segregated</c> for physical host/tenant separation —
+/// implementation lands in Phase 2B of Epic #2377.
 /// </remarks>
 [DependsOn(
     typeof(GranitWebhooksModule),

--- a/src/Granit.Webhooks.EntityFrameworkCore/WebhooksEntityFrameworkCoreOptions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/WebhooksEntityFrameworkCoreOptions.cs
@@ -1,0 +1,65 @@
+using Granit.Persistence.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Webhooks.EntityFrameworkCore;
+
+/// <summary>
+/// Configuration shape for <see cref="Extensions.WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
+/// .AddGranitWebhooksEntityFrameworkCore"/>. Carries the dual-scope storage choice and the
+/// EF Core <see cref="DbContextOptionsBuilder"/> callbacks per context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per ADR-063, Webhooks is a dual-scope module: platform-managed subscriptions
+/// (host SIEM forwards for SOC2) coexist with tenant-managed subscriptions (per-tenant
+/// self-service). <see cref="StorageMode"/> selects how the two are physically laid out.
+/// </para>
+/// <para>
+/// <b>Shared (default)</b> — single host table; tenant rows carry a <c>TenantId</c>
+/// and are filtered by a row-level query filter. Backwards compatible with pre-ADR-063
+/// deployments. Only <see cref="Configure"/> is consulted.
+/// </para>
+/// <para>
+/// <b>Segregated</b> — host rows live in a host-pinned context; tenant rows live in an
+/// isolated tenant context (schema-per-tenant or database-per-tenant). Provides
+/// defense-in-depth against row-level filter regressions and native
+/// <c>DROP SCHEMA &lt;tenant&gt; CASCADE</c> lessivage for RGPD Art. 17. Requires
+/// <see cref="ConfigureHost"/> for the host context and at least one of the tenant-side
+/// configurations for the isolated context. <b>Implementation pending — Phase 2B of #2377.</b>
+/// </para>
+/// </remarks>
+public sealed class WebhooksEntityFrameworkCoreOptions
+{
+    /// <summary>
+    /// The dual-scope storage layout — see <see cref="DualScopeStorageMode"/>.
+    /// </summary>
+    public DualScopeStorageMode StorageMode { get; set; } = DualScopeStorageMode.Shared;
+
+    /// <summary>
+    /// EF Core configuration for the single shared <c>WebhooksDbContext</c>.
+    /// Consulted when <see cref="StorageMode"/> is <see cref="DualScopeStorageMode.Shared"/>.
+    /// </summary>
+    public Action<DbContextOptionsBuilder>? Configure { get; set; }
+
+    /// <summary>
+    /// EF Core configuration for the host-pinned context that holds platform-managed
+    /// subscriptions. Consulted when <see cref="StorageMode"/> is
+    /// <see cref="DualScopeStorageMode.Segregated"/>.
+    /// </summary>
+    public Action<DbContextOptionsBuilder>? ConfigureHost { get; set; }
+
+    /// <summary>
+    /// EF Core configuration for the tenant-isolated context under
+    /// <c>TenantIsolationStrategy.SchemaPerTenant</c>. The string argument is the active
+    /// tenant schema name. Consulted when <see cref="StorageMode"/> is
+    /// <see cref="DualScopeStorageMode.Segregated"/>.
+    /// </summary>
+    public Action<DbContextOptionsBuilder, string>? ConfigureSchemaPerTenant { get; set; }
+
+    /// <summary>
+    /// EF Core configuration for the tenant-isolated context under
+    /// <c>TenantIsolationStrategy.DatabasePerTenant</c>. Consulted when
+    /// <see cref="StorageMode"/> is <see cref="DualScopeStorageMode.Segregated"/>.
+    /// </summary>
+    public Action<DbContextOptionsBuilder>? ConfigureDatabasePerTenant { get; set; }
+}

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/AddGranitWebhooksEntityFrameworkCoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/AddGranitWebhooksEntityFrameworkCoreTests.cs
@@ -1,0 +1,119 @@
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Persistence.MultiTenancy;
+using Granit.Webhooks.Abstractions;
+using Granit.Webhooks.EntityFrameworkCore.Extensions;
+using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Verifies the registration shape of
+/// <see cref="WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
+/// .AddGranitWebhooksEntityFrameworkCore"/> after the ADR-063 option refactor.
+/// </summary>
+public sealed class AddGranitWebhooksEntityFrameworkCoreTests
+{
+    [Fact]
+    public void NullConfigure_Throws()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        Should.Throw<ArgumentNullException>(() =>
+            builder.AddGranitWebhooksEntityFrameworkCore(configure: null!));
+    }
+
+    [Fact]
+    public void Shared_WithoutConfigure_Throws()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            builder.AddGranitWebhooksEntityFrameworkCore(opts =>
+            {
+                opts.StorageMode = DualScopeStorageMode.Shared;
+                // Configure intentionally left null
+            }));
+
+        ex.Message.ShouldContain("Configure");
+        ex.Message.ShouldContain("Shared");
+    }
+
+    [Fact]
+    public void Shared_DefaultMode_RegistersDbContextAndStores()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        builder.AddGranitWebhooksEntityFrameworkCore(opts =>
+        {
+            opts.Configure = b => b.UseInMemoryDatabase("webhooks-test");
+        });
+
+        ServiceDescriptor? subscriptionReader = builder.Services
+            .FirstOrDefault(d => d.ServiceType == typeof(IWebhookSubscriptionReader));
+        subscriptionReader.ShouldNotBeNull();
+        subscriptionReader.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+
+        ServiceDescriptor? deliveryWriter = builder.Services
+            .FirstOrDefault(d => d.ServiceType == typeof(IWebhookDeliveryWriter));
+        deliveryWriter.ShouldNotBeNull();
+        deliveryWriter.ImplementationType.ShouldBe(typeof(EfWebhookDeliveryStore));
+
+        ServiceDescriptor? dbContextFactory = builder.Services
+            .FirstOrDefault(d => d.ServiceType == typeof(IDbContextFactory<WebhooksDbContext>));
+        dbContextFactory.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Segregated_WithSharedDatabaseStrategy_ThrowsBeforeRegistration()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["MultiTenancy:TenantIsolation:Strategy"] = nameof(TenantIsolationStrategy.SharedDatabase),
+        });
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            builder.AddGranitWebhooksEntityFrameworkCore(opts =>
+            {
+                opts.StorageMode = DualScopeStorageMode.Segregated;
+                opts.ConfigureHost = b => b.UseInMemoryDatabase("host");
+            }));
+
+        // The DualScopeValidation guard fires before the NotSupportedException path.
+        ex.Message.ShouldContain("Webhooks");
+        ex.Message.ShouldContain("Segregated");
+        ex.Message.ShouldContain("SharedDatabase");
+        ex.Message.ShouldContain("ADR-063");
+    }
+
+    [Theory]
+    [InlineData(nameof(TenantIsolationStrategy.SchemaPerTenant))]
+    [InlineData(nameof(TenantIsolationStrategy.DatabasePerTenant))]
+    public void Segregated_WithPhysicalIsolationStrategy_PassesValidationThenThrowsNotSupported(string strategyName)
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["MultiTenancy:TenantIsolation:Strategy"] = strategyName,
+        });
+
+        // Validation passes (no ADR-063 rejection), then registration throws NotSupported
+        // because Phase 2B is not yet implemented.
+        NotSupportedException ex = Should.Throw<NotSupportedException>(() =>
+            builder.AddGranitWebhooksEntityFrameworkCore(opts =>
+            {
+                opts.StorageMode = DualScopeStorageMode.Segregated;
+                opts.ConfigureHost = b => b.UseInMemoryDatabase("host");
+                opts.ConfigureSchemaPerTenant = (b, _) => b.UseInMemoryDatabase("tenant");
+            }));
+
+        ex.Message.ShouldContain("Segregated");
+        ex.Message.ShouldContain("#2377");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2A of Epic #2377 (V1 of the broader epic #2382). Establishes the per-module ADR-063 surface for Granit.Webhooks. **No behavior change in `Shared` mode** (the default); `Segregated` mode is reserved and throws `NotSupportedException` pointing at Phase 2B, which will ship the actual `WebhooksHostDbContext` + `WebhooksTenantDbContext` split and store dispatch.

## What changes

- `WebhooksEntityFrameworkCoreOptions` — new public options carrier with:
  - `StorageMode` (defaults to `DualScopeStorageMode.Shared`)
  - `Configure` (shared mode)
  - `ConfigureHost`, `ConfigureSchemaPerTenant`, `ConfigureDatabasePerTenant` (segregated mode, used by Phase 2B)
- `AddGranitWebhooksEntityFrameworkCore(Action<WebhooksEntityFrameworkCoreOptions>)` — replaces the prior `Action<DbContextOptionsBuilder>` overload. Call sites migrate from `opts => opts.UseNpgsql(...)` to `opts => opts.Configure = b => b.UseNpgsql(...)`.
- `DualScopeValidation.ValidateStorageMode` (shipped in #2386) is wired at registration time — the `Segregated`+`SharedDatabase` contradiction fails synchronously with the ADR-063 message before any DbContext is materialised.
- `GranitWebhooksEntityFrameworkCoreModule` xmldoc updated to match the new options-based API.

## Why ship 2A separately

Lets the public API contract land before the heavy refactor. V2/V3 features (#2383, #2384, #2385) reference the same `WebhooksEntityFrameworkCoreOptions` shape as the template — no rename cycle once they start. The `Segregated` path failing loudly with a clear message is preferable to a half-baked code path.

## Breaking change

Pre-1.0 framework, no `[Obsolete]` shim (per CLAUDE.md). Existing call sites must migrate:

```diff
- builder.AddGranitWebhooksEntityFrameworkCore(opts => opts.UseNpgsql(connString));
+ builder.AddGranitWebhooksEntityFrameworkCore(opts =>
+ {
+     opts.Configure = b => b.UseNpgsql(connString);
+ });
```

No call sites inside granit-dotnet today (the only references are docs). Downstream:
- `granit-showcase-dotnet` will pick up the change in a separate session (GitLab handoff per CLAUDE.md cross-repo rule).
- `granit-microservice-template` ditto.

## Test plan

- [x] `dotnet build src/Granit.Webhooks.EntityFrameworkCore` — green
- [x] `dotnet test tests/Granit.Webhooks.EntityFrameworkCore.Tests` — 39/39 (6 new tests cover null configure, missing Configure under Shared, Segregated under SharedDatabase rejection, Segregated under physical isolation pass-then-NotSupported)
- [x] `dotnet format --verify-no-changes` clean