### PR TITLE
refactor(authorization-ai): migrate anomaly detector to IStructuredCompletion (F3)

### DIFF
--- a/src/Granit.Authorization.AI/Internal/LlmAccessAnomalyDetector.cs
+++ b/src/Granit.Authorization.AI/Internal/LlmAccessAnomalyDetector.cs
@@ -1,32 +1,27 @@
-using System.Text.Json;
 using Granit.AI;
 using Granit.AI.Internal;
 using Granit.Authorization.AI.Options;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Authorization.AI.Internal;
 
 /// <summary>
-/// LLM-backed access anomaly detector that evaluates access patterns for suspicious behavior.
+/// LLM-backed access anomaly detector that evaluates access patterns for suspicious behavior
+/// via the <see cref="IStructuredCompletion"/> primitive (ADR-064).
 /// </summary>
 /// <remarks>
-/// When the LLM is unavailable or times out, returns a configurable uncertainty score
-/// (default 0.5) and logs a warning for manual review. Configure
-/// <see cref="AuthorizationAIOptions.UnavailableRiskScore"/> to control fail-open (0.0)
-/// or fail-closed (1.0) behavior.
+/// When the LLM is unavailable, times out, or returns an unusable response, returns a
+/// configurable uncertainty score (default 0.5) and logs a warning for manual review.
+/// Configure <see cref="AuthorizationAIOptions.UnavailableRiskScore"/> to control fail-open
+/// (0.0) or fail-closed (1.0) behavior. The user id is pseudonymized before it leaves the
+/// process; the primitive owns schema enforcement, usage tracking, and PII-safe errors.
 /// </remarks>
 internal sealed partial class LlmAccessAnomalyDetector(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     IOptions<AuthorizationAIOptions> options,
     ILogger<LlmAccessAnomalyDetector> logger) : IAIAccessAnomalyDetector
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     /// <inheritdoc/>
     public async Task<AccessRiskScore> EvaluateAccessAsync(
         string userId,
@@ -39,91 +34,63 @@ internal sealed partial class LlmAccessAnomalyDetector(
 
         AuthorizationAIOptions config = options.Value;
 
+        // Aggressive timeout (authorization must not block). Layered over the primitive's own
+        // timeout; when ours fires the primitive rethrows the cancellation and we fall back.
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+
+        IReadOnlyList<KeyValuePair<string, string?>> requestContext = context is null
+            ? [new("User ID", LlmInputSanitizer.PseudonymizeUserId(userId))]
+            : [new("User ID", LlmInputSanitizer.PseudonymizeUserId(userId)), new("Additional context", context)];
+
+        var request = new StructuredCompletionRequest
+        {
+            Instruction = AnomalyInstruction,
+            Content = permission,
+            ContentLabel = "Permission requested",
+            Context = requestContext,
+            WorkspaceName = config.WorkspaceName,
+        };
+
         try
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                timeoutCts.Token, cancellationToken);
-
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient chatClient = await chatClientFactory
-                .CreateAsync(config.WorkspaceName, linkedCts.Token)
+            StructuredCompletionResult<LlmRiskResponse> result = await structuredCompletion
+                .CompleteAsync<LlmRiskResponse>(request, linkedCts.Token)
                 .ConfigureAwait(false);
 
-            string prompt = BuildPrompt(userId, permission, context);
+            if (result.Status == StructuredCompletionStatus.Succeeded)
+            {
+                return BuildScore(result.Value!);
+            }
 
-            ChatResponse response = await chatClient.GetResponseAsync(
-                prompt, cancellationToken: linkedCts.Token).ConfigureAwait(false);
-
-            string responseText = response.Text ?? string.Empty;
-
-            return ParseResponse(responseText);
+            // Transport failure, refusal, or unusable output — fall back to the configured
+            // uncertainty score and flag for manual review.
+            LogEvaluationFailed(result.Status.ToString());
+            return UnavailableScore(config);
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             LogEvaluationTimeout(config.TimeoutSeconds);
             return UnavailableScore(config);
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            LogEvaluationFailed(ex);
-            return UnavailableScore(config);
-        }
     }
 
