### PR TITLE
feat(notifications): DualScopeStorageMode.Segregated for V3 wave (#2432)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -31738,12 +31738,12 @@
       "kind": "class",
       "project": "Granit.Notifications.EntityFrameworkCore",
       "file": "src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "AddGranitNotificationsEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitNotificationsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitNotificationsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<NotificationsEntityFrameworkCoreOptions> configure)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -31788,6 +31788,22 @@
       "file": "src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsEntityFrameworkCoreModule.cs",
       "line": 20,
       "members": []
+    },
+    {
+      "name": "NotificationsEntityFrameworkCoreOptions",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.Options.NotificationsEntityFrameworkCoreOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/Options/NotificationsEntityFrameworkCoreOptions.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "StorageMode",
+          "kind": "property",
+          "signature": "DualScopeStorageMode StorageMode",
+          "returnType": "DualScopeStorageMode"
+        }
+      ]
     },
     {
       "name": "EntityStateChangedData",

--- a/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,16 +1,17 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.EntityFrameworkCore.Internal;
+using Granit.Notifications.EntityFrameworkCore.Options;
 using Granit.Notifications.Internal;
 using Granit.Notifications.MobilePush;
 using Granit.Notifications.MobilePush.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Persistence.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
-
-// EntityTrackingInterceptor requires manual wiring because UseGranitInterceptors
-// only resolves the 6 standard Granit.Persistence interceptors.
 
 namespace Granit.Notifications.EntityFrameworkCore.Extensions;
 
@@ -20,75 +21,164 @@ namespace Granit.Notifications.EntityFrameworkCore.Extensions;
 public static class NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions
 {
     /// <summary>
-    /// Replaces the default InMemory/no-op stores with durable EF Core implementations
-    /// backed by a PostgreSQL database.
+    /// Replaces the default InMemory/no-op stores with durable EF Core implementations.
     /// </summary>
     /// <remarks>
-    /// Must be called after <c>AddGranitNotifications()</c>.
-    /// Registers:
+    /// <para>
+    /// Must be called after <c>AddGranitNotifications()</c>. The
+    /// <see cref="NotificationsEntityFrameworkCoreOptions.StorageMode"/> option chooses how
+    /// host-level and tenant-level notifications are laid out — see ADR-063.
+    /// </para>
     /// <list type="bullet">
-    ///   <item><see cref="EfCoreUserNotificationStore"/> — replaces <c>InMemoryUserNotificationStore</c>.</item>
-    ///   <item><see cref="EfCoreNotificationPreferenceStore"/> — replaces <c>InMemoryNotificationPreferenceStore</c>.</item>
-    ///   <item><see cref="EfCoreNotificationSubscriptionStore"/> — replaces <c>InMemoryNotificationSubscriptionStore</c>.</item>
-    ///   <item><see cref="EfCoreNotificationDeliveryStore"/> — replaces <c>NullNotificationDeliveryStore</c> (enables ISO 27001 audit trail).</item>
-    ///   <item><see cref="EfCoreMobilePushTokenStore"/> — replaces <c>InMemoryMobilePushTokenStore</c>.</item>
-    ///   <item><see cref="Internal.NotificationsDbContext"/> — registered via <c>IDbContextFactory</c> for thread-safe usage in Wolverine handlers.</item>
+    ///   <item>
+    ///     <see cref="DualScopeStorageMode.Shared"/> (default) — single host table; tenant
+    ///     rows carry <c>TenantId</c> and are filtered by a row-level query filter.
+    ///   </item>
+    ///   <item>
+    ///     <see cref="DualScopeStorageMode.Segregated"/> — host rows in
+    ///     <c>NotificationsHostDbContext</c>, tenant rows in the isolated
+    ///     <c>NotificationsTenantDbContext</c>. NotificationDeliveryAttempt audit rows
+    ///     always land in the host context (centralised SOC2 trail), regardless of the
+    ///     parent notification's scope.
+    ///   </item>
     /// </list>
     /// </remarks>
     /// <param name="builder">The host application builder.</param>
-    /// <param name="configure">EF Core <see cref="DbContextOptionsBuilder"/> configuration (provider + connection string).</param>
+    /// <param name="configure">Configuration callback for
+    /// <see cref="NotificationsEntityFrameworkCoreOptions"/>.</param>
     /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitNotificationsEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<NotificationsEntityFrameworkCoreOptions> configure)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        NotificationsEntityFrameworkCoreOptions options = new();
+        configure(options);
+
+        TenantIsolationStrategy strategy = ResolveTenantIsolationStrategy(builder.Configuration);
+        DualScopeValidation.ValidateStorageMode(options.StorageMode, strategy, moduleName: "Notifications");
+
+        builder.Services.AddSingleton(options);
+
+        // EntityTrackingInterceptor implements IGranitAutoInterceptor — registered with
+        // both the concrete type and the auto-interceptor marker so UseGranitInterceptors
+        // (invoked by AddGranitDbContext / AddGranitIsolatedDbContext) picks it up.
         builder.Services.TryAddScoped<EntityTrackingInterceptor>();
-        builder.Services.AddDbContextFactory<NotificationsDbContext>((sp, options) =>
+        builder.Services.AddScoped<Persistence.EntityFrameworkCore.Interceptors.IGranitAutoInterceptor>(sp =>
+            sp.GetRequiredService<EntityTrackingInterceptor>());
+
+        switch (options.StorageMode)
         {
-            configure(options);
-            options.UseGranitInterceptors(sp);
-            options.AddInterceptors(sp.GetRequiredService<EntityTrackingInterceptor>());
-        }, ServiceLifetime.Scoped);
+            case DualScopeStorageMode.Shared:
+                RegisterSharedMode(builder, options);
+                break;
 
-        // UserNotification store — CQRS forwarding pattern
-        // Scoped: AddGranitDbContext registers IDbContextFactory<T> as Scoped (interceptors
-        // depend on ICurrentTenant/ICurrentUser which are Scoped). Stores injecting the factory
-        // must also be Scoped to avoid captive dependency violations.
-        builder.Services.RemoveAll<InMemoryUserNotificationStore>();
-        builder.Services.AddScoped<EfCoreUserNotificationStore>();
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<IUserNotificationReader>(sp => sp.GetRequiredService<EfCoreUserNotificationStore>()));
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<IUserNotificationWriter>(sp => sp.GetRequiredService<EfCoreUserNotificationStore>()));
+            case DualScopeStorageMode.Segregated:
+                RegisterSegregatedMode(builder, options);
+                break;
 
-        // Preference store — CQRS forwarding pattern
-        builder.Services.RemoveAll<InMemoryNotificationPreferenceStore>();
-        builder.Services.AddScoped<EfCoreNotificationPreferenceStore>();
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<INotificationPreferenceReader>(sp => sp.GetRequiredService<EfCoreNotificationPreferenceStore>()));
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<INotificationPreferenceWriter>(sp => sp.GetRequiredService<EfCoreNotificationPreferenceStore>()));
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(configure),
+                    options.StorageMode,
+                    "Unknown DualScopeStorageMode value.");
+        }
 
-        // Subscription store — CQRS forwarding pattern
-        builder.Services.RemoveAll<InMemoryNotificationSubscriptionStore>();
-        builder.Services.AddScoped<EfCoreNotificationSubscriptionStore>();
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<INotificationSubscriptionReader>(sp => sp.GetRequiredService<EfCoreNotificationSubscriptionStore>()));
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<INotificationSubscriptionWriter>(sp => sp.GetRequiredService<EfCoreNotificationSubscriptionStore>()));
-
-        // Delivery store — write-only (ISO 27001 audit)
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<INotificationDeliveryWriter, EfCoreNotificationDeliveryStore>());
-
-        // MobilePush token store — CQRS forwarding pattern
-        builder.Services.RemoveAll<InMemoryMobilePushTokenStore>();
-        builder.Services.AddScoped<EfCoreMobilePushTokenStore>();
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<IMobilePushTokenReader>(sp => sp.GetRequiredService<EfCoreMobilePushTokenStore>()));
-        builder.Services.Replace(
-            ServiceDescriptor.Scoped<IMobilePushTokenWriter>(sp => sp.GetRequiredService<EfCoreMobilePushTokenStore>()));
+        RegisterStores(builder.Services);
 
         return builder;
