### PR TITLE
feat(domain): AbsoluteUrl value object

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -16049,6 +16049,28 @@
       ]
     },
     {
+      "name": "AbsoluteUrl",
+      "fqn": "Granit.Domain.ValueObjects.AbsoluteUrl",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/AbsoluteUrl.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public AbsoluteUrl"
+        },
+        {
+          "name": "AbsoluteUrl",
+          "kind": "method",
+          "signature": "AbsoluteUrl(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
       "name": "BlobReference",
       "fqn": "Granit.Domain.ValueObjects.BlobReference",
       "kind": "class",

--- a/src/Granit/Domain/ValueObjects/AbsoluteUrl.cs
+++ b/src/Granit/Domain/ValueObjects/AbsoluteUrl.cs
@@ -1,0 +1,54 @@
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// An absolute HTTP or HTTPS URL. Maximum 2048 characters.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="HttpsUrl"/>, this permits plain <c>http</c> so a single value
+/// object serves development / preview origins (e.g. <c>http://localhost:3000</c>) as
+/// well as production. Where HTTPS is mandatory (e.g. a production canonical URL),
+/// enforce it in FluentValidation at the endpoint boundary — together with any SSRF /
+/// host restrictions — rather than in the value object, so non-production environments
+/// are not locked out.
+/// </remarks>
+public sealed class AbsoluteUrl : SingleValueObject<string>
+{
+    private const int MaxLength = 2048;
+
+    /// <inheritdoc />
+    public override required string Value { get; init; }
+
+    /// <summary>
+    /// Creates a validated <see cref="AbsoluteUrl"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// When <paramref name="value"/> is empty, exceeds 2048 characters, or is not an
+    /// absolute <c>http</c> / <c>https</c> URL.
+    /// </exception>
+    public static AbsoluteUrl Create(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        if (value.Length > MaxLength)
+        {
+            throw new ArgumentException(
+                $"URL exceeds maximum length of {MaxLength} characters.", nameof(value));
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            || (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException(
+                "Value must be an absolute HTTP or HTTPS URL.", nameof(value));
+        }
+
+        return new AbsoluteUrl { Value = value };
+    }
+
+    /// <summary>Implicit conversion to <see cref="string"/>.</summary>
+    public static implicit operator string(AbsoluteUrl url) => url.Value;
+
+    /// <summary>Implicit conversion from <see cref="string"/>.</summary>
+    public static implicit operator AbsoluteUrl(string value) => Create(value);
+}

--- a/tests/Granit.Tests/Domain/ValueObjects/AbsoluteUrlTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/AbsoluteUrlTests.cs
@@ -1,0 +1,62 @@
+using Granit.Domain;
+using Granit.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Domain.ValueObjects;
+
+public sealed class AbsoluteUrlTests
+{
+    [Theory]
+    [InlineData("https://www.acme.com")]
+    [InlineData("https://acme.com/about/team?x=1#frag")]
+    [InlineData("http://localhost:3000/preview")] // dev / preview origins are http
+    [InlineData("http://127.0.0.1:5000")]
+    public void Create_AbsoluteHttpOrHttps_Succeeds(string value)
+    {
+        AbsoluteUrl.Create(value).Value.ShouldBe(value);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("/relative/path")]
+    [InlineData("www.acme.com")]
+    [InlineData("ftp://acme.com/file")]
+    [InlineData("mailto:hi@acme.com")]
+    [InlineData("javascript:alert(1)")]
+    public void Create_NotAbsoluteHttpUrl_Throws(string value)
+    {
+        Should.Throw<ArgumentException>(() => AbsoluteUrl.Create(value));
+    }
+
+    [Fact]
+    public void Create_TooLong_Throws()
+    {
+        string tooLong = "https://acme.com/" + new string('a', 2048);
+
+        Should.Throw<ArgumentException>(() => AbsoluteUrl.Create(tooLong));
+    }
+
+    [Fact]
+    public void ImplicitConversions_RoundTrip()
+    {
+        AbsoluteUrl url = "https://acme.com";
+        string raw = url;
+
+        raw.ShouldBe("https://acme.com");
+    }
+
+    [Fact]
+    public void Equality_IsStructural()
+    {
+        AbsoluteUrl.Create("https://acme.com").ShouldBe(AbsoluteUrl.Create("https://acme.com"));
+        AbsoluteUrl.Create("https://acme.com").ShouldNotBe(AbsoluteUrl.Create("https://acme.org"));
+    }
+
+    [Fact]
+    public void IsSingleValueObject()
+    {
+        AbsoluteUrl.Create("https://acme.com").ShouldBeAssignableTo<ValueObject>();
+    }
+}


### PR DESCRIPTION
## What

Adds `Granit.Domain.ValueObjects.AbsoluteUrl` — an absolute **http or https** URL value object, sibling to `HttpsUrl`.

- Validates absolute URI + http/https scheme + ≤2048 chars; structural equality; implicit string conversions (same shape as `HttpsUrl`).
- Permits plain `http` so one type serves **dev / preview origins** (`http://localhost:3000`) as well as production. HTTPS-only enforcement, where required, belongs in endpoint FluentValidation (environment-aware) — not the VO — so non-prod isn't locked out.

## Why

`Granit.Cms.Seo` needs a URL VO for `og:url` / `og:image` / canonical that doesn't break in non-https dev/staging. `HttpsUrl` is too strict there; a raw string is too loose. Generic enough for the framework (same call as the `ImageDimensions` VO in #2430).

## Tests

15 unit tests (`AbsoluteUrlTests`): http/https accept, relative/ftp/mailto/js/empty reject, length cap, implicit conversions, structural equality. `dotnet format` clean.