### PR TITLE
refactor(notifications-ai): channel selection + content gen via IStructuredCompletion (ADR-064)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -30883,6 +30883,44 @@
       ]
     },
     {
+      "name": "ChannelSelectionResponse",
+      "fqn": "Granit.Notifications.AI.Schema.ChannelSelectionResponse",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/Schema/ChannelSelectionResponse.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Channels",
+          "kind": "property",
+          "signature": "List<string> Channels",
+          "returnType": "List<string>"
+        }
+      ]
+    },
+    {
+      "name": "NotificationContentResponse",
+      "fqn": "Granit.Notifications.AI.Schema.NotificationContentResponse",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/Schema/NotificationContentResponse.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Subject",
+          "kind": "property",
+          "signature": "string Subject",
+          "returnType": "string"
+        },
+        {
+          "name": "Body",
+          "kind": "property",
+          "signature": "string Body",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "INotificationChannel",
       "fqn": "Granit.Notifications.Abstractions.INotificationChannel",
       "kind": "interface",

--- a/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
@@ -34,8 +34,10 @@ public static class NotificationsAIHostApplicationBuilderExtensions
             .AddOptions<NotificationsAIOptions>()
             .BindConfiguration(NotificationsAIOptions.SectionName);
 
-        builder.Services.AddSingleton<IAINotificationContentGenerator, LlmNotificationContentGenerator>();
-        builder.Services.AddSingleton<IAIChannelSelector, LlmChannelSelector>();
+        // Scoped, not singleton: both depend on the scoped IStructuredCompletion primitive
+        // (ADR-064), so a singleton here would capture a stale scope.
+        builder.Services.AddScoped<IAINotificationContentGenerator, LlmNotificationContentGenerator>();
+        builder.Services.AddScoped<IAIChannelSelector, LlmChannelSelector>();
 
         return builder;
     }

--- a/src/Granit.Notifications.AI/Internal/LlmChannelSelector.cs
+++ b/src/Granit.Notifications.AI/Internal/LlmChannelSelector.cs
@@ -1,25 +1,23 @@
+using System.Globalization;
 using System.Text.Json;
 using Granit.AI;
 using Granit.Notifications.AI.Options;
-using Microsoft.Extensions.AI;
+using Granit.Notifications.AI.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.AI.Internal;
 
 /// <summary>
-/// LLM-based channel selector that recommends optimal delivery channels based on context analysis.
+/// LLM-based channel selector that recommends optimal delivery channels via the
+/// <see cref="IStructuredCompletion"/> primitive (ADR-064). Falls back to the full available
+/// channel list whenever the model is unavailable or returns nothing usable.
 /// </summary>
 internal sealed partial class LlmChannelSelector(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     IOptions<NotificationsAIOptions> options,
     ILogger<LlmChannelSelector> logger) : IAIChannelSelector
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     /// <inheritdoc/>
     public async Task<IReadOnlyList<string>> SelectChannelsAsync(
         NotificationDeliveryContext context,
@@ -36,109 +34,69 @@ internal sealed partial class LlmChannelSelector(
 
         NotificationsAIOptions config = options.Value;
 
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        var request = new StructuredCompletionRequest
+        {
+            Instruction = BuildInstruction(availableChannels),
+            Content = BuildContent(context),
+            ContentLabel = "Notification",
+            WorkspaceName = config.WorkspaceName,
+        };
+
         try
         {
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient chatClient = await chatClientFactory
-                .CreateAsync(config.WorkspaceName, cancellationToken)
+            StructuredCompletionResult<ChannelSelectionResponse> result = await structuredCompletion
+                .CompleteAsync<ChannelSelectionResponse>(request, linkedCts.Token)
                 .ConfigureAwait(false);
 
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken, timeoutCts.Token);
+            if (result.Status != StructuredCompletionStatus.Succeeded)
+            {
+                LogChannelSelectionRejected(logger, context.NotificationTypeName, result.Status.ToString());
+                return availableChannels;
+            }
 
-            string prompt = BuildChannelSelectionPrompt(context, availableChannels);
+            List<string> selected = FilterToAvailable(result.Value!.Channels, availableChannels);
 
-            ChatResponse response = await chatClient.GetResponseAsync(
-                prompt, cancellationToken: linkedCts.Token).ConfigureAwait(false);
-
-            string responseText = response.Text ?? string.Empty;
-
-            IReadOnlyList<string> selected = ParseChannelSelectionResponse(responseText, availableChannels);
-
+            // Default-to-all: an empty (or fully-rejected) recommendation must not silently drop delivery.
             return selected.Count > 0 ? selected : availableChannels;
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             LogChannelSelectionTimeout(logger, context.NotificationTypeName, config.TimeoutSeconds);
             return availableChannels;
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            LogChannelSelectionFailure(logger, context.NotificationTypeName, ex);
-            return availableChannels;
-        }
     }
 
