### PR TITLE
feat(auditing): IAuditChildResolver for parent-child timeline aggregation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4873,6 +4873,15 @@
       "members": []
     },
     {
+      "name": "AuditChildScope",
+      "fqn": "Granit.Auditing.AuditChildScope",
+      "kind": "record",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/AuditChildScope.cs",
+      "line": 17,
+      "members": []
+    },
+    {
       "name": "AuthenticationAuditEntry",
       "fqn": "Granit.Auditing.AuthenticationAuditEntry",
       "kind": "class",
@@ -5332,6 +5341,22 @@
       ]
     },
     {
+      "name": "AuditChildResolverExtensions",
+      "fqn": "Granit.Auditing.Extensions.AuditChildResolverExtensions",
+      "kind": "class",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/Extensions/AuditChildResolverExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ResolveAllAsync",
+          "kind": "method",
+          "signature": "ResolveAllAsync(this IEnumerable<IAuditChildResolver> resolvers, string parentEntityType, string parentEntityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyCollection<AuditChildScope>>"
+        }
+      ]
+    },
+    {
       "name": "AuditEntityTypeAliasProviderExtensions",
       "fqn": "Granit.Auditing.Extensions.AuditEntityTypeAliasProviderExtensions",
       "kind": "class",
@@ -5392,6 +5417,22 @@
           "kind": "method",
           "signature": "PersistAsync(AuditingBatch batch, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IAuditChildResolver",
+      "fqn": "Granit.Auditing.IAuditChildResolver",
+      "kind": "interface",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/IAuditChildResolver.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(string parentEntityType, string parentEntityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyCollection<AuditChildScope>>"
         }
       ]
     },
@@ -5468,6 +5509,12 @@
           "kind": "method",
           "signature": "GetByEntityAsync(string entityType, string entityId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
           "returnType": "Task<PagedResult<AuditEntry>>"
