### PR TITLE
refactor(dataexchange-ai): semantic mapping via IStructuredCompletion (ADR-064)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12889,6 +12889,44 @@
       ]
     },
     {
+      "name": "MappingSuggestionItem",
+      "fqn": "Granit.DataExchange.AI.Schema.MappingSuggestionItem",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/Schema/MappingSuggestionsResponse.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "Source",
+          "kind": "property",
+          "signature": "string Source",
+          "returnType": "string"
+        },
+        {
+          "name": "Target",
+          "kind": "property",
+          "signature": "string Target",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "MappingSuggestionsResponse",
+      "fqn": "Granit.DataExchange.AI.Schema.MappingSuggestionsResponse",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/Schema/MappingSuggestionsResponse.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Mappings",
+          "kind": "property",
+          "signature": "List<MappingSuggestionItem> Mappings",
+          "returnType": "List<MappingSuggestionItem>"
+        }
+      ]
+    },
+    {
       "name": "ServiceCollectionExtensions",
       "fqn": "Granit.DataExchange.BlobStorage.Extensions.ServiceCollectionExtensions",
       "kind": "class",

--- a/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
+++ b/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
@@ -1,34 +1,37 @@
+using System.Globalization;
 using System.Text;
-using System.Text.Json;
 using Granit.AI;
-using Granit.AI.Internal;
 using Granit.DataExchange.AI.Options;
+using Granit.DataExchange.AI.Schema;
 using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.DataExchange.AI.Internal;
 
 /// <summary>
-/// AI-powered implementation of <see cref="ISemanticMappingService"/> that uses
-/// an LLM via <see cref="IAIChatClientFactory"/> to suggest column-to-property mappings.
+/// AI-powered implementation of <see cref="ISemanticMappingService"/> that suggests
+/// column-to-property mappings via the <see cref="IStructuredCompletion"/> primitive (ADR-064).
 /// </summary>
 /// <remarks>
-/// Only column headers and field metadata are sent to the LLM — never business data (GDPR safe).
-/// On failure, gracefully degrades to an empty result set.
+/// <para>
+/// Only column headers and (opt-in) preview rows travel as untrusted
+/// <see cref="StructuredCompletionRequest.Content"/>; the developer-controlled target schema and
+/// confidence threshold are the <see cref="StructuredCompletionRequest.Instruction"/>. By default
+/// no business data is sent (headers-only mode, GDPR-safe).
+/// </para>
+/// <para>
+/// On any non-success outcome the service gracefully degrades to an empty result set. Returned
+/// mappings are intersected with the known source columns and target properties, so a model that
+/// invents or echoes an out-of-schema name contributes nothing.
+/// </para>
 /// </remarks>
 internal sealed partial class AISemanticMappingService(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     IOptions<DataExchangeAIOptions> options,
     ILogger<AISemanticMappingService> logger) : ISemanticMappingService
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     /// <inheritdoc/>
     public bool IsAvailable => true;
 
@@ -56,77 +59,75 @@ internal sealed partial class AISemanticMappingService(
 
         DataExchangeAIOptions opts = options.Value;
 
-        // Only include preview rows if the option is explicitly enabled (GDPR opt-in)
-        // Truncate to configured limit to prevent unbounded prompt size.
+        // Only include preview rows if the option is explicitly enabled (GDPR opt-in),
+        // truncated to the configured limit to bound prompt size.
         IReadOnlyList<string[]>? effectivePreview = GetEffectivePreview(opts, previewRows);
 
         using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(opts.TimeoutSeconds));
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
+        var request = new StructuredCompletionRequest
+        {
+            Instruction = BuildInstruction(targetFields, opts.MinConfidenceScore),
+            Content = BuildContent(headers, effectivePreview),
+            ContentLabel = "Import sample",
+            WorkspaceName = opts.WorkspaceName,
+        };
+
         try
         {
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient chatClient = await chatClientFactory
-                .CreateAsync(opts.WorkspaceName, linkedCts.Token)
+            StructuredCompletionResult<MappingSuggestionsResponse> result = await structuredCompletion
+                .CompleteAsync<MappingSuggestionsResponse>(request, linkedCts.Token)
                 .ConfigureAwait(false);
 
-            string prompt = BuildPrompt(headers, targetFields, opts.MinConfidenceScore, effectivePreview);
+            if (result.Status != StructuredCompletionStatus.Succeeded)
+            {
+                LogSemanticMappingRejected(result.Status.ToString());
+                return [];
+            }
 
-            ChatResponse response = await chatClient
-                .GetResponseAsync(prompt, cancellationToken: linkedCts.Token)
-                .ConfigureAwait(false);
-
-            string responseText = response.Text ?? string.Empty;
-
-            LogLlmResponseReceived(responseText.Length);
-
-            IReadOnlyList<SemanticMappingSuggestion> suggestions = ParseSuggestions(responseText);
-
-            // Validate LLM output against known properties and headers.
-            HashSet<string> validTargets = new(targetFields.Select(f => f.PropertyPath), StringComparer.OrdinalIgnoreCase);
-            HashSet<string> validSources = new(headers, StringComparer.OrdinalIgnoreCase);
-
-            var filtered = suggestions
-                .Where(s => s.Score >= opts.MinConfidenceScore
-                            && validTargets.Contains(s.TargetProperty)
-                            && validSources.Contains(s.SourceColumn))
-                .OrderByDescending(s => s.Score)
-                .ToList();
-
-            LogSuggestionsFiltered(suggestions.Count, filtered.Count, opts.MinConfidenceScore);
-
-            return filtered;
+            return Filter(result.Value!, headers, targetFields, opts.MinConfidenceScore);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
-            LogSemanticMappingFailed(ex);
+            LogSemanticMappingTimeout(opts.TimeoutSeconds);
             return [];
         }
     }
 
