### PR TITLE
refactor(queryengine-ai): NLQ translation via IStructuredCompletion (ADR-064)

### DIFF
--- a/src/Granit.QueryEngine.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
+++ b/src/Granit.QueryEngine.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
@@ -1,36 +1,32 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
-using System.Text.Json;
 using Granit.AI;
-using Granit.AI.Internal;
 using Granit.MultiTenancy;
 using Granit.QueryEngine.AI.Diagnostics;
 using Granit.QueryEngine.AI.Options;
 using Granit.QueryEngine.Meta;
 using Granit.Timing;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.QueryEngine.AI.Internal;
 
 /// <summary>
-/// LLM-backed implementation of <see cref="INaturalLanguageQueryTranslator"/>.
-/// Sends query metadata to the LLM as schema context and parses the structured JSON response.
+/// LLM-backed <see cref="INaturalLanguageQueryTranslator"/> built on the
+/// <see cref="IStructuredCompletion"/> primitive (ADR-064). The query schema and available
+/// fields are folded into the developer-controlled instruction; the user's phrase travels as
+/// untrusted, sanitized content. The model's output is whitelisted against the metadata
+/// (CWE-20 / OWASP LLM02) before it becomes a <see cref="QueryRequest"/>.
 /// </summary>
 internal sealed partial class LlmNaturalLanguageQueryTranslator(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     IOptions<QueryEngineAIOptions> options,
     ILogger<LlmNaturalLanguageQueryTranslator> logger,
     IClock clock,
     QueryEngineAIMetrics? metrics = null,
     ICurrentTenant? currentTenant = null) : INaturalLanguageQueryTranslator
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     /// <inheritdoc/>
     public async Task<QueryRequest?> TranslateAsync(
         string naturalLanguage,
@@ -46,65 +42,39 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
         long startTimestamp = Stopwatch.GetTimestamp();
         string? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id?.ToString() : null;
 
+        QueryEngineAIOptions opts = options.Value;
+
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(opts.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        var request = new StructuredCompletionRequest
+        {
+            Instruction = BuildInstruction(metadata),
+            Content = naturalLanguage,
+            ContentLabel = "Query",
+            WorkspaceName = opts.WorkspaceName,
+        };
+
         try
         {
-            QueryEngineAIOptions opts = options.Value;
-
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(opts.TimeoutSeconds));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient chatClient = await chatClientFactory
-                .CreateAsync(opts.WorkspaceName, linkedCts.Token)
+            StructuredCompletionResult<LlmQueryPayload> result = await structuredCompletion
+                .CompleteAsync<LlmQueryPayload>(request, linkedCts.Token)
                 .ConfigureAwait(false);
 
-            string systemPrompt = BuildSystemPrompt(metadata);
-
-            // Sanitize user input via PromptBuilder to mitigate prompt injection
-            var userPb = new PromptBuilder(maxInputLength: 2_000);
-            userPb.AppendUserTextBlock("Query", naturalLanguage);
-
-            List<ChatMessage> messages =
-            [
-                new(ChatRole.System, systemPrompt),
-                new(ChatRole.User, userPb.Build()),
-            ];
-
-            ChatResponse response = await chatClient
-                .GetResponseAsync(messages, cancellationToken: linkedCts.Token)
-                .ConfigureAwait(false);
-
-            string rawJson = response.Text ?? string.Empty;
-            string json = StripMarkdownFences(rawJson);
-
-            QueryRequest? request = TryDeserializeAndConvert(json, metadata, out bool deserializedToNull);
-            if (deserializedToNull)
+            if (result.Status != StructuredCompletionStatus.Succeeded)
             {
-                LogInvalidResponse(logger, naturalLanguage.Length);
-                metrics?.RecordTranslationFailed(tenantId, "invalid_response");
+                LogInvalidResponse(logger, naturalLanguage.Length, result.Status.ToString());
+                metrics?.RecordTranslationFailed(tenantId, MapFailureReason(result.Status));
                 return null;
             }
 
             metrics?.RecordTranslationExecuted(tenantId, "success");
-            return request;
+            return ValidateAndConvert(result.Value!, metadata);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             LogTimeout(logger, naturalLanguage.Length);
             metrics?.RecordTranslationFailed(tenantId, "timeout");
-            return null;
-        }
-        catch (JsonException ex)
-        {
-            LogJsonParseError(logger, naturalLanguage.Length, ex);
-            metrics?.RecordTranslationFailed(tenantId, "json_parse_error");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            LogTranslationError(logger, naturalLanguage.Length, ex);
-            metrics?.RecordTranslationFailed(tenantId, "error");
             return null;
         }
         finally
@@ -114,22 +84,23 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
         }
     }
 
