### PR TITLE
feat(presence): resource-scoped editing rooms (#2408)

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -190,6 +190,8 @@
       "src/Granit.Persistence.EntityFrameworkCore.SqlServer/Granit.Persistence.EntityFrameworkCore.SqlServer.csproj",
       "src/Granit.Persistence.EntityFrameworkCore/Granit.Persistence.EntityFrameworkCore.csproj",
       "src/Granit.Persistence/Granit.Persistence.csproj",
+      "src/Granit.Presence.Endpoints/Granit.Presence.Endpoints.csproj",
+      "src/Granit.Presence/Granit.Presence.csproj",
       "src/Granit.Privacy.AI/Granit.Privacy.AI.csproj",
       "src/Granit.Privacy.BackgroundJobs/Granit.Privacy.BackgroundJobs.csproj",
       "src/Granit.Privacy.BlobStorage/Granit.Privacy.BlobStorage.csproj",

--- a/.github/shard-filters/infrastructure.slnf
+++ b/.github/shard-filters/infrastructure.slnf
@@ -101,6 +101,7 @@
       "src/Granit.Settings.EntityFrameworkCore/Granit.Settings.EntityFrameworkCore.csproj",
       "src/Granit.Settings/Granit.Settings.csproj",
       "src/Granit.Templating/Granit.Templating.csproj",
+      "src/Granit.Testing/Granit.Testing.csproj",
       "src/Granit.Timing/Granit.Timing.csproj",
       "src/Granit.Validation/Granit.Validation.csproj",
       "src/Granit.Wolverine.Encryption/Granit.Wolverine.Encryption.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36735,6 +36735,90 @@
       ]
     },
     {
+      "name": "IResourcePresenceTracker",
+      "fqn": "Granit.Presence.Abstractions.IResourcePresenceTracker",
+      "kind": "interface",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/IResourcePresenceTracker.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "JoinAsync",
+          "kind": "method",
+          "signature": "JoinAsync(ResourceRef resource, Guid userId, string? metadata = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ResourceRoom>"
+        },
+        {
+          "name": "LeaveAsync",
+          "kind": "method",
+          "signature": "LeaveAsync(ResourceRef resource, Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(ResourceRef resource, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ResourceRoom>"
+        }
+      ]
+    },
+    {
+      "name": "IResourcePresenceVisibilityPolicy",
+      "fqn": "Granit.Presence.Abstractions.IResourcePresenceVisibilityPolicy",
+      "kind": "interface",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/IResourcePresenceVisibilityPolicy.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "CanReadRoomAsync",
+          "kind": "method",
+          "signature": "CanReadRoomAsync(Guid callerUserId, ResourceRef resource, CancellationToken cancellationToken)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "FilterVisibleParticipantsAsync",
+          "kind": "method",
+          "signature": "FilterVisibleParticipantsAsync(Guid callerUserId, ResourceRef resource, IReadOnlyCollection<Guid> participantUserIds, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlySet<Guid>>"
+        }
+      ]
+    },
+    {
+      "name": "ResourcePresenceEntry",
+      "fqn": "Granit.Presence.Abstractions.ResourcePresenceEntry",
+      "kind": "record",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/ResourcePresenceEntry.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ResourceRoom",
+      "fqn": "Granit.Presence.Abstractions.ResourceRoom",
+      "kind": "record",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/ResourceRoom.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Presence.Abstractions.struct",
+      "kind": "record",
+      "project": "Granit.Presence",
+      "file": "src/Granit.Presence/Abstractions/ResourceRef.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "PresenceMetrics",
       "fqn": "Granit.Presence.Diagnostics.PresenceMetrics",
       "kind": "class",
@@ -36758,6 +36842,30 @@
           "name": "RecordNotificationGated",
           "kind": "method",
           "signature": "RecordNotificationGated(string? tenantId, string channelName)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRoomJoin",
+          "kind": "method",
+          "signature": "RecordRoomJoin(string? tenantId, string resourceKind)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRoomLeave",
+          "kind": "method",
+          "signature": "RecordRoomLeave(string? tenantId, string resourceKind, string reason)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRoomSize",
+          "kind": "method",
+          "signature": "RecordRoomSize(string? tenantId, string resourceKind, int participantCount)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRoomMetadataBytes",
+          "kind": "method",
+          "signature": "RecordRoomMetadataBytes(string resourceKind, int byteCount)",
           "returnType": "void"
         }
       ]
@@ -36851,12 +36959,39 @@
       "members": []
     },
     {
+      "name": "HeartbeatRoomRequest",
+      "fqn": "Granit.Presence.Endpoints.Dtos.HeartbeatRoomRequest",
+      "kind": "record",
+      "project": "Granit.Presence.Endpoints",
+      "file": "src/Granit.Presence.Endpoints/Dtos/HeartbeatRoomRequest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "PresenceResponse",
       "fqn": "Granit.Presence.Endpoints.Dtos.PresenceResponse",
       "kind": "record",
       "project": "Granit.Presence.Endpoints",
       "file": "src/Granit.Presence.Endpoints/Dtos/PresenceResponse.cs",
       "line": 16,
+      "members": []
+    },
+    {
+      "name": "ResourcePresenceParticipantResponse",
+      "fqn": "Granit.Presence.Endpoints.Dtos.ResourcePresenceParticipantResponse",
+      "kind": "record",
+      "project": "Granit.Presence.Endpoints",
+      "file": "src/Granit.Presence.Endpoints/Dtos/ResourceRoomResponse.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ResourceRoomResponse",
+      "fqn": "Granit.Presence.Endpoints.Dtos.ResourceRoomResponse",
+      "kind": "record",
+      "project": "Granit.Presence.Endpoints",
+      "file": "src/Granit.Presence.Endpoints/Dtos/ResourceRoomResponse.cs",
+      "line": 9,
       "members": []
     },
     {
@@ -36919,6 +37054,12 @@
           "kind": "property",
           "signature": "string TagName",
           "returnType": "string"
+        },
+        {
+          "name": "RoomsTagName",
+          "kind": "property",
+          "signature": "string RoomsTagName",
+          "returnType": "string"
         }
       ]
     },
@@ -36938,6 +37079,15 @@
       "project": "Granit.Presence.Endpoints",
       "file": "src/Granit.Presence.Endpoints/Permissions/PresenceRateLimitPolicies.cs",
       "line": 18,
+      "members": []
+    },
+    {
+      "name": "Rooms",
+      "fqn": "Granit.Presence.Endpoints.Permissions.Rooms",
+      "kind": "class",
+      "project": "Granit.Presence.Endpoints",
+      "file": "src/Granit.Presence.Endpoints/Permissions/PresencePermissions.cs",
+      "line": 26,
       "members": []
     },
     {

--- a/src/Granit.Presence.Endpoints/Dtos/HeartbeatRoomRequest.cs
+++ b/src/Granit.Presence.Endpoints/Dtos/HeartbeatRoomRequest.cs
@@ -1,0 +1,11 @@
+namespace Granit.Presence.Endpoints.Dtos;
+
+/// <summary>
+/// Heartbeat payload for a resource room.
+/// </summary>
+/// <param name="Metadata">
+/// Optional opaque, caller-supplied UTF-8 string (≤ 512 bytes). Typically a JSON blob the UI
+/// uses to render a colored cursor / section indicator next to the participant. Pass <c>null</c>
+/// to clear any previously recorded metadata.
+/// </param>
+public sealed record HeartbeatRoomRequest(string? Metadata = null);

--- a/src/Granit.Presence.Endpoints/Dtos/ResourceRoomResponse.cs
+++ b/src/Granit.Presence.Endpoints/Dtos/ResourceRoomResponse.cs
@@ -1,0 +1,23 @@
+namespace Granit.Presence.Endpoints.Dtos;
+
+/// <summary>
+/// Resource room snapshot returned by the room endpoints.
+/// </summary>
+/// <param name="Kind">Resource kind discriminator (echoes the URL segment).</param>
+/// <param name="Id">Resource identifier (echoes the URL segment).</param>
+/// <param name="Participants">Live participants, filtered by the visibility policy.</param>
+public sealed record ResourceRoomResponse(
+    string Kind,
+    string Id,
+    IReadOnlyList<ResourcePresenceParticipantResponse> Participants);
+
+/// <summary>
+/// A single participant entry inside a <see cref="ResourceRoomResponse"/>.
+/// </summary>
+/// <param name="UserId">The participant's user identifier.</param>
+/// <param name="LastSeenUtc">Server-side instant of the participant's most recent heartbeat.</param>
+/// <param name="Metadata">Optional caller-supplied opaque metadata (≤ 512 bytes UTF-8).</param>
+public sealed record ResourcePresenceParticipantResponse(
+    Guid UserId,
+    DateTimeOffset LastSeenUtc,
+    string? Metadata);

--- a/src/Granit.Presence.Endpoints/Endpoints/PresenceRoomEndpoints.cs
+++ b/src/Granit.Presence.Endpoints/Endpoints/PresenceRoomEndpoints.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using Granit.Http.RateLimiting.AspNetCore;
+using Granit.Presence.Abstractions;
+using Granit.Presence.Endpoints.Dtos;
+using Granit.Presence.Endpoints.Internal;
+using Granit.Presence.Endpoints.Permissions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Presence.Endpoints.Endpoints;
+
+/// <summary>
+/// Endpoints for resource-scoped multi-user awareness rooms — "who is also editing this CMS
+/// page / dashboard / kanban card?".
+/// </summary>
+internal static class PresenceRoomEndpoints
+{
+    public static RouteGroupBuilder MapRoomEndpoints(this RouteGroupBuilder group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        group.MapPost("/rooms/{kind}/{id}/heartbeat", HeartbeatRoomAsync)
+            .WithName("HeartbeatPresenceRoom")
+            .WithSummary("Joins or refreshes the caller's heartbeat in a resource room.")
+            .WithDescription("Acts as both join and refresh — clients should call this every 30-60 s while the user remains in the room. Returns the full room snapshot to save a round-trip; participants are filtered through IResourcePresenceVisibilityPolicy.")
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Poll)
+            .RequireAuthorization(PresencePermissions.Rooms.Join)
+            .Produces<ResourceRoomResponse>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+
+        group.MapGet("/rooms/{kind}/{id}", GetRoomAsync)
+            .WithName("GetPresenceRoom")
+            .WithSummary("Returns the participants currently active in a resource room.")
+            .WithDescription("Filters stale entries (older than Presence:OfflineThreshold) and consults IResourcePresenceVisibilityPolicy. Policy denial surfaces as 404 to avoid leaking room existence — same anti-enumeration contract as user presence reads.")
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Query)
+            .RequireAuthorization(PresencePermissions.Rooms.Read)
+            .Produces<ResourceRoomResponse>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+
+        group.MapDelete("/rooms/{kind}/{id}", LeaveRoomAsync)
+            .WithName("LeavePresenceRoom")
+            .WithSummary("Removes the caller from a resource room.")
+            .WithDescription("Idempotent — returns 204 whether or not the caller was present. The room cache entry is evicted entirely when the last participant leaves.")
+            .RequireGranitRateLimiting(PresenceRateLimitPolicies.Mutate)
+            .RequireAuthorization(PresencePermissions.Rooms.Join)
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<ResourceRoomResponse>, ProblemHttpResult, NotFound, ValidationProblem>> HeartbeatRoomAsync(
+        string kind,
+        string id,
+        HeartbeatRoomRequest? request,
+        ClaimsPrincipal user,
+        [FromServices] IResourcePresenceTracker tracker,
+        [FromServices] IResourcePresenceVisibilityPolicy visibilityPolicy,
+        CancellationToken cancellationToken)
+    {
+        if (!PresenceCallerContext.TryResolveSelf(user, out Guid userId, out ProblemHttpResult? unauthorized))
+        {
+            return unauthorized;
+        }
+
+        if (!TryValidateResource(kind, id, out ValidationProblem? badResource, out ResourceRef resource))
+        {
+            return badResource;
+        }
+
+        ResourceRoom room = await tracker
+            .JoinAsync(resource, userId, request?.Metadata, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Visibility policy still applies on the response — the caller may not be allowed
+        // to read the room (would be 404 on a separate GET), so we mirror that here.
+        bool canRead = await visibilityPolicy
+            .CanReadRoomAsync(userId, resource, cancellationToken).ConfigureAwait(false);
+        if (!canRead)
+        {
+            return TypedResults.NotFound();
+        }
+
+        IReadOnlySet<Guid> participantIds = room.Participants.Count == 0
+            ? new HashSet<Guid>()
+            : [.. room.Participants.Select(p => p.UserId)];
+
+        IReadOnlySet<Guid> visible = await visibilityPolicy
+            .FilterVisibleParticipantsAsync(userId, resource, participantIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(ResourceRoomResponseMapper.ToResponse(room, visible));
+    }
+
+    private static async Task<Results<Ok<ResourceRoomResponse>, ProblemHttpResult, NotFound, ValidationProblem>> GetRoomAsync(
+        string kind,
+        string id,
+        ClaimsPrincipal user,
+        [FromServices] IResourcePresenceTracker tracker,
+        [FromServices] IResourcePresenceVisibilityPolicy visibilityPolicy,
+        CancellationToken cancellationToken)
+    {
+        Guid callerId = PresenceCallerContext.TryGetUserId(user) ?? Guid.Empty;
+
+        if (!TryValidateResource(kind, id, out ValidationProblem? badResource, out ResourceRef resource))
+        {
+            return badResource;
+        }
+
+        bool canRead = await visibilityPolicy
+            .CanReadRoomAsync(callerId, resource, cancellationToken).ConfigureAwait(false);
+        if (!canRead)
+        {
+            return TypedResults.NotFound();
+        }
+
+        ResourceRoom room = await tracker.GetAsync(resource, cancellationToken).ConfigureAwait(false);
+        IReadOnlySet<Guid> participantIds = room.Participants.Count == 0
+            ? new HashSet<Guid>()
+            : [.. room.Participants.Select(p => p.UserId)];
+
+        IReadOnlySet<Guid> visible = await visibilityPolicy
+            .FilterVisibleParticipantsAsync(callerId, resource, participantIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(ResourceRoomResponseMapper.ToResponse(room, visible));
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult, ValidationProblem>> LeaveRoomAsync(
+        string kind,
+        string id,
+        ClaimsPrincipal user,
+        [FromServices] IResourcePresenceTracker tracker,
+        CancellationToken cancellationToken)
+    {
+        if (!PresenceCallerContext.TryResolveSelf(user, out Guid userId, out ProblemHttpResult? unauthorized))
+        {
+            return unauthorized;
+        }
+
+        if (!TryValidateResource(kind, id, out ValidationProblem? badResource, out ResourceRef resource))
+        {
+            return badResource;
+        }
+
+        await tracker.LeaveAsync(resource, userId, cancellationToken).ConfigureAwait(false);
+        return TypedResults.NoContent();
+    }
+
+    /// <summary>
+    /// Wraps <see cref="ResourceRef.Validate"/> so route-bound kind/id values surface as a
+    /// 400 ProblemDetails (RFC 7807) rather than a 500.
+    /// </summary>
+    private static bool TryValidateResource(
+        string kind,
+        string id,
+        [NotNullWhen(false)] out ValidationProblem? problem,
+        out ResourceRef resource)
+    {
+        resource = new ResourceRef(kind, id);
+
+        try
+        {
+            resource.Validate();
+            problem = null;
+            return true;
+        }
+        catch (ArgumentException ex)
+        {
+            problem = TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                [ex.ParamName ?? "resource"] = [ex.Message],
+            });
+            return false;
+        }
+    }
+}

--- a/src/Granit.Presence.Endpoints/Extensions/PresenceEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Presence.Endpoints/Extensions/PresenceEndpointRouteBuilderExtensions.cs
@@ -61,6 +61,15 @@ public static class PresenceEndpointRouteBuilderExtensions
         group.MapQueryEndpoints()
             .RequireAuthorization(PresencePermissions.Users.Read);
 
+        // Resource-scoped rooms live under the same prefix but carry their own OpenAPI tag.
+        // Per-route RequireAuthorization is applied at the endpoint declaration so each verb
+        // can require a different permission (Presence.Rooms.Read vs .Join).
+        endpoints
+            .MapGranitGroup(options.RoutePrefix)
+            .WithTags(options.RoomsTagName)
+            .RequireAuthorization()
+            .MapRoomEndpoints();
+
         return group;
     }
 }

