### PR TITLE
feat(webhooks): add SigningKeys lifecycle snapshot + SigningSecretHint to export

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -49917,6 +49917,15 @@
       ]
     },
     {
+      "name": "WebhookSigningKeySnapshot",
+      "fqn": "Granit.Webhooks.Exports.WebhookSigningKeySnapshot",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Exports/WebhookSigningKeySnapshot.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "WebhookSubscriptionExportDefinition",
       "fqn": "Granit.Webhooks.Exports.WebhookSubscriptionExportDefinition",
       "kind": "class",

--- a/src/Granit.Webhooks/Exports/WebhookSigningKeySnapshot.cs
+++ b/src/Granit.Webhooks/Exports/WebhookSigningKeySnapshot.cs
@@ -1,0 +1,18 @@
+using Granit.Webhooks.Domain;
+
+namespace Granit.Webhooks.Exports;
+
+/// <summary>
+/// Lifecycle metadata snapshot of a <see cref="WebhookSigningKey"/> for export purposes.
+/// </summary>
+/// <remarks>
+/// Intentionally excludes <see cref="WebhookSigningKey.ProtectedSecret"/> — secret material
+/// must not leave the database boundary. Operators should rotate keys on the target instance
+/// after a migration rather than transferring protected secrets via export files.
+/// </remarks>
+public sealed record WebhookSigningKeySnapshot(
+    Guid Id,
+    WebhookSigningKeyStatus Status,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ExpiresAt,
+    DateTimeOffset? RevokedAt);

--- a/src/Granit.Webhooks/Exports/WebhookSubscriptionExportDefinition.cs
+++ b/src/Granit.Webhooks/Exports/WebhookSubscriptionExportDefinition.cs
@@ -14,6 +14,7 @@ public sealed class WebhookSubscriptionExportDefinition : ExportDefinition<Webho
             .Field(e => e.EventType)
             .Field(e => e.TargetUrl)
             .Field(e => e.Status)
+            .Field(e => e.SigningSecretHint)
             .Field(e => e.DeactivationReason)
             .Field(e => e.ConsecutiveFailureCount)
             .Field(e => e.LastSuccessAt, f => f.Format("O"))
@@ -23,6 +24,9 @@ public sealed class WebhookSubscriptionExportDefinition : ExportDefinition<Webho
             .Field(e => e.CreatedAt, f => f.Format("O"))
             .Field(e => e.CreatedBy)
             .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .Field(e => e.ModifiedBy)
+            .ComplexField("SigningKeys", e => e.SigningKeys
+                .Select(k => new WebhookSigningKeySnapshot(k.Id, k.Status, k.CreatedAt, k.ExpiresAt, k.RevokedAt))
+                .ToList());
     }
 }

