### PR TITLE
feat(ai-extraction): typed generation via ExtractionRequest + model provenance

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3243,6 +3243,15 @@
       ]
     },
     {
+      "name": "ExtractionRequest",
+      "fqn": "Granit.AI.Extraction.ExtractionRequest",
+      "kind": "record",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/ExtractionRequest.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "ExtractionResult",
       "fqn": "Granit.AI.Extraction.ExtractionResult",
       "kind": "class",
@@ -3291,6 +3300,12 @@
       "file": "src/Granit.AI.Extraction/IDocumentExtractor.cs",
       "line": 12,
       "members": [
+        {
+          "name": "ExtractAsync",
+          "kind": "method",
+          "signature": "ExtractAsync(ExtractionRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExtractionResult<TResult>>"
+        },
         {
           "name": "ExtractAsync",
           "kind": "method",

--- a/src/Granit.AI.Extraction/ExtractionRequest.cs
+++ b/src/Granit.AI.Extraction/ExtractionRequest.cs
@@ -1,0 +1,46 @@
+namespace Granit.AI.Extraction;
+
+/// <summary>
+/// Describes a structured-extraction (or typed-generation) request for
+/// <see cref="IDocumentExtractor{TResult}"/>.
+/// </summary>
+/// <remarks>
+/// Separates the developer-controlled task <see cref="Instruction"/> from the untrusted
+/// <see cref="Content"/> (and optional <see cref="Context"/>) so the extractor can sanitize
+/// and delimit everything that originates from outside the application — the framework's
+/// first line of defence against OWASP LLM01 prompt injection. The instruction is the only
+/// member that is never sanitized: it must come from code or a developer-authored template,
+/// never from an end user.
+/// </remarks>
+public sealed record ExtractionRequest
+{
+    /// <summary>
+    /// Developer-controlled task instruction (e.g. a per-locale generation prompt). When
+    /// <c>null</c> or blank, the extractor falls back to its generic extraction instruction.
+    /// </summary>
+    /// <remarks>
+    /// NEVER sanitized — it is appended verbatim to the prompt. Supply only code- or
+    /// template-controlled text here; routing untrusted input through this member would
+    /// defeat the prompt-injection isolation provided for <see cref="Content"/>.
+    /// </remarks>
+    public string? Instruction { get; init; }
+
+    /// <summary>
+    /// The untrusted text to analyze. Sanitized and wrapped in a <c>&lt;data&gt;</c> block
+    /// by the extractor before it reaches the model.
+    /// </summary>
+    public required string Content { get; init; }
+
+    /// <summary>
+    /// Developer-controlled label for the <see cref="Content"/> block. Defaults to
+    /// <c>"Document"</c> when <c>null</c>.
+    /// </summary>
+    public string? ContentLabel { get; init; }
+
+    /// <summary>
+    /// Optional additional named untrusted sections (title, locale, …). Each entry is
+    /// sanitized and delimited alongside <see cref="Content"/>. The keys are
+    /// developer-controlled labels; the values are treated as untrusted.
+    /// </summary>
+    public IReadOnlyList<KeyValuePair<string, string?>>? Context { get; init; }
+}

--- a/src/Granit.AI.Extraction/ExtractionResult.cs
+++ b/src/Granit.AI.Extraction/ExtractionResult.cs
@@ -12,8 +12,9 @@ public static class ExtractionResult
     /// <param name="data">The extracted data.</param>
     /// <param name="confidence">Confidence score between 0.0 and 1.0.</param>
     /// <param name="warnings">Optional warnings.</param>
+    /// <param name="modelId">Identifier of the model that produced the result, if known.</param>
     /// <returns>A successful <see cref="ExtractionResult{TResult}"/>.</returns>
-    public static ExtractionResult<TResult> Success<TResult>(TResult data, double confidence, IReadOnlyList<string>? warnings = null)
+    public static ExtractionResult<TResult> Success<TResult>(TResult data, double confidence, IReadOnlyList<string>? warnings = null, string? modelId = null)
         where TResult : class =>
         new()
         {
@@ -21,6 +22,7 @@ public static class ExtractionResult
             Data = data,
             ConfidenceScore = confidence,
             Warnings = warnings ?? [],
+            ModelId = modelId,
         };
 
     /// <summary>
@@ -28,13 +30,15 @@ public static class ExtractionResult
     /// </summary>
     /// <typeparam name="TResult">The type of the extracted data.</typeparam>
     /// <param name="errorMessage">Description of the failure.</param>
+    /// <param name="modelId">Identifier of the model that produced the result, if known.</param>
     /// <returns>A failed <see cref="ExtractionResult{TResult}"/>.</returns>
-    public static ExtractionResult<TResult> Failed<TResult>(string errorMessage)
+    public static ExtractionResult<TResult> Failed<TResult>(string errorMessage, string? modelId = null)
         where TResult : class =>
         new()
         {
             Status = ExtractionStatus.Failed,
             ErrorMessage = errorMessage,
+            ModelId = modelId,
         };
 
     /// <summary>
@@ -44,8 +48,9 @@ public static class ExtractionResult
     /// <param name="data">The extracted data.</param>
     /// <param name="confidence">Confidence score between 0.0 and 1.0.</param>
     /// <param name="warnings">Warnings explaining why review is needed.</param>
+    /// <param name="modelId">Identifier of the model that produced the result, if known.</param>
     /// <returns>A <see cref="ExtractionResult{TResult}"/> with <see cref="ExtractionStatus.NeedsReview"/> status.</returns>
-    public static ExtractionResult<TResult> NeedsReview<TResult>(TResult data, double confidence, IReadOnlyList<string> warnings)
+    public static ExtractionResult<TResult> NeedsReview<TResult>(TResult data, double confidence, IReadOnlyList<string> warnings, string? modelId = null)
         where TResult : class =>
         new()
         {
@@ -53,6 +58,7 @@ public static class ExtractionResult
             Data = data,
             ConfidenceScore = confidence,
             Warnings = warnings,
+            ModelId = modelId,
         };
 }
 
@@ -86,4 +92,10 @@ public sealed record ExtractionResult<TResult> where TResult : class
     /// Warnings produced during extraction (e.g. missing optional fields, low-confidence fields).
     /// </summary>
     public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>
+    /// Identifier of the model that produced this result, as reported by the provider.
+    /// <c>null</c> when the provider did not surface a model identifier (e.g. early failures).
+    /// </summary>
+    public string? ModelId { get; init; }
 }

--- a/src/Granit.AI.Extraction/IDocumentExtractor.cs
+++ b/src/Granit.AI.Extraction/IDocumentExtractor.cs
@@ -12,12 +12,35 @@ namespace Granit.AI.Extraction;
 public interface IDocumentExtractor<TResult> where TResult : class
 {
     /// <summary>
-    /// Extracts structured data from a document.
+    /// Extracts (or generates) structured data of type <typeparamref name="TResult"/> from
+    /// the supplied <paramref name="request"/>.
+    /// </summary>
+    /// <param name="request">
+    /// The request carrying the developer-controlled <see cref="ExtractionRequest.Instruction"/>
+    /// and the untrusted <see cref="ExtractionRequest.Content"/> / <see cref="ExtractionRequest.Context"/>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Extraction result with typed data, confidence score, status, and model provenance.</returns>
+    Task<ExtractionResult<TResult>> ExtractAsync(
+        ExtractionRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extracts structured data from raw document text using the generic extraction instruction.
     /// </summary>
     /// <param name="content">Document text content (already extracted from PDF/image).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Extraction result with typed data, confidence score, and status.</returns>
+    /// <remarks>
+    /// Convenience overload that delegates to <see cref="ExtractAsync(ExtractionRequest, CancellationToken)"/>
+    /// with a default <see cref="ExtractionRequest"/>. Implementers only need to provide the
+    /// <see cref="ExtractionRequest"/> overload.
+    /// </remarks>
     Task<ExtractionResult<TResult>> ExtractAsync(
         string content,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return ExtractAsync(new ExtractionRequest { Content = content }, cancellationToken);
+    }
 }

--- a/src/Granit.AI.Extraction/Internal/DefaultDocumentExtractor.cs
+++ b/src/Granit.AI.Extraction/Internal/DefaultDocumentExtractor.cs
@@ -29,12 +29,14 @@ internal sealed partial class DefaultDocumentExtractor<TResult>(
         ResponseFormat = ChatResponseFormat.ForJsonSchema<TResult>(),
     };
 
+    private const string DefaultInstruction = "Extract structured data from the following document.";
+
     /// <inheritdoc />
     public async Task<ExtractionResult<TResult>> ExtractAsync(
-        string content,
+        ExtractionRequest request,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(request);
 
         ExtractionOptions extractionOptions = options.Value;
 
@@ -51,13 +53,14 @@ internal sealed partial class DefaultDocumentExtractor<TResult>(
 
             var messages = new List<ChatMessage>
             {
-                new(ChatRole.User, BuildPrompt(content)),
+                new(ChatRole.User, BuildPrompt(request)),
             };
 
             ChatResponse response = await chatClient
                 .GetResponseAsync(messages, StructuredOutputOptions, linkedCts.Token)
                 .ConfigureAwait(false);
 
+            string? modelId = response.ModelId;
             string responseText = response.Text ?? string.Empty;
 
             TResult? data = JsonSerializer.Deserialize<TResult>(responseText, SerializerOptions);
@@ -65,7 +68,7 @@ internal sealed partial class DefaultDocumentExtractor<TResult>(
             if (data is null)
             {
                 LogDeserializationNull(typeof(TResult).Name);
-                return ExtractionResult.Failed<TResult>("Deserialization returned null.");
+                return ExtractionResult.Failed<TResult>("Deserialization returned null.", modelId);
             }
 
             double confidence = EstimateConfidence(response);
@@ -75,11 +78,11 @@ internal sealed partial class DefaultDocumentExtractor<TResult>(
             {
                 warnings.Add($"Confidence score ({confidence:F2}) is below the review threshold ({extractionOptions.ReviewThreshold:F2}).");
                 LogLowConfidence(typeof(TResult).Name, confidence, extractionOptions.ReviewThreshold);
-                return ExtractionResult.NeedsReview(data, confidence, warnings);
+                return ExtractionResult.NeedsReview(data, confidence, warnings, modelId);
             }
 
             LogExtractionSucceeded(typeof(TResult).Name, confidence);
-            return ExtractionResult.Success(data, confidence);
+            return ExtractionResult.Success(data, confidence, modelId: modelId);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
@@ -107,14 +110,23 @@ internal sealed partial class DefaultDocumentExtractor<TResult>(
         }
     }
 
-    private static string BuildPrompt(string content) =>
-        $"""
-         Extract structured data from the following document.
-         Document:
-         ---
-         {content}
-         ---
-         """;
+    private static string BuildPrompt(ExtractionRequest request)
+    {
+        var builder = new PromptBuilder();
+
+        builder.AppendInstruction(string.IsNullOrWhiteSpace(request.Instruction)
+            ? DefaultInstruction
+            : request.Instruction);
+
+        if (request.Context is { Count: > 0 })
+        {
+            builder.AppendUserDataMap("Context", request.Context);
+        }
+
+        builder.AppendUserTextBlock(request.ContentLabel ?? "Document", request.Content);
+
+        return builder.Build();
+    }
 
     private static double EstimateConfidence(ChatResponse response)
     {

--- a/tests/Granit.AI.Extraction.Tests/DefaultDocumentExtractorTests.cs
+++ b/tests/Granit.AI.Extraction.Tests/DefaultDocumentExtractorTests.cs
@@ -27,7 +27,9 @@ public sealed class DefaultDocumentExtractorTests
         TimeoutSeconds = 30,
     });
 
-    private readonly DefaultDocumentExtractor<InvoiceData> _sut;
+    // Typed as the interface so ExtractAsync(string) resolves to the default-interface-method
+    // that delegates to the ExtractAsync(ExtractionRequest) implementation.
+    private readonly IDocumentExtractor<InvoiceData> _sut;
 
     public DefaultDocumentExtractorTests()
     {
@@ -85,7 +87,7 @@ public sealed class DefaultDocumentExtractorTests
             TimeoutSeconds = 30,
         });
 
-        var extractor = new DefaultDocumentExtractor<InvoiceData>(
+        IDocumentExtractor<InvoiceData> extractor = new DefaultDocumentExtractor<InvoiceData>(
             _chatClientFactory,
             highThresholdOptions,
             NullLogger<DefaultDocumentExtractor<InvoiceData>>.Instance);
@@ -180,5 +182,139 @@ public sealed class DefaultDocumentExtractorTests
 
     [Fact]
     public async Task ExtractAsync_NullContent_ThrowsArgumentNullException() =>
-        await Should.ThrowAsync<ArgumentNullException>(() => _sut.ExtractAsync(null!, TestContext.Current.CancellationToken));
+        await Should.ThrowAsync<ArgumentNullException>(() => _sut.ExtractAsync((string)null!, TestContext.Current.CancellationToken));
+
+    [Fact]
+    public async Task ExtractAsync_CustomInstruction_FlowsIntoPromptWithContentInDataBlock()
+    {
+        // Arrange
+        const string jsonResponse = """{"supplier":"Acme Corp","amount":100,"currency":"EUR"}""";
+        const string customInstruction = "Generate SEO metadata for the page below in French.";
+        const string untrustedContent = "Page body authored by the editor.";
+
+        List<ChatMessage>? capturedMessages = null;
+        _chatClient
+            .GetResponseAsync(
+                Arg.Do<IEnumerable<ChatMessage>>(m => capturedMessages = m.ToList()),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse))
+            {
+                FinishReason = ChatFinishReason.Stop,
+            });
+
+        // Act
+        await _sut.ExtractAsync(
+            new ExtractionRequest
+            {
+                Instruction = customInstruction,
+                Content = untrustedContent,
+                ContentLabel = "Page content",
+            },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        capturedMessages.ShouldNotBeNull();
+        string prompt = capturedMessages.Single().Text;
+        prompt.ShouldContain(customInstruction);
+        prompt.ShouldContain("Page content");
+        prompt.ShouldContain("<data>");
+        prompt.ShouldContain(untrustedContent);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_DefaultsToGenericInstruction_WhenInstructionBlank()
+    {
+        // Arrange
+        const string jsonResponse = """{"supplier":"Acme Corp","amount":100,"currency":"EUR"}""";
+
+        List<ChatMessage>? capturedMessages = null;
+        _chatClient
+            .GetResponseAsync(
+                Arg.Do<IEnumerable<ChatMessage>>(m => capturedMessages = m.ToList()),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse))
+            {
+                FinishReason = ChatFinishReason.Stop,
+            });
+
+        // Act — string overload (default-interface-method) routes through the generic instruction
+        await _sut.ExtractAsync("Invoice from Acme Corp", TestContext.Current.CancellationToken);
+
+        // Assert
+        capturedMessages.ShouldNotBeNull();
+        capturedMessages.Single().Text.ShouldContain("Extract structured data from the following document.");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ResponseModelId_FlowsIntoResult()
+    {
+        // Arrange
+        const string jsonResponse = """{"supplier":"Acme Corp","amount":100,"currency":"EUR"}""";
+
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse))
+            {
+                FinishReason = ChatFinishReason.Stop,
+                ModelId = "gpt-4o-mini-2024-07-18",
+            });
+
+        // Act
+        ExtractionResult<InvoiceData> result = await _sut.ExtractAsync(
+            new ExtractionRequest { Content = "Some document" },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Succeeded);
+        result.ModelId.ShouldBe("gpt-4o-mini-2024-07-18");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WithContext_SanitizesAndDelimitsEachSection()
+    {
+        // Arrange
+        const string jsonResponse = """{"supplier":"Acme Corp","amount":100,"currency":"EUR"}""";
+
+        List<ChatMessage>? capturedMessages = null;
+        _chatClient
+            .GetResponseAsync(
+                Arg.Do<IEnumerable<ChatMessage>>(m => capturedMessages = m.ToList()),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse))
+            {
+                FinishReason = ChatFinishReason.Stop,
+            });
+
+        // Act
+        ExtractionResult<InvoiceData> result = await _sut.ExtractAsync(
+            new ExtractionRequest
+            {
+                Instruction = "Generate SEO metadata.",
+                Content = "The page body.",
+                ContentLabel = "Page content",
+                Context =
+                [
+                    new("Title", "Home page"),
+                    new("Locale", "fr-FR"),
+                ],
+            },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Succeeded);
+        capturedMessages.ShouldNotBeNull();
+        string prompt = capturedMessages.Single().Text;
+        prompt.ShouldContain("Context");
+        prompt.ShouldContain("Title");
+        prompt.ShouldContain("Home page");
+        prompt.ShouldContain("Locale");
+        prompt.ShouldContain("fr-FR");
+        prompt.ShouldContain("Page content");
+    }
 }


