### PR TITLE
fix(identity-federated): finish ITenantEnumerator → ITenantsAccessor rename

### DIFF
--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
@@ -17,16 +17,16 @@ namespace Granit.Identity.Federated.EntityFrameworkCore.Internal;
 /// All read operations use <c>AsNoTracking</c> for performance. Under
 /// <see cref="DualScopeStorageMode.Segregated"/>, the cross-tenant
 /// <see cref="FindFirstByExternalIdAsync"/> path probes the host context plus every tenant
-/// returned by <see cref="ITenantEnumerator"/> via <see cref="ICurrentTenant.Change"/>.
-/// Soft-dep on <see cref="ITenantEnumerator"/> — single-tenant deployments running with
-/// the default <c>NullTenantEnumerator</c> see host-only results without a hard package
+/// returned by <see cref="ITenantsAccessor"/> via <see cref="ICurrentTenant.Change"/>.
+/// Soft-dep on <see cref="ITenantsAccessor"/> — single-tenant deployments running with
+/// the default <c>NullTenantsAccessor</c> see host-only results without a hard package
 /// dependency on <c>Granit.MultiTenancy</c>.
 /// </remarks>
 internal sealed class EfCoreUserCacheStore(
     IdentityFederatedContextResolver resolver,
     IUserLookupHasher hasher,
     ICurrentTenant currentTenant,
-    ITenantEnumerator tenantEnumerator) : IUserCacheStore
+    ITenantsAccessor tenantsAccessor) : IUserCacheStore
 {
     // -- Read --
 
@@ -71,8 +71,8 @@ internal sealed class EfCoreUserCacheStore(
             }
 
             // Host-admin lookup under Segregated: iterate every tenant known to the
-            // enumerator. Empty under NullTenantEnumerator — degrades to host-only.
-            IReadOnlyList<(Guid Id, string Name)> tenants = await tenantEnumerator
+            // accessor. Empty under NullTenantsAccessor — degrades to host-only.
+            IReadOnlyList<(Guid Id, string Name)> tenants = await tenantsAccessor
                 .GetAllAsync(cancellationToken).ConfigureAwait(false);
 
             foreach ((Guid id, string name) in tenants)

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
@@ -38,10 +38,10 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
         TestIdentityFederatedHostDbContextFactory factory = new(options, _filter.Filter);
         IdentityFederatedContextResolver resolver = new(DualScopeStorageMode.Shared, factory);
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
-        ITenantEnumerator tenantEnumerator = Substitute.For<ITenantEnumerator>();
-        tenantEnumerator.GetAllAsync(Arg.Any<CancellationToken>())
+        ITenantsAccessor tenantsAccessor = Substitute.For<ITenantsAccessor>();
+        tenantsAccessor.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<(Guid, string)>>([]));
-        return new EfCoreUserCacheStore(resolver, Hasher, currentTenant, tenantEnumerator);
+        return new EfCoreUserCacheStore(resolver, Hasher, currentTenant, tenantsAccessor);
     }
 
     private static FederatedIdentity CreateEntry(

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
@@ -30,13 +30,13 @@ public sealed class IdentityEfCoreDiRegistrationTests
         builder.Services.AddSingleton(Substitute.For<IGuidGenerator>());
         builder.Services.AddSingleton(Substitute.For<IUserDirectoryWriter>());
 
-        // EfCoreUserCacheStore depends on the soft-dep ITenantEnumerator primitive (base
-        // Granit). The default NullTenantEnumerator is registered by AddGranit<T>(), but
+        // EfCoreUserCacheStore depends on the soft-dep ITenantsAccessor primitive (base
+        // Granit). The default NullTenantsAccessor is registered by AddGranit<T>(), but
         // this test bypasses the module loader — stub it explicitly.
-        ITenantEnumerator enumerator = Substitute.For<ITenantEnumerator>();
-        enumerator.GetAllAsync(Arg.Any<CancellationToken>())
+        ITenantsAccessor accessor = Substitute.For<ITenantsAccessor>();
+        accessor.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<(Guid, string)>>([]));
-        builder.Services.AddSingleton(enumerator);
+        builder.Services.AddSingleton(accessor);
 
         // Phase B options-based registration — Shared mode default.
         builder.AddGranitIdentityFederatedEntityFrameworkCore(opts =>

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/SegregatedDispatchTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/SegregatedDispatchTests.cs
@@ -16,7 +16,7 @@ namespace Granit.Identity.Federated.EntityFrameworkCore.Tests;
 /// Pins the Phase B Segregated dispatch contract: <see cref="EfCoreUserCacheStore"/>
 /// routes writes to the host context when <c>tenantId</c> is null and to the tenant
 /// context otherwise; <see cref="EfCoreUserCacheStore.FindFirstByExternalIdAsync"/>
-/// iterates every tenant returned by <see cref="ITenantEnumerator"/> under host-admin
+/// iterates every tenant returned by <see cref="ITenantsAccessor"/> under host-admin
 /// scope.
 /// </summary>
 public sealed class SegregatedDispatchTests : IDisposable
@@ -42,9 +42,9 @@ public sealed class SegregatedDispatchTests : IDisposable
         IdentityFederatedContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
 
         ICurrentTenant currentTenant = NewSwitchableTenant();
-        ITenantEnumerator enumerator = StubEnumerator(_tenantA, _tenantB);
+        ITenantsAccessor accessor = StubAccessor(_tenantA, _tenantB);
 
-        EfCoreUserCacheStore sut = new(resolver, StubHasher(), currentTenant, enumerator);
+        EfCoreUserCacheStore sut = new(resolver, StubHasher(), currentTenant, accessor);
 
         FederatedIdentity? result = await sut.FindFirstByExternalIdAsync(
             "federated-user-1", TestContext.Current.CancellationToken);
@@ -64,9 +64,9 @@ public sealed class SegregatedDispatchTests : IDisposable
         IdentityFederatedContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
 
         ICurrentTenant currentTenant = NewSwitchableTenant();
-        ITenantEnumerator enumerator = StubEnumerator(_tenantA);
+        ITenantsAccessor accessor = StubAccessor(_tenantA);
 
-        EfCoreUserCacheStore sut = new(resolver, StubHasher(), currentTenant, enumerator);
+        EfCoreUserCacheStore sut = new(resolver, StubHasher(), currentTenant, accessor);
 
         await sut.UpsertAsync(CreateEntry("tenant-A-user", _tenantA), TestContext.Current.CancellationToken);
 
@@ -89,9 +89,9 @@ public sealed class SegregatedDispatchTests : IDisposable
         IdentityFederatedContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
 
         ICurrentTenant currentTenant = NewSwitchableTenant();
-        ITenantEnumerator enumerator = StubEnumerator();
+        ITenantsAccessor accessor = StubAccessor();
 
-        EfCoreUserCacheStore sut = new(resolver, StubHasher(), currentTenant, enumerator);
+        EfCoreUserCacheStore sut = new(resolver, StubHasher(), currentTenant, accessor);
 
         await sut.UpsertAsync(CreateEntry("host-admin-user", tenantId: null), TestContext.Current.CancellationToken);
 
@@ -142,13 +142,13 @@ public sealed class SegregatedDispatchTests : IDisposable
         return hasher;
     }
 
