### PR TITLE
fix(auditing): durable-by-default persistence + graceful drain + channel health check

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -5154,6 +5154,22 @@
       ]
     },
     {
+      "name": "AuditingHealthChecksBuilderExtensions",
+      "fqn": "Granit.Auditing.Endpoints.Extensions.AuditingHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Auditing.Endpoints",
+      "file": "src/Granit.Auditing.Endpoints/Extensions/AuditingHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitAuditingChannelHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitAuditingChannelHealthCheck(this IHealthChecksBuilder builder, string name = \"auditing-channel\", HealthStatus? failureStatus = null, IEnumerable<string>? tags = null, TimeSpan? timeout = null)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
       "name": "GranitAuditingEndpointsModule",
       "fqn": "Granit.Auditing.Endpoints.GranitAuditingEndpointsModule",
       "kind": "class",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Changed (framework — BREAKING: behavior)
+
+- **Auditing now persists synchronously (`Strict`) by default.** `AuditPersistenceMode.Strict` is now both the default value of `AuditingOptions.PersistenceMode` *and* the enum's zero value, so an unconfigured options instance is durable by default — the right posture for an ISO 27001 / GDPR audit trail. The previous default (`Async`) buffers entries in an in-memory channel and could silently drop them on shutdown. Only entity-change capture (via the EF Core interceptor) is affected; explicit writes through `IAuditingWriter` were already synchronous. Throughput-sensitive apps must now opt into async buffering explicitly. Reordering the enum's underlying int values is wire-safe (the enum is persisted/serialized by name).
+
+  **Migration** — to keep the previous async-buffered behavior:
+
+  ```json
+  "Auditing": { "PersistenceMode": "Async" }
+  ```
+
+  When running in `Async` mode under Kubernetes, also raise the host shutdown timeout so the graceful drain (below) can flush the buffer before SIGKILL — the .NET default is only 5s, well under the typical 30s `terminationGracePeriodSeconds`:
+
+  ```csharp
+  builder.Services.Configure<HostOptions>(o => o.ShutdownTimeout = TimeSpan.FromSeconds(25));
+  ```
+
 ### Changed (framework — BREAKING: appsettings)
 
 - **`SectionName` homogenization across the framework.** Every `public const string SectionName` on a Granit options class now follows the same convention: a colon-separated, ASP.NET-style hierarchical path aligned on the project namespace after stripping the internal `Granit` prefix (`Granit.Foo.Bar.Baz` → `"Foo:Bar:Baz"`). Three classes of legacy values were eliminated: (1) the `Granit:` root prefix (which was leaking the code namespace into config — `"Granit:ApiKeys"`, `"Granit:IO:TempFiles"`, `"Granit:Templating:App"`, `"Granit:DataExchange:BlobStorage"`); (2) PascalCase-glued compound names that hid a real hierarchy (`"WolverinePostgresql"`, `"WolverineSqlServer"`, `"GranitMigrations"`, `"TenantSchema"`, every `"*Endpoints"` umbrella, every `Http.*` flat name); (3) vendor-rooted or wrong-segmented names under `Notifications.*` and `Identity.Federated.*` (`"AzureCommunicationServices:Email"`, `"Notifications:Smtp"`, `"KeycloakAdmin"`, `"EntraIdAdmin"`, `"CognitoAdmin"`, `"Identity:UserCacheHasher"`, …). One real binding collision was also fixed: `ImportOptions` and the root data-exchange config both bound to `"DataExchange"`, silently shadowing one another — `ImportOptions` now lives at `"DataExchange:Import"` and `ExportOptions` at `"DataExchange:Export"`. `TenantIsolationOptions` (which had no `SectionName` const and was bound to the literal `"TenantIsolation"`) now exposes the const and binds to `"MultiTenancy:TenantIsolation"`, aligned with `MultiTenancy:TenantSchema`. The convention is enforced going forward by `Granit.ArchitectureTests.SectionNameConventionTests` (forbids `Granit:` root, forbids flat compound names, requires SectionName uniqueness). Every renamed section also has its `*OptionsTests.SectionName.ShouldBe(...)` assertion updated, every test that builds an in-memory `IConfiguration` for a service-collection extension was migrated to the new prefix (otherwise the binder fails silently and tests assert default values), and the `templates/granit-api-full/appsettings.json` was repointed (`"Cors"` → `"Http:Cors"`). The Keycloak JwtBearer rename (`"Keycloak"` → `"Authentication:Keycloak"`) shipped earlier in this release is part of the same sweep.
@@ -163,6 +179,8 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- **Auditing — graceful drain for the async persistence worker.** On SIGTERM the `AuditingPersistenceWorker` completes the channel and drains every buffered batch before exiting, eliminating audit-trail gaps on rolling deploys (bounded by the host `ShutdownTimeout`; an ungraceful SIGKILL/OOMKilled still loses the buffer — use `Strict` for hard durability). The worker is also a no-op in `Strict` mode instead of parking an idle channel reader.
+- **Auditing — `AddGranitAuditingChannelHealthCheck()` on `IHealthChecksBuilder`** (`Granit.Auditing.Endpoints`) — reports `Degraded` at ≥80% channel fill and `Unhealthy` when the bounded channel is saturated (producers blocked on backpressure), letting Kubernetes readiness probes detect a stuck audit persister. Reports `Healthy` in `Strict` mode (channel unused). Opt-in, `["readiness"]` tag, 10s timeout.
 - Initialisation du repository granit-dotnet
 - Structure solution .NET 10 avec Central Package Management
 - Projets : Abstractions, Security, Persistence, Vault, Observability

--- a/src/Granit.Auditing.Endpoints/Extensions/AuditingHealthChecksBuilderExtensions.cs
+++ b/src/Granit.Auditing.Endpoints/Extensions/AuditingHealthChecksBuilderExtensions.cs
@@ -1,0 +1,39 @@
+using Granit.Auditing.Endpoints.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.Auditing.Endpoints.Extensions;
+
+/// <summary>
+/// Extension methods for adding the Granit auditing health checks to <see cref="IHealthChecksBuilder"/>.
+/// </summary>
+public static class AuditingHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Adds a health check that reports the depth of the async audit persistence channel,
+    /// surfacing backpressure before the bounded channel saturates. Reports
+    /// <see cref="HealthStatus.Healthy"/> when persistence runs in
+    /// <see cref="Granit.Auditing.Domain.AuditPersistenceMode.Strict"/> (the channel is unused).
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">The health check name. Defaults to <c>"auditing-channel"</c>.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> reported when the check fails. Defaults to
+    /// <see cref="HealthStatus.Unhealthy"/>.
+    /// </param>
+    /// <param name="tags">Tags for filtering. Defaults to <c>["readiness"]</c>.</param>
+    /// <param name="timeout">Optional probe timeout. Defaults to 10 seconds.</param>
+    /// <returns>The health checks builder for chaining.</returns>
+    public static IHealthChecksBuilder AddGranitAuditingChannelHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "auditing-channel",
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        tags ??= ["readiness"];
+        return builder.AddCheck<AuditingChannelHealthCheck>(
+            name, failureStatus, tags, timeout ?? TimeSpan.FromSeconds(10));
+    }
+}

