### PR TITLE
fix(webhooks): align WebhooksEntityFrameworkCoreOptions namespace with Options/ folder

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -48818,7 +48818,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.EntityFrameworkCore",
       "file": "src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitWebhooksEntityFrameworkCore",
@@ -48871,11 +48871,11 @@
     },
     {
       "name": "WebhooksEntityFrameworkCoreOptions",
-      "fqn": "Granit.Webhooks.EntityFrameworkCore.WebhooksEntityFrameworkCoreOptions",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.Options.WebhooksEntityFrameworkCoreOptions",
       "kind": "class",
       "project": "Granit.Webhooks.EntityFrameworkCore",
       "file": "src/Granit.Webhooks.EntityFrameworkCore/Options/WebhooksEntityFrameworkCoreOptions.cs",
-      "line": 31,
+      "line": 32,
       "members": [
         {
           "name": "StorageMode",

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Granit.QueryEngine;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Granit.Webhooks.EntityFrameworkCore.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
@@ -3,6 +3,7 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.Webhooks.Domain;
+using Granit.Webhooks.EntityFrameworkCore.Options;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Webhooks.EntityFrameworkCore.Internal;

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
@@ -3,6 +3,7 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.Webhooks.Domain;
+using Granit.Webhooks.EntityFrameworkCore.Options;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Webhooks.EntityFrameworkCore.Internal;

--- a/src/Granit.Webhooks.EntityFrameworkCore/Options/WebhooksEntityFrameworkCoreOptions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Options/WebhooksEntityFrameworkCoreOptions.cs
@@ -1,12 +1,13 @@
 using Granit.Persistence.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 
-namespace Granit.Webhooks.EntityFrameworkCore;
+namespace Granit.Webhooks.EntityFrameworkCore.Options;
 
 /// <summary>
-/// Configuration shape for <see cref="Extensions.WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
-/// .AddGranitWebhooksEntityFrameworkCore"/>. Carries the dual-scope storage choice and the
-/// EF Core <see cref="DbContextOptionsBuilder"/> callbacks per context.
+/// Configuration shape for
+/// <c>WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.AddGranitWebhooksEntityFrameworkCore</c>.
+/// Carries the dual-scope storage choice and the EF Core
+/// <see cref="DbContextOptionsBuilder"/> callbacks per context.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionQueryableSourceTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionQueryableSourceTests.cs
@@ -4,6 +4,7 @@ using Granit.MultiTenancy;
 using Granit.Persistence.MultiTenancy;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Granit.Webhooks.EntityFrameworkCore.Options;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
@@ -6,6 +6,7 @@ using Granit.Persistence.MultiTenancy;
 using Granit.Timing;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Granit.Webhooks.EntityFrameworkCore.Options;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;


### PR DESCRIPTION
## Summary

- `WebhooksEntityFrameworkCoreOptions.cs` was moved to `Options/` in #2406 but its namespace stayed at `Granit.Webhooks.EntityFrameworkCore` — the architecture shard caught it on develop (`Namespace_should_match_folder_structure_in_src`).
- Updates the namespace to `Granit.Webhooks.EntityFrameworkCore.Options` and adds the explicit `using` in the 5 consumer files (3 src, 2 tests).
- Trims one `<see cref=...>` that crossed namespaces in the XML doc to keep it stable.

No public API change — this type is not consumed via a typed alias; callers either `Configure<>()` it or construct it inline in tests.

## Test plan

- [x] `dotnet build src/Granit.Webhooks.EntityFrameworkCore -c Release` — 0 errors
- [x] `dotnet build tests/Granit.Webhooks.EntityFrameworkCore.Tests -c Release` — 0 errors
- [x] `dotnet build tests/Granit.ArchitectureTests -c Release` — 0 errors
- [x] `dotnet test tests/Granit.ArchitectureTests` filtered on `Namespace_should_match_folder_structure_in_src` + `Options_classes_should_not_be_at_module_root` — both pass
- [x] `dotnet test tests/Granit.Webhooks.EntityFrameworkCore.Tests` — 50/50 pass
- [x] `dotnet format --verify-no-changes` on both touched projects — clean