### PR TITLE
refactor(timeline-ai): migrate anomaly detector to IStructuredCompletion (F3)

### DIFF
--- a/src/Granit.Timeline.AI/Internal/LlmTimelineAnomalyDetector.cs
+++ b/src/Granit.Timeline.AI/Internal/LlmTimelineAnomalyDetector.cs
@@ -1,27 +1,26 @@
 using System.Diagnostics;
 using System.Text;
-using System.Text.Json;
 using Granit.AI;
-using Granit.AI.Internal;
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
 using Granit.Timeline.AI.Diagnostics;
 using Granit.Timeline.AI.Options;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Timeline.AI.Internal;
 
 /// <summary>
-/// LLM-based implementation of <see cref="ITimelineAnomalyDetector"/>.
-/// Fetches timeline entries via <see cref="ITimelineReader"/> and asks the LLM to detect
-/// unusual patterns such as bulk edits, off-hours activity, and privilege escalation.
+/// LLM-based implementation of <see cref="ITimelineAnomalyDetector"/> built on the
+/// <see cref="IStructuredCompletion"/> primitive (ADR-064). Fetches timeline entries via
+/// <see cref="ITimelineReader"/> and asks the model to detect unusual patterns such as bulk
+/// edits, off-hours activity, and privilege escalation. Fail-soft: any unavailable response
+/// yields no anomalies.
 /// </summary>
 #pragma warning disable CA1001 // Lifetime managed by DI container — SemaphoreSlim does not hold unmanaged resources
 internal sealed partial class LlmTimelineAnomalyDetector(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     ITimelineReader timelineReader,
     IOptions<TimelineAIOptions> options,
     ICurrentTenant currentTenant,
@@ -35,11 +34,6 @@ internal sealed partial class LlmTimelineAnomalyDetector(
 
     private static readonly AnomalyReport NoAnomalies = new(HasAnomalies: false, Anomalies: []);
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     /// <inheritdoc/>
     public async Task<AnomalyReport> DetectAnomaliesAsync(
         string entityType,
@@ -50,6 +44,7 @@ internal sealed partial class LlmTimelineAnomalyDetector(
 
         long startTimestamp = Stopwatch.GetTimestamp();
         TimelineAIOptions config = options.Value;
+        string? tenantId = currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null;
 
         List<TimelineStreamEntry> entries = await FetchEntriesAsync(
             entityType, entityId, config.AnomalyDetectorMaxEntries, ct).ConfigureAwait(false);
@@ -59,53 +54,50 @@ internal sealed partial class LlmTimelineAnomalyDetector(
             return NoAnomalies;
         }
 
-        // Concurrency limiter to prevent denial-of-wallet.
         await _concurrencyLimiter.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient chatClient = await chatClientFactory
-                .CreateAsync(config.WorkspaceName, ct)
-                .ConfigureAwait(false);
-
             using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
-            string prompt = BuildAnomalyDetectionPrompt(entityType, entityId, entries);
-
-            ChatResponse response = await chatClient.GetResponseAsync(
-                prompt, cancellationToken: linkedCts.Token).ConfigureAwait(false);
-
-            string responseText = response.Text ?? string.Empty;
-
-            AnomalyReport report = ParseAnomalyResponse(responseText);
-
-            metrics.RecordAnomalyDetectionCompleted(tenantId: currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null, entityType);
-            metrics.RecordAnomalyDetectionDuration(tenantId: currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null, entityType, Stopwatch.GetElapsedTime(startTimestamp));
-
-            if (report.HasAnomalies)
+            var request = new StructuredCompletionRequest
             {
-                metrics.RecordAnomaliesFound(tenantId: currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null, entityType, report.Anomalies.Count);
-            }
+                Instruction = BuildInstruction(entityType, entityId),
+                Content = BuildEntriesBlock(entries),
+                ContentLabel = "Timeline entries (newest first)",
+                WorkspaceName = config.WorkspaceName,
+            };
 
-            return report;
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            metrics.RecordAnomalyDetectionFailure(tenantId: currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null, entityType);
-            LogAnomalyDetectionTimeout(logger, entityType, entityId, config.TimeoutSeconds);
-            return NoAnomalies;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            metrics.RecordAnomalyDetectionFailure(tenantId: currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null, entityType);
-            LogAnomalyDetectionFailure(logger, entityType, entityId, ex);
-            return NoAnomalies;
+            try
+            {
+                StructuredCompletionResult<AnomalyResponseJson> result = await structuredCompletion
+                    .CompleteAsync<AnomalyResponseJson>(request, linkedCts.Token)
+                    .ConfigureAwait(false);
+
+                if (result.Status != StructuredCompletionStatus.Succeeded)
+                {
+                    metrics.RecordAnomalyDetectionFailure(tenantId, entityType);
+                    LogAnomalyDetectionUnavailable(logger, entityType, entityId, result.Status.ToString());
+                    return NoAnomalies;
+                }
+
+                AnomalyReport report = BuildReport(result.Value!);
+
+                metrics.RecordAnomalyDetectionCompleted(tenantId, entityType);
+                metrics.RecordAnomalyDetectionDuration(tenantId, entityType, Stopwatch.GetElapsedTime(startTimestamp));
+                if (report.HasAnomalies)
+                {
+                    metrics.RecordAnomaliesFound(tenantId, entityType, report.Anomalies.Count);
+                }
+
+                return report;
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            {
+                metrics.RecordAnomalyDetectionFailure(tenantId, entityType);
+                LogAnomalyDetectionTimeout(logger, entityType, entityId, config.TimeoutSeconds);
+                return NoAnomalies;
+            }
         }
         finally
         {
@@ -162,61 +154,41 @@ internal sealed partial class LlmTimelineAnomalyDetector(
         return allEntries;
     }
 
-    internal static string BuildAnomalyDetectionPrompt(
-        string entityType,
-        Guid entityId,
-        List<TimelineStreamEntry> entries)
+    private static string BuildInstruction(string entityType, Guid entityId) =>
+        $"""
+         Analyze the supplied activity timeline for {entityType} '{entityId}' and detect any anomalies.
+         Look for: bulk edits in short time windows, off-hours activity (outside 06:00-22:00 UTC),
+         privilege escalation patterns, unusual author patterns, rapid state changes, and any other
+         suspicious behavior. Each anomaly has a description and a severity of Low, Medium, or High.
+         Return an empty anomalies array if none are detected.
+         """;
+
+    // Pseudonymize PII — never send AuthorName ([SensitiveData]) to the external LLM.
+    internal static string BuildEntriesBlock(List<TimelineStreamEntry> entries)
     {
-        var pb = new PromptBuilder(maxInputLength: 50_000);
-
-        pb.AppendInstruction($"Analyze the following activity timeline for {entityType} '{entityId}' and detect any anomalies.");
-        pb.AppendInstruction("Look for: bulk edits in short time windows, off-hours activity (outside 06:00-22:00 UTC), privilege escalation patterns, unusual author patterns, rapid state changes, and any other suspicious behavior.");
-        pb.AppendInstruction(string.Empty);
-        pb.AppendInstruction("""
-            Return JSON only, no markdown fences:
-            {"anomalies": [{"description": "<string>", "severity": "Low|Medium|High"}]}
-            Return an empty array if no anomalies are detected.
-            """);
-
         var sb = new StringBuilder();
         foreach (TimelineStreamEntry entry in entries)
         {
-            // Pseudonymize PII — never send AuthorName ([SensitiveData]) to external LLM.
             string author = entry.AuthorId is { Length: >= 8 } id ? $"User-{id[..8]}" : "System";
             sb.AppendLine($"- [{entry.OccurredAt:u}] ({entry.EntryType}) {author}: {entry.Body}");
         }
 
-        pb.AppendUserTextBlock("Timeline entries (newest first)", sb.ToString());
-
-        return pb.Build();
+        return sb.ToString();
     }
 
-    internal static AnomalyReport ParseAnomalyResponse(string responseText)
+    internal static AnomalyReport BuildReport(AnomalyResponseJson parsed)
     {
-        string trimmed = LlmResponseHelper.StripMarkdownCodeFences(responseText);
-
-        try
-        {
-            AnomalyResponseJson? parsed = JsonSerializer.Deserialize<AnomalyResponseJson>(trimmed, JsonOptions);
-
-            if (parsed?.Anomalies is null || parsed.Anomalies.Count == 0)
-            {
-                return NoAnomalies;
-            }
-
-            var anomalies = parsed.Anomalies
-                .Where(a => !string.IsNullOrWhiteSpace(a.Description))
-                .Select(a => new TimelineAnomaly(
-                    a.Description!,
-                    NormalizeSeverity(a.Severity)))
-                .ToList();
-
-            return new AnomalyReport(anomalies.Count > 0, anomalies);
-        }
-        catch (JsonException)
+        if (parsed.Anomalies is null || parsed.Anomalies.Count == 0)
         {
             return NoAnomalies;
         }
+
+        var anomalies = parsed.Anomalies
+            .Where(a => !string.IsNullOrWhiteSpace(a.Description))
+            .Select(a => new TimelineAnomaly(a.Description!, NormalizeSeverity(a.Severity)))
+            .ToList();
+
+        return new AnomalyReport(anomalies.Count > 0, anomalies);
     }
 
     private static string NormalizeSeverity(string? severity) =>
@@ -228,19 +200,15 @@ internal sealed partial class LlmTimelineAnomalyDetector(
             _ => "Low",
         };
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Timeline anomaly detection unavailable ({Status}) for {EntityType} '{EntityId}'")]
+    private static partial void LogAnomalyDetectionUnavailable(ILogger logger, string entityType, Guid entityId, string status);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Timeline anomaly detection timed out after {TimeoutSeconds}s for {EntityType} '{EntityId}'")]
     private static partial void LogAnomalyDetectionTimeout(ILogger logger, string entityType, Guid entityId, int timeoutSeconds);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Timeline anomaly detection failed for {EntityType} '{EntityId}'")]
-    private static partial void LogAnomalyDetectionFailure(ILogger logger, string entityType, Guid entityId, Exception exception);
+    /// <summary>Internal DTO for deserializing the LLM JSON response.</summary>
+    internal sealed record AnomalyResponseJson(List<AnomalyItemJson>? Anomalies);
 
-    /// <summary>
-    /// Internal DTO for deserializing the LLM JSON response.
-    /// </summary>
-    private sealed record AnomalyResponseJson(List<AnomalyItemJson>? Anomalies);
-
-    /// <summary>
-    /// Internal DTO for a single anomaly in the LLM JSON response.
-    /// </summary>
-    private sealed record AnomalyItemJson(string? Description, string? Severity);
+    /// <summary>Internal DTO for a single anomaly in the LLM JSON response.</summary>
+    internal sealed record AnomalyItemJson(string? Description, string? Severity);
 }

--- a/tests/Granit.Timeline.AI.Tests/LlmTimelineAnomalyDetectorTests.cs
+++ b/tests/Granit.Timeline.AI.Tests/LlmTimelineAnomalyDetectorTests.cs
@@ -6,14 +6,13 @@ using Granit.Timeline.Abstractions;
 using Granit.Timeline.AI.Diagnostics;
 using Granit.Timeline.AI.Internal;
 using Granit.Timeline.AI.Options;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Xunit;
-
+using AnomalyItemJson = Granit.Timeline.AI.Internal.LlmTimelineAnomalyDetector.AnomalyItemJson;
+using AnomalyResponseJson = Granit.Timeline.AI.Internal.LlmTimelineAnomalyDetector.AnomalyResponseJson;
 using MsOptions = Microsoft.Extensions.Options.Options;
 
 namespace Granit.Timeline.AI.Tests;
@@ -22,22 +21,14 @@ public sealed class LlmTimelineAnomalyDetectorTests
 {
     private static readonly Guid TestEntityId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
 
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly ITimelineReader _timelineReader = Substitute.For<ITimelineReader>();
     private readonly IOptions<TimelineAIOptions> _options = MsOptions.Create(new TimelineAIOptions());
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
     private readonly TimelineAIMetrics _metrics = CreateTestMetrics();
 
-    public LlmTimelineAnomalyDetectorTests()
-    {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-    }
-
     private LlmTimelineAnomalyDetector CreateSut() =>
-        new(_chatClientFactory, _timelineReader, _options, _currentTenant, _metrics, NullLogger<LlmTimelineAnomalyDetector>.Instance);
+        new(_structured, _timelineReader, _options, _currentTenant, _metrics, NullLogger<LlmTimelineAnomalyDetector>.Instance);
 
     private static TimelineAIMetrics CreateTestMetrics()
     {
@@ -45,6 +36,11 @@ public sealed class LlmTimelineAnomalyDetectorTests
         factory.Create(Arg.Any<MeterOptions>()).Returns(new Meter("test"));
         return new TimelineAIMetrics(factory);
     }
+
+    private void HasEntries(int count) =>
+        _timelineReader
+            .GetStreamAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>(MakeEntries(count), count, false, null), []));
 
     private static List<TimelineStreamEntry> MakeEntries(int count)
     {
@@ -64,17 +60,19 @@ public sealed class LlmTimelineAnomalyDetectorTests
         return entries;
     }
 
+    private void Completes(StructuredCompletionStatus status, AnomalyResponseJson? value = null) =>
+        _structured
+            .CompleteAsync<AnomalyResponseJson>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<AnomalyResponseJson> { Status = status, Value = value });
+
     [Fact]
     public async Task DetectAnomaliesAsync_NoEntries_ReturnsNoAnomalies()
     {
-        LlmTimelineAnomalyDetector sut = CreateSut();
-
         _timelineReader
             .GetStreamAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>([], 0, false, null), []));
 
