### PR TITLE
feat(webhooks): cross-tenant aggregation for Segregated host admin (Phase 2C of #2377)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2413,7 +2413,8 @@
       "name": "Granit.Webhooks.EntityFrameworkCore",
       "deps": [
         "Granit.Webhooks",
-        "Granit.Persistence.EntityFrameworkCore"
+        "Granit.Persistence.EntityFrameworkCore",
+        "Granit.MultiTenancy"
       ],
       "framework": "net10.0"
     },
@@ -48859,7 +48860,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.EntityFrameworkCore",
       "file": "src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs",
-      "line": 20,
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.Webhooks.EntityFrameworkCore/Granit.Webhooks.EntityFrameworkCore.csproj
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Granit.Webhooks.EntityFrameworkCore.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Webhooks\Granit.Webhooks.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
@@ -1,4 +1,5 @@
 using Granit.Modularity;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 
 namespace Granit.Webhooks.EntityFrameworkCore;
@@ -12,9 +13,11 @@ namespace Granit.Webhooks.EntityFrameworkCore;
 /// <c>AddGranitWebhooksEntityFrameworkCore(opts => opts.Configure = b => b.UseNpgsql(connectionString))</c>
 /// (Shared mode, default). Per ADR-063 the <c>StorageMode</c> option also accepts
 /// <c>DualScopeStorageMode.Segregated</c> for physical host/tenant separation —
-/// implementation lands in Phase 2B of Epic #2377.
+/// implementation completed across Phases 2B (#2377) and 2C (cross-tenant host-admin
+/// aggregation via <c>ITenantReader</c>).
 /// </remarks>
 [DependsOn(
     typeof(GranitWebhooksModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitMultiTenancyModule))]
 public sealed class GranitWebhooksEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
@@ -1,4 +1,5 @@
 using Granit.MultiTenancy;
+using Granit.MultiTenancy.Stores;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.MultiTenancy;
 using Granit.QueryEngine;
@@ -11,34 +12,45 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="WebhookDeliveryAttempt"/>.
 /// Mirrors the dispatch contract of <see cref="EfWebhookSubscriptionQueryableSource"/>.
 /// </summary>
+/// <remarks>
+/// Under <c>Segregated</c> + host-admin scope, delivery attempts are materialised across
+/// host + every tenant schema. Delivery volumes grow faster than subscription counts
+/// (every webhook delivery writes a row, ISO 27001 3-year retention), so admin dashboards
+/// using this source should always paginate and filter on <c>OccurredAt</c>. A Postgres
+/// cross-schema view is recommended for deployments with high delivery volume.
+/// </remarks>
 internal sealed class EfWebhookDeliveryAttemptQueryableSource : IQueryableSource<WebhookDeliveryAttempt>, IDisposable
 {
     private readonly DualScopeStorageMode _storageMode;
     private readonly bool _bypassTenantFilter;
     private readonly IDbContextFactory<WebhooksHostDbContext> _hostFactory;
     private readonly IDbContextFactory<WebhooksTenantDbContext>? _tenantFactory;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly ITenantReader? _tenantReader;
     private DbContext? _context;
+    private List<WebhookDeliveryAttempt>? _materialized;
 
     public EfWebhookDeliveryAttemptQueryableSource(
         WebhooksEntityFrameworkCoreOptions options,
         ICurrentTenant currentTenant,
         IDbContextFactory<WebhooksHostDbContext> hostFactory,
-        IDbContextFactory<WebhooksTenantDbContext>? tenantFactory = null)
+        IDbContextFactory<WebhooksTenantDbContext>? tenantFactory = null,
+        ITenantReader? tenantReader = null)
     {
         _storageMode = options.StorageMode;
         _bypassTenantFilter = !currentTenant.IsAvailable;
         _hostFactory = hostFactory;
         _tenantFactory = tenantFactory;
+        _currentTenant = currentTenant;
+        _tenantReader = tenantReader;
     }
 
     public IQueryable<WebhookDeliveryAttempt> GetQueryable()
     {
         if (_storageMode == DualScopeStorageMode.Segregated && _bypassTenantFilter)
         {
-            throw new NotSupportedException(
-                "Cross-tenant host-admin browse of webhook delivery attempts under DualScopeStorageMode.Segregated " +
-                "requires UNION ALL across host and every tenant schema — deferred to Phase 2C of Epic #2377. " +
-                "Use DualScopeStorageMode.Shared if cross-tenant admin browsing is required today.");
+            _materialized ??= MaterialiseAcrossAllTenants();
+            return _materialized.AsQueryable();
         }
 
         _context ??= OpenContext();
@@ -59,4 +71,38 @@ internal sealed class EfWebhookDeliveryAttemptQueryableSource : IQueryableSource
         DualScopeStorageMode.Segregated => _tenantFactory!.CreateDbContext(),
         _ => throw new InvalidOperationException($"Unknown DualScopeStorageMode: {_storageMode}."),
     };