--- a/src/Granit.Presence.Endpoints/Internal/ResourceRoomResponseMapper.cs
+++ b/src/Granit.Presence.Endpoints/Internal/ResourceRoomResponseMapper.cs
@@ -1,0 +1,33 @@
+using Granit.Presence.Abstractions;
+using Granit.Presence.Endpoints.Dtos;
+
+namespace Granit.Presence.Endpoints.Internal;
+
+internal static class ResourceRoomResponseMapper
+{
+    /// <summary>
+    /// Projects a <see cref="ResourceRoom"/> to its API response, optionally restricted to
+    /// the supplied <paramref name="visibleParticipantIds"/> set (used by the visibility policy).
+    /// When <paramref name="visibleParticipantIds"/> is <c>null</c>, every participant is included.
+    /// </summary>
+    public static ResourceRoomResponse ToResponse(
+        ResourceRoom room,
+        IReadOnlySet<Guid>? visibleParticipantIds)
+    {
+        List<ResourcePresenceParticipantResponse> projected = new(room.Participants.Count);
+        foreach (ResourcePresenceEntry entry in room.Participants)
+        {
+            if (visibleParticipantIds is not null && !visibleParticipantIds.Contains(entry.UserId))
+            {
+                continue;
+            }
+
+            projected.Add(new ResourcePresenceParticipantResponse(
+                entry.UserId,
+                entry.LastSeenUtc,
+                entry.Metadata));
+        }
+
+        return new ResourceRoomResponse(room.Resource.Kind, room.Resource.Id, projected);
+    }
+}

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/cs.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/cs.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "Doba nečinnosti překračuje maximální povolenou hodnotu.",
     "Granit:Validation:PresenceOverrideUntilInPast": "Vypršení platnosti přepsání musí být v budoucnosti.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "Vypršení platnosti přepsání je příliš daleko v budoucnosti.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Metadata překračují maximální povolenou velikost.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Vypršení platnosti nelze zadat, pokud je ruční stav Dostupný.",
+    "Permission:Presence.Rooms.Join": "Připojit se ke sdílenému prostředku (stránka CMS, řídicí panel, …) a sdělit ostatním svou přítomnost",
+    "Permission:Presence.Rooms.Read": "Zobrazit, kdo je aktuálně aktivní ve sdíleném prostředku (stránka CMS, řídicí panel, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/de.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/de.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "Die Leerlaufzeit überschreitet den maximal zulässigen Wert.",
     "Granit:Validation:PresenceOverrideUntilInPast": "Das Ablaufdatum der Übersteuerung muss in der Zukunft liegen.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "Das Ablaufdatum der Übersteuerung liegt zu weit in der Zukunft.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Metadaten überschreiten die maximal zulässige Größe.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Ein Ablaufdatum kann nicht angegeben werden, wenn der manuelle Status Verfügbar ist.",
+    "Permission:Presence.Rooms.Join": "Einer gemeinsamen Ressource (CMS-Seite, Dashboard, …) beitreten und meine Anwesenheit teilen",
+    "Permission:Presence.Rooms.Read": "Anzeigen, wer eine gemeinsame Ressource (CMS-Seite, Dashboard, …) gerade verwendet",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/en-GB.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/en-GB.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "Idle duration exceeds the maximum allowed value.",
     "Granit:Validation:PresenceOverrideUntilInPast": "Override expiration must be in the future.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "Override expiration is too far in the future.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Metadata exceeds the maximum allowed size.",
     "Granit:Validation:PresenceUntilWithoutOverride": "An expiration cannot be supplied when the manual status is Available.",
+    "Permission:Presence.Rooms.Join": "Join a shared resource (CMS page, dashboard, …) and broadcast my presence to others",
+    "Permission:Presence.Rooms.Read": "View who else is currently active in a shared resource (CMS page, dashboard, …)",
     "Permission:Presence.Self.Manage": "Set or clear my own presence status (Available, Busy, Do Not Disturb, Appear Offline)",
     "Permission:Presence.Users.Read": "View the presence status of other users",
     "PermissionGroup:Presence": "Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/en.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/en.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "Idle duration exceeds the maximum allowed value.",
     "Granit:Validation:PresenceOverrideUntilInPast": "Override expiration must be in the future.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "Override expiration is too far in the future.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Metadata exceeds the maximum allowed size.",
     "Granit:Validation:PresenceUntilWithoutOverride": "An expiration cannot be supplied when the manual status is Available.",
+    "Permission:Presence.Rooms.Join": "Join a shared resource (CMS page, dashboard, …) and broadcast my presence to others",
+    "Permission:Presence.Rooms.Read": "View who else is currently active in a shared resource (CMS page, dashboard, …)",
     "Permission:Presence.Self.Manage": "Set or clear my own presence status (Available, Busy, Do Not Disturb, Appear Offline)",
     "Permission:Presence.Users.Read": "View the presence status of other users",
     "PermissionGroup:Presence": "Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/es.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/es.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "La duración de inactividad supera el valor máximo permitido.",
     "Granit:Validation:PresenceOverrideUntilInPast": "La expiración de la anulación debe estar en el futuro.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "La expiración de la anulación está demasiado lejos en el futuro.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Los metadatos superan el tamaño máximo permitido.",
     "Granit:Validation:PresenceUntilWithoutOverride": "No se puede proporcionar una expiración cuando el estado manual es Disponible.",
+    "Permission:Presence.Rooms.Join": "Unirse a un recurso compartido (página CMS, panel, …) y transmitir mi presencia",
+    "Permission:Presence.Rooms.Read": "Ver quién está activo actualmente en un recurso compartido (página CMS, panel, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/fr-CA.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/fr-CA.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "La durée d'inactivité dépasse la valeur maximale autorisée.",
     "Granit:Validation:PresenceOverrideUntilInPast": "L'expiration de la surcharge doit être dans le futur.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "L'expiration de la surcharge est trop éloignée dans le futur.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Les métadonnées dépassent la taille maximale autorisée.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Aucune expiration ne peut être fournie lorsque le statut manuel est Disponible.",
+    "Permission:Presence.Rooms.Join": "Rejoindre une ressource partagée (page CMS, tableau de bord, …) et diffuser ma présence",
+    "Permission:Presence.Rooms.Read": "Voir qui consulte actuellement une ressource partagée (page CMS, tableau de bord, …)",
     "Permission:Presence.Self.Manage": "Définir ou effacer mon propre statut de disponibilité (Disponible, Occupé, Ne pas déranger, Apparaître hors ligne)",
     "Permission:Presence.Users.Read": "Consulter le statut de disponibilité des autres utilisateurs",
     "PermissionGroup:Presence": "Disponibilité"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/fr.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/fr.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "La durée d'inactivité dépasse la valeur maximale autorisée.",
     "Granit:Validation:PresenceOverrideUntilInPast": "L'expiration de la surcharge doit être dans le futur.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "L'expiration de la surcharge est trop éloignée dans le futur.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Les métadonnées dépassent la taille maximale autorisée.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Une expiration ne peut pas être fournie lorsque le statut manuel est Disponible.",
+    "Permission:Presence.Rooms.Join": "Rejoindre une ressource partagée (page CMS, tableau de bord, …) et diffuser ma présence",
+    "Permission:Presence.Rooms.Read": "Voir qui consulte actuellement une ressource partagée (page CMS, tableau de bord, …)",
     "Permission:Presence.Self.Manage": "Définir ou effacer mon propre statut de disponibilité (Disponible, Occupé, Ne pas déranger, Apparaître hors ligne)",
     "Permission:Presence.Users.Read": "Consulter le statut de disponibilité des autres utilisateurs",
     "PermissionGroup:Presence": "Disponibilité"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/hi.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/hi.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "निष्क्रिय अवधि अधिकतम अनुमत मान से अधिक है।",
     "Granit:Validation:PresenceOverrideUntilInPast": "ओवरराइड की समाप्ति भविष्य में होनी चाहिए।",
     "Granit:Validation:PresenceOverrideUntilTooFar": "ओवरराइड की समाप्ति भविष्य में बहुत दूर है।",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "मेटाडेटा अनुमत अधिकतम आकार से अधिक है।",
     "Granit:Validation:PresenceUntilWithoutOverride": "जब मैनुअल स्थिति उपलब्ध हो तो समाप्ति प्रदान नहीं की जा सकती।",
+    "Permission:Presence.Rooms.Join": "साझा संसाधन (CMS पृष्ठ, डैशबोर्ड, …) में शामिल हों और अपनी उपस्थिति दूसरों को दिखाएँ",
+    "Permission:Presence.Rooms.Read": "देखें कि साझा संसाधन (CMS पृष्ठ, डैशबोर्ड, …) में अभी कौन सक्रिय है",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/it.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/it.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "La durata di inattività supera il valore massimo consentito.",
     "Granit:Validation:PresenceOverrideUntilInPast": "La scadenza dell'override deve essere nel futuro.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "La scadenza dell'override è troppo lontana nel futuro.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "I metadati superano la dimensione massima consentita.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Non è possibile fornire una scadenza quando lo stato manuale è Disponibile.",