-    internal static string BuildPrompt(
+    /// <summary>
+    /// Projects the schema-pinned response onto the public surface: clamps scores, drops
+    /// below-threshold and out-of-schema entries, and orders by descending confidence.
+    /// </summary>
+    private List<SemanticMappingSuggestion> Filter(
+        MappingSuggestionsResponse response,
         IReadOnlyList<string> headers,
         IReadOnlyList<ImportFieldMetadata> targetFields,
-        double minConfidenceScore,
-        IReadOnlyList<string[]>? previewRows = null)
+        double minConfidenceScore)
+    {
+        HashSet<string> validTargets = new(targetFields.Select(f => f.PropertyPath), StringComparer.OrdinalIgnoreCase);
+        HashSet<string> validSources = new(headers, StringComparer.OrdinalIgnoreCase);
+
+        var filtered = response.Mappings
+            .Where(m => !string.IsNullOrEmpty(m.Source) && !string.IsNullOrEmpty(m.Target))
+            .Select(m => new SemanticMappingSuggestion(m.Source, m.Target, Math.Clamp(m.Score, 0.0, 1.0)))
+            .Where(s => s.Score >= minConfidenceScore
+                        && validTargets.Contains(s.TargetProperty)
+                        && validSources.Contains(s.SourceColumn))
+            .OrderByDescending(s => s.Score)
+            .ToList();
+
+        LogSuggestionsFiltered(response.Mappings.Count, filtered.Count, minConfidenceScore);
+
+        return filtered;
+    }
+
+    private static string BuildInstruction(IReadOnlyList<ImportFieldMetadata> targetFields, double minConfidenceScore)
     {
         var sb = new StringBuilder();
 
-        sb.AppendLine("You are a data mapping assistant. Match source CSV/Excel columns to target entity properties.");
-        sb.AppendLine();
-
-        // Wrap user-controlled headers in a PromptBuilder data block
-        var headerPb = new PromptBuilder(maxInputLength: 10_000);
-        headerPb.AppendUserDataMap("Source columns", headers.Select(h => new KeyValuePair<string, string?>(h, null)));
-        sb.Append(headerPb.Build());
-
-        // Include preview rows when provided (opt-in, caller is responsible for GDPR compliance)
-        if (previewRows is { Count: > 0 })
-        {
-            AppendPreviewTable(sb, headers, previewRows);
-        }
-
+        sb.AppendLine("You are a data-mapping assistant. Match the source columns in the data block to the");
+        sb.AppendLine("target entity properties below, assigning each match a confidence score from 0.0 to 1.0.");
         sb.AppendLine();
         sb.AppendLine("Target properties:");
         sb.AppendLine("| Property | Type | Display Name | Description | Required |");
@@ -148,14 +149,27 @@ internal sealed partial class AISemanticMappingService(
         }
 
         sb.AppendLine();
-        sb.AppendLine("Return a JSON array of mappings. Each mapping has:");
-        sb.AppendLine("""- "source": exact source column name""");
-        sb.AppendLine("""- "target": exact target property path""");
-        sb.AppendLine("""- "score": confidence score 0.0 to 1.0""");
-        sb.AppendLine();
-        sb.Append($"Only include confident matches (score >= {minConfidenceScore:F1}). ");
-        sb.AppendLine("Return [] if no good matches found.");
-        sb.AppendLine("Return ONLY the JSON array, no markdown fences or extra text.");
+        sb.Append(CultureInfo.InvariantCulture, $"Only include confident matches (score >= {minConfidenceScore:F1}); ");
+        sb.AppendLine("use the exact source-column and target-property names. Return no mapping for columns you cannot place.");
+
+        return sb.ToString();
+    }
+
+    private static string BuildContent(IReadOnlyList<string> headers, IReadOnlyList<string[]>? previewRows)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("Source columns:");
+        foreach (string header in headers)
+        {
+            sb.Append("- ");
+            sb.AppendLine(SanitizeCellValue(header));
+        }
+
+        if (previewRows is { Count: > 0 })
+        {
+            AppendPreviewTable(sb, headers, previewRows);
+        }
 
         return sb.ToString();
     }