-    private static ITenantEnumerator StubEnumerator(params Guid[] tenantIds)
+    private static ITenantsAccessor StubAccessor(params Guid[] tenantIds)
     {
-        ITenantEnumerator enumerator = Substitute.For<ITenantEnumerator>();
+        ITenantsAccessor accessor = Substitute.For<ITenantsAccessor>();
         (Guid Id, string Name)[] tenants = [.. tenantIds.Select(id => (id, $"tenant-{id}"))];
-        enumerator.GetAllAsync(Arg.Any<CancellationToken>())
+        accessor.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<(Guid, string)>>(tenants));
-        return enumerator;
+        return accessor;
     }
 
     private static ICurrentTenant NewSwitchableTenant()


### PR DESCRIPTION
Develop build is failing with `CS0246: ITenantEnumerator could not be found` in `EfCoreUserCacheStore.cs`. Root cause: #2421 renamed `Granit.MultiTenancy.ITenantEnumerator` → `ITenantsAccessor` to resolve the namespace collision against `Granit.Persistence.EntityFrameworkCore.Migrations.ITenantEnumerator`, but `Granit.Identity.Federated.EntityFrameworkCore` was added in #2420 (Phase B) and slipped past the rename — its consumer file was missed.

## Summary

- `EfCoreUserCacheStore`: ctor param `ITenantEnumerator tenantEnumerator` → `ITenantsAccessor tenantsAccessor`, two `<see cref>` and one inline comment updated.
- Three test files in `Granit.Identity.Federated.EntityFrameworkCore.Tests` updated in lockstep (`EfCoreUserCacheStoreTests`, `SegregatedDispatchTests`, `IdentityEfCoreDiRegistrationTests`).

Mechanical rename (`sed -e s/ITenantEnumerator/ITenantsAccessor/g -e s/NullTenantEnumerator/NullTenantsAccessor/g -e s/tenantEnumerator/tenantsAccessor/g -e s/StubEnumerator/StubAccessor/g`).

## Test plan

- [x] `Granit.Identity.Federated.EntityFrameworkCore` builds clean
- [x] `Granit.Identity.Federated.EntityFrameworkCore.Tests` builds clean
- [x] 35/35 tests pass
- [ ] CI green