-    internal string BuildSystemPrompt(QueryMetadata metadata)
+    private static string MapFailureReason(StructuredCompletionStatus status) => status switch
+    {
+        StructuredCompletionStatus.TransportFailure => "error",
+        _ => "invalid_response",
+    };
+
+    internal string BuildInstruction(QueryMetadata metadata)
     {
         var sb = new StringBuilder();
 
-        sb.AppendLine("You are a query translator. Convert the user's natural language phrase into a JSON object matching this schema:");
-        sb.AppendLine();
-        sb.AppendLine("```json");
-        sb.AppendLine("{");
-        sb.AppendLine("  \"page\": <int or null>,");
-        sb.AppendLine("  \"pageSize\": <int or null>,");
-        sb.AppendLine("  \"sort\": \"<comma-separated fields, prefix - for desc>\" or null,");
-        sb.AppendLine("  \"filter\": { \"<field.operator>\": \"<value>\", ... } or null,");
-        sb.AppendLine("  \"quickFilters\": [\"<name>\", ...] or null,");
-        sb.AppendLine("  \"groupBy\": \"<field>\" or null");
-        sb.AppendLine("}");
-        sb.AppendLine("```");
+        sb.AppendLine("You are a query translator. Convert the user's natural-language phrase (in the data block)");
+        sb.AppendLine("into the structured query format. Produce only the fields you need, omitting the rest:");
+        sb.AppendLine("- page / pageSize: integers for pagination.");
+        sb.AppendLine("- sort: comma-separated field names, prefix - for descending (e.g. \"-createdAt,lastName\").");
+        sb.AppendLine("- filter: a list of clauses, each a \"key\" of the form \"fieldName.operator\" and a string \"value\".");
+        sb.AppendLine("- quickFilters: names drawn from the available quick-filter list.");
+        sb.AppendLine("- groupBy: a single field name.");
         sb.AppendLine();
 
         // Filterable fields
@@ -201,41 +172,18 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
         }
 
         sb.AppendLine("Filter key format: \"fieldName.operator\" (e.g. \"status.eq\", \"amount.gte\", \"name.contains\").");
-        sb.AppendLine($"Current date: {clock.Now:yyyy-MM-dd}. Use this for relative date references (\"this week\", \"last month\").");
+        sb.Append(CultureInfo.InvariantCulture, $"Current date: {clock.Now:yyyy-MM-dd}. ");
+        sb.AppendLine("Use this for relative date references (\"this week\", \"last month\").");
         sb.AppendLine();
         sb.AppendLine("Rules:");
-        sb.AppendLine("- Return ONLY valid JSON, no explanation.");
         sb.AppendLine("- Use only the fields and operators listed above.");
-        sb.AppendLine("- Omit properties that are not needed (use null).");
+        sb.AppendLine("- Omit properties that are not needed.");
         sb.AppendLine("- For date ranges, use gte/lte operators with ISO 8601 dates.");
 
         return sb.ToString();
     }
 
