### PR TITLE
fix(persistence): fail fast on explicit OwnsOne over a ValueObject subtype

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -359,8 +359,17 @@ public static class ModelBuilderExtensions
     // the value object entity types themselves as owners clears the FKs between nested value
     // objects (OpenGraph → OgImage) before those types are removed.
     //
-    // Note: value objects mapped explicitly as EF complex types (builder.ComplexProperty(...))
-    // are not entity types, so they never appear here and the convention leaves them untouched.
+    // Two carve-outs:
+    //   - ComplexProperty(...): value objects mapped explicitly as EF complex types are not
+    //     entity types, so they never appear here and the convention leaves them untouched.
+    //   - OwnsOne(...): owned entity types DO surface in Model.GetEntityTypes(). Granit
+    //     reserves ValueObject persistence to two paths — convention (auto JSON / scalar) or
+    //     ComplexProperty (typed flat columns). Allowing OwnsOne would create a third path
+    //     that fragments the framework invariant codified by ADR-017 and ADR-058. The
+    //     convention fails fast at model build with a clear message directing the author to
+    //     one of the two supported paths, rather than silently overriding the explicit
+    //     configuration (which would discard per-property HasMaxLength / column-name / etc.
+    //     and surface only as schema drift or a runtime STJ deserialization error).
     private static void RemoveValueObjectEntityTypes(ModelBuilder modelBuilder)
     {
         var valueObjectEntityTypes = modelBuilder.Model.GetEntityTypes()
@@ -405,6 +414,25 @@ public static class ModelBuilderExtensions
 
             foreach (System.Reflection.PropertyInfo clrProperty in valueObjectClrProperties)
             {
+                // Fail fast on explicit OwnsOne(...) over a ValueObject subtype on a real entity
+                // owner: this would create a third VO persistence path beyond the two supported
+                // by ADR-017 / ADR-058 (convention auto-JSON / scalar, or ComplexProperty for
+                // typed flat columns). Silent-override the previous behavior — produced schema
+                // drift and late STJ failures with no diagnostic. A nested-VO owner stays on
+                // the existing detach-only path: nobody opts in to OwnsOne on a VO-inside-VO.
+                IMutableNavigation? nav = ownerEntityType.FindNavigation(clrProperty.Name);
+                if (!ownerIsValueObject && nav?.ForeignKey.IsOwnership == true)
+                {
+                    throw new InvalidOperationException(
+                        $"'{ownerEntityType.ClrType.Name}.{clrProperty.Name}' is a ValueObject " +
+                        $"subtype configured via OwnsOne(...). Granit reserves ValueObject " +
+                        $"persistence to two paths: (1) let ApplyGranitConventions auto-serialize " +
+                        $"to JSON (multi-field) or a scalar column (SingleValueObject<T>), or " +
+                        $"(2) map explicitly via ComplexProperty(...) for typed flat columns. " +
+                        $"Drop the OwnsOne call or switch to ComplexProperty. " +
+                        $"See ADR-017 (DDD VO strategy) and ADR-058 (JSON persistence policy).");
+                }
+
                 ownerBuilder.Ignore(clrProperty.Name);
 
                 // A value object owner is removed wholesale below — only the navigation needs

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ValueObjectEntityAutoDiscoveryRemovalTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ValueObjectEntityAutoDiscoveryRemovalTests.cs
@@ -66,6 +66,32 @@ public sealed class ValueObjectEntityAutoDiscoveryRemovalTests
     }
 
     [Fact]
+    public void ApplyGranitConventions_EntityWithExplicitOwnsOneOnValueObject_FailsFastWithGuidance()
+    {
+        // Arrange — explicit OwnsOne(...) on a ValueObject subtype is unsupported. The
+        // convention must fail fast at model build with a message directing the author to one
+        // of the two supported paths (convention auto-JSON / scalar, or ComplexProperty for
+        // typed flat columns). Silent-override would discard the per-property configuration
+        // (column names, HasMaxLength, etc.) and surface only as a runtime schema drift or
+        // STJ deserialization error.
+        using ExplicitOwnsOneDbContext context = new(new DbContextOptionsBuilder<ExplicitOwnsOneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+        // Act + Assert — touching context.Model triggers OnModelCreating.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() => _ = context.Model);
+
+        // The message must name the offending pattern, point at the typed-columns alternative,
+        // cite the two ADRs, and locate the offending entity + property by name.
+        ex.Message.ShouldContain("OwnsOne");
+        ex.Message.ShouldContain("ComplexProperty");
+        ex.Message.ShouldContain("ADR-017");
+        ex.Message.ShouldContain("ADR-058");
+        ex.Message.ShouldContain(nameof(OwnsOneOwnerEntity));
+        ex.Message.ShouldContain(nameof(OwnsOneOwnerEntity.Location));
+    }
+
+    [Fact]
     public void ApplyGranitConventions_ValueObjectMappedAsComplexProperty_IsLeftUntouched()
     {
         // Arrange — opt out of the jsonb default by declaring the value object as an EF
@@ -145,6 +171,12 @@ public sealed class ValueObjectEntityAutoDiscoveryRemovalTests
         public GeoCoordinate Location { get; set; } = new();
     }
 
+    public sealed class OwnsOneOwnerEntity
+    {
+        public Guid Id { get; set; }
+        public GeoCoordinate Location { get; set; } = new();
+    }
+
     private sealed class SeoOwnerDbContext(DbContextOptions<SeoOwnerDbContext> options)
         : DbContext(options)
     {
@@ -164,6 +196,26 @@ public sealed class ValueObjectEntityAutoDiscoveryRemovalTests
             // Opt out of jsonb: map the value object as a complex type (flat columns).
             modelBuilder.Entity<ComplexOwnerEntity>()
                 .ComplexProperty(e => e.Location);
+
+            modelBuilder.ApplyGranitConventions();
+        }
+    }
+
+    private sealed class ExplicitOwnsOneDbContext(DbContextOptions<ExplicitOwnsOneDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<OwnsOneOwnerEntity> Owners => Set<OwnsOneOwnerEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Unsupported third path: OwnsOne(...) on a ValueObject subtype with per-property
+            // configuration. The convention must reject this at model build time.
+            modelBuilder.Entity<OwnsOneOwnerEntity>()
+                .OwnsOne(e => e.Location, loc =>
+                {
+                    loc.Property(g => g.Latitude).HasColumnName("lat");
+                    loc.Property(g => g.Longitude).HasColumnName("lng");
+                });
 
             modelBuilder.ApplyGranitConventions();
         }


### PR DESCRIPTION
Closes #2482.

## Why

`RemoveValueObjectEntityTypes` silently overrode any explicit `OwnsOne(...)` configuration on a property whose CLR type derived from `ValueObject`, replacing the per-property mapping (column names, `HasMaxLength`, `HasDefaultValue`, …) with a single `jsonb` column. No warning, no log, no exception — discovered only as schema drift or a runtime STJ deserialization error.

Granit reserves ValueObject persistence to two supported paths per [ADR-017](https://granit-fx.dev/dotnet/architecture/adr/017-ddd-aggregate-value-object-strategy/) and [ADR-058](https://granit-fx.dev/dotnet/architecture/adr/058-json-persistence-policy/):

1. **Convention auto-persistence** — multi-field → JSON, `SingleValueObject<T>` → scalar
2. **`ComplexProperty(...)`** — typed flat columns

`OwnsOne` would constitute a third path that fragments the framework invariant. Allowing it is the wrong fix; silently overriding it was the actual bug.

## What

Make the convention fail fast at model build with an `InvalidOperationException` that:

- Names the offending entity and property
- Points at both supported alternatives
- Cites ADR-017 and ADR-058 by ID for navigability

The two existing paths are unchanged: auto-discovered VO navigations still get the JSON / scalar treatment, `ComplexProperty(...)` is still left untouched.

## Validation

| | Status |
| --- | --- |
| `dotnet build src/Granit.Persistence.EntityFrameworkCore -c Release` | ✅ 0 warnings, 0 errors |
| `Granit.Persistence.EntityFrameworkCore.Tests` | ✅ **371 / 371** (3 / 3 in `ValueObjectEntityAutoDiscoveryRemovalTests`) |
| `Granit.ArchitectureTests` | 242 / 244 — **2 pre-existing failures** unrelated to this change (introduced by #2481 `feat(data-exchange)`): `Every_src_package_should_have_a_README` and `Exception_classes_should_reside_in_Exceptions_folder` (the latter flags `Granit.DataExchange.Abstractions/Export/ExportProviderIncompatibleException.cs`). Verified by `git stash` + re-run. |
| `dotnet format --verify-no-changes` (src + tests) | ✅ clean |

## Diff stat

~~~
 2 files changed, 82 insertions(+), 2 deletions(-)
~~~

## Test plan

- [x] Build / tests / format
- [x] New `ApplyGranitConventions_EntityWithExplicitOwnsOneOnValueObject_FailsFastWithGuidance` asserts on every required message fragment (`OwnsOne`, `ComplexProperty`, `ADR-017`, `ADR-058`, entity + property names)
- [x] Non-regression on the two supported paths covered by the existing tests in the same file
- [ ] CI shards green