-    internal static string BuildPrompt(string userId, string permission, string? context)
-    {
-        var pb = new PromptBuilder(maxInputLength: 2_000);
+    internal const string AnomalyInstruction =
+        """
+        Analyze the supplied access request for anomalies and suspicious behavior, and return a
+        structured risk assessment: a score between 0.0 and 1.0, brief reasoning, and any risk
+        factors.
+        Score guidelines:
+        - 0.0-0.3: Normal access pattern
+        - 0.3-0.7: Unusual but not necessarily malicious
+        - 0.7-1.0: Suspicious, warrants investigation
+        """;
 
-        pb.AppendInstruction("Analyze the following access request for anomalies and suspicious behavior.");
-        pb.AppendInstruction(string.Empty);
-
-        // Pseudonymize userId to prevent PII leakage to external AI services.
-        pb.AppendUserData("User ID", LlmInputSanitizer.PseudonymizeUserId(userId));
-        pb.AppendUserData("Permission requested", permission);
-
-        if (context is not null)
-        {
-            // Control character stripping is now handled by PromptBuilder.SanitizeInput().
-            pb.AppendUserData("Additional context", context);
-        }
-
-        pb.AppendInstruction(string.Empty);
-        pb.AppendInstruction("""
-            Return ONLY a JSON object with this exact structure (no markdown, no explanation):
-            { "score": 0.0-1.0, "reasoning": "brief explanation", "riskFactors": ["factor1", "factor2"] }
-
-            Score guidelines:
-            - 0.0-0.3: Normal access pattern
-            - 0.3-0.7: Unusual but not necessarily malicious
-            - 0.7-1.0: Suspicious, warrants investigation
-            """);
-
-        return pb.Build();
-    }
-
-    internal static AccessRiskScore ParseResponse(string responseText)
-    {
-        string json = LlmResponseHelper.StripMarkdownCodeFences(responseText);
-
-        LlmRiskResponse? parsed = JsonSerializer.Deserialize<LlmRiskResponse>(json, JsonOptions);
-
-        if (parsed is null)
-        {
-            return new AccessRiskScore(0.0, "Unable to parse AI response", []);
-        }
-
-        double score = Math.Clamp(parsed.Score, 0.0, 1.0);
-        string reasoning = parsed.Reasoning ?? "No reasoning provided";
-        List<string> riskFactors = parsed.RiskFactors ?? [];
-
-        return new AccessRiskScore(score, reasoning, riskFactors);
-    }
+    private static AccessRiskScore BuildScore(LlmRiskResponse parsed) =>
+        new(
+            Math.Clamp(parsed.Score, 0.0, 1.0),
+            parsed.Reasoning ?? "No reasoning provided",
+            parsed.RiskFactors ?? []);
 
     private static AccessRiskScore UnavailableScore(AuthorizationAIOptions config) =>
         new(Math.Clamp(config.UnavailableRiskScore, 0.0, 1.0),
@@ -134,8 +101,8 @@ internal sealed partial class LlmAccessAnomalyDetector(
     private partial void LogEvaluationTimeout(int timeoutSeconds);
 
     [LoggerMessage(Level = LogLevel.Warning,
-        Message = "AI access anomaly evaluation failed — flagged for manual review")]
-    private partial void LogEvaluationFailed(Exception exception);
+        Message = "AI access anomaly evaluation unavailable ({Status}) — flagged for manual review")]
+    private partial void LogEvaluationFailed(string status);
 
-    private sealed record LlmRiskResponse(double Score, string? Reasoning, List<string>? RiskFactors);
+    internal sealed record LlmRiskResponse(double Score, string? Reasoning, List<string>? RiskFactors);
 }

--- a/tests/Granit.Authorization.AI.Tests/LlmAccessAnomalyDetectorAdditionalTests.cs
+++ b/tests/Granit.Authorization.AI.Tests/LlmAccessAnomalyDetectorAdditionalTests.cs
@@ -1,166 +1,88 @@
 using Granit.AI;
 using Granit.Authorization.AI.Internal;
 using Granit.Authorization.AI.Options;
