### PR TITLE
fix(persistence): un-map multi-field ValueObjects in ApplyGranitConventions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35473,7 +35473,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "ApplyGranitConventions",

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -1,10 +1,12 @@
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.Json;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.ValueConverters;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
@@ -26,6 +28,10 @@ public static class ModelBuilderExtensions
     private static readonly MethodInfo ConfigureMergeTombstoneMethod =
         typeof(ModelBuilderExtensions)
             .GetMethod(nameof(ConfigureMergeTombstone), BindingFlags.Static | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: generic EF Core property configuration requires reflection
+
+    private static readonly MethodInfo ApplyJsonValueObjectConverterMethod =
+        typeof(ModelBuilderExtensions)
+            .GetMethod(nameof(ApplyJsonValueObjectConverter), BindingFlags.Static | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: generic value converter over the property CLR type requires reflection
 
     /// <summary>
     /// Applies Granit conventions to all entity types in the model:
@@ -58,6 +64,18 @@ public static class ModelBuilderExtensions
     ///     property with <see cref="PersistAsIntAttribute"/>; <see cref="FlagsAttribute"/>
     ///     enums are skipped automatically. Explicit
     ///     <c>HasConversion&lt;...&gt;()</c> calls in entity configurations always win.
+    ///   </item>
+    ///   <item><b>Value object conventions</b>:
+    ///     Types deriving from <c>Granit.Domain.ValueObject</c> have no identity and must
+    ///     never be mapped as entities. Any that EF Core auto-discovered as entity types
+    ///     (because they appear as reference-typed properties) are un-mapped and re-attached
+    ///     to their owner: <c>SingleValueObject&lt;T&gt;</c> as a scalar column wrapping the
+    ///     underlying primitive, multi-field value objects (e.g. <c>OpenGraph</c>,
+    ///     <c>ImageDimensions</c>) as a JSON-serialized column (marked with
+    ///     <see cref="GranitPersistenceAnnotationNames.JsonSerialized"/> so the PostgreSQL
+    ///     provider upgrades it to <c>jsonb</c>). To store a multi-field value object as flat
+    ///     columns instead, declare it explicitly with <c>builder.ComplexProperty(...)</c> —
+    ///     the convention then leaves it untouched (it is no longer an entity type).
     ///   </item>
     /// </list>
     /// </summary>
@@ -179,11 +197,13 @@ public static class ModelBuilderExtensions
                 .Invoke(null, [modelBuilder]);
         }
 
-        // --- SingleValueObject<T> conventions ---
-        // 1. Remove any SingleValueObject<T> types that EF Core auto-discovered as entity
-        //    types. These are value objects (e.g. PlanId, InvoiceId) used as scalar
-        //    properties on entities — they must NOT be treated as entities themselves.
-        RemoveSingleValueObjectEntityTypes(modelBuilder);
+        // --- Value object conventions ---
+        // 1. Remove any ValueObject type that EF Core auto-discovered as an entity type.
+        //    Value objects (e.g. PlanId, OpenGraph, ImageDimensions) have no identity and
+        //    must NOT be treated as entities. Each is re-attached to its owner as a column:
+        //    SingleValueObject<T> as a scalar (primitive converter applied in step 2);
+        //    multi-field value objects as a JSON-serialized column (jsonb on PostgreSQL).
+        RemoveValueObjectEntityTypes(modelBuilder);
 
         // 2. Auto-apply value converters for properties whose CLR type inherits from
         //    SingleValueObject<T>, mapping them to the underlying primitive column type.
@@ -320,71 +340,124 @@ public static class ModelBuilderExtensions
         return underlying.IsEnum ? underlying : null;
     }
 
-    // Removes any SingleValueObject<T> subclass that EF Core auto-discovered as an entity type.
-    // When a class property (e.g. Subscription.PlanId of type PlanId : SingleValueObject<Guid>)
-    // is not explicitly configured via builder.Property(), EF Core's convention scanner treats
-    // the CLR type as a navigation target and adds it as an entity type — which then fails
-    // validation because no primary key is defined. This step removes those phantom entities
-    // so the subsequent converter step can safely map the property as a scalar column.
+    // Removes any ValueObject subclass that EF Core auto-discovered as an entity type.
+    // When a reference-typed property whose CLR type is a value object (e.g.
+    // Subscription.PlanId : SingleValueObject<Guid>, or SeoMetadata.OpenGraph : ValueObject)
+    // is not explicitly configured, EF Core's convention scanner treats the CLR type as a
+    // navigation target and adds it as an entity type — which then fails validation because
+    // value objects have no key and no parameterless constructor (e.g.
+    // "No suitable constructor was found for the type 'ImageDimensions'"). This step un-maps
+    // those phantom entities so the property survives as a column instead:
+    //   - SingleValueObject<T>    → scalar column (primitive converter applied next by
+    //                               ApplySingleValueObjectConverters).
+    //   - multi-field ValueObject → JSON-serialized column (jsonb on PostgreSQL) — the value
+    //                               object lives entirely inside the blob, including nested
+    //                               value objects (OpenGraph → OgImage → ImageDimensions).
     //