--- a/src/Granit.Auditing.Endpoints/Internal/AuditingChannelHealthCheck.cs
+++ b/src/Granit.Auditing.Endpoints/Internal/AuditingChannelHealthCheck.cs
@@ -1,0 +1,77 @@
+using System.Threading.Channels;
+using Granit.Auditing.Domain;
+using Granit.Auditing.Messages;
+using Granit.Auditing.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Auditing.Endpoints.Internal;
+
+/// <summary>
+/// Health check for the async audit persistence channel, surfacing backpressure to the
+/// Kubernetes readiness probe before the bounded channel saturates and starts blocking
+/// request threads (<c>BoundedChannelFullMode.Wait</c>).
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item><b>Healthy</b>: fill ratio below 80% (or <see cref="AuditPersistenceMode.Strict"/>, where the channel is unused).</item>
+/// <item><b>Degraded</b>: fill ratio at or above 80% — backpressure is imminent.</item>
+/// <item><b>Unhealthy</b>: channel saturated — producers (interceptors) are blocked waiting for capacity.</item>
+/// </list>
+/// Exposes only counters/ratios — never any audited payload.
+/// </remarks>
+internal sealed class AuditingChannelHealthCheck(
+    Channel<AuditingBatch> channel,
+    IOptions<AuditingOptions> options) : IHealthCheck
+{
+    private const double DegradedThreshold = 0.8;
+
+    /// <inheritdoc/>
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        AuditingOptions opts = options.Value;
+
+        // Strict mode persists synchronously and never writes to the channel — nothing to monitor.
+        if (opts.PersistenceMode != AuditPersistenceMode.Async)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy(
+                "Auditing persistence mode is Strict; the async channel is unused."));
+        }
+
+        if (!channel.Reader.CanCount)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy("Audit channel depth is not observable."));
+        }
+
+        int depth = channel.Reader.Count;
+        int capacity = opts.ChannelCapacity;
+        double fillRatio = capacity > 0 ? (double)depth / capacity : 0;
+
+        Dictionary<string, object> data = new()
+        {
+            ["depth"] = depth,
+            ["capacity"] = capacity,
+            ["fill_ratio"] = fillRatio,
+        };
+
+        if (depth >= capacity)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"Audit channel saturated: {depth}/{capacity} ({fillRatio:P0}) — producers are blocked on backpressure.",
+                data: data));
+        }
+
+        if (fillRatio >= DegradedThreshold)
+        {
+            return Task.FromResult(HealthCheckResult.Degraded(
+                $"Audit channel under pressure: {depth}/{capacity} ({fillRatio:P0}).",
+                data: data));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy(
+            $"Audit channel healthy: {depth}/{capacity} ({fillRatio:P0}).",
+            data: data));
+    }
+}

