### PR TITLE
feat(domain): ImageDimensions value object

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -16159,6 +16159,40 @@
       ]
     },
     {
+      "name": "ImageDimensions",
+      "fqn": "Granit.Domain.ValueObjects.ImageDimensions",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/ImageDimensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "IsLandscape",
+          "kind": "property",
+          "signature": "bool IsLandscape",
+          "returnType": "bool"
+        },
+        {
+          "name": "IsPortrait",
+          "kind": "property",
+          "signature": "bool IsPortrait",
+          "returnType": "bool"
+        },
+        {
+          "name": "IsSquare",
+          "kind": "property",
+          "signature": "bool IsSquare",
+          "returnType": "bool"
+        },
+        {
+          "name": "TotalPixels",
+          "kind": "property",
+          "signature": "long TotalPixels",
+          "returnType": "long"
+        }
+      ]
+    },
+    {
       "name": "ICryptoShreddingAuditRecorder",
       "fqn": "Granit.Encryption.CryptoShredding.ICryptoShreddingAuditRecorder",
       "kind": "interface",

--- a/src/Granit/Domain/ValueObjects/ImageDimensions.cs
+++ b/src/Granit/Domain/ValueObjects/ImageDimensions.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Serialization;
+
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Pixel dimensions of a raster image — width and height. A reusable value object
+/// for any domain that records image size: media libraries, document renditions,
+/// Open Graph / social cards, thumbnails, avatars.
+/// </summary>
+/// <remarks>
+/// Equality is structural over <see cref="Width"/> and <see cref="Height"/>. The
+/// derived geometry members (<see cref="AspectRatio"/>, orientation flags,
+/// <see cref="TotalPixels"/>) are computed and excluded from JSON so a serialized
+/// value stays the minimal <c>{ "width": …, "height": … }</c> shape.
+/// </remarks>
+public sealed class ImageDimensions : ValueObject
+{
+    /// <summary>Creates validated, non-negative pixel dimensions.</summary>
+    /// <param name="width">Width in pixels (non-negative).</param>
+    /// <param name="height">Height in pixels (non-negative).</param>
+    /// <exception cref="ArgumentOutOfRangeException">When a dimension is negative.</exception>
+    public ImageDimensions(int width, int height)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(width);
+        ArgumentOutOfRangeException.ThrowIfNegative(height);
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>Width in pixels (non-negative).</summary>
+    public int Width { get; }
+
+    /// <summary>Height in pixels (non-negative).</summary>
+    public int Height { get; }
+
+    /// <summary>
+    /// Width divided by height. Returns <c>0</c> when <see cref="Height"/> is <c>0</c>
+    /// (degenerate) rather than producing infinity / NaN.
+    /// </summary>
+    [JsonIgnore]
+    public double AspectRatio => Height == 0 ? 0d : (double)Width / Height;
+
+    /// <summary><c>true</c> when wider than tall.</summary>
+    [JsonIgnore]
+    public bool IsLandscape => Width > Height;
+
+    /// <summary><c>true</c> when taller than wide.</summary>
+    [JsonIgnore]
+    public bool IsPortrait => Height > Width;
+
+    /// <summary><c>true</c> when width equals height.</summary>
+    [JsonIgnore]
+    public bool IsSquare => Width == Height;
+
+    /// <summary>Total pixel count (<see cref="long"/> so large images cannot overflow).</summary>
+    [JsonIgnore]
+    public long TotalPixels => (long)Width * Height;
+
+    /// <inheritdoc />
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Width;
+        yield return Height;
+    }
+
+    /// <summary>Human-readable form, e.g. <c>1200x630px</c>.</summary>
+    public override string ToString() => $"{Width}x{Height}px";
+}