-    internal static string BuildChannelSelectionPrompt(
-        NotificationDeliveryContext context,
-        IReadOnlyList<string> availableChannels)
+    private static List<string> FilterToAvailable(List<string> selected, IReadOnlyList<string> availableChannels)
+    {
+        HashSet<string> availableSet = new(availableChannels, StringComparer.OrdinalIgnoreCase);
+        return selected.Where(availableSet.Contains).ToList();
+    }
+
+    private static string BuildInstruction(IReadOnlyList<string> availableChannels)
     {
         string channelsJson = JsonSerializer.Serialize(availableChannels);
 
-        var pb = new PromptBuilder(maxInputLength: 5_000);
-
-        pb.AppendInstruction($"""
-            Recommend the optimal delivery channels from this list: {channelsJson}.
-            Return JSON only, no markdown fences: an array of channel names, e.g. ["email", "push"].
-            Only include channels from the available list. Order by priority (most important first).
+        return $"""
+            Recommend the optimal delivery channels for the notification described in the data block,
+            choosing only from this available list: {channelsJson}.
+            Order the result by priority (most important first) and include only channels from that list.
             For critical/fatal severity, prefer all real-time channels. For info, prefer less intrusive channels.
+            """;
+    }
+
+    private static string BuildContent(NotificationDeliveryContext context) =>
+        string.Create(CultureInfo.InvariantCulture, $"""
+            Notification type: {context.NotificationTypeName}
+            Severity: {context.Severity}
+            Time: {context.OccurredAt:O}
             """);
 
-        pb.AppendUserData("Notification type", context.NotificationTypeName);
-        pb.AppendUserData("Severity", context.Severity.ToString());
-        pb.AppendUserData("Time", context.OccurredAt.ToString("O"));
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI channel selection rejected (status: {Status}) for type '{NotificationTypeName}', falling back to all channels")]
+    private static partial void LogChannelSelectionRejected(ILogger logger, string notificationTypeName, string status);
 
-        return pb.Build();
-    }
-
-    internal static IReadOnlyList<string> ParseChannelSelectionResponse(
-        string responseText,
-        IReadOnlyList<string> availableChannels)
-    {
-        string trimmed = responseText.Trim();
-
-        // Strip markdown code fences if the LLM wraps the JSON anyway
-        if (trimmed.StartsWith("```", StringComparison.Ordinal))
-        {
-            int firstNewline = trimmed.IndexOf('\n');
-            int lastFence = trimmed.LastIndexOf("```", StringComparison.Ordinal);
-            if (firstNewline >= 0 && lastFence > firstNewline)
-            {
-                trimmed = trimmed[(firstNewline + 1)..lastFence].Trim();
-            }
-        }
-
-        try
-        {
-            List<string>? parsed = JsonSerializer.Deserialize<List<string>>(trimmed, JsonOptions);
-
-            if (parsed is null || parsed.Count == 0)
-            {
-                return [];
-            }
-
-            // Only keep channels that are actually available (case-insensitive)
-            HashSet<string> availableSet = new(availableChannels, StringComparer.OrdinalIgnoreCase);
-
-            return parsed
-                .Where(c => availableSet.Contains(c))
-                .ToList();
-        }
-        catch (JsonException)
-        {
-            return [];
-        }
-    }
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "AI channel selection timed out after {TimeoutSeconds}s for type '{NotificationTypeName}'")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI channel selection timed out after {TimeoutSeconds}s for type '{NotificationTypeName}', falling back to all channels")]
     private static partial void LogChannelSelectionTimeout(ILogger logger, string notificationTypeName, int timeoutSeconds);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "AI channel selection failed for type '{NotificationTypeName}'")]
-    private static partial void LogChannelSelectionFailure(ILogger logger, string notificationTypeName, Exception exception);
 }

--- a/src/Granit.Notifications.AI/Internal/LlmNotificationContentGenerator.cs
+++ b/src/Granit.Notifications.AI/Internal/LlmNotificationContentGenerator.cs
@@ -1,26 +1,22 @@
 using System.Text.Json;
 using Granit.AI;
-using Granit.AI.Internal;
 using Granit.Notifications.AI.Options;
-using Microsoft.Extensions.AI;
+using Granit.Notifications.AI.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.AI.Internal;
 
 /// <summary>
-/// LLM-based notification content generator that produces localized subject and body text.
+/// LLM-based notification content generator that produces a localized subject and body via the
+/// <see cref="IStructuredCompletion"/> primitive (ADR-064). Returns <c>null</c> on any non-success
+/// outcome so callers fall back to template-based content.
 /// </summary>
 internal sealed partial class LlmNotificationContentGenerator(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     IOptions<NotificationsAIOptions> options,
     ILogger<LlmNotificationContentGenerator> logger) : IAINotificationContentGenerator
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     /// <inheritdoc/>
     public async Task<NotificationContent?> GenerateAsync(
         NotificationDeliveryContext context,
@@ -30,93 +26,66 @@ internal sealed partial class LlmNotificationContentGenerator(
 
         NotificationsAIOptions config = options.Value;
 
-        try
-        {
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient chatClient = await chatClientFactory
-                .CreateAsync(config.WorkspaceName, cancellationToken)
-                .ConfigureAwait(false);
-
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken, timeoutCts.Token);
-
-            string prompt = BuildContentPrompt(context);
-
-            ChatResponse response = await chatClient.GetResponseAsync(
-                prompt, cancellationToken: linkedCts.Token).ConfigureAwait(false);
-
-            string responseText = response.Text ?? string.Empty;
-
-            return ParseContentResponse(responseText);
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-        {
-            LogContentGenerationTimeout(logger, context.NotificationTypeName, config.TimeoutSeconds);
-            return null;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            LogContentGenerationFailure(logger, context.NotificationTypeName, ex);
-            return null;
-        }
-    }
-
-    internal static string BuildContentPrompt(NotificationDeliveryContext context)
-    {
         string culture = context.Culture ?? "en";
         string dataJson = context.Data.ValueKind != JsonValueKind.Undefined
             ? context.Data.GetRawText()
             : "{}";
 
-        var pb = new PromptBuilder(maxInputLength: 10_000);
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(config.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
-        pb.AppendInstruction($"Generate a notification subject and body for the notification described below in locale '{culture}'.");
-        pb.AppendInstruction("""Return JSON only, no markdown fences: {"subject": "<string>", "body": "<string>"}""");
-        pb.AppendInstruction("The subject should be concise (under 100 characters). The body should be informative but brief.");
-        pb.AppendInstruction("Do NOT include HTML, scripts, or any markup in the generated text.");
-
-        pb.AppendUserData("Notification type", context.NotificationTypeName);
-        pb.AppendUserData("Severity", context.Severity.ToString());
-        pb.AppendUserTextBlock("Context data", dataJson);
-
-        return pb.Build();
-    }
-
-    internal static NotificationContent? ParseContentResponse(string responseText)
-    {
-        string trimmed = LlmResponseHelper.StripMarkdownCodeFences(responseText);
+        var request = new StructuredCompletionRequest
+        {
+            Instruction = BuildInstruction(culture),
+            Content = dataJson,
+            ContentLabel = "Context data",
+            Context =
+            [
+                new("Notification type", context.NotificationTypeName),
+                new("Severity", context.Severity.ToString()),
+            ],
+            WorkspaceName = config.WorkspaceName,
+        };
 
         try
         {
-            ContentJson? parsed = JsonSerializer.Deserialize<ContentJson>(trimmed, JsonOptions);
+            StructuredCompletionResult<NotificationContentResponse> result = await structuredCompletion
+                .CompleteAsync<NotificationContentResponse>(request, linkedCts.Token)
+                .ConfigureAwait(false);
 
-            if (parsed is null || string.IsNullOrWhiteSpace(parsed.Subject) || string.IsNullOrWhiteSpace(parsed.Body))
+            if (result.Status != StructuredCompletionStatus.Succeeded)
+            {
+                LogContentGenerationRejected(logger, context.NotificationTypeName, result.Status.ToString());
+                return null;
+            }
+
+            NotificationContentResponse content = result.Value!;
+
+            if (string.IsNullOrWhiteSpace(content.Subject) || string.IsNullOrWhiteSpace(content.Body))
             {
                 return null;
             }
 
-            return new NotificationContent(parsed.Subject, parsed.Body);
+            return new NotificationContent(content.Subject, content.Body);
         }
-        catch (JsonException)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
+            LogContentGenerationTimeout(logger, context.NotificationTypeName, config.TimeoutSeconds);
             return null;
         }
     }
 
+    private static string BuildInstruction(string culture) =>
+        $"""
+        Generate a notification subject and body, in locale '{culture}', for the notification described
+        by the context type/severity and the data block.
+        The subject should be concise (under 100 characters). The body should be informative but brief.
+        Do NOT include HTML, scripts, or any markup in the generated text.
+        """;
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI notification content generation rejected (status: {Status}) for type '{NotificationTypeName}'")]
+    private static partial void LogContentGenerationRejected(ILogger logger, string notificationTypeName, string status);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "AI notification content generation timed out after {TimeoutSeconds}s for type '{NotificationTypeName}'")]
     private static partial void LogContentGenerationTimeout(ILogger logger, string notificationTypeName, int timeoutSeconds);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "AI notification content generation failed for type '{NotificationTypeName}'")]
-    private static partial void LogContentGenerationFailure(ILogger logger, string notificationTypeName, Exception exception);
-
-    /// <summary>
-    /// Internal DTO for deserializing the LLM JSON response.
-    /// </summary>
-    private sealed record ContentJson(string? Subject, string? Body);
 }

--- a/src/Granit.Notifications.AI/Schema/ChannelSelectionResponse.cs
+++ b/src/Granit.Notifications.AI/Schema/ChannelSelectionResponse.cs
@@ -1,0 +1,17 @@
+namespace Granit.Notifications.AI.Schema;
+
+/// <summary>
+/// JSON-schema-pinned response shape for the AI channel selector. The recommended channels
+/// are wrapped in this fixed object rather than returned as a root-level array, because
+/// provider-enforced strict schema (ADR-064) rejects a top-level array. The service intersects
+/// <see cref="Channels"/> with the registered available set, so a model that invents a channel
+/// contributes nothing.
+/// </summary>
+public sealed class ChannelSelectionResponse
+{
+    /// <summary>
+    /// Recommended channel names, ordered by priority (most important first). Validated against
+    /// the available channel list by the selector.
+    /// </summary>
+    public List<string> Channels { get; set; } = [];
+}

--- a/src/Granit.Notifications.AI/Schema/NotificationContentResponse.cs
+++ b/src/Granit.Notifications.AI/Schema/NotificationContentResponse.cs
@@ -1,0 +1,15 @@
+namespace Granit.Notifications.AI.Schema;
+
+/// <summary>
+/// JSON-schema-pinned response shape for the AI notification content generator, pinned via
+/// <c>ChatResponseFormat.ForJsonSchema&lt;NotificationContentResponse&gt;()</c> (ADR-064). The
+/// generator returns <c>null</c> when either field comes back blank.
+/// </summary>
+public sealed class NotificationContentResponse
+{
+    /// <summary>Concise subject line for the notification.</summary>
+    public string Subject { get; set; } = string.Empty;
+
+    /// <summary>Body text of the notification.</summary>
+    public string Body { get; set; } = string.Empty;
+}

--- a/tests/Granit.Notifications.AI.Tests/LlmChannelSelectorTests.cs
+++ b/tests/Granit.Notifications.AI.Tests/LlmChannelSelectorTests.cs
@@ -2,12 +2,11 @@ using System.Text.Json;
 using Granit.AI;
 using Granit.Notifications.AI.Internal;
 using Granit.Notifications.AI.Options;
-using Microsoft.Extensions.AI;
+using Granit.Notifications.AI.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Xunit;
 
@@ -19,19 +18,11 @@ public sealed class LlmChannelSelectorTests
 {
     private static readonly IReadOnlyList<string> DefaultChannels = ["email", "push", "sms", "inapp"];
 
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<NotificationsAIOptions> _options = MsOptions.Create(new NotificationsAIOptions());
     private readonly ILogger<LlmChannelSelector> _logger = NullLogger<LlmChannelSelector>.Instance;
 
-    public LlmChannelSelectorTests()
-    {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-    }
-
-    private LlmChannelSelector CreateSut() => new(_chatClientFactory, _options, _logger);
+    private LlmChannelSelector CreateSut() => new(_structured, _options, _logger);
 
     private static NotificationDeliveryContext MakeContext(
         NotificationSeverity severity = NotificationSeverity.Info) =>
@@ -47,21 +38,24 @@ public sealed class LlmChannelSelectorTests
             Culture = "en",
         };
 
+    private static StructuredCompletionResult<ChannelSelectionResponse> Ok(params string[] channels) =>
+        new()
+        {
+            Status = StructuredCompletionStatus.Succeeded,
+            Value = new ChannelSelectionResponse { Channels = [.. channels] },
+        };
+
+    private void Respond(StructuredCompletionResult<ChannelSelectionResponse> result) =>
+        _structured
+            .CompleteAsync<ChannelSelectionResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
     [Fact]
     public async Task SelectChannelsAsync_ValidResponse_ReturnsSelectedChannels()
     {
-        LlmChannelSelector sut = CreateSut();
-        string json = """["email", "push"]""";
+        Respond(Ok("email", "push"));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        IReadOnlyList<string> result = await sut.SelectChannelsAsync(
+        IReadOnlyList<string> result = await CreateSut().SelectChannelsAsync(
             MakeContext(), DefaultChannels, TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(2);
@@ -70,52 +64,13 @@ public sealed class LlmChannelSelectorTests
     }
 
     [Fact]
-    public async Task SelectChannelsAsync_LLMFailure_ReturnsAllAvailable()
+    public async Task SelectChannelsAsync_FiltersUnavailableChannels()
     {
-        LlmChannelSelector sut = CreateSut();
+        // Model invents "telegram" — dropped because it is not in the available set.
+        Respond(Ok("email", "telegram", "push"));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
-
-        IReadOnlyList<string> result = await sut.SelectChannelsAsync(
+        IReadOnlyList<string> result = await CreateSut().SelectChannelsAsync(
             MakeContext(), DefaultChannels, TestContext.Current.CancellationToken);
-
-        result.ShouldBe(DefaultChannels);
-    }
-
-    [Fact]
-    public async Task SelectChannelsAsync_EmptyAvailableChannels_ReturnsEmpty()
-    {
-        LlmChannelSelector sut = CreateSut();
-
-        IReadOnlyList<string> result = await sut.SelectChannelsAsync(
-            MakeContext(), [], TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void ParseChannelSelectionResponse_ValidJson_ReturnsChannels()
-    {
-        string json = """["email", "sms"]""";
-
-        IReadOnlyList<string> result = LlmChannelSelector.ParseChannelSelectionResponse(json, DefaultChannels);
-
-        result.Count.ShouldBe(2);
-        result.ShouldContain("email");
-        result.ShouldContain("sms");
-    }
-
-    [Fact]
-    public void ParseChannelSelectionResponse_FiltersUnavailableChannels()
-    {
-        string json = """["email", "telegram", "push"]""";
-
-        IReadOnlyList<string> result = LlmChannelSelector.ParseChannelSelectionResponse(json, DefaultChannels);
 
         result.Count.ShouldBe(2);
         result.ShouldContain("email");
@@ -123,38 +78,62 @@ public sealed class LlmChannelSelectorTests
         result.ShouldNotContain("telegram");
     }
 
-    [Fact]
-    public void ParseChannelSelectionResponse_MarkdownFencedJson_ReturnsChannels()
+    [Theory]
+    [InlineData(StructuredCompletionStatus.ModelRefused)]
+    [InlineData(StructuredCompletionStatus.SchemaViolation)]
+    [InlineData(StructuredCompletionStatus.TransportFailure)]
+    public async Task SelectChannelsAsync_NonSuccessStatus_FallsBackToAllAvailable(StructuredCompletionStatus status)
     {
-        string json = """
-            ```json
-            ["email", "push"]
-            ```
-            """;
+        Respond(new StructuredCompletionResult<ChannelSelectionResponse> { Status = status });
 
-        IReadOnlyList<string> result = LlmChannelSelector.ParseChannelSelectionResponse(json, DefaultChannels);
+        IReadOnlyList<string> result = await CreateSut().SelectChannelsAsync(
+            MakeContext(), DefaultChannels, TestContext.Current.CancellationToken);
 
-        result.Count.ShouldBe(2);
+        result.ShouldBe(DefaultChannels);
     }
 
     [Fact]
-    public void ParseChannelSelectionResponse_InvalidJson_ReturnsEmpty()
+    public async Task SelectChannelsAsync_EmptySelectionAfterFiltering_FallsBackToAllAvailable()
     {
-        IReadOnlyList<string> result = LlmChannelSelector.ParseChannelSelectionResponse("not json", DefaultChannels);
+        // Everything the model returned is out-of-set, so the default-to-all guard kicks in.
+        Respond(Ok("telegram", "whatsapp"));
+
+        IReadOnlyList<string> result = await CreateSut().SelectChannelsAsync(
+            MakeContext(), DefaultChannels, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(DefaultChannels);
+    }
+
+    [Fact]
+    public async Task SelectChannelsAsync_EmptyAvailableChannels_ReturnsEmptyWithoutCallingTheModel()
+    {
+        IReadOnlyList<string> result = await CreateSut().SelectChannelsAsync(
+            MakeContext(), [], TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
+        await _structured
+            .DidNotReceiveWithAnyArgs()
+            .CompleteAsync<ChannelSelectionResponse>(default!, TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public void BuildChannelSelectionPrompt_ContainsSeverityAndChannels()
+    public async Task SelectChannelsAsync_RoutesAvailableChannelsAsInstructionAndContextAsContent()
     {
-        NotificationDeliveryContext context = MakeContext(NotificationSeverity.Fatal);
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<ChannelSelectionResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Ok("email"));
 
-        string prompt = LlmChannelSelector.BuildChannelSelectionPrompt(context, DefaultChannels);
+        await CreateSut().SelectChannelsAsync(
+            MakeContext(NotificationSeverity.Fatal), DefaultChannels, TestContext.Current.CancellationToken);
 
-        prompt.ShouldContain("Fatal");
-        prompt.ShouldContain("email");
-        prompt.ShouldContain("push");
-        prompt.ShouldContain("order.completed");
+        captured.ShouldNotBeNull();
+        // Available channels are developer/framework-controlled guidance.
+        captured.Instruction.ShouldNotBeNull();
+        captured.Instruction.ShouldContain("email");
+        captured.Instruction.ShouldContain("push");
+        // The notification context is the analyzed content.
+        captured.Content.ShouldContain("order.completed");
+        captured.Content.ShouldContain("Fatal");
     }
 }

--- a/tests/Granit.Notifications.AI.Tests/LlmNotificationContentGeneratorTests.cs
+++ b/tests/Granit.Notifications.AI.Tests/LlmNotificationContentGeneratorTests.cs
@@ -2,12 +2,11 @@ using System.Text.Json;
 using Granit.AI;
 using Granit.Notifications.AI.Internal;
 using Granit.Notifications.AI.Options;
-using Microsoft.Extensions.AI;
+using Granit.Notifications.AI.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Xunit;
 
@@ -17,19 +16,11 @@ namespace Granit.Notifications.AI.Tests;
 
 public sealed class LlmNotificationContentGeneratorTests
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<NotificationsAIOptions> _options = MsOptions.Create(new NotificationsAIOptions());
     private readonly ILogger<LlmNotificationContentGenerator> _logger = NullLogger<LlmNotificationContentGenerator>.Instance;
 
-    public LlmNotificationContentGeneratorTests()
-    {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-    }
-
-    private LlmNotificationContentGenerator CreateSut() => new(_chatClientFactory, _options, _logger);
+    private LlmNotificationContentGenerator CreateSut() => new(_structured, _options, _logger);
 
     private static NotificationDeliveryContext MakeContext(
         string typeName = "order.completed",
@@ -47,118 +38,81 @@ public sealed class LlmNotificationContentGeneratorTests
             Culture = culture,
         };
 
+    private static StructuredCompletionResult<NotificationContentResponse> Ok(string subject, string body) =>
+        new()
+        {
+            Status = StructuredCompletionStatus.Succeeded,
+            Value = new NotificationContentResponse { Subject = subject, Body = body },
+        };
+
+    private void Respond(StructuredCompletionResult<NotificationContentResponse> result) =>
+        _structured
+            .CompleteAsync<NotificationContentResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
     [Fact]
     public async Task GenerateAsync_ValidResponse_ReturnsContent()
     {
-        LlmNotificationContentGenerator sut = CreateSut();
-        string json = """{"subject": "Order Completed", "body": "Your order ORD-001 has been completed."}""";
+        Respond(Ok("Order Completed", "Your order ORD-001 has been completed."));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, json)]));
-
-        NotificationContent? result = await sut.GenerateAsync(
-            MakeContext(), TestContext.Current.CancellationToken);
+        NotificationContent? result = await CreateSut().GenerateAsync(MakeContext(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.Subject.ShouldBe("Order Completed");
         result.Body.ShouldBe("Your order ORD-001 has been completed.");
     }
 
-    [Fact]
-    public async Task GenerateAsync_LLMFailure_ReturnsNull()
+    [Theory]
+    [InlineData(StructuredCompletionStatus.ModelRefused)]
+    [InlineData(StructuredCompletionStatus.SchemaViolation)]
+    [InlineData(StructuredCompletionStatus.TransportFailure)]
+    public async Task GenerateAsync_NonSuccessStatus_ReturnsNull(StructuredCompletionStatus status)
     {
-        LlmNotificationContentGenerator sut = CreateSut();
+        Respond(new StructuredCompletionResult<NotificationContentResponse> { Status = status });
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
-
-        NotificationContent? result = await sut.GenerateAsync(
-            MakeContext(), TestContext.Current.CancellationToken);
+        NotificationContent? result = await CreateSut().GenerateAsync(MakeContext(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
 
     [Fact]
-    public async Task GenerateAsync_InvalidJsonResponse_ReturnsNull()
+    public async Task GenerateAsync_BlankSubject_ReturnsNull()
     {
-        LlmNotificationContentGenerator sut = CreateSut();
+        Respond(Ok("", "Some body"));
 
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new ChatResponse(
-                [new ChatMessage(ChatRole.Assistant, "not valid json")]));
-
-        NotificationContent? result = await sut.GenerateAsync(
-            MakeContext(), TestContext.Current.CancellationToken);
+        NotificationContent? result = await CreateSut().GenerateAsync(MakeContext(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
 
     [Fact]
-    public void ParseContentResponse_ValidJson_ReturnsContent()
+    public async Task GenerateAsync_BlankBody_ReturnsNull()
     {
-        string json = """{"subject": "Alert", "body": "Something happened."}""";
+        Respond(Ok("Some subject", "   "));
 
-        NotificationContent? result = LlmNotificationContentGenerator.ParseContentResponse(json);
-
-        result.ShouldNotBeNull();
-        result.Subject.ShouldBe("Alert");
-        result.Body.ShouldBe("Something happened.");
-    }
-
-    [Fact]
-    public void ParseContentResponse_MarkdownFencedJson_ReturnsContent()
-    {
-        string json = """
-            ```json
-            {"subject": "Alert", "body": "Something happened."}
-            ```
-            """;
-
-        NotificationContent? result = LlmNotificationContentGenerator.ParseContentResponse(json);
-
-        result.ShouldNotBeNull();
-        result.Subject.ShouldBe("Alert");
-    }
-
-    [Fact]
-    public void ParseContentResponse_MissingSubject_ReturnsNull()
-    {
-        string json = """{"subject": "", "body": "Some body"}""";
-
-        NotificationContent? result = LlmNotificationContentGenerator.ParseContentResponse(json);
+        NotificationContent? result = await CreateSut().GenerateAsync(MakeContext(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
 
     [Fact]
-    public void ParseContentResponse_InvalidJson_ReturnsNull()
+    public async Task GenerateAsync_RoutesDataAsContentAndTypeCultureAsInstructionContext()
     {
-        NotificationContent? result = LlmNotificationContentGenerator.ParseContentResponse("not json");
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<NotificationContentResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Ok("S", "B"));
 
-        result.ShouldBeNull();
-    }
+        await CreateSut().GenerateAsync(
+            MakeContext(typeName: "user.registered", culture: "fr"), TestContext.Current.CancellationToken);
 
-    [Fact]
-    public void BuildContentPrompt_ContainsNotificationTypeAndCulture()
-    {
-        NotificationDeliveryContext context = MakeContext(typeName: "user.registered", culture: "fr");
-
-        string prompt = LlmNotificationContentGenerator.BuildContentPrompt(context);
-
-        prompt.ShouldContain("user.registered");
-        prompt.ShouldContain("fr");
+        captured.ShouldNotBeNull();
+        // Untrusted business data flows through the Content channel...
+        captured.Content.ShouldContain("ORD-001");
+        // ...the locale is developer-controlled instruction...
+        captured.Instruction!.ShouldContain("fr");
+        // ...and the notification type travels as labelled context.
+        captured.Context.ShouldNotBeNull();
+        captured.Context.ShouldContain(kv => kv.Value == "user.registered");
     }
 }


### PR DESCRIPTION
## What

Migrates both `Granit.Notifications.AI` services off the hand-rolled `IAIChatClientFactory` + manual JSON parsing onto the **`IStructuredCompletion`** primitive (ADR-064, Epic #2452).

Third of the four **reshape outliers** (the channel selector is the `List<string>` root-array case).

## `LlmChannelSelector` — reshape

The root-level channel array — rejected by provider-enforced strict schema — is wrapped in a fixed object:

```jsonc
{ "channels": ["email", "push"] }
```

- Returned channels are **intersected with the registered available set** (case-insensitive); a model that invents `"telegram"` contributes nothing.
- **Default-to-all** preserved: an empty or fully-rejected recommendation falls back to all available channels — never silently drops delivery.
- Available channel list = developer/framework-controlled `Instruction`; notification context (type/severity/time) = analyzed `Content`.

## `LlmNotificationContentGenerator` — straight migration

Already object-shaped (`{ subject, body }`), so a direct move to `CompleteAsync<NotificationContentResponse>`. Untrusted context **data** flows through `Content`; locale is `Instruction`; type/severity travel as labelled `Context`. Blank subject or body still yields `null`.

## Both

- Four-valued status maps non-success to the existing graceful default (all-channels / `null`); caller cancellation propagates while the internal timeout yields the fallback.
- Registrations switched **Singleton → Scoped** to match the scoped primitive (captive-dependency fix).

## Tests

15 tests green. Dropped the now-obsolete `Parse*` / `Build*Prompt` / markdown-fence cases (parsing owned by the primitive); added status-mapping, out-of-set channel rejection, empty-selection fallback, and Content/Instruction/Context channel-routing assertions.

`dotnet build` + `dotnet test` green, `dotnet format --verify-no-changes` clean.

Part of Epic #2452 / ADR-064.