+    }
+
+    private static void RegisterSharedMode(
+        IHostApplicationBuilder builder,
+        NotificationsEntityFrameworkCoreOptions options)
+    {
+        if (options.Configure is null)
+        {
+            throw new InvalidOperationException(
+                "NotificationsEntityFrameworkCoreOptions.Configure must be set when StorageMode is " +
+                "DualScopeStorageMode.Shared (the default). Provide an Action<DbContextOptionsBuilder> " +
+                "that configures the EF Core provider and connection string.");
+        }
+
+        builder.Services.AddGranitDbContext<NotificationsHostDbContext>(options.Configure);
+        builder.Services.AddHostedService<NotificationsDualScopeIntegrationValidator>();
+
+        builder.Services.AddScoped(sp => new NotificationsContextResolver(
+            DualScopeStorageMode.Shared,
+            hostFactory: sp.GetRequiredService<IDbContextFactory<NotificationsHostDbContext>>(),
+            tenantFactory: null));
+    }
+
+    private static void RegisterSegregatedMode(
+        IHostApplicationBuilder builder,
+        NotificationsEntityFrameworkCoreOptions options)
+    {
+        if (options.ConfigureHost is null)
+        {
+            throw new InvalidOperationException(
+                "NotificationsEntityFrameworkCoreOptions.ConfigureHost must be set when StorageMode is " +
+                "DualScopeStorageMode.Segregated.");
+        }
+
+        if (options.ConfigureSchemaPerTenant is null && options.ConfigureDatabasePerTenant is null)
+        {
+            throw new InvalidOperationException(
+                "NotificationsEntityFrameworkCoreOptions: at least one of ConfigureSchemaPerTenant or " +
+                "ConfigureDatabasePerTenant must be set when StorageMode is DualScopeStorageMode.Segregated.");
+        }
+
+        builder.Services.AddGranitDbContext<NotificationsHostDbContext>(options.ConfigureHost);
+
+        builder.Services.AddGranitIsolatedDbContext<NotificationsTenantDbContext>(
+            configureShared: _ => { /* SharedDatabase already rejected by DualScopeValidation. */ },
+            configureDatabasePerTenant: options.ConfigureDatabasePerTenant,
+            configureSchemaPerTenant: options.ConfigureSchemaPerTenant);
+
+        builder.Services.AddScoped(sp => new NotificationsContextResolver(
+            DualScopeStorageMode.Segregated,
+            hostFactory: sp.GetRequiredService<IDbContextFactory<NotificationsHostDbContext>>(),
+            tenantFactory: sp.GetRequiredService<IDbContextFactory<NotificationsTenantDbContext>>()));
+    }
+
+    private static void RegisterStores(IServiceCollection services)
+    {
+        // UserNotification — CQRS forwarding
+        services.RemoveAll<InMemoryUserNotificationStore>();
+        services.AddScoped<EfCoreUserNotificationStore>();
+        services.Replace(ServiceDescriptor.Scoped<IUserNotificationReader>(sp => sp.GetRequiredService<EfCoreUserNotificationStore>()));
+        services.Replace(ServiceDescriptor.Scoped<IUserNotificationWriter>(sp => sp.GetRequiredService<EfCoreUserNotificationStore>()));
+
+        // Preference — CQRS forwarding
+        services.RemoveAll<InMemoryNotificationPreferenceStore>();
+        services.AddScoped<EfCoreNotificationPreferenceStore>();
+        services.Replace(ServiceDescriptor.Scoped<INotificationPreferenceReader>(sp => sp.GetRequiredService<EfCoreNotificationPreferenceStore>()));
+        services.Replace(ServiceDescriptor.Scoped<INotificationPreferenceWriter>(sp => sp.GetRequiredService<EfCoreNotificationPreferenceStore>()));
+
+        // Subscription — CQRS forwarding
+        services.RemoveAll<InMemoryNotificationSubscriptionStore>();
+        services.AddScoped<EfCoreNotificationSubscriptionStore>();
+        services.Replace(ServiceDescriptor.Scoped<INotificationSubscriptionReader>(sp => sp.GetRequiredService<EfCoreNotificationSubscriptionStore>()));
+        services.Replace(ServiceDescriptor.Scoped<INotificationSubscriptionWriter>(sp => sp.GetRequiredService<EfCoreNotificationSubscriptionStore>()));
+
+        // Delivery — write-only ISO 27001 audit (always host-routed)
+        services.Replace(ServiceDescriptor.Scoped<INotificationDeliveryWriter, EfCoreNotificationDeliveryStore>());
+
+        // MobilePush — CQRS forwarding
+        services.RemoveAll<InMemoryMobilePushTokenStore>();
+        services.AddScoped<EfCoreMobilePushTokenStore>();
+        services.Replace(ServiceDescriptor.Scoped<IMobilePushTokenReader>(sp => sp.GetRequiredService<EfCoreMobilePushTokenStore>()));
+        services.Replace(ServiceDescriptor.Scoped<IMobilePushTokenWriter>(sp => sp.GetRequiredService<EfCoreMobilePushTokenStore>()));
+    }
+
+    private static TenantIsolationStrategy ResolveTenantIsolationStrategy(IConfiguration configuration)
+    {
+        TenantIsolationOptions? bound = configuration
+            .GetSection("MultiTenancy:TenantIsolation")
+            .Get<TenantIsolationOptions>();
+
+        return bound?.Strategy ?? TenantIsolationStrategy.SharedDatabase;
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreMobilePushTokenStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreMobilePushTokenStore.cs
@@ -1,8 +1,6 @@
-using Granit.MultiTenancy;
 using Granit.Notifications.MobilePush;
 using Granit.Notifications.MobilePush.Domain;
 using Granit.Notifications.MobilePush.Internal;
-using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
@@ -11,55 +9,56 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IMobilePushTokenReader"/> and
 /// <see cref="IMobilePushTokenWriter"/>. Upsert / remove paths route through
 /// <see cref="IMobilePushTokenHasher"/> since
-/// <see cref="MobilePushToken.DeviceToken"/> is encrypted at rest and not
-/// queryable for equality.
+/// <see cref="MobilePushToken.DeviceToken"/> is encrypted at rest and not queryable for
+/// equality.
 /// </summary>
 internal sealed class EfCoreMobilePushTokenStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory,
-    ICurrentTenant currentTenant,
+    NotificationsContextResolver resolver,
     IMobilePushTokenHasher hasher)