-    internal static string StripMarkdownFences(string text) =>
-        LlmResponseHelper.StripMarkdownCodeFences(text);
-
-    /// <summary>
-    /// Deserializes an LLM JSON payload into a validated <see cref="QueryRequest"/>.
-    /// Returns <c>null</c> when deserialization yields a <c>null</c> payload (signalled via
-    /// <paramref name="deserializedToNull"/> = <c>true</c>) so callers can distinguish that case
-    /// from a valid empty result. Throws <see cref="JsonException"/> on malformed JSON — the
-    /// production caller catches it; the fuzz harness intentionally swallows it.
-    /// </summary>
-    internal static QueryRequest? TryDeserializeAndConvert(string json, QueryMetadata metadata, out bool deserializedToNull)
-    {
-        LlmQueryPayload? dto = JsonSerializer.Deserialize<LlmQueryPayload>(json, JsonOptions);
-        if (dto is null)
-        {
-            deserializedToNull = true;
-            return null;
-        }
-
-        deserializedToNull = false;
-        return ValidateAndConvert(dto, metadata);
-    }
-
-    private static QueryRequest? ValidateAndConvert(LlmQueryPayload dto, QueryMetadata metadata)
+    private static QueryRequest ValidateAndConvert(LlmQueryPayload dto, QueryMetadata metadata)
     {
         // Build whitelist of allowed filter keys from metadata (CWE-20, LLM02)
         var allowedFilterKeys = metadata.FilterableFields
@@ -254,16 +202,20 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
             .Select(f => f.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        // Validate and strip non-whitelisted fields from LLM output
-        Dictionary<string, string>? validatedFilter = dto.Filter is { Count: > 0 }
-            ? dto.Filter
-                .Where(kv => allowedFilterKeys.Contains(kv.Key))
-                .ToDictionary(kv => kv.Key, kv => kv.Value)
-            : null;
-
-        if (validatedFilter is { Count: 0 })
+        // Validate and strip non-whitelisted clauses; the list may carry duplicate keys, so
+        // collapse them (first wins) before building the dictionary the domain expects.
+        Dictionary<string, string>? validatedFilter = null;
+        if (dto.Filter is { Count: > 0 })
         {
-            validatedFilter = null;
+            validatedFilter = dto.Filter
+                .Where(c => !string.IsNullOrEmpty(c.Key) && allowedFilterKeys.Contains(c.Key))
+                .GroupBy(c => c.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.First().Key, g => g.First().Value, StringComparer.OrdinalIgnoreCase);
+
+            if (validatedFilter.Count == 0)
+            {
+                validatedFilter = null;
+            }
         }
 
         // Validate sort fields
@@ -288,7 +240,7 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
 
         // Validate quick filters
         List<string>? validatedQuickFilters = dto.QuickFilters is { Count: > 0 }
-            ? dto.QuickFilters.Where(qf => allowedQuickFilters.Contains(qf)).ToList()
+            ? dto.QuickFilters.Where(allowedQuickFilters.Contains).ToList()
             : null;
 
         if (validatedQuickFilters is { Count: 0 })
@@ -307,15 +259,9 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
         };
     }
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "NLQ translation returned invalid response (input length: {InputLength})")]
-    private static partial void LogInvalidResponse(ILogger logger, int inputLength);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "NLQ translation returned a non-success status {Status} (input length: {InputLength})")]
+    private static partial void LogInvalidResponse(ILogger logger, int inputLength, string status);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "NLQ translation timed out (input length: {InputLength})")]
     private static partial void LogTimeout(ILogger logger, int inputLength);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "NLQ translation failed to parse JSON (input length: {InputLength})")]
-    private static partial void LogJsonParseError(ILogger logger, int inputLength, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "NLQ translation failed (input length: {InputLength})")]
-    private static partial void LogTranslationError(ILogger logger, int inputLength, Exception exception);
 }

--- a/src/Granit.QueryEngine.AI/Internal/LlmQueryPayload.cs
+++ b/src/Granit.QueryEngine.AI/Internal/LlmQueryPayload.cs
@@ -1,9 +1,15 @@
 namespace Granit.QueryEngine.AI.Internal;
 
 /// <summary>
-/// Internal DTO for JSON deserialization of the LLM response.
-/// Maps to <see cref="QueryRequest"/> after validation.
+/// Schema-pinned DTO (ADR-064) for the structured-completion response. Maps to
+/// <see cref="Granit.QueryEngine.QueryRequest"/> after metadata validation.
 /// </summary>
+/// <remarks>
+/// <see cref="Filter"/> is a list of fixed-shape <see cref="LlmFilterClause"/> entries rather than
+/// a dynamic-keyed map: provider-enforced strict JSON schema rejects free-form object keys, so the
+/// <c>"field.operator"</c> key travels inside each clause and is reassembled into a dictionary by
+/// the translator.
+/// </remarks>
 internal sealed class LlmQueryPayload
 {
     public int? Page { get; set; }
@@ -12,9 +18,19 @@ internal sealed class LlmQueryPayload
 
     public string? Sort { get; set; }
 
-    public Dictionary<string, string>? Filter { get; set; }
+    public List<LlmFilterClause>? Filter { get; set; }
 
     public List<string>? QuickFilters { get; set; }
 
     public string? GroupBy { get; set; }
+}
+
+/// <summary>
+/// A single filter clause: a <c>"fieldName.operator"</c> key and its string value.
+/// </summary>
+internal sealed class LlmFilterClause
+{
+    public string Key { get; set; } = string.Empty;
+
+    public string Value { get; set; } = string.Empty;
 }