+
+    private List<WebhookDeliveryAttempt> MaterialiseAcrossAllTenants()
+    {
+        List<WebhookDeliveryAttempt> results = [];
+
+        using (WebhooksHostDbContext host = _hostFactory.CreateDbContext())
+        {
+            results.AddRange(host.WebhookDeliveryAttempts
+                .AsNoTracking()
+                .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+                .ToList());
+        }
+
+        if (_tenantReader is null || _tenantFactory is null)
+        {
+            return results;
+        }
+
+        IReadOnlyList<TenantData> tenants = _tenantReader
+            .GetAllAsync().GetAwaiter().GetResult();
+
+        foreach (TenantData tenant in tenants)
+        {
+            using (_currentTenant.Change(tenant.Id, tenant.Name))
+            using (WebhooksTenantDbContext tenantCtx = _tenantFactory.CreateDbContext())
+            {
+                results.AddRange(tenantCtx.WebhookDeliveryAttempts
+                    .AsNoTracking()
+                    .ToList());
+            }
+        }
+
+        return results;
+    }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookStatsReader.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookStatsReader.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+using Granit.MultiTenancy.Stores;
 using Granit.Persistence.MultiTenancy;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
@@ -7,98 +9,172 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// EF Core implementation of <see cref="IWebhookStatsReader"/>. Provides aggregate
-/// statistics for the webhook administration dashboard, dispatching through
-/// <see cref="WebhooksContextResolver"/> so the same reader serves both
-/// <c>Shared</c> and <c>Segregated</c> storage modes.
+/// EF Core implementation of <see cref="IWebhookStatsReader"/>. Aggregates dashboard
+/// statistics across whatever scope the current request belongs to.
 /// </summary>
 /// <remarks>