-using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
+using LlmRiskResponse = Granit.Authorization.AI.Internal.LlmAccessAnomalyDetector.LlmRiskResponse;
 
 namespace Granit.Authorization.AI.Tests;
 
 public sealed class LlmAccessAnomalyDetectorAdditionalTests
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<AuthorizationAIOptions> _options = Microsoft.Extensions.Options.Options.Create(
-        new AuthorizationAIOptions { WorkspaceName = "default", TimeoutSeconds = 5 });
+        new AuthorizationAIOptions { WorkspaceName = "default", TimeoutSeconds = 5, UnavailableRiskScore = 0.5 });
 
-    private LlmAccessAnomalyDetector CreateDetector(ILogger<LlmAccessAnomalyDetector>? logger = null) =>
-        new(_chatClientFactory, _options, logger ?? NullLogger<LlmAccessAnomalyDetector>.Instance);
+    private LlmAccessAnomalyDetector CreateDetector() =>
+        new(_structured, _options, NullLogger<LlmAccessAnomalyDetector>.Instance);
 
-    // ── ParseResponse edge cases ───────────────────────────────────────────
+    private async Task<AccessRiskScore> Evaluate(LlmRiskResponse value)
+    {
+        _structured
+            .CompleteAsync<LlmRiskResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmRiskResponse> { Status = StructuredCompletionStatus.Succeeded, Value = value });
+        return await CreateDetector().EvaluateAccessAsync(
+            "user-1", "Admin.Access", cancellationToken: TestContext.Current.CancellationToken);
+    }
 
     [Fact]
-    public void ParseResponse_NegativeScore_ClampedToZero()
+    public async Task EvaluateAccessAsync_NegativeScore_ClampedToZero()
     {
-        const string response = """{ "score": -0.5, "reasoning": "Under min", "riskFactors": [] }""";
-
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
+        AccessRiskScore result = await Evaluate(new LlmRiskResponse(-0.5, "Under min", []));
 
         result.Score.ShouldBe(0.0);
     }
 
     [Fact]