+    "Permission:Presence.Rooms.Join": "Entra in una risorsa condivisa (pagina CMS, dashboard, …) e diffondi la mia presenza",
+    "Permission:Presence.Rooms.Read": "Visualizza chi è attualmente attivo su una risorsa condivisa (pagina CMS, dashboard, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/ja.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/ja.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "アイドル時間が許可された最大値を超えています。",
     "Granit:Validation:PresenceOverrideUntilInPast": "オーバーライドの有効期限は将来である必要があります。",
     "Granit:Validation:PresenceOverrideUntilTooFar": "オーバーライドの有効期限が将来に遠すぎます。",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "メタデータが許可される最大サイズを超えています。",
     "Granit:Validation:PresenceUntilWithoutOverride": "手動ステータスが「利用可能」の場合、有効期限を指定できません。",
+    "Permission:Presence.Rooms.Join": "共有リソース（CMSページ、ダッシュボードなど）に参加し、自分のプレゼンスを他のユーザーに通知する",
+    "Permission:Presence.Rooms.Read": "共有リソース（CMSページ、ダッシュボードなど）に現在アクセスしている他のユーザーを表示する",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/ko.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/ko.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "유휴 시간이 허용된 최대값을 초과합니다.",
     "Granit:Validation:PresenceOverrideUntilInPast": "재정의 만료는 미래여야 합니다.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "재정의 만료가 미래에 너무 멉니다.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "메타데이터가 허용되는 최대 크기를 초과합니다.",
     "Granit:Validation:PresenceUntilWithoutOverride": "수동 상태가 '사용 가능'일 때는 만료를 제공할 수 없습니다.",
+    "Permission:Presence.Rooms.Join": "공유 리소스(CMS 페이지, 대시보드 등)에 참여하고 내 존재를 다른 사용자에게 알립니다",
+    "Permission:Presence.Rooms.Read": "공유 리소스(CMS 페이지, 대시보드 등)에서 현재 활동 중인 다른 사용자를 봅니다",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/nl.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/nl.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "De inactiviteitsduur overschrijdt de maximaal toegestane waarde.",
     "Granit:Validation:PresenceOverrideUntilInPast": "De vervaldatum van de overschrijving moet in de toekomst liggen.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "De vervaldatum van de overschrijving ligt te ver in de toekomst.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Metadata overschrijdt de maximaal toegestane grootte.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Er kan geen vervaldatum worden opgegeven wanneer de handmatige status Beschikbaar is.",
+    "Permission:Presence.Rooms.Join": "Neem deel aan een gedeelde resource (CMS-pagina, dashboard, …) en deel mijn aanwezigheid",
+    "Permission:Presence.Rooms.Read": "Bekijk wie er momenteel actief is op een gedeelde resource (CMS-pagina, dashboard, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/pl.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/pl.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "Czas bezczynności przekracza maksymalną dozwoloną wartość.",
     "Granit:Validation:PresenceOverrideUntilInPast": "Wygaśnięcie nadpisania musi być w przyszłości.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "Wygaśnięcie nadpisania jest zbyt odległe w przyszłości.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Metadane przekraczają maksymalny dozwolony rozmiar.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Nie można podać wygaśnięcia, gdy status ręczny to Dostępny.",
+    "Permission:Presence.Rooms.Join": "Dołącz do współdzielonego zasobu (strona CMS, pulpit, …) i nadawaj swoją obecność",
+    "Permission:Presence.Rooms.Read": "Zobacz, kto jest obecnie aktywny we współdzielonym zasobie (strona CMS, pulpit, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/pt-BR.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/pt-BR.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "A duração de inatividade excede o valor máximo permitido.",
     "Granit:Validation:PresenceOverrideUntilInPast": "A expiração da substituição deve estar no futuro.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "A expiração da substituição está muito distante no futuro.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Os metadados excedem o tamanho máximo permitido.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Não é possível fornecer uma expiração quando o status manual é Disponível.",
+    "Permission:Presence.Rooms.Join": "Entrar em um recurso compartilhado (página CMS, painel, …) e divulgar minha presença",
+    "Permission:Presence.Rooms.Read": "Ver quem está atualmente ativo em um recurso compartilhado (página CMS, painel, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/pt.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/pt.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "A duração de inactividade excede o valor máximo permitido.",
     "Granit:Validation:PresenceOverrideUntilInPast": "A expiração da substituição deve estar no futuro.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "A expiração da substituição está demasiado distante no futuro.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Os metadados excedem o tamanho máximo permitido.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Não pode ser fornecida uma expiração quando o estado manual é Disponível.",
+    "Permission:Presence.Rooms.Join": "Entrar num recurso partilhado (página CMS, painel, …) e divulgar a minha presença",
+    "Permission:Presence.Rooms.Read": "Ver quem está atualmente ativo num recurso partilhado (página CMS, painel, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/sv.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/sv.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "Inaktivitetstid överstiger det maximalt tillåtna värdet.",
     "Granit:Validation:PresenceOverrideUntilInPast": "Åsidosättningens utgång måste vara i framtiden.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "Åsidosättningens utgång är för långt fram i tiden.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Metadata överskrider den högsta tillåtna storleken.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Ett utgångsdatum kan inte anges när den manuella statusen är Tillgänglig.",
+    "Permission:Presence.Rooms.Join": "Gå med i en delad resurs (CMS-sida, instrumentpanel, …) och visa min närvaro för andra",
+    "Permission:Presence.Rooms.Read": "Visa vem som för närvarande är aktiv i en delad resurs (CMS-sida, instrumentpanel, …)",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/tr.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/tr.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "Boşta kalma süresi izin verilen maksimum değeri aşıyor.",
     "Granit:Validation:PresenceOverrideUntilInPast": "Geçersiz kılma sona erme tarihi gelecekte olmalıdır.",
     "Granit:Validation:PresenceOverrideUntilTooFar": "Geçersiz kılma sona erme tarihi gelecekte çok uzak.",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "Meta veriler izin verilen maksimum boyutu aşıyor.",
     "Granit:Validation:PresenceUntilWithoutOverride": "Manuel durum Müsait olduğunda sona erme tarihi sağlanamaz.",
+    "Permission:Presence.Rooms.Join": "Paylaşılan bir kaynağa (CMS sayfası, gösterge tablosu, …) katılın ve varlığımı diğerlerine yayınlayın",
+    "Permission:Presence.Rooms.Read": "Paylaşılan bir kaynakta (CMS sayfası, gösterge tablosu, …) şu anda kimin etkin olduğunu görüntüleyin",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/zh.json
+++ b/src/Granit.Presence.Endpoints/Localization/PresenceEndpoints/zh.json
@@ -7,7 +7,10 @@
     "Granit:Validation:PresenceIdleSecondsTooLarge": "空闲时间超过允许的最大值。",
     "Granit:Validation:PresenceOverrideUntilInPast": "覆盖的到期时间必须在将来。",
     "Granit:Validation:PresenceOverrideUntilTooFar": "覆盖的到期时间在将来过于遥远。",
+    "Granit:Validation:PresenceRoomMetadataTooLarge": "元数据超出允许的最大大小。",
     "Granit:Validation:PresenceUntilWithoutOverride": "当手动状态为“可用”时不能提供到期时间。",
+    "Permission:Presence.Rooms.Join": "加入共享资源（CMS 页面、仪表板等）并向其他用户广播我的在线状态",
+    "Permission:Presence.Rooms.Read": "查看当前在共享资源（CMS 页面、仪表板等）上活跃的其他用户",
     "Permission:Presence.Self.Manage": "<!-- AUTO-TRANSLATED -->Set or clear my own presence status",
     "Permission:Presence.Users.Read": "<!-- AUTO-TRANSLATED -->View the presence status of other users",
     "PermissionGroup:Presence": "<!-- AUTO-TRANSLATED -->Presence"

--- a/src/Granit.Presence.Endpoints/Options/PresenceEndpointsOptions.cs
+++ b/src/Granit.Presence.Endpoints/Options/PresenceEndpointsOptions.cs
@@ -13,4 +13,7 @@ public sealed class PresenceEndpointsOptions
 
     /// <summary>OpenAPI tag name for grouping presence endpoints. Default: <c>"Presence"</c>.</summary>
     public string TagName { get; set; } = "Presence";
+
+    /// <summary>OpenAPI tag name for the resource-room endpoints. Default: <c>"Presence - Rooms"</c>.</summary>
+    public string RoomsTagName { get; set; } = "Presence - Rooms";
 }