--- a/tests/Granit.Tests/Domain/ValueObjects/ImageDimensionsTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/ImageDimensionsTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Granit.Domain;
+using Granit.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Domain.ValueObjects;
+
+public sealed class ImageDimensionsTests
+{
+    // -------------------------------------------------------------------------
+    // Construction + validation
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(1200, 630)]
+    [InlineData(0, 0)]
+    [InlineData(1080, 1080)]
+    public void Ctor_NonNegative_Succeeds(int width, int height)
+    {
+        var dimensions = new ImageDimensions(width, height);
+
+        dimensions.Width.ShouldBe(width);
+        dimensions.Height.ShouldBe(height);
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(10, -1)]
+    public void Ctor_NegativeDimension_Throws(int width, int height)
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new ImageDimensions(width, height));
+    }
+
+    // -------------------------------------------------------------------------
+    // Derived geometry
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AspectRatio_DividesWidthByHeight()
+    {
+        new ImageDimensions(1600, 800).AspectRatio.ShouldBe(2d);
+    }
+
+    [Fact]
+    public void AspectRatio_ZeroHeight_ReturnsZeroNotInfinity()
+    {
+        new ImageDimensions(100, 0).AspectRatio.ShouldBe(0d);
+    }
+
+    [Theory]
+    [InlineData(1200, 630, true, false, false)]
+    [InlineData(630, 1200, false, true, false)]
+    [InlineData(500, 500, false, false, true)]
+    public void OrientationFlags_ReflectShape(
+        int width, int height, bool landscape, bool portrait, bool square)
+    {
+        var dimensions = new ImageDimensions(width, height);
+
+        dimensions.IsLandscape.ShouldBe(landscape);
+        dimensions.IsPortrait.ShouldBe(portrait);
+        dimensions.IsSquare.ShouldBe(square);
+    }
+
+    [Fact]
+    public void TotalPixels_DoesNotOverflowInt()
+    {
+        // 50000 * 50000 = 2.5e9, beyond int.MaxValue (~2.147e9).
+        new ImageDimensions(50_000, 50_000).TotalPixels.ShouldBe(2_500_000_000L);
+    }
+
+    [Fact]
+    public void ToString_IsHumanReadable()
+    {
+        new ImageDimensions(1200, 630).ToString().ShouldBe("1200x630px");
+    }
+
+    // -------------------------------------------------------------------------
+    // Value semantics
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Equality_IsStructural()
+    {
+        var a = new ImageDimensions(1200, 630);
+        var b = new ImageDimensions(1200, 630);
+        var c = new ImageDimensions(1200, 631);
+
+        a.ShouldBe(b);
+        (a == b).ShouldBeTrue();
+        a.ShouldNotBe(c);
+    }
+
+    [Fact]
+    public void IsValueObject()
+    {
+        new ImageDimensions(1, 1).ShouldBeAssignableTo<ValueObject>();
+    }
+
+    // -------------------------------------------------------------------------
+    // Serialization — only width/height; computed members are ignored
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Json_SerializesWidthAndHeightOnly()
+    {
+        string json = JsonSerializer.Serialize(new ImageDimensions(1200, 630));
+
+        json.ShouldContain("\"Width\":1200");
+        json.ShouldContain("\"Height\":630");
+        json.ShouldNotContain("AspectRatio");
+        json.ShouldNotContain("TotalPixels");
+        json.ShouldNotContain("IsLandscape");
+    }
+
+    [Fact]
+    public void Json_RoundTrips()
+    {
+        var original = new ImageDimensions(1200, 630);
+
+        ImageDimensions? restored = JsonSerializer.Deserialize<ImageDimensions>(
+            JsonSerializer.Serialize(original));
+
+        restored.ShouldBe(original);
+    }
+}


### PR DESCRIPTION
## What

Adds `Granit.Domain.ValueObjects.ImageDimensions` — a reusable value object for raster image size (width + height), sitting alongside `HttpsUrl` / `FileName` / `BlobReference`.

- Structural equality over `Width` / `Height` (derives from `ValueObject`).
- Non-negative validation in the constructor.
- Derived geometry helpers: `AspectRatio` (returns 0 on zero height rather than ∞/NaN), `IsLandscape` / `IsPortrait` / `IsSquare`, `TotalPixels` (`long`, so a 50000² image can't overflow `int`).
- Computed members are `[JsonIgnore]`d, so a serialized value stays the minimal `{ "Width": …, "Height": … }` shape and round-trips cleanly.

## Why

Extracted while building **Granit.Cms.Seo** (the OG-image / social-card value object), but pixel dimensions are a universal concept — media libraries, document renditions, thumbnails, avatars — so the framework is the right home rather than the CMS module. `granit-website`'s `Granit.Cms.Seo` will consume this once it ships in a dev package.

## Tests

16 unit tests in `Granit.Tests/Domain/ValueObjects/ImageDimensionsTests.cs`: validation, derived geometry (incl. zero-height + overflow), structural equality, and JSON shape/round-trip. `dotnet format` clean.