### PR TITLE
refactor(observability-ai): migrate log analyzer to IStructuredCompletion (F3)

### DIFF
--- a/src/Granit.Observability.AI/Internal/LlmLogAnalyzer.cs
+++ b/src/Granit.Observability.AI/Internal/LlmLogAnalyzer.cs
@@ -1,38 +1,34 @@
 using System.Diagnostics;
 using System.Text;
-using System.Text.Json;
 using Granit.AI;
-using Granit.AI.Internal;
 using Granit.MultiTenancy;
 using Granit.Observability.AI.Diagnostics;
 using Granit.Observability.AI.Options;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Observability.AI.Internal;
 
 /// <summary>
-/// Analyzes log entries by sending them to an LLM and parsing the structured response.
+/// Analyzes log entries via the <see cref="IStructuredCompletion"/> primitive (ADR-064) and
+/// returns a structured report.
 /// </summary>
 /// <remarks>
 /// <para><b>PII warning:</b> Log messages and exception texts are sent to the configured LLM.
 /// Callers must ensure log entries are pre-sanitized if they may contain PII
 /// (usernames, emails, IP addresses, tokens). Use <see cref="ObservabilityAIOptions.WorkspaceName"/>
 /// to target an on-premise model (e.g., Ollama) for sensitive environments.</para>
+/// <para>An unparseable model response degrades to a fallback report; a transport failure or
+/// timeout is surfaced as an exception (records the failure metric first), preserving the
+/// original contract.</para>
 /// </remarks>
 internal sealed partial class LlmLogAnalyzer(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     IOptions<ObservabilityAIOptions> options,
     ObservabilityAIMetrics metrics,
     ICurrentTenant? currentTenant,
     ILogger<LlmLogAnalyzer> logger) : IAILogAnalyzer
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     /// <inheritdoc />
     public async Task<LogAnalysisReport> AnalyzeAsync(
         IReadOnlyList<LogEntry> entries,
@@ -56,73 +52,73 @@ internal sealed partial class LlmLogAnalyzer(
 
         var sw = Stopwatch.StartNew();
 
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        var request = new StructuredCompletionRequest
+        {
+            Instruction = AnalysisInstruction,
+            Content = BuildEntriesBlock(truncatedEntries),
+            ContentLabel = "Log entries",
+            WorkspaceName = config.WorkspaceName,
+        };
+
         try
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient client = await chatClientFactory
-                .CreateAsync(config.WorkspaceName, linkedCts.Token)
+            StructuredCompletionResult<LlmAnalysisResponse> result = await structuredCompletion
+                .CompleteAsync<LlmAnalysisResponse>(request, linkedCts.Token)
                 .ConfigureAwait(false);
 
-            string prompt = BuildPrompt(truncatedEntries);
+            switch (result.Status)
+            {
+                case StructuredCompletionStatus.Succeeded:
+                    LogAnalysisReport report = BuildReport(result.Value!, truncatedEntries.Count);
+                    sw.Stop();
+                    LogAnalysisComplete(logger, report.Insights.Count, truncatedEntries.Count);
+                    metrics.RecordAnalysisCompleted(tenantId, report.Insights.Count, truncatedEntries.Count);
+                    metrics.RecordAnalysisDuration(tenantId, sw.Elapsed.TotalSeconds);
+                    return report;
 
-            ChatMessage[] messages =
-            [
-                new(ChatRole.System, SystemPrompt),
-                new(ChatRole.User, prompt),
-            ];
+                case StructuredCompletionStatus.ModelRefused:
+                case StructuredCompletionStatus.SchemaViolation:
+                    // Unparseable/refused output degrades to a fallback report (no exception).
+                    sw.Stop();
+                    metrics.RecordAnalysisFailed(tenantId, "parse");
+                    metrics.RecordAnalysisDuration(tenantId, sw.Elapsed.TotalSeconds);
+                    return new LogAnalysisReport("AI analysis returned a non-JSON response.", [], truncatedEntries.Count);
 
-            ChatResponse response = await client
-                .GetResponseAsync(messages, cancellationToken: linkedCts.Token)
-                .ConfigureAwait(false);
-
-            string content = response.Messages.LastOrDefault()?.Text ?? string.Empty;
-
-            LogAnalysisReport report = ParseReport(content, truncatedEntries.Count);
-
-            sw.Stop();
-            LogAnalysisComplete(logger, report.Insights.Count, truncatedEntries.Count);
-            metrics.RecordAnalysisCompleted(tenantId, report.Insights.Count, truncatedEntries.Count);
-            metrics.RecordAnalysisDuration(tenantId, sw.Elapsed.TotalSeconds);
-
-            return report;
+                case StructuredCompletionStatus.TransportFailure:
+                default:
+                    // Transport problems are surfaced to the caller, as before.
+                    sw.Stop();
+                    metrics.RecordAnalysisFailed(tenantId, "error");
+                    metrics.RecordAnalysisDuration(tenantId, sw.Elapsed.TotalSeconds);
+                    throw new InvalidOperationException(result.ErrorMessage ?? "AI log analysis failed.");
+            }
         }
-        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             sw.Stop();
-            metrics.RecordAnalysisFailed(tenantId, "error");
+            metrics.RecordAnalysisFailed(tenantId, "timeout");
             metrics.RecordAnalysisDuration(tenantId, sw.Elapsed.TotalSeconds);
             throw;
         }
     }
 