--- a/src/Granit.Presence.Endpoints/Permissions/PresencePermissionDefinitionProvider.cs
+++ b/src/Granit.Presence.Endpoints/Permissions/PresencePermissionDefinitionProvider.cs
@@ -31,5 +31,17 @@ internal sealed class PresencePermissionDefinitionProvider : IPermissionDefiniti
             LocalizableString.Create<PresenceEndpointsLocalizationResource>(
                 "Permission:Presence.Users.Read"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            PresencePermissions.Rooms.Read,
+            LocalizableString.Create<PresenceEndpointsLocalizationResource>(
+                "Permission:Presence.Rooms.Read"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            PresencePermissions.Rooms.Join,
+            LocalizableString.Create<PresenceEndpointsLocalizationResource>(
+                "Permission:Presence.Rooms.Join"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Presence.Endpoints/Permissions/PresencePermissions.cs
+++ b/src/Granit.Presence.Endpoints/Permissions/PresencePermissions.cs
@@ -21,4 +21,14 @@ public static class PresencePermissions
         /// <summary>Grants the right to read another user's presence snapshot (single or batch).</summary>
         public const string Read = "Presence.Users.Read";
     }
+
+    /// <summary>Permissions covering resource-scoped presence rooms (multi-user awareness).</summary>
+    public static class Rooms
+    {
+        /// <summary>Grants the right to read a resource room — the list of users currently present.</summary>
+        public const string Read = "Presence.Rooms.Read";
+
+        /// <summary>Grants the right to join (heartbeat) or leave a resource room.</summary>
+        public const string Join = "Presence.Rooms.Join";
+    }
 }

--- a/src/Granit.Presence.Endpoints/Validators/HeartbeatRoomRequestValidator.cs
+++ b/src/Granit.Presence.Endpoints/Validators/HeartbeatRoomRequestValidator.cs
@@ -1,0 +1,20 @@
+using System.Text;
+using FluentValidation;
+using Granit.Presence.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Presence.Endpoints.Validators;
+
+internal sealed class HeartbeatRoomRequestValidator : GranitValidator<HeartbeatRoomRequest>
+{
+    /// <summary>Maximum metadata UTF-8 byte size accepted on a heartbeat.</summary>
+    public const int MaxMetadataBytes = 512;
+
+    public HeartbeatRoomRequestValidator()
+    {
+        RuleFor(x => x.Metadata)
+            .Must(m => m is null || Encoding.UTF8.GetByteCount(m) <= MaxMetadataBytes)
+            .WithErrorCodeAndMessage("Granit:Validation:PresenceRoomMetadataTooLarge");
+    }
+}

--- a/src/Granit.Presence/Abstractions/IResourcePresenceTracker.cs
+++ b/src/Granit.Presence/Abstractions/IResourcePresenceTracker.cs
@@ -1,0 +1,57 @@
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// Resource-scoped multi-user awareness tracker — complements the user-keyed
+/// <see cref="IPresenceTracker"/> with "who else is here?" semantics for collaborative
+/// surfaces (CMS pages, dashboards, kanban cards…).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations MUST de-duplicate by <see cref="ResourcePresenceEntry.UserId"/> (multi-tab
+/// safe), apply the MAX anti-flapping rule on <c>LastSeenUtc</c>, filter out entries older than
+/// <c>PresenceOptions.OfflineThreshold</c> at read time, and remove the cache entry entirely
+/// when the room becomes empty so no <c>{}</c> blob lingers.
+/// </para>
+/// <para>
+/// Metadata is capped at 512 bytes serialized; oversize values are rejected with
+/// <see cref="ArgumentException"/> at join time.
+/// </para>
+/// </remarks>
+public interface IResourcePresenceTracker
+{
+    /// <summary>
+    /// Joins (or heartbeats) the supplied user into the room and returns the resulting snapshot.
+    /// Idempotent on <paramref name="userId"/>: a repeat call refreshes <c>LastSeenUtc</c>
+    /// (MAX-merged) and overwrites the metadata.
+    /// </summary>
+    /// <param name="resource">The room's resource identifier.</param>
+    /// <param name="userId">The joining user. MUST be a non-empty GUID.</param>
+    /// <param name="metadata">
+    /// Optional opaque caller-supplied UTF-8 string (≤ 512 bytes serialized). Pass <c>null</c>
+    /// to clear any previously recorded metadata for the user in this room.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The room after the user has been merged in.</returns>
+    Task<ResourceRoom> JoinAsync(
+        ResourceRef resource,
+        Guid userId,
+        string? metadata = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the user from the room. No-op when the user is absent. When the resulting
+    /// room is empty the cache entry is evicted entirely.
+    /// </summary>
+    Task LeaveAsync(
+        ResourceRef resource,
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the room snapshot — stale participants (older than
+    /// <c>PresenceOptions.OfflineThreshold</c>) are filtered at read time.
+    /// </summary>
+    Task<ResourceRoom> GetAsync(
+        ResourceRef resource,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Presence/Abstractions/IResourcePresenceVisibilityPolicy.cs
+++ b/src/Granit.Presence/Abstractions/IResourcePresenceVisibilityPolicy.cs
@@ -1,0 +1,54 @@
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// Authorises read access to a <see cref="ResourceRoom"/> and filters its participants. The
+/// counterpart to <see cref="IPresenceVisibilityPolicy"/> for the resource-scoped surface —
+/// rooms are referenced by an opaque (kind, id) pair the framework cannot independently
+/// authorise, so the host application MUST provide this seam in any deployment where rooms
+/// are not freely readable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework ships <see cref="Internal.AllowAllResourcePresenceVisibilityPolicy"/> as a
+/// permissive default. Multi-tenant deployments — or any host where room kinds carry their
+/// own authorisation model — MUST register a replacement before the endpoints are mapped.
+/// </para>
+/// <para>
+/// Failed authorisation surfaces as <c>404 Not Found</c> at the endpoint layer (not 403) to
+/// avoid leaking room existence — same rationale as user-presence reads.
+/// </para>
+/// <para>
+/// This policy is consulted on <b>read</b> operations only. <c>JoinAsync</c> is a self-action
+/// guarded by the <c>Presence.Rooms.Join</c> route permission.
+/// </para>
+/// </remarks>
+public interface IResourcePresenceVisibilityPolicy
+{
+    /// <summary>Returns <c>true</c> when the caller is allowed to observe the room at all.</summary>
+    /// <param name="callerUserId">
+    /// Authenticated caller's user identifier, or <see cref="Guid.Empty"/> when unresolved.
+    /// </param>
+    /// <param name="resource">The room identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<bool> CanReadRoomAsync(
+        Guid callerUserId,
+        ResourceRef resource,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Filters the room's participant list down to those visible to the caller. Implementations
+    /// may use this to hide users in other tenants / outside the caller's collaboration scope
+    /// even when the room itself is readable.
+    /// </summary>
+    /// <param name="callerUserId">
+    /// Authenticated caller's user identifier, or <see cref="Guid.Empty"/> when unresolved.
+    /// </param>
+    /// <param name="resource">The room identifier.</param>
+    /// <param name="participantUserIds">The room's current participant user identifiers.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlySet<Guid>> FilterVisibleParticipantsAsync(
+        Guid callerUserId,
+        ResourceRef resource,
+        IReadOnlyCollection<Guid> participantUserIds,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Presence/Abstractions/ResourcePresenceEntry.cs
+++ b/src/Granit.Presence/Abstractions/ResourcePresenceEntry.cs
@@ -1,0 +1,19 @@
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// A single participant entry inside a <see cref="ResourceRoom"/>. Stored verbatim in the
+/// presence cache and returned to clients via the resource-presence endpoints.
+/// </summary>
+/// <param name="UserId">The participant's user identifier.</param>
+/// <param name="LastSeenUtc">
+/// Server-side instant of the participant's most recent heartbeat into this room. Used to
+/// expire stale entries on read (older than <c>PresenceOptions.OfflineThreshold</c>).
+/// </param>
+/// <param name="Metadata">
+/// Optional opaque, caller-supplied UTF-8 string (≤ 512 bytes — enforced at write time)
+/// — typically a JSON blob describing the participant's UI cursor / section.
+/// </param>
+public sealed record ResourcePresenceEntry(
+    Guid UserId,
+    DateTimeOffset LastSeenUtc,
+    string? Metadata = null);

--- a/src/Granit.Presence/Abstractions/ResourceRef.cs
+++ b/src/Granit.Presence/Abstractions/ResourceRef.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// Identifies a "room" — a single resource that multiple users may concurrently
+/// view or edit. Combined with a tenant scope, drives the cache-key for
+/// <see cref="IResourcePresenceTracker"/>.
+/// </summary>
+/// <param name="Kind">
+/// Resource kind discriminator (e.g. <c>"document"</c>, <c>"cms.page"</c>). MUST match
+/// <c>^[a-z][a-z0-9_.-]{0,63}$</c> — lowercase, kebab/snake/dotted, ≤ 64 chars — to bound
+/// metric tag cardinality and keep room keys URL-friendly.
+/// </param>
+/// <param name="Id">
+/// Opaque resource identifier (≤ 256 chars). Typically a stringified Guid, slug, or
+/// composite key chosen by the consuming module.
+/// </param>
+public readonly partial record struct ResourceRef(string Kind, string Id)
+{
+    /// <summary>Maximum length of <see cref="Id"/>.</summary>
+    public const int MaxIdLength = 256;
+
+    /// <summary>Maximum length of <see cref="Kind"/>.</summary>
+    public const int MaxKindLength = 64;
+
+    /// <summary>Throws when <see cref="Kind"/> / <see cref="Id"/> are missing or out-of-range.</summary>
+    /// <exception cref="ArgumentException">When validation fails.</exception>
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrEmpty(Kind);
+        ArgumentException.ThrowIfNullOrEmpty(Id);
+
+        if (!KindPattern().IsMatch(Kind))
+        {
+            throw new ArgumentException(
+                $"Resource kind '{Kind}' is invalid. Must match ^[a-z][a-z0-9_.-]{{0,63}}$.",
+                nameof(Kind));
+        }
+
+        if (Id.Length > MaxIdLength)
+        {
+            throw new ArgumentException(
+                $"Resource id length {Id.Length} exceeds maximum {MaxIdLength}.",
+                nameof(Id));
+        }
+    }
+
+    [GeneratedRegex("^[a-z][a-z0-9_.-]{0,63}$")]
+    private static partial Regex KindPattern();
+}

--- a/src/Granit.Presence/Abstractions/ResourceRoom.cs
+++ b/src/Granit.Presence/Abstractions/ResourceRoom.cs
@@ -1,0 +1,14 @@
+namespace Granit.Presence.Abstractions;
+
+/// <summary>
+/// Snapshot of the participants currently active inside a resource room.
+/// </summary>
+/// <param name="Resource">The room's resource identifier.</param>
+/// <param name="Participants">
+/// Live participants, de-duplicated by <see cref="ResourcePresenceEntry.UserId"/> and
+/// filtered to those whose <see cref="ResourcePresenceEntry.LastSeenUtc"/> is within
+/// <c>PresenceOptions.OfflineThreshold</c>.
+/// </param>
+public sealed record ResourceRoom(
+    ResourceRef Resource,
+    IReadOnlyList<ResourcePresenceEntry> Participants);

--- a/src/Granit.Presence/Diagnostics/PresenceActivitySource.cs
+++ b/src/Granit.Presence/Diagnostics/PresenceActivitySource.cs
@@ -23,4 +23,10 @@ internal static class PresenceActivitySource
     internal const string QueryEffective = "presence.query_effective";
     internal const string SetOverride = "presence.set_override";
     internal const string GateNotification = "presence.gate_notification";
+
+    // ──── Resource-room operations ────
+
+    internal const string RoomJoin = "Granit.Presence.Room.Join";
+    internal const string RoomLeave = "Granit.Presence.Room.Leave";
+    internal const string RoomGet = "Granit.Presence.Room.Get";
 }

--- a/src/Granit.Presence/Diagnostics/PresenceMetrics.cs
+++ b/src/Granit.Presence/Diagnostics/PresenceMetrics.cs
@@ -19,11 +19,23 @@ public sealed class PresenceMetrics
     private const string TagTo = "to";
     private const string TagStatus = "status";
     private const string TagHasUntil = "has_until";
+    private const string TagResourceKind = "resource_kind";
+    private const string TagReason = "reason";
+
+    /// <summary>Reasons emitted by <see cref="RecordRoomLeave"/>.</summary>
+    public const string ReasonExplicit = "explicit";
+
+    /// <summary>Reasons emitted by <see cref="RecordRoomLeave"/>.</summary>
+    public const string ReasonStale = "stale";
 
     private readonly Counter<long> _heartbeatReceived;
     private readonly Counter<long> _statusChanged;
     private readonly Counter<long> _overrideSet;
     private readonly Counter<long> _notificationGated;
+    private readonly Counter<long> _roomJoin;
+    private readonly Counter<long> _roomLeave;
+    private readonly Histogram<int> _roomSize;
+    private readonly Histogram<int> _roomMetadataBytes;
 
     /// <summary>Initializes the meter and all instruments.</summary>
     public PresenceMetrics(IMeterFactory meterFactory)
@@ -47,6 +59,24 @@ public sealed class PresenceMetrics
         _notificationGated = meter.CreateCounter<long>(
             "granit.presence.notification.gated",
             description: "Number of notification deliveries suppressed by the presence gate.");
+
+        _roomJoin = meter.CreateCounter<long>(
+            "granit.presence.room.join",
+            description: "Number of join heartbeats received against a resource room.");
+
+        _roomLeave = meter.CreateCounter<long>(
+            "granit.presence.room.leave",
+            description: "Number of leaves from a resource room (explicit or stale eviction).");
+
+        _roomSize = meter.CreateHistogram<int>(
+            "granit.presence.room.size",
+            unit: "{participants}",
+            description: "Participant count observed when a resource room is fetched or mutated.");
+
+        _roomMetadataBytes = meter.CreateHistogram<int>(
+            "granit.presence.room.metadata.bytes",
+            unit: "By",
+            description: "Size in bytes of metadata supplied on a resource room join.");
     }
 
     /// <summary>Records a single heartbeat received from a client.</summary>
@@ -80,5 +110,40 @@ public sealed class PresenceMetrics
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { "channel", channelName },
+        });
+
+    /// <summary>Records a successful join (or re-heartbeat) into a resource room.</summary>
+    public void RecordRoomJoin(string? tenantId, string resourceKind) =>
+        _roomJoin.Add(1, new TagList
+        {
+            { TagResourceKind, resourceKind },
+            { TagTenantId, tenantId ?? DefaultTenant },
+        });
+
+    /// <summary>
+    /// Records a leave from a resource room. <paramref name="reason"/> SHOULD be one of
+    /// <see cref="ReasonExplicit"/> / <see cref="ReasonStale"/>.
+    /// </summary>
+    public void RecordRoomLeave(string? tenantId, string resourceKind, string reason) =>
+        _roomLeave.Add(1, new TagList
+        {
+            { TagResourceKind, resourceKind },
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagReason, reason },
+        });
+
+    /// <summary>Records the size of a resource room observed at a join / leave / get.</summary>
+    public void RecordRoomSize(string? tenantId, string resourceKind, int participantCount) =>
+        _roomSize.Record(participantCount, new TagList
+        {
+            { TagResourceKind, resourceKind },
+            { TagTenantId, tenantId ?? DefaultTenant },
+        });
+
+    /// <summary>Records the metadata payload size in bytes on a room join.</summary>
+    public void RecordRoomMetadataBytes(string resourceKind, int byteCount) =>
+        _roomMetadataBytes.Record(byteCount, new TagList
+        {
+            { TagResourceKind, resourceKind },
         });
 }

--- a/src/Granit.Presence/Extensions/PresenceHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Presence/Extensions/PresenceHostApplicationBuilderExtensions.cs
@@ -52,9 +52,14 @@ public static class PresenceHostApplicationBuilderExtensions
         // Default tracker uses IFusionCache from Granit.Caching (L1 + optional Redis L2 backplane).
         builder.Services.TryAddSingleton<IPresenceTracker, FusionCachePresenceTracker>();
 
+        // Resource-scoped multi-user awareness rooms. Scoped because it consults the request-scoped
+        // ICurrentTenant; FusionCache itself is a singleton so concurrency stays cheap.
+        builder.Services.TryAddScoped<IResourcePresenceTracker, FusionCacheResourcePresenceTracker>();
+
         // Permissive default visibility policy. Multi-tenant apps MUST register a tenant-aware
         // replacement before the endpoints are mapped (otherwise cross-tenant reads succeed).
         builder.Services.TryAddSingleton<IPresenceVisibilityPolicy, AllowAllPresenceVisibilityPolicy>();
+        builder.Services.TryAddScoped<IResourcePresenceVisibilityPolicy, AllowAllResourcePresenceVisibilityPolicy>();
 
         // Query service is concrete + interface-registered so internal consumers can take the concrete type.
         builder.Services.TryAddScoped<PresenceQueryService>();