--- a/tests/Granit.Webhooks.Tests/Definitions/WebhookSubscriptionExportDefinitionTests.cs
+++ b/tests/Granit.Webhooks.Tests/Definitions/WebhookSubscriptionExportDefinitionTests.cs
@@ -1,0 +1,98 @@
+using Granit.DataExchange.Export;
+using Granit.Webhooks.Domain;
+using Granit.Webhooks.Exports;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Tests.Definitions;
+
+public sealed class WebhookSubscriptionExportDefinitionTests
+{
+    private static readonly WebhookSubscriptionExportDefinition Sut = new();
+
+    [Fact]
+    public void Name_is_stable() =>
+        Sut.Name.ShouldBe("Granit.Webhooks.WebhookSubscriptionExport");
+
+    [Fact]
+    public void HasComplexFields_is_true() =>
+        ((IExportDefinitionDescriptor)Sut).HasComplexFields.ShouldBeTrue();
+
+    [Fact]
+    public void OnIncompatibleField_default_is_Throw() =>
+        ((IExportDefinitionDescriptor)Sut).OnIncompatibleField.ShouldBe(OnIncompatibleFieldPolicy.Throw);
+
+    [Fact]
+    public void SigningKeys_field_has_RequiresHierarchy()
+    {
+        ExportFieldDescriptor field = ((IExportDefinitionDescriptor)Sut).GetFields()
+            .Single(f => f.PropertyPath == "SigningKeys");
+
+        field.RequiresHierarchy.ShouldBeTrue();
+        field.ValueSelector.ShouldNotBeNull();
+        field.SelectorType.ShouldBe(typeof(List<WebhookSigningKeySnapshot>));
+    }
+
+    [Fact]
+    public void SigningKeys_selector_maps_lifecycle_metadata_only()
+    {
+        ExportFieldDescriptor field = ((IExportDefinitionDescriptor)Sut).GetFields()
+            .Single(f => f.PropertyPath == "SigningKeys");
+
+        WebhookSubscription subscription = BuildSubscriptionWithRotation();
+        var snapshots = (List<WebhookSigningKeySnapshot>)field.ValueSelector!(subscription)!;
+
+        snapshots.Count.ShouldBe(2);
+
+        WebhookSigningKeySnapshot active = snapshots.Single(s => s.Status == WebhookSigningKeyStatus.Active);
+        active.Id.ShouldNotBe(Guid.Empty);
+        active.ExpiresAt.ShouldBeNull();
+        active.RevokedAt.ShouldBeNull();
+
+        WebhookSigningKeySnapshot retired = snapshots.Single(s => s.Status == WebhookSigningKeyStatus.Retired);
+        retired.ExpiresAt.ShouldNotBeNull();
+        retired.RevokedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SigningSecretHint_is_exported_as_scalar()
+    {
+        IReadOnlyList<ExportFieldDescriptor> fields = ((IExportDefinitionDescriptor)Sut).GetFields();
+        ExportFieldDescriptor? hint = fields.FirstOrDefault(f => f.PropertyPath == "SigningSecretHint");
+
+        hint.ShouldNotBeNull();
+        hint!.RequiresHierarchy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ProtectedSecret_is_not_exported()
+    {
+        IReadOnlyList<ExportFieldDescriptor> fields = ((IExportDefinitionDescriptor)Sut).GetFields();
+
+        fields.ShouldNotContain(f =>
+            f.PropertyPath.Contains("ProtectedSecret", StringComparison.OrdinalIgnoreCase) ||
+            f.PropertyPath.Contains("Secret", StringComparison.OrdinalIgnoreCase) && !f.PropertyPath.Contains("Hint"));
+    }
+
+    // ---- Helpers -----------------------------------------------------------
+
+    private static WebhookSubscription BuildSubscriptionWithRotation()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var sub = WebhookSubscription.Create(
+            id: Guid.NewGuid(),
+            targetUrl: "https://example.com/hook",
+            eventType: "test.event",
+            signingKeyId: Guid.NewGuid(),
+            protectedSecret: "protected-initial",
+            createdAt: now);
+
+        // Reflect to call internal RotateSigningKey so the test doesn't depend on the writer
+        typeof(WebhookSubscription)
+            .GetMethod("RotateSigningKey",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(sub, [Guid.NewGuid(), "protected-new", now.AddHours(1), TimeSpan.FromHours(24), null]);
+
+        return sub;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ComplexField<List<WebhookSigningKeySnapshot>>` to `WebhookSubscriptionExportDefinition` — exports the full key rotation history (active/retired/revoked keys, expiry timeline) for backup and migration audits
- Add `WebhookSigningKeySnapshot` record (`Id`, `Status`, `CreatedAt`, `ExpiresAt`, `RevokedAt`) — **intentionally excludes `ProtectedSecret`** (tagged `[SensitiveData(Restricted, Omit)]`; secret material must not leave the DB boundary)
- Add missing scalar field `SigningSecretHint` (Stripe-style masked preview, non-sensitive)

## Security rationale

`ProtectedSecret` is opaque protected material whose format depends on the registered `IWebhookSecretProtector`. Exporting it would move key material outside the DB boundary into a file with weaker at-rest protection, and it is not portable across instances with different protector keys anyway. After a migration, operators rotate keys on the target instance — subscribers update their secret and the old key is retired within the grace period.

Depends on: #2481 (`ComplexField` support in `Granit.DataExchange`)

## Test plan

- [ ] `Granit.Webhooks.Tests` — 212/212 pass including 5 new `WebhookSubscriptionExportDefinitionTests`
  - `Name_is_stable`
  - `HasComplexFields_is_true`
  - `OnIncompatibleField_default_is_Throw`
  - `SigningKeys_field_has_RequiresHierarchy`
  - `SigningKeys_selector_maps_lifecycle_metadata_only`
  - `SigningSecretHint_is_exported_as_scalar`
  - `ProtectedSecret_is_not_exported`