-    : EfStoreBase<MobilePushToken, NotificationsDbContext>(contextFactory, currentTenant), IMobilePushTokenReader, IMobilePushTokenWriter
+    : IMobilePushTokenReader, IMobilePushTokenWriter
 {
-    /// <inheritdoc />
-    public Task<IReadOnlyList<MobilePushToken>> GetTokensAsync(
-        string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        ReadAsync(async db =>
-            (IReadOnlyList<MobilePushToken>)await db.MobilePushTokens
-                .Where(t => t.UserId == userId && t.TenantId == tenantId)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken);
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<MobilePushToken>> GetTokensAsync(
+        string userId, Guid? tenantId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.MobilePushTokens
+            .Where(t => t.UserId == userId && t.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task RegisterAsync(
-        string userId,
-        string deviceToken,
-        MobilePlatform platform,
-        Guid? tenantId,
+        string userId, string deviceToken, MobilePlatform platform, Guid? tenantId,
         CancellationToken cancellationToken = default)
     {
         string tokenHash = hasher.ComputeHash(deviceToken)
             ?? throw new ArgumentException("DeviceToken cannot be null or empty.", nameof(deviceToken));
 
-        await WriteAsync(async db =>
-        {
-            MobilePushToken? existing = await db.MobilePushTokens
-                .FirstOrDefaultAsync(t => t.DeviceTokenHash == tokenHash && t.TenantId == tenantId, cancellationToken)
-                .ConfigureAwait(false);
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
 
-            if (existing is not null)
-            {
-                existing.Reassign(userId, platform);
-            }
-            else
-            {
-                db.MobilePushTokens.Add(MobilePushToken.Create(userId, deviceToken, tokenHash, platform, tenantId));
-            }
-        }, cancellationToken).ConfigureAwait(false);
+        MobilePushToken? existing = await db.MobilePushTokens
+            .FirstOrDefaultAsync(
+                t => t.DeviceTokenHash == tokenHash && t.TenantId == tenantId,
+                cancellationToken).ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            existing.Reassign(userId, platform);
+        }
+        else
+        {
+            db.MobilePushTokens.Add(MobilePushToken.Create(userId, deviceToken, tokenHash, platform, tenantId));
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    /// <inheritdoc />
-    public async Task RemoveAsync(string deviceToken, string userId, Guid? tenantId, CancellationToken cancellationToken = default)
+    /// <inheritdoc/>
+    public async Task RemoveAsync(
+        string deviceToken, string userId, Guid? tenantId, CancellationToken cancellationToken = default)
     {
         string? tokenHash = hasher.ComputeHash(deviceToken);
         if (tokenHash is null)
@@ -67,11 +66,10 @@ internal sealed class EfCoreMobilePushTokenStore(
             return;
         }
 
-        await WriteAsync(async db =>
-            await db.MobilePushTokens
-                .Where(t => t.DeviceTokenHash == tokenHash && t.UserId == userId && t.TenantId == tenantId)
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken).ConfigureAwait(false);
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        await db.MobilePushTokens
+            .Where(t => t.DeviceTokenHash == tokenHash && t.UserId == userId && t.TenantId == tenantId)
+            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationDeliveryStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationDeliveryStore.cs
@@ -1,6 +1,5 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
-using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.ExceptionHandling;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
@@ -12,26 +11,36 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Records carry a unique <see cref="NotificationDeliveryAttempt.DeliveryId"/> captured at claim time
-/// (#947) before the outbound transport runs, so duplicate claims cannot double-send.
+/// Delivery attempts are platform-level audit rows — they always land in the host context
+/// regardless of <see cref="Granit.Persistence.MultiTenancy.DualScopeStorageMode"/>. This
+/// keeps the SOC2 trail centralized and cross-tenant-queryable, even under Segregated
+/// storage (the parent notification may live in a tenant DB, but the audit row tracking
+/// the attempt stays in host for compliance ops).
 /// </para>
 /// <para>
-/// After retention expires, <see cref="DeleteBeforeAsync"/> enables GDPR-compliant data minimization.
+/// Records carry a unique <see cref="NotificationDeliveryAttempt.DeliveryId"/> captured
+/// at claim time (#947) before the outbound transport runs, so duplicate claims cannot
+/// double-send.
 /// </para>
 /// </remarks>
 internal sealed class EfCoreNotificationDeliveryStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory,
-    IClock clock)
-    : EfStoreBase<NotificationDeliveryAttempt, NotificationsDbContext>(contextFactory), INotificationDeliveryWriter
+    NotificationsContextResolver resolver,
+    IClock clock) : INotificationDeliveryWriter
 {
-    // Rows claimed but never finalized (worker crash, host OOM) are eligible for re-acquisition
-    // after this window. Keeps the audit row in place but unblocks subsequent retries instead of
-    // permanently dropping the notification.
+    // Rows claimed but never finalized (worker crash, host OOM) are eligible for
+    // re-acquisition after this window. Keeps the audit row in place but unblocks
+    // subsequent retries instead of permanently dropping the notification.
     internal static readonly TimeSpan InFlightClaimTimeout = TimeSpan.FromMinutes(5);
 
     /// <inheritdoc/>
-    public Task<bool> HasBeenDeliveredAsync(Guid deliveryId, CancellationToken cancellationToken = default) =>
-        AnyAsync(a => a.DeliveryId == deliveryId && a.IsSuccess == true, cancellationToken);
+    public async Task<bool> HasBeenDeliveredAsync(Guid deliveryId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId: null, cancellationToken).ConfigureAwait(false);
+        return await db.DeliveryAttempts
+            .AnyAsync(a => a.DeliveryId == deliveryId && a.IsSuccess == true, cancellationToken)
+            .ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
     public async Task<bool> TryAcquireDeliveryAttemptAsync(
@@ -43,7 +52,10 @@ internal sealed class EfCoreNotificationDeliveryStore(
 
         try
         {
-            await AddAsync(claim, cancellationToken).ConfigureAwait(false);
+            await using INotificationsDbContext db = await resolver
+                .OpenForScopeAsync(tenantId: null, cancellationToken).ConfigureAwait(false);
+            db.DeliveryAttempts.Add(claim);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             return true;
         }
         catch (DbUpdateException ex) when (DbUpdateExceptionHelper.IsDuplicateKeyException(ex))
@@ -54,64 +66,50 @@ internal sealed class EfCoreNotificationDeliveryStore(
     }
 
     /// <inheritdoc/>
-    public Task CompleteDeliveryAttemptAsync(
-        Guid deliveryId,
-        bool success,
-        long durationMilliseconds,
-        string? errorMessage,
-        CancellationToken cancellationToken = default) =>
-        WriteAsync(
-            async db => await Query(db)
-                .Where(a => a.DeliveryId == deliveryId && a.IsSuccess == null)
-                .ExecuteUpdateAsync(
-                    setters => setters
-                        .SetProperty(a => a.IsSuccess, success)
-                        .SetProperty(a => a.DurationMs, durationMilliseconds)
-                        .SetProperty(a => a.ErrorMessage, errorMessage),
-                    cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken);
+    public async Task CompleteDeliveryAttemptAsync(
+        Guid deliveryId, bool success, long durationMilliseconds, string? errorMessage,
+        CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId: null, cancellationToken).ConfigureAwait(false);
+        await db.DeliveryAttempts
+            .Where(a => a.DeliveryId == deliveryId && a.IsSuccess == null)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(a => a.IsSuccess, success)
+                    .SetProperty(a => a.DurationMs, durationMilliseconds)
+                    .SetProperty(a => a.ErrorMessage, errorMessage),
+                cancellationToken).ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
-    public Task<int> DeleteBeforeAsync(
-        DateTimeOffset cutoff,
-        int batchSize,
-        CancellationToken cancellationToken = default) =>
-        WriteAsync(async db =>
-            await db.DeliveryAttempts
-                .Where(a => a.OccurredAt < cutoff)
-                .OrderBy(a => a.OccurredAt)
-                .Take(batchSize)
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken);
+    public async Task<int> DeleteBeforeAsync(
+        DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId: null, cancellationToken).ConfigureAwait(false);
+        return await db.DeliveryAttempts
+            .Where(a => a.OccurredAt < cutoff)
+            .OrderBy(a => a.OccurredAt)
+            .Take(batchSize)
+            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+    }
 
-    // The unique index on DeliveryId means there is exactly one audit row per logical delivery,
-    // so resume mutates that row in place rather than appending. ErrorMessage and DurationMs from
-    // the prior failed attempt are intentionally preserved: CompleteDeliveryAttemptAsync overwrites
-    // them with the outcome of the new attempt, so the row always reflects the LAST attempt — never
-    // a half-zeroed state that would mislead operators investigating ISO 27001 audit trails.
-    //
-    // OccurredAt is rewritten to "now" because it is the freshness signal the in-flight TTL
-    // depends on. Without this bump, a resume of a long-stale failed row would leave OccurredAt
-    // far in the past — a concurrent worker arriving milliseconds later would see the TTL as
-    // already expired and double-claim, regressing the duplicate-send guarantee from #947.
-    private Task<bool> ResumeFailedOrStuckDeliveryAsync(Guid deliveryId, CancellationToken cancellationToken) =>
-        WriteAsync(
-            async db =>
-            {
-                DateTimeOffset now = clock.Now;
-                DateTimeOffset stuckCutoff = now - InFlightClaimTimeout;
-                int updated = await Query(db)
-                    .Where(a => a.DeliveryId == deliveryId
-                        && (a.IsSuccess == false || (a.IsSuccess == null && a.OccurredAt < stuckCutoff)))
-                    .ExecuteUpdateAsync(
-                        setters => setters
-                            .SetProperty(a => a.IsSuccess, (bool?)null)
-                            .SetProperty(a => a.OccurredAt, now),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                return updated == 1;
-            },
-            cancellationToken);
+    private async Task<bool> ResumeFailedOrStuckDeliveryAsync(Guid deliveryId, CancellationToken cancellationToken)
+    {
+        DateTimeOffset now = clock.Now;
+        DateTimeOffset stuckCutoff = now - InFlightClaimTimeout;
+
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId: null, cancellationToken).ConfigureAwait(false);
+        int updated = await db.DeliveryAttempts
+            .Where(a => a.DeliveryId == deliveryId
+                     && (a.IsSuccess == false || (a.IsSuccess == null && a.OccurredAt < stuckCutoff)))
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(a => a.IsSuccess, (bool?)null)
+                    .SetProperty(a => a.OccurredAt, now),
+                cancellationToken).ConfigureAwait(false);
+        return updated == 1;
+    }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationPreferenceStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationPreferenceStore.cs
@@ -1,60 +1,81 @@
-using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
-using Granit.Persistence;
-using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="INotificationPreferenceReader"/> and
-/// <see cref="INotificationPreferenceWriter"/> backed by PostgreSQL.
+/// <see cref="INotificationPreferenceWriter"/>. Dispatches through
+/// <see cref="NotificationsContextResolver"/>.
 /// </summary>
-internal sealed class EfCoreNotificationPreferenceStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory,
-    ICurrentTenant currentTenant)
-    : EfStoreBase<NotificationPreference, NotificationsDbContext>(contextFactory, currentTenant), INotificationPreferenceReader, INotificationPreferenceWriter
+internal sealed class EfCoreNotificationPreferenceStore(NotificationsContextResolver resolver)
+    : INotificationPreferenceReader, INotificationPreferenceWriter
 {
     /// <inheritdoc/>
-    public Task<IReadOnlyList<NotificationPreference>> GetListAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        ListAsync(
-            Spec.For<NotificationPreference>()
-                .Where(p => p.UserId == userId && p.TenantId == tenantId),
-            cancellationToken);
+    public async Task<IReadOnlyList<NotificationPreference>> GetListAsync(
+        string userId, Guid? tenantId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.Preferences
+            .Where(p => p.UserId == userId && p.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
-    public Task<NotificationPreference?> GetAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        FirstOrDefaultAsync(p => p.UserId == userId && p.NotificationTypeName == notificationTypeName && p.ChannelName == channelName && p.TenantId == tenantId, cancellationToken);
+    public async Task<NotificationPreference?> GetAsync(
+        string userId, string notificationTypeName, string channelName, Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.Preferences
+            .FirstOrDefaultAsync(
+                p => p.UserId == userId
+                  && p.NotificationTypeName == notificationTypeName
+                  && p.ChannelName == channelName
+                  && p.TenantId == tenantId,
+                cancellationToken).ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
     public async Task SetAsync(NotificationPreference preference, CancellationToken cancellationToken = default)
     {
-        await WriteAsync(async db =>
-        {
-            NotificationPreference? existing = await db.Preferences
-                .FirstOrDefaultAsync(p => p.UserId == preference.UserId && p.NotificationTypeName == preference.NotificationTypeName && p.ChannelName == preference.ChannelName && p.TenantId == preference.TenantId, cancellationToken)
-                .ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(preference);
 
-            if (existing is not null)
-            {
-                existing.IsEnabled = preference.IsEnabled;
-                existing.ModifiedAt = preference.ModifiedAt;
-                existing.ModifiedBy = preference.ModifiedBy;
-            }
-            else
-            {
-                db.Preferences.Add(preference);
-            }
-        }, cancellationToken).ConfigureAwait(false);
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(preference.TenantId, cancellationToken).ConfigureAwait(false);
+
+        NotificationPreference? existing = await db.Preferences
+            .FirstOrDefaultAsync(
+                p => p.UserId == preference.UserId
+                  && p.NotificationTypeName == preference.NotificationTypeName
+                  && p.ChannelName == preference.ChannelName
+                  && p.TenantId == preference.TenantId,
+                cancellationToken).ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            existing.IsEnabled = preference.IsEnabled;
+            existing.ModifiedAt = preference.ModifiedAt;
+            existing.ModifiedBy = preference.ModifiedBy;
+        }
+        else
+        {
+            db.Preferences.Add(preference);
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<bool> IsChannelEnabledAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default)
+    public async Task<bool> IsChannelEnabledAsync(
+        string userId, string notificationTypeName, string channelName, Guid? tenantId,
+        CancellationToken cancellationToken = default)
     {
-        NotificationPreference? preference = await FirstOrDefaultAsync(
-            p => p.UserId == userId && p.NotificationTypeName == notificationTypeName && p.ChannelName == channelName && p.TenantId == tenantId,
-            cancellationToken).ConfigureAwait(false);
+        NotificationPreference? preference = await GetAsync(
+            userId, notificationTypeName, channelName, tenantId, cancellationToken).ConfigureAwait(false);
         return preference?.IsEnabled ?? true; // Default: enabled
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationSubscriptionStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationSubscriptionStore.cs
@@ -1,124 +1,175 @@
 using Granit.Guids;
-using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
-using Granit.Persistence;
-using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="INotificationSubscriptionReader"/> and
-/// <see cref="INotificationSubscriptionWriter"/> backed by PostgreSQL.
+/// <see cref="INotificationSubscriptionWriter"/>. Dispatches through
+/// <see cref="NotificationsContextResolver"/>.
 /// </summary>
 internal sealed class EfCoreNotificationSubscriptionStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory,
-    ICurrentTenant currentTenant,
+    NotificationsContextResolver resolver,
     IGuidGenerator guidGenerator)
-    : EfStoreBase<NotificationSubscription, NotificationsDbContext>(contextFactory, currentTenant), INotificationSubscriptionReader, INotificationSubscriptionWriter
+    : INotificationSubscriptionReader, INotificationSubscriptionWriter
 {
     /// <inheritdoc/>
-    public Task SubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        WriteAsync(async db =>
-        {
-            bool exists = await db.Subscriptions
-                .AnyAsync(s => s.UserId == userId && s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null, cancellationToken)
-                .ConfigureAwait(false);
-            if (!exists)
-            {
-                db.Subscriptions.Add(new NotificationSubscription
-                {
-                    Id = guidGenerator.Create(),
-                    UserId = userId,
-                    NotificationTypeName = notificationTypeName,
-                    TenantId = tenantId,
-                });
-            }
-        }, cancellationToken);
-
-    /// <inheritdoc/>
-    public async Task UnsubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)
+    public async Task SubscribeAsync(
+        string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await WriteAsync(async db =>
-            await db.Subscriptions
-                .Where(s => s.UserId == userId && s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null)
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken).ConfigureAwait(false);
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        bool exists = await db.Subscriptions
+            .AnyAsync(
+                s => s.UserId == userId
+                  && s.NotificationTypeName == notificationTypeName
+                  && s.TenantId == tenantId
+                  && s.EntityType == null,
+                cancellationToken).ConfigureAwait(false);
+        if (!exists)
+        {
+            db.Subscriptions.Add(new NotificationSubscription
+            {
+                Id = guidGenerator.Create(),
+                UserId = userId,
+                NotificationTypeName = notificationTypeName,
+                TenantId = tenantId,
+            });
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<string>> GetSubscriberIdsAsync(string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        ReadAsync(async db =>
-            (IReadOnlyList<string>)await db.Subscriptions
-                .Where(s => s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null)
-                .Select(s => s.UserId)
-                .Distinct()
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken);
-
-    /// <inheritdoc/>
-    public Task<IReadOnlyList<NotificationSubscription>> GetUserSubscriptionsAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        ListAsync(
-            Spec.For<NotificationSubscription>()
-                .Where(s => s.UserId == userId && s.TenantId == tenantId)
-                .AsReadOnly(),
-            cancellationToken);
-
-    /// <inheritdoc/>
-    public Task FollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        WriteAsync(async db =>
-        {
-            bool exists = await db.Subscriptions
-                .AnyAsync(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId, cancellationToken)
-                .ConfigureAwait(false);
-            if (!exists)
-            {
-                db.Subscriptions.Add(new NotificationSubscription
-                {
-                    Id = guidGenerator.Create(),
-                    UserId = userId,
-                    NotificationTypeName = string.Empty,
-                    EntityType = entityType,
-                    EntityId = entityId,
-                    TenantId = tenantId,
-                });
-            }
-        }, cancellationToken);
-
-    /// <inheritdoc/>
-    public async Task UnfollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
+    public async Task UnsubscribeAsync(
+        string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await WriteAsync(async db =>
-            await db.Subscriptions
-                .Where(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken).ConfigureAwait(false);
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        await db.Subscriptions
+            .Where(s => s.UserId == userId
+                     && s.NotificationTypeName == notificationTypeName
+                     && s.TenantId == tenantId
+                     && s.EntityType == null)
+            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<string>> GetEntityFollowerIdsAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        ReadAsync(async db =>
-            (IReadOnlyList<string>)await db.Subscriptions
-                .Where(s => s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
-                .Select(s => s.UserId)
-                .Distinct()
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false),
-            cancellationToken);
+    public async Task<IReadOnlyList<string>> GetSubscriberIdsAsync(
+        string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.Subscriptions
+            .Where(s => s.NotificationTypeName == notificationTypeName
+                     && s.TenantId == tenantId
+                     && s.EntityType == null)
+            .Select(s => s.UserId)
+            .Distinct()
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<NotificationSubscription>> GetEntityFollowersAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        ListAsync(
-            Spec.For<NotificationSubscription>()
-                .Where(s => s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
-                .AsReadOnly(),
-            cancellationToken);
+    public async Task<IReadOnlyList<NotificationSubscription>> GetUserSubscriptionsAsync(
+        string userId, Guid? tenantId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.Subscriptions
+            .AsNoTracking()
+            .Where(s => s.UserId == userId && s.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
-    public Task<bool> IsFollowingEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        AnyAsync(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId, cancellationToken);
+    public async Task FollowEntityAsync(
+        string userId, string entityType, string entityId, Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        bool exists = await db.Subscriptions
+            .AnyAsync(
+                s => s.UserId == userId
+                  && s.EntityType == entityType
+                  && s.EntityId == entityId
+                  && s.TenantId == tenantId,
+                cancellationToken).ConfigureAwait(false);
+        if (!exists)
+        {
+            db.Subscriptions.Add(new NotificationSubscription
+            {
+                Id = guidGenerator.Create(),
+                UserId = userId,
+                NotificationTypeName = string.Empty,
+                EntityType = entityType,
+                EntityId = entityId,
+                TenantId = tenantId,
+            });
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task UnfollowEntityAsync(
+        string userId, string entityType, string entityId, Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        await db.Subscriptions
+            .Where(s => s.UserId == userId
+                     && s.EntityType == entityType
+                     && s.EntityId == entityId
+                     && s.TenantId == tenantId)
+            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<string>> GetEntityFollowerIdsAsync(
+        string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.Subscriptions
+            .Where(s => s.EntityType == entityType
+                     && s.EntityId == entityId
+                     && s.TenantId == tenantId)
+            .Select(s => s.UserId)
+            .Distinct()
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<NotificationSubscription>> GetEntityFollowersAsync(
+        string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.Subscriptions
+            .AsNoTracking()
+            .Where(s => s.EntityType == entityType
+                     && s.EntityId == entityId
+                     && s.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> IsFollowingEntityAsync(
+        string userId, string entityType, string entityId, Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.Subscriptions
+            .AnyAsync(
+                s => s.UserId == userId
+                  && s.EntityType == entityType
+                  && s.EntityId == entityId
+                  && s.TenantId == tenantId,
+                cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
@@ -1,8 +1,5 @@
-using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
-using Granit.Persistence;
-using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,85 +7,165 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="IUserNotificationReader"/> and
-/// <see cref="IUserNotificationWriter"/> backed by PostgreSQL.
+/// <see cref="IUserNotificationWriter"/>. Dispatches through
+/// <see cref="NotificationsContextResolver"/>.
 /// </summary>
-internal sealed class EfCoreUserNotificationStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory,
-    ICurrentTenant currentTenant)
-    : EfStoreBase<UserNotification, NotificationsDbContext>(contextFactory, currentTenant), IUserNotificationReader, IUserNotificationWriter
+internal sealed class EfCoreUserNotificationStore(NotificationsContextResolver resolver)
+    : IUserNotificationReader, IUserNotificationWriter
 {
     /// <inheritdoc/>
-    public Task InsertAsync(UserNotification notification, CancellationToken cancellationToken = default) =>
-        AddAsync(notification, cancellationToken);
-
-    /// <inheritdoc/>
-    public Task<UserNotification?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>
-        FindByIdAsync(id, cancellationToken);
-
-    /// <inheritdoc/>
-    public Task<PagedResult<UserNotification>> GetListAsync(string recipientUserId, Guid? tenantId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
+    public async Task InsertAsync(UserNotification notification, CancellationToken cancellationToken = default)
     {
-        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
-
-        return PagedAsync(
-            Spec.For<UserNotification>()
-                .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId)
-                .OrderByDescending(n => n.CreatedAt),
-            clampedPage,
-            clampedPageSize,
-            cancellationToken);
+        ArgumentNullException.ThrowIfNull(notification);
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(notification.TenantId, cancellationToken).ConfigureAwait(false);
+        db.UserNotifications.Add(notification);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public Task<int> GetUnreadCountAsync(string recipientUserId, Guid? tenantId, CancellationToken cancellationToken = default) =>
-        CountAsync(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId && n.State == UserNotificationState.Unread, cancellationToken);
+    public async Task<UserNotification?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<INotificationsDbContext> contexts = await resolver
+            .OpenForUnknownScopeAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            foreach (INotificationsDbContext db in contexts)
+            {
+                UserNotification? hit = await db.UserNotifications
+                    .FirstOrDefaultAsync(n => n.Id == id, cancellationToken).ConfigureAwait(false);
+                if (hit is not null)
+                {
+                    return hit;
+                }
+            }
+            return null;
+        }
+        finally
+        {
+            await DisposeAllAsync(contexts).ConfigureAwait(false);
+        }
+    }
 
     /// <inheritdoc/>
-    public async Task MarkAsReadAsync(Guid id, string recipientUserId, DateTimeOffset readAt, CancellationToken cancellationToken = default)
+    public async Task<PagedResult<UserNotification>> GetListAsync(
+        string recipientUserId, Guid? tenantId, int page = 1,
+        int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
-        await WriteAsync(async db =>
-        {
-            UserNotification? notification = await db.UserNotifications
-                .FirstOrDefaultAsync(n => n.Id == id && n.RecipientUserId == recipientUserId, cancellationToken)
-                .ConfigureAwait(false);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
-            if (notification is null)
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        IQueryable<UserNotification> query = db.UserNotifications
+            .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId)
+            .OrderByDescending(n => n.CreatedAt);
+
+        int total = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+        List<UserNotification> items = await query
+            .Skip((clampedPage - 1) * clampedPageSize)
+            .Take(clampedPageSize)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return new PagedResult<UserNotification>(items, total, HasMore: (clampedPage * clampedPageSize) < total);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> GetUnreadCountAsync(
+        string recipientUserId, Guid? tenantId, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        return await db.UserNotifications
+            .CountAsync(
+                n => n.RecipientUserId == recipientUserId
+                  && n.TenantId == tenantId
+                  && n.State == UserNotificationState.Unread,
+                cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task MarkAsReadAsync(
+        Guid id, string recipientUserId, DateTimeOffset readAt, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<INotificationsDbContext> contexts = await resolver
+            .OpenForUnknownScopeAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            foreach (INotificationsDbContext db in contexts)
             {
+                UserNotification? notification = await db.UserNotifications
+                    .FirstOrDefaultAsync(
+                        n => n.Id == id && n.RecipientUserId == recipientUserId,
+                        cancellationToken).ConfigureAwait(false);
+
+                if (notification is null)
+                {
+                    continue;
+                }
+
+                notification.MarkAsRead(readAt);
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
                 return;
             }
-
-            notification.MarkAsRead(readAt);
-        }, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public async Task MarkAllAsReadAsync(string recipientUserId, Guid? tenantId, DateTimeOffset readAt, CancellationToken cancellationToken = default)
-    {
-        await WriteAsync(async db =>
+        }
+        finally
         {
-            List<UserNotification> unread = await db.UserNotifications
-                .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId && n.State == UserNotificationState.Unread)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            foreach (UserNotification notification in unread)
-            {
-                notification.MarkAsRead(readAt);
-            }
-        }, cancellationToken).ConfigureAwait(false);
+            await DisposeAllAsync(contexts).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc/>
-    public Task<PagedResult<UserNotification>> GetByEntityAsync(string entityType, string entityId, Guid? tenantId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
+    public async Task MarkAllAsReadAsync(
+        string recipientUserId, Guid? tenantId, DateTimeOffset readAt, CancellationToken cancellationToken = default)
+    {
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        List<UserNotification> unread = await db.UserNotifications
+            .Where(n => n.RecipientUserId == recipientUserId
+                     && n.TenantId == tenantId
+                     && n.State == UserNotificationState.Unread)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (UserNotification notification in unread)
+        {
+            notification.MarkAsRead(readAt);
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<PagedResult<UserNotification>> GetByEntityAsync(
+        string entityType, string entityId, Guid? tenantId, int page = 1,
+        int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
         (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
-        return PagedAsync(
-            Spec.For<UserNotification>()
-                .Where(n => n.RelatedEntityType == entityType && n.RelatedEntityId == entityId && n.TenantId == tenantId)
-                .OrderByDescending(n => n.CreatedAt),
-            clampedPage,
-            clampedPageSize,
-            cancellationToken);
+        await using INotificationsDbContext db = await resolver
+            .OpenForScopeAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        IQueryable<UserNotification> query = db.UserNotifications
+            .Where(n => n.RelatedEntityType == entityType
+                     && n.RelatedEntityId == entityId
+                     && n.TenantId == tenantId)
+            .OrderByDescending(n => n.CreatedAt);
+
+        int total = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+        List<UserNotification> items = await query
+            .Skip((clampedPage - 1) * clampedPageSize)
+            .Take(clampedPageSize)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return new PagedResult<UserNotification>(items, total, HasMore: (clampedPage * clampedPageSize) < total);
+    }
+
+    private static async Task DisposeAllAsync(IReadOnlyList<INotificationsDbContext> contexts)
+    {
+        foreach (INotificationsDbContext db in contexts)
+        {
+            await db.DisposeAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EntityTrackingInterceptor.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EntityTrackingInterceptor.cs
@@ -1,5 +1,6 @@
 using Granit.Domain;
 using Granit.Notifications.Abstractions;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -11,9 +12,14 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// EF Core SaveChanges interceptor that detects modifications on <see cref="ITrackedEntity"/>
 /// and publishes notifications to entity followers via automatic change tracking.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IGranitAutoInterceptor"/> so it is automatically picked up by
+/// <c>UseGranitInterceptors(sp)</c> on every Granit-registered DbContext — no manual
+/// <c>AddInterceptors</c> call needed.
+/// </remarks>
 internal sealed class EntityTrackingInterceptor(
     INotificationPublisher notificationPublisher,
-    IClock clock) : SaveChangesInterceptor
+    IClock clock) : SaveChangesInterceptor, IGranitAutoInterceptor
 {
     /// <inheritdoc/>
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/INotificationsDbContext.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/INotificationsDbContext.cs
@@ -1,0 +1,38 @@
+using Granit.Notifications.Domain;
+using Granit.Notifications.MobilePush.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Notifications.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Common shape exposed by every Notifications DbContext flavour so stores can dispatch
+/// reads and writes regardless of whether the storage layout is <c>Shared</c> (one
+/// context) or <c>Segregated</c> (host context + tenant context).
+/// </summary>
+/// <remarks>
+/// Per ADR-063 the two concrete implementations are:
+/// <list type="bullet">
+///   <item><see cref="NotificationsHostDbContext"/> — host-pinned. Serves both <c>Shared</c> mode (single context for all rows, row-level filter) and the host portion of <c>Segregated</c> mode (platform-level notifications only).</item>
+///   <item><see cref="NotificationsTenantDbContext"/> — tenant-isolated. Used only under <c>Segregated</c> mode for per-tenant notifications.</item>
+/// </list>
+/// </remarks>
+internal interface INotificationsDbContext : IAsyncDisposable, IDisposable
+{
+    /// <summary>In-app user notifications (inbox).</summary>
+    DbSet<UserNotification> UserNotifications { get; }
+
+    /// <summary>Notification subscriptions (topic + entity followers).</summary>
+    DbSet<NotificationSubscription> Subscriptions { get; }
+
+    /// <summary>User notification preferences (opt-in/opt-out per channel).</summary>
+    DbSet<NotificationPreference> Preferences { get; }
+
+    /// <summary>Immutable ISO 27001 audit trail of delivery attempts.</summary>
+    DbSet<NotificationDeliveryAttempt> DeliveryAttempts { get; }
+
+    /// <summary>Mobile push device tokens.</summary>
+    DbSet<MobilePushToken> MobilePushTokens { get; }
+
+    /// <summary>Persists pending changes.</summary>
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsContextResolver.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsContextResolver.cs
@@ -1,0 +1,80 @@
+using Granit.Persistence.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Notifications.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Central dispatch helper that hands every Notifications store the right
+/// <see cref="INotificationsDbContext"/> for a given scope, independently of the
+/// configured <see cref="DualScopeStorageMode"/>.
+/// </summary>
+internal sealed class NotificationsContextResolver(
+    DualScopeStorageMode storageMode,
+    IDbContextFactory<NotificationsHostDbContext> hostFactory,
+    IDbContextFactory<NotificationsTenantDbContext>? tenantFactory = null)
+{
+    /// <summary>The active storage mode declared at registration.</summary>
+    public DualScopeStorageMode StorageMode { get; } = storageMode;
+
+    /// <summary>
+    /// Opens the appropriate context for an operation whose <c>TenantId</c> is known
+    /// up-front (the caller knows whether the write targets host or tenant scope).
+    /// </summary>
+    public async Task<INotificationsDbContext> OpenForScopeAsync(
+        Guid? tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        return StorageMode switch
+        {
+            DualScopeStorageMode.Shared
+                => await hostFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false),
+            DualScopeStorageMode.Segregated when tenantId is null
+                => await hostFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false),
+            DualScopeStorageMode.Segregated
+                => await RequireTenantFactory().CreateDbContextAsync(cancellationToken).ConfigureAwait(false),
+            _ => throw new InvalidOperationException($"Unknown DualScopeStorageMode: {StorageMode}."),
+        };
+    }
+
+    /// <summary>
+    /// Opens every context that may hold notifications visible to the current scope.
+    /// Under <see cref="DualScopeStorageMode.Shared"/> returns a single context; under
+    /// <see cref="DualScopeStorageMode.Segregated"/> returns both the host and the active
+    /// tenant context. Caller disposes every returned context.
+    /// </summary>
+    public async Task<IReadOnlyList<INotificationsDbContext>> OpenAllAsync(
+        CancellationToken cancellationToken = default)
+    {
+        INotificationsDbContext host = await hostFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        if (StorageMode == DualScopeStorageMode.Shared)
+        {
+            return [host];
+        }
+
+        INotificationsDbContext tenant = await RequireTenantFactory()
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return [host, tenant];
+    }
+
+    /// <summary>
+    /// Opens every context that might hold a notification whose scope is unknown at call
+    /// time (writes by id). Same behaviour as <see cref="OpenAllAsync"/>.
+    /// </summary>
+    public Task<IReadOnlyList<INotificationsDbContext>> OpenForUnknownScopeAsync(
+        CancellationToken cancellationToken = default)
+        => OpenAllAsync(cancellationToken);
+
+    private IDbContextFactory<NotificationsTenantDbContext> RequireTenantFactory()
+    {
+        if (tenantFactory is null)
+        {
+            throw new InvalidOperationException(
+                "NotificationsContextResolver: storage mode is Segregated but no IDbContextFactory<NotificationsTenantDbContext> " +
+                "is registered. This is a bug in AddGranitNotificationsEntityFrameworkCore.");
+        }
+
+        return tenantFactory;
+    }
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsDualScopeIntegrationValidator.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsDualScopeIntegrationValidator.cs
@@ -1,0 +1,135 @@
+using System.Text;
+using Granit.Notifications.Domain;
+using Granit.Notifications.MobilePush.Domain;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Notifications.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Fail-fast guard for the <c>Shared</c> storage mode: detects when a tenant-isolated
+/// <see cref="DbContext"/> outside Granit.Notifications folds the Notifications model via
+/// <see cref="Extensions.NotificationsModelBuilderExtensions.ConfigureNotificationsModule"/>.
+/// </summary>
+internal sealed partial class NotificationsDualScopeIntegrationValidator(
+    IEnumerable<IsolatedDbContextMarker> markers,
+    IServiceProvider serviceProvider,
+    ILogger<NotificationsDualScopeIntegrationValidator> logger) : IHostedService
+{
+    private static readonly HashSet<Type> NotificationsOwnedContexts =
+    [
+        typeof(NotificationsTenantDbContext),
+    ];
+
+    private static readonly HashSet<Type> NotificationsAggregates =
+    [
+        typeof(UserNotification),
+        typeof(NotificationSubscription),
+        typeof(NotificationPreference),
+        typeof(NotificationDeliveryAttempt),
+        typeof(MobilePushToken),
+    ];
+
+    /// <inheritdoc/>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        List<(Type DbContextType, List<string> Entities)> offenders = [];
+
+        foreach (IsolatedDbContextMarker marker in markers)
+        {
+            if (NotificationsOwnedContexts.Contains(marker.DbContextType))
+            {
+                continue;
+            }
+
+            List<string>? folded = TryFindFoldedNotificationsEntities(marker.DbContextType);
+            if (folded is { Count: > 0 })
+            {
+                offenders.Add((marker.DbContextType, folded));
+            }
+        }
+
+        if (offenders.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        StringBuilder sb = new();
+        sb.AppendLine(
+            "Granit.Notifications is a dual-scope module: its tables live in the host " +
+            "schema and tenant isolation is enforced by the MultiTenant row-level query " +
+            "filter. ConfigureNotificationsModule() must be folded into a host-scoped " +
+            "DbContext (registered via AddGranitDbContext<T>), never into a tenant-isolated " +
+            "DbContext (registered via AddGranitIsolatedDbContext<T>) — otherwise the " +
+            "migration creates the table in the tenant schema while runtime queries target " +
+            "the host schema, causing PostgreSQL 42P01 at the first request.");
+        sb.AppendLine();
+        sb.AppendLine("The following isolated DbContexts incorrectly fold Notifications entities:");
+        foreach ((Type type, List<string> entities) in offenders)
+        {
+            sb.Append("  - ").Append(type.FullName ?? type.Name)
+              .Append(" → ").AppendLine(string.Join(", ", entities));
+        }
+        sb.AppendLine();
+        sb.Append("Switch NotificationsEntityFrameworkCoreOptions.StorageMode to ");
+        sb.Append("DualScopeStorageMode.Segregated if you need physically separate ");
+        sb.Append("Notifications tables per tenant.");
+
+        throw new InvalidOperationException(sb.ToString());
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private List<string>? TryFindFoldedNotificationsEntities(Type dbContextType)
+    {
+        using IServiceScope scope = serviceProvider.CreateScope();
+
+        Type factoryType = typeof(IDbContextFactory<>).MakeGenericType(dbContextType);
+        object? factory = scope.ServiceProvider.GetKeyedService(factoryType, TenantIsolationStrategy.SharedDatabase);
+        if (factory is null)
+        {
+            LogNoSharedFactory(dbContextType.Name);
+            return null;
+        }
+
+        try
+        {
+            var context = (DbContext)factoryType
+                .GetMethod(nameof(IDbContextFactory<DbContext>.CreateDbContext))!
+                .Invoke(factory, parameters: null)!;
+
+            try
+            {
+                List<string> matches = [];
+                foreach (IEntityType entityType in context.Model.GetEntityTypes())
+                {
+                    if (NotificationsAggregates.Contains(entityType.ClrType))
+                    {
+                        matches.Add(entityType.ClrType.Name);
+                    }
+                }
+                return matches;
+            }
+            finally
+            {
+                context.Dispose();
+            }
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            LogValidationSkipped(dbContextType.Name, ex.GetType().Name, ex.Message);
+            return null;
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping Notifications dual-scope validation for {ContextType}: no SharedDatabase keyed factory registered.")]
+    private partial void LogNoSharedFactory(string contextType);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping Notifications dual-scope validation for {ContextType}: model inspection failed with {ExceptionType}: {Message}.")]
+    private partial void LogValidationSkipped(string contextType, string exceptionType, string message);
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsHostDbContext.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsHostDbContext.cs
@@ -1,0 +1,48 @@
+using Granit.DataFiltering;
+using Granit.Encryption;
+using Granit.Encryption.EntityFrameworkCore.Extensions;
+using Granit.MultiTenancy;
+using Granit.Notifications.Domain;
+using Granit.Notifications.EntityFrameworkCore.Extensions;
+using Granit.Notifications.MobilePush.Domain;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Notifications.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Host-pinned EF Core DbContext for Notifications. Serves both Shared mode (single
+/// context for all rows) and the host portion of Segregated mode (platform-level
+/// notifications only).
+/// </summary>
+internal sealed class NotificationsHostDbContext(
+    DbContextOptions<NotificationsHostDbContext> options,
+    IStringEncryptionService encryption,
+    ICurrentTenant currentTenant,
+    IDataFilter? dataFilter = null)
+    : GranitDbContext(options, currentTenant, dataFilter), INotificationsDbContext
+{
+    private readonly IStringEncryptionService _encryption = encryption;
+
+    /// <inheritdoc/>
+    public DbSet<UserNotification> UserNotifications => Set<UserNotification>();
+
+    /// <inheritdoc/>
+    public DbSet<NotificationSubscription> Subscriptions => Set<NotificationSubscription>();
+
+    /// <inheritdoc/>
+    public DbSet<NotificationPreference> Preferences => Set<NotificationPreference>();
+
+    /// <inheritdoc/>
+    public DbSet<NotificationDeliveryAttempt> DeliveryAttempts => Set<NotificationDeliveryAttempt>();
+
+    /// <inheritdoc/>
+    public DbSet<MobilePushToken> MobilePushTokens => Set<MobilePushToken>();
+
+    /// <inheritdoc/>
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ConfigureNotificationsModule();
+        modelBuilder.ApplyEncryptionConventions(_encryption);
+    }
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsTenantDbContext.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationsTenantDbContext.cs
@@ -11,30 +11,34 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// EF Core DbContext for notification persistence.
+/// Tenant-isolated EF Core DbContext for Notifications under
+/// <see cref="Granit.Persistence.MultiTenancy.DualScopeStorageMode.Segregated"/>. Holds
+/// tenant-scoped notifications, preferences, subscriptions, delivery attempts, and push
+/// tokens. <c>DROP SCHEMA &lt;tenant&gt; CASCADE</c> lessivage on tenant offboarding is
+/// the RGPD Art. 17 primitive enabled by this layout — notification bodies carry PII.
 /// </summary>
-internal sealed class NotificationsDbContext(
-    DbContextOptions<NotificationsDbContext> options,
+internal sealed class NotificationsTenantDbContext(
+    DbContextOptions<NotificationsTenantDbContext> options,
     IStringEncryptionService encryption,
     ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : GranitDbContext(options, currentTenant, dataFilter)
+    : GranitDbContext(options, currentTenant, dataFilter), INotificationsDbContext
 {
     private readonly IStringEncryptionService _encryption = encryption;
 
-    /// <summary>In-app user notifications (inbox).</summary>
+    /// <inheritdoc/>
     public DbSet<UserNotification> UserNotifications => Set<UserNotification>();
 
-    /// <summary>Notification subscriptions (topic + entity followers).</summary>
+    /// <inheritdoc/>
     public DbSet<NotificationSubscription> Subscriptions => Set<NotificationSubscription>();
 
-    /// <summary>User notification preferences (opt-in/opt-out per channel).</summary>
+    /// <inheritdoc/>
     public DbSet<NotificationPreference> Preferences => Set<NotificationPreference>();
 
-    /// <summary>Immutable ISO 27001 audit trail of delivery attempts.</summary>
+    /// <inheritdoc/>
     public DbSet<NotificationDeliveryAttempt> DeliveryAttempts => Set<NotificationDeliveryAttempt>();
 
-    /// <summary>Mobile push device tokens.</summary>
+    /// <inheritdoc/>
     public DbSet<MobilePushToken> MobilePushTokens => Set<MobilePushToken>();
 
     /// <inheritdoc/>

--- a/src/Granit.Notifications.EntityFrameworkCore/Options/NotificationsEntityFrameworkCoreOptions.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Options/NotificationsEntityFrameworkCoreOptions.cs
@@ -1,0 +1,60 @@
+using Granit.Persistence.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Notifications.EntityFrameworkCore.Options;
+
+/// <summary>
+/// Configuration shape for
+/// <c>NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions.AddGranitNotificationsEntityFrameworkCore</c>.
+/// Carries the dual-scope storage choice and the EF Core
+/// <see cref="DbContextOptionsBuilder"/> callbacks per context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per ADR-063, Granit.Notifications is a dual-scope module: platform-level notifications
+/// (host announcements, SOC2 broadcasts, <c>TenantId == null</c>) coexist with per-tenant
+/// notifications (user inboxes, preferences, push tokens). <see cref="StorageMode"/>
+/// selects how the two are physically laid out.
+/// </para>
+/// <para>
+/// <b>Shared (default)</b> — single host table; tenant rows carry a <c>TenantId</c> and
+/// are filtered by a row-level query filter. Backwards compatible with pre-ADR-063
+/// deployments. Only <see cref="Configure"/> is consulted.
+/// </para>
+/// <para>
+/// <b>Segregated</b> — host rows live in a host-pinned context; tenant rows live in an
+/// isolated tenant context. Provides native <c>DROP SCHEMA &lt;tenant&gt; CASCADE</c>
+/// lessivage for RGPD Art. 17 — notification bodies carry PII (message text, recipient
+/// metadata).
+/// </para>
+/// </remarks>
+public sealed class NotificationsEntityFrameworkCoreOptions
+{
+    /// <summary>The dual-scope storage layout — see <see cref="DualScopeStorageMode"/>.</summary>
+    public DualScopeStorageMode StorageMode { get; set; } = DualScopeStorageMode.Shared;
+
+    /// <summary>
+    /// EF Core configuration for the single shared <c>NotificationsHostDbContext</c>.
+    /// Consulted when <see cref="StorageMode"/> is <see cref="DualScopeStorageMode.Shared"/>.
+    /// </summary>
+    public Action<DbContextOptionsBuilder>? Configure { get; set; }
+
+    /// <summary>
+    /// EF Core configuration for the host-pinned context. Consulted when
+    /// <see cref="StorageMode"/> is <see cref="DualScopeStorageMode.Segregated"/>.
+    /// </summary>
+    public Action<DbContextOptionsBuilder>? ConfigureHost { get; set; }
+
+    /// <summary>
+    /// EF Core configuration for <c>NotificationsTenantDbContext</c> under
+    /// <c>TenantIsolationStrategy.SchemaPerTenant</c>.
+    /// </summary>
+    public Action<DbContextOptionsBuilder>? ConfigureSchemaPerTenant { get; set; }
+
+    /// <summary>
+    /// EF Core configuration for <c>NotificationsTenantDbContext</c> under
+    /// <c>TenantIsolationStrategy.DatabasePerTenant</c>. The string argument is the
+    /// per-tenant connection string.
+    /// </summary>
+    public Action<DbContextOptionsBuilder, string>? ConfigureDatabasePerTenant { get; set; }
+}

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreMobilePushTokenStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreMobilePushTokenStoreTests.cs
@@ -1,9 +1,7 @@
-using Granit.MultiTenancy;
 using Granit.Notifications.EntityFrameworkCore.Internal;
 using Granit.Notifications.MobilePush;
 using Granit.Notifications.MobilePush.Domain;
 using Granit.Notifications.MobilePush.Internal;
-using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -22,10 +20,8 @@ public sealed class EfCoreMobilePushTokenStoreTests : IDisposable
 
     public EfCoreMobilePushTokenStoreTests()
     {
-        _store = new EfCoreMobilePushTokenStore(
-            _factory,
-            Substitute.For<ICurrentTenant>(),
-            new IdentityHasher());
+        NotificationsContextResolver resolver = new(Granit.Persistence.MultiTenancy.DualScopeStorageMode.Shared, _factory);
+        _store = new EfCoreMobilePushTokenStore(resolver, new IdentityHasher());
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationDeliveryStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationDeliveryStoreTests.cs
@@ -24,7 +24,8 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
     public EfCoreNotificationDeliveryStoreTests()
     {
         _clock.Now.Returns(_ => _now);
-        _store = new EfCoreNotificationDeliveryStore(_factory, _clock);
+        NotificationsContextResolver resolver = new(Granit.Persistence.MultiTenancy.DualScopeStorageMode.Shared, _factory);
+        _store = new EfCoreNotificationDeliveryStore(resolver, _clock);
     }
 
     public void Dispose() => _factory.Dispose();
@@ -42,7 +43,7 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
             errorMessage: null,
             TestContext.Current.CancellationToken);
 
-        await using NotificationsDbContext db = _factory.CreateDbContext();
+        await using NotificationsHostDbContext db = _factory.CreateDbContext();
         NotificationDeliveryAttempt? result = await db.DeliveryAttempts
             .AsNoTracking()
             .SingleAsync(a => a.DeliveryId == claim.DeliveryId, TestContext.Current.CancellationToken);
@@ -88,7 +89,7 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
             null,
             TestContext.Current.CancellationToken);
 
-        await using NotificationsDbContext db = _factory.CreateDbContext();
+        await using NotificationsHostDbContext db = _factory.CreateDbContext();
         List<NotificationDeliveryAttempt> all = await db.DeliveryAttempts
             .Where(a => a.NotificationId == notificationId)
             .AsNoTracking()
@@ -149,7 +150,7 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
 
         // Between resume and the next Complete, the row keeps the prior attempt's audit fields
         // (ISO 27001: never zero out failure context — the next Complete will overwrite it).
-        await using NotificationsDbContext db = _factory.CreateDbContext();
+        await using NotificationsHostDbContext db = _factory.CreateDbContext();
         NotificationDeliveryAttempt midFlight = await db.DeliveryAttempts
             .AsNoTracking()
             .SingleAsync(a => a.DeliveryId == first.DeliveryId, TestContext.Current.CancellationToken);
@@ -280,7 +281,7 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
 
         deleted.ShouldBe(2);
 
-        await using NotificationsDbContext db = _factory.CreateDbContext();
+        await using NotificationsHostDbContext db = _factory.CreateDbContext();
         List<NotificationDeliveryAttempt> remaining = await db.DeliveryAttempts
             .ToListAsync(TestContext.Current.CancellationToken);
         remaining.Count.ShouldBe(1);
@@ -304,7 +305,7 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
 
         deleted.ShouldBe(3);
 
-        await using NotificationsDbContext db = _factory.CreateDbContext();
+        await using NotificationsHostDbContext db = _factory.CreateDbContext();
         int remaining = await db.DeliveryAttempts.CountAsync(TestContext.Current.CancellationToken);
         remaining.ShouldBe(2);
     }

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationPreferenceStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationPreferenceStoreTests.cs
@@ -5,10 +5,8 @@
 // channel enabled check with default-true fallback.
 // =============================================================================
 
-using Granit.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Internal;
-using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -21,7 +19,8 @@ public sealed class EfCoreNotificationPreferenceStoreTests : IDisposable
 
     public EfCoreNotificationPreferenceStoreTests()
     {
-        _store = new EfCoreNotificationPreferenceStore(_factory, Substitute.For<ICurrentTenant>());
+        NotificationsContextResolver resolver = new(Granit.Persistence.MultiTenancy.DualScopeStorageMode.Shared, _factory);
+        _store = new EfCoreNotificationPreferenceStore(resolver);
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationSubscriptionStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationSubscriptionStoreTests.cs
@@ -6,10 +6,8 @@
 // =============================================================================
 
 using Granit.Guids;
-using Granit.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Internal;
-using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -22,7 +20,8 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
 
     public EfCoreNotificationSubscriptionStoreTests()
     {
-        _store = new EfCoreNotificationSubscriptionStore(_factory, Substitute.For<ICurrentTenant>(), new SimpleGuidGenerator());
+        NotificationsContextResolver resolver = new(Granit.Persistence.MultiTenancy.DualScopeStorageMode.Shared, _factory);
+        _store = new EfCoreNotificationSubscriptionStore(resolver, new SimpleGuidGenerator());
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreUserNotificationStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreUserNotificationStoreTests.cs
@@ -6,11 +6,10 @@
 // =============================================================================
 
 using System.Text.Json;
-using Granit.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Internal;
+using Granit.Persistence.MultiTenancy;
 using Granit.QueryEngine;
-using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -23,7 +22,8 @@ public sealed class EfCoreUserNotificationStoreTests : IDisposable
 
     public EfCoreUserNotificationStoreTests()
     {
-        _store = new EfCoreUserNotificationStore(_factory, Substitute.For<ICurrentTenant>());
+        NotificationsContextResolver resolver = new(DualScopeStorageMode.Shared, _factory);
+        _store = new EfCoreUserNotificationStore(resolver);
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/Granit.Notifications.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/Granit.Notifications.EntityFrameworkCore.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
   </ItemGroup>

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/NotificationDeliveryHandlerConcurrencyTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/NotificationDeliveryHandlerConcurrencyTests.cs
@@ -34,7 +34,8 @@ public sealed class NotificationDeliveryHandlerConcurrencyTests : IDisposable
     public NotificationDeliveryHandlerConcurrencyTests()
     {
         _clock.Now.Returns(_ => DateTimeOffset.UtcNow);
-        _store = new EfCoreNotificationDeliveryStore(_factory, _clock);
+        NotificationsContextResolver resolver = new(Granit.Persistence.MultiTenancy.DualScopeStorageMode.Shared, _factory);
+        _store = new EfCoreNotificationDeliveryStore(resolver, _clock);
 
         ServiceCollection svc = new();
         svc.AddMetrics();
@@ -64,7 +65,7 @@ public sealed class NotificationDeliveryHandlerConcurrencyTests : IDisposable
         _channel.SendCount.ShouldBe(1);
         (await _store.HasBeenDeliveredAsync(command.DeliveryId, TestContext.Current.CancellationToken)).ShouldBeTrue();
 
-        await using NotificationsDbContext db = _factory.CreateDbContext();
+        await using NotificationsHostDbContext db = _factory.CreateDbContext();
         (await db.DeliveryAttempts.AsNoTracking()
             .CountAsync(a => a.DeliveryId == command.DeliveryId, TestContext.Current.CancellationToken))
             .ShouldBe(1);

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/SegregatedCrossTenantAggregationTests.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Encryption;
+using Granit.Notifications.Domain;
+using Granit.Notifications.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Pins the V3 cross-tenant routing contract for Notifications under
+/// <see cref="DualScopeStorageMode.Segregated"/>: writes route to the correct DB based on
+/// the entity's <c>TenantId</c>, and reads by id fan out across both contexts.
+/// </summary>
+public sealed class SegregatedCrossTenantAggregationTests : IDisposable
+{
+    private readonly Guid _tenantA = Guid.NewGuid();
+    private readonly DataFilter _filter = new();
+    private readonly IDisposable _filterDisable;
+    private readonly IStringEncryptionService _encryption = new PassthroughEncryption();
+
+    public SegregatedCrossTenantAggregationTests()
+        => _filterDisable = _filter.Disable<IMultiTenant>();
+
+    public void Dispose() => _filterDisable.Dispose();
+
+    [Fact]
+    public async Task UserNotificationStore_Insert_TenantScoped_RoutesToTenantContext()
+    {
+        DbContextOptions<NotificationsHostDbContext> hostOpts = InMemoryHostOptions("notif-host-route");
+        DbContextOptions<NotificationsTenantDbContext> tenantOpts = InMemoryTenantOptions("notif-tenant-route");
+
+        IDbContextFactory<NotificationsHostDbContext> hostFactory = StubHostFactory(hostOpts);
+        IDbContextFactory<NotificationsTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts);
+        NotificationsContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
+
+        EfCoreUserNotificationStore store = new(resolver);
+
+        UserNotification tenantNotification = NewNotification(tenantId: _tenantA);
+        await store.InsertAsync(tenantNotification, TestContext.Current.CancellationToken);
+
+        // Tenant DB should hold it; host DB should not.
+        await using NotificationsHostDbContext hostCtx = new(hostOpts, _encryption, GranitDesignTime.CurrentTenant, _filter);
+        (await hostCtx.UserNotifications.IgnoreQueryFilters().CountAsync(TestContext.Current.CancellationToken))
+            .ShouldBe(0);
+
+        await using NotificationsTenantDbContext tenantCtx = new(tenantOpts, _encryption, GranitDesignTime.CurrentTenant, _filter);
+        UserNotification persisted = (await tenantCtx.UserNotifications
+            .IgnoreQueryFilters()
+            .ToListAsync(TestContext.Current.CancellationToken))
+            .ShouldHaveSingleItem();
+        persisted.Id.ShouldBe(tenantNotification.Id);
+        persisted.TenantId.ShouldBe(_tenantA);
+    }
+
+    [Fact]
+    public async Task UserNotificationStore_Insert_HostScoped_RoutesToHostContext()
+    {
+        DbContextOptions<NotificationsHostDbContext> hostOpts = InMemoryHostOptions("notif-host-route-h");
+        DbContextOptions<NotificationsTenantDbContext> tenantOpts = InMemoryTenantOptions("notif-tenant-route-h");
+
+        IDbContextFactory<NotificationsHostDbContext> hostFactory = StubHostFactory(hostOpts);
+        IDbContextFactory<NotificationsTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts);
+        NotificationsContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
+
+        EfCoreUserNotificationStore store = new(resolver);
+
+        UserNotification hostNotification = NewNotification(tenantId: null);
+        await store.InsertAsync(hostNotification, TestContext.Current.CancellationToken);
+
+        await using NotificationsHostDbContext hostCtx = new(hostOpts, _encryption, GranitDesignTime.CurrentTenant, _filter);
+        (await hostCtx.UserNotifications.IgnoreQueryFilters().CountAsync(TestContext.Current.CancellationToken))
+            .ShouldBe(1);
+
+        await using NotificationsTenantDbContext tenantCtx = new(tenantOpts, _encryption, GranitDesignTime.CurrentTenant, _filter);
+        (await tenantCtx.UserNotifications.IgnoreQueryFilters().CountAsync(TestContext.Current.CancellationToken))
+            .ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task UserNotificationStore_GetById_FansOutAcrossBothContexts()
+    {
+        DbContextOptions<NotificationsHostDbContext> hostOpts = InMemoryHostOptions("notif-host-getid");
+        DbContextOptions<NotificationsTenantDbContext> tenantOpts = InMemoryTenantOptions("notif-tenant-getid");
+
+        UserNotification hostNotification = NewNotification(tenantId: null);
+        UserNotification tenantNotification = NewNotification(tenantId: _tenantA);
+
+        await SeedHostAsync(hostOpts, hostNotification);
+        await SeedTenantAsync(tenantOpts, tenantNotification);
+
+        IDbContextFactory<NotificationsHostDbContext> hostFactory = StubHostFactory(hostOpts);
+        IDbContextFactory<NotificationsTenantDbContext> tenantFactory = StubTenantFactory(tenantOpts);
+        NotificationsContextResolver resolver = new(DualScopeStorageMode.Segregated, hostFactory, tenantFactory);
+
+        EfCoreUserNotificationStore store = new(resolver);
+
+        UserNotification? foundHost = await store.GetAsync(hostNotification.Id, TestContext.Current.CancellationToken);
+        UserNotification? foundTenant = await store.GetAsync(tenantNotification.Id, TestContext.Current.CancellationToken);
+
+        foundHost.ShouldNotBeNull();
+        foundHost!.Id.ShouldBe(hostNotification.Id);
+        foundTenant.ShouldNotBeNull();
+        foundTenant!.Id.ShouldBe(tenantNotification.Id);
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static DbContextOptions<NotificationsHostDbContext> InMemoryHostOptions(string name)
+        => new DbContextOptionsBuilder<NotificationsHostDbContext>()
+            .UseInMemoryDatabase($"{name}-{Guid.NewGuid()}")
+            .Options;
+
+    private static DbContextOptions<NotificationsTenantDbContext> InMemoryTenantOptions(string name)
+        => new DbContextOptionsBuilder<NotificationsTenantDbContext>()
+            .UseInMemoryDatabase($"{name}-{Guid.NewGuid()}")
+            .Options;
+
+    private async Task SeedHostAsync(
+        DbContextOptions<NotificationsHostDbContext> opts,
+        params UserNotification[] entries)
+    {
+        await using NotificationsHostDbContext db = new(opts, _encryption, GranitDesignTime.CurrentTenant, _filter);
+        db.UserNotifications.AddRange(entries);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task SeedTenantAsync(
+        DbContextOptions<NotificationsTenantDbContext> opts,
+        params UserNotification[] entries)
+    {
+        await using NotificationsTenantDbContext db = new(opts, _encryption, GranitDesignTime.CurrentTenant, _filter);
+        db.UserNotifications.AddRange(entries);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private IDbContextFactory<NotificationsHostDbContext> StubHostFactory(
+        DbContextOptions<NotificationsHostDbContext> opts)
+    {
+        IDbContextFactory<NotificationsHostDbContext> factory = Substitute.For<IDbContextFactory<NotificationsHostDbContext>>();
+        factory.CreateDbContext().Returns(_ => new NotificationsHostDbContext(opts, _encryption, GranitDesignTime.CurrentTenant, _filter));
+        factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new NotificationsHostDbContext(opts, _encryption, GranitDesignTime.CurrentTenant, _filter)));
+        return factory;
+    }
+
+    private IDbContextFactory<NotificationsTenantDbContext> StubTenantFactory(
+        DbContextOptions<NotificationsTenantDbContext> opts)
+    {
+        IDbContextFactory<NotificationsTenantDbContext> factory = Substitute.For<IDbContextFactory<NotificationsTenantDbContext>>();
+        factory.CreateDbContext().Returns(_ => new NotificationsTenantDbContext(opts, _encryption, GranitDesignTime.CurrentTenant, _filter));
+        factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new NotificationsTenantDbContext(opts, _encryption, GranitDesignTime.CurrentTenant, _filter)));
+        return factory;
+    }
+
+    private static UserNotification NewNotification(Guid? tenantId) =>
+        UserNotification.Create(
+            id: Guid.NewGuid(),
+            notificationId: Guid.NewGuid(),
+            notificationTypeName: "test.notif",
+            severity: NotificationSeverity.Info,
+            recipientUserId: "user-1",
+            data: JsonSerializer.SerializeToElement(new { key = "value" }),
+            createdAt: DateTimeOffset.UtcNow,
+            tenantId: tenantId);
+
+    private sealed class PassthroughEncryption : IStringEncryptionService
+    {
+        public string Encrypt(string plainText) => plainText;
+        public string? Decrypt(string cipherText) => cipherText;
+    }
+}

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -13,25 +13,25 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Granit.Notifications.EntityFrameworkCore.Tests;
 
 /// <summary>
-/// Creates <see cref="NotificationsDbContext"/> instances backed by SQLite in-memory
-/// for fast, isolated integration tests that support all relational operations
-/// (including <c>ExecuteUpdateAsync</c> / <c>ExecuteDeleteAsync</c>).
+/// Creates <see cref="NotificationsHostDbContext"/> instances backed by SQLite in-memory
+/// for fast, isolated integration tests that support all relational operations (including
+/// <c>ExecuteUpdateAsync</c> / <c>ExecuteDeleteAsync</c>).
 /// </summary>
 /// <remarks>
 /// The <see cref="IMultiTenant"/> query filter is disabled via a dedicated
-/// <see cref="DataFilter"/> instance so tests can insert/read rows under
-/// arbitrary tenant ids without setting up an ambient <c>ICurrentTenant</c>.
+/// <see cref="DataFilter"/> instance so tests can insert/read rows under arbitrary tenant
+/// ids without setting up an ambient <c>ICurrentTenant</c>.
 /// </remarks>
-internal sealed class TestDbContextFactory : IDbContextFactory<NotificationsDbContext>, IDisposable
+internal sealed class TestDbContextFactory : IDbContextFactory<NotificationsHostDbContext>, IDisposable
 {
     private readonly SqliteConnection _connection;
-    private readonly DbContextOptions<NotificationsDbContext> _options;
+    private readonly DbContextOptions<NotificationsHostDbContext> _options;
     private readonly IDataFilter _dataFilter;
     private readonly IDisposable _multiTenantDisabled;
 
     private TestDbContextFactory(
         SqliteConnection connection,
-        DbContextOptions<NotificationsDbContext> options,
+        DbContextOptions<NotificationsHostDbContext> options,
         IDataFilter dataFilter,
         IDisposable multiTenantDisabled)
     {
@@ -46,17 +46,16 @@ internal sealed class TestDbContextFactory : IDbContextFactory<NotificationsDbCo
         SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
-        DbContextOptionsBuilder<NotificationsDbContext> optionsBuilder = new();
+        DbContextOptionsBuilder<NotificationsHostDbContext> optionsBuilder = new();
         optionsBuilder.UseSqlite(connection);
         optionsBuilder.ReplaceService<IModelCustomizer, SqliteCompatibleModelCustomizer>();
 
-        DbContextOptions<NotificationsDbContext> options = optionsBuilder.Options;
+        DbContextOptions<NotificationsHostDbContext> options = optionsBuilder.Options;
 
         DataFilter dataFilter = new();
         IDisposable multiTenantDisabled = dataFilter.Disable<IMultiTenant>();
 
-        // Create the schema
-        using (NotificationsDbContext db = new(options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant, dataFilter))
+        using (NotificationsHostDbContext db = new(options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant, dataFilter))
         {
             db.Database.EnsureCreated();
         }
@@ -64,7 +63,8 @@ internal sealed class TestDbContextFactory : IDbContextFactory<NotificationsDbCo
         return new TestDbContextFactory(connection, options, dataFilter, multiTenantDisabled);
     }
 
-    public NotificationsDbContext CreateDbContext() => new(_options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant, _dataFilter);
+    public NotificationsHostDbContext CreateDbContext()
+        => new(_options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant, _dataFilter);
 
     public void Dispose()
     {
@@ -80,10 +80,11 @@ internal sealed class TestDbContextFactory : IDbContextFactory<NotificationsDbCo
 }
 
 /// <summary>
-/// Model customizer that remaps PostgreSQL-specific types (jsonb, DateTimeOffset)
-/// to SQLite-compatible types with value converters.
+/// Model customizer that remaps PostgreSQL-specific types (jsonb, DateTimeOffset) to
+/// SQLite-compatible types with value converters.
 /// </summary>
-internal sealed class SqliteCompatibleModelCustomizer(ModelCustomizerDependencies dependencies) : RelationalModelCustomizer(dependencies)
+internal sealed class SqliteCompatibleModelCustomizer(ModelCustomizerDependencies dependencies)
+    : RelationalModelCustomizer(dependencies)
 {
     private static readonly ValueConverter<JsonElement, string> JsonElementConverter = new(
         v => v.GetRawText(),

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/packages.lock.json
@@ -20,6 +20,17 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.InMemory": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "C3T9khx1oiLPrS6ehoSnZptiEuTOIaX60it9SGvCkWTeF5i6+IceK6p7mtx+mkFwWB5qx+v3IhgG51iUEtLq9w==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.8",
+          "Microsoft.Extensions.Caching.Memory": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Direct",
         "requested": "[10.*, )",


### PR DESCRIPTION
Closes #2432. Brings ADR-063 / Epic #2382 V3 to \`Granit.Notifications\`.

## What ships

| File | Role |
| --- | --- |
| \`NotificationsHostDbContext\` | Host-pinned. Serves Shared (all entries + row-level filter) + Segregated host portion. |
| \`NotificationsTenantDbContext\` | Tenant-isolated. Used only under Segregated. Enables \`DROP SCHEMA <tenant> CASCADE\` lessivage (RGPD Art. 17) — notification bodies carry PII. |
| \`INotificationsDbContext\` | Common shape (5 DbSets + \`SaveChangesAsync\`) for resolver dispatch. |
| \`NotificationsContextResolver\` | Central dispatcher — \`OpenForScopeAsync\` / \`OpenAllAsync\` / \`OpenForUnknownScopeAsync\`. |
| \`Options/NotificationsEntityFrameworkCoreOptions\` | \`StorageMode\` + per-mode EF Core config callbacks. |
| \`NotificationsDualScopeIntegrationValidator\` | Fail-fast under Shared mode if a consumer folds Notifications entities into a tenant-isolated AppDbContext. |

All 5 stores rewired:

- \`EfCoreUserNotificationStore\` — routes on \`notification.TenantId\`; reads by id fan out.
- \`EfCoreNotificationPreferenceStore\` — routes on \`preference.TenantId\`.
- \`EfCoreNotificationSubscriptionStore\` — routes on \`tenantId\` arg.
- \`EfCoreMobilePushTokenStore\` — routes on \`tenantId\` arg.
- \`EfCoreNotificationDeliveryStore\` — **ALWAYS routes to host** (centralised SOC2 audit trail — parent notification may live in a tenant DB under Segregated, but the delivery-attempt audit row stays in host for compliance ops).

\`EntityTrackingInterceptor\` now implements \`IGranitAutoInterceptor\` so it auto-wires via \`UseGranitInterceptors\` — drops the prior manual \`(sp, options)\` registration pattern; \`AddGranitDbContext\` can be used cleanly.

## Breaking change (pre-1.0)

\`AddGranitNotificationsEntityFrameworkCore\` moves from \`Action<DbContextOptionsBuilder>\` to \`Action<NotificationsEntityFrameworkCoreOptions>\`. Pre-1.0 breaking change per CLAUDE.md (no \`[Obsolete]\` shim). Old internal \`NotificationsDbContext\` removed (renamed to \`NotificationsHostDbContext\`).

## Test plan

- [x] \`dotnet build src/Granit.Notifications.EntityFrameworkCore -c Release\` — 0 errors
- [x] \`dotnet test tests/Granit.Notifications.EntityFrameworkCore.Tests\` — **49/49 pass** (46 existing + 3 new cross-tenant routing)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — **241/241 pass**
- [x] \`dotnet format src/Granit.Notifications.EntityFrameworkCore --verify-no-changes\` — clean
- [x] \`dotnet format tests/Granit.Notifications.EntityFrameworkCore.Tests --verify-no-changes\` — clean

## Commits

2 logical commits:
- \`c7cc85192\` source layer (scaffolding + 5 stores refactor + extension + validator)
- \`be4ddea5a\` tests rewire + cross-tenant routing tests

## Epic state after merge

#2382 V3 wave progress:
- ✅ #2434 Timeline V3 (#2436)
- ✅ #2432 Notifications V3 (this PR)
- ⏳ #2433 Auditing V3 — remains

Plus downstream cleanup (granit-showcase-dotnet / granit-microservice-template) blocked on hotfix #2437 publication.