### PR TITLE
fix(archi-tests): refresh packages.lock.json after EntityMerge rename

### DIFF
--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2134,6 +2134,32 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.entitymerge": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entitymerge.backgroundjobs": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.BackgroundJobs": "[0.1.0-dev, )",
+          "Granit.EntityMerge.EntityFrameworkCore": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entitymerge.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.EntityMerge": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
       "granit.events": {
         "type": "Project",
         "dependencies": {
@@ -2612,32 +2638,6 @@
           "Granit.Mcp": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "ModelContextProtocol.AspNetCore": "[1.3.*, )"
-        }
-      },
-      "granit.mergeable": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.mergeable.backgroundjobs": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.BackgroundJobs": "[0.1.0-dev, )",
-          "Granit.Mergeable.EntityFrameworkCore": "[0.1.0-dev, )"
-        }
-      },
-      "granit.mergeable.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Mergeable": "[0.1.0-dev, )",
-          "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
       },
       "granit.multitenancy": {
@@ -3519,7 +3519,6 @@
       "granit.webhooks.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
-          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Webhooks": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"


### PR DESCRIPTION
Follow-up to #2422. CI on the architecture shard now fails restore in locked mode with NU1004:

```
error NU1004: A new project reference to Granit.EntityMerge was found for net10.0 target framework.
...the packages lock file is inconsistent with the project dependencies
```

The `tests/Granit.ArchitectureTests/packages.lock.json` still pinned the old `granit.mergeable*` package IDs after #2422 merged, because that project's build was pre-existingly broken at the time of the rename (the `ITenantEnumerator` ambiguity introduced by #2420, resolved on develop in #2421). So `dotnet restore --force-evaluate` skipped persisting the renamed `ProjectReference` lines to the lockfile.

This PR re-runs `dotnet restore tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj --force-evaluate` on current develop (where the `ITenantEnumerator` fix has already landed) and commits only the resulting lockfile diff. Entries flipped from `granit.mergeable*` to `granit.entitymerge*`. No code change.

## Test plan

- [x] `grep -in mergeable tests/Granit.ArchitectureTests/packages.lock.json` → no matches
- [x] Lockfile diff is local to the renamed package IDs (no unrelated drift)
- [ ] CI architecture shard restores and builds in locked mode