### PR DESCRIPTION
## Why

The downstream module **Granit.Cms.Seo.AI** (repo `granit-website`) needs typed SEO-metadata generation with a custom, dev-controlled business prompt **per locale**. Today `Granit.AI.Extraction` can't do this: `IDocumentExtractor<TResult>.ExtractAsync(string)` bakes a fixed generic prompt internally (`"Extract structured data from the following document"`). There's no way to inject a custom instruction, no `PromptBuilder` isolation for the untrusted content, and `ExtractionResult<T>` doesn't carry the model used (provenance). As a result, consumers (`Localization.AI`, `Validation.AI`) bypass Extraction and go straight to `IAIChatClientFactory`.

This makes Extraction flexible enough for **typed generation**, not just document extraction — backward-compatible.

## What

- **New `ExtractionRequest` record** (`Granit.AI.Extraction`):
  - `string? Instruction` — dev-controlled task instruction; `null`/blank falls back to the current generic instruction. **Never sanitized** (must come from code/templates).
  - `required string Content` — untrusted text, sanitized + `<data>`-wrapped by the extractor.
  - `string? ContentLabel` — block label (default `"Document"`).
  - `IReadOnlyList<KeyValuePair<string,string?>>? Context` — additional named untrusted sections (title, locale…), each sanitized/delimited.