--- a/src/Granit.Auditing/Domain/AuditPersistenceMode.cs
+++ b/src/Granit.Auditing/Domain/AuditPersistenceMode.cs
@@ -6,15 +6,21 @@ namespace Granit.Auditing.Domain;
 public enum AuditPersistenceMode
 {
     /// <summary>
-    /// Entries are published to a <c>Channel&lt;T&gt;</c> and persisted asynchronously
-    /// by a background worker. Best performance, but entries may be lost on crash.
-    /// </summary>
-    Async = 0,
-
-    /// <summary>
     /// Entries are persisted synchronously within the interceptor's <c>SavedChangesAsync</c>
     /// callback. Guarantees durability at the cost of added latency.
     /// Required for ISO 27001 strict compliance (banking, HDS).
     /// </summary>
-    Strict = 1,
+    /// <remarks>
+    /// Secure by default: this is the zero value so an unconfigured
+    /// <see cref="Granit.Auditing.Options.AuditingOptions.PersistenceMode"/> never silently
+    /// falls back to a lossy mode. Opt into <see cref="Async"/> explicitly for throughput.
+    /// </remarks>
+    Strict = 0,
+
+    /// <summary>
+    /// Entries are published to a <c>Channel&lt;T&gt;</c> and persisted asynchronously
+    /// by a background worker. Best performance, but buffered entries may be lost on an
+    /// ungraceful crash (the graceful-shutdown drain only covers SIGTERM, not SIGKILL).
+    /// </summary>
+    Async = 1,
 }

--- a/src/Granit.Auditing/Internal/Services/AuditingPersistenceWorker.cs
+++ b/src/Granit.Auditing/Internal/Services/AuditingPersistenceWorker.cs
@@ -19,7 +19,20 @@ namespace Granit.Auditing.Internal.Services;
 /// and persists them via <see cref="IAuditBatchPersister"/>.
 /// </summary>
 /// <remarks>