--- a/src/Granit.Presence/Internal/AllowAllResourcePresenceVisibilityPolicy.cs
+++ b/src/Granit.Presence/Internal/AllowAllResourcePresenceVisibilityPolicy.cs
@@ -1,0 +1,27 @@
+using Granit.Presence.Abstractions;
+
+namespace Granit.Presence.Internal;
+
+/// <summary>
+/// Permissive default <see cref="IResourcePresenceVisibilityPolicy"/>: every caller may read
+/// every room and see every participant. Suitable only for single-tenant or fully-public
+/// deployments — multi-tenant hosts MUST replace this.
+/// </summary>
+internal sealed class AllowAllResourcePresenceVisibilityPolicy : IResourcePresenceVisibilityPolicy
+{
+    public Task<bool> CanReadRoomAsync(
+        Guid callerUserId,
+        ResourceRef resource,
+        CancellationToken cancellationToken) => Task.FromResult(true);
+
+    public Task<IReadOnlySet<Guid>> FilterVisibleParticipantsAsync(
+        Guid callerUserId,
+        ResourceRef resource,
+        IReadOnlyCollection<Guid> participantUserIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(participantUserIds);
+        IReadOnlySet<Guid> visible = participantUserIds is HashSet<Guid> hs ? hs : [.. participantUserIds];
+        return Task.FromResult(visible);
+    }
+}

--- a/src/Granit.Presence/Internal/FusionCacheResourcePresenceTracker.cs
+++ b/src/Granit.Presence/Internal/FusionCacheResourcePresenceTracker.cs
@@ -1,0 +1,276 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using Granit.MultiTenancy;
+using Granit.Presence.Abstractions;
+using Granit.Presence.Diagnostics;
+using Granit.Presence.Options;
+using Granit.Timing;
+using Microsoft.Extensions.Options;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Presence.Internal;
+
+/// <summary>
+/// <see cref="IResourcePresenceTracker"/> implementation backed by <see cref="IFusionCache"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cache key shape: <c>granit.presence.room:{tenantId}:{kind}:{id}</c>. <c>tenantId</c>
+/// coalesces to <c>"global"</c> when no tenant context is available — keeps the rooms
+/// tenant-scoped without requiring a hard <see cref="ICurrentTenant"/> dependency.
+/// </para>
+/// <para>
+/// Concurrency: under high contention two parallel <c>JoinAsync</c> calls may race on the
+/// read-modify-write; the MAX-merge on timestamps makes the loss self-healing on the next
+/// heartbeat. FusionCache's L1 lock keeps the writes consistent on a single node; the L2
+/// backplane (when wired) propagates the final state.
+/// </para>
+/// </remarks>
+internal sealed class FusionCacheResourcePresenceTracker(
+    IFusionCache cache,
+    IClock clock,
+    ICurrentTenant currentTenant,
+    IOptionsMonitor<PresenceOptions> options,
+    PresenceMetrics metrics) : IResourcePresenceTracker
+{
+    private const string CacheKeyPrefix = "granit.presence.room";
+    private const string GlobalTenant = "global";
+
+    /// <summary>Maximum metadata size in bytes (UTF-8) accepted by <see cref="JoinAsync"/>.</summary>
+    public const int MaxMetadataBytes = 512;
+
+    public async Task<ResourceRoom> JoinAsync(
+        ResourceRef resource,
+        Guid userId,
+        string? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        resource.Validate();
+
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        int metadataBytes = metadata is null ? 0 : Encoding.UTF8.GetByteCount(metadata);
+        if (metadataBytes > MaxMetadataBytes)
+        {
+            throw new ArgumentException(
+                $"Metadata size {metadataBytes} bytes exceeds the maximum of {MaxMetadataBytes} bytes.",
+                nameof(metadata));
+        }
+
+        string? tenantId = ResolveTenantTag();
+
+        using Activity? activity = PresenceActivitySource.Source.StartActivity(PresenceActivitySource.RoomJoin);
+        EnrichActivity(activity, resource, tenantId);
+
+        PresenceOptions opts = options.CurrentValue;
+        DateTimeOffset nowUtc = clock.Now;
+        string key = CacheKey(resource, tenantId);
+
+        List<ResourcePresenceEntry>? existing = await cache
+            .GetOrDefaultAsync<List<ResourcePresenceEntry>?>(key, defaultValue: null, token: cancellationToken)
+            .ConfigureAwait(false);
+
+        List<ResourcePresenceEntry> merged = MergeJoin(existing, userId, nowUtc, metadata, opts.OfflineThreshold);
+
+        await cache.SetAsync(key, merged, opts.HeartbeatCacheTtl, token: cancellationToken).ConfigureAwait(false);
+
+        metrics.RecordRoomJoin(tenantId, resource.Kind);
+        metrics.RecordRoomSize(tenantId, resource.Kind, merged.Count);
+        if (metadata is not null)
+        {
+            metrics.RecordRoomMetadataBytes(resource.Kind, metadataBytes);
+        }
+        activity?.SetTag("room.size", merged.Count);
+
+        return new ResourceRoom(resource, merged);
+    }
+
+    public async Task LeaveAsync(
+        ResourceRef resource,
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        resource.Validate();
+
+        string? tenantId = ResolveTenantTag();
+        using Activity? activity = PresenceActivitySource.Source.StartActivity(PresenceActivitySource.RoomLeave);
+        EnrichActivity(activity, resource, tenantId);
+
+        string key = CacheKey(resource, tenantId);
+
+        List<ResourcePresenceEntry>? existing = await cache
+            .GetOrDefaultAsync<List<ResourcePresenceEntry>?>(key, defaultValue: null, token: cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is null || existing.Count == 0)
+        {
+            activity?.SetTag("room.size", 0);
+            return;
+        }
+
+        PresenceOptions opts = options.CurrentValue;
+        DateTimeOffset cutoff = clock.Now - opts.OfflineThreshold;
+
+        int staleDropped = 0;
+        bool removedSelf = false;
+        List<ResourcePresenceEntry> remaining = new(existing.Count);
+        foreach (ResourcePresenceEntry e in existing)
+        {
+            if (e.UserId == userId)
+            {
+                removedSelf = true;
+                continue;
+            }
+
+            if (e.LastSeenUtc >= cutoff)
+            {
+                remaining.Add(e);
+            }
+            else
+            {
+                staleDropped++;
+            }
+        }
+
+        if (removedSelf)
+        {
+            metrics.RecordRoomLeave(tenantId, resource.Kind, PresenceMetrics.ReasonExplicit);
+        }
+        for (int i = 0; i < staleDropped; i++)
+        {
+            metrics.RecordRoomLeave(tenantId, resource.Kind, PresenceMetrics.ReasonStale);
+        }
+
+        if (remaining.Count == 0)
+        {
+            await cache.RemoveAsync(key, token: cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await cache.SetAsync(key, remaining, opts.HeartbeatCacheTtl, token: cancellationToken).ConfigureAwait(false);
+        }
+
+        metrics.RecordRoomSize(tenantId, resource.Kind, remaining.Count);
+        activity?.SetTag("room.size", remaining.Count);
+    }
+
+    public async Task<ResourceRoom> GetAsync(
+        ResourceRef resource,
+        CancellationToken cancellationToken = default)
+    {
+        resource.Validate();
+
+        string? tenantId = ResolveTenantTag();
+        using Activity? activity = PresenceActivitySource.Source.StartActivity(PresenceActivitySource.RoomGet);
+        EnrichActivity(activity, resource, tenantId);
+
+        string key = CacheKey(resource, tenantId);
+
+        List<ResourcePresenceEntry>? existing = await cache
+            .GetOrDefaultAsync<List<ResourcePresenceEntry>?>(key, defaultValue: null, token: cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is null || existing.Count == 0)
+        {
+            activity?.SetTag("room.size", 0);
+            metrics.RecordRoomSize(tenantId, resource.Kind, 0);
+            return new ResourceRoom(resource, []);
+        }
+
+        PresenceOptions opts = options.CurrentValue;
+        DateTimeOffset cutoff = clock.Now - opts.OfflineThreshold;
+
+        List<ResourcePresenceEntry> live = new(existing.Count);
+        foreach (ResourcePresenceEntry e in existing)
+        {
+            if (e.LastSeenUtc >= cutoff)
+            {
+                live.Add(e);
+            }
+        }
+
+        metrics.RecordRoomSize(tenantId, resource.Kind, live.Count);
+        activity?.SetTag("room.size", live.Count);
+
+        return new ResourceRoom(resource, live);
+    }
+
+    /// <summary>
+    /// Applies the MAX anti-flapping rule + multi-tab dedup. Existing stale entries are
+    /// pruned in the same pass so the cache value doesn't grow unbounded under churn.
+    /// </summary>
+    private static List<ResourcePresenceEntry> MergeJoin(
+        List<ResourcePresenceEntry>? existing,
+        Guid userId,
+        DateTimeOffset nowUtc,
+        string? newMetadata,
+        TimeSpan offlineThreshold)
+    {
+        DateTimeOffset cutoff = nowUtc - offlineThreshold;
+        List<ResourcePresenceEntry> merged = existing is null ? [] : new List<ResourcePresenceEntry>(existing.Count + 1);
+
+        bool seen = false;
+        if (existing is not null)
+        {
+            foreach (ResourcePresenceEntry e in existing)
+            {
+                if (e.UserId == userId)
+                {
+                    seen = true;
+                    // MAX rule on LastSeenUtc; last metadata wins.
+                    DateTimeOffset maxSeen = e.LastSeenUtc > nowUtc ? e.LastSeenUtc : nowUtc;
+                    merged.Add(new ResourcePresenceEntry(userId, maxSeen, newMetadata));
+                }
+                else if (e.LastSeenUtc >= cutoff)
+                {
+                    merged.Add(e);
+                }
+                // stale → drop
+            }
+        }
+
+        if (!seen)
+        {
+            merged.Add(new ResourcePresenceEntry(userId, nowUtc, newMetadata));
+        }
+
+        return merged;
+    }
+
+    private string? ResolveTenantTag() =>
+        currentTenant.IsAvailable && currentTenant.Id is { } id ? id.ToString("N") : null;
+
+    private static string CacheKey(ResourceRef resource, string? tenantId) =>
+        $"{CacheKeyPrefix}:{tenantId ?? GlobalTenant}:{resource.Kind}:{resource.Id}";
+
+    /// <summary>
+    /// Stamps the activity with the resource tags. Long ids are SHA256-hashed (first 16 hex
+    /// chars) to keep span cardinality bounded — full ids still live in the cache key.
+    /// </summary>
+    private static void EnrichActivity(Activity? activity, ResourceRef resource, string? tenantId)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        activity.SetTag("resource.kind", resource.Kind);
+        activity.SetTag("resource.id", HashIfLong(resource.Id));
+        activity.SetTag("tenant.id", tenantId ?? GlobalTenant);
+    }
+
+    private static string HashIfLong(string id)
+    {
+        if (id.Length <= 32)
+        {
+            return id;
+        }
+
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(id));
+        return Convert.ToHexString(hash, 0, 8); // 8 bytes → 16 hex chars
+    }
+}

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -215,6 +215,8 @@
     <ProjectReference Include="..\..\src\Granit.Persistence.EntityFrameworkCore.Migrations\Granit.Persistence.EntityFrameworkCore.Migrations.csproj" />
     <ProjectReference Include="..\..\src\Granit.Persistence.EntityFrameworkCore.Postgres\Granit.Persistence.EntityFrameworkCore.Postgres.csproj" />
     <ProjectReference Include="..\..\src\Granit.Persistence.EntityFrameworkCore.SqlServer\Granit.Persistence.EntityFrameworkCore.SqlServer.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Presence\Granit.Presence.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Presence.Endpoints\Granit.Presence.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Privacy\Granit.Privacy.csproj" />
     <ProjectReference Include="..\..\src\Granit.Privacy.AI\Granit.Privacy.AI.csproj" />
     <ProjectReference Include="..\..\src\Granit.Privacy.BackgroundJobs\Granit.Privacy.BackgroundJobs.csproj" />