@@ -164,7 +178,7 @@ internal sealed partial class AISemanticMappingService(
     {
         sb.AppendLine();
         sb.AppendLine("Sample data (first rows):");
-        sb.AppendLine("| " + string.Join(" | ", headers) + " |");
+        sb.AppendLine("| " + string.Join(" | ", headers.Select(SanitizeCellValue)) + " |");
         sb.AppendLine("| " + string.Join(" | ", headers.Select(_ => "---")) + " |");
 
         foreach (string[] row in previewRows)
@@ -181,59 +195,12 @@ internal sealed partial class AISemanticMappingService(
         }
     }
 
-    internal static IReadOnlyList<SemanticMappingSuggestion> ParseSuggestions(string responseText)
-    {
-        string trimmed = LlmResponseHelper.StripMarkdownCodeFences(responseText);
-
-        // Find the JSON array boundaries
-        int startIndex = trimmed.IndexOf('[');
-        int endIndex = trimmed.LastIndexOf(']');
-
-        if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex)
-        {
-            return [];
-        }
-
-        string jsonArray = trimmed[startIndex..(endIndex + 1)];
-
-        List<MappingDto>? dtos = JsonSerializer.Deserialize<List<MappingDto>>(jsonArray, JsonOptions);
-
-        if (dtos is null)
-        {
-            return [];
-        }
-
-        return dtos
-            .Where(d => d.Source is not null && d.Target is not null)
-            .Select(d => new SemanticMappingSuggestion(d.Source!, d.Target!, Math.Clamp(d.Score, 0.0, 1.0)))
-            .ToList();
-    }
-
     private static string SanitizeCellValue(string value) =>
         value.Replace("<", "&lt;", StringComparison.Ordinal)
              .Replace(">", "&gt;", StringComparison.Ordinal)
              .Replace("|", "\\|", StringComparison.Ordinal)
              .Replace("\n", " ", StringComparison.Ordinal)
              .Replace("\r", " ", StringComparison.Ordinal);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "LLM response received for semantic mapping ({ResponseLength} chars)")]
-    private partial void LogLlmResponseReceived(int responseLength);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Semantic mapping: {TotalCount} suggestions from LLM, {FilteredCount} after filtering (min score: {MinScore:F2})")]
-    private partial void LogSuggestionsFiltered(int totalCount, int filteredCount, double minScore);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "AI semantic mapping failed, returning empty suggestions (graceful degradation)")]
-    private partial void LogSemanticMappingFailed(Exception exception);
-
-    /// <summary>
-    /// Internal DTO for deserializing the LLM JSON response.
-    /// </summary>
-    internal sealed class MappingDto
-    {
-        public string? Source { get; set; }
-        public string? Target { get; set; }
-        public double Score { get; set; }
-    }
 
     private static IReadOnlyList<string[]>? GetEffectivePreview(
         DataExchangeAIOptions opts, IReadOnlyList<string[]>? previewRows)
@@ -247,4 +214,13 @@ internal sealed partial class AISemanticMappingService(
             ? previewRows
             : previewRows.Take(opts.PreviewRowCount).ToList();
     }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Semantic mapping: {TotalCount} suggestions from LLM, {FilteredCount} after filtering (min score: {MinScore:F2})")]
