### PR TITLE
fix(multitenancy): rename ITenantEnumerator → ITenantsAccessor (resolve namespace collision)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29852,15 +29852,6 @@
       "members": []
     },
     {
-      "name": "ITenantEnumerator",
-      "fqn": "Granit.MultiTenancy.ITenantEnumerator",
-      "kind": "interface",
-      "project": "Granit",
-      "file": "src/Granit/MultiTenancy/ITenantEnumerator.cs",
-      "line": 24,
-      "members": []
-    },
-    {
       "name": "ITenantInfo",
       "fqn": "Granit.MultiTenancy.ITenantInfo",
       "kind": "interface",
@@ -29884,6 +29875,15 @@
           "returnType": "Task<string>"
         }
       ]
+    },
+    {
+      "name": "ITenantsAccessor",
+      "fqn": "Granit.MultiTenancy.ITenantsAccessor",
+      "kind": "interface",
+      "project": "Granit",
+      "file": "src/Granit/MultiTenancy/ITenantsAccessor.cs",
+      "line": 24,
+      "members": []
     },
     {
       "name": "TenantResolutionMiddleware",

--- a/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
+++ b/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
@@ -67,10 +67,10 @@ public static class MultiTenancyServiceCollectionExtensions
         // Granit.MultiTenancy.EntityFrameworkCore is in the module tree.
         services.TryAddScoped<ITenantReader, NullTenantReader>();
 
-        // Replace the NullTenantEnumerator registered by AddGranit<T>() with the adapter
+        // Replace the NullTenantsAccessor registered by AddGranit<T>() with the adapter
         // that bridges to ITenantReader. Soft-dep modules (Webhooks, Identity.Federated,
-        // etc.) inject ITenantEnumerator without referencing Granit.MultiTenancy.
-        services.Replace(ServiceDescriptor.Scoped<ITenantEnumerator, TenantReaderEnumeratorAdapter>());
+        // etc.) inject ITenantsAccessor without referencing Granit.MultiTenancy.
+        services.Replace(ServiceDescriptor.Scoped<ITenantsAccessor, TenantReaderTenantsAccessorAdapter>());
 
         // Resolvers: CustomDomain (25) → Domain (50) → Header (100) → JWT (200) → QueryString (300)
         // Registered as scoped: DomainTenantResolver depends on ITenantReader (scoped, EF Core).

--- a/src/Granit.MultiTenancy/Internal/TenantReaderTenantsAccessorAdapter.cs
+++ b/src/Granit.MultiTenancy/Internal/TenantReaderTenantsAccessorAdapter.cs
@@ -4,16 +4,16 @@ namespace Granit.MultiTenancy.Internal;
 
 /// <summary>
 /// Adapts the rich <see cref="ITenantReader"/> aggregate query to the lightweight
-/// <see cref="ITenantEnumerator"/> primitive exposed by base <c>Granit</c>.
+/// <see cref="ITenantsAccessor"/> primitive exposed by base <c>Granit</c>.
 /// </summary>
 /// <remarks>
 /// Registered by <c>AddGranitMultiTenancy</c> as a <c>Replace</c> on the default
-/// <c>NullTenantEnumerator</c>. Soft-dep modules (Webhooks, Identity.Federated,
+/// <c>NullTenantsAccessor</c>. Soft-dep modules (Webhooks, Identity.Federated,
 /// future Notifications/Auditing under Segregated host-admin paths) inject
-/// <see cref="ITenantEnumerator"/> directly and remain free of any
+/// <see cref="ITenantsAccessor"/> directly and remain free of any
 /// <c>Granit.MultiTenancy</c> package reference.
 /// </remarks>
-internal sealed class TenantReaderEnumeratorAdapter(ITenantReader reader) : ITenantEnumerator
+internal sealed class TenantReaderTenantsAccessorAdapter(ITenantReader reader) : ITenantsAccessor
 {
     public async Task<IReadOnlyList<(Guid Id, string Name)>> GetAllAsync(
         CancellationToken cancellationToken = default)

--- a/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
@@ -14,12 +14,12 @@ namespace Granit.Webhooks.EntityFrameworkCore;
 /// (Shared mode, default). Per ADR-063 the <c>StorageMode</c> option also accepts
 /// <c>DualScopeStorageMode.Segregated</c> for physical host/tenant separation —
 /// implementation completed across Phases 2B (#2377) and 2C (cross-tenant host-admin
-/// aggregation via <c>ITenantEnumerator</c>).
+/// aggregation via <c>ITenantsAccessor</c>).
 /// </para>
 /// <para>
 /// <c>Granit.MultiTenancy</c> is intentionally NOT a hard dependency: cross-tenant
-/// aggregation routes through the framework-primitive <c>ITenantEnumerator</c>
-/// (default <c>NullTenantEnumerator</c>) so single-tenant deployments can consume the
+/// aggregation routes through the framework-primitive <c>ITenantsAccessor</c>
+/// (default <c>NullTenantsAccessor</c>) so single-tenant deployments can consume the
 /// module without pulling the multi-tenant infrastructure. The full
 /// <c>Granit.MultiTenancy</c> registration replaces the default enumerator with an
 /// <c>ITenantReader</c>-backed adapter; without it, the Segregated host-admin browse

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
@@ -13,7 +13,7 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </summary>
 /// <remarks>
 /// Under <c>Segregated</c> + host-admin scope, delivery attempts are materialised across
-/// host + every tenant returned by <see cref="ITenantEnumerator"/>. Delivery volumes grow
+/// host + every tenant returned by <see cref="ITenantsAccessor"/>. Delivery volumes grow
 /// faster than subscription counts (every webhook delivery writes a row, ISO 27001 3-year
 /// retention), so admin dashboards using this source should always paginate and filter on
 /// <c>OccurredAt</c>. A Postgres cross-schema view is recommended for deployments with
@@ -26,14 +26,14 @@ internal sealed class EfWebhookDeliveryAttemptQueryableSource : IQueryableSource
     private readonly IDbContextFactory<WebhooksHostDbContext> _hostFactory;
     private readonly IDbContextFactory<WebhooksTenantDbContext>? _tenantFactory;
     private readonly ICurrentTenant _currentTenant;
-    private readonly ITenantEnumerator _tenantEnumerator;
+    private readonly ITenantsAccessor _tenantsAccessor;
     private DbContext? _context;
     private List<WebhookDeliveryAttempt>? _materialized;
 
     public EfWebhookDeliveryAttemptQueryableSource(
         WebhooksEntityFrameworkCoreOptions options,
         ICurrentTenant currentTenant,
-        ITenantEnumerator tenantEnumerator,
+        ITenantsAccessor tenantsAccessor,
         IDbContextFactory<WebhooksHostDbContext> hostFactory,
         IDbContextFactory<WebhooksTenantDbContext>? tenantFactory = null)
     {
@@ -42,7 +42,7 @@ internal sealed class EfWebhookDeliveryAttemptQueryableSource : IQueryableSource
         _hostFactory = hostFactory;
         _tenantFactory = tenantFactory;
         _currentTenant = currentTenant;
-        _tenantEnumerator = tenantEnumerator;
+        _tenantsAccessor = tenantsAccessor;
     }
 
     public IQueryable<WebhookDeliveryAttempt> GetQueryable()
@@ -89,7 +89,7 @@ internal sealed class EfWebhookDeliveryAttemptQueryableSource : IQueryableSource
             return results;
         }
 
-        IReadOnlyList<(Guid Id, string Name)> tenants = _tenantEnumerator
+        IReadOnlyList<(Guid Id, string Name)> tenants = _tenantsAccessor
             .GetAllAsync().GetAwaiter().GetResult();
 
         foreach ((Guid id, string name) in tenants)

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookStatsReader.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookStatsReader.cs
@@ -21,21 +21,21 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </para>
 /// <para>
 /// <b>Segregated + host-admin scope</b> (Phase 2C). Iterates every tenant returned by
-/// the framework-primitive <see cref="ITenantEnumerator"/> via
+/// the framework-primitive <see cref="ITenantsAccessor"/> via
 /// <see cref="ICurrentTenant.Change"/>, opens that tenant's isolated context, and sums
 /// into the host aggregate. <b>O(N) connections per stats call, N = number of tenants</b>
 /// — acceptable for the admin dashboard which is read rarely; a Postgres cross-schema
 /// materialised view is the documented optimisation path for deployments with hundreds
-/// of tenants. Soft-dep on <see cref="ITenantEnumerator"/> means this module never
+/// of tenants. Soft-dep on <see cref="ITenantsAccessor"/> means this module never
 /// references the <c>Granit.MultiTenancy</c> package directly — the default
-/// <c>NullTenantEnumerator</c> returns an empty list, gracefully degrading to host-only
+/// <c>NullTenantsAccessor</c> returns an empty list, gracefully degrading to host-only
 /// aggregation when no multi-tenancy stack is loaded.
 /// </para>
 /// </remarks>
 internal sealed class EfWebhookStatsReader(
     WebhooksContextResolver resolver,
     ICurrentTenant currentTenant,
-    ITenantEnumerator tenantEnumerator,
+    ITenantsAccessor tenantsAccessor,
     IClock clock) : IWebhookStatsReader
 {
     public async Task<WebhookStats> GetStatsAsync(CancellationToken cancellationToken = default)
@@ -79,10 +79,10 @@ internal sealed class EfWebhookStatsReader(
             await AggregateAsync(host, cutoff, acc, cancellationToken).ConfigureAwait(false);
         }
 
-        IReadOnlyList<(Guid Id, string Name)> tenants = await tenantEnumerator
+        IReadOnlyList<(Guid Id, string Name)> tenants = await tenantsAccessor
             .GetAllAsync(cancellationToken).ConfigureAwait(false);
 
-        // Empty under NullTenantEnumerator (no Granit.MultiTenancy package loaded) —
+        // Empty under NullTenantsAccessor (no Granit.MultiTenancy package loaded) —
         // the foreach short-circuits and host counts stand alone, no exception thrown.
         foreach ((Guid id, string name) in tenants)
         {

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
@@ -23,7 +23,7 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </para>
 /// <para>
 /// <b>Segregated + host-admin scope.</b> Materialises across the host context plus every
-/// tenant returned by <see cref="ITenantEnumerator"/> via
+/// tenant returned by <see cref="ITenantsAccessor"/> via
 /// <see cref="ICurrentTenant.Change"/>, then exposes the result as an in-memory
 /// <see cref="IQueryable{T}"/>. Filters, ordering and paging applied by
 /// <c>Granit.QueryEngine</c> downstream run in LINQ-to-Objects, not translated to SQL —
@@ -32,8 +32,8 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// deployments with thousands of subscriptions per tenant.
 /// </para>
 /// <para>
-/// Soft-dep on <see cref="ITenantEnumerator"/>: the default
-/// <c>NullTenantEnumerator</c> returns an empty list when <c>Granit.MultiTenancy</c> is
+/// Soft-dep on <see cref="ITenantsAccessor"/>: the default
+/// <c>NullTenantsAccessor</c> returns an empty list when <c>Granit.MultiTenancy</c> is
 /// not loaded, so single-tenant deployments still get a host-only result without a hard
 /// package dependency.
 /// </para>
@@ -45,14 +45,14 @@ internal sealed class EfWebhookSubscriptionQueryableSource : IQueryableSource<We
     private readonly IDbContextFactory<WebhooksHostDbContext> _hostFactory;
     private readonly IDbContextFactory<WebhooksTenantDbContext>? _tenantFactory;
     private readonly ICurrentTenant _currentTenant;
-    private readonly ITenantEnumerator _tenantEnumerator;
+    private readonly ITenantsAccessor _tenantsAccessor;
     private DbContext? _context;
     private List<WebhookSubscription>? _materialized;
 
     public EfWebhookSubscriptionQueryableSource(
         WebhooksEntityFrameworkCoreOptions options,
         ICurrentTenant currentTenant,
-        ITenantEnumerator tenantEnumerator,
+        ITenantsAccessor tenantsAccessor,
         IDbContextFactory<WebhooksHostDbContext> hostFactory,
         IDbContextFactory<WebhooksTenantDbContext>? tenantFactory = null)
     {
@@ -61,7 +61,7 @@ internal sealed class EfWebhookSubscriptionQueryableSource : IQueryableSource<We
         _hostFactory = hostFactory;
         _tenantFactory = tenantFactory;
         _currentTenant = currentTenant;
-        _tenantEnumerator = tenantEnumerator;
+        _tenantsAccessor = tenantsAccessor;
     }
 
     public IQueryable<WebhookSubscription> GetQueryable()
@@ -109,10 +109,10 @@ internal sealed class EfWebhookSubscriptionQueryableSource : IQueryableSource<We
             return results;
         }
 
-        IReadOnlyList<(Guid Id, string Name)> tenants = _tenantEnumerator
+        IReadOnlyList<(Guid Id, string Name)> tenants = _tenantsAccessor
             .GetAllAsync().GetAwaiter().GetResult();
 
-        // Empty under NullTenantEnumerator — host-only result, no exception.
+        // Empty under NullTenantsAccessor — host-only result, no exception.
         foreach ((Guid id, string name) in tenants)
         {
             using (_currentTenant.Change(id, name))

--- a/src/Granit/Extensions/GranitHostBuilderExtensions.cs
+++ b/src/Granit/Extensions/GranitHostBuilderExtensions.cs
@@ -101,7 +101,7 @@ public static class GranitHostBuilderExtensions
             moduleAssemblies);
 
         builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
-        builder.Services.TryAddSingleton<ITenantEnumerator>(NullTenantEnumerator.Instance);
+        builder.Services.TryAddSingleton<ITenantsAccessor>(NullTenantsAccessor.Instance);
 
         ConfigureJsonDefaults(builder);
 
@@ -127,7 +127,7 @@ public static class GranitHostBuilderExtensions
             moduleAssemblies);
 
         builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
-        builder.Services.TryAddSingleton<ITenantEnumerator>(NullTenantEnumerator.Instance);
+        builder.Services.TryAddSingleton<ITenantsAccessor>(NullTenantsAccessor.Instance);
 
         ConfigureJsonDefaults(builder);
 

--- a/src/Granit/MultiTenancy/ITenantsAccessor.cs
+++ b/src/Granit/MultiTenancy/ITenantsAccessor.cs
@@ -9,7 +9,7 @@ namespace Granit.MultiTenancy;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Default registration is <see cref="NullTenantEnumerator"/>, which returns an empty
+/// Default registration is <see cref="NullTenantsAccessor"/>, which returns an empty
 /// list — graceful fallback for single-tenant deployments that do not load
 /// <c>Granit.MultiTenancy</c>. The full <c>Granit.MultiTenancy</c> registration replaces
 /// the default with an adapter over <c>ITenantReader</c>.
@@ -21,13 +21,13 @@ namespace Granit.MultiTenancy;
 /// <c>ITenantReader</c> directly and accept the package dependency.
 /// </para>
 /// </remarks>
-public interface ITenantEnumerator
+public interface ITenantsAccessor
 {
     /// <summary>
     /// Returns the identifier and display name of every tenant in the system.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An empty list when no tenants exist or when the default
-    /// <see cref="NullTenantEnumerator"/> is in effect.</returns>
+    /// <see cref="NullTenantsAccessor"/> is in effect.</returns>
     Task<IReadOnlyList<(Guid Id, string Name)>> GetAllAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Granit/MultiTenancy/NullTenantsAccessor.cs
+++ b/src/Granit/MultiTenancy/NullTenantsAccessor.cs
@@ -1,16 +1,16 @@
 namespace Granit.MultiTenancy;
 
 /// <summary>
-/// Default <see cref="ITenantEnumerator"/> registered by base <c>Granit</c>. Returns an
+/// Default <see cref="ITenantsAccessor"/> registered by base <c>Granit</c>. Returns an
 /// empty list. Replaced by an <c>ITenantReader</c>-backed adapter when the application
 /// loads the <c>Granit.MultiTenancy</c> package.
 /// </summary>
-internal sealed class NullTenantEnumerator : ITenantEnumerator
+internal sealed class NullTenantsAccessor : ITenantsAccessor
 {
     /// <summary>Shared singleton — the type holds no state.</summary>
-    public static readonly NullTenantEnumerator Instance = new();
+    public static readonly NullTenantsAccessor Instance = new();
 
-    private NullTenantEnumerator() { }
+    private NullTenantsAccessor() { }
 
     public Task<IReadOnlyList<(Guid Id, string Name)>> GetAllAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<(Guid, string)>>([]);

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionQueryableSourceTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionQueryableSourceTests.cs
@@ -49,7 +49,7 @@ public sealed class EfWebhookSubscriptionQueryableSourceTests
         var sut = new EfWebhookSubscriptionQueryableSource(
             opts,
             tenantA,
-            EmptyEnumerator(),
+            EmptyAccessor(),
             new TenantScopedDbContextFactory(_options, tenantA, _filter));
 
         // Act
@@ -76,7 +76,7 @@ public sealed class EfWebhookSubscriptionQueryableSourceTests
         var sut = new EfWebhookSubscriptionQueryableSource(
             opts,
             host,
-            EmptyEnumerator(),
+            EmptyAccessor(),
             new TenantScopedDbContextFactory(_options, host, _filter));
 
         // Act
@@ -117,9 +117,9 @@ public sealed class EfWebhookSubscriptionQueryableSourceTests
             tenantId: tenantId);
 
 
-    private static ITenantEnumerator EmptyEnumerator()
+    private static ITenantsAccessor EmptyAccessor()
     {
-        ITenantEnumerator e = Substitute.For<ITenantEnumerator>();
+        ITenantsAccessor e = Substitute.For<ITenantsAccessor>();
         e.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<(Guid, string)>>([]));
         return e;

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
@@ -18,7 +18,7 @@ namespace Granit.Webhooks.EntityFrameworkCore.Tests;
 /// scope, <see cref="EfWebhookSubscriptionQueryableSource"/>,
 /// <see cref="EfWebhookDeliveryAttemptQueryableSource"/> and
 /// <see cref="EfWebhookStatsReader"/> iterate every tenant via
-/// <see cref="ITenantEnumerator"/> + <see cref="ICurrentTenant.Change"/>.
+/// <see cref="ITenantsAccessor"/> + <see cref="ICurrentTenant.Change"/>.
 /// </summary>
 public sealed class SegregatedCrossTenantAggregationTests
 {
@@ -45,12 +45,12 @@ public sealed class SegregatedCrossTenantAggregationTests
         IDbContextFactory<WebhooksHostDbContext> hostFactory = StubHostFactory(hostOpts);
         ICurrentTenant currentTenant = NewSwitchableTenant(initiallyAvailable: false);
         IDbContextFactory<WebhooksTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts, currentTenant);
-        ITenantEnumerator tenantEnumerator = StubTenantEnumerator(_tenantA, _tenantB);
+        ITenantsAccessor tenantsAccessor = StubTenantsAccessor(_tenantA, _tenantB);
 
         EfWebhookSubscriptionQueryableSource sut = new(
             new WebhooksEntityFrameworkCoreOptions { StorageMode = DualScopeStorageMode.Segregated },
             currentTenant,
-            tenantEnumerator,
+            tenantsAccessor,
             hostFactory,
             tenantFactory);
 
@@ -78,13 +78,13 @@ public sealed class SegregatedCrossTenantAggregationTests
         IDbContextFactory<WebhooksHostDbContext> hostFactory = StubHostFactory(hostOpts);
         ICurrentTenant currentTenant = NewSwitchableTenant(initiallyAvailable: false);
         IDbContextFactory<WebhooksTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts, currentTenant);
-        ITenantEnumerator tenantEnumerator = StubTenantEnumerator(_tenantA, _tenantB);
+        ITenantsAccessor tenantsAccessor = StubTenantsAccessor(_tenantA, _tenantB);
         WebhooksContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
 
         IClock clock = Substitute.For<IClock>();
         clock.Now.Returns(new DateTimeOffset(2026, 5, 28, 12, 0, 0, TimeSpan.Zero));
 
-        EfWebhookStatsReader sut = new(resolver, currentTenant, tenantEnumerator, clock);
+        EfWebhookStatsReader sut = new(resolver, currentTenant, tenantsAccessor, clock);
 
         Webhooks.Abstractions.WebhookStats stats = await sut.GetStatsAsync(TestContext.Current.CancellationToken);
 
@@ -105,11 +105,11 @@ public sealed class SegregatedCrossTenantAggregationTests
         ICurrentTenant currentTenant = NewSwitchableTenant(initiallyAvailable: false);
         IDbContextFactory<WebhooksTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts, currentTenant);
 