--- a/tests/Granit.ArchitectureTests/ResourcePresenceConventionsTests.cs
+++ b/tests/Granit.ArchitectureTests/ResourcePresenceConventionsTests.cs
@@ -1,0 +1,107 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Granit.Presence.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Conventions for the resource-scoped presence rooms surface introduced in #2408. Keeps the
+/// base <c>Granit.Presence</c> package free of HTTP / EF concerns and verifies that the new
+/// abstractions live in the canonical namespace.
+/// </summary>
+public sealed partial class ResourcePresenceConventionsTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void IResourcePresenceTracker_lives_in_abstractions_namespace()
+    {
+        typeof(IResourcePresenceTracker).Namespace.ShouldBe("Granit.Presence.Abstractions");
+    }
+
+    [Fact]
+    public void IResourcePresenceVisibilityPolicy_lives_in_abstractions_namespace()
+    {
+        typeof(IResourcePresenceVisibilityPolicy).Namespace.ShouldBe("Granit.Presence.Abstractions");
+    }
+
+    [Fact]
+    public void ResourceRef_lives_in_abstractions_namespace()
+    {
+        typeof(ResourceRef).Namespace.ShouldBe("Granit.Presence.Abstractions");
+    }
+
+    [Fact]
+    public void FusionCacheResourcePresenceTracker_is_internal_sealed()
+    {
+        Assembly presenceAssembly = typeof(IResourcePresenceTracker).Assembly;
+        Type? type = presenceAssembly.GetType("Granit.Presence.Internal.FusionCacheResourcePresenceTracker");
+        type.ShouldNotBeNull("FusionCacheResourcePresenceTracker type must exist in Granit.Presence.");
+        type!.IsSealed.ShouldBeTrue("FusionCacheResourcePresenceTracker must be sealed.");
+        type.IsVisible.ShouldBeFalse("FusionCacheResourcePresenceTracker must not be visible outside the assembly.");
+    }
+
+    [Fact]
+    public void Granit_Presence_base_module_does_not_reference_EntityFrameworkCore()
+    {
+        string csproj = Path.Join(RepoRoot, "src", "Granit.Presence", "Granit.Presence.csproj");
+        File.Exists(csproj).ShouldBeTrue();
+
+        string content = File.ReadAllText(csproj);
+        AnyReferenceMatching(content, "Microsoft.EntityFrameworkCore")
+            .ShouldBeFalse("Granit.Presence (base module) must not depend on EF Core.");
+    }
+
+    [Fact]
+    public void Granit_Presence_base_module_does_not_reference_AspNetCore()
+    {
+        string csproj = Path.Join(RepoRoot, "src", "Granit.Presence", "Granit.Presence.csproj");
+        File.Exists(csproj).ShouldBeTrue();
+
+        string content = File.ReadAllText(csproj);
+
+        AnyReferenceMatching(content, "Microsoft.AspNetCore")
+            .ShouldBeFalse("Granit.Presence (base module) must not depend on ASP.NET Core.");
+
+        FrameworkReferenceAspNetCore().IsMatch(content)
+            .ShouldBeFalse("Granit.Presence must not declare a FrameworkReference on Microsoft.AspNetCore.App.");
+    }
+
+    private static bool AnyReferenceMatching(string csproj, string prefix)
+    {
+        foreach (Match m in PackageReferenceInclude().Matches(csproj))
+        {
+            if (m.Groups[1].Value.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    [GeneratedRegex(@"<PackageReference\s+Include\s*=\s*""([^""]+)""")]
+    private static partial Regex PackageReferenceInclude();
+
+    [GeneratedRegex(@"<FrameworkReference\s+Include\s*=\s*""Microsoft\.AspNetCore\.App""")]
+    private static partial Regex FrameworkReferenceAspNetCore();
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(ResourcePresenceConventionsTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not locate repository root (no .git found).");
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3050,6 +3050,25 @@
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.*, )"
         }
       },
+      "granit.presence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.presence.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.RateLimiting": "[0.1.0-dev, )",
+          "Granit.Presence": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
       "granit.privacy": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Presence.Endpoints.Tests/Granit.Presence.Endpoints.Tests.csproj
+++ b/tests/Granit.Presence.Endpoints.Tests/Granit.Presence.Endpoints.Tests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
@@ -16,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Presence.Endpoints\Granit.Presence.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Presence.Endpoints.Tests/PresenceRoomEndpointsTests.cs
+++ b/tests/Granit.Presence.Endpoints.Tests/PresenceRoomEndpointsTests.cs
@@ -1,0 +1,354 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using FluentValidation;
+using Granit.MultiTenancy;
+using Granit.Presence.Abstractions;
+using Granit.Presence.Endpoints.Dtos;
+using Granit.Presence.Endpoints.Endpoints;
+using Granit.Presence.Endpoints.Permissions;
+using Granit.Presence.Endpoints.Validators;
+using Granit.RateLimiting;
+using Granit.RateLimiting.Abstractions;
+using Granit.RateLimiting.Diagnostics;
+using Granit.RateLimiting.Options;
+using Granit.Testing.Endpoints;
+using Granit.Users;
+using Granit.Validation.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Presence.Endpoints.Tests;
+
+/// <summary>
+/// HTTP-level tests for the resource-room endpoints. Drives a real <see cref="GranitEndpointTestHost"/>
+/// with a custom authentication handler so the caller's Guid sub-claim flows through to
+/// <c>PresenceCallerContext</c>.
+/// </summary>
+public sealed class PresenceRoomEndpointsTests
+{
+    private const string SchemeName = "GuidTest";
+    private const string UserIdHeader = "X-Test-UserId";
+
+    private static readonly ResourceRef SampleResource = new("document", "abc-123");
+
+    private static async Task<GranitEndpointTestHost> StartAsync(
+        IResourcePresenceTracker? tracker = null,
+        IResourcePresenceVisibilityPolicy? visibilityPolicy = null) =>
+        await GranitEndpointTestHost.StartAsync(
+            configureServices: services =>
+            {
+                // Replace the default test auth scheme with one that mints a configurable Guid sub claim.
+                services
+                    .AddAuthentication(SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, GuidSubAuthHandler>(SchemeName, _ => { });
+                services.PostConfigure<AuthenticationOptions>(o =>
+                {
+                    o.DefaultScheme = SchemeName;
+                    o.DefaultAuthenticateScheme = SchemeName;
+                    o.DefaultChallengeScheme = SchemeName;
+                });
+
+                services.AddAuthorizationBuilder()
+                    .AddPolicy(PresencePermissions.Rooms.Read,
+                        p => p.RequireAuthenticatedUser())
+                    .AddPolicy(PresencePermissions.Rooms.Join,
+                        p => p.RequireAuthenticatedUser());
+
+                services.AddSingleton(tracker ?? Substitute.For<IResourcePresenceTracker>());
+                services.AddSingleton(visibilityPolicy ?? new AllowAllResourcePresenceVisibilityPolicyForTests());
+                services.AddScoped<IValidator<HeartbeatRoomRequest>, HeartbeatRoomRequestValidator>();
+                services.AddProblemDetails();
+                services.AddMetrics();
+
+                // Rate-limiting stack: pre-wire just enough for the `RequireGranitRateLimiting`
+                // endpoint filter to short-circuit cheaply (Enabled = false).
+                services.AddSingleton<ICurrentTenant, NullTenantContext>();
+                services.AddSingleton<ICurrentUserService, SystemCurrentUserService>();
+                services.Configure<GranitRateLimitingOptions>(o => o.Enabled = false);
+                services.AddSingleton<IRateLimitCounterStore>(Substitute.For<IRateLimitCounterStore>());
+                services.AddSingleton<IRateLimitQuotaProvider>(Substitute.For<IRateLimitQuotaProvider>());
+                services.AddSingleton<RateLimitingMetrics>();
+                services.AddSingleton<TenantPartitionedRateLimiter>();
+            },
+            configureEndpoints: app =>
+            {
+                // Mount only the room endpoints to avoid pulling the full presence services
+                // (heartbeat recorder, override service, query service, …) into the test host.
+                RouteGroupBuilder group = app.MapGranitGroup("presence")
+                    .WithTags("Presence - Rooms")
+                    .RequireAuthorization();
+                group.MapRoomEndpoints();
+            });
+
+    private static HttpClient AuthedClient(GranitEndpointTestHost host, Guid userId)
+    {
+        HttpClient client = host.Application.GetTestClient();
+        client.DefaultRequestHeaders.Add(UserIdHeader, userId.ToString());
+        return client;
+    }
+
+    [Fact]
+    public async Task Heartbeat_returns_room_snapshot_on_success()
+    {
+        var userId = Guid.NewGuid();
+        IResourcePresenceTracker tracker = Substitute.For<IResourcePresenceTracker>();
+        tracker
+            .JoinAsync(Arg.Any<ResourceRef>(), Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceRoom(SampleResource, [new ResourcePresenceEntry(userId, DateTimeOffset.UtcNow, "{}")]));
+
+        await using GranitEndpointTestHost host = await StartAsync(tracker);
+        using HttpClient client = AuthedClient(host, userId);
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}/heartbeat",
+            new HeartbeatRoomRequest("{}"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        ResourceRoomResponse? body = await response.Content
+            .ReadFromJsonAsync<ResourceRoomResponse>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body!.Kind.ShouldBe(SampleResource.Kind);
+        body.Id.ShouldBe(SampleResource.Id);
+        body.Participants.Count.ShouldBe(1);
+        body.Participants[0].UserId.ShouldBe(userId);
+    }
+
+    [Fact]
+    public async Task Heartbeat_returns_401_when_caller_has_no_user_claim()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        // No header → anonymous (handler returns NoResult).
+        HttpClient client = host.Application.GetTestClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}/heartbeat",
+            new HeartbeatRoomRequest(null),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Heartbeat_returns_400_for_invalid_kind()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        using HttpClient client = AuthedClient(host, Guid.NewGuid());
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/presence/rooms/Document/abc/heartbeat", // uppercase kind
+            new HeartbeatRoomRequest(null),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Heartbeat_returns_422_when_metadata_exceeds_512_bytes()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        using HttpClient client = AuthedClient(host, Guid.NewGuid());
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}/heartbeat",
+            new HeartbeatRoomRequest(new string('x', 513)),
+            TestContext.Current.CancellationToken);
+
+        // FluentValidation auto-filter surfaces failures as 422 Unprocessable Entity.
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Get_returns_room_snapshot()
+    {
+        var alice = Guid.NewGuid();
+        IResourcePresenceTracker tracker = Substitute.For<IResourcePresenceTracker>();
+        tracker
+            .GetAsync(Arg.Any<ResourceRef>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceRoom(SampleResource, [new ResourcePresenceEntry(alice, DateTimeOffset.UtcNow, null)]));
+
+        await using GranitEndpointTestHost host = await StartAsync(tracker);
+        using HttpClient client = AuthedClient(host, Guid.NewGuid());
+
+        HttpResponseMessage response = await client.GetAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        ResourceRoomResponse? body = await response.Content
+            .ReadFromJsonAsync<ResourceRoomResponse>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body!.Participants.Count.ShouldBe(1);
+        body.Participants[0].UserId.ShouldBe(alice);
+    }
+
+    [Fact]
+    public async Task Get_returns_404_when_visibility_policy_denies_read()
+    {
+        var alice = Guid.NewGuid();
+        IResourcePresenceTracker tracker = Substitute.For<IResourcePresenceTracker>();
+        tracker
+            .GetAsync(Arg.Any<ResourceRef>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceRoom(SampleResource, [new ResourcePresenceEntry(alice, DateTimeOffset.UtcNow, null)]));
+
+        DenyAllResourcePresenceVisibilityPolicy denyPolicy = new();
+
+        await using GranitEndpointTestHost host = await StartAsync(tracker, denyPolicy);
+        using HttpClient client = AuthedClient(host, Guid.NewGuid());
+
+        HttpResponseMessage response = await client.GetAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_filters_participants_through_visibility_policy()
+    {
+        var visible = Guid.NewGuid();
+        var hidden = Guid.NewGuid();
+        IResourcePresenceTracker tracker = Substitute.For<IResourcePresenceTracker>();
+        tracker
+            .GetAsync(Arg.Any<ResourceRef>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceRoom(SampleResource,
+            [
+                new ResourcePresenceEntry(visible, DateTimeOffset.UtcNow, null),
+                new ResourcePresenceEntry(hidden, DateTimeOffset.UtcNow, null),
+            ]));
+
+        WhitelistResourcePresenceVisibilityPolicy whitelist = new(new HashSet<Guid> { visible });
+
+        await using GranitEndpointTestHost host = await StartAsync(tracker, whitelist);
+        using HttpClient client = AuthedClient(host, Guid.NewGuid());
+
+        HttpResponseMessage response = await client.GetAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        ResourceRoomResponse? body = await response.Content
+            .ReadFromJsonAsync<ResourceRoomResponse>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body!.Participants.Select(p => p.UserId).ShouldBe([visible]);
+    }
+
+    [Fact]
+    public async Task Delete_returns_204_when_user_leaves()
+    {
+        IResourcePresenceTracker tracker = Substitute.For<IResourcePresenceTracker>();
+
+        await using GranitEndpointTestHost host = await StartAsync(tracker);
+        using HttpClient client = AuthedClient(host, Guid.NewGuid());
+
+        HttpResponseMessage response = await client.DeleteAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        await tracker.Received(1).LeaveAsync(
+            Arg.Is<ResourceRef>(r => r.Kind == SampleResource.Kind && r.Id == SampleResource.Id),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Delete_returns_401_when_unauthenticated()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+        HttpClient client = host.Application.GetTestClient();
+
+        HttpResponseMessage response = await client.DeleteAsync(
+            $"/presence/rooms/{SampleResource.Kind}/{SampleResource.Id}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    // ──── Test-only auth handler ────
+
+    private sealed class GuidSubAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue(UserIdHeader, out Microsoft.Extensions.Primitives.StringValues raw)
+                || string.IsNullOrWhiteSpace(raw))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            Claim[] claims = [new Claim("sub", raw.ToString())];
+            ClaimsIdentity identity = new(claims, SchemeName);
+            ClaimsPrincipal principal = new(identity);
+            return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal, SchemeName)));
+        }
+    }
+
+    // ──── Visibility policy stubs ────
+
+    private sealed class AllowAllResourcePresenceVisibilityPolicyForTests : IResourcePresenceVisibilityPolicy
+    {
+        public Task<bool> CanReadRoomAsync(Guid callerUserId, ResourceRef resource, CancellationToken cancellationToken) =>
+            Task.FromResult(true);
+
+        public Task<IReadOnlySet<Guid>> FilterVisibleParticipantsAsync(
+            Guid callerUserId,
+            ResourceRef resource,
+            IReadOnlyCollection<Guid> participantUserIds,
+            CancellationToken cancellationToken)
+        {
+            IReadOnlySet<Guid> set = new HashSet<Guid>(participantUserIds);
+            return Task.FromResult(set);
+        }
+    }
+
+    private sealed class DenyAllResourcePresenceVisibilityPolicy : IResourcePresenceVisibilityPolicy
+    {
+        public Task<bool> CanReadRoomAsync(Guid callerUserId, ResourceRef resource, CancellationToken cancellationToken) =>
+            Task.FromResult(false);
+
+        public Task<IReadOnlySet<Guid>> FilterVisibleParticipantsAsync(
+            Guid callerUserId,
+            ResourceRef resource,
+            IReadOnlyCollection<Guid> participantUserIds,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlySet<Guid>>(new HashSet<Guid>());
+    }
+
+    private sealed class WhitelistResourcePresenceVisibilityPolicy(IReadOnlySet<Guid> allowed) : IResourcePresenceVisibilityPolicy
+    {
+        public Task<bool> CanReadRoomAsync(Guid callerUserId, ResourceRef resource, CancellationToken cancellationToken) =>
+            Task.FromResult(true);
+
+        public Task<IReadOnlySet<Guid>> FilterVisibleParticipantsAsync(
+            Guid callerUserId,
+            ResourceRef resource,
+            IReadOnlyCollection<Guid> participantUserIds,
+            CancellationToken cancellationToken)
+        {
+            HashSet<Guid> result = [];
+            foreach (Guid id in participantUserIds)
+            {
+                if (allowed.Contains(id))
+                {
+                    result.Add(id);
+                }
+            }
+            return Task.FromResult<IReadOnlySet<Guid>>(result);
+        }
+    }
+}