-    private const string SystemPrompt =
+    // The former system prompt + user instruction, folded into one developer-controlled
+    // instruction (the primitive sends a single user message and isolates the entries in a
+    // <data> block). The schema is enforced by the primitive.
+    internal const string AnalysisInstruction =
         """
-        You are a log analysis assistant. Analyze the provided log entries and return a JSON object with this exact structure:
-        {
-          "summary": "A concise summary of the overall log health and key findings",
-          "insights": [
-            {
-              "description": "Description of the finding",
-              "severity": "Critical|High|Medium|Low",
-              "category": "Anomaly|Pattern|Regression|Performance|ErrorSpike|Configuration"
-            }
-          ]
-        }
-        Return ONLY valid JSON. No markdown, no explanation, no code fences.
-        Focus on: recurring errors, anomalous patterns, error spikes, performance degradation signals, and configuration issues.
+        You are a log analysis assistant. Analyze the supplied log entries and produce a concise
+        summary of the overall log health plus a list of insights. Each insight has a description,
+        a severity of Critical, High, Medium, or Low, and a category of Anomaly, Pattern,
+        Regression, Performance, ErrorSpike, or Configuration. Focus on recurring errors, anomalous
+        patterns, error spikes, performance-degradation signals, and configuration issues.
         """;
 
-    internal static string BuildPrompt(IReadOnlyList<LogEntry> entries)
+    internal static string BuildEntriesBlock(IReadOnlyList<LogEntry> entries)
     {
-        var pb = new PromptBuilder(maxInputLength: 100_000);
-
-        pb.AppendInstruction("Analyze these log entries:");
-        pb.AppendInstruction(string.Empty);
-
         var sb = new StringBuilder();
         foreach (LogEntry entry in entries)
         {
@@ -136,46 +132,19 @@ internal sealed partial class LlmLogAnalyzer(
             }
         }
 
-        pb.AppendUserTextBlock("Log entries", sb.ToString());
-
-        return pb.Build();
+        return sb.ToString();
     }
 