-        // NullTenantEnumerator-style stub (empty list) → fallback to host-only.
+        // NullTenantsAccessor-style stub (empty list) → fallback to host-only.
         EfWebhookSubscriptionQueryableSource sut = new(
             new WebhooksEntityFrameworkCoreOptions { StorageMode = DualScopeStorageMode.Segregated },
             currentTenant,
-            tenantEnumerator: StubTenantEnumerator() /* empty */,
+            tenantsAccessor: StubTenantsAccessor() /* empty */,
             hostFactory,
             tenantFactory);
 
@@ -176,9 +176,9 @@ public sealed class SegregatedCrossTenantAggregationTests
         return factory;
     }
 
-    private static ITenantEnumerator StubTenantEnumerator(params Guid[] tenantIds)
+    private static ITenantsAccessor StubTenantsAccessor(params Guid[] tenantIds)
     {
-        ITenantEnumerator enumerator = Substitute.For<ITenantEnumerator>();
+        ITenantsAccessor enumerator = Substitute.For<ITenantsAccessor>();
         (Guid Id, string Name)[] tenants = [.. tenantIds.Select(id => (id, $"tenant-{id}"))];
         enumerator.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<(Guid, string)>>(tenants));


### PR DESCRIPTION
## Summary

Hotfix for the develop CI failure introduced by #2407. The new `Granit.MultiTenancy.ITenantEnumerator` collided with the pre-existing `Granit.Persistence.EntityFrameworkCore.Migrations.ITenantEnumerator`:

\`\`\`
GranitMigrationRunner.cs(218,9): CS0104: 'ITenantEnumerator' is an ambiguous reference
EfCoreTenantEnumerator.cs(26,83): CS0535: does not implement interface member 'ITenantEnumerator.GetAllAsync(CancellationToken)'
\`\`\`

The two interfaces have **different shapes** — they were never meant to be the same type:

| Interface | Shape | Used by |
|-----------|-------|---------|
| `Granit.Persistence.EntityFrameworkCore.Migrations.ITenantEnumerator` | `IAsyncEnumerable<Guid> GetActiveTenantIdsAsync(CancellationToken)` | `GranitMigrationRunner` (per-tenant migration loop) |
| `Granit.MultiTenancy.ITenantEnumerator` (mine, #2407) | `Task<IReadOnlyList<(Guid Id, string Name)>> GetAllAsync(CancellationToken)` | Webhooks cross-tenant aggregation (host admin) |

The Migrations one is older, public, has app-level consumers (custom impls registered via `services.AddSingleton<ITenantEnumerator, MyImpl>()`). My primitive is fresh, has a small consumer set (Webhooks 2C + future modules). Renaming the new one is the lower-blast-radius fix.

## Renames

- `Granit.MultiTenancy.ITenantEnumerator` → `ITenantsAccessor`
- `Granit.MultiTenancy.NullTenantEnumerator` → `NullTenantsAccessor`
- `Granit.MultiTenancy.Internal.TenantReaderEnumeratorAdapter` → `TenantReaderTenantsAccessorAdapter`

Method signature unchanged (`Task<IReadOnlyList<(Guid Id, string Name)>> GetAllAsync(CancellationToken)`) — call sites only see a type rename.

## Consumers updated (mine, soft-dep)

- `src/Granit/Extensions/GranitHostBuilderExtensions.cs` — `TryAddSingleton` fallback
- `src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs` — `Replace` adapter
- `src/Granit.Webhooks.EntityFrameworkCore` — Stats reader + 2 QueryableSources + module xmldoc

Untouched: `GranitMigrationRunner`, `EfCoreTenantEnumerator` (Granit.MultiTenancy.EntityFrameworkCore), `IDataSeedTenantProvider` xmldoc — all reference `Migrations.ITenantEnumerator` and now build cleanly.

## Test plan

- [x] `dotnet build` — green on Granit, Granit.MultiTenancy, Granit.MultiTenancy.EntityFrameworkCore, Granit.Webhooks.EntityFrameworkCore, Granit.Persistence.EntityFrameworkCore.Hosting (the file with the ambiguity error)
- [x] `dotnet test Granit.Webhooks.EntityFrameworkCore.Tests` — **50/50 green**
- [x] `dotnet format --verify-no-changes` clean

## After merge

PR #2420 (Identity.Federated Phase B Segregated) needs rebasing onto the renamed primitive. I'll handle that as a separate push to its branch.

Refs follow-up to #2407