-/// Only active in <see cref="AuditPersistenceMode.Async"/> mode.
+/// <para>
+/// Only active in <see cref="AuditPersistenceMode.Async"/> mode; a no-op otherwise.
+/// </para>
+/// <para>
+/// On graceful shutdown (SIGTERM), <see cref="StopAsync"/> completes the channel and the
+/// worker drains every buffered batch before exiting, so no audit entries are lost during a
+/// rolling deploy. The drain is bounded by the host <c>ShutdownTimeout</c> — whose .NET
+/// default is only <b>5 seconds</b>. Under load this is shorter than the Kubernetes
+/// <c>terminationGracePeriodSeconds</c> (default 30s), so consuming apps that run in
+/// <see cref="AuditPersistenceMode.Async"/> SHOULD raise it to give the drain a real window,
+/// e.g. <c>services.Configure&lt;HostOptions&gt;(o =&gt; o.ShutdownTimeout = TimeSpan.FromSeconds(25));</c>
+/// (kept below the pod grace period). An ungraceful kill (SIGKILL / OOMKilled) still loses
+/// the buffer — <see cref="AuditPersistenceMode.Strict"/> is the durable mode.
+/// </para>
 /// </remarks>
 internal sealed partial class AuditingPersistenceWorker(
     Channel<AuditingBatch> channel,
@@ -40,15 +53,45 @@ internal sealed partial class AuditingPersistenceWorker(
     /// <inheritdoc/>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (options.Value.PersistenceMode == AuditPersistenceMode.Async)
+        // In Strict mode the channel is never written to (the interceptor persists
+        // synchronously), so there is nothing to consume — stay idle instead of parking
+        // a reader on a channel that will never receive a batch.
+        if (options.Value.PersistenceMode != AuditPersistenceMode.Async)
         {
-            LogAsyncModeWarning();
+            return;
         }
 
-        await foreach (AuditingBatch batch in channel.Reader.ReadAllAsync(stoppingToken))
+        LogAsyncModeWarning();
+
+        try
         {
-            await PersistWithRetryAsync(batch, stoppingToken).ConfigureAwait(false);
+            await foreach (AuditingBatch batch in channel.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await PersistWithRetryAsync(batch, stoppingToken).ConfigureAwait(false);
+            }
         }
+        catch (OperationCanceledException)
+        {
+            // Shutdown requested — fall through and drain whatever is still buffered.
+        }
+
+        // Graceful drain: StopAsync has completed the writer, so no new batches arrive.
+        // Persist the remainder with an uncancellable token so the drain is not aborted by
+        // the already-signalled stopping token (it is still bounded by the host
+        // ShutdownTimeout, after which the process exits and terminates this worker).
+        while (channel.Reader.TryRead(out AuditingBatch? batch))
+        {
+            await PersistWithRetryAsync(batch, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Stop accepting new batches so the drain loop in ExecuteAsync can terminate
+        // naturally once the buffer is emptied.
+        channel.Writer.TryComplete();
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task PersistWithRetryAsync(AuditingBatch batch, CancellationToken stoppingToken)

--- a/src/Granit.Auditing/Options/AuditingOptions.cs
+++ b/src/Granit.Auditing/Options/AuditingOptions.cs
@@ -14,11 +14,12 @@ public sealed class AuditingOptions
 
     /// <summary>
     /// Controls how audit entries are persisted after capture.
-    /// <see cref="AuditPersistenceMode.Async"/> uses a background channel (best performance).
-    /// <see cref="AuditPersistenceMode.Strict"/> persists synchronously (ISO 27001 strict).
-    /// Default: <see cref="AuditPersistenceMode.Async"/>.
+    /// <see cref="AuditPersistenceMode.Strict"/> persists synchronously (ISO 27001 strict, durable).
+    /// <see cref="AuditPersistenceMode.Async"/> uses a background channel (best performance, buffered).
+    /// Default: <see cref="AuditPersistenceMode.Strict"/> — secure by default; opt into
+    /// <see cref="AuditPersistenceMode.Async"/> for throughput-sensitive workloads.
     /// </summary>
-    public AuditPersistenceMode PersistenceMode { get; set; } = AuditPersistenceMode.Async;
+    public AuditPersistenceMode PersistenceMode { get; set; } = AuditPersistenceMode.Strict;
 
     /// <summary>
     /// Whether to capture property-level old/new values in <see cref="AuditPropertyChange"/>.

--- a/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingChannelHealthCheckTests.cs
+++ b/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingChannelHealthCheckTests.cs
@@ -1,0 +1,71 @@
+using System.Threading.Channels;
+using Granit.Auditing.Domain;
+using Granit.Auditing.Endpoints.Internal;
+using Granit.Auditing.Messages;
+using Granit.Auditing.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+using Xunit;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.Auditing.Endpoints.Tests.Internal;
+
+public sealed class AuditingChannelHealthCheckTests
+{
+    private static AuditingBatch CreateBatch() => new(
+        Timestamp: DateTimeOffset.UtcNow,
+        UserId: "user-1",
+        UserName: "Test User",
+        Category: AuditCategory.DataMutation,
+        IpAddress: null,
+        UserAgent: null,
+        TenantId: null,
+        CorrelationId: null,
+        EntityChanges: []);
+
+    private static async Task<HealthCheckResult> CheckAsync(int capacity, int fill, AuditPersistenceMode mode)
+    {
+        var channel = Channel.CreateBounded<AuditingBatch>(capacity);
+        for (int i = 0; i < fill; i++)
+        {
+            await channel.Writer.WriteAsync(CreateBatch(), TestContext.Current.CancellationToken);
+        }
+
+        AuditingOptions opts = new() { PersistenceMode = mode, ChannelCapacity = capacity };
+        AuditingChannelHealthCheck check = new(channel, MsOptions.Create(opts));
+
+        return await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Healthy_InStrictMode_EvenWhenChannelFull()
+    {
+        HealthCheckResult result = await CheckAsync(capacity: 10, fill: 10, mode: AuditPersistenceMode.Strict);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Healthy_WhenBelowDegradedThreshold()
+    {
+        HealthCheckResult result = await CheckAsync(capacity: 10, fill: 5, mode: AuditPersistenceMode.Async);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Degraded_WhenAtOrAboveEightyPercent()
+    {
+        HealthCheckResult result = await CheckAsync(capacity: 10, fill: 8, mode: AuditPersistenceMode.Async);
+
+        result.Status.ShouldBe(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task Unhealthy_WhenSaturated()
+    {
+        HealthCheckResult result = await CheckAsync(capacity: 10, fill: 10, mode: AuditPersistenceMode.Async);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+}

--- a/tests/Granit.Auditing.Tests/Domain/AuditPersistenceModeTests.cs
+++ b/tests/Granit.Auditing.Tests/Domain/AuditPersistenceModeTests.cs
@@ -7,9 +7,12 @@ namespace Granit.Auditing.Tests.Domain;
 public sealed class AuditPersistenceModeTests
 {
     [Theory]
-    [InlineData(AuditPersistenceMode.Async, 0)]
-    [InlineData(AuditPersistenceMode.Strict, 1)]
+    [InlineData(AuditPersistenceMode.Strict, 0)]
+    [InlineData(AuditPersistenceMode.Async, 1)]
     public void Values_HaveExpectedNumericValues(AuditPersistenceMode mode, int expectedValue) => ((int)mode).ShouldBe(expectedValue);
+
+    [Fact]
+    public void Default_IsStrict_SoUnconfiguredIsDurable() => default(AuditPersistenceMode).ShouldBe(AuditPersistenceMode.Strict);
 
     [Fact]
     public void HasTwoValues()

--- a/tests/Granit.Auditing.Tests/Domain/AuditingOptionsTests.cs
+++ b/tests/Granit.Auditing.Tests/Domain/AuditingOptionsTests.cs
@@ -12,7 +12,7 @@ public sealed class AuditingOptionsTests
     {
         AuditingOptions options = new();
 
-        options.PersistenceMode.ShouldBe(AuditPersistenceMode.Async);
+        options.PersistenceMode.ShouldBe(AuditPersistenceMode.Strict);
         options.EnablePropertyTracking.ShouldBeTrue();
         options.CleanupBatchSize.ShouldBe(10_000);
         options.CleanupInterval.ShouldBe(TimeSpan.FromHours(24));

--- a/tests/Granit.Auditing.Tests/Internal/Services/AuditingPersistenceWorkerTests.cs
+++ b/tests/Granit.Auditing.Tests/Internal/Services/AuditingPersistenceWorkerTests.cs
@@ -107,6 +107,40 @@ public sealed class AuditingPersistenceWorkerTests : IDisposable
     }
 
     [Fact]
+    public async Task StopAsync_DrainsBufferedBatches_WithoutExplicitComplete()
+    {
+        // Producer never completes the channel — a graceful shutdown (SIGTERM) must
+        // complete it and drain every buffered batch so none are lost on a rolling deploy.
+        await _channel.Writer.WriteAsync(CreateBatch(), TestContext.Current.CancellationToken);
+        await _channel.Writer.WriteAsync(CreateBatch(), TestContext.Current.CancellationToken);
+        await _channel.Writer.WriteAsync(CreateBatch(), TestContext.Current.CancellationToken);
+
+        AuditingPersistenceWorker worker = CreateWorker();
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await worker.StartAsync(ct);
+        await Task.Delay(200, ct);
+        await worker.StopAsync(ct);
+
+        await _persister.Received(3).PersistAsync(Arg.Any<AuditingBatch>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IsNoOp_InStrictMode()
+    {
+        // In Strict mode the interceptor persists synchronously and never feeds the channel,
+        // so the worker must not consume anything that happens to be buffered.
+        await _channel.Writer.WriteAsync(CreateBatch(), TestContext.Current.CancellationToken);
+
+        AuditingPersistenceWorker worker = CreateWorker(AuditPersistenceMode.Strict);
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await worker.StartAsync(ct);
+        await Task.Delay(200, ct);
+        await worker.StopAsync(ct);
+
+        await _persister.DidNotReceive().PersistAsync(Arg.Any<AuditingBatch>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RetriesOnTransientFailure()
     {
         _persister.PersistAsync(Arg.Any<AuditingBatch>(), Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Context

First PR of a 3-part series hardening the `Granit.Auditing` family for multi-replica K8s, from the 2026-05-29 `/audit` resilience findings. The audit trail is the framework's ISO 27001 / GDPR backbone, yet its default persistence was lossy and the async worker dropped buffered entries on shutdown.

## Changes

### Secure by default (BREAKING)
- `AuditPersistenceMode`: **`Strict` is now the zero value AND the `AuditingOptions` default**, so an unconfigured audit trail is durable by default. `Async` (in-memory buffered) becomes explicit opt-in. The enum is name-serialized (config + `JsonStringEnumConverter`), so reordering the int values is wire/DB-safe — only `default()` changes.
- Only entity-change capture (EF Core interceptor) was lossy; explicit `IAuditingWriter` writes were already synchronous.

### Graceful drain (#3) + no-op in Strict (#5)
- `AuditingPersistenceWorker` now overrides `StopAsync` to complete the channel and **drain every buffered batch before exit** → no audit-trail gaps on rolling deploys (bounded by host `ShutdownTimeout`; an ungraceful SIGKILL/OOMKilled still loses the buffer — `Strict` is the durable mode).
- No-op in `Strict` mode instead of parking an idle reader.
- Documents the `ShutdownTimeout` pitfall (5s .NET default vs 30s K8s `terminationGracePeriodSeconds`) for the Async path.

### Channel health check (#6)
- `AddGranitAuditingChannelHealthCheck()` on `IHealthChecksBuilder` (in **`.Endpoints`**, no new package on the base module): `Degraded` ≥80% fill, `Unhealthy` when saturated (producers blocked on backpressure), `Healthy` in `Strict`. Opt-in, `["readiness"]` tag, 10s timeout.

## Migration

```json
"Auditing": { "PersistenceMode": "Async" }   // keep the previous async-buffered behavior
```

When opting into `Async` under K8s, raise the host shutdown timeout so the drain has a real window:

```csharp
builder.Services.Configure<HostOptions>(o => o.ShutdownTimeout = TimeSpan.FromSeconds(25));
```

## Verification
- `Granit.Auditing.Tests` ✅ 123 (incl. drain + no-op-strict)
- `Granit.Auditing.Endpoints.Tests` ✅ 39 (incl. 4 health-check)
- `Granit.Auditing.EntityFrameworkCore.Tests` ✅ 139
- `dotnet format --verify-no-changes` ✅ · `markdownlint CHANGELOG.md` ✅

No new project → no shard/lockfile changes. Docs (migration note + health check) ship separately in `granit-docs`.

## Follow-ups (same series)
- PR A — split `Granit.Auditing.Abstractions`
- PR B — retention cleanup → distributed `[RecurringJob]`