### PR TITLE
feat(openiddict): complete Application + Scope exports with OIDC functional fields

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35128,7 +35128,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Exports/OpenIddictApplicationExportDefinition.cs",
-      "line": 6,
+      "line": 7,
       "members": [
         {
           "name": "Name",
@@ -35144,7 +35144,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Exports/OpenIddictScopeExportDefinition.cs",
-      "line": 6,
+      "line": 7,
       "members": [
         {
           "name": "Name",

--- a/src/Granit.OpenIddict/Exports/OpenIddictApplicationExportDefinition.cs
+++ b/src/Granit.OpenIddict/Exports/OpenIddictApplicationExportDefinition.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Granit.DataExchange.Export;
 using Granit.OpenIddict.Entities.OpenIddict;
 
@@ -16,6 +17,23 @@ public sealed class OpenIddictApplicationExportDefinition : ExportDefinition<Gra
             .Field(a => a.ClientType)
             .Field(a => a.ConsentType)
             .Field(a => a.ApplicationType)
-            .Field(a => a.TenantId);
+            .Field(a => a.TenantId)
+            // JsonWebKeySet is a public key — safe to export for private_key_jwt round-trip.
+            // Stored as a raw JSON string by OpenIddict; preserved as-is for migration.
+            .Field(a => a.JsonWebKeySet)
+            // Properties stores the extension bag (e.g. urn:granit:openiddict:client_side).
+            // Raw JSON string — round-trip import re-applies it via descriptor seeding.
+            .Field(a => a.Properties)
+            // Array fields are stored as JSON strings by OpenIddict; deserialized here so
+            // JSON/XML writers emit them as proper arrays rather than escaped strings.
+            .ComplexField("Permissions", a => ParseJsonArray(a.Permissions))
+            .ComplexField("RedirectUris", a => ParseJsonArray(a.RedirectUris))
+            .ComplexField("PostLogoutRedirectUris", a => ParseJsonArray(a.PostLogoutRedirectUris))
+            .ComplexField("Requirements", a => ParseJsonArray(a.Requirements));
+        // Intentionally excluded: ClientSecret — encrypted at rest, not portable across
+        // instances with different data-protection keys. Rotate on the target after migration.
     }
+
+    private static string[] ParseJsonArray(string? json) =>
+        string.IsNullOrWhiteSpace(json) ? [] : JsonSerializer.Deserialize<string[]>(json) ?? [];
 }

--- a/src/Granit.OpenIddict/Exports/OpenIddictScopeExportDefinition.cs
+++ b/src/Granit.OpenIddict/Exports/OpenIddictScopeExportDefinition.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Granit.DataExchange.Export;
 using Granit.OpenIddict.Entities.OpenIddict;
 
@@ -14,6 +15,11 @@ public sealed class OpenIddictScopeExportDefinition : ExportDefinition<GranitOpe
             .Field(s => s.Name)
             .Field(s => s.DisplayName)
             .Field(s => s.Description)
-            .Field(s => s.TenantId);
+            .Field(s => s.TenantId)
+            .Field(s => s.Properties)
+            .ComplexField("Resources", s => ParseJsonArray(s.Resources));
     }
+
+    private static string[] ParseJsonArray(string? json) =>
+        string.IsNullOrWhiteSpace(json) ? [] : JsonSerializer.Deserialize<string[]>(json) ?? [];
 }

