### PR TITLE
feat(ai-extraction): instruction-driven typed generation with model provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ temp/
 fuzz/**/corpus/
 fuzz/**/findings/
 fuzz/**/crashes/
+
+# Temp audit report (local only)
+AUDIT-microservices-k8s.md

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3218,6 +3218,15 @@
       ]
     },
     {
+      "name": "ExtractionRequest",
+      "fqn": "Granit.AI.Extraction.ExtractionRequest",
+      "kind": "record",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/ExtractionRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "ExtractionResult",
       "fqn": "Granit.AI.Extraction.ExtractionResult",
       "kind": "class",

--- a/src/Granit.AI.Extraction/ExtractionRequest.cs
+++ b/src/Granit.AI.Extraction/ExtractionRequest.cs
@@ -1,0 +1,34 @@
+namespace Granit.AI.Extraction;
+
+/// <summary>
+/// Describes a structured-data extraction or generation request, separating the trusted,
+/// developer-controlled task instruction from the untrusted content that must be sanitised and
+/// delimited before reaching the model (OWASP LLM01).
+/// </summary>
+public sealed record ExtractionRequest
+{
+    /// <summary>
+    /// Gets the trusted, developer-controlled task instruction. This is never sanitised, so it must
+    /// originate from code or a template — never from untrusted input. When <see langword="null"/> or
+    /// blank, the extractor falls back to its generic structured-extraction instruction.
+    /// </summary>
+    public string? Instruction { get; init; }
+
+    /// <summary>
+    /// Gets the untrusted content the model should reason over. The extractor sanitises it and wraps it
+    /// in <c>&lt;data&gt;</c> delimiters before sending it to the model.
+    /// </summary>
+    public required string Content { get; init; }
+
+    /// <summary>
+    /// Gets the trusted label describing the <see cref="Content"/> block (e.g. "Page content").
+    /// Defaults to "Document" when <see langword="null"/> or blank.
+    /// </summary>
+    public string? ContentLabel { get; init; }
+
+    /// <summary>
+    /// Gets additional named, untrusted context sections (e.g. title, locale). Each value is sanitised
+    /// and delimited by the extractor before being sent to the model.
+    /// </summary>
+    public IReadOnlyList<KeyValuePair<string, string?>>? Context { get; init; }
+}


### PR DESCRIPTION
## Why

`Granit.AI.Extraction` could only run a fixed, generic extraction prompt
(`IDocumentExtractor<T>.ExtractAsync(string)` → *"Extract structured data from
the following document"*). Consumers that need **typed generation** with a
custom, business-controlled instruction per locale (e.g. `Granit.Cms.Seo.AI` in
`granit-website`) had no way in — they couldn't inject an instruction, couldn't
use `PromptBuilder` to delimit untrusted content, and `ExtractionResult<T>`
exposed no model provenance. As a result, `Localization.AI` / `Validation.AI`
bypass Extraction and go straight to `IAIChatClientFactory`.

This makes Extraction flexible enough for typed generation, not just document
extraction — **fully backward-compatible**.

## What

- **`ExtractionRequest`** (new record):
  - `Instruction` — dev-controlled task instruction, **never sanitised** (must come
    from code/template). `null`/blank → current generic instruction.
  - `Content` (required) — untrusted text, sanitised + `<data>`-wrapped by the extractor.
  - `ContentLabel` — block label (default `"Document"`).
  - `Context` — additional named untrusted sections (title, locale…), each sanitised/delimited.
- **`IDocumentExtractor<T>`** — new primary `ExtractAsync(ExtractionRequest, ct)`.
  `ExtractAsync(string, ct)` kept as a delegating **default-interface-method**
  (`ThrowIfNull` → `new ExtractionRequest { Content = content }`) → zero breaking
  change; implementers only provide the request version.
- **`ExtractionResult<T>`** — new `string? ModelId` for provenance.
  `Success`/`NeedsReview`/`Failed` take an optional `modelId` (back-compatible).
- **`DefaultDocumentExtractor<T>`** — prompt built via `PromptBuilder`
  (`AppendInstruction` → optional `AppendUserDataMap("Context", …)` →
  `AppendUserTextBlock(label, content)`); captures `response.ModelId`.

## Consumer target (design validation)

```csharp
extractor.ExtractAsync(new ExtractionRequest
{
    Instruction = templatePerLocale,
    Content     = editorBody,
    ContentLabel = "Page content",
    Context     = [new("Title", title)],
}, ct);
// → ExtractionResult<SeoExtraction> typed + ModelId for audit
```

## Tests

`DefaultDocumentExtractorTests` — `_sut` typed as `IDocumentExtractor<InvoiceData>`
so the string overload resolves through the default-interface-method. Added:
custom-instruction prompt shaping (instruction present, content in a `<data>`
block, generic default absent), `Context` data map, and `ModelId` propagation.
Existing string-based tests stay green. All 8 pass; `core-ai` shard builds clean;
`dotnet format --verify-no-changes` clean.

No `.csproj` dependency changes (no lockfile churn). No public-API snapshot test
exists for this surface.