-        AnomalyReport result = await sut.DetectAnomaliesAsync(
-            "Order", TestEntityId, TestContext.Current.CancellationToken);
+        AnomalyReport result = await CreateSut().DetectAnomaliesAsync("Order", TestEntityId, TestContext.Current.CancellationToken);
 
         result.HasAnomalies.ShouldBeFalse();
         result.Anomalies.ShouldBeEmpty();
@@ -83,25 +81,14 @@ public sealed class LlmTimelineAnomalyDetectorTests
     [Fact]
     public async Task DetectAnomaliesAsync_AnomaliesFound_ReturnsReport()
     {
-        LlmTimelineAnomalyDetector sut = CreateSut();
-        List<TimelineStreamEntry> entries = MakeEntries(5);
+        HasEntries(5);
+        Completes(StructuredCompletionStatus.Succeeded, new AnomalyResponseJson(
+        [
+            new AnomalyItemJson("Bulk edits detected: 5 entries in 4 hours", "Medium"),
+            new AnomalyItemJson("Off-hours activity at 03:00 UTC", "Low"),
+        ]));
 
-        _timelineReader
-            .GetStreamAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>(entries, 5, false, null), []));
-
-        string json = """{"anomalies": [{"description": "Bulk edits detected: 5 entries in 4 hours", "severity": "Medium"}, {"description": "Off-hours activity at 03:00 UTC", "severity": "Low"}]}""";
-
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        AnomalyReport result = await sut.DetectAnomaliesAsync(
-            "Order", TestEntityId, TestContext.Current.CancellationToken);
+        AnomalyReport result = await CreateSut().DetectAnomaliesAsync("Order", TestEntityId, TestContext.Current.CancellationToken);
 
         result.HasAnomalies.ShouldBeTrue();
         result.Anomalies.Count.ShouldBe(2);
