### PR TITLE
feat(notifications): add Data (JsonElement) to UserNotificationExportDefinition

### DIFF
--- a/src/Granit.Notifications/Exports/UserNotificationExportDefinition.cs
+++ b/src/Granit.Notifications/Exports/UserNotificationExportDefinition.cs
@@ -20,6 +20,10 @@ public sealed class UserNotificationExportDefinition : ExportDefinition<UserNoti
             .Field(e => e.ReadAt, f => f.Format("O"))
             .Field(e => e.RelatedEntityType)
             .Field(e => e.RelatedEntityId)
-            .Field(e => e.TenantId);
+            .Field(e => e.TenantId)
+            // Data is the typed notification payload (JsonElement stored as jsonb).
+            // Requires a structured writer (JSON) — CSV/Excel exports throw
+            // ExportProviderIncompatibleException under the default Throw policy.
+            .ComplexField("Data", e => e.Data);
     }
 }

--- a/tests/Granit.Notifications.Tests/Exports/UserNotificationExportDefinitionTests.cs
+++ b/tests/Granit.Notifications.Tests/Exports/UserNotificationExportDefinitionTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using Granit.DataExchange.Export;
+using Granit.Notifications.Domain;
+using Granit.Notifications.Exports;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.Tests.Exports;
+
+public sealed class UserNotificationExportDefinitionTests
+{
+    private static readonly UserNotificationExportDefinition Sut = new();
+    private static IReadOnlyList<ExportFieldDescriptor> Fields =>
+        ((IExportDefinitionDescriptor)Sut).GetFields();
+
+    [Fact]
+    public void Name_is_stable() =>
+        Sut.Name.ShouldBe("Granit.Notifications.UserNotificationExport");
+
+    [Fact]
+    public void HasComplexFields_is_true() =>
+        ((IExportDefinitionDescriptor)Sut).HasComplexFields.ShouldBeTrue();
+
+    [Fact]
+    public void OnIncompatibleField_default_is_Throw() =>
+        ((IExportDefinitionDescriptor)Sut).OnIncompatibleField.ShouldBe(OnIncompatibleFieldPolicy.Throw);
+
+    [Fact]
+    public void Data_field_has_RequiresHierarchy()
+    {
+        ExportFieldDescriptor field = Fields.Single(f => f.PropertyPath == "Data");
+        field.RequiresHierarchy.ShouldBeTrue();
+        field.ValueSelector.ShouldNotBeNull();
+        field.SelectorType.ShouldBe(typeof(JsonElement));
+    }
+
+    [Fact]
+    public void Data_selector_returns_JsonElement_from_notification()
+    {
+        ExportFieldDescriptor field = Fields.Single(f => f.PropertyPath == "Data");
+        JsonElement payload = JsonSerializer.Deserialize<JsonElement>("""{"subject":"Hello","body":"World"}""");
+        var notification = UserNotification.Create(
+            id: Guid.NewGuid(),
+            notificationId: Guid.NewGuid(),
+            notificationTypeName: "test.notification",
+            severity: NotificationSeverity.Info,
+            recipientUserId: "user-1",
+            data: payload,
+            createdAt: DateTimeOffset.UtcNow);
+
+        field.ValueSelector!(notification).ShouldBeOfType<JsonElement>()
+            .GetProperty("subject").GetString().ShouldBe("Hello");
+    }
+
+    [Fact]
+    public void Scalar_fields_do_not_include_Data()
+    {
+        IReadOnlyList<ExportFieldDescriptor> scalarFields = Fields.Where(f => !f.RequiresHierarchy).ToList();
+        scalarFields.ShouldNotContain(f => f.PropertyPath == "Data");
+    }
+}


### PR DESCRIPTION
## Summary

Add `ComplexField<JsonElement>("Data", e => e.Data)` to `UserNotificationExportDefinition`.

Without `Data`, exported notifications are hollow — the typed payload (subject, body, template variables) is absent, making re-delivery and in-app display impossible on the target instance after migration.

`Data` is stored as `jsonb` (a `JsonElement` on the domain entity). `ComplexField<JsonElement>` captures `SelectorType = typeof(JsonElement)` at definition time, so the JSON writer calls `JsonSerializer.Serialize(writer, value, typeof(JsonElement), options)` — the value is embedded as a proper nested JSON object, not as an escaped string.

Tabular formats (CSV/Excel) throw `ExportProviderIncompatibleException` under the default `Throw` policy — correct, a `JsonElement` payload is meaningless in a flat row.

## Test plan

- [ ] `Granit.Notifications.Tests` — 254/254 pass including 4 new `UserNotificationExportDefinitionTests`
  - `Name_is_stable`
  - `HasComplexFields_is_true`
  - `OnIncompatibleField_default_is_Throw`
  - `Data_field_has_RequiresHierarchy`
  - `Data_selector_returns_JsonElement_from_notification`
  - `Scalar_fields_do_not_include_Data`