-    internal static LogAnalysisReport ParseReport(string content, int totalEntries)
+    internal static LogAnalysisReport BuildReport(LlmAnalysisResponse parsed, int totalEntries)
     {
-        try
-        {
-            string json = LlmResponseHelper.StripMarkdownCodeFences(content);
-            LlmAnalysisResponse? parsed = JsonSerializer.Deserialize<LlmAnalysisResponse>(json, JsonOptions);
+        List<LogInsight> insights = parsed.Insights
+            ?.Select(i => new LogInsight(
+                i.Description ?? "Unknown",
+                i.Severity ?? "Medium",
+                i.Category ?? "Pattern"))
+            .ToList() ?? [];
 
-            if (parsed is null)
-            {
-                return new LogAnalysisReport(
-                    "AI analysis returned an unparseable response.",
-                    [],
-                    totalEntries);
-            }
-
-            List<LogInsight> insights = parsed.Insights
-                ?.Select(i => new LogInsight(
-                    i.Description ?? "Unknown",
-                    i.Severity ?? "Medium",
-                    i.Category ?? "Pattern"))
-                .ToList() ?? [];
-
-            return new LogAnalysisReport(
-                parsed.Summary ?? "No summary available.",
-                insights,
-                totalEntries);
-        }
-        catch (JsonException)
-        {
-            // Return a generic message instead of raw LLM content to prevent data leakage.
-            return new LogAnalysisReport(
-                "AI analysis returned a non-JSON response.",
-                [],
-                totalEntries);
-        }
+        return new LogAnalysisReport(parsed.Summary ?? "No summary available.", insights, totalEntries);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Analyzing {TruncatedCount} log entries (total: {TotalCount})")]
@@ -184,18 +153,14 @@ internal sealed partial class LlmLogAnalyzer(
     [LoggerMessage(Level = LogLevel.Information, Message = "Log analysis complete: {InsightCount} insights from {EntryCount} entries")]
     private static partial void LogAnalysisComplete(ILogger logger, int insightCount, int entryCount);
 
-    /// <summary>
-    /// Internal DTO for deserializing the LLM JSON response.
-    /// </summary>
+    /// <summary>Internal DTO for deserializing the LLM JSON response.</summary>
     internal sealed class LlmAnalysisResponse
     {
         public string? Summary { get; set; }
         public List<LlmInsightResponse>? Insights { get; set; }
     }
 
-    /// <summary>
-    /// Internal DTO for deserializing an individual insight from the LLM response.
-    /// </summary>
+    /// <summary>Internal DTO for deserializing an individual insight from the LLM response.</summary>
     internal sealed class LlmInsightResponse
     {
         public string? Description { get; set; }

--- a/tests/Granit.Observability.AI.Tests/LlmLogAnalyzerParseTests.cs
+++ b/tests/Granit.Observability.AI.Tests/LlmLogAnalyzerParseTests.cs
@@ -1,45 +1,46 @@
 using Granit.Observability.AI.Internal;
 using Shouldly;
+using LlmAnalysisResponse = Granit.Observability.AI.Internal.LlmLogAnalyzer.LlmAnalysisResponse;
+using LlmInsightResponse = Granit.Observability.AI.Internal.LlmLogAnalyzer.LlmInsightResponse;
 
 namespace Granit.Observability.AI.Tests;
 
+/// <summary>
+/// Report mapping and entry-block building. JSON parsing / fence-stripping is now the
+/// primitive's responsibility, so those tests are exercised through
+/// <see cref="LlmLogAnalyzer.BuildReport"/> and <see cref="LlmLogAnalyzer.BuildEntriesBlock"/>.
+/// </summary>
 public sealed class LlmLogAnalyzerParseTests
 {
     [Fact]
-    public void ParseReport_ValidJson_ReturnsParsedReport()
+    public void BuildReport_ValidResponse_ReturnsReport()
     {
-        const string json = """
-            {
-              "summary": "3 errors detected",
-              "insights": [
-                { "description": "Memory leak", "severity": "Critical", "category": "Anomaly" },
-                { "description": "Slow queries", "severity": "Medium", "category": "Performance" }
-              ]
-            }
-            """;
-
-        LogAnalysisReport report = LlmLogAnalyzer.ParseReport(json, 10);
+        LogAnalysisReport report = LlmLogAnalyzer.BuildReport(new LlmAnalysisResponse
+        {
+            Summary = "3 errors detected",
+            Insights =
+            [
+                new LlmInsightResponse { Description = "Memory leak", Severity = "Critical", Category = "Anomaly" },
+                new LlmInsightResponse { Description = "Slow queries", Severity = "Medium", Category = "Performance" },
+            ],
+        }, 10);
 
         report.Summary.ShouldBe("3 errors detected");
         report.Insights.Count.ShouldBe(2);
         report.Insights[0].Description.ShouldBe("Memory leak");
         report.Insights[0].Severity.ShouldBe("Critical");
         report.Insights[0].Category.ShouldBe("Anomaly");
-        report.Insights[1].Description.ShouldBe("Slow queries");
         report.TotalEntries.ShouldBe(10);
     }
 
     [Fact]
-    public void ParseReport_NullFields_UsesDefaults()
+    public void BuildReport_NullFields_UsesDefaults()
     {
-        const string json = """
-            {
-              "summary": null,
-              "insights": [{ "description": null, "severity": null, "category": null }]
-            }
-            """;
-
-        LogAnalysisReport report = LlmLogAnalyzer.ParseReport(json, 5);
+        LogAnalysisReport report = LlmLogAnalyzer.BuildReport(new LlmAnalysisResponse
+        {
+            Summary = null,
+            Insights = [new LlmInsightResponse { Description = null, Severity = null, Category = null }],
+        }, 5);
 
         report.Summary.ShouldBe("No summary available.");
         report.Insights.Count.ShouldBe(1);
@@ -49,23 +50,9 @@ public sealed class LlmLogAnalyzerParseTests
     }
 
     [Fact]
-    public void ParseReport_InvalidJson_ReturnsFallback()
+    public void BuildReport_NullInsights_ReturnsEmptyList()
     {
-        const string badJson = "not json {{{";
-
-        LogAnalysisReport report = LlmLogAnalyzer.ParseReport(badJson, 7);
-
-        report.Summary.ShouldBe("AI analysis returned a non-JSON response.");
-        report.Insights.ShouldBeEmpty();
-        report.TotalEntries.ShouldBe(7);
-    }
-
-    [Fact]
-    public void ParseReport_EmptyInsightsArray_ReturnsEmptyList()
-    {
-        const string json = """{"summary": "All clear", "insights": []}""";
-
-        LogAnalysisReport report = LlmLogAnalyzer.ParseReport(json, 20);
+        LogAnalysisReport report = LlmLogAnalyzer.BuildReport(new LlmAnalysisResponse { Summary = "All clear", Insights = null }, 20);
 
         report.Summary.ShouldBe("All clear");
         report.Insights.ShouldBeEmpty();
@@ -73,7 +60,7 @@ public sealed class LlmLogAnalyzerParseTests
     }
 
     [Fact]
-    public void BuildPrompt_IncludesAllEntries()
+    public void BuildEntriesBlock_IncludesAllEntries()
     {
         List<LogEntry> entries =
         [
@@ -81,27 +68,21 @@ public sealed class LlmLogAnalyzerParseTests
             new(DateTimeOffset.Parse("2026-01-01T12:01:00Z"), "Information", "All good", null),
         ];
 
-        string prompt = LlmLogAnalyzer.BuildPrompt(entries);
+        string block = LlmLogAnalyzer.BuildEntriesBlock(entries);
 
-        prompt.ShouldContain("Something failed");
-        prompt.ShouldContain("All good");
-        prompt.ShouldContain("Exception: System.Exception: boom");
-        // Only one "  Exception:" prefix line should appear (for the entry that has an exception)
-        int exceptionPrefixCount = prompt.Split("  Exception:").Length - 1;
-        exceptionPrefixCount.ShouldBe(1);
+        block.ShouldContain("Something failed");
+        block.ShouldContain("All good");
+        block.ShouldContain("Exception: System.Exception: boom");
+        (block.Split("  Exception:").Length - 1).ShouldBe(1);
     }
 
     [Fact]
-    public void BuildPrompt_NoException_OmitsExceptionLine()
+    public void BuildEntriesBlock_NoException_OmitsExceptionLine()
     {
-        List<LogEntry> entries =
-        [
-            new(DateTimeOffset.Parse("2026-01-01T12:00:00Z"), "Information", "Normal log", null),
-        ];
+        string block = LlmLogAnalyzer.BuildEntriesBlock(
+            [new(DateTimeOffset.Parse("2026-01-01T12:00:00Z"), "Information", "Normal log", null)]);
 
-        string prompt = LlmLogAnalyzer.BuildPrompt(entries);
-
-        prompt.ShouldContain("Normal log");
-        prompt.ShouldNotContain("Exception:");
+        block.ShouldContain("Normal log");
+        block.ShouldNotContain("Exception:");
     }
 }

--- a/tests/Granit.Observability.AI.Tests/LlmLogAnalyzerTests.cs
+++ b/tests/Granit.Observability.AI.Tests/LlmLogAnalyzerTests.cs
@@ -3,19 +3,18 @@ using Granit.AI;
 using Granit.Observability.AI.Diagnostics;
 using Granit.Observability.AI.Internal;
 using Granit.Observability.AI.Options;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
+using LlmAnalysisResponse = Granit.Observability.AI.Internal.LlmLogAnalyzer.LlmAnalysisResponse;
+using LlmInsightResponse = Granit.Observability.AI.Internal.LlmLogAnalyzer.LlmInsightResponse;
 
 namespace Granit.Observability.AI.Tests;
 
 public sealed class LlmLogAnalyzerTests : IDisposable
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
-
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<ObservabilityAIOptions> _options =
         Microsoft.Extensions.Options.Options.Create(new ObservabilityAIOptions
         {
@@ -26,8 +25,8 @@ public sealed class LlmLogAnalyzerTests : IDisposable
 
     private readonly TestMeterFactory _meterFactory = new();
 
-    private LlmLogAnalyzer CreateAnalyzer() =>
-        new(_chatClientFactory, _options, new ObservabilityAIMetrics(_meterFactory), null, NullLogger<LlmLogAnalyzer>.Instance);
+    private LlmLogAnalyzer CreateAnalyzer(IOptions<ObservabilityAIOptions>? opts = null) =>
+        new(_structured, opts ?? _options, new ObservabilityAIMetrics(_meterFactory), null, NullLogger<LlmLogAnalyzer>.Instance);
 
     public void Dispose() => _meterFactory.Dispose();
 
@@ -36,6 +35,11 @@ public sealed class LlmLogAnalyzerTests : IDisposable
         public Meter Create(MeterOptions options) => new(options);
         public void Dispose() { }
     }
+
+    private void Completes(StructuredCompletionStatus status, LlmAnalysisResponse? value = null) =>
+        _structured
+            .CompleteAsync<LlmAnalysisResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmAnalysisResponse> { Status = status, Value = value });
 
     private static List<LogEntry> CreateSampleEntries(int count = 3) =>
         Enumerable.Range(0, count)
@@ -49,9 +53,7 @@ public sealed class LlmLogAnalyzerTests : IDisposable
     [Fact]
     public async Task AnalyzeAsync_EmptyEntries_ReturnsEmptyReport()
     {
-        LlmLogAnalyzer analyzer = CreateAnalyzer();
-
-        LogAnalysisReport report = await analyzer.AnalyzeAsync([], TestContext.Current.CancellationToken);
+        LogAnalysisReport report = await CreateAnalyzer().AnalyzeAsync([], TestContext.Current.CancellationToken);
 
         report.Summary.ShouldBe("No log entries to analyze.");
         report.Insights.ShouldBeEmpty();
@@ -59,42 +61,20 @@ public sealed class LlmLogAnalyzerTests : IDisposable
     }
 
     [Fact]
-    public async Task AnalyzeAsync_NullEntries_ThrowsArgumentNullException()
-    {
-        LlmLogAnalyzer analyzer = CreateAnalyzer();
-
+    public async Task AnalyzeAsync_NullEntries_ThrowsArgumentNullException() =>
         await Should.ThrowAsync<ArgumentNullException>(
-            () => analyzer.AnalyzeAsync(null!, TestContext.Current.CancellationToken));
-    }
+            () => CreateAnalyzer().AnalyzeAsync(null!, TestContext.Current.CancellationToken));
 
     [Fact]
-    public async Task AnalyzeAsync_ValidEntries_CallsChatClientAndReturnsReport()
+    public async Task AnalyzeAsync_ValidEntries_ReturnsReport()
     {
-        const string llmResponse = """
-            {
-              "summary": "Found 1 error pattern",
-              "insights": [
-                {
-                  "description": "Recurring NullReferenceException",
-                  "severity": "High",
-                  "category": "Pattern"
-                }
-              ]
-            }
-            """;
+        Completes(StructuredCompletionStatus.Succeeded, new LlmAnalysisResponse
+        {
+            Summary = "Found 1 error pattern",
+            Insights = [new LlmInsightResponse { Description = "Recurring NullReferenceException", Severity = "High", Category = "Pattern" }],
+        });
 
-        _chatClientFactory
-            .CreateAsync("test-workspace", Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-
-        _chatClient
-            .GetResponseAsync(Arg.Any<IList<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, llmResponse)));
-
-        LlmLogAnalyzer analyzer = CreateAnalyzer();
-        List<LogEntry> entries = CreateSampleEntries();
-
-        LogAnalysisReport report = await analyzer.AnalyzeAsync(entries, TestContext.Current.CancellationToken);
+        LogAnalysisReport report = await CreateAnalyzer().AnalyzeAsync(CreateSampleEntries(), TestContext.Current.CancellationToken);
 
         report.Summary.ShouldBe("Found 1 error pattern");
         report.Insights.Count.ShouldBe(1);
@@ -107,52 +87,54 @@ public sealed class LlmLogAnalyzerTests : IDisposable
     [Fact]
     public async Task AnalyzeAsync_EntriesExceedMax_TruncatesToMaxLogEntries()
     {
-        IOptions<ObservabilityAIOptions> smallOptions =
-            Microsoft.Extensions.Options.Options.Create(new ObservabilityAIOptions
-            {
-                WorkspaceName = "test-workspace",
-                TimeoutSeconds = 30,
-                MaxLogEntries = 2,
-            });
+        Completes(StructuredCompletionStatus.Succeeded, new LlmAnalysisResponse { Summary = "OK", Insights = [] });
 
-        const string llmResponse = """{"summary": "OK", "insights": []}""";
+        IOptions<ObservabilityAIOptions> smallOptions = Microsoft.Extensions.Options.Options.Create(
+            new ObservabilityAIOptions { WorkspaceName = "test-workspace", TimeoutSeconds = 30, MaxLogEntries = 2 });
 
-        _chatClientFactory
-            .CreateAsync("test-workspace", Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-
-        _chatClient
-            .GetResponseAsync(Arg.Any<IList<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, llmResponse)));
-
-        var analyzer = new LlmLogAnalyzer(_chatClientFactory, smallOptions, new ObservabilityAIMetrics(_meterFactory), null, NullLogger<LlmLogAnalyzer>.Instance);
-        List<LogEntry> entries = CreateSampleEntries(5);
-
-        LogAnalysisReport report = await analyzer.AnalyzeAsync(entries, TestContext.Current.CancellationToken);
+        LogAnalysisReport report = await CreateAnalyzer(smallOptions).AnalyzeAsync(CreateSampleEntries(5), TestContext.Current.CancellationToken);
 
         report.TotalEntries.ShouldBe(2);
     }
 
     [Fact]
-    public async Task AnalyzeAsync_InvalidJsonResponse_ReturnsFallbackReport()
+    public async Task AnalyzeAsync_SchemaViolation_ReturnsFallbackReport()
     {
-        const string invalidJson = "This is not JSON at all";
+        Completes(StructuredCompletionStatus.SchemaViolation);
 
-        _chatClientFactory
-            .CreateAsync("test-workspace", Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-
-        _chatClient
-            .GetResponseAsync(Arg.Any<IList<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, invalidJson)));
-
-        LlmLogAnalyzer analyzer = CreateAnalyzer();
-        List<LogEntry> entries = CreateSampleEntries();
-
-        LogAnalysisReport report = await analyzer.AnalyzeAsync(entries, TestContext.Current.CancellationToken);
+        LogAnalysisReport report = await CreateAnalyzer().AnalyzeAsync(CreateSampleEntries(), TestContext.Current.CancellationToken);
 
         report.Summary.ShouldBe("AI analysis returned a non-JSON response.");
         report.Insights.ShouldBeEmpty();
         report.TotalEntries.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_TransportFailure_Throws()
+    {
+        Completes(StructuredCompletionStatus.TransportFailure);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => CreateAnalyzer().AnalyzeAsync(CreateSampleEntries(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_PassesEntriesAsContent()
+    {
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<LlmAnalysisResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmAnalysisResponse>
+            {
+                Status = StructuredCompletionStatus.Succeeded,
+                Value = new LlmAnalysisResponse { Summary = "ok", Insights = [] },
+            });
+
+        await CreateAnalyzer().AnalyzeAsync(
+            [new LogEntry(DateTimeOffset.UtcNow, "Error", "boom happened", null)], TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Content.ShouldContain("boom happened");
+        captured.WorkspaceName.ShouldBe("test-workspace");
     }
 }

--- a/tests/Granit.Observability.AI.Tests/ObservabilityAIServiceRegistrationTests.cs
+++ b/tests/Granit.Observability.AI.Tests/ObservabilityAIServiceRegistrationTests.cs
@@ -15,7 +15,7 @@ public sealed class ObservabilityAIServiceRegistrationTests
     [Fact]
     public void AddGranitObservabilityAI_should_pass_scope_validation_with_scoped_chat_client_factory()
     {
-        // Regression: LlmLogAnalyzer captures IAIChatClientFactory (scoped). Registering
+        // Regression: LlmLogAnalyzer captures IStructuredCompletion (scoped). Registering
         // the analyzer as singleton breaks ValidateScopes (default in Development).
         HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings
         {
@@ -25,7 +25,7 @@ public sealed class ObservabilityAIServiceRegistrationTests
         builder.Services.AddLogging();
         builder.Services.AddMetrics();
 
-        builder.Services.TryAddScoped(_ => Substitute.For<IAIChatClientFactory>());
+        builder.Services.TryAddScoped(_ => Substitute.For<IStructuredCompletion>());
         builder.Services.TryAddSingleton<ICurrentTenant>(new NullTenantContext());
 
         builder.AddGranitObservabilityAI();


### PR DESCRIPTION
Seventh **F3** migration (Epic #2452, feature #2455) — first of the *system-prompt-fold* group.

`LlmLogAnalyzer` → `CompleteAsync<LlmAnalysisResponse>`. The former **system message** folds into the dev-controlled `Instruction`; log entries are the `Content`. Gains provider-enforced schema, usage tracking, PII-safe errors.

Behaviour preserved exactly:
- Unparseable / refused response → fallback report (`"AI analysis returned a non-JSON response."`).
- **Transport failure or caller-side timeout → records the failure metric and throws** (unchanged contract — this analyzer surfaces transport errors rather than degrading).
- `MaxLogEntries` truncation and `ObservabilityAIMetrics` kept.

13 tests updated (mock; `BuildReport` + `BuildEntriesBlock` replace removed `ParseReport`/`BuildPrompt`; scope-validation regression test now registers a scoped `IStructuredCompletion`). `dotnet format` clean; no new deps.

**Progress: 7/13** (Validation #2460, Authorization #2461, Privacy #2462, BlobStorage #2463, Workflow #2464, Timeline #2465 merged; Observability here). Remaining: LanguageDetection, Indexing (system-prompt fold); reshape outliers (Localization, DataExchange, Notifications, QueryEngine). Non-targets: Imaging (multimodal), Templating + Timeline-summarizer (text-gen).