-    public void ParseResponse_MissingReasoning_DefaultsToNoReasoningProvided()
+    public async Task EvaluateAccessAsync_ExactlyZeroScore_IsValid()
     {
-        const string response = """{ "score": 0.3, "reasoning": null, "riskFactors": [] }""";
-
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
-
-        result.Reasoning.ShouldBe("No reasoning provided");
-    }
-
-    [Fact]
-    public void ParseResponse_MissingRiskFactors_DefaultsToEmptyList()
-    {
-        const string response = """{ "score": 0.3, "reasoning": "Low risk", "riskFactors": null }""";
-
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
-
-        result.RiskFactors.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void ParseResponse_InvalidJson_ThrowsJsonException()
-    {
-        const string response = "this is not valid json";
-
-        // ParseResponse is an internal method — invalid JSON propagates as JsonException.
-        // The caller (EvaluateAccessAsync) catches it via the generic catch block.
-        Should.Throw<System.Text.Json.JsonException>(
-            () => LlmAccessAnomalyDetector.ParseResponse(response));
-    }
-
-    [Fact]
-    public void ParseResponse_EmptyString_ThrowsJsonException()
-    {
-        // Empty string is not valid JSON — JsonSerializer throws.
-        Should.Throw<System.Text.Json.JsonException>(
-            () => LlmAccessAnomalyDetector.ParseResponse(""));
-    }
-
-    [Fact]
-    public void ParseResponse_MarkdownFencesWithoutLanguage_ParsesCorrectly()
-    {
-        const string response = """
-            ```
-            { "score": 0.4, "reasoning": "Moderate", "riskFactors": ["factor1"] }
-            ```
-            """;
-
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
-
-        result.Score.ShouldBe(0.4);
-        result.Reasoning.ShouldBe("Moderate");
-    }
-
-    [Fact]
-    public void ParseResponse_ExactlyZeroScore_IsValid()
-    {
-        const string response = """{ "score": 0.0, "reasoning": "No risk", "riskFactors": [] }""";
-
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
+        AccessRiskScore result = await Evaluate(new LlmRiskResponse(0.0, "No risk", []));
 
         result.Score.ShouldBe(0.0);
     }
 
     [Fact]
-    public void ParseResponse_ExactlyOneScore_IsValid()
+    public async Task EvaluateAccessAsync_ExactlyOneScore_IsValid()
     {
-        const string response = """{ "score": 1.0, "reasoning": "Critical risk", "riskFactors": ["critical"] }""";
-
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
+        AccessRiskScore result = await Evaluate(new LlmRiskResponse(1.0, "Critical risk", ["critical"]));
 
         result.Score.ShouldBe(1.0);
     }
 
-    // ── Timeout scenario ───────────────────────────────────────────────────
-
     [Fact]
-    public async Task EvaluateAccessAsync_Timeout_ReturnsUncertaintyScore()
-    {
-        // Simulate a timeout by throwing OperationCanceledException from a non-user cancellation source
-        _chatClientFactory.CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new OperationCanceledException());
-
-        LlmAccessAnomalyDetector detector = CreateDetector();
-
-        AccessRiskScore result = await detector.EvaluateAccessAsync(
-            "user-timeout", "Admin.Access", cancellationToken: TestContext.Current.CancellationToken);
-
-        result.Score.ShouldBe(0.5);
-        result.Reasoning.ShouldContain("unavailable");
-    }
-
-    [Fact]
-    public async Task EvaluateAccessAsync_UserCancellation_Throws()
+    public async Task EvaluateAccessAsync_CallerCancellation_Throws()
     {
         using CancellationTokenSource cts = new();
         await cts.CancelAsync();
 
-        // When the user's token is cancelled, the linked CTS propagates it.
-        // The code re-throws OperationCanceledException when cancellationToken.IsCancellationRequested.
-        _chatClientFactory.CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new OperationCanceledException(cts.Token));
-
-        LlmAccessAnomalyDetector detector = CreateDetector();
+        // Caller cancellation (not the aggressive timeout) must propagate, not fall back.
+        _structured
+            .CompleteAsync<LlmRiskResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns<StructuredCompletionResult<LlmRiskResponse>>(_ => throw new OperationCanceledException(cts.Token));
 
         await Should.ThrowAsync<OperationCanceledException>(
-            () => detector.EvaluateAccessAsync("user-1", "Documents.Read", cancellationToken: cts.Token));
-    }
-
-    // ── BuildPrompt additional ─────────────────────────────────────────────
-
-    [Fact]
-    public void BuildPrompt_ContainsScoreGuidelines()
-    {
-        string prompt = LlmAccessAnomalyDetector.BuildPrompt("user-1", "Admin.Access", null);
-
-        prompt.ShouldContain("0.0-0.3");
-        prompt.ShouldContain("0.3-0.7");
-        prompt.ShouldContain("0.7-1.0");
+            () => CreateDetector().EvaluateAccessAsync("user-1", "Documents.Read", cancellationToken: cts.Token));
     }
 
     [Fact]
-    public void BuildPrompt_ContainsJsonStructure()
+    public async Task EvaluateAccessAsync_InstructionCarriesScoreGuidelines()
     {
-        string prompt = LlmAccessAnomalyDetector.BuildPrompt("user-1", "Admin.Access", null);
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<LlmRiskResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmRiskResponse>
+            {
+                Status = StructuredCompletionStatus.Succeeded,
+                Value = new LlmRiskResponse(0.1, "ok", []),
+            });
 
-        prompt.ShouldContain("score");
-        prompt.ShouldContain("reasoning");
-        prompt.ShouldContain("riskFactors");
+        await CreateDetector().EvaluateAccessAsync("user-1", "Admin.Access", cancellationToken: TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Instruction.ShouldNotBeNull();
+        captured.Instruction.ShouldContain("0.0-0.3");
+        captured.Instruction.ShouldContain("0.7-1.0");
     }
 }

--- a/tests/Granit.Authorization.AI.Tests/LlmAccessAnomalyDetectorTests.cs
+++ b/tests/Granit.Authorization.AI.Tests/LlmAccessAnomalyDetectorTests.cs
@@ -2,49 +2,36 @@ using Granit.AI;
 using Granit.AI.Internal;
 using Granit.Authorization.AI.Internal;
 using Granit.Authorization.AI.Options;
-using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
+using LlmRiskResponse = Granit.Authorization.AI.Internal.LlmAccessAnomalyDetector.LlmRiskResponse;
 
 namespace Granit.Authorization.AI.Tests;
 
 public sealed class LlmAccessAnomalyDetectorTests
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<AuthorizationAIOptions> _options = Microsoft.Extensions.Options.Options.Create(
-        new AuthorizationAIOptions { WorkspaceName = "default", TimeoutSeconds = 5 });
+        new AuthorizationAIOptions { WorkspaceName = "default", TimeoutSeconds = 5, UnavailableRiskScore = 0.5 });
 
