### PR TITLE
fix(identity-federated): expose UserCacheModelBuilderExtensions as public

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22795,6 +22795,22 @@
       ]
     },
     {
+      "name": "UserCacheModelBuilderExtensions",
+      "fqn": "Granit.Identity.Federated.EntityFrameworkCore.Extensions.UserCacheModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Federated.EntityFrameworkCore",
+      "file": "src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/UserCacheModelBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ConfigureIdentityModule",
+          "kind": "method",
+          "signature": "ConfigureIdentityModule(this ModelBuilder builder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
       "name": "GranitIdentityDbProperties",
       "fqn": "Granit.Identity.Federated.EntityFrameworkCore.GranitIdentityDbProperties",
       "kind": "class",

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/UserCacheModelBuilderExtensions.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/UserCacheModelBuilderExtensions.cs
@@ -1,15 +1,18 @@
 using Granit.Identity.Federated.Domain;
 using Microsoft.EntityFrameworkCore;
 
-namespace Granit.Identity.Federated.EntityFrameworkCore.Internal;
+namespace Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 
-/// <summary>EF Core model builder extensions for the Identity.Federated module.</summary>
+/// <summary>EF Core model builder extensions for the Granit.Identity.Federated module.</summary>
 /// <remarks>
-/// Called by <see cref="IdentityFederatedHostDbContext"/>. Internal since the dedicated
-/// DbContext landed in Epic #2382 V2 — consuming apps no longer fold the model into
-/// their own context.
+/// Called by <see cref="Internal.IdentityFederatedHostDbContext"/> and
+/// <see cref="Internal.IdentityFederatedTenantDbContext"/>, AND publicly exposed so
+/// consuming applications can fold the federated user-cache model into their own
+/// host-owned <see cref="DbContext"/> when they own the migration set (the framework
+/// ships no migrations per the standard Granit pattern — same shape as
+/// <c>Granit.Webhooks.EntityFrameworkCore.Extensions.WebhooksModelBuilderExtensions</c>).
 /// </remarks>
-internal static class UserCacheModelBuilderExtensions
+public static class UserCacheModelBuilderExtensions
 {
     /// <summary>
     /// Applies all entity configurations for the Granit.Identity.Federated module.

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/IdentityFederatedHostDbContext.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/IdentityFederatedHostDbContext.cs
@@ -1,5 +1,6 @@
 using Granit.DataFiltering;
 using Granit.Identity.Federated.Domain;
+using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/IdentityFederatedTenantDbContext.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/IdentityFederatedTenantDbContext.cs
@@ -1,5 +1,6 @@
 using Granit.DataFiltering;
 using Granit.Identity.Federated.Domain;
+using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
## Context

Reported by the showcase team while migrating \`granit-microservice-template\` to the V2 API.

Phase A of #2406 (commit \`cab685453\`) left \`UserCacheModelBuilderExtensions\` as \`internal static class\` in \`Internal/\`, under the assumption that the new dedicated \`IdentityFederatedHostDbContext\` made consumer-side folding unnecessary. That assumption breaks consuming apps that need to own the migration set.

Per CLAUDE.md "Framework packages NEVER ship EF migrations; consuming app owns them" — the host's migration generator must have a path to call \`ConfigureIdentityModule()\` on its own \`ModelBuilder\`, otherwise the \`identity_user_cache_entries\` table can never be provisioned in production.

## Fix

Mirrors the Webhooks shape exactly (\`public static class WebhooksModelBuilderExtensions\` in \`Extensions/\`):

- Move \`UserCacheModelBuilderExtensions.cs\` from \`Internal/\` to \`Extensions/\`.
- Bump namespace from \`…EntityFrameworkCore.Internal\` to \`…EntityFrameworkCore.Extensions\`.
- Change visibility \`internal static class\` → \`public static class\`.
- Update internal callers (\`IdentityFederatedHostDbContext\`, \`IdentityFederatedTenantDbContext\`) with the new \`using\` directive.
- Refresh the XML summary to document the public exposure rationale.

No method-name change in this hotfix — \`ConfigureIdentityModule\` keeps its existing name to minimise diff. Renaming to \`ConfigureIdentityFederatedModule\` for naming consistency with \`ConfigureWebhooksModule\` can be a follow-up.

## Unblocks downstream

Once this lands and a dev package publishes to the GitLab Package Registry, the showcase / microservice-template MRs can adopt the V2 API.

## Note for the showcase team

The downstream report stated that \`Granit.Identity.EntityFrameworkCore\` (l'annuaire canonique) kept its \`IServiceCollection\` API — that is **incorrect**. PR #2431 (Identity V2) also migrated it to \`IHostApplicationBuilder\` + \`Action<IdentityEntityFrameworkCoreOptions>\`. Program.cs:66 needs the same migration as Program.cs:65.

## Test plan

- [x] \`dotnet build src/Granit.Identity.Federated.EntityFrameworkCore -c Release\` — 0 errors
- [x] \`dotnet test tests/Granit.Identity.Federated.EntityFrameworkCore.Tests\` — **35/35 pass**
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — **241/241 pass** (incl. namespace/folder coherence, options placement, file organisation)
- [x] \`dotnet format src/Granit.Identity.Federated.EntityFrameworkCore --verify-no-changes\` — clean