+    private partial void LogSuggestionsFiltered(int totalCount, int filteredCount, double minScore);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI semantic mapping rejected (status: {Status}), returning empty suggestions (graceful degradation)")]
+    private partial void LogSemanticMappingRejected(string status);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI semantic mapping timed out after {TimeoutSeconds}s, returning empty suggestions (graceful degradation)")]
+    private partial void LogSemanticMappingTimeout(int timeoutSeconds);
 }

--- a/src/Granit.DataExchange.AI/Schema/MappingSuggestionsResponse.cs
+++ b/src/Granit.DataExchange.AI/Schema/MappingSuggestionsResponse.cs
@@ -1,0 +1,32 @@
+namespace Granit.DataExchange.AI.Schema;
+
+/// <summary>
+/// JSON-schema-pinned response shape for the AI semantic mapper. The LLM is constrained via
+/// <c>ChatResponseFormat.ForJsonSchema&lt;MappingSuggestionsResponse&gt;()</c> (ADR-064). The
+/// suggestions are wrapped in this fixed object rather than returned as a root-level array,
+/// because provider-enforced strict schema rejects a top-level array.
+/// </summary>
+public sealed class MappingSuggestionsResponse
+{
+    /// <summary>
+    /// Proposed column-to-property mappings. The service validates each entry against the
+    /// known source columns and target properties and drops anything outside that universe,
+    /// so a model that invents a column or property contributes nothing.
+    /// </summary>
+    public List<MappingSuggestionItem> Mappings { get; set; } = [];
+}
+
+/// <summary>
+/// A single source-column → target-property mapping inside a <see cref="MappingSuggestionsResponse"/>.
+/// </summary>
+public sealed class MappingSuggestionItem
+{
+    /// <summary>Exact source column name from the imported file.</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Exact target property path on the destination entity.</summary>
+    public string Target { get; set; } = string.Empty;
+
+    /// <summary>Model confidence in the mapping, clamped to <c>0.0..1.0</c> by the service.</summary>
+    public double Score { get; set; }
+}

--- a/src/Granit.DataExchange/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.DataExchange/Extensions/ServiceCollectionExtensions.cs
@@ -134,6 +134,10 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Replaces the default <see cref="ISemanticMappingService"/> with an AI-backed implementation.
     /// </summary>
+    /// <remarks>
+    /// Registered <b>Scoped</b>: realistic implementations call the scoped
+    /// <c>IStructuredCompletion</c> primitive (ADR-064), so a singleton here would capture a stale scope.
+    /// </remarks>
     /// <typeparam name="TService">The semantic mapping service implementation.</typeparam>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
@@ -141,7 +145,7 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services)
         where TService : class, ISemanticMappingService
     {
-        services.Replace(ServiceDescriptor.Singleton<ISemanticMappingService, TService>());
+        services.Replace(ServiceDescriptor.Scoped<ISemanticMappingService, TService>());
         return services;
     }
 }

--- a/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
+++ b/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
@@ -1,22 +1,18 @@
 using Granit.AI;
 using Granit.DataExchange.AI.Internal;
 using Granit.DataExchange.AI.Options;
+using Granit.DataExchange.AI.Schema;
 using Granit.DataExchange.Import;
 using Granit.DataExchange.Import.Mapping;
-using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
 
 namespace Granit.DataExchange.AI.Tests;
 
 public sealed class AISemanticMappingServiceTests
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
-    private readonly ILogger<AISemanticMappingService> _logger = NullLogger<AISemanticMappingService>.Instance;
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
 
     private readonly DataExchangeAIOptions _options = new()
     {
@@ -35,94 +31,48 @@ public sealed class AISemanticMappingServiceTests
     ];
 
     private AISemanticMappingService CreateService() =>
-        new(_chatClientFactory, Microsoft.Extensions.Options.Options.Create(_options), _logger);
+        new(_structured, Microsoft.Extensions.Options.Options.Create(_options), NullLogger<AISemanticMappingService>.Instance);
 