--- a/tests/Granit.QueryEngine.AI.Tests/LlmNaturalLanguageQueryTranslatorAdditionalTests.cs
+++ b/tests/Granit.QueryEngine.AI.Tests/LlmNaturalLanguageQueryTranslatorAdditionalTests.cs
@@ -3,7 +3,6 @@ using Granit.QueryEngine.AI.Internal;
 using Granit.QueryEngine.AI.Options;
 using Granit.QueryEngine.Meta;
 using Granit.Timing;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -13,55 +12,49 @@ namespace Granit.QueryEngine.AI.Tests;
 
 public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<QueryEngineAIOptions> _options = Microsoft.Extensions.Options.Options.Create(new QueryEngineAIOptions());
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly LlmNaturalLanguageQueryTranslator _sut;
 
     public LlmNaturalLanguageQueryTranslatorAdditionalTests()
     {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-
         _clock.Now.Returns(new DateTimeOffset(2026, 3, 21, 0, 0, 0, TimeSpan.Zero));
 
         _sut = new LlmNaturalLanguageQueryTranslator(
-            _chatClientFactory,
+            _structured,
             _options,
             NullLogger<LlmNaturalLanguageQueryTranslator>.Instance,
             _clock);
     }
 
-    [Fact]
-    public void BuildSystemPrompt_includes_date_filters()
-    {
-        QueryMetadata metadata = CreateMetadataWithDateFilters();
+    private void Respond(LlmQueryPayload payload) =>
+        _structured
+            .CompleteAsync<LlmQueryPayload>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmQueryPayload> { Status = StructuredCompletionStatus.Succeeded, Value = payload });
 
-        string prompt = _sut.BuildSystemPrompt(metadata);
+    [Fact]
+    public void BuildInstruction_includes_date_filters()
+    {
+        string prompt = _sut.BuildInstruction(CreateMetadataWithDateFilters());
 
         prompt.ShouldContain("createdAt");
         prompt.ShouldContain("Today");
     }
 
     [Fact]
-    public void BuildSystemPrompt_includes_group_by_fields()
+    public void BuildInstruction_includes_group_by_fields()
     {
-        QueryMetadata metadata = CreateMetadataWithGroupBy();
-
-        string prompt = _sut.BuildSystemPrompt(metadata);
+        string prompt = _sut.BuildInstruction(CreateMetadataWithGroupBy());
 
         prompt.ShouldContain("category");
         prompt.ShouldContain("group-by");
     }
 
     [Fact]
-    public void BuildSystemPrompt_includes_sortable_fields()
+    public void BuildInstruction_includes_sortable_fields()
     {
-        QueryMetadata metadata = CreateMetadataWithSortableFields();
-
-        string prompt = _sut.BuildSystemPrompt(metadata);
+        string prompt = _sut.BuildInstruction(CreateMetadataWithSortableFields());
 
         prompt.ShouldContain("name");
         prompt.ShouldContain("createdAt");
@@ -69,32 +62,26 @@ public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
     }
 
     [Fact]
-    public void BuildSystemPrompt_includes_current_date()
+    public void BuildInstruction_includes_current_date()
     {
-        QueryMetadata metadata = CreateMinimalMetadata();
-
-        string prompt = _sut.BuildSystemPrompt(metadata);
+        string prompt = _sut.BuildInstruction(CreateMinimalMetadata());
 
         prompt.ShouldContain("2026-03-21");
     }
 
     [Fact]
-    public void BuildSystemPrompt_includes_quick_filters()
+    public void BuildInstruction_includes_quick_filters()
     {
-        QueryMetadata metadata = CreateMetadataWithQuickFilters();
-
-        string prompt = _sut.BuildSystemPrompt(metadata);
+        string prompt = _sut.BuildInstruction(CreateMetadataWithQuickFilters());
 
         prompt.ShouldContain("active");
         prompt.ShouldContain("Active Items");
     }
 
     [Fact]