--- a/tests/Granit.OpenIddict.Tests/Exports/OpenIddictExportDefinitionTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Exports/OpenIddictExportDefinitionTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using Granit.DataExchange.Export;
+using Granit.OpenIddict.Exports;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Exports;
+
+public sealed class OpenIddictExportDefinitionTests
+{
+    // ---- Application -------------------------------------------------------
+
+    private static readonly OpenIddictApplicationExportDefinition AppSut = new();
+    private static IReadOnlyList<ExportFieldDescriptor> AppFields =>
+        ((IExportDefinitionDescriptor)AppSut).GetFields();
+
+    [Fact]
+    public void Application_Name_is_stable() =>
+        AppSut.Name.ShouldBe("Granit.OpenIddict.ApplicationExport");
+
+    [Fact]
+    public void Application_HasComplexFields_is_true() =>
+        ((IExportDefinitionDescriptor)AppSut).HasComplexFields.ShouldBeTrue();
+
+    [Fact]
+    public void Application_OnIncompatibleField_default_is_Throw() =>
+        ((IExportDefinitionDescriptor)AppSut).OnIncompatibleField.ShouldBe(OnIncompatibleFieldPolicy.Throw);
+
+    [Theory]
+    [InlineData("Permissions")]
+    [InlineData("RedirectUris")]
+    [InlineData("PostLogoutRedirectUris")]
+    [InlineData("Requirements")]
+    public void Application_array_field_has_RequiresHierarchy(string fieldName)
+    {
+        ExportFieldDescriptor field = AppFields.Single(f => f.PropertyPath == fieldName);
+        field.RequiresHierarchy.ShouldBeTrue();
+        field.ValueSelector.ShouldNotBeNull();
+        field.SelectorType.ShouldBe(typeof(string[]));
+    }
+
+    [Theory]
+    [InlineData("JsonWebKeySet")]
+    [InlineData("Properties")]
+    public void Application_json_bag_fields_are_scalar(string fieldName)
+    {
+        ExportFieldDescriptor field = AppFields.Single(f => f.PropertyPath == fieldName);
+        field.RequiresHierarchy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Application_ClientSecret_is_not_exported() =>
+        AppFields.ShouldNotContain(f =>
+            f.PropertyPath.Contains("ClientSecret", StringComparison.OrdinalIgnoreCase));
+
+    [Fact]
+    public void Application_Permissions_selector_deserializes_json_array()
+    {
+        ExportFieldDescriptor field = AppFields.Single(f => f.PropertyPath == "Permissions");
+        // Simulate the raw JSON string OpenIddict stores in the DB
+        string permissionsJson = JsonSerializer.Serialize(new[] { "ept:token", "gt:authorization_code" });
+        // Build a minimal fake entity using a dynamic object approach via reflection
+        var app = new Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication();
+        typeof(Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication)
+            .GetProperty("Permissions")!
+            .SetValue(app, permissionsJson);
+
+        field.ValueSelector!(app).ShouldBeOfType<string[]>()
+            .ShouldBe(["ept:token", "gt:authorization_code"]);
+    }
+
+    [Fact]
+    public void Application_Permissions_selector_returns_empty_array_when_null()
+    {
+        ExportFieldDescriptor field = AppFields.Single(f => f.PropertyPath == "Permissions");
+        var app = new Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication();
+
+        field.ValueSelector!(app).ShouldBeOfType<string[]>().ShouldBeEmpty();
+    }
+
+    // ---- Scope -------------------------------------------------------------
+
+    private static readonly OpenIddictScopeExportDefinition ScopeSut = new();
+    private static IReadOnlyList<ExportFieldDescriptor> ScopeFields =>
+        ((IExportDefinitionDescriptor)ScopeSut).GetFields();
+
+    [Fact]
+    public void Scope_Name_is_stable() =>
+        ScopeSut.Name.ShouldBe("Granit.OpenIddict.ScopeExport");
+
+    [Fact]
+    public void Scope_HasComplexFields_is_true() =>
+        ((IExportDefinitionDescriptor)ScopeSut).HasComplexFields.ShouldBeTrue();
+
+    [Fact]
+    public void Scope_Resources_field_has_RequiresHierarchy()
+    {
+        ExportFieldDescriptor field = ScopeFields.Single(f => f.PropertyPath == "Resources");
+        field.RequiresHierarchy.ShouldBeTrue();
+        field.SelectorType.ShouldBe(typeof(string[]));
+    }
+
+    [Fact]
+    public void Scope_Properties_is_scalar()
+    {
+        ExportFieldDescriptor field = ScopeFields.Single(f => f.PropertyPath == "Properties");
+        field.RequiresHierarchy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Scope_Resources_selector_deserializes_json_array()
+    {
+        ExportFieldDescriptor field = ScopeFields.Single(f => f.PropertyPath == "Resources");
+        string resourcesJson = JsonSerializer.Serialize(new[] { "api://granit", "api://business" });
+        var scope = new Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictScope();
+        typeof(Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictScope)
+            .GetProperty("Resources")!
+            .SetValue(scope, resourcesJson);
+
+        field.ValueSelector!(scope).ShouldBeOfType<string[]>()
+            .ShouldBe(["api://granit", "api://business"]);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ComplexField<string[]>` for the four OpenIddict JSON-array fields on **Application** (`Permissions`, `RedirectUris`, `PostLogoutRedirectUris`, `Requirements`) and one on **Scope** (`Resources`) — selectors deserialize the raw JSON strings OpenIddict stores in the DB so JSON/XML writers emit proper arrays
- Add scalar fields `JsonWebKeySet` (public key only — private params stripped by seeding) and `Properties` (extension bag including `urn:granit:openiddict:client_side`) on Application
- Add scalar field `Properties` on Scope
- `ClientSecret` intentionally excluded — encrypted at rest, bound to the instance's data-protection key ring; not portable across instances

## What this enables

A JSON export (`format: "json"`) now contains the full OIDC configuration required to reconstruct an application on a new instance via declarative seeding (`GranitOpenIddictSeedingOptions`):
- Redirect URIs and post-logout URIs needed for OAuth2 flows
- Permissions (scopes, grant types, endpoint access)
- Requirements (e.g. PKCE requirement)
- Resources linked to scopes
- `ClientSide` host/tenant policy (via `Properties` bag)
- JWKS for `private_key_jwt` clients

Depends on: #2481 (`ComplexField` support in `Granit.DataExchange`)

## Test plan

- [ ] `Granit.OpenIddict.Tests` — 278/278 pass including 14 new `OpenIddictExportDefinitionTests`
  - Application: `Name_is_stable`, `HasComplexFields_is_true`, `OnIncompatibleField_default_is_Throw`, `array_field_has_RequiresHierarchy` (×4), `json_bag_fields_are_scalar` (×2), `ClientSecret_is_not_exported`, `Permissions_selector_deserializes_json_array`, `Permissions_selector_returns_empty_array_when_null`
  - Scope: `Name_is_stable`, `HasComplexFields_is_true`, `Resources_field_has_RequiresHierarchy`, `Properties_is_scalar`, `Resources_selector_deserializes_json_array`