-    private void SetupChatClient(string jsonResponse)
-    {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
+    private static StructuredCompletionResult<MappingSuggestionsResponse> Ok(params (string Source, string Target, double Score)[] items) =>
+        new()
+        {
+            Status = StructuredCompletionStatus.Succeeded,
+            Value = new MappingSuggestionsResponse
+            {
+                Mappings = [.. items.Select(i => new MappingSuggestionItem { Source = i.Source, Target = i.Target, Score = i.Score })],
+            },
+        };
 
-        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
-    }
-
-    [Fact]
-    public void IsAvailable_ReturnsTrue()
-    {
-        AISemanticMappingService service = CreateService();
-
-        service.IsAvailable.ShouldBeTrue();
-    }
+    private void Respond(StructuredCompletionResult<MappingSuggestionsResponse> result) =>
+        _structured
+            .CompleteAsync<MappingSuggestionsResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(result);
 
     [Fact]
-    public async Task SuggestSemanticMappingsAsync_WithValidResponse_ReturnsMappings()
+    public void IsAvailable_ReturnsTrue() => CreateService().IsAvailable.ShouldBeTrue();
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithValidResponse_ReturnsMappingsSortedByScoreDescending()
     {
-        const string jsonResponse = """
-            [
-                {"source": "Email", "target": "Email", "score": 0.95},
-                {"source": "Full Name", "target": "FullName", "score": 0.90},
-                {"source": "Phone Number", "target": "PhoneNumber", "score": 0.85}
-            ]
-            """;
+        Respond(Ok(("Full Name", "FullName", 0.90), ("Email", "Email", 0.95), ("Phone Number", "PhoneNumber", 0.85)));
 
-        SetupChatClient(jsonResponse);
-
-        AISemanticMappingService service = CreateService();
-
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
             .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(3);
         result[0].SourceColumn.ShouldBe("Email");
         result[0].TargetProperty.ShouldBe("Email");
         result[0].Score.ShouldBe(0.95);
-        result[1].SourceColumn.ShouldBe("Full Name");
-        result[1].TargetProperty.ShouldBe("FullName");
-        result[2].SourceColumn.ShouldBe("Phone Number");
-        result[2].TargetProperty.ShouldBe("PhoneNumber");
-
-        // Should be sorted by score descending
         result[0].Score.ShouldBeGreaterThanOrEqualTo(result[1].Score);
         result[1].Score.ShouldBeGreaterThanOrEqualTo(result[2].Score);
     }
 
     [Fact]
-    public async Task SuggestSemanticMappingsAsync_WithLLMFailure_ReturnsEmptyList()
-    {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("LLM provider unavailable"));
-
-        AISemanticMappingService service = CreateService();
-
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
-            .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
-    }
-
-    [Fact]
     public async Task SuggestSemanticMappingsAsync_FiltersLowConfidence()
     {
-        const string jsonResponse = """
-            [
-                {"source": "Email", "target": "Email", "score": 0.95},
-                {"source": "Full Name", "target": "FullName", "score": 0.40},
-                {"source": "Phone Number", "target": "PhoneNumber", "score": 0.55}
-            ]
-            """;
+        Respond(Ok(("Email", "Email", 0.95), ("Full Name", "FullName", 0.40), ("Phone Number", "PhoneNumber", 0.55)));
 
-        SetupChatClient(jsonResponse);
-
-        AISemanticMappingService service = CreateService();
-
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
             .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(1);
@@ -131,151 +81,114 @@ public sealed class AISemanticMappingServiceTests
     }
 
     [Fact]