-    // Convention also detaches any auto-discovered foreign key whose principal is an SVO type
-    // (e.g. Party.AvatarTempId : BlobReference creates an auto-FK that EF refuses to release
-    // when we call RemoveEntityType). The underlying scalar column survives and is then wrapped
-    // by ApplySingleValueObjectConverters with the matching ValueConverter.
-    private static void RemoveSingleValueObjectEntityTypes(ModelBuilder modelBuilder)
+    // Ignoring the navigation also detaches the auto-discovered foreign key that EF refuses to
+    // release when we call RemoveEntityType (e.g. Party.AvatarTempId : BlobReference). Walking
+    // the value object entity types themselves as owners clears the FKs between nested value
+    // objects (OpenGraph → OgImage) before those types are removed.
+    //
+    // Note: value objects mapped explicitly as EF complex types (builder.ComplexProperty(...))
+    // are not entity types, so they never appear here and the convention leaves them untouched.
+    private static void RemoveValueObjectEntityTypes(ModelBuilder modelBuilder)
     {
-        var svoEntityTypes = modelBuilder.Model.GetEntityTypes()
-            .Where(et => GetSingleValueObjectBase(et.ClrType) is not null)
+        var valueObjectEntityTypes = modelBuilder.Model.GetEntityTypes()
+            .Where(et => typeof(ValueObject).IsAssignableFrom(et.ClrType))
             .ToList();
 
-        if (svoEntityTypes.Count == 0)
+        if (valueObjectEntityTypes.Count == 0)
         {
             return;
         }
 
-        HashSet<Type> svoClrTypes = [.. svoEntityTypes.Select(et => et.ClrType)];
+        HashSet<Type> valueObjectClrTypes = [.. valueObjectEntityTypes.Select(et => et.ClrType)];
 
-        foreach (IMutableEntityType ownerEntityType in modelBuilder.Model.GetEntityTypes()
-            .Where(et => !svoClrTypes.Contains(et.ClrType))
-            .ToList())
+        // Walk every entity type — including the value object entity types themselves, whose
+        // navigations to nested value objects (OpenGraph → OgImage) must also be stripped so
+        // RemoveEntityType is never blocked by a dangling foreign key.
+        foreach (IMutableEntityType ownerEntityType in modelBuilder.Model.GetEntityTypes().ToList())
         {
-            // Capture the SVO-typed CLR properties EF auto-discovered as navigations
-            // on this owner (e.g. Party.AvatarTempId : BlobReference). We will
-            // re-attach them as scalar properties once the navigation is gone.
-            List<System.Reflection.PropertyInfo> svoClrProperties = [.. ownerEntityType
+            // Capture the value-object-typed CLR properties EF auto-discovered as navigations
+            // on this owner. On a real entity they are re-attached as columns; on a value
+            // object owner (itself slated for removal) they only need detaching.
+            List<System.Reflection.PropertyInfo> valueObjectClrProperties = [.. ownerEntityType
                 .GetNavigations()
-                .Where(nav => svoClrTypes.Contains(nav.TargetEntityType.ClrType))
+                .Where(nav => valueObjectClrTypes.Contains(nav.TargetEntityType.ClrType))
                 .Select(nav => nav.PropertyInfo)
                 .OfType<System.Reflection.PropertyInfo>()];
 
-            if (svoClrProperties.Count == 0)
+            if (valueObjectClrProperties.Count == 0)
             {
                 continue;
             }
 
-            // Use the builder API for both steps: `Ignore(name)` strips the
-            // auto-discovered navigation (and its backing FK) cleanly, then
-            // `Property(name)` re-registers the same CLR member as a scalar.
-            // Doing this at builder level avoids the IMutable* surface's
-            // navigation/property name conflicts and lets EF Core re-validate
-            // the model after each step.
+            // Use the builder API for both steps: `Ignore(name)` strips the auto-discovered
+            // navigation (and its backing FK) cleanly, then `Property(name)` re-registers the
+            // same CLR member as a column. Doing this at builder level avoids the IMutable*
+            // surface's navigation/property name conflicts and lets EF Core re-validate the
+            // model after each step.
             Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder ownerBuilder =
                 modelBuilder.Entity(ownerEntityType.ClrType);
 
-            foreach (System.Reflection.PropertyInfo clrProperty in svoClrProperties)
+            bool ownerIsValueObject = valueObjectClrTypes.Contains(ownerEntityType.ClrType);
+
+            foreach (System.Reflection.PropertyInfo clrProperty in valueObjectClrProperties)
             {
                 ownerBuilder.Ignore(clrProperty.Name);
-                ownerBuilder.Property(clrProperty.PropertyType, clrProperty.Name);
+
+                // A value object owner is removed wholesale below — only the navigation needs
+                // detaching. A real entity keeps the data, re-attached as a column.
+                if (ownerIsValueObject)
+                {
+                    continue;
+                }
+
+                Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder propertyBuilder =
+                    ownerBuilder.Property(clrProperty.PropertyType, clrProperty.Name);
+
+                // SingleValueObject<T> maps to its underlying primitive (ApplySingleValueObjectConverters,
+                // next step). A multi-field value object has no single primitive — serialize it to JSON.
+                if (GetSingleValueObjectBase(clrProperty.PropertyType) is null)
+                {
+                    ApplyJsonValueObjectConverterMethod // NOSONAR S3011 - intentional: generic value converter over the property CLR type requires reflection
+                        .MakeGenericMethod(clrProperty.PropertyType)
+                        .Invoke(null, [propertyBuilder.Metadata]);
+                }
             }
         }
 
-        // Now that no FK or navigation references them, the SVO entity types can be
-        // removed. ApplySingleValueObjectConverters runs next and wraps each promoted
-        // scalar property with the matching ValueConverter.
-        foreach (IMutableEntityType svoEntityType in svoEntityTypes)
+        // Now that no FK or navigation references them, the value object entity types can be
+        // removed. ApplySingleValueObjectConverters runs next and wraps each promoted SVO
+        // scalar property with the matching primitive ValueConverter.
+        foreach (IMutableEntityType valueObjectEntityType in valueObjectEntityTypes)
         {
-            modelBuilder.Model.RemoveEntityType(svoEntityType.ClrType);
+            modelBuilder.Model.RemoveEntityType(valueObjectEntityType.ClrType);
         }
+    }
+
+    // Wraps a multi-field value object property with a JSON ValueConverter (+ deep-equality
+    // ValueComparer for change tracking) and flags it with the JsonSerialized annotation so the
+    // PostgreSQL provider upgrades the column to jsonb. Mirrors HasJsonConversion<T> but operates
+    // on the IMutableProperty directly because the convention re-attaches the property through the
+    // non-generic builder. STJ defaults are used (matches HasJsonConversion's default).
+    private static void ApplyJsonValueObjectConverter<T>(IMutableProperty property)
+    {
+        ValueConverter<T, string> converter = new(
+            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+            v => JsonSerializer.Deserialize<T>(v, (JsonSerializerOptions?)null)!);
+
+        // Lambdas become Expression<> trees in the ValueComparer ctor, so constructs disallowed
+        // in expression trees (pattern matching, switch expressions) cannot appear here.
+        ValueComparer<T> comparer = new(
+            (a, b) => JsonSerializer.Serialize(a, (JsonSerializerOptions?)null) == JsonSerializer.Serialize(b, (JsonSerializerOptions?)null),
+            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null).GetHashCode(StringComparison.Ordinal),
+            v => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(v, (JsonSerializerOptions?)null), (JsonSerializerOptions?)null)!);
+
+        property.SetValueConverter(converter);
+        property.SetValueComparer(comparer);
+        property.SetAnnotation(GranitPersistenceAnnotationNames.JsonSerialized, true);
     }
 
     // Scans all entity properties for SingleValueObject<T> types and applies a ValueConverter

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ValueObjectEntityAutoDiscoveryRemovalTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ValueObjectEntityAutoDiscoveryRemovalTests.cs
@@ -1,0 +1,171 @@
+// =============================================================================
+// Repro — multi-field ValueObject auto-discovery removal (SEO shard crash)
+// =============================================================================
+// `ApplyGranitConventions` un-mapped SingleValueObject<T> entity types but not
+// multi-field value objects (types deriving from `Granit.Domain.ValueObject`
+// with more than one field). When an entity exposes such a value object as a
+// property — directly or nested — EF Core's convention scanner registers it
+// (and every nested value object) as an entity type and then fails model
+// validation while binding their constructors:
+//
+//   System.InvalidOperationException :
+//     No suitable constructor was found for the type 'ImageDimensions'.
+//     Cannot bind 'width', 'height' in 'ImageDimensions(int width, int height)'
+//
+// Reported by the SEO integration shard: SeoMetadata.OpenGraph (OpenGraph →
+// OgImage → ImageDimensions) crashed the model build before any test touched
+// Postgres.
+//
+// The fix un-maps every auto-discovered ValueObject. Multi-field value objects
+// are re-attached as a JSON-serialized column (marked JsonSerialized so the
+// Postgres provider upgrades it to jsonb) — the whole graph, including nested
+// value objects, lives inside the blob. A value object mapped explicitly as an
+// EF complex type is never an entity type, so the convention leaves it alone.
+// =============================================================================
+
+using Granit.Domain.ValueObjects;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class ValueObjectEntityAutoDiscoveryRemovalTests
+{
+    [Fact]
+    public void ApplyGranitConventions_EntityWithNestedValueObject_RemovesValueObjectsAndSerializesAsJson()
+    {
+        // Arrange — model the SEO scenario: an entity exposes a multi-field value
+        // object that nests further value objects (OpenGraph → OgImage → ImageDimensions).
+        using SeoOwnerDbContext context = new(new DbContextOptionsBuilder<SeoOwnerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+        // Act — model build triggers ApplyGranitConventions on first access. Without the
+        // fix this throws "No suitable constructor was found for the type 'ImageDimensions'".
+        IReadOnlyList<string> entityNames = [.. context.Model.GetEntityTypes()
+            .Select(et => et.ClrType.Name)];
+
+        // Assert — only the real entity survives; every value object in the graph is gone.
+        entityNames.ShouldContain(nameof(SeoMetadataEntity), "the owner entity must remain");
+        entityNames.ShouldNotContain(nameof(TestOpenGraph), "the top-level value object must not be an entity");
+        entityNames.ShouldNotContain(nameof(TestOgImage), "the nested value object must not be an entity");
+        entityNames.ShouldNotContain(nameof(ImageDimensions), "the leaf value object must not be an entity");
+
+        // The property survives as a JSON-serialized column wrapping the whole graph.
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType owner = context.Model
+            .FindEntityType(typeof(SeoMetadataEntity))!;
+        Microsoft.EntityFrameworkCore.Metadata.IProperty property =
+            owner.FindProperty(nameof(SeoMetadataEntity.OpenGraph)).ShouldNotBeNull(
+                "the value object must survive as a scalar (JSON) property");
+
+        property.GetValueConverter().ShouldNotBeNull("a JSON value converter must be wired");
+        property.FindAnnotation(GranitPersistenceAnnotationNames.JsonSerialized)?.Value
+            .ShouldBe(true, "the property must be flagged so the Postgres provider upgrades it to jsonb");
+    }
+
+    [Fact]
+    public void ApplyGranitConventions_ValueObjectMappedAsComplexProperty_IsLeftUntouched()
+    {
+        // Arrange — opt out of the jsonb default by declaring the value object as an EF
+        // complex type. It maps to flat columns (Latitude, Longitude) and is not an entity
+        // type, so the convention must not touch it (no removal, no JSON converter).
+        using ComplexOwnerDbContext context = new(new DbContextOptionsBuilder<ComplexOwnerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+        // Act
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType owner = context.Model
+            .FindEntityType(typeof(ComplexOwnerEntity))!;
+
+        // Assert — GeoCoordinate stays a complex type with flat members, not a JSON blob.
+        owner.GetComplexProperties()
+            .ShouldContain(cp => cp.Name == nameof(ComplexOwnerEntity.Location),
+                "the value object must remain mapped as a complex property");
+
+        Microsoft.EntityFrameworkCore.Metadata.IComplexProperty complex =
+            owner.FindComplexProperty(nameof(ComplexOwnerEntity.Location))!;
+        complex.ComplexType.GetProperties().Select(p => p.Name)
+            .ShouldBe([nameof(GeoCoordinate.Latitude), nameof(GeoCoordinate.Longitude)], ignoreOrder: true);
+    }
+
+    // --- Test value objects modelling the SEO chain (multi-field, nested). -----------------
+    // ImageDimensions is the real framework value object reused as the leaf.
+
+    public sealed class TestOgImage(string url, ImageDimensions dimensions) : Granit.Domain.ValueObject
+    {
+        public string Url { get; } = url;
+        public ImageDimensions Dimensions { get; } = dimensions;
+
+        protected override IEnumerable<object?> GetEqualityComponents()
+        {
+            yield return Url;
+            yield return Dimensions;
+        }
+    }
+
+    public sealed class TestOpenGraph(string title, TestOgImage image) : Granit.Domain.ValueObject
+    {
+        public string Title { get; } = title;
+        public TestOgImage Image { get; } = image;
+
+        protected override IEnumerable<object?> GetEqualityComponents()
+        {
+            yield return Title;
+            yield return Image;
+        }
+    }
+
+    public sealed class SeoMetadataEntity
+    {
+        public Guid Id { get; set; }
+
+        // No explicit configuration — relies on the framework convention.
+        public TestOpenGraph? OpenGraph { get; set; }
+    }
+
+    // A multi-field value object with settable members — a clean EF complex-type candidate
+    // (EF complex-type constructor binding is more limited than entity binding).
+    public sealed class GeoCoordinate : Granit.Domain.ValueObject
+    {
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+
+        protected override IEnumerable<object?> GetEqualityComponents()
+        {
+            yield return Latitude;
+            yield return Longitude;
+        }
+    }
+
+    public sealed class ComplexOwnerEntity
+    {
+        public Guid Id { get; set; }
+        public GeoCoordinate Location { get; set; } = new();
+    }
+
+    private sealed class SeoOwnerDbContext(DbContextOptions<SeoOwnerDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<SeoMetadataEntity> Pages => Set<SeoMetadataEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ApplyGranitConventions();
+    }
+
+    private sealed class ComplexOwnerDbContext(DbContextOptions<ComplexOwnerDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<ComplexOwnerEntity> Owners => Set<ComplexOwnerEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Opt out of jsonb: map the value object as a complex type (flat columns).
+            modelBuilder.Entity<ComplexOwnerEntity>()
+                .ComplexProperty(e => e.Location);
+
+            modelBuilder.ApplyGranitConventions();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ApplyGranitConventions` only un-mapped `SingleValueObject<T>` entity types, not multi-field value objects. So EF Core auto-discovered types like `OpenGraph`, `OgImage`, and `ImageDimensions` as **entity types** and failed model validation while binding their constructors:

```
System.InvalidOperationException : No suitable constructor was found for the type 'ImageDimensions'.
Cannot bind 'width', 'height' in 'ImageDimensions(int width, int height)'
```

This crashed the **SEO integration shard at model build** — every integration test errored before touching Postgres.

## Fix

Generalize the value-object convention from `SingleValueObject<T>` to every `Granit.Domain.ValueObject`:

- **`SingleValueObject<T>`** → scalar primitive column (unchanged).
- **Multi-field `ValueObject`** → JSON-serialized column, flagged with the `JsonSerialized` annotation so the PostgreSQL provider upgrades it to `jsonb`. The whole graph — including nested value objects (`OpenGraph → OgImage → ImageDimensions`) — lives inside the blob.

Walking the value-object entity types *as owners* strips the navigations between nested value objects, so `RemoveEntityType` is never blocked by a dangling foreign key.

### Opt-out

Want flat columns instead of `jsonb` for a given VO? Declare it explicitly as an EF complex type:

```csharp
builder.ComplexProperty(e => e.Dimensions);
```

It's then no longer an entity type, so the convention leaves it untouched.

## Tests

`ValueObjectEntityAutoDiscoveryRemovalTests`:
- Repro of the SEO chain (reusing the real `ImageDimensions` as the leaf) — fails before, passes after; asserts the VOs are gone as entities and the property carries a JSON converter + `JsonSerialized` annotation.
- Opt-out test proving a `ComplexProperty`-mapped VO is left untouched (flat columns).

`dotnet test` on the persistence project: **378/378**. Postgres provider tests: 37/37. `dotnet format --verify-no-changes` clean.

> Note: docs (granit-docs) to follow in a decoupled PR per repo convention.