-    public void BuildSystemPrompt_empty_metadata_includes_schema()
+    public void BuildInstruction_empty_metadata_still_describes_the_output_fields_and_rules()
     {
-        QueryMetadata metadata = CreateMinimalMetadata();
-
-        string prompt = _sut.BuildSystemPrompt(metadata);
+        string prompt = _sut.BuildInstruction(CreateMinimalMetadata());
 
         prompt.ShouldContain("page");
         prompt.ShouldContain("filter");
@@ -104,19 +91,7 @@ public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
     [Fact]
     public async Task TranslateAsync_response_with_quickFilters_is_mapped()
     {
-        const string jsonText = """
-            {
-                "quickFilters": ["active", "recent"]
-            }
-            """;
-
-        ChatResponse response = new(new ChatMessage(ChatRole.Assistant, jsonText));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
+        Respond(new LlmQueryPayload { QuickFilters = ["active", "recent"] });
 
         QueryMetadata metadata = CreateMinimalMetadata() with
         {
@@ -128,9 +103,7 @@ public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
         };
 
         QueryRequest? result = await _sut.TranslateAsync(
-            "show active recent items",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "show active recent items", metadata, TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.QuickFilters.ShouldNotBeNull();
@@ -140,27 +113,10 @@ public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
     [Fact]
     public async Task TranslateAsync_response_with_empty_filter_maps_to_null()
     {
-        const string jsonText = """
-            {
-                "filter": {},
-                "quickFilters": []
-            }
-            """;
-
-        ChatResponse response = new(new ChatMessage(ChatRole.Assistant, jsonText));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
-
-        QueryMetadata metadata = CreateMinimalMetadata();
+        Respond(new LlmQueryPayload { Filter = [], QuickFilters = [] });
 
         QueryRequest? result = await _sut.TranslateAsync(
-            "show all",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "show all", CreateMinimalMetadata(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.Filter.ShouldBeNull();
@@ -168,35 +124,9 @@ public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
     }
 
     [Fact]
-    public void StripMarkdownFences_handles_bare_backticks_without_json_suffix()
-    {
-        const string input = """
-            ```
-            {"sort": "name"}
-            ```
-            """;
-
-        string result = LlmNaturalLanguageQueryTranslator.StripMarkdownFences(input);
-
-        result.ShouldBe("{\"sort\": \"name\"}");
-    }
-
-    [Fact]
     public async Task TranslateAsync_response_with_groupBy_is_mapped()
     {
-        const string jsonText = """
-            {
-                "groupBy": "category"
-            }
-            """;
-
-        ChatResponse response = new(new ChatMessage(ChatRole.Assistant, jsonText));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
+        Respond(new LlmQueryPayload { GroupBy = "category" });
 
         QueryMetadata metadata = CreateMinimalMetadata() with
         {
@@ -204,9 +134,7 @@ public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
         };
 
         QueryRequest? result = await _sut.TranslateAsync(
-            "group by category",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "group by category", metadata, TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.GroupBy.ShouldBe("category");
@@ -215,27 +143,10 @@ public sealed class LlmNaturalLanguageQueryTranslatorAdditionalTests
     [Fact]
     public async Task TranslateAsync_response_with_page_and_pageSize_is_mapped()
     {
-        const string jsonText = """
-            {
-                "page": 3,
-                "pageSize": 50
-            }
-            """;
-
-        ChatResponse response = new(new ChatMessage(ChatRole.Assistant, jsonText));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
-
-        QueryMetadata metadata = CreateMinimalMetadata();
+        Respond(new LlmQueryPayload { Page = 3, PageSize = 50 });
 
         QueryRequest? result = await _sut.TranslateAsync(
-            "page 3 with 50 items",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "page 3 with 50 items", CreateMinimalMetadata(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.Page.ShouldBe(3);

--- a/tests/Granit.QueryEngine.AI.Tests/LlmNaturalLanguageQueryTranslatorTests.cs
+++ b/tests/Granit.QueryEngine.AI.Tests/LlmNaturalLanguageQueryTranslatorTests.cs
@@ -4,69 +4,56 @@ using Granit.QueryEngine.AI.Options;
 using Granit.QueryEngine.Filtering;
 using Granit.QueryEngine.Meta;
 using Granit.Timing;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
 
 namespace Granit.QueryEngine.AI.Tests;
 
 public sealed class LlmNaturalLanguageQueryTranslatorTests
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
     private readonly IOptions<QueryEngineAIOptions> _options = Microsoft.Extensions.Options.Options.Create(new QueryEngineAIOptions());
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly LlmNaturalLanguageQueryTranslator _sut;
 
     public LlmNaturalLanguageQueryTranslatorTests()
     {
-        _chatClientFactory
-            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(_chatClient);
-
         _clock.Now.Returns(new DateTimeOffset(2026, 3, 16, 0, 0, 0, TimeSpan.Zero));
 
         _sut = new LlmNaturalLanguageQueryTranslator(
-            _chatClientFactory,
+            _structured,
             _options,
             NullLogger<LlmNaturalLanguageQueryTranslator>.Instance,
             _clock);
     }
 
+    internal static List<LlmFilterClause> Clauses(params (string Key, string Value)[] clauses) =>
+        [.. clauses.Select(c => new LlmFilterClause { Key = c.Key, Value = c.Value })];
+
+    private void Respond(LlmQueryPayload payload) =>
+        _structured
+            .CompleteAsync<LlmQueryPayload>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmQueryPayload> { Status = StructuredCompletionStatus.Succeeded, Value = payload });
+
+    private void RespondWith(StructuredCompletionStatus status) =>
+        _structured
+            .CompleteAsync<LlmQueryPayload>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmQueryPayload> { Status = status });
+
     [Fact]
     public async Task TranslateAsync_ValidResponse_ReturnsQueryRequest()
     {
-        // Arrange
-        const string jsonText = """
-            {
-                "sort": "-createdAt",
-                "filter": {
-                    "status.eq": "active",
-                    "amount.gte": "1000"
-                }
-            }
-            """;
+        Respond(new LlmQueryPayload
+        {
+            Sort = "-createdAt",
+            Filter = Clauses(("status.eq", "active"), ("amount.gte", "1000")),
+        });
 
-        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonText));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
-
-        QueryMetadata metadata = CreateTestMetadata();
-
-        // Act
         QueryRequest? result = await _sut.TranslateAsync(
-            "show active items over 1000, newest first",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "show active items over 1000, newest first", CreateTestMetadata(), TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldNotBeNull();
         result.Sort.ShouldBe("-createdAt");
         result.Filter.ShouldNotBeNull();
@@ -75,159 +62,105 @@ public sealed class LlmNaturalLanguageQueryTranslatorTests
         result.Filter["amount.gte"].ShouldBe("1000");
     }
 
-    [Fact]
-    public async Task TranslateAsync_LLMFailure_ReturnsNull()
+    [Theory]
+    [InlineData(StructuredCompletionStatus.ModelRefused)]
+    [InlineData(StructuredCompletionStatus.SchemaViolation)]
+    [InlineData(StructuredCompletionStatus.TransportFailure)]
+    public async Task TranslateAsync_NonSuccessStatus_ReturnsNull(StructuredCompletionStatus status)
     {
-        // Arrange
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
+        RespondWith(status);
 
-        QueryMetadata metadata = CreateTestMetadata();
-
-        // Act
         QueryRequest? result = await _sut.TranslateAsync(
-            "show all items",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "show all items", CreateTestMetadata(), TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeNull();
     }
 
     [Fact]
-    public async Task TranslateAsync_InvalidJson_ReturnsNull()
+    public async Task TranslateAsync_StripsFilterClausesOutsideTheMetadataWhitelist()
     {
-        // Arrange
-        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, "this is not valid json at all"));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
+        // "ssn.eq" is not a filterable field — the model cannot smuggle it past validation (LLM02).
+        Respond(new LlmQueryPayload
+        {
+            Filter = Clauses(("status.eq", "active"), ("ssn.eq", "123-45-6789")),
+        });
 
-        QueryMetadata metadata = CreateTestMetadata();
-
-        // Act
         QueryRequest? result = await _sut.TranslateAsync(
-            "show all items",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "active items", CreateTestMetadata(), TestContext.Current.CancellationToken);
 
-        // Assert
-        result.ShouldBeNull();
-    }
-
-    [Fact]
-    public async Task TranslateAsync_EmptyInput_ReturnsNull()
-    {
-        // Arrange
-        QueryMetadata metadata = CreateTestMetadata();
-
-        // Act
-        QueryRequest? result = await _sut.TranslateAsync(
-            "",
-            metadata,
-            TestContext.Current.CancellationToken);
-
-        // Assert
-        result.ShouldBeNull();
-    }
-
-    [Fact]
-    public async Task TranslateAsync_MarkdownFencedResponse_ParsesCorrectly()
-    {
-        // Arrange
-        const string jsonText = """
-            ```json
-            {
-                "sort": "name",
-                "filter": { "name.contains": "alice" }
-            }
-            ```
-            """;
-
-        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonText));
-        _chatClient
-            .GetResponseAsync(
-                Arg.Any<IEnumerable<ChatMessage>>(),
-                Arg.Any<ChatOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(response);
-
-        QueryMetadata metadata = CreateTestMetadata();
-
-        // Act
-        QueryRequest? result = await _sut.TranslateAsync(
-            "find alice",
-            metadata,
-            TestContext.Current.CancellationToken);
-
-        // Assert
         result.ShouldNotBeNull();
-        result.Sort.ShouldBe("name");
         result.Filter.ShouldNotBeNull();
-        result.Filter["name.contains"].ShouldBe("alice");
+        result.Filter.Count.ShouldBe(1);
+        result.Filter.ContainsKey("status.eq").ShouldBeTrue();
+        result.Filter.ContainsKey("ssn.eq").ShouldBeFalse();
     }
 
     [Fact]
-    public async Task TranslateAsync_WhitespaceInput_ReturnsNull()
+    public async Task TranslateAsync_CollapsesDuplicateFilterClauseKeys()
     {
-        // Arrange
-        QueryMetadata metadata = CreateTestMetadata();
+        Respond(new LlmQueryPayload
+        {
+            Filter = Clauses(("status.eq", "active"), ("status.eq", "inactive")),
+        });
 
-        // Act
         QueryRequest? result = await _sut.TranslateAsync(
-            "   ",
-            metadata,
-            TestContext.Current.CancellationToken);
+            "active items", CreateTestMetadata(), TestContext.Current.CancellationToken);
 
-        // Assert
-        result.ShouldBeNull();
+        result.ShouldNotBeNull();
+        result.Filter.ShouldNotBeNull();
+        result.Filter.Count.ShouldBe(1);
+        result.Filter["status.eq"].ShouldBe("active");
     }
 
     [Fact]
-    public void BuildSystemPrompt_IncludesFilterableFields()
+    public async Task TranslateAsync_EmptyInput_ReturnsNullWithoutCallingTheModel()
     {
-        // Arrange
-        QueryMetadata metadata = CreateTestMetadata();
+        QueryRequest? result = await _sut.TranslateAsync("", CreateTestMetadata(), TestContext.Current.CancellationToken);
 
-        // Act
-        string prompt = _sut.BuildSystemPrompt(metadata);
+        result.ShouldBeNull();
+        await _structured
+            .DidNotReceiveWithAnyArgs()
+            .CompleteAsync<LlmQueryPayload>(default!, TestContext.Current.CancellationToken);
+    }
 
-        // Assert
+    [Fact]
+    public async Task TranslateAsync_WhitespaceInput_ReturnsNullWithoutCallingTheModel()
+    {
+        QueryRequest? result = await _sut.TranslateAsync("   ", CreateTestMetadata(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+        await _structured
+            .DidNotReceiveWithAnyArgs()
+            .CompleteAsync<LlmQueryPayload>(default!, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task TranslateAsync_RoutesQueryAsContentAndSchemaAsInstruction()
+    {
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<LlmQueryPayload>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new StructuredCompletionResult<LlmQueryPayload> { Status = StructuredCompletionStatus.Succeeded, Value = new LlmQueryPayload() });
+
+        await _sut.TranslateAsync("find alice", CreateTestMetadata(), TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        // The untrusted phrase is the content; the field schema is developer-controlled instruction.
+        captured.Content.ShouldBe("find alice");
+        captured.Instruction.ShouldNotBeNull();
+        captured.Instruction.ShouldContain("status");
+        captured.Instruction.ShouldContain("amount");
+    }
+
+    [Fact]
+    public void BuildInstruction_IncludesFilterableFields()
+    {
+        string prompt = _sut.BuildInstruction(CreateTestMetadata());
+
         prompt.ShouldContain("status");
         prompt.ShouldContain("amount");
         prompt.ShouldContain("eq");
         prompt.ShouldContain("gte");
-    }
-
-    [Fact]
-    public void StripMarkdownFences_RemovesFences()
-    {
-        const string input = """
-            ```json
-            {"sort": "name"}
-            ```
-            """;
-
-        string result = LlmNaturalLanguageQueryTranslator.StripMarkdownFences(input);
-
-        result.ShouldBe("{\"sort\": \"name\"}");
-    }
-
-    [Fact]
-    public void StripMarkdownFences_PlainJsonUnchanged()
-    {
-        const string input = """{"sort": "name"}""";
-
-        string result = LlmNaturalLanguageQueryTranslator.StripMarkdownFences(input);
-
-        result.ShouldBe("{\"sort\": \"name\"}");
     }
 
     private static QueryMetadata CreateTestMetadata() =>

--- a/tests/Granit.QueryEngine.AI.Tests/LlmQueryPayloadTests.cs
+++ b/tests/Granit.QueryEngine.AI.Tests/LlmQueryPayloadTests.cs
@@ -26,7 +26,7 @@ public sealed class LlmQueryPayloadTests
             Page = 2,
             PageSize = 25,
             Sort = "-name",
-            Filter = new Dictionary<string, string> { ["name.eq"] = "test" },
+            Filter = [new LlmFilterClause { Key = "name.eq", Value = "test" }],
             QuickFilters = ["Active"],
             GroupBy = "status",
         };
@@ -36,8 +36,19 @@ public sealed class LlmQueryPayloadTests
         dto.Sort.ShouldBe("-name");
         dto.Filter.ShouldNotBeNull();
         dto.Filter.Count.ShouldBe(1);
+        dto.Filter[0].Key.ShouldBe("name.eq");
+        dto.Filter[0].Value.ShouldBe("test");
         dto.QuickFilters.ShouldNotBeNull();
         dto.QuickFilters.Count.ShouldBe(1);
         dto.GroupBy.ShouldBe("status");
+    }
+
+    [Fact]
+    public void FilterClause_defaults_to_empty_strings()
+    {
+        LlmFilterClause clause = new();
+
+        clause.Key.ShouldBe(string.Empty);
+        clause.Value.ShouldBe(string.Empty);
     }
 }


### PR DESCRIPTION
## What

Migrates `Granit.QueryEngine.AI` (`LlmNaturalLanguageQueryTranslator`) off the hand-rolled `IAIChatClientFactory` + System/User messages + manual JSON parsing onto the **`IStructuredCompletion`** primitive (ADR-064, Epic #2452).

**Last of the four reshape outliers — the F3 migration set is now complete (13/13).**

## Reshape

The dynamic-keyed filter map — which provider-enforced strict schema rejects — becomes a list of fixed clauses:

```jsonc
// before: "filter": { "status.eq": "active", "amount.gte": "1000" }
// after:  "filter": [ { "key": "status.eq", "value": "active" },
//                     { "key": "amount.gte", "value": "1000" } ]
```

`LlmQueryPayload.Filter` is now `List<LlmFilterClause>`; the `"field.operator"` key rides inside each clause and is reassembled into the `QueryRequest.Filter` dictionary (duplicate keys collapsed, first wins).

## System-prompt fold

The system prompt — query-format description, available fields/operators, current date, rules — is folded into the developer-controlled **`Instruction`**; the user's phrase travels as untrusted, sanitized **`Content`** (`<data>` block).

## Security / robustness

- The metadata **whitelist** (CWE-20 / OWASP LLM02) still strips any filter / sort / group-by / quick-filter the model returns outside the allowed set — e.g. an injected `"ssn.eq"` clause is dropped.
- Four-valued status maps non-success to the existing graceful `null`, preserving the module's translation-failed metric reasons (`transport→error`, `refused`/`schema→invalid_response`, caught `timeout→timeout`).
- Translator was already registered `Scoped` — no lifetime change.

## Tests

31 tests green. Schema pinning + fence-strip + JSON parsing are now the primitive's job, so the bespoke `StripMarkdownFences` / `TryDeserializeAndConvert` cases are gone; `BuildSystemPrompt` tests became `BuildInstruction` tests; added whitelist-strip, duplicate-key-collapse, and Content/Instruction channel-routing assertions.

`dotnet build` + `dotnet test` green, `dotnet format --verify-no-changes` clean.

Part of Epic #2452 / ADR-064 — completes F3.