-    public async Task SuggestSemanticMappingsAsync_WithEmptyHeaders_ReturnsEmptyList()
+    public async Task SuggestSemanticMappingsAsync_DropsMappingsOutsideTheKnownSchema()
     {
-        AISemanticMappingService service = CreateService();
+        // Model invents a source column and a target property nobody supplied — both discarded.
+        Respond(Ok(("Email", "Email", 0.95), ("Ghost Column", "FullName", 0.99), ("Phone Number", "GhostProperty", 0.99)));
 
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
-            .SuggestSemanticMappingsAsync([], _targetFields, TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public async Task SuggestSemanticMappingsAsync_WithEmptyTargetFields_ReturnsEmptyList()
-    {
-        AISemanticMappingService service = CreateService();
-
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
-            .SuggestSemanticMappingsAsync(_headers, [], TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public async Task SuggestSemanticMappingsAsync_WithMarkdownFencedResponse_ParsesCorrectly()
-    {
-        const string jsonResponse = """
-            ```json
-            [
-                {"source": "Email", "target": "Email", "score": 0.95}
-            ]
-            ```
-            """;
-
-        SetupChatClient(jsonResponse);
-
-        AISemanticMappingService service = CreateService();
-
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
             .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(1);
         result[0].SourceColumn.ShouldBe("Email");
     }
 
-    [Fact]
-    public void BuildPrompt_ContainsHeadersAndFields()
+    [Theory]
+    [InlineData(StructuredCompletionStatus.ModelRefused)]
+    [InlineData(StructuredCompletionStatus.SchemaViolation)]
+    [InlineData(StructuredCompletionStatus.TransportFailure)]
+    public async Task SuggestSemanticMappingsAsync_NonSuccessStatus_ReturnsEmptyList(StructuredCompletionStatus status)
     {
-        string prompt = AISemanticMappingService.BuildPrompt(_headers, _targetFields, 0.6);
+        Respond(new StructuredCompletionResult<MappingSuggestionsResponse> { Status = status });
 
-        prompt.ShouldContain("Email");
-        prompt.ShouldContain("Full Name");
-        prompt.ShouldContain("Phone Number");
-        prompt.ShouldContain("Email Address");
-        prompt.ShouldContain("The user's email");
-        prompt.ShouldContain("FullName");
-        prompt.ShouldContain("PhoneNumber");
-        prompt.ShouldContain("0.6");
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
+            .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void BuildPrompt_WithPreviewRows_IncludesSampleData()
+    public async Task SuggestSemanticMappingsAsync_WithEmptyHeaders_ReturnsEmptyWithoutCallingTheModel()
     {
-        IReadOnlyList<string[]> previewRows =
-        [
-            ["john@example.com", "John Doe", "+32 123 456"],
-            ["jane@example.com", "Jane Smith", "+32 789 012"],
-        ];
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
+            .SuggestSemanticMappingsAsync([], _targetFields, TestContext.Current.CancellationToken);
 
-        string prompt = AISemanticMappingService.BuildPrompt(_headers, _targetFields, 0.6, previewRows);
-
-        prompt.ShouldContain("Sample data (first rows):");
-        prompt.ShouldContain("john@example.com");
-        prompt.ShouldContain("Jane Smith");
+        result.ShouldBeEmpty();
+        await _structured
+            .DidNotReceiveWithAnyArgs()
+            .CompleteAsync<MappingSuggestionsResponse>(default!, TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public void BuildPrompt_WithoutPreviewRows_DoesNotContainSampleData()
+    public async Task SuggestSemanticMappingsAsync_WithEmptyTargetFields_ReturnsEmptyWithoutCallingTheModel()
     {
-        string prompt = AISemanticMappingService.BuildPrompt(_headers, _targetFields, 0.6, previewRows: null);
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
+            .SuggestSemanticMappingsAsync(_headers, [], TestContext.Current.CancellationToken);
 
-        prompt.ShouldNotContain("Sample data");
+        result.ShouldBeEmpty();
+        await _structured
+            .DidNotReceiveWithAnyArgs()
+            .CompleteAsync<MappingSuggestionsResponse>(default!, TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public async Task SuggestSemanticMappingsAsync_WithPreviewRows_IgnoredWhenOptionDisabled()
+    public async Task SuggestSemanticMappingsAsync_RoutesHeadersAndTargetSchemaThroughTheRightChannels()
+    {
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<MappingSuggestionsResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Ok(("Email", "Email", 0.95)));
+
+        await CreateService().SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        // Untrusted source columns flow through the sanitized Content channel...
+        captured.Content.ShouldContain("Email");
+        captured.Content.ShouldContain("Phone Number");
+        // ...the developer-controlled target schema is the instruction.
+        captured.Instruction.ShouldNotBeNull();
+        captured.Instruction.ShouldContain("FullName");
+        captured.Instruction.ShouldContain("Email Address");
+        captured.WorkspaceName.ShouldBe("test-workspace");
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_PreviewRows_OmittedFromContentWhenOptionDisabled()
     {
         _options.IncludePreviewRows = false;
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<MappingSuggestionsResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Ok(("COL1", "Email", 0.9)));
 
-        const string jsonResponse = """[{"source": "COL1", "target": "Email", "score": 0.9}]""";
-        SetupChatClient(jsonResponse);
-
-        AISemanticMappingService service = CreateService();
         IReadOnlyList<string[]> previewRows = [["john@example.com"]];
 
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
             .SuggestSemanticMappingsAsync(["COL1"], _targetFields, previewRows, TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(1);
-
-        // Verify the prompt does NOT contain sample data (option is disabled)
-        await _chatClient.Received(1).GetResponseAsync(
-            Arg.Is<IEnumerable<ChatMessage>>(msgs =>
-                !string.Join("", msgs.Select(m => m.Text)).Contains("Sample data")),
-            Arg.Any<ChatOptions?>(),
-            Arg.Any<CancellationToken>());
+        captured.ShouldNotBeNull();
+        captured.Content.ShouldNotContain("Sample data");
+        captured.Content.ShouldNotContain("john@example.com");
     }
 
     [Fact]
-    public async Task SuggestSemanticMappingsAsync_WithPreviewRows_IncludedWhenOptionEnabled()
+    public async Task SuggestSemanticMappingsAsync_PreviewRows_IncludedInContentWhenOptionEnabled()
     {
         _options.IncludePreviewRows = true;
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<MappingSuggestionsResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Ok(("COL1", "Email", 0.9)));
 
-        const string jsonResponse = """[{"source": "COL1", "target": "Email", "score": 0.9}]""";
-        SetupChatClient(jsonResponse);
-
-        AISemanticMappingService service = CreateService();
         IReadOnlyList<string[]> previewRows = [["john@example.com"]];
 
-        IReadOnlyList<SemanticMappingSuggestion> result = await service
+        IReadOnlyList<SemanticMappingSuggestion> result = await CreateService()
             .SuggestSemanticMappingsAsync(["COL1"], _targetFields, previewRows, TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(1);
-
-        // Verify the prompt DOES contain sample data
-        await _chatClient.Received(1).GetResponseAsync(
-            Arg.Is<IEnumerable<ChatMessage>>(msgs =>
-                string.Join("", msgs.Select(m => m.Text)).Contains("Sample data")),
-            Arg.Any<ChatOptions?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public void ParseSuggestions_WithInvalidJson_ReturnsEmptyList()
-    {
-        IReadOnlyList<SemanticMappingSuggestion> result =
-            AISemanticMappingService.ParseSuggestions("not valid json");
-
-        result.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void ParseSuggestions_WithEmptyArray_ReturnsEmptyList()
-    {
-        IReadOnlyList<SemanticMappingSuggestion> result =
-            AISemanticMappingService.ParseSuggestions("[]");
-
-        result.ShouldBeEmpty();
+        captured.ShouldNotBeNull();
+        captured.Content.ShouldContain("Sample data");
+        captured.Content.ShouldContain("john@example.com");
     }
 }


### PR DESCRIPTION
## What

Migrates `Granit.DataExchange.AI` (`AISemanticMappingService`) off the hand-rolled `IAIChatClientFactory` + manual JSON parsing onto the **`IStructuredCompletion`** primitive (ADR-064, Epic #2452).

Second of the four **reshape outliers**.

## Reshape

The root-level mapping array — which provider-enforced strict schema rejects — is wrapped in a fixed object:

```jsonc
{ "mappings": [ { "source": "Email", "target": "Email", "score": 0.95 }, ... ] }
```

`MappingSuggestionsResponse { List<MappingSuggestionItem> Mappings }` is pinned via `ChatResponseFormat.ForJsonSchema<T>()` inside the primitive.

## Security / robustness

- Untrusted **source columns + opt-in preview rows** travel as sanitized `Content` (GDPR headers-only default unchanged); the developer-controlled **target schema + confidence threshold** are the `Instruction`.
- Returned mappings are **intersected with the known source columns and target properties** and score-clamped — a model that invents or echoes an out-of-schema name contributes nothing (server-side validation). Below-threshold matches dropped, ordering by descending score preserved.
- Four-valued status: `ModelRefused` / `SchemaViolation` / `TransportFailure` → graceful **empty list**; caller cancellation propagates while the internal timeout yields `[]`.

## Lifetime fix

`AddSemanticMappingService<T>` (base `Granit.DataExchange`) switched **Singleton → Scoped**: the realistic implementation depends on the scoped primitive, so a singleton captures a stale scope. The null-object default stays singleton (stateless).

## Tests

22 AI tests + 353 base `Granit.DataExchange` tests green. Dropped the now-obsolete `BuildPrompt` / `ParseSuggestions` / markdown-fence cases (parsing owned by the primitive); added status-mapping, out-of-schema rejection, and Content/Instruction channel-routing assertions (incl. GDPR preview opt-in/out via the captured request).

`dotnet build` + `dotnet test` green, `dotnet format --verify-no-changes` clean.

Part of Epic #2452 / ADR-064.