### PR TITLE
feat(scheduling): add PayloadJson to ScheduledActionExportDefinition

### DIFF
--- a/src/Granit.Scheduling/Exports/ScheduledActionExportDefinition.cs
+++ b/src/Granit.Scheduling/Exports/ScheduledActionExportDefinition.cs
@@ -12,6 +12,7 @@ public sealed class ScheduledActionExportDefinition : ExportDefinition<Scheduled
         builder
             .IncludeId()
             .Field(e => e.PayloadType)
+            .Field(e => e.PayloadJson)
             .Field(e => e.ExecuteAt, f => f.Format("O"))
             .Field(e => e.CorrelationId)
             .Field(e => e.Status)

--- a/tests/Granit.Scheduling.Tests/Exports/ScheduledActionExportDefinitionTests.cs
+++ b/tests/Granit.Scheduling.Tests/Exports/ScheduledActionExportDefinitionTests.cs
@@ -1,0 +1,39 @@
+using Granit.DataExchange.Export;
+using Granit.Scheduling.Exports;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Scheduling.Tests.Exports;
+
+public sealed class ScheduledActionExportDefinitionTests
+{
+    private static readonly ScheduledActionExportDefinition Sut = new();
+    private static IReadOnlyList<ExportFieldDescriptor> Fields =>
+        ((IExportDefinitionDescriptor)Sut).GetFields();
+
+    [Fact]
+    public void Name_is_stable() =>
+        Sut.Name.ShouldBe("Granit.Scheduling.ScheduledActionExport");
+
+    [Fact]
+    public void PayloadJson_is_exported_as_scalar()
+    {
+        ExportFieldDescriptor field = Fields.Single(f => f.PropertyPath == "PayloadJson");
+        field.RequiresHierarchy.ShouldBeFalse();
+        field.ValueSelector.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PayloadType_and_PayloadJson_are_adjacent()
+    {
+        // PayloadJson must immediately follow PayloadType so the pair is co-located
+        // when consumers iterate fields for deserialization.
+        int typeOrder = Fields.Single(f => f.PropertyPath == "PayloadType").Order;
+        int jsonOrder = Fields.Single(f => f.PropertyPath == "PayloadJson").Order;
+        jsonOrder.ShouldBe(typeOrder + 1);
+    }
+
+    [Fact]
+    public void HasComplexFields_is_false() =>
+        ((IExportDefinitionDescriptor)Sut).HasComplexFields.ShouldBeFalse();
+}


### PR DESCRIPTION
## Summary

Add `PayloadJson` as a scalar field to `ScheduledActionExportDefinition`, positioned immediately after `PayloadType`.

Without it, an export of `Pending` scheduled actions omits the Wolverine message body — re-imported actions are inert because the handler has no payload to dispatch.

`PayloadJson` is a raw JSON string (the domain stores it as `string`), so it exports as-is for all formats. CSV consumers get a JSON string inside a cell; JSON/XML consumers get a string property. Either way the `PayloadType` + `PayloadJson` pair is sufficient to reconstruct a `ScheduledAction.Create(...)` call on the target instance.

Note: `HasComplexFields` remains `false` — no `ComplexField` is needed since the field is already a plain string.

## Test plan

- [ ] `Granit.Scheduling.Tests` — 11/11 pass including 3 new `ScheduledActionExportDefinitionTests`
  - `Name_is_stable`
  - `PayloadJson_is_exported_as_scalar`
  - `PayloadType_and_PayloadJson_are_adjacent`
  - `HasComplexFields_is_false`