-/// Under <see cref="DualScopeStorageMode.Segregated"/>, the reader aggregates across the
-/// host context and the active tenant context — the cross-tenant host-admin view that
-/// iterates every tenant schema is deferred to a follow-up PR (Phase 2C of #2377). Today
-/// a host admin viewing stats under <c>Segregated</c> sees only host-scope counts.
+/// <para>
+/// <b>Shared.</b> Single-context aggregation, every row visible to the active scope.
+/// </para>
+/// <para>
+/// <b>Segregated + tenant scope.</b> Sums host stats and active-tenant stats — a tenant
+/// dashboard sees its own subscriptions plus host SIEM forwards relevant to its events.
+/// </para>
+/// <para>
+/// <b>Segregated + host-admin scope</b> (Phase 2C). Iterates every tenant returned by
+/// <see cref="ITenantReader"/> via <see cref="ICurrentTenant.Change"/>, opens that tenant's
+/// isolated context, and sums into the host aggregate. <b>O(N) connections per stats call,
+/// N = number of tenants</b> — acceptable for the admin dashboard which is read rarely;
+/// a Postgres cross-schema materialised view is the documented optimisation path for
+/// deployments with hundreds of tenants.
+/// </para>
 /// </remarks>
 internal sealed class EfWebhookStatsReader(
     WebhooksContextResolver resolver,
-    IClock clock) : IWebhookStatsReader
+    ICurrentTenant currentTenant,
+    IClock clock,
+    ITenantReader? tenantReader = null) : IWebhookStatsReader
 {
     public async Task<WebhookStats> GetStatsAsync(CancellationToken cancellationToken = default)
     {
         DateTimeOffset cutoff = clock.Now.AddHours(-24);
+        StatsAccumulator acc = new();
 
-        IReadOnlyList<IWebhooksDbContext> contexts = await resolver
-            .OpenAllAsync(cancellationToken).ConfigureAwait(false);
-        try
+        if (resolver.StorageMode == DualScopeStorageMode.Segregated && !currentTenant.IsAvailable)
         {
-            int totalSubscriptions = 0;
-            int activeCount = 0;
-            int suspendedCount = 0;
-            int deactivatedCount = 0;
-            int deliveriesLast24h = 0;
-            int successCountLast24h = 0;
-            double durationSumMs = 0;
-            int durationSamples = 0;
-
-            foreach (IWebhooksDbContext db in contexts)
+            await AggregateAcrossAllTenantsAsync(acc, cutoff, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            IReadOnlyList<IWebhooksDbContext> contexts = await resolver
+                .OpenAllAsync(cancellationToken).ConfigureAwait(false);
+            try
             {
-                List<WebhookSubscriptionStatus> statuses = await db.WebhookSubscriptions
-                    .AsNoTracking()
-                    .Select(s => s.Status)
-                    .ToListAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                totalSubscriptions += statuses.Count;
-                activeCount += statuses.Count(s => s == WebhookSubscriptionStatus.Active);
-                suspendedCount += statuses.Count(s => s == WebhookSubscriptionStatus.Suspended);
-                deactivatedCount += statuses.Count(s => s == WebhookSubscriptionStatus.Deactivated);
-
-                var deliveryStats = await db.WebhookDeliveryAttempts
-                    .AsNoTracking()
-                    .Where(d => d.OccurredAt >= cutoff)
-                    .GroupBy(_ => 1)
-                    .Select(g => new
-                    {
-                        Total = g.Count(),
-                        SuccessCount = g.Count(d => d.IsSuccess),
-                        DurationSum = (double?)g
-                            .Where(d => d.HttpStatusCode != null)
-                            .Sum(d => (long?)d.DurationMs) ?? 0.0,
-                        DurationSamples = g.Count(d => d.HttpStatusCode != null),
-                    })
-                    .FirstOrDefaultAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (deliveryStats is not null)
+                foreach (IWebhooksDbContext db in contexts)
                 {
-                    deliveriesLast24h += deliveryStats.Total;
-                    successCountLast24h += deliveryStats.SuccessCount;
-                    durationSumMs += deliveryStats.DurationSum;
-                    durationSamples += deliveryStats.DurationSamples;
+                    await AggregateAsync(db, cutoff, acc, cancellationToken).ConfigureAwait(false);
                 }
             }
+            finally
+            {
+                await DisposeAllAsync(contexts).ConfigureAwait(false);
+            }
+        }
 
-            double successRateLast24h = deliveriesLast24h > 0
-                ? Math.Round((double)successCountLast24h / deliveriesLast24h * 100, 2)
+        return acc.Build();
+    }
+
+    private async Task AggregateAcrossAllTenantsAsync(
+        StatsAccumulator acc,
+        DateTimeOffset cutoff,
+        CancellationToken cancellationToken)
+    {
+        // Host context: scope already host-admin, open directly.
+        await using (IWebhooksDbContext host = await resolver
+            .OpenForScopeAsync(tenantId: null, cancellationToken).ConfigureAwait(false))
+        {
+            await AggregateAsync(host, cutoff, acc, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (tenantReader is null)
+        {
+            // Without ITenantReader we cannot enumerate tenants — host counts only.
+            // Granit.MultiTenancy.EntityFrameworkCore must be registered for cross-tenant aggregation.
+            return;
+        }
+
+        IReadOnlyList<TenantData> tenants = await tenantReader
+            .GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (TenantData tenant in tenants)
+        {
+            using (currentTenant.Change(tenant.Id, tenant.Name))
+            {
+                await using IWebhooksDbContext db = await resolver
+                    .OpenForScopeAsync(tenant.Id, cancellationToken).ConfigureAwait(false);
+                await AggregateAsync(db, cutoff, acc, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task AggregateAsync(
+        IWebhooksDbContext db,
+        DateTimeOffset cutoff,
+        StatsAccumulator acc,
+        CancellationToken cancellationToken)
+    {
+        List<WebhookSubscriptionStatus> statuses = await db.WebhookSubscriptions
+            .AsNoTracking()
+            .Select(s => s.Status)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        acc.Subscriptions += statuses.Count;
+        acc.Active += statuses.Count(s => s == WebhookSubscriptionStatus.Active);
+        acc.Suspended += statuses.Count(s => s == WebhookSubscriptionStatus.Suspended);
+        acc.Deactivated += statuses.Count(s => s == WebhookSubscriptionStatus.Deactivated);
+
+        var deliveryStats = await db.WebhookDeliveryAttempts
+            .AsNoTracking()
+            .Where(d => d.OccurredAt >= cutoff)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Total = g.Count(),
+                SuccessCount = g.Count(d => d.IsSuccess),
+                DurationSum = (double?)g
+                    .Where(d => d.HttpStatusCode != null)
+                    .Sum(d => (long?)d.DurationMs) ?? 0.0,
+                DurationSamples = g.Count(d => d.HttpStatusCode != null),
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (deliveryStats is not null)
+        {
+            acc.Deliveries += deliveryStats.Total;
+            acc.SuccessCount += deliveryStats.SuccessCount;
+            acc.DurationSum += deliveryStats.DurationSum;
+            acc.DurationSamples += deliveryStats.DurationSamples;
+        }
+    }
+
+    private static async ValueTask DisposeAllAsync(IReadOnlyList<IWebhooksDbContext> contexts)
+    {
+        foreach (IWebhooksDbContext db in contexts)
+        {
+            await db.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class StatsAccumulator
+    {
+        public int Subscriptions { get; set; }
+        public int Active { get; set; }
+        public int Suspended { get; set; }
+        public int Deactivated { get; set; }
+        public int Deliveries { get; set; }
+        public int SuccessCount { get; set; }
+        public double DurationSum { get; set; }
+        public int DurationSamples { get; set; }
+
+        public WebhookStats Build()
+        {
+            double successRate = Deliveries > 0
+                ? Math.Round((double)SuccessCount / Deliveries * 100, 2)
                 : 0.0;
-            double avgResponseTimeMsLast24h = durationSamples > 0
-                ? Math.Round(durationSumMs / durationSamples, 2)
+            double avgResponse = DurationSamples > 0
+                ? Math.Round(DurationSum / DurationSamples, 2)
                 : 0.0;
 
             return new WebhookStats(
-                totalSubscriptions,
-                activeCount,
-                suspendedCount,
-                deactivatedCount,
-                deliveriesLast24h,
-                successRateLast24h,
-                avgResponseTimeMsLast24h);
-        }
-        finally
-        {
-            foreach (IWebhooksDbContext db in contexts)
-            {
-                await db.DisposeAsync().ConfigureAwait(false);
-            }
+                Subscriptions,
+                Active,
+                Suspended,
+                Deactivated,
+                Deliveries,
+                successRate,
+                avgResponse);
         }
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
@@ -1,4 +1,5 @@
 using Granit.MultiTenancy;
+using Granit.MultiTenancy.Stores;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.MultiTenancy;
 using Granit.QueryEngine;
@@ -19,10 +20,16 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// returned cross-tenant.
 /// </para>
 /// <para>
-/// <b>Segregated mode.</b> When a tenant context is active, opens the tenant-isolated
-/// context. Cross-tenant host-admin browsing requires a <c>UNION ALL</c> across the host
-/// context and every tenant schema — deferred to a follow-up PR (Phase 2C of #2377);
-/// <see cref="GetQueryable"/> throws <see cref="NotSupportedException"/> on that path.
+/// <b>Segregated + tenant scope.</b> Opens the tenant-isolated context only.
+/// </para>
+/// <para>
+/// <b>Segregated + host-admin scope.</b> Materialises across the host context plus every
+/// tenant returned by <see cref="ITenantReader"/> via <see cref="ICurrentTenant.Change"/>,
+/// then exposes the result as an in-memory <see cref="IQueryable{T}"/>. Filters, ordering
+/// and paging applied by <c>Granit.QueryEngine</c> downstream run in LINQ-to-Objects, not
+/// translated to SQL — acceptable for the admin browse use case (small subscription
+/// volumes per tenant). A Postgres cross-schema materialised view is the documented
+/// optimisation path for deployments with thousands of subscriptions per tenant.
 /// </para>
 /// </remarks>
 internal sealed class EfWebhookSubscriptionQueryableSource : IQueryableSource<WebhookSubscription>, IDisposable
@@ -31,28 +38,32 @@ internal sealed class EfWebhookSubscriptionQueryableSource : IQueryableSource<We
     private readonly bool _bypassTenantFilter;
     private readonly IDbContextFactory<WebhooksHostDbContext> _hostFactory;
     private readonly IDbContextFactory<WebhooksTenantDbContext>? _tenantFactory;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly ITenantReader? _tenantReader;
     private DbContext? _context;
+    private List<WebhookSubscription>? _materialized;
 
     public EfWebhookSubscriptionQueryableSource(
         WebhooksEntityFrameworkCoreOptions options,
         ICurrentTenant currentTenant,
         IDbContextFactory<WebhooksHostDbContext> hostFactory,
-        IDbContextFactory<WebhooksTenantDbContext>? tenantFactory = null)
+        IDbContextFactory<WebhooksTenantDbContext>? tenantFactory = null,
+        ITenantReader? tenantReader = null)
     {
         _storageMode = options.StorageMode;
         _bypassTenantFilter = !currentTenant.IsAvailable;
         _hostFactory = hostFactory;
         _tenantFactory = tenantFactory;
+        _currentTenant = currentTenant;
+        _tenantReader = tenantReader;
     }
 
     public IQueryable<WebhookSubscription> GetQueryable()
     {
         if (_storageMode == DualScopeStorageMode.Segregated && _bypassTenantFilter)
         {
-            throw new NotSupportedException(
-                "Cross-tenant host-admin browse of webhook subscriptions under DualScopeStorageMode.Segregated " +
-                "requires UNION ALL across host and every tenant schema — deferred to Phase 2C of Epic #2377. " +
-                "Use DualScopeStorageMode.Shared if cross-tenant admin browsing is required today.");
+            _materialized ??= MaterialiseAcrossAllTenants();
+            return _materialized.AsQueryable();
         }
 
         _context ??= OpenContext();
@@ -73,4 +84,42 @@ internal sealed class EfWebhookSubscriptionQueryableSource : IQueryableSource<We
         DualScopeStorageMode.Segregated => _tenantFactory!.CreateDbContext(),
         _ => throw new InvalidOperationException($"Unknown DualScopeStorageMode: {_storageMode}."),
     };
+
+    private List<WebhookSubscription> MaterialiseAcrossAllTenants()
+    {
+        List<WebhookSubscription> results = [];
+
+        // Host context — all rows there are platform subscriptions.
+        using (WebhooksHostDbContext host = _hostFactory.CreateDbContext())
+        {
+            results.AddRange(host.WebhookSubscriptions
+                .AsNoTracking()
+                .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+                .ToList());
+        }
+
+        if (_tenantReader is null || _tenantFactory is null)
+        {
+            // Cross-tenant aggregation requires both ITenantReader (to enumerate tenants)
+            // and the tenant factory (registered only under Segregated). Host-only result
+            // is the best we can do.
+            return results;
+        }
+
+        IReadOnlyList<TenantData> tenants = _tenantReader
+            .GetAllAsync().GetAwaiter().GetResult();
+
+        foreach (TenantData tenant in tenants)
+        {
+            using (_currentTenant.Change(tenant.Id, tenant.Name))
+            using (WebhooksTenantDbContext tenantCtx = _tenantFactory.CreateDbContext())
+            {
+                results.AddRange(tenantCtx.WebhookSubscriptions
+                    .AsNoTracking()
+                    .ToList());
+            }
+        }
+
+        return results;
+    }
 }

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
@@ -1,0 +1,233 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.MultiTenancy.Stores;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.MultiTenancy;
+using Granit.Timing;
+using Granit.Webhooks.Domain;
+using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Pins the Phase 2C cross-tenant aggregation contract: under Segregated + host-admin
+/// scope, <see cref="EfWebhookSubscriptionQueryableSource"/>,
+/// <see cref="EfWebhookDeliveryAttemptQueryableSource"/> and
+/// <see cref="EfWebhookStatsReader"/> iterate every tenant via
+/// <see cref="ITenantReader"/> + <see cref="ICurrentTenant.Change"/>.
+/// </summary>
+public sealed class SegregatedCrossTenantAggregationTests
+{
+    private readonly Guid _tenantA = Guid.NewGuid();
+    private readonly Guid _tenantB = Guid.NewGuid();
+    private readonly DataFilter _filter = new();
+
+    [Fact]
+    public async Task SubscriptionQueryable_HostAdmin_MaterialisesHostPlusEveryTenant()
+    {
+        DbContextOptions<WebhooksHostDbContext> hostOpts = InMemoryHostOptions("subs-host");
+        DbContextOptions<WebhooksTenantDbContext> tenantOpts = InMemoryTenantOptions("subs-tenant");
+
+        // Seed: 1 host sub + 1 tenant-A sub + 1 tenant-B sub. We seed the tenant DB ONCE
+        // with both rows even though in production they'd live in distinct schemas — the
+        // InMemory provider has no schema concept, so the test stub returns the same DB
+        // for any tenant scope. The IMultiTenant row-level filter on the tenant DB ensures
+        // only the active-tenant's rows are visible per iteration.
+        await SeedHostAsync(hostOpts, CreateSubscription("evt", tenantId: null));
+        await SeedTenantAsync(tenantOpts,
+            CreateSubscription("evt", _tenantA),
+            CreateSubscription("evt", _tenantB));
+
+        IDbContextFactory<WebhooksHostDbContext> hostFactory = StubHostFactory(hostOpts);
+        ICurrentTenant currentTenant = NewSwitchableTenant(initiallyAvailable: false);
+        IDbContextFactory<WebhooksTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts, currentTenant);
+        ITenantReader tenantReader = StubTenantReader(_tenantA, _tenantB);
+
+        EfWebhookSubscriptionQueryableSource sut = new(
+            new WebhooksEntityFrameworkCoreOptions { StorageMode = DualScopeStorageMode.Segregated },
+            currentTenant,
+            hostFactory,
+            tenantFactory,
+            tenantReader);
+
+        WebhookSubscription[] result = [.. sut.GetQueryable()];
+
+        // Host row + tenant A row (active when iterating) + tenant B row (active when iterating).
+        result.Length.ShouldBe(3);
+        result.Count(s => s.TenantId is null).ShouldBe(1);
+        result.Count(s => s.TenantId == _tenantA).ShouldBe(1);
+        result.Count(s => s.TenantId == _tenantB).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task StatsReader_HostAdmin_AggregatesAcrossAllTenants()
+    {
+        DbContextOptions<WebhooksHostDbContext> hostOpts = InMemoryHostOptions("stats-host");
+        DbContextOptions<WebhooksTenantDbContext> tenantOpts = InMemoryTenantOptions("stats-tenant");
+
+        await SeedHostAsync(hostOpts, CreateSubscription("evt", tenantId: null));
+        await SeedTenantAsync(tenantOpts,
+            CreateSubscription("evt", _tenantA),
+            CreateSubscription("evt", _tenantB),
+            CreateSubscription("evt", _tenantB));
+
+        IDbContextFactory<WebhooksHostDbContext> hostFactory = StubHostFactory(hostOpts);
+        ICurrentTenant currentTenant = NewSwitchableTenant(initiallyAvailable: false);
+        IDbContextFactory<WebhooksTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts, currentTenant);
+        ITenantReader tenantReader = StubTenantReader(_tenantA, _tenantB);
+        WebhooksContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(new DateTimeOffset(2026, 5, 28, 12, 0, 0, TimeSpan.Zero));
+
+        EfWebhookStatsReader sut = new(resolver, currentTenant, clock, tenantReader);
+
+        Webhooks.Abstractions.WebhookStats stats = await sut.GetStatsAsync(TestContext.Current.CancellationToken);
+
+        // 1 host + 1 tenant-A + 2 tenant-B subscriptions.
+        stats.TotalSubscriptions.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task SubscriptionQueryable_HostAdmin_NoTenantReader_ReturnsHostOnly()
+    {
+        DbContextOptions<WebhooksHostDbContext> hostOpts = InMemoryHostOptions("subs-host-noreader");
+        DbContextOptions<WebhooksTenantDbContext> tenantOpts = InMemoryTenantOptions("subs-tenant-noreader");
+
+        await SeedHostAsync(hostOpts, CreateSubscription("evt", tenantId: null));
+        await SeedTenantAsync(tenantOpts, CreateSubscription("evt", _tenantA));
+
+        IDbContextFactory<WebhooksHostDbContext> hostFactory = StubHostFactory(hostOpts);
+        ICurrentTenant currentTenant = NewSwitchableTenant(initiallyAvailable: false);
+        IDbContextFactory<WebhooksTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts, currentTenant);
+
+        // No ITenantReader → fallback to host-only.
+        EfWebhookSubscriptionQueryableSource sut = new(
+            new WebhooksEntityFrameworkCoreOptions { StorageMode = DualScopeStorageMode.Segregated },
+            currentTenant,
+            hostFactory,
+            tenantFactory,
+            tenantReader: null);
+
+        WebhookSubscription[] result = [.. sut.GetQueryable()];
+
+        result.Length.ShouldBe(1);
+        result[0].TenantId.ShouldBeNull();
+    }
+
+    // ---- helpers ------------------------------------------------------------
+
+    private static DbContextOptions<WebhooksHostDbContext> InMemoryHostOptions(string name)
+        => new DbContextOptionsBuilder<WebhooksHostDbContext>()
+            .UseInMemoryDatabase($"{name}-{Guid.NewGuid()}")
+            .Options;
+
+    private static DbContextOptions<WebhooksTenantDbContext> InMemoryTenantOptions(string name)
+        => new DbContextOptionsBuilder<WebhooksTenantDbContext>()
+            .UseInMemoryDatabase($"{name}-{Guid.NewGuid()}")
+            .Options;
+
+    private async Task SeedHostAsync(
+        DbContextOptions<WebhooksHostDbContext> opts,
+        params WebhookSubscription[] subscriptions)
+    {
+        using IDisposable _ = _filter.Disable<IMultiTenant>();
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        await using WebhooksHostDbContext db = new(opts, tenant, _filter);
+        db.WebhookSubscriptions.AddRange(subscriptions);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task SeedTenantAsync(
+        DbContextOptions<WebhooksTenantDbContext> opts,
+        params WebhookSubscription[] subscriptions)
+    {
+        using IDisposable _ = _filter.Disable<IMultiTenant>();
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        await using WebhooksTenantDbContext db = new(opts, tenant, _filter);
+        db.WebhookSubscriptions.AddRange(subscriptions);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static IDbContextFactory<WebhooksHostDbContext> StubHostFactory(
+        DbContextOptions<WebhooksHostDbContext> opts)
+    {
+        IDbContextFactory<WebhooksHostDbContext> factory = Substitute.For<IDbContextFactory<WebhooksHostDbContext>>();
+        factory.CreateDbContext().Returns(_ => new WebhooksHostDbContext(opts, GranitDesignTime.CurrentTenant));
+        factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new WebhooksHostDbContext(opts, GranitDesignTime.CurrentTenant)));
+        return factory;
+    }
+
+    private IDbContextFactory<WebhooksTenantDbContext> StubTenantFactory(
+        DbContextOptions<WebhooksTenantDbContext> opts,
+        ICurrentTenant currentTenant)
+    {
+        IDbContextFactory<WebhooksTenantDbContext> factory = Substitute.For<IDbContextFactory<WebhooksTenantDbContext>>();
+        factory.CreateDbContext().Returns(_ => new WebhooksTenantDbContext(opts, currentTenant, _filter));
+        factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new WebhooksTenantDbContext(opts, currentTenant, _filter)));
+        return factory;
+    }
+
+    private static ITenantReader StubTenantReader(params Guid[] tenantIds)
+    {
+        ITenantReader reader = Substitute.For<ITenantReader>();
+        TenantData[] tenants = [.. tenantIds.Select(id => new TenantData(
+            Id: id,
+            Name: $"tenant-{id}",
+            Identifier: $"tenant-{id}",
+            ContactEmail: null,
+            Activated: true,
+            Jurisdiction: null,
+            CreatedAt: DateTimeOffset.UtcNow,
+            CustomDomain: null))];
+        reader.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TenantData>>(tenants));
+        return reader;
+    }
+
+    private static ICurrentTenant NewSwitchableTenant(bool initiallyAvailable)
+    {
+        // A minimal ambient-style stub: Change() flips the IsAvailable/Id to the new value
+        // and the returned IDisposable restores the previous values.
+        Guid? currentId = null;
+        bool available = initiallyAvailable;
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(_ => available);
+        tenant.Id.Returns(_ => currentId);
+        tenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>())
+            .Returns(call =>
+            {
+                Guid? previousId = currentId;
+                bool previousAvail = available;
+                currentId = call.ArgAt<Guid?>(0);
+                available = currentId is not null;
+                return new ChangeScope(() => { currentId = previousId; available = previousAvail; });
+            });
+        return tenant;
+    }
+
+    private sealed class ChangeScope(Action onDispose) : IDisposable
+    {
+        public void Dispose() => onDispose();
+    }
+
+    private static WebhookSubscription CreateSubscription(string eventType, Guid? tenantId) =>
+        WebhookSubscription.Create(
+            Guid.NewGuid(),
+            $"https://example.com/{Guid.NewGuid()}",
+            eventType,
+            signingKeyId: Guid.NewGuid(),
+            protectedSecret: "protected-secret",
+            createdAt: DateTimeOffset.UtcNow,
+            tenantId: tenantId);
+}

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/packages.lock.json
@@ -684,6 +684,7 @@
       "granit.webhooks.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Webhooks": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",


### PR DESCRIPTION
## Summary

Closes the V1 gap left by Phase 2B (#2402): under `DualScopeStorageMode.Segregated`, the host-admin browse and stats paths no longer throw `NotSupportedException`. V1 (Webhooks Segregated mode) is now feature-complete.

## How

Three consumers under Segregated + host-admin scope iterate every tenant from `ITenantReader` via `ICurrentTenant.Change()` and open the tenant-isolated context per tenant:

- `EfWebhookSubscriptionQueryableSource` — materialises across host + every tenant, returns via `.AsQueryable()` so `Granit.QueryEngine`'s filter/order/page composition keeps working (in-memory).
- `EfWebhookDeliveryAttemptQueryableSource` — same pattern.
- `EfWebhookStatsReader` — aggregates per-context counts and sums via a small `StatsAccumulator`.

`Granit.MultiTenancy` is now a project reference + `[DependsOn]` of `Granit.Webhooks.EntityFrameworkCore` (was previously a transitive concept-only dependency). Small package, foundational to the module's tenant-aware behaviour.

## Trade-off

The cross-tenant path is **O(N) connections per call** (N = number of tenants). Acceptable for the admin dashboard (read rarely, subscription volumes small per tenant). The xmldoc points at a Postgres cross-schema materialised view as the future optimisation path for deployments with high delivery volumes — a follow-up only if anyone asks.

## Graceful fallback

When `ITenantReader` is not registered (e.g. single-tenant deployment without `Granit.MultiTenancy.EntityFrameworkCore`), the cross-tenant iteration short-circuits with a **host-only result** rather than throwing. The base `Granit.MultiTenancy` module registers `NullTenantReader` via `TryAddScoped`, so the default fallback is a graceful no-op.

## Test plan

- [x] `dotnet build src/Granit.Webhooks.EntityFrameworkCore` — green
- [x] `dotnet test tests/Granit.Webhooks.EntityFrameworkCore.Tests` — **50/50** (was 47; +3 new in `SegregatedCrossTenantAggregationTests`)
  - Pin: host admin sees host row + tenant A row + tenant B row
  - Pin: stats reader aggregates across all tenants
  - Pin: missing `ITenantReader` falls back to host-only
- [x] `dotnet format --verify-no-changes` clean

## V1 status

With this PR landed, V1 of Epic #2377 (Webhooks Segregated mode) is **complete**:

| Phase | PR | Status |
|-------|----|--------|
| ADR-063 | granit-docs #88 + #89 | ✅ merged |
| Framework primitive (`DualScopeStorageMode`) | #2386 | ✅ merged |
| Webhooks options shape | #2387 | ✅ merged |
| Phase 2B: context split + dispatch | #2402 | ✅ merged |
| Phase 2C: cross-tenant host-admin | **this PR** | 🟡 in review |

After merge, V2 wave (Identity / Authorization / Identity.Federated under #2383/#2384/#2385) and downstream cleanup (showcase + microservice-template handoffs) become unblocked.

Refs ADR-063, Epic #2377, parent epic #2382