+        },
+        {
+          "name": "GetByEntitiesAsync",
+          "kind": "method",
+          "signature": "GetByEntitiesAsync(IReadOnlyCollection<AuditEntityRef> targets, int limit, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<AuditEntry>>"
         },
         {
           "name": "GetByCorrelationIdAsync",
@@ -5820,6 +5867,15 @@
       "project": "Granit.Auditing",
       "file": "src/Granit.Auditing/StaticAuditEntityTypeAliasProvider.cs",
       "line": 11,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Auditing.struct",
+      "kind": "record",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/AuditEntityRef.cs",
+      "line": 10,
       "members": []
     },
     {

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
@@ -1,3 +1,5 @@
+using System.Linq.Expressions;
+using System.Reflection;
 using Granit.Auditing.Domain;
 using Granit.Auditing.Extensions;
 using Granit.Auditing.Options;
@@ -96,6 +98,76 @@ internal sealed class EfCoreAuditingReader(
     }
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyList<AuditEntry>> GetByEntitiesAsync(
+        IReadOnlyCollection<AuditEntityRef> targets,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(targets);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        if (targets.Count == 0)
+        {
+            return [];
+        }
+
+        // Group by EntityType so each scope becomes ONE predicate branch
+        // (ec.EntityType == type AND ids.Contains(ec.EntityId)) and the
+        // branches OR together. Strict pair semantics — no cross-type bleed,
+        // no reliance on Guid cross-table uniqueness as an implicit invariant.
+        Expression<Func<AuditEntityChange, bool>>? predicate = null;
+        ParameterExpression ecParam = Expression.Parameter(typeof(AuditEntityChange), "ec");
+
+        foreach (IGrouping<string, AuditEntityRef> group in targets.GroupBy(t => t.EntityType, StringComparer.Ordinal))
+        {
+            // Materialise to string[] so Npgsql translates Contains to a SQL
+            // IN-list (the same constraint observed at GetByEntityAsync above).
+            string[] ids = [.. group.Select(t => t.EntityId).Distinct(StringComparer.Ordinal)];
+            if (ids.Length == 0)
+            {
+                continue;
+            }
+
+            Expression<Func<AuditEntityChange, bool>> branch =
+                ec => ec.EntityType == group.Key && ids.Contains(ec.EntityId);
+
+            Expression rebound = ParameterRebinder.Replace(branch.Body, branch.Parameters[0], ecParam);
+            predicate = predicate is null
+                ? Expression.Lambda<Func<AuditEntityChange, bool>>(rebound, ecParam)
+                : Expression.Lambda<Func<AuditEntityChange, bool>>(
+                    Expression.OrElse(predicate.Body, rebound), ecParam);
+        }
+
+        if (predicate is null)
+        {
+            return [];
+        }
+
+        // Hoist the predicate into the outer .Any() — that subquery is what the
+        // covering index (EntityType, EntityId, AuditEntryId) was added for.
+        ParameterExpression entryParam = Expression.Parameter(typeof(AuditEntry), "e");
+        MemberExpression changes = Expression.Property(entryParam, nameof(AuditEntry.EntityChanges));
+        MethodCallExpression any = Expression.Call(AnyMethodInfo, changes, predicate);
+        var outer = Expression.Lambda<Func<AuditEntry, bool>>(any, entryParam);
+
+        await using AuditingDbContext dbContext = await dbContextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // No FusionCache on the batch path — per-request target sets cause
+        // cache-key explosion and the merger only fetches top-K, so any hit
+        // rate would be coincidental at best.
+        return await dbContext.AuditEntries
+            .Include(e => e.EntityChanges)
+                .ThenInclude(ec => ec.PropertyChanges)
+            .Where(outer)
+            .OrderByDescending(e => e.Timestamp)
+            .Take(limit)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
     public async Task<List<AuditEntry>> GetByUserAsync(
         string userId,
         int limit,
@@ -136,5 +208,26 @@ internal sealed class EfCoreAuditingReader(
             .AsNoTracking()
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private static readonly MethodInfo AnyMethodInfo = typeof(Enumerable)
+        .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .Single(m => m.Name == nameof(Enumerable.Any)
+            && m.GetParameters().Length == 2)
+        .MakeGenericMethod(typeof(AuditEntityChange));
+
+    /// <summary>
+    /// Rewrites every reference to <c>from</c> in an expression tree as
+    /// <c>to</c>. Lets us re-use the body of an <c>Expression{Func{T,bool}}</c>
+    /// under a fresh parameter when combining per-scope predicates via
+    /// <c>Expression.OrElse</c>.
+    /// </summary>
+    private sealed class ParameterRebinder(ParameterExpression from, ParameterExpression to) : ExpressionVisitor
+    {
+        public static Expression Replace(Expression body, ParameterExpression from, ParameterExpression to) =>
+            new ParameterRebinder(from, to).Visit(body);
+
+        protected override Expression VisitParameter(ParameterExpression node) =>
+            node == from ? to : base.VisitParameter(node);
     }
 }

--- a/src/Granit.Auditing/AuditChildScope.cs
+++ b/src/Granit.Auditing/AuditChildScope.cs
@@ -1,0 +1,19 @@
+namespace Granit.Auditing;
+
+/// <summary>
+/// A set of audited child entities of one CLR type that belong to a parent
+/// aggregate. Returned by <see cref="IAuditChildResolver"/> implementations so
+/// the batch read path can include the children's audit rows in the parent's
+/// timeline without separate round-trips per child type.
+/// </summary>
+/// <param name="ChildEntityType">
+/// CLR type name the audit log stamps on rows for this child (matches
+/// <c>AuditEntityChange.EntityType</c>).
+/// </param>
+/// <param name="ChildEntityIds">
+/// Audit-store identifiers (<c>AuditEntityChange.EntityId</c>) for every
+/// child of the parent. Empty when the parent has no children of this type.
+/// </param>
+public sealed record AuditChildScope(
+    string ChildEntityType,
+    IReadOnlyCollection<string> ChildEntityIds);

--- a/src/Granit.Auditing/AuditEntityRef.cs
+++ b/src/Granit.Auditing/AuditEntityRef.cs
@@ -1,0 +1,10 @@
+namespace Granit.Auditing;
+
+/// <summary>
+/// Lightweight reference to an audited entity — the pair
+/// (<see cref="EntityType"/>, <see cref="EntityId"/>) that the audit store
+/// stamps on every <c>AuditEntityChange</c>. Used by the batch read path
+/// (<see cref="IAuditingReader.GetByEntitiesAsync"/>) to request audits for
+/// many entities in a single query.
+/// </summary>
+public readonly record struct AuditEntityRef(string EntityType, string EntityId);

--- a/src/Granit.Auditing/Extensions/AuditChildResolverExtensions.cs
+++ b/src/Granit.Auditing/Extensions/AuditChildResolverExtensions.cs
@@ -1,0 +1,97 @@
+namespace Granit.Auditing.Extensions;
+
+/// <summary>
+/// Helpers for unioning the contributions of multiple
+/// <see cref="IAuditChildResolver"/> instances and shaping the result for the
+/// batch read path.
+/// </summary>
+public static class AuditChildResolverExtensions
+{
+    /// <summary>
+    /// Invokes every resolver and merges their scopes by
+    /// <see cref="AuditChildScope.ChildEntityType"/>, deduplicating child ids
+    /// with ordinal comparison. Returns an empty collection when no resolver
+    /// is registered — callers append the parent ref themselves.
+    /// </summary>
+    public static async Task<IReadOnlyCollection<AuditChildScope>> ResolveAllAsync(
+        this IEnumerable<IAuditChildResolver> resolvers,
+        string parentEntityType,
+        string parentEntityId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resolvers);
+        ArgumentException.ThrowIfNullOrEmpty(parentEntityType);
+        ArgumentException.ThrowIfNullOrEmpty(parentEntityId);
+
+        Dictionary<string, HashSet<string>>? merged = null;
+
+        foreach (IAuditChildResolver resolver in resolvers)
+        {
+            IReadOnlyCollection<AuditChildScope> scopes = await resolver
+                .ResolveAsync(parentEntityType, parentEntityId, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (AuditChildScope scope in scopes)
+            {
+                if (scope.ChildEntityIds.Count == 0)
+                {
+                    continue;
+                }
+
+                merged ??= new(StringComparer.Ordinal);
+                if (!merged.TryGetValue(scope.ChildEntityType, out HashSet<string>? ids))
+                {
+                    ids = new(StringComparer.Ordinal);
+                    merged[scope.ChildEntityType] = ids;
+                }
+
+                foreach (string id in scope.ChildEntityIds)
+                {
+                    ids.Add(id);
+                }
+            }
+        }
+
+        if (merged is null)
+        {
+            return [];
+        }
+
+        var result = new AuditChildScope[merged.Count];
+        int i = 0;
+        foreach ((string type, HashSet<string> ids) in merged)
+        {
+            result[i++] = new AuditChildScope(type, ids);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Flattens a parent ref and a collection of child scopes into the
+    /// <see cref="AuditEntityRef"/> set consumed by
+    /// <see cref="IAuditingReader.GetByEntitiesAsync"/>. The parent ref is
+    /// always included first; child refs follow grouped by type.
+    /// </summary>
+    public static IReadOnlyCollection<AuditEntityRef> ToTargets(
+        this IReadOnlyCollection<AuditChildScope> scopes,
+        AuditEntityRef parent)
+    {
+        ArgumentNullException.ThrowIfNull(scopes);
+
+        int total = 1;
+        foreach (AuditChildScope scope in scopes)
+        {
+            total += scope.ChildEntityIds.Count;
+        }
+
+        List<AuditEntityRef> targets = new(total) { parent };
+        foreach (AuditChildScope scope in scopes)
+        {
+            foreach (string id in scope.ChildEntityIds)
+            {
+                targets.Add(new AuditEntityRef(scope.ChildEntityType, id));
+            }
+        }
+        return targets;
+    }
+}

--- a/src/Granit.Auditing/IAuditChildResolver.cs
+++ b/src/Granit.Auditing/IAuditChildResolver.cs
@@ -1,0 +1,35 @@
+namespace Granit.Auditing;
+
+/// <summary>
+/// Resolves the audited child entities of an aggregate root so the parent's
+/// timeline can surface their audit rows alongside its own. Solves the generic
+/// parent–child gap in the audit trail: an audit on <c>PageVersion</c> belongs
+/// in the timeline of its owning <c>Page</c>, on <c>OrderLine</c> in the
+/// timeline of its <c>Order</c>, and so on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the registration model of <see cref="IAuditEntityTypeAliasProvider"/>
+/// — opt-in per module via <c>TryAddEnumerable</c>; the reader unions the
+/// contributions of every registered provider. Hosts with no resolver
+/// registered keep the pre-existing behaviour (parent-only audits).
+/// </para>
+/// <para>
+/// Implementations run inside the caller's request scope and inherit the
+/// ambient <c>ICurrentTenant</c>, so child-id lookups stay within the tenant
+/// boundary without extra work.
+/// </para>
+/// </remarks>
+public interface IAuditChildResolver
+{
+    /// <summary>
+    /// Returns the audited children of <paramref name="parentEntityType"/>
+    /// with id <paramref name="parentEntityId"/>, grouped by child CLR type.
+    /// An empty result means this resolver has no children to contribute for
+    /// the supplied parent — return <c>[]</c> rather than throwing.
+    /// </summary>
+    Task<IReadOnlyCollection<AuditChildScope>> ResolveAsync(
+        string parentEntityType,
+        string parentEntityId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Auditing/IAuditingReader.cs
+++ b/src/Granit.Auditing/IAuditingReader.cs
@@ -30,6 +30,24 @@ public interface IAuditingReader
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves the audit trail for many entities in a single query, ordered
+    /// from most recent and capped at <paramref name="limit"/>. Powers the
+    /// parent-child timeline aggregation (see <see cref="IAuditChildResolver"/>)
+    /// — the caller assembles a <see cref="AuditEntityRef"/> set that mixes the
+    /// parent entity and its audited children.
+    /// </summary>
+    /// <remarks>
+    /// Intentionally not paginated. The federated timeline merger only fetches
+    /// top-K per source and cross-target pagination has no meaningful offset
+    /// semantics. An empty <paramref name="targets"/> collection yields an
+    /// empty result without issuing a query.
+    /// </remarks>
+    Task<IReadOnlyList<AuditEntry>> GetByEntitiesAsync(
+        IReadOnlyCollection<AuditEntityRef> targets,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Retrieves all audit log entries matching a distributed tracing correlation ID.
     /// </summary>
     Task<List<AuditEntry>> GetByCorrelationIdAsync(

--- a/src/Granit.Timeline.Auditing/Internal/AuditingTimelineSource.cs
+++ b/src/Granit.Timeline.Auditing/Internal/AuditingTimelineSource.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Granit.Auditing;
 using Granit.Auditing.Domain;
 using Granit.Auditing.Extensions;
-using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
 
 namespace Granit.Timeline.Auditing.Internal;
@@ -12,11 +11,14 @@ namespace Granit.Timeline.Auditing.Internal;
 /// Projects <see cref="AuditEntry"/> rows into the federated activity stream.
 /// Registered as <see cref="ITimelineSource"/> by
 /// <c>AddGranitTimelineAuditing</c>; once present, every audited mutation on
-/// an entity shows up in that entity's timeline without per-module wiring.
+/// an entity (or any of its audited children, via
+/// <see cref="IAuditChildResolver"/>) shows up in that entity's timeline
+/// without per-module wiring.
 /// </summary>
 internal sealed class AuditingTimelineSource(
     IAuditingReader auditing,
-    IEnumerable<IAuditEntityTypeAliasProvider> aliasProviders) : ITimelineSource
+    IEnumerable<IAuditEntityTypeAliasProvider> aliasProviders,
+    IEnumerable<IAuditChildResolver> childResolvers) : ITimelineSource
 {
     /// <inheritdoc/>
     public string SourceKey => "auditing";
@@ -30,13 +32,31 @@ internal sealed class AuditingTimelineSource(
     {
         IReadOnlySet<string> matchTypes = aliasProviders.Resolve(entityType);
 
-        // Single page sized to the merger's fetch budget — the reader only
-        // ever asks for top-K and merges across sources.
-        PagedResult<AuditEntry> result = await auditing
-            .GetByEntityAsync(entityType, entityId, page: 1, pageSize: limit, cancellationToken)
+        IReadOnlyCollection<AuditChildScope> children = await childResolvers
+            .ResolveAllAsync(entityType, entityId, cancellationToken)
             .ConfigureAwait(false);
 
-        return [.. result.Items.Select(e => Project(matchTypes, entityId, e))];
+        // Parent-only fast path keeps the cached GetByEntityAsync hot for
+        // entities with no child-resolver contribution. The batch overload
+        // intentionally skips FusionCache (per-request target sets cause
+        // cache-key explosion), so a no-children call should never go through
+        // it.
+        if (children.Count == 0)
+        {
+            Granit.QueryEngine.PagedResult<AuditEntry> page = await auditing
+                .GetByEntityAsync(entityType, entityId, page: 1, pageSize: limit, cancellationToken)
+                .ConfigureAwait(false);
+            return [.. page.Items.Select(e => Project(matchTypes, entityId, children, e))];
+        }
+
+        IReadOnlyCollection<AuditEntityRef> targets = children.ToTargets(
+            new AuditEntityRef(entityType, entityId));
+
+        IReadOnlyList<AuditEntry> entries = await auditing
+            .GetByEntitiesAsync(targets, limit, cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entries.Select(e => Project(matchTypes, entityId, children, e))];
     }
 
     /// <inheritdoc/>
@@ -58,22 +78,44 @@ internal sealed class AuditingTimelineSource(
         }
 
         IReadOnlySet<string> matchTypes = aliasProviders.Resolve(entityType);
+        IReadOnlyCollection<AuditChildScope> children = await childResolvers
+            .ResolveAllAsync(entityType, entityId, cancellationToken)
+            .ConfigureAwait(false);
 
-        // Security: refuse to anchor an audit row that does not target this
-        // entity — the caller's URL claims an entity scope that must match
-        // either the canonical name or any aliased CLR name.
+        // Security: refuse to anchor an audit row that does not target the
+        // claimed entity OR any of its resolved children. Without the child
+        // branch, a forged URL like /timeline/Page/{otherPageId}?audit=X
+        // could anchor a PageVersion audit from a different aggregate.
         bool targetsEntity = entry.EntityChanges.Any(c =>
             matchTypes.Contains(c.EntityType) &&
             string.Equals(c.EntityId, entityId, StringComparison.Ordinal));
 
-        return targetsEntity ? Project(matchTypes, entityId, entry) : null;
+        bool targetsChild = !targetsEntity && entry.EntityChanges.Any(c =>
+            children.Any(scope =>
+                string.Equals(scope.ChildEntityType, c.EntityType, StringComparison.Ordinal) &&
+                scope.ChildEntityIds.Contains(c.EntityId)));
+
+        return targetsEntity || targetsChild
+            ? Project(matchTypes, entityId, children, entry)
+            : null;
     }
 
-    private static TimelineStreamEntry Project(IReadOnlySet<string> matchTypes, string entityId, AuditEntry entry)
+    private static TimelineStreamEntry Project(
+        IReadOnlySet<string> matchTypes,
+        string entityId,
+        IReadOnlyCollection<AuditChildScope> children,
+        AuditEntry entry)
     {
         AuditEntityChange? change = entry.EntityChanges.FirstOrDefault(c =>
             matchTypes.Contains(c.EntityType) &&
             string.Equals(c.EntityId, entityId, StringComparison.Ordinal));
+
+        // Child-aggregated audits don't match the parent ref — fall back to the
+        // child change so the body reflects what actually mutated.
+        change ??= entry.EntityChanges.FirstOrDefault(c =>
+            children.Any(scope =>
+                string.Equals(scope.ChildEntityType, c.EntityType, StringComparison.Ordinal) &&
+                scope.ChildEntityIds.Contains(c.EntityId)));
 
         return new TimelineStreamEntry
         {
@@ -98,6 +140,8 @@ internal sealed class AuditingTimelineSource(
         var payload = new
         {
             category = entry.Category.ToString(),
+            entityType = change?.EntityType,
+            entityId = change?.EntityId,
             changeType = change?.ChangeType.ToString(),
             changes = (change?.PropertyChanges ?? [])
                 .Select(p => new

--- a/src/Granit.Timeline.Auditing/README.md
+++ b/src/Granit.Timeline.Auditing/README.md
@@ -33,6 +33,40 @@ Timeline reader fans out to it on every `GET /timeline/{entityType}/{entityId}`
 and merges the audit projection with native timeline entries under the
 canonical sort.
 
+### Parent–child aggregation
+
+Audits on child entities surface in the parent aggregate's timeline once a
+module registers an `IAuditChildResolver`. The resolver returns the audited
+child ids for a given parent, and the bridge issues a single batch query
+covering parent + every child in one round-trip.
+
+```csharp
+public sealed class CmsPageAuditChildResolver(CmsDbContext db) : IAuditChildResolver
+{
+    public async Task<IReadOnlyCollection<AuditChildScope>> ResolveAsync(
+        string parentEntityType, string parentEntityId, CancellationToken ct)
+    {
+        if (parentEntityType != "Page" || !Guid.TryParse(parentEntityId, out var pageId))
+            return [];
+
+        string[] versions = await db.PageVersions
+            .Where(v => v.PageId == pageId)
+            .Select(v => v.Id.ToString())
+            .ToArrayAsync(ct);
+
+        return [new AuditChildScope("PageVersion", versions)];
+    }
+}
+
+// Registration — auto-discovered as IEnumerable<IAuditChildResolver>.
+services.TryAddEnumerable(
+    ServiceDescriptor.Scoped<IAuditChildResolver, CmsPageAuditChildResolver>());
+```
+
+Hosts with no resolver registered keep the pre-existing behaviour: only
+audit rows whose `(EntityType, EntityId)` matches the URL exactly are
+returned, and the cached `GetByEntityAsync` fast path stays hot.
+
 To make an audit entry interactive (reactions / threaded replies), the
 client first calls `POST /timeline/{entityType}/{entityId}/anchor` with
 `{ sourceKey: "auditing", sourceId: "<audit-guid>" }` — the server

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingReaderGetByEntitiesTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/EfCoreAuditingReaderGetByEntitiesTests.cs
@@ -1,0 +1,191 @@
+using Granit.Auditing.Domain;
+using Granit.Auditing.EntityFrameworkCore.Internal;
+using Granit.Auditing.EntityFrameworkCore.Internal.Services;
+using Granit.Auditing.Options;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+#pragma warning disable EF1001 // Internal EF Core API usage — required to construct AuditingDbContext directly.
+
+namespace Granit.Auditing.EntityFrameworkCore.Tests.Internal;
+
+public sealed class EfCoreAuditingReaderGetByEntitiesTests : IDisposable
+{
+    private readonly DbContextOptions<AuditingDbContext> _dbOptions;
+    private readonly FusionCache _cache = new(new FusionCacheOptions());
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly IOptions<AuditingOptions> _options = Microsoft.Extensions.Options.Options.Create(new AuditingOptions());
+
+    public EfCoreAuditingReaderGetByEntitiesTests()
+    {
+        _dbOptions = new DbContextOptionsBuilder<AuditingDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+    }
+
+    public void Dispose() => _cache.Dispose();
+
+    [Fact]
+    public async Task GetByEntitiesAsync_NoTargets_ReturnsEmpty()
+    {
+        EfCoreAuditingReader reader = NewReader();
+
+        IReadOnlyList<AuditEntry> result = await reader.GetByEntitiesAsync(
+            [], limit: 10, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetByEntitiesAsync_SingleTarget_BehavesLikeGetByEntity()
+    {
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "Page", "page-1");
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "Page", "page-2");
+
+        EfCoreAuditingReader reader = NewReader();
+
+        IReadOnlyList<AuditEntry> result = await reader.GetByEntitiesAsync(
+            [new AuditEntityRef("Page", "page-1")], limit: 10, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        result.Single().EntityChanges.Single().EntityId.ShouldBe("page-1");
+    }
+
+    [Fact]
+    public async Task GetByEntitiesAsync_MultipleTypesAndIds_UnionsTheirAudits()
+    {
+        // Parent + 2 child entity types — the typical aggregate shape.
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "Page", "page-1");
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "PageVersion", "v1");
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "PageVersion", "v2");
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "PageTranslation", "t-fr");
+        // Decoy — a Page-2 row that must NOT leak in.
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "Page", "page-2");
+
+        EfCoreAuditingReader reader = NewReader();
+
+        AuditEntityRef[] targets =
+        [
+            new("Page", "page-1"),
+            new("PageVersion", "v1"),
+            new("PageVersion", "v2"),
+            new("PageTranslation", "t-fr"),
+        ];
+
+        IReadOnlyList<AuditEntry> result = await reader.GetByEntitiesAsync(
+            targets, limit: 10, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(4);
+        result.SelectMany(e => e.EntityChanges).Select(c => c.EntityId)
+            .ShouldBe(new[] { "page-1", "v1", "v2", "t-fr" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task GetByEntitiesAsync_DoesNotCrossMatchPairsOfDifferentTypes()
+    {
+        // The OR-per-scope shape must keep (TypeA, IdB) from matching just
+        // because TypeA exists in one scope and IdB in another.
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "Order", "shared-id");
+        await SeedEntryWithEntityChangeAsync(Guid.NewGuid(), "Invoice", "other-id");
+
+        EfCoreAuditingReader reader = NewReader();
+
+        // We ask for (Order, other-id) and (Invoice, shared-id) — neither pair
+        // exists in the audit log, even though both types and both ids appear
+        // somewhere. A flattened-array implementation would have returned both.
+        AuditEntityRef[] targets =
+        [
+            new("Order", "other-id"),
+            new("Invoice", "shared-id"),
+        ];
+
+        IReadOnlyList<AuditEntry> result = await reader.GetByEntitiesAsync(
+            targets, limit: 10, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetByEntitiesAsync_OrdersByTimestampDescendingAndHonoursLimit()
+    {
+        // Oldest → newest.
+        var oldId = Guid.NewGuid();
+        var midId = Guid.NewGuid();
+        var newId = Guid.NewGuid();
+        await SeedEntryWithEntityChangeAsync(oldId, "Page", "page-1", DateTimeOffset.UtcNow.AddMinutes(-10));
+        await SeedEntryWithEntityChangeAsync(midId, "PageVersion", "v1", DateTimeOffset.UtcNow.AddMinutes(-5));
+        await SeedEntryWithEntityChangeAsync(newId, "PageTranslation", "t-fr", DateTimeOffset.UtcNow);
+
+        EfCoreAuditingReader reader = NewReader();
+
+        AuditEntityRef[] targets =
+        [
+            new("Page", "page-1"),
+            new("PageVersion", "v1"),
+            new("PageTranslation", "t-fr"),
+        ];
+
+        IReadOnlyList<AuditEntry> result = await reader.GetByEntitiesAsync(
+            targets, limit: 2, TestContext.Current.CancellationToken);
+
+        result.Select(e => e.Id).ShouldBe([newId, midId]);
+    }
+
+    [Fact]
+    public async Task GetByEntitiesAsync_NullTargets_Throws() =>
+        await Should.ThrowAsync<ArgumentNullException>(() =>
+            NewReader().GetByEntitiesAsync(null!, 10));
+
+    [Fact]
+    public async Task GetByEntitiesAsync_ZeroLimit_Throws() =>
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            NewReader().GetByEntitiesAsync([new AuditEntityRef("X", "1")], 0));
+
+    [Fact]
+    public async Task GetByEntitiesAsync_NegativeLimit_Throws() =>
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            NewReader().GetByEntitiesAsync([new AuditEntityRef("X", "1")], -1));
+
+    // --- Helpers ---
+
+    private EfCoreAuditingReader NewReader()
+    {
+        IDbContextFactory<AuditingDbContext> factory = new TestDbContextFactory(_dbOptions);
+        return new EfCoreAuditingReader(factory, _cache, _currentTenant, [], _options);
+    }
+
+    private async Task SeedEntryWithEntityChangeAsync(
+        Guid entryId, string entityType, string entityId, DateTimeOffset? timestamp = null)
+    {
+        await using AuditingDbContext ctx = new(_dbOptions, GranitDesignTime.CurrentTenant);
+        var entry = new AuditEntry
+        {
+            Id = entryId,
+            Timestamp = timestamp ?? DateTimeOffset.UtcNow,
+            UserId = "user-1",
+            Category = AuditCategory.DataMutation,
+        };
+        entry.EntityChanges.Add(new AuditEntityChange
+        {
+            Id = Guid.NewGuid(),
+            AuditEntryId = entryId,
+            EntityType = entityType,
+            EntityId = entityId,
+            ChangeType = AuditChangeType.Created,
+        });
+        ctx.AuditEntries.Add(entry);
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<AuditingDbContext> options)
+        : IDbContextFactory<AuditingDbContext>
+    {
+        public AuditingDbContext CreateDbContext() => new(options, GranitDesignTime.CurrentTenant);
+    }
+}

--- a/tests/Granit.Auditing.Tests/Extensions/AuditChildResolverExtensionsTests.cs
+++ b/tests/Granit.Auditing.Tests/Extensions/AuditChildResolverExtensionsTests.cs
@@ -1,0 +1,132 @@
+using Granit.Auditing.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Auditing.Tests.Extensions;
+
+public sealed class AuditChildResolverExtensionsTests
+{
+    [Fact]
+    public async Task ResolveAllAsync_NoResolvers_ReturnsEmpty()
+    {
+        IReadOnlyCollection<AuditChildScope> result = await Array
+            .Empty<IAuditChildResolver>()
+            .ResolveAllAsync("Page", "page-1", TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAllAsync_SingleResolver_ReturnsItsScopes()
+    {
+        FakeResolver r = new(
+            ("Page", "page-1"),
+            [new AuditChildScope("PageVersion", ["v1", "v2"])]);
+
+        IReadOnlyCollection<AuditChildScope> result = await new[] { (IAuditChildResolver)r }
+            .ResolveAllAsync("Page", "page-1", TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        AuditChildScope scope = result.Single();
+        scope.ChildEntityType.ShouldBe("PageVersion");
+        scope.ChildEntityIds.ShouldBe(new[] { "v1", "v2" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ResolveAllAsync_MultipleResolversSameChildType_UnionsIdsWithoutDuplicates()
+    {
+        FakeResolver r1 = new(("Page", "page-1"), [new AuditChildScope("PageVersion", ["v1", "v2"])]);
+        FakeResolver r2 = new(("Page", "page-1"), [new AuditChildScope("PageVersion", ["v2", "v3"])]);
+
+        IReadOnlyCollection<AuditChildScope> result = await new IAuditChildResolver[] { r1, r2 }
+            .ResolveAllAsync("Page", "page-1", TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        result.Single().ChildEntityIds.ShouldBe(new[] { "v1", "v2", "v3" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ResolveAllAsync_MultipleResolversDifferentChildTypes_KeepsBothScopes()
+    {
+        FakeResolver r1 = new(("Page", "page-1"), [new AuditChildScope("PageVersion", ["v1"])]);
+        FakeResolver r2 = new(("Page", "page-1"), [new AuditChildScope("PageTranslation", ["t-fr", "t-en"])]);
+
+        IReadOnlyCollection<AuditChildScope> result = await new IAuditChildResolver[] { r1, r2 }
+            .ResolveAllAsync("Page", "page-1", TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(2);
+        result.Single(s => s.ChildEntityType == "PageVersion").ChildEntityIds.ShouldBe(new[] { "v1" });
+        result.Single(s => s.ChildEntityType == "PageTranslation").ChildEntityIds.ShouldBe(new[] { "t-fr", "t-en" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ResolveAllAsync_EmptyChildIdsCollection_IsDropped()
+    {
+        // A resolver returning a scope with no ids contributes nothing — keeps
+        // the downstream batch query from issuing empty IN-lists per scope.
+        FakeResolver r = new(("Page", "page-1"), [new AuditChildScope("PageVersion", [])]);
+
+        IReadOnlyCollection<AuditChildScope> result = await new[] { (IAuditChildResolver)r }
+            .ResolveAllAsync("Page", "page-1", TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAllAsync_NullResolvers_Throws() =>
+        await Should.ThrowAsync<ArgumentNullException>(() =>
+            ((IEnumerable<IAuditChildResolver>)null!).ResolveAllAsync("Page", "page-1"));
+
+    [Fact]
+    public async Task ResolveAllAsync_EmptyParentType_Throws() =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            Array.Empty<IAuditChildResolver>().ResolveAllAsync("", "page-1"));
+
+    [Fact]
+    public async Task ResolveAllAsync_EmptyParentId_Throws() =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            Array.Empty<IAuditChildResolver>().ResolveAllAsync("Page", ""));
+
+    [Fact]
+    public void ToTargets_NoScopes_ReturnsParentOnly()
+    {
+        AuditEntityRef parent = new("Page", "page-1");
+
+        IReadOnlyCollection<AuditEntityRef> result = Array.Empty<AuditChildScope>().ToTargets(parent);
+
+        result.ShouldBe(new[] { parent });
+    }
+
+    [Fact]
+    public void ToTargets_WithScopes_PrependsParentAndFlattensChildren()
+    {
+        AuditEntityRef parent = new("Page", "page-1");
+        AuditChildScope[] scopes =
+        [
+            new("PageVersion", ["v1", "v2"]),
+            new("PageTranslation", ["t-fr"]),
+        ];
+
+        IReadOnlyCollection<AuditEntityRef> result = scopes.ToTargets(parent);
+
+        result.ShouldBe(new[]
+        {
+            parent,
+            new AuditEntityRef("PageVersion", "v1"),
+            new AuditEntityRef("PageVersion", "v2"),
+            new AuditEntityRef("PageTranslation", "t-fr"),
+        });
+    }
+
+    private sealed class FakeResolver(
+        (string ParentType, string ParentId) expected,
+        IReadOnlyCollection<AuditChildScope> scopes) : IAuditChildResolver
+    {
+        public Task<IReadOnlyCollection<AuditChildScope>> ResolveAsync(
+            string parentEntityType, string parentEntityId, CancellationToken cancellationToken = default)
+        {
+            (parentEntityType, parentEntityId).ShouldBe(expected);
+            return Task.FromResult(scopes);
+        }
+    }
+}

--- a/tests/Granit.Timeline.Auditing.Tests/AuditingTimelineSourceTests.cs
+++ b/tests/Granit.Timeline.Auditing.Tests/AuditingTimelineSourceTests.cs
@@ -22,7 +22,7 @@ public sealed class AuditingTimelineSourceTests
     private readonly IAuditingReader _auditing = Substitute.For<IAuditingReader>();
     private readonly AuditingTimelineSource _source;
 
-    public AuditingTimelineSourceTests() => _source = new AuditingTimelineSource(_auditing, []);
+    public AuditingTimelineSourceTests() => _source = new AuditingTimelineSource(_auditing, [], []);
 
     private static AuditingTimelineSource WithUserAlias(IAuditingReader auditing) =>
         new(auditing, [
@@ -31,7 +31,7 @@ public sealed class AuditingTimelineSourceTests
                 {
                     ["User"] = new HashSet<string>(StringComparer.Ordinal) { "LocalIdentity", "FederatedIdentity" },
                 }),
-        ]);
+        ], []);
 
     [Fact]
     public void SourceKey_IsAuditing() => _source.SourceKey.ShouldBe("auditing");
@@ -222,5 +222,151 @@ public sealed class AuditingTimelineSourceTests
             .GetEntryAsync("LocalIdentity", "user-42", auditId.ToString(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Parent-child aggregation — IAuditChildResolver
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetEntriesAsync_NoResolvers_UsesCachedSingleEntityPath()
+    {
+        // No resolver registered → fast path goes through GetByEntityAsync
+        // (which is FusionCache-backed). The batch overload must NOT be hit.
+        var entry = new AuditEntry
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            UserId = "u-1",
+            EntityChanges = [new AuditEntityChange { EntityType = "Page", EntityId = "page-1", ChangeType = AuditChangeType.Modified }],
+        };
+        _auditing.GetByEntityAsync("Page", "page-1", 1, 50, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<AuditEntry>([entry], 1, false));
+
+        IReadOnlyList<TimelineStreamEntry> result = await _source
+            .GetEntriesAsync("Page", "page-1", 50, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        await _auditing.DidNotReceive().GetByEntitiesAsync(
+            Arg.Any<IReadOnlyCollection<AuditEntityRef>>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetEntriesAsync_WithChildResolver_UnionsParentAndChildAudits()
+    {
+        // Parent + 2 children — verifies (a) batch overload is invoked,
+        // (b) target set assembled correctly, (c) every returned entry projects.
+        AuditEntry parentEntry = MakeEntry("Page", "page-1", AuditChangeType.Modified);
+        AuditEntry version1Entry = MakeEntry("PageVersion", "v1", AuditChangeType.Created);
+        AuditEntry version2Entry = MakeEntry("PageVersion", "v2", AuditChangeType.Modified);
+
+        _auditing.GetByEntitiesAsync(
+                Arg.Any<IReadOnlyCollection<AuditEntityRef>>(),
+                50,
+                Arg.Any<CancellationToken>())
+            .Returns([parentEntry, version1Entry, version2Entry]);
+
+        FakeChildResolver resolver = new("Page", "page-1",
+            [new AuditChildScope("PageVersion", ["v1", "v2"])]);
+        AuditingTimelineSource source = new(_auditing, [], [resolver]);
+
+        IReadOnlyList<TimelineStreamEntry> result = await source
+            .GetEntriesAsync("Page", "page-1", 50, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(3);
+        await _auditing.Received(1).GetByEntitiesAsync(
+            Arg.Is<IReadOnlyCollection<AuditEntityRef>>(t =>
+                t.Contains(new AuditEntityRef("Page", "page-1")) &&
+                t.Contains(new AuditEntityRef("PageVersion", "v1")) &&
+                t.Contains(new AuditEntityRef("PageVersion", "v2"))),
+            50,
+            Arg.Any<CancellationToken>());
+        // Single-entity path is NOT hit when children are present.
+        await _auditing.DidNotReceive().GetByEntityAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetEntryAsync_AcceptsAuditTargetingResolvedChild()
+    {
+        // Audit row targets PageVersion v1, anchored under /timeline/Page/page-1.
+        // The security check must let it through because v1 IS a child of page-1.
+        var auditId = Guid.NewGuid();
+        var entry = new AuditEntry
+        {
+            Id = auditId,
+            Timestamp = DateTimeOffset.UtcNow,
+            UserId = "u-1",
+            EntityChanges = [new AuditEntityChange { EntityType = "PageVersion", EntityId = "v1", ChangeType = AuditChangeType.Modified }],
+        };
+        _auditing.GetByIdAsync(auditId, Arg.Any<CancellationToken>()).Returns(entry);
+
+        FakeChildResolver resolver = new("Page", "page-1",
+            [new AuditChildScope("PageVersion", ["v1"])]);
+        AuditingTimelineSource source = new(_auditing, [], [resolver]);
+
+        TimelineStreamEntry? result = await source
+            .GetEntryAsync("Page", "page-1", auditId.ToString(), TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.SourceId.ShouldBe(auditId.ToString("D"));
+        // Body reflects the child mutation, not a (missing) parent change.
+        using var payload = JsonDocument.Parse(result.Body);
+        payload.RootElement.GetProperty("entityType").GetString().ShouldBe("PageVersion");
+        payload.RootElement.GetProperty("entityId").GetString().ShouldBe("v1");
+    }
+
+    [Fact]
+    public async Task GetEntryAsync_RejectsAuditTargetingChildOfDifferentParent()
+    {
+        // Audit row targets PageVersion v1, anchored under /timeline/Page/page-2.
+        // Resolver returns v1 as child of page-1 only — security check must
+        // refuse, preventing cross-aggregate anchoring via forged URLs.
+        var auditId = Guid.NewGuid();
+        var entry = new AuditEntry
+        {
+            Id = auditId,
+            Timestamp = DateTimeOffset.UtcNow,
+            UserId = "u-1",
+            EntityChanges = [new AuditEntityChange { EntityType = "PageVersion", EntityId = "v1", ChangeType = AuditChangeType.Modified }],
+        };
+        _auditing.GetByIdAsync(auditId, Arg.Any<CancellationToken>()).Returns(entry);
+
+        // Resolver only yields children for page-1, not page-2.
+        FakeChildResolver resolver = new("Page", "page-2", []);
+        AuditingTimelineSource source = new(_auditing, [], [resolver]);
+
+        TimelineStreamEntry? result = await source
+            .GetEntryAsync("Page", "page-2", auditId.ToString(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    private static AuditEntry MakeEntry(string type, string id, AuditChangeType changeType) => new()
+    {
+        Id = Guid.NewGuid(),
+        Timestamp = DateTimeOffset.UtcNow,
+        UserId = "u-1",
+        Category = AuditCategory.DataMutation,
+        EntityChanges = [new AuditEntityChange { EntityType = type, EntityId = id, ChangeType = changeType }],
+    };
+
+    private sealed class FakeChildResolver(
+        string expectedParentType,
+        string expectedParentId,
+        IReadOnlyCollection<AuditChildScope> scopes) : IAuditChildResolver
+    {
+        public Task<IReadOnlyCollection<AuditChildScope>> ResolveAsync(
+            string parentEntityType, string parentEntityId, CancellationToken cancellationToken = default)
+        {
+            if (!string.Equals(parentEntityType, expectedParentType, StringComparison.Ordinal) ||
+                !string.Equals(parentEntityId, expectedParentId, StringComparison.Ordinal))
+            {
+                return Task.FromResult<IReadOnlyCollection<AuditChildScope>>([]);
+            }
+            return Task.FromResult(scopes);
+        }
     }
 }


### PR DESCRIPTION
Closes #2416, #2417, #2418, #2419. Part of Epic #2415.

## Summary

Adds a framework-level seam so audits on child entities surface in the parent aggregate's timeline. Solves the generic gap where `AuditingTimelineSource` matched `EntityId` exactly — Page audits never showed `PageVersion` mutations, Order audits never showed `OrderLine` changes, and so on for every aggregate root with audited children.

## Changes

### `Granit.Auditing` (S1 — #2417)

- New `IAuditChildResolver` + `AuditChildScope` + `AuditEntityRef`.
- New `IAuditingReader.GetByEntitiesAsync(targets, limit, ct)` overload — intentionally unpaginated (the timeline merger only fetches top-K; cross-target pagination has no meaningful offset semantics).
- `AuditChildResolverExtensions.ResolveAllAsync` unions multiple providers with ordinal dedup, mirroring the existing `IAuditEntityTypeAliasProvider` pattern (`TryAddEnumerable` registration).

### `Granit.Auditing.EntityFrameworkCore` (S2 — #2418)

- `EfCoreAuditingReader.GetByEntitiesAsync` builds an **OR-per-scope** predicate (one branch per `(EntityType, ids[])` group), preserving strict pair semantics — no reliance on Guid cross-table uniqueness as an implicit invariant. Test `DoesNotCrossMatchPairsOfDifferentTypes` guards this.
- Skips FusionCache on the batch path (per-request target sets cause cache-key explosion). The single-entity `GetByEntityAsync` fast path stays cache-hot for no-children calls.

### `Granit.Timeline.Auditing` (S3 — #2419)

- `AuditingTimelineSource` consumes `IEnumerable<IAuditChildResolver>`. No-resolver hosts keep the cached single-entity fast path; resolver-equipped hosts hit `GetByEntitiesAsync` once per timeline read.
- `GetEntryAsync` security check accepts audits on resolved children (without this, child audits would surface in `GetEntriesAsync` but anchoring one via `/timeline/.../anchor` would be rejected). Cross-aggregate anchoring stays blocked — see `RejectsAuditTargetingChildOfDifferentParent`.
- README documents the resolver registration pattern with a `CmsPageAuditChildResolver` example.

## Consumer use case

`granit-business` will ship `CmsPageAuditChildResolver` once this lands in `0.1.0-dev.*`, replacing the SHA-1 custom projection from granit-business MR !36 (closed in favour of this).

## Test plan

- [x] `Granit.Auditing.Tests` — 120/120 (10 new for `AuditChildResolverExtensions`)
- [x] `Granit.Auditing.EntityFrameworkCore.Tests` — 136/136 (8 new for `GetByEntitiesAsync`)
- [x] `Granit.Auditing.Privacy.Tests` — 9/9 (consumer mocks `IAuditingReader` — verifies new interface member doesn't break NSubstitute)
- [x] `Granit.Timeline.Auditing.Tests` — 11/11 (4 new for parent+children, security check both directions)
- [x] `Granit.ArchitectureTests` — 241/241
- [x] `dotnet format --verify-no-changes` clean on all modified projects

## Out of scope

- Doc page on granit-fx.dev (`dotnet/cross-cutting/auditing/parent-child-aggregation.mdx`) — separate PR against `granit-docs` per CLAUDE.md decoupling rule.
- Cross-target pagination — flagged in the `GetByEntitiesAsync` docstring; future re-architecture if a consumer needs it.