-    private LlmAccessAnomalyDetector CreateDetector(ILogger<LlmAccessAnomalyDetector>? logger = null) =>
-        new(_chatClientFactory, _options, logger ?? NullLogger<LlmAccessAnomalyDetector>.Instance);
+    private LlmAccessAnomalyDetector CreateDetector() =>
+        new(_structured, _options, NullLogger<LlmAccessAnomalyDetector>.Instance);
 
-    private void SetupChatResponse(string responseJson)
-    {
-        _chatClientFactory.CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
+    private void CompletionReturns(StructuredCompletionStatus status, LlmRiskResponse? value = null) =>
+        _structured
+            .CompleteAsync<LlmRiskResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmRiskResponse> { Status = status, Value = value });
 
-        var chatMessage = new ChatMessage(ChatRole.Assistant, responseJson);
-        var chatResponse = new ChatResponse(chatMessage);
-
-        _chatClient.GetResponseAsync(
-                Arg.Any<IList<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(chatResponse);
-    }
+    private void Succeeds(LlmRiskResponse value) => CompletionReturns(StructuredCompletionStatus.Succeeded, value);
 
     [Fact]
     public async Task EvaluateAccessAsync_NormalAccess_ReturnsLowRisk()
     {
-        SetupChatResponse("""{ "score": 0.1, "reasoning": "Normal access pattern", "riskFactors": [] }""");
+        Succeeds(new LlmRiskResponse(0.1, "Normal access pattern", []));
 
-        LlmAccessAnomalyDetector detector = CreateDetector();
-
-        AccessRiskScore result = await detector.EvaluateAccessAsync(
+        AccessRiskScore result = await CreateDetector().EvaluateAccessAsync(
             "user-123", "Documents.Read", cancellationToken: TestContext.Current.CancellationToken);
 
         result.Score.ShouldBe(0.1);
@@ -55,13 +42,10 @@ public sealed class LlmAccessAnomalyDetectorTests
     [Fact]
     public async Task EvaluateAccessAsync_SuspiciousAccess_ReturnsHighRisk()
     {
-        SetupChatResponse("""
-            { "score": 0.85, "reasoning": "Unusual admin access at 3 AM", "riskFactors": ["off-hours access", "elevated permission request"] }
-            """);
+        Succeeds(new LlmRiskResponse(0.85, "Unusual admin access at 3 AM",
+            ["off-hours access", "elevated permission request"]));
 
-        LlmAccessAnomalyDetector detector = CreateDetector();
-
-        AccessRiskScore result = await detector.EvaluateAccessAsync(
+        AccessRiskScore result = await CreateDetector().EvaluateAccessAsync(
             "user-456", "Admin.FullControl", "access at 3 AM from new IP",
             cancellationToken: TestContext.Current.CancellationToken);
 
@@ -69,18 +53,37 @@ public sealed class LlmAccessAnomalyDetectorTests
         result.Reasoning.ShouldBe("Unusual admin access at 3 AM");
         result.RiskFactors.Count.ShouldBe(2);
         result.RiskFactors.ShouldContain("off-hours access");
-        result.RiskFactors.ShouldContain("elevated permission request");
     }
 
     [Fact]
-    public async Task EvaluateAccessAsync_LLMFailure_ReturnsUncertaintyScore()
+    public async Task EvaluateAccessAsync_ScoreOutOfRange_ClampedToValidRange()
     {
-        _chatClientFactory.CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("LLM service unavailable"));
+        Succeeds(new LlmRiskResponse(1.5, "Over max", []));
 
-        LlmAccessAnomalyDetector detector = CreateDetector();
+        AccessRiskScore result = await CreateDetector().EvaluateAccessAsync(
+            "user-1", "Documents.Read", cancellationToken: TestContext.Current.CancellationToken);
 
-        AccessRiskScore result = await detector.EvaluateAccessAsync(
+        result.Score.ShouldBe(1.0);
+    }
+
+    [Fact]
+    public async Task EvaluateAccessAsync_NullReasoningAndFactors_UsesDefaults()
+    {
+        Succeeds(new LlmRiskResponse(0.4, null, null));
+
+        AccessRiskScore result = await CreateDetector().EvaluateAccessAsync(
+            "user-1", "Documents.Read", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Reasoning.ShouldBe("No reasoning provided");
+        result.RiskFactors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task EvaluateAccessAsync_TransportFailure_ReturnsUncertaintyScore()
+    {
+        CompletionReturns(StructuredCompletionStatus.TransportFailure);
+
+        AccessRiskScore result = await CreateDetector().EvaluateAccessAsync(
             "user-789", "Documents.Write", cancellationToken: TestContext.Current.CancellationToken);
 
         result.Score.ShouldBe(0.5);
@@ -89,77 +92,86 @@ public sealed class LlmAccessAnomalyDetectorTests
     }
 
     [Fact]
-    public async Task EvaluateAccessAsync_NullUserId_ThrowsArgumentNullException()
+    public async Task EvaluateAccessAsync_SchemaViolation_ReturnsUncertaintyScore()
     {
-        LlmAccessAnomalyDetector detector = CreateDetector();
+        CompletionReturns(StructuredCompletionStatus.SchemaViolation);
 
-        await Should.ThrowAsync<ArgumentNullException>(
-            () => detector.EvaluateAccessAsync(null!, "Documents.Read",
-                cancellationToken: TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task EvaluateAccessAsync_NullPermission_ThrowsArgumentNullException()
-    {
-        LlmAccessAnomalyDetector detector = CreateDetector();
-
-        await Should.ThrowAsync<ArgumentNullException>(
-            () => detector.EvaluateAccessAsync("user-123", null!,
-                cancellationToken: TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public void ParseResponse_WithMarkdownFences_ParsesCorrectly()
-    {
-        const string response = """
-            ```json
-            { "score": 0.5, "reasoning": "Moderate risk", "riskFactors": ["unusual time"] }
-            ```
-            """;
-
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
+        AccessRiskScore result = await CreateDetector().EvaluateAccessAsync(
+            "user-1", "Documents.Read", cancellationToken: TestContext.Current.CancellationToken);
 
         result.Score.ShouldBe(0.5);
-        result.Reasoning.ShouldBe("Moderate risk");
-        result.RiskFactors.Count.ShouldBe(1);
+        result.Reasoning.ShouldContain("unavailable");
     }
 
     [Fact]
-    public void ParseResponse_ScoreOutOfRange_ClampedToValidRange()
+    public async Task EvaluateAccessAsync_FailClosedConfig_ReturnsHighRiskOnUnavailable()
     {
-        const string response = """{ "score": 1.5, "reasoning": "Over max", "riskFactors": [] }""";
+        IOptions<AuthorizationAIOptions> failClosed = Microsoft.Extensions.Options.Options.Create(
+            new AuthorizationAIOptions { WorkspaceName = "default", TimeoutSeconds = 5, UnavailableRiskScore = 1.0 });
+        _structured
+            .CompleteAsync<LlmRiskResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmRiskResponse> { Status = StructuredCompletionStatus.TransportFailure });
 
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse(response);
+        var detector = new LlmAccessAnomalyDetector(_structured, failClosed, NullLogger<LlmAccessAnomalyDetector>.Instance);
+
+        AccessRiskScore result = await detector.EvaluateAccessAsync(
+            "user-1", "Documents.Read", cancellationToken: TestContext.Current.CancellationToken);
 
         result.Score.ShouldBe(1.0);
     }
 
     [Fact]
-    public void ParseResponse_NullResponse_ReturnsZeroScore()
+    public async Task EvaluateAccessAsync_PseudonymizesUserId_AndPassesPermissionAsContent()
     {
-        AccessRiskScore result = LlmAccessAnomalyDetector.ParseResponse("null");
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<LlmRiskResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmRiskResponse>
+            {
+                Status = StructuredCompletionStatus.Succeeded,
+                Value = new LlmRiskResponse(0.1, "ok", []),
+            });
 
-        result.Score.ShouldBe(0.0);
-        result.Reasoning.ShouldContain("Unable to parse");
+        await CreateDetector().EvaluateAccessAsync("user-1", "Admin.Access", "off-hours login", TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Content.ShouldBe("Admin.Access");
+        captured.Context.ShouldNotBeNull();
+        // User id must be pseudonymized, never raw, before leaving the process.
+        captured.Context.ShouldContain(kv => kv.Key == "User ID" && kv.Value == LlmInputSanitizer.PseudonymizeUserId("user-1"));
+        captured.Context.ShouldNotContain(kv => kv.Value == "user-1");
+        captured.Context.ShouldContain(kv => kv.Key == "Additional context" && kv.Value == "off-hours login");
     }
 
     [Fact]
-    public void BuildPrompt_WithContext_IncludesContext()
+    public async Task EvaluateAccessAsync_WithoutContext_OmitsAdditionalContext()
     {
-        string prompt = LlmAccessAnomalyDetector.BuildPrompt("user-1", "Admin.Access", "off-hours login");
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<LlmRiskResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmRiskResponse>
+            {
+                Status = StructuredCompletionStatus.Succeeded,
+                Value = new LlmRiskResponse(0.1, "ok", []),
+            });
 
-        prompt.ShouldContain("off-hours login");
-        prompt.ShouldContain(LlmInputSanitizer.PseudonymizeUserId("user-1"));
-        prompt.ShouldContain("Admin.Access");
+        await CreateDetector().EvaluateAccessAsync("user-1", "Documents.Read", cancellationToken: TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Context.ShouldNotBeNull();
+        captured.Context.Count.ShouldBe(1);
+        captured.Context.ShouldNotContain(kv => kv.Key == "Additional context");
     }
 
     [Fact]
-    public void BuildPrompt_WithoutContext_OmitsContextPart()
-    {
-        string prompt = LlmAccessAnomalyDetector.BuildPrompt("user-1", "Documents.Read", null);
+    public async Task EvaluateAccessAsync_NullUserId_ThrowsArgumentNullException() =>
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => CreateDetector().EvaluateAccessAsync(null!, "Documents.Read",
+                cancellationToken: TestContext.Current.CancellationToken));
 
-        prompt.ShouldNotContain("Additional context:");
-        prompt.ShouldContain(LlmInputSanitizer.PseudonymizeUserId("user-1"));
-        prompt.ShouldContain("Documents.Read");
-    }
+    [Fact]
+    public async Task EvaluateAccessAsync_NullPermission_ThrowsArgumentNullException() =>
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => CreateDetector().EvaluateAccessAsync("user-123", null!,
+                cancellationToken: TestContext.Current.CancellationToken));
 }


### PR DESCRIPTION
Second **F3** consumer migration (Epic #2452, feature #2455), following the #2460 template.

## What

`LlmAccessAnomalyDetector` now calls `IStructuredCompletion.CompleteAsync<LlmRiskResponse>` instead of the `IAIChatClientFactory` bypass (build prompt → `GetResponseAsync` → fence-strip → deserialize). **Gains** provider-enforced JSON schema (it had none), usage tracking, and PII-safe error mapping; **drops** the bespoke plumbing.

## Behaviour preserved

- Any non-success status (`TransportFailure` / `SchemaViolation` / `ModelRefused`) → the configurable **`UnavailableRiskScore`** (default 0.5, "uncertain — manual review"). `UnavailableRiskScore = 1.0` still gives fail-closed.
- Aggressive **5s** timeout stays caller-side (linked CTS); caller cancellation propagates.
- **User id is still pseudonymized** (`LlmInputSanitizer.PseudonymizeUserId`) before leaving the process — now carried in the request `Context`; the permission is the `Content`. A test asserts the raw id never appears.

Minor unification: a `null` JSON literal now maps to `UnavailableScore` like any other unusable output (was `0.0`), consistent with "AI unavailable → manual review".

## Tests

28 tests rewritten to mock `IStructuredCompletion` (score/clamp/defaults, status→score mapping, fail-closed config, pseudonymization + request pass-through, null guards, caller-cancellation). JSON-parse/fence tests dropped — now the primitive's job. `dotnet format` clean; no new deps.

Progress: 2/13 (Validation #2460 merged, Authorization here). 7 fixed-shape modules remain + 3 dynamic-keyed outliers (reshape).