--- a/tests/Granit.Presence.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Presence.Endpoints.Tests/packages.lock.json
@@ -67,10 +67,7 @@
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
-        }
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "DiffEngine": {
         "type": "Transitive",
@@ -91,6 +88,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HRH/XAke90wkHv9ykCsrvpVqvKOUt53jQzvHHIXrPIPZWAjyPq6B5/InCmPYWvme+WKMXD10rplMAitzNMtC3w=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -101,27 +103,10 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
-      "Microsoft.Extensions.Configuration": {
+      "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.8",
-        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
@@ -191,11 +176,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.IO.Hashing": {
         "type": "Transitive",
@@ -299,12 +279,6 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
-          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
           "OpenTelemetry.Api": "[1.15.*, )",
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
@@ -342,9 +316,7 @@
       "granit.guids": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.http.abstractions": {
@@ -370,8 +342,6 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Microsoft.Extensions.Localization": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
         }
       },
@@ -409,12 +379,20 @@
           "StackExchange.Redis": "[2.*, )"
         }
       },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.validation": {
@@ -433,6 +411,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
+      },
       "FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[12.*, )",
@@ -445,8 +429,17 @@
         "resolved": "12.1.1",
         "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
-          "FluentValidation": "12.1.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+          "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "C9kMpUciPgx7ObqoO6W+eXEf3zHFWb7XpQgFJBzdO8GsmmVYrgcErTLMuki6e3EihycGpHbcJECYHDgM7XRMkg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.8",
+          "Microsoft.Extensions.DependencyModel": "10.0.8"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
@@ -456,94 +449,6 @@
         "contentHash": "cw24xHE2QaWwyEG9GQwFbjboyabub6Vd80DIItUGENzcQOa/BEnTrXsg2GADqWTmY/3ycqk9ToLGjgvF/VRlGA==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
-        }
-      },
-      "Microsoft.Extensions.Caching.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "EoK2TwVR1daxmfXUPnvIYZSk5XQjHe45sGekox4kvMt88KQZQhDVzYW5Na5+oNwTuRpE48hipyGJg12F1Tm70w==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Caching.Memory": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "sYMYQjNprfqPTryuLNnr0/AOtnhlfuZ0ZxyOV0d3AXOEL8j9KV0EbelpZYyIatT2hJiaSGO9XGr5YDRsh22OfQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
-      },
-      "Microsoft.Extensions.Localization": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "3F6zrhfjuvBSR8ZOb5dN51kh3hFSCWSIZ7/VnCkg/03kL6HnIAoNcYcix7TVJj3gIVRROcZVrhCBWVSZcklbQA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Localization.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Localization.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "cabARyzKklYa2MeuVV9pr0vQSvgvFzGwBXvoUBT75pQ1PIV3h/XyjqvTez+yzPiN4Ui7HM/BDlUktssy7806ag=="
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.8",
-        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
       "OpenTelemetry.Api": {
@@ -567,7 +472,6 @@
         "resolved": "2.13.17",
         "contentHash": "P7o7ZDBAmBrOLQEw8Pt44iIA08ioj48smRxn4Jp6yzCu6P3DOSU6lj7f+IOtN3pPvSgC9YufvM92ycukEEBCYQ==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.16",
           "System.IO.Hashing": "10.0.2"
         }
@@ -576,10 +480,7 @@
         "type": "CentralTransitive",
         "requested": "[2.*, )",
         "resolved": "2.6.0",