@@ -111,35 +98,63 @@ public sealed class LlmTimelineAnomalyDetectorTests
     }
 
     [Fact]
-    public async Task DetectAnomaliesAsync_LlmFailure_ReturnsNoAnomalies()
+    public async Task DetectAnomaliesAsync_TransportFailure_ReturnsNoAnomalies()
     {
-        LlmTimelineAnomalyDetector sut = CreateSut();
-        List<TimelineStreamEntry> entries = MakeEntries(2);
+        HasEntries(2);
+        Completes(StructuredCompletionStatus.TransportFailure);
 
-        _timelineReader
-            .GetStreamAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>(entries, 2, false, null), []));
-
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
-
-        AnomalyReport result = await sut.DetectAnomaliesAsync(
-            "Order", TestEntityId, TestContext.Current.CancellationToken);
+        AnomalyReport result = await CreateSut().DetectAnomaliesAsync("Order", TestEntityId, TestContext.Current.CancellationToken);
 
         result.HasAnomalies.ShouldBeFalse();
         result.Anomalies.ShouldBeEmpty();
     }
 
     [Fact]
-    public void ParseAnomalyResponse_ValidJson_ReturnsAnomalies()
+    public async Task DetectAnomaliesAsync_SchemaViolation_ReturnsNoAnomalies()
     {
-        string json = """{"anomalies": [{"description": "Privilege escalation pattern", "severity": "High"}]}""";
+        HasEntries(2);
+        Completes(StructuredCompletionStatus.SchemaViolation);
 
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
+        AnomalyReport result = await CreateSut().DetectAnomaliesAsync("Order", TestEntityId, TestContext.Current.CancellationToken);
+
+        result.HasAnomalies.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DetectAnomaliesAsync_PassesPseudonymizedEntriesAsContent()
+    {
+        var entry = new TimelineStreamEntry
+        {
+            Id = Guid.NewGuid(),
+            OccurredAt = new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero),
+            EntryType = TimelineStreamEntryType.Comment,
+            AuthorId = "abcdef1234567890",
+            AuthorName = "Jane Doe",
+            Body = "Did a thing",
+        };
+        _timelineReader
+            .GetStreamAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>([entry], 1, false, null), []));
+
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<AnomalyResponseJson>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<AnomalyResponseJson> { Status = StructuredCompletionStatus.Succeeded, Value = new AnomalyResponseJson([]) });
+
+        await CreateSut().DetectAnomaliesAsync("Ticket", TestEntityId, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Content.ShouldContain("Did a thing");
+        captured.Content.ShouldContain("User-abcdef12"); // pseudonymized author
+        captured.Content.ShouldNotContain("Jane Doe");   // raw author name never sent
+        captured.Instruction!.ShouldContain("Ticket");
+    }
+
+    [Fact]
+    public void BuildReport_ValidAnomalies_ReturnsReport()
+    {
+        AnomalyReport result = LlmTimelineAnomalyDetector.BuildReport(
+            new AnomalyResponseJson([new AnomalyItemJson("Privilege escalation pattern", "High")]));
 
         result.HasAnomalies.ShouldBeTrue();
         result.Anomalies.Count.ShouldBe(1);
@@ -148,50 +163,11 @@ public sealed class LlmTimelineAnomalyDetectorTests
     }
 
     [Fact]
