### PR TITLE
refactor(blobstorage-ai): migrate blob classifier to IStructuredCompletion (F3)

### DIFF
--- a/src/Granit.BlobStorage.AI/Internal/AIBlobClassifierService.cs
+++ b/src/Granit.BlobStorage.AI/Internal/AIBlobClassifierService.cs
@@ -1,15 +1,13 @@
-using System.Text.Json;
 using Granit.AI;
-using Granit.AI.Internal;
 using Granit.BlobStorage.AI.Options;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.AI.Internal;
 
 /// <summary>
-/// LLM-based blob classifier that also participates in the <see cref="IBlobValidator"/> pipeline.
+/// LLM-based blob classifier that also participates in the <see cref="IBlobValidator"/> pipeline,
+/// built on the <see cref="IStructuredCompletion"/> primitive (ADR-064).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -21,10 +19,13 @@ namespace Granit.BlobStorage.AI.Internal;
 /// <para>
 /// As <see cref="IAIBlobClassifier"/>: provides classification on demand outside the pipeline.
 /// </para>
+/// <para>
+/// Classification is fail-soft: any unavailable / unusable AI response yields
+/// <see cref="UnknownClassification"/>. The quota guard is applied by the primitive.
+/// </para>
 /// </remarks>
 internal sealed partial class AIBlobClassifierService(
-    IAIChatClientFactory chatClientFactory,
-    IAIQuotaGuard quotaGuard,
+    IStructuredCompletion structuredCompletion,
     IOptions<BlobStorageAIOptions> options,
     ILogger<AIBlobClassifierService> logger) : IAIBlobClassifier, IBlobValidator
 {
@@ -33,11 +34,6 @@ internal sealed partial class AIBlobClassifierService(
         Confidence: 0.0,
         DetectedTags: [],
         ContainsPiiInFileName: false);
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
 
     /// <inheritdoc/>
     public int Order => 100;
@@ -53,46 +49,40 @@ internal sealed partial class AIBlobClassifierService(
 
         BlobStorageAIOptions config = options.Value;
 
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        var request = new StructuredCompletionRequest
+        {
+            Instruction = ClassificationInstruction,
+            Content = fileName,
+            ContentLabel = "Filename",
+            Context = [new("Content type", contentType)],
+            WorkspaceName = config.WorkspaceName,
+        };
+
         try
         {
-            AIQuotaResult quota = await quotaGuard.CheckAsync(cancellationToken).ConfigureAwait(false);
-            if (!quota.IsAllowed)
+            StructuredCompletionResult<ClassificationJson> result = await structuredCompletion
+                .CompleteAsync<ClassificationJson>(request, linkedCts.Token)
+                .ConfigureAwait(false);
+
+            if (result.Status != StructuredCompletionStatus.Succeeded)
             {
-                LogQuotaExceeded(logger, fileName, quota.Reason ?? "quota exceeded");
+                LogClassificationUnavailable(logger, fileName, result.Status.ToString());
                 return UnknownClassification;
             }
 
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient chatClient = await chatClientFactory
-                .CreateAsync(config.WorkspaceName, cancellationToken)
-                .ConfigureAwait(false);
-
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken, timeoutCts.Token);
-
-            string prompt = BuildClassificationPrompt(fileName, contentType);
-
-            ChatResponse response = await chatClient.GetResponseAsync(
-                prompt, cancellationToken: linkedCts.Token).ConfigureAwait(false);
-
-            string responseText = response.Text ?? string.Empty;
-
-            return ParseClassificationResponse(responseText);
+            ClassificationJson parsed = result.Value!;
+            return new BlobClassification(
+                Category: parsed.Category ?? "unknown",
+                Confidence: Math.Clamp(parsed.Confidence, 0.0, 1.0),
+                DetectedTags: parsed.Tags ?? [],
+                ContainsPiiInFileName: parsed.ContainsPiiInFileName);
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             LogClassificationTimeout(logger, fileName, config.TimeoutSeconds);
-            return UnknownClassification;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            LogClassificationFailure(logger, fileName, ex);
             return UnknownClassification;
         }
     }
@@ -120,64 +110,26 @@ internal sealed partial class AIBlobClassifierService(
         return BlobValidationResult.Success();
     }
 