-        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Memory": "10.0.1"
-        }
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
       },
       "ZiggyCreatures.FusionCache.OpenTelemetry": {
         "type": "CentralTransitive",

--- a/tests/Granit.Presence.Tests/Internal/AllowAllResourcePresenceVisibilityPolicyTests.cs
+++ b/tests/Granit.Presence.Tests/Internal/AllowAllResourcePresenceVisibilityPolicyTests.cs
@@ -1,0 +1,39 @@
+using Granit.Presence.Abstractions;
+using Granit.Presence.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Presence.Tests.Internal;
+
+public sealed class AllowAllResourcePresenceVisibilityPolicyTests
+{
+    private static readonly ResourceRef SampleResource = new("document", "abc-123");
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task CanReadRoomAsync_returns_true_always()
+    {
+        var policy = new AllowAllResourcePresenceVisibilityPolicy();
+
+        bool ok = await policy.CanReadRoomAsync(Guid.NewGuid(), SampleResource, Ct);
+
+        ok.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task FilterVisibleParticipantsAsync_returns_unchanged_set()
+    {
+        var policy = new AllowAllResourcePresenceVisibilityPolicy();
+        Guid[] participants = [Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()];
+
+        IReadOnlySet<Guid> visible = await policy.FilterVisibleParticipantsAsync(
+            Guid.NewGuid(), SampleResource, participants, Ct);
+
+        visible.Count.ShouldBe(participants.Length);
+        foreach (Guid id in participants)
+        {
+            visible.ShouldContain(id);
+        }
+    }
+}

--- a/tests/Granit.Presence.Tests/Internal/FusionCacheResourcePresenceTrackerTests.cs
+++ b/tests/Granit.Presence.Tests/Internal/FusionCacheResourcePresenceTrackerTests.cs
@@ -1,0 +1,296 @@
+using System.Diagnostics.Metrics;
+using Granit.MultiTenancy;
+using Granit.Presence.Abstractions;
+using Granit.Presence.Diagnostics;
+using Granit.Presence.Internal;
+using Granit.Presence.Options;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Presence.Tests.Internal;
+
+/// <summary>
+/// Behavioural tests for the resource-room tracker. Drives a real <see cref="IFusionCache"/>
+/// so the cache-key shape, multi-tab dedup, MAX rule, stale-entry filter and empty-room
+/// eviction can all be observed end-to-end inside the test process.
+/// </summary>
+public sealed class FusionCacheResourcePresenceTrackerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 28, 12, 0, 0, TimeSpan.Zero);
+    private static readonly ResourceRef SampleResource = new("document", "abc-123");
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>Lightweight test rig that wraps the tracker + its supporting fakes.</summary>
+    private sealed class TestRig
+    {
+        public required FusionCacheResourcePresenceTracker Tracker { get; init; }
+        public required IClock Clock { get; init; }
+        public required IFusionCache Cache { get; init; }
+    }
+
+    private static TestRig CreateTracker(
+        PresenceOptions? options = null,
+        ICurrentTenant? currentTenant = null,
+        IMeterFactory? meterFactory = null)
+    {
+        ServiceCollection services = [];
+        services.AddFusionCache();
+        services.AddMetrics();
+        ServiceProvider sp = services.BuildServiceProvider();
+        IFusionCache cache = sp.GetRequiredService<IFusionCache>();
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Now);
+
+        IOptionsMonitor<PresenceOptions> optionsMonitor = Substitute.For<IOptionsMonitor<PresenceOptions>>();
+        optionsMonitor.CurrentValue.Returns(options ?? new PresenceOptions());
+
+        ICurrentTenant tenant = currentTenant ?? Substitute.For<ICurrentTenant>();
+
+        PresenceMetrics metrics = new(meterFactory ?? sp.GetRequiredService<IMeterFactory>());
+
+        return new TestRig
+        {
+            Tracker = new FusionCacheResourcePresenceTracker(cache, clock, tenant, optionsMonitor, metrics),
+            Clock = clock,
+            Cache = cache,
+        };
+    }
+
+    [Fact]
+    public async Task JoinAsync_creates_room_with_single_entry_when_user_first_joins()
+    {
+        TestRig rig = CreateTracker();
+        var userId = Guid.NewGuid();
+
+        ResourceRoom room = await rig.Tracker.JoinAsync(SampleResource, userId, metadata: "{}", Ct);
+
+        room.Resource.ShouldBe(SampleResource);
+        room.Participants.Count.ShouldBe(1);
+        room.Participants[0].UserId.ShouldBe(userId);
+        room.Participants[0].Metadata.ShouldBe("{}");
+        room.Participants[0].LastSeenUtc.ShouldBe(Now);
+    }
+
+    [Fact]
+    public async Task JoinAsync_merges_multiple_distinct_users_into_same_room()
+    {
+        TestRig rig = CreateTracker();
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await rig.Tracker.JoinAsync(SampleResource, alice, cancellationToken: Ct);
+        ResourceRoom room = await rig.Tracker.JoinAsync(SampleResource, bob, cancellationToken: Ct);
+
+        room.Participants.Count.ShouldBe(2);
+        room.Participants.Select(p => p.UserId).ShouldBe([alice, bob], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task JoinAsync_dedup_multi_tab_keeps_single_entry_per_user_with_max_timestamp_and_last_metadata()
+    {
+        TestRig rig = CreateTracker();
+        var userId = Guid.NewGuid();
+
+        // First tab joins at Now.
+        await rig.Tracker.JoinAsync(SampleResource, userId, metadata: "tab-1", Ct);
+
+        // Second tab joins 5 seconds later with new metadata.
+        DateTimeOffset later = Now.AddSeconds(5);
+        rig.Clock.Now.Returns(later);
+        ResourceRoom room = await rig.Tracker.JoinAsync(SampleResource, userId, metadata: "tab-2", Ct);
+
+        room.Participants.Count.ShouldBe(1);
+        room.Participants[0].UserId.ShouldBe(userId);
+        room.Participants[0].LastSeenUtc.ShouldBe(later);
+        room.Participants[0].Metadata.ShouldBe("tab-2");
+    }
+
+    [Fact]
+    public async Task JoinAsync_applies_max_rule_when_existing_timestamp_is_greater_than_now()
+    {
+        // Repro: a backplane echo arrives that contains a newer LastSeenUtc than the local clock.
+        TestRig rig = CreateTracker();
+        var userId = Guid.NewGuid();
+
+        // Pre-seed the cache directly with a forward-dated entry.
+        DateTimeOffset future = Now.AddSeconds(30);
+        await rig.Cache.SetAsync(
+            $"granit.presence.room:global:{SampleResource.Kind}:{SampleResource.Id}",
+            new List<ResourcePresenceEntry>
+            {
+                new(userId, future, "forward-dated"),
+            },
+            TimeSpan.FromMinutes(2),
+            token: Ct);
+
+        rig.Clock.Now.Returns(Now);
+        ResourceRoom room = await rig.Tracker.JoinAsync(SampleResource, userId, metadata: "new", Ct);
+
+        room.Participants[0].LastSeenUtc.ShouldBe(future, "MAX rule: keep the larger timestamp");
+        room.Participants[0].Metadata.ShouldBe("new", "metadata: last write wins");
+    }
+
+    [Fact]
+    public async Task JoinAsync_throws_when_metadata_exceeds_512_bytes()
+    {
+        TestRig rig = CreateTracker();
+        string oversize = new('x', 513);
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            rig.Tracker.JoinAsync(SampleResource, Guid.NewGuid(), oversize, Ct));
+    }
+
+    [Fact]
+    public async Task JoinAsync_accepts_metadata_at_exact_limit()
+    {
+        TestRig rig = CreateTracker();
+        string atLimit = new('x', 512);
+
+        ResourceRoom room = await rig.Tracker.JoinAsync(SampleResource, Guid.NewGuid(), atLimit, Ct);
+
+        room.Participants[0].Metadata!.Length.ShouldBe(512);
+    }
+
+    [Fact]
+    public async Task JoinAsync_throws_when_kind_violates_regex()
+    {
+        TestRig rig = CreateTracker();
+        var bad = new ResourceRef("Document", "abc"); // uppercase forbidden
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            rig.Tracker.JoinAsync(bad, Guid.NewGuid(), cancellationToken: Ct));
+    }
+
+    [Fact]
+    public async Task JoinAsync_throws_when_id_exceeds_256_chars()
+    {
+        TestRig rig = CreateTracker();
+        var bad = new ResourceRef("document", new string('x', 257));
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            rig.Tracker.JoinAsync(bad, Guid.NewGuid(), cancellationToken: Ct));
+    }
+
+    [Fact]
+    public async Task JoinAsync_throws_when_user_id_is_empty()
+    {
+        TestRig rig = CreateTracker();
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            rig.Tracker.JoinAsync(SampleResource, Guid.Empty, cancellationToken: Ct));
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_empty_room_when_never_joined()
+    {
+        TestRig rig = CreateTracker();
+
+        ResourceRoom room = await rig.Tracker.GetAsync(SampleResource, Ct);
+
+        room.Participants.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAsync_filters_stale_entries_at_read_time()
+    {
+        PresenceOptions opts = new() { OfflineThreshold = TimeSpan.FromMinutes(1) };
+        TestRig rig = CreateTracker(opts);
+        var stale = Guid.NewGuid();
+        var fresh = Guid.NewGuid();
+
+        // Stale entry joined 5 minutes ago.
+        rig.Clock.Now.Returns(Now.AddMinutes(-5));
+        await rig.Tracker.JoinAsync(SampleResource, stale, cancellationToken: Ct);
+
+        // Fresh join at Now.
+        rig.Clock.Now.Returns(Now);
+        await rig.Tracker.JoinAsync(SampleResource, fresh, cancellationToken: Ct);
+
+        ResourceRoom room = await rig.Tracker.GetAsync(SampleResource, Ct);
+
+        room.Participants.Select(p => p.UserId).ShouldBe([fresh]);
+    }
+
+    [Fact]
+    public async Task LeaveAsync_removes_only_the_specified_user()
+    {
+        TestRig rig = CreateTracker();
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await rig.Tracker.JoinAsync(SampleResource, alice, cancellationToken: Ct);
+        await rig.Tracker.JoinAsync(SampleResource, bob, cancellationToken: Ct);
+
+        await rig.Tracker.LeaveAsync(SampleResource, alice, Ct);
+
+        ResourceRoom room = await rig.Tracker.GetAsync(SampleResource, Ct);
+        room.Participants.Select(p => p.UserId).ShouldBe([bob]);
+    }
+
+    [Fact]
+    public async Task LeaveAsync_evicts_cache_entry_entirely_when_room_becomes_empty()
+    {
+        TestRig rig = CreateTracker();
+        var userId = Guid.NewGuid();
+
+        await rig.Tracker.JoinAsync(SampleResource, userId, cancellationToken: Ct);
+        await rig.Tracker.LeaveAsync(SampleResource, userId, Ct);
+
+        // Direct cache probe — the entry must be gone, not present as an empty list.
+        string key = $"granit.presence.room:global:{SampleResource.Kind}:{SampleResource.Id}";
+        List<ResourcePresenceEntry>? raw = await rig.Cache.GetOrDefaultAsync<List<ResourcePresenceEntry>?>(
+            key, defaultValue: null, token: Ct);
+        raw.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LeaveAsync_is_noop_when_user_is_absent()
+    {
+        TestRig rig = CreateTracker();
+        var alice = Guid.NewGuid();
+
+        await rig.Tracker.JoinAsync(SampleResource, alice, cancellationToken: Ct);
+        await rig.Tracker.LeaveAsync(SampleResource, Guid.NewGuid(), Ct); // unrelated user
+
+        ResourceRoom room = await rig.Tracker.GetAsync(SampleResource, Ct);
+        room.Participants.Select(p => p.UserId).ShouldBe([alice]);
+    }
+
+    [Fact]
+    public async Task Cache_key_is_scoped_per_tenant()
+    {
+        // Tenant A
+        ICurrentTenant tenantA = Substitute.For<ICurrentTenant>();
+        tenantA.IsAvailable.Returns(true);
+        tenantA.Id.Returns(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        TestRig rigA = CreateTracker(currentTenant: tenantA);
+
+        // Tenant B sharing the same FusionCache instance
+        ICurrentTenant tenantB = Substitute.For<ICurrentTenant>();
+        tenantB.IsAvailable.Returns(true);
+        tenantB.Id.Returns(Guid.Parse("22222222-2222-2222-2222-222222222222"));
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Now);
+        IOptionsMonitor<PresenceOptions> opts = Substitute.For<IOptionsMonitor<PresenceOptions>>();
+        opts.CurrentValue.Returns(new PresenceOptions());
+        ServiceCollection bServices = [];
+        bServices.AddMetrics();
+        IMeterFactory bMeterFactory = bServices.BuildServiceProvider().GetRequiredService<IMeterFactory>();
+        FusionCacheResourcePresenceTracker trackerB = new(
+            rigA.Cache, clock, tenantB, opts, new PresenceMetrics(bMeterFactory));
+
+        var alice = Guid.NewGuid();
+        await rigA.Tracker.JoinAsync(SampleResource, alice, cancellationToken: Ct);
+
+        // From tenant B's view the room must be empty (isolation).
+        ResourceRoom roomB = await trackerB.GetAsync(SampleResource, Ct);
+        roomB.Participants.ShouldBeEmpty();
+    }
+}

--- a/tests/Granit.Presence.Tests/Internal/ResourceRefTests.cs
+++ b/tests/Granit.Presence.Tests/Internal/ResourceRefTests.cs
@@ -1,0 +1,70 @@
+using Granit.Presence.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Presence.Tests.Internal;
+
+public sealed class ResourceRefTests
+{
+    [Theory]
+    [InlineData("a")]
+    [InlineData("document")]
+    [InlineData("cms.page")]
+    [InlineData("kanban-card")]
+    [InlineData("workflow_state")]
+    [InlineData("a1b2c3")]
+    public void Validate_accepts_well_formed_kind(string kind)
+    {
+        var r = new ResourceRef(kind, "id");
+        Should.NotThrow(() => r.Validate());
+    }
+
+    [Theory]
+    [InlineData("Document")] // uppercase forbidden
+    [InlineData("1document")] // must start with letter
+    [InlineData("-document")] // must start with letter
+    [InlineData(".document")] // must start with letter
+    [InlineData("doc ument")] // space forbidden
+    [InlineData("doc/ument")] // slash forbidden
+    [InlineData("")] // empty
+    public void Validate_rejects_invalid_kind(string kind)
+    {
+        var r = new ResourceRef(kind, "id");
+        Should.Throw<ArgumentException>(() => r.Validate());
+    }
+
+    [Fact]
+    public void Validate_rejects_kind_longer_than_64_chars()
+    {
+        var r = new ResourceRef(new string('a', 65), "id");
+        Should.Throw<ArgumentException>(() => r.Validate());
+    }
+
+    [Fact]
+    public void Validate_accepts_kind_exactly_64_chars()
+    {
+        var r = new ResourceRef(new string('a', 64), "id");
+        Should.NotThrow(() => r.Validate());
+    }
+
+    [Fact]
+    public void Validate_rejects_id_longer_than_256_chars()
+    {
+        var r = new ResourceRef("document", new string('x', 257));
+        Should.Throw<ArgumentException>(() => r.Validate());
+    }
+
+    [Fact]
+    public void Validate_accepts_id_exactly_256_chars()
+    {
+        var r = new ResourceRef("document", new string('x', 256));
+        Should.NotThrow(() => r.Validate());
+    }
+
+    [Fact]
+    public void Validate_rejects_empty_id()
+    {
+        var r = new ResourceRef("document", "");
+        Should.Throw<ArgumentException>(() => r.Validate());
+    }
+}


### PR DESCRIPTION
## Summary

Adds **resource-scoped editing presence rooms** to `Granit.Presence` — a second dimension alongside the existing user-keyed presence model. Answers "who is currently looking at this resource?" (informational, non-blocking — Google Docs / Notion style).

Implements epic #2408 and sub-stories #2409, #2410, #2411, #2412, #2413. Story #2414 (docs on `granit-docs`) ships as a separate PR per repo convention.

- **New abstractions** (`Granit.Presence.Abstractions`): `IResourcePresenceTracker`, `IResourcePresenceVisibilityPolicy`, `ResourceRef` (record struct with `[GeneratedRegex]` kind validator), `ResourceRoom`, `ResourcePresenceEntry`
- **FusionCache-backed impl** (`Granit.Presence.Internal.FusionCacheResourcePresenceTracker`): tenant-scoped cache key, MAX anti-flapping rule, multi-tab dedup, stale filter (`PresenceOptions.OfflineThreshold`), empty-room eviction, 512-byte metadata cap
- **REST endpoints** (`Granit.Presence.Endpoints`): `POST /presence/rooms/{kind}/{id}/heartbeat`, `GET /presence/rooms/{kind}/{id}`, `DELETE /presence/rooms/{kind}/{id}` — tagged `Presence - Rooms`, full OpenAPI metadata, FluentValidation, RFC 7807 errors
- **Permissions**: `Presence.Rooms.Read` (GET), `Presence.Rooms.Join` (POST/DELETE) — registered + localized in all 18 cultures
- **Diagnostics**: 4 new instruments on existing `PresenceMetrics` meter (`granit.presence.room.{join,leave,size,metadata.bytes}`), 3 new spans on existing `PresenceActivitySource` (`Room.{Join,Leave,Get}`), SHA256-truncated `resource.id` in spans only (never as metric tag — cardinality bound)
- **Tests**: 47 new unit tests, 8 new endpoint tests, 5 new architecture tests — all green

## Why not extend `Granit.EditLocking` (#293)?

Different semantics. #293 is pessimistic 1-to-1 locking ("Bob is editing, save disabled"). This PR is informational 1-to-N awareness ("Alice is also viewing"). Both are stackable — many products use both. Kept in separate concerns; see epic #2408 for the full decision table.

## Why not store URL / persist history?

Out of scope (non-goals documented in #2408):
- URL would couple logical identity to physical routing — `(Kind, Id)` is the stable room key. Per-participant `Metadata` covers sub-context needs.
- Persistent tracking (marketing funnels, page-view history) is a different concern with different consent/retention/ROPA implications. See `Granit.Timeline.Auditing` for audit-grade trails or `granit-business` Analytics for KPI tracking.

## Drive case

In-house implementation in `granit-website` MR !35 (H-F7) will be **closed and reimplemented as a thin consumer** of this framework primitive once shipped.

## Test plan

- [x] `dotnet test tests/Granit.Presence.Tests` — **62/62 passed** (47 new + 15 pre-existing)
- [x] `dotnet test tests/Granit.Presence.Endpoints.Tests` — **12/12 passed** (8 new room tests + 4 pre-existing)
- [x] `dotnet test tests/Granit.ArchitectureTests --filter "FullyQualifiedName~ResourcePresence"` — **6/6 passed**
- [x] `dotnet format src/Granit.Presence --verify-no-changes` — clean
- [x] `dotnet format src/Granit.Presence.Endpoints --verify-no-changes` — clean
- [x] `dotnet format tests/Granit.Presence.Tests --verify-no-changes` — clean
- [x] `dotnet format tests/Granit.Presence.Endpoints.Tests --verify-no-changes` — clean
- [x] Rebased on `origin/develop` (`3dc47f72a`)

## Out of scope / follow-ups

- **#2414** — Docs on `granit-docs` (separate repo, separate PR per convention)
- **Integration tests with Redis backplane** — no existing `Granit.Presence.Tests.Integration` project; scaffolding is heavier (shard registration + restore) and orthogonal to the feature. Follow-up issue can be opened if needed.
- **`WithoutRateLimiting` test helper** — tracking issue opened separately (duplicated plumbing across `*.Endpoints.Tests`)
- **Configurable metadata cap** — currently `const int 512` co-located in validator + tracker (defense in depth). Move to `PresenceOptions.RoomMetadataMaxBytes` only when a host needs a non-default value (YAGNI).

Closes #2409 #2410 #2411 #2412 #2413.
Part of #2408.