-    public void ParseAnomalyResponse_EmptyAnomalies_ReturnsNoAnomalies()
+    public void BuildReport_EmptyAnomalies_ReturnsNoAnomalies()
     {
-        string json = """{"anomalies": []}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
+        AnomalyReport result = LlmTimelineAnomalyDetector.BuildReport(new AnomalyResponseJson([]));
 
         result.HasAnomalies.ShouldBeFalse();
         result.Anomalies.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void ParseAnomalyResponse_InvalidJson_ReturnsNoAnomalies()
-    {
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse("not valid json");
-
-        result.HasAnomalies.ShouldBeFalse();
-        result.Anomalies.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void ParseAnomalyResponse_MarkdownFencedJson_ReturnsAnomalies()
-    {
-        string json = """
-            ```json
-            {"anomalies": [{"description": "Rapid state changes", "severity": "medium"}]}
-            ```
-            """;
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
-
-        result.HasAnomalies.ShouldBeTrue();
-        result.Anomalies[0].Severity.ShouldBe("Medium");
-    }
-
-    [Fact]
-    public void BuildAnomalyDetectionPrompt_ContainsEntityTypeAndEntries()
-    {
-        List<TimelineStreamEntry> entries = MakeEntries(2);
-
-        string prompt = LlmTimelineAnomalyDetector.BuildAnomalyDetectionPrompt("Ticket", TestEntityId, entries);
-
-        prompt.ShouldContain("Ticket");
-        prompt.ShouldContain(TestEntityId.ToString());
-        prompt.ShouldContain("Entry body 0");
-        prompt.ShouldContain("bulk edits");
     }
 }

--- a/tests/Granit.Timeline.AI.Tests/ParseAnomalyResponseAdditionalTests.cs
+++ b/tests/Granit.Timeline.AI.Tests/ParseAnomalyResponseAdditionalTests.cs
@@ -1,69 +1,45 @@
 using Granit.Timeline.AI.Internal;
 using Shouldly;
 using Xunit;
+using AnomalyItemJson = Granit.Timeline.AI.Internal.LlmTimelineAnomalyDetector.AnomalyItemJson;
+using AnomalyResponseJson = Granit.Timeline.AI.Internal.LlmTimelineAnomalyDetector.AnomalyResponseJson;
 
 namespace Granit.Timeline.AI.Tests;
 
+/// <summary>
+/// Severity normalization and description filtering — now exercised through
+/// <see cref="LlmTimelineAnomalyDetector.BuildReport"/> (JSON parsing/fence-stripping is the
+/// primitive's responsibility).
+/// </summary>
 public sealed class ParseAnomalyResponseAdditionalTests
 {
-    [Fact]
-    public void ParseAnomalyResponse_NullSeverity_DefaultsToLow()
-    {
-        string json = """{"anomalies": [{"description": "Something odd", "severity": null}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
-
-        result.HasAnomalies.ShouldBeTrue();
-        result.Anomalies[0].Severity.ShouldBe("Low");
-    }
+    private static AnomalyReport Build(string? description, string? severity) =>
+        LlmTimelineAnomalyDetector.BuildReport(new AnomalyResponseJson([new AnomalyItemJson(description, severity)]));
 
     [Fact]
-    public void ParseAnomalyResponse_UnknownSeverity_DefaultsToLow()
-    {
-        string json = """{"anomalies": [{"description": "Something odd", "severity": "Critical"}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
-
-        result.HasAnomalies.ShouldBeTrue();
-        result.Anomalies[0].Severity.ShouldBe("Low");
-    }
+    public void BuildReport_NullSeverity_DefaultsToLow() =>
+        Build("Something odd", null).Anomalies[0].Severity.ShouldBe("Low");
 
     [Fact]
-    public void ParseAnomalyResponse_HighSeverity_NormalizedCorrectly()
-    {
-        string json = """{"anomalies": [{"description": "Privilege escalation", "severity": "high"}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
-
-        result.Anomalies[0].Severity.ShouldBe("High");
-    }
+    public void BuildReport_UnknownSeverity_DefaultsToLow() =>
+        Build("Something odd", "Critical").Anomalies[0].Severity.ShouldBe("Low");
 
     [Fact]
-    public void ParseAnomalyResponse_LowSeverity_NormalizedCorrectly()
-    {
-        string json = """{"anomalies": [{"description": "Minor issue", "severity": "low"}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
-
-        result.Anomalies[0].Severity.ShouldBe("Low");
-    }
+    public void BuildReport_HighSeverity_NormalizedCorrectly() =>
+        Build("Privilege escalation", "high").Anomalies[0].Severity.ShouldBe("High");
 
     [Fact]
-    public void ParseAnomalyResponse_MediumSeverity_NormalizedCorrectly()
-    {
-        string json = """{"anomalies": [{"description": "Bulk edits", "severity": "MEDIUM"}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
-
-        result.Anomalies[0].Severity.ShouldBe("Medium");
-    }
+    public void BuildReport_MediumSeverity_NormalizedCorrectly() =>
+        Build("Bulk edits", "MEDIUM").Anomalies[0].Severity.ShouldBe("Medium");
 
     [Fact]
-    public void ParseAnomalyResponse_EmptyDescription_Filtered()
+    public void BuildReport_EmptyDescription_Filtered()
     {
-        string json = """{"anomalies": [{"description": "", "severity": "Low"}, {"description": "Valid", "severity": "High"}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
+        AnomalyReport result = LlmTimelineAnomalyDetector.BuildReport(new AnomalyResponseJson(
+        [
+            new AnomalyItemJson("", "Low"),
+            new AnomalyItemJson("Valid", "High"),
+        ]));
 
         result.HasAnomalies.ShouldBeTrue();
         result.Anomalies.Count.ShouldBe(1);
@@ -71,32 +47,27 @@ public sealed class ParseAnomalyResponseAdditionalTests
     }
 
     [Fact]
-    public void ParseAnomalyResponse_WhitespaceDescription_Filtered()
+    public void BuildReport_WhitespaceDescription_Filtered()
     {
-        string json = """{"anomalies": [{"description": "   ", "severity": "Low"}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
+        AnomalyReport result = Build("   ", "Low");
 
         result.HasAnomalies.ShouldBeFalse();
         result.Anomalies.ShouldBeEmpty();
     }
 
     [Fact]
-    public void ParseAnomalyResponse_NullAnomaliesProperty_ReturnsNoAnomalies()
-    {
-        string json = """{"anomalies": null}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
-
-        result.HasAnomalies.ShouldBeFalse();
-    }
+    public void BuildReport_NullAnomaliesProperty_ReturnsNoAnomalies() =>
+        LlmTimelineAnomalyDetector.BuildReport(new AnomalyResponseJson(null)).HasAnomalies.ShouldBeFalse();
 
     [Fact]
-    public void ParseAnomalyResponse_MultipleAnomalies_AllParsed()
+    public void BuildReport_MultipleAnomalies_AllParsed()
     {
-        string json = """{"anomalies": [{"description": "A", "severity": "Low"}, {"description": "B", "severity": "Medium"}, {"description": "C", "severity": "High"}]}""";
-
-        AnomalyReport result = LlmTimelineAnomalyDetector.ParseAnomalyResponse(json);
+        AnomalyReport result = LlmTimelineAnomalyDetector.BuildReport(new AnomalyResponseJson(
+        [
+            new AnomalyItemJson("A", "Low"),
+            new AnomalyItemJson("B", "Medium"),
+            new AnomalyItemJson("C", "High"),
+        ]));
 
         result.Anomalies.Count.ShouldBe(3);
     }


### PR DESCRIPTION
Sixth **F3** migration (Epic #2452, feature #2455), per the #2460 template.

`LlmTimelineAnomalyDetector` → `CompleteAsync<AnomalyResponseJson>`. Gains provider-enforced schema, usage tracking, PII-safe errors. **Keeps** the per-process `SemaphoreSlim` concurrency limiter (denial-of-wallet), `TimelineAIMetrics`, entry fetching, **author pseudonymization**, severity normalization, and the fail-soft policy (any non-success / timeout → `NoAnomalies`). Pseudonymized entries are the `Content`; the analysis guidance is the `Instruction`.

`LlmTimelineSummarizer` is **intentionally left** on `IAIChatClientFactory` — it returns a raw text summary (no JSON), so it's a text-generation consumer, not an `IStructuredCompletion` target (same category as Templating.AI).

38 tests updated (behaviour via mock; `BuildReport` severity/description tests replacing the removed `ParseAnomalyResponse`; pseudonymization pass-through). Fence/invalid-json/BuildPrompt tests dropped. `dotnet format` clean; no new deps.

**Progress: 6/13** (Validation #2460, Authorization #2461, Privacy #2462, BlobStorage #2463, Workflow #2464 merged; Timeline here). Remaining: system-prompt fold (Observability, LanguageDetection, Indexing); reshape outliers (Localization, DataExchange, Notifications, QueryEngine). Non-targets: Imaging (multimodal), Templating + Timeline-summarizer (text-gen).