-    internal static string BuildClassificationPrompt(string fileName, string contentType)
-    {
-        var pb = new PromptBuilder(maxInputLength: 1_000);
+    internal const string ClassificationInstruction =
+        """
+        Classify the file described by the supplied metadata. Choose a category from:
+        invoice, identity_document, photo, contract, report, spreadsheet, presentation, archive, code, other.
+        Provide a confidence between 0.0 and 1.0 and any descriptive tags. For containsPiiInFileName,
+        report true when the filename contains patterns resembling social security numbers, email
+        addresses, phone numbers, national ID numbers, or full personal names.
+        """;
 
-        pb.AppendInstruction("""
-            Classify this file based on the metadata below.
-            Return JSON only, no markdown fences: {"category": "<string>", "confidence": <0.0-1.0>, "tags": ["<string>"], "containsPiiInFileName": <true|false>}
-            Categories: invoice, identity_document, photo, contract, report, spreadsheet, presentation, archive, code, other.
-            For PII detection, check if the filename contains patterns resembling: social security numbers, email addresses, phone numbers, national ID numbers, or full personal names.
-            """);
-
-        pb.AppendUserData("Filename", fileName);
-        pb.AppendUserData("Content type", contentType);
-
-        return pb.Build();
-    }
-
-    internal static BlobClassification ParseClassificationResponse(string responseText)
-    {
-        string trimmed = LlmResponseHelper.StripMarkdownCodeFences(responseText);
-
-        try
-        {
-            ClassificationJson? parsed = JsonSerializer.Deserialize<ClassificationJson>(trimmed, JsonOptions);
-
-            if (parsed is null)
-            {
-                return UnknownClassification;
-            }
-
-            return new BlobClassification(
-                Category: parsed.Category ?? "unknown",
-                Confidence: Math.Clamp(parsed.Confidence, 0.0, 1.0),
-                DetectedTags: parsed.Tags ?? [],
-                ContainsPiiInFileName: parsed.ContainsPiiInFileName);
-        }
-        catch (JsonException)
-        {
-            return UnknownClassification;
-        }
-    }
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "AI blob classification skipped for '{FileName}': {Reason}")]
-    private static partial void LogQuotaExceeded(ILogger logger, string fileName, string reason);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI blob classification unavailable ({Status}) for file '{FileName}' — treated as unknown")]
+    private static partial void LogClassificationUnavailable(ILogger logger, string fileName, string status);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "AI blob classification timed out after {TimeoutSeconds}s for file '{FileName}'")]
     private static partial void LogClassificationTimeout(ILogger logger, string fileName, int timeoutSeconds);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "AI blob classification failed for file '{FileName}'")]
-    private static partial void LogClassificationFailure(ILogger logger, string fileName, Exception exception);
-
     [LoggerMessage(Level = LogLevel.Warning, Message = "PII detected in filename '{FileName}' — upload rejected")]
     private static partial void LogPiiDetected(ILogger logger, string fileName);
 
-    /// <summary>
-    /// Internal DTO for deserializing the LLM JSON response.
-    /// </summary>
-    private sealed record ClassificationJson(
+    /// <summary>Internal DTO for deserializing the LLM JSON response.</summary>
+    internal sealed record ClassificationJson(
         string? Category,
         double Confidence,
         List<string>? Tags,

--- a/tests/Granit.BlobStorage.AI.Tests/AIBlobClassifierServiceTests.cs
+++ b/tests/Granit.BlobStorage.AI.Tests/AIBlobClassifierServiceTests.cs
@@ -2,15 +2,12 @@ using Granit.AI;
 using Granit.BlobStorage.AI.Internal;
 using Granit.BlobStorage.AI.Options;
 using Granit.BlobStorage.Domain;
-using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Xunit;
-
+using ClassificationJson = Granit.BlobStorage.AI.Internal.AIBlobClassifierService.ClassificationJson;
 using MsOptions = Microsoft.Extensions.Options.Options;
 
 namespace Granit.BlobStorage.AI.Tests;
@@ -20,80 +17,56 @@ public sealed class AIBlobClassifierServiceTests
     private static readonly DateTimeOffset Now = new(2026, 3, 16, 12, 0, 0, TimeSpan.Zero);
     private static readonly Guid TestTenantId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
-    private readonly IAIQuotaGuard _quotaGuard = Substitute.For<IAIQuotaGuard>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<BlobStorageAIOptions> _options = MsOptions.Create(new BlobStorageAIOptions());
-    private readonly ILogger<AIBlobClassifierService> _logger = NullLogger<AIBlobClassifierService>.Instance;
 
-    public AIBlobClassifierServiceTests()
-    {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
+    private AIBlobClassifierService CreateSut(IOptions<BlobStorageAIOptions>? opts = null) =>
+        new(_structured, opts ?? _options, NullLogger<AIBlobClassifierService>.Instance);
 
-        _quotaGuard.CheckAsync(Arg.Any<CancellationToken>()).Returns(AIQuotaResult.Allowed);
-    }
+    private void Succeeds(ClassificationJson value) =>
+        _structured
+            .CompleteAsync<ClassificationJson>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<ClassificationJson> { Status = StructuredCompletionStatus.Succeeded, Value = value });
 
-    private AIBlobClassifierService CreateSut() => new(_chatClientFactory, _quotaGuard, _options, _logger);
-
-    private static BlobDescriptor MakeDescriptor(string fileName, string contentType) =>
-        BlobDescriptor.Create(
-            id: Guid.NewGuid(),
-            tenantId: TestTenantId,
-            containerName: "uploads",
-            objectKey: $"{TestTenantId}/uploads/2026/03/some-id",
-            request: new BlobUploadRequest(fileName, contentType, 10_000_000L),
-            createdAt: Now);
+    private void Fails(StructuredCompletionStatus status) =>
+        _structured
+            .CompleteAsync<ClassificationJson>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<ClassificationJson> { Status = status });
 
     private static BlobValidationContext MakeContext(string fileName, string contentType) =>
         new()
         {
-            Descriptor = MakeDescriptor(fileName, contentType),
+            Descriptor = BlobDescriptor.Create(
+                id: Guid.NewGuid(),
+                tenantId: TestTenantId,
+                containerName: "uploads",
+                objectKey: $"{TestTenantId}/uploads/2026/03/some-id",
+                request: new BlobUploadRequest(fileName, contentType, 10_000_000L),
+                createdAt: Now),
             ActualSizeBytes = 1024,
-            OpenPartialStreamAsync = (_, _) =>
-                Task.FromResult<Stream>(new MemoryStream(Array.Empty<byte>())),
+            OpenPartialStreamAsync = (_, _) => Task.FromResult<Stream>(new MemoryStream([])),
         };
 
     [Fact]
     public async Task ClassifyAsync_ValidResponse_ReturnsClassification()
     {
-        AIBlobClassifierService sut = CreateSut();
-        string json = """{"category": "invoice", "confidence": 0.95, "tags": ["financial", "document"], "containsPiiInFileName": false}""";
+        Succeeds(new ClassificationJson("invoice", 0.95, ["financial", "document"], false));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        BlobClassification result = await sut.ClassifyAsync(
+        BlobClassification result = await CreateSut().ClassifyAsync(
             "invoice-2026-03.pdf", "application/pdf", TestContext.Current.CancellationToken);
 
         result.Category.ShouldBe("invoice");
         result.Confidence.ShouldBe(0.95);
         result.DetectedTags.ShouldContain("financial");
-        result.DetectedTags.ShouldContain("document");
         result.ContainsPiiInFileName.ShouldBeFalse();
     }
 
     [Fact]
     public async Task ClassifyAsync_DetectsPiiInFileName()
     {
-        AIBlobClassifierService sut = CreateSut();
-        string json = """{"category": "identity_document", "confidence": 0.88, "tags": ["personal"], "containsPiiInFileName": true}""";
+        Succeeds(new ClassificationJson("identity_document", 0.88, ["personal"], true));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        BlobClassification result = await sut.ClassifyAsync(
+        BlobClassification result = await CreateSut().ClassifyAsync(
             "john-doe-ssn-123456789.pdf", "application/pdf", TestContext.Current.CancellationToken);
 
         result.ContainsPiiInFileName.ShouldBeTrue();
@@ -101,18 +74,34 @@ public sealed class AIBlobClassifierServiceTests
     }
 
     [Fact]
-    public async Task ClassifyAsync_LLMFailure_ReturnsUnknown()
+    public async Task ClassifyAsync_ClampsConfidenceAbove1()
     {
-        AIBlobClassifierService sut = CreateSut();
+        Succeeds(new ClassificationJson("photo", 1.5, [], false));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
+        BlobClassification result = await CreateSut().ClassifyAsync(
+            "p.jpg", "image/jpeg", TestContext.Current.CancellationToken);
 
-        BlobClassification result = await sut.ClassifyAsync(
+        result.Confidence.ShouldBe(1.0);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_NullCategoryAndTags_DefaultsApplied()
+    {
+        Succeeds(new ClassificationJson(null, 0.5, null, false));
+
+        BlobClassification result = await CreateSut().ClassifyAsync(
+            "x.bin", "application/octet-stream", TestContext.Current.CancellationToken);
+
+        result.Category.ShouldBe("unknown");
+        result.DetectedTags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_Unavailable_ReturnsUnknown()
+    {
+        Fails(StructuredCompletionStatus.TransportFailure);
+
+        BlobClassification result = await CreateSut().ClassifyAsync(
             "report.pdf", "application/pdf", TestContext.Current.CancellationToken);
 
         result.Category.ShouldBe("unknown");
@@ -122,23 +111,43 @@ public sealed class AIBlobClassifierServiceTests
     }
 
     [Fact]
+    public async Task ClassifyAsync_SchemaViolation_ReturnsUnknown()
+    {
+        Fails(StructuredCompletionStatus.SchemaViolation);
+
+        BlobClassification result = await CreateSut().ClassifyAsync(
+            "report.pdf", "application/pdf", TestContext.Current.CancellationToken);
+
+        result.Category.ShouldBe("unknown");
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_PassesFileNameAsContentAndContentTypeAsContext()
+    {
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<ClassificationJson>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<ClassificationJson>
+            {
+                Status = StructuredCompletionStatus.Succeeded,
+                Value = new ClassificationJson("other", 0.1, [], false),
+            });
+
+        await CreateSut().ClassifyAsync("test.pdf", "application/pdf", TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Content.ShouldBe("test.pdf");
+        captured.Context.ShouldNotBeNull();
+        captured.Context.ShouldContain(kv => kv.Key == "Content type" && kv.Value == "application/pdf");
+    }
+
+    [Fact]
     public async Task ValidateAsync_ReturnsValidResult()
     {
-        AIBlobClassifierService sut = CreateSut();
-        string json = """{"category": "photo", "confidence": 0.92, "tags": ["image"], "containsPiiInFileName": false}""";
+        Succeeds(new ClassificationJson("photo", 0.92, ["image"], false));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        BlobValidationContext context = MakeContext("vacation-photo.jpg", "image/jpeg");
-
-        BlobValidationResult result = await sut.ValidateAsync(
-            context, TestContext.Current.CancellationToken);
+        BlobValidationResult result = await CreateSut().ValidateAsync(
+            MakeContext("vacation-photo.jpg", "image/jpeg"), TestContext.Current.CancellationToken);
 
         result.IsValid.ShouldBeTrue();
     }
@@ -146,21 +155,10 @@ public sealed class AIBlobClassifierServiceTests
     [Fact]
     public async Task ValidateAsync_PiiDetected_ReturnsFailure()
     {
-        AIBlobClassifierService sut = CreateSut();
-        string json = """{"category": "identity_document", "confidence": 0.9, "tags": ["personal"], "containsPiiInFileName": true}""";
+        Succeeds(new ClassificationJson("identity_document", 0.9, ["personal"], true));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        BlobValidationContext context = MakeContext("john-doe-ssn-123456789.pdf", "application/pdf");
-
-        BlobValidationResult result = await sut.ValidateAsync(
-            context, TestContext.Current.CancellationToken);
+        BlobValidationResult result = await CreateSut().ValidateAsync(
+            MakeContext("john-doe-ssn-123456789.pdf", "application/pdf"), TestContext.Current.CancellationToken);
 
         result.IsValid.ShouldBeFalse();
         result.FailureReason.ShouldNotBeNull();
@@ -170,83 +168,14 @@ public sealed class AIBlobClassifierServiceTests
     [Fact]
     public async Task ValidateAsync_PiiDetected_ButDisabled_ReturnsValid()
     {
-        IOptions<BlobStorageAIOptions> disabledPiiOptions = MsOptions.Create(
-            new BlobStorageAIOptions { EnablePiiDetection = false });
-        var sut = new AIBlobClassifierService(_chatClientFactory, _quotaGuard, disabledPiiOptions, _logger);
+        Succeeds(new ClassificationJson("identity_document", 0.9, ["personal"], true));
 
-        string json = """{"category": "identity_document", "confidence": 0.9, "tags": ["personal"], "containsPiiInFileName": true}""";
-
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        BlobValidationContext context = MakeContext("john-doe-ssn-123456789.pdf", "application/pdf");
-
-        BlobValidationResult result = await sut.ValidateAsync(
-            context, TestContext.Current.CancellationToken);
+        BlobValidationResult result = await CreateSut(MsOptions.Create(new BlobStorageAIOptions { EnablePiiDetection = false }))
+            .ValidateAsync(MakeContext("john-doe-ssn-123456789.pdf", "application/pdf"), TestContext.Current.CancellationToken);
 
         result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
-    public void Order_Is100() =>
-        CreateSut().Order.ShouldBe(100);
-
-    [Fact]
-    public void ParseClassificationResponse_ValidJson_ReturnsClassification()
-    {
-        string json = """{"category": "contract", "confidence": 0.85, "tags": ["legal"], "containsPiiInFileName": false}""";
-
-        BlobClassification result = AIBlobClassifierService.ParseClassificationResponse(json);
-
-        result.Category.ShouldBe("contract");
-        result.Confidence.ShouldBe(0.85);
-        result.DetectedTags.ShouldContain("legal");
-    }
-
-    [Fact]
-    public void ParseClassificationResponse_MarkdownFencedJson_ReturnsClassification()
-    {
-        string json = """
-            ```json
-            {"category": "invoice", "confidence": 0.9, "tags": [], "containsPiiInFileName": false}
-            ```
-            """;
-
-        BlobClassification result = AIBlobClassifierService.ParseClassificationResponse(json);
-
-        result.Category.ShouldBe("invoice");
-    }
-
-    [Fact]
-    public void ParseClassificationResponse_InvalidJson_ReturnsUnknown()
-    {
-        BlobClassification result = AIBlobClassifierService.ParseClassificationResponse("not valid json");
-
-        result.Category.ShouldBe("unknown");
-        result.Confidence.ShouldBe(0.0);
-    }
-
-    [Fact]
-    public void ParseClassificationResponse_ClampsConfidenceAbove1()
-    {
-        string json = """{"category": "photo", "confidence": 1.5, "tags": [], "containsPiiInFileName": false}""";
-
-        BlobClassification result = AIBlobClassifierService.ParseClassificationResponse(json);
-
-        result.Confidence.ShouldBe(1.0);
-    }
-
-    [Fact]
-    public void BuildClassificationPrompt_ContainsFileNameAndContentType()
-    {
-        string prompt = AIBlobClassifierService.BuildClassificationPrompt("test.pdf", "application/pdf");
-
-        prompt.ShouldContain("test.pdf");
-        prompt.ShouldContain("application/pdf");
-    }
+    public void Order_Is100() => CreateSut().Order.ShouldBe(100);
 }


### PR DESCRIPTION
Fourth **F3** migration (Epic #2452, feature #2455), per the #2460 template.

`AIBlobClassifierService` now calls `IStructuredCompletion.CompleteAsync<ClassificationJson>` instead of the `IAIChatClientFactory` bypass. **Gains** provider-enforced schema, usage tracking, PII-safe errors; **drops** the bespoke plumbing **and the explicit `IAIQuotaGuard` dependency** — the primitive applies the quota guard (a denial surfaces as `TransportFailure` → fail-soft Unknown, like any unavailability).

Behaviour preserved: classification is **fail-soft** (never rejects) — any non-success status or the 10s caller-side timeout → `UnknownClassification`; `ValidateAsync` still rejects uploads whose filename is flagged `ContainsPiiInFileName` when `EnablePiiDetection` is on. fileName→`Content`, contentType→`Context`.

20 tests rewritten to mock `IStructuredCompletion`. Fence/invalid-json/BuildPrompt tests dropped (primitive's job). `dotnet format` clean; no new deps.

**Progress: 4/13 structured migrations** (Validation #2460, Authorization #2461, Privacy #2462 merged; BlobStorage here). See #2455 for the corrected triage — Imaging is a multimodal exemption, Templating is text-gen (not structured), and QueryEngine joins the reshape outliers (nested dict).