- **`IDocumentExtractor<TResult>`**: new primary `ExtractAsync(ExtractionRequest, ct)`. The legacy `ExtractAsync(string, ct)` is now a **default-interface-method** delegating to it (`ThrowIfNull(content)` → `new ExtractionRequest { Content = content }`) → zero breaking change; implementers only provide the `ExtractionRequest` overload.
- **`ExtractionResult<TResult>`**: new `string? ModelId`. `Success`/`NeedsReview`/`Failed` take an optional `modelId` (back-compat) and propagate it.
- **`DefaultDocumentExtractor`**: implements the `ExtractionRequest` overload; builds the prompt with `PromptBuilder` (`AppendInstruction` → `AppendUserDataMap("Context", …)` → `AppendUserTextBlock`), gaining prompt-injection isolation it previously lacked, and captures `ChatResponse.ModelId`.

## Consumer target (design validation)

```csharp
var result = await extractor.ExtractAsync(new ExtractionRequest
{
    Instruction = templatePerLocale,
    Content     = editorBody,
    ContentLabel = "Page content",
    Context     = [new("Title", title)],
}, ct);
// → ExtractionResult<SeoExtraction> + ModelId for audit
```

## Tests

`DefaultDocumentExtractorTests` — `_sut` retyped to the interface to reach the default-interface-method. Added: custom instruction flows into the prompt with content delimited in a `<data>` block; blank instruction defaults to the generic one; `ChatResponse.ModelId` round-trips into `ExtractionResult.ModelId`; `ExtractionRequest` with `Context`. All 36 tests green.

## Notes

- No new dependencies; `THIRD-PARTY-NOTICES.md` unaffected.
- `dotnet format --verify-no-changes` clean on both projects.
- No public-API snapshot mechanism in this repo, so no baseline to regenerate.
- Doc-site updates (if any) ship separately in `granit-docs` per repo convention.