### PR TITLE
feat(identity-federated): add UserId + MetadataJson to FederatedIdentityExportDefinition

### DIFF
--- a/src/Granit.Identity.Federated/Exports/FederatedIdentityExportDefinition.cs
+++ b/src/Granit.Identity.Federated/Exports/FederatedIdentityExportDefinition.cs
@@ -11,13 +11,23 @@ public sealed class FederatedIdentityExportDefinition : ExportDefinition<Federat
     {
         builder
             .IncludeId()
+            // UserId is the FK to the canonical User aggregate (ADR-051 B-step 3).
+            // Without it the federated→canonical user link is lost on re-import.
+            .Field(u => u.UserId)
             .Field(u => u.ExternalUserId)
             .Field(u => u.Enabled)
             .Field(u => u.LastSyncedAt, f => f.Format("O"))
+            // MetadataJson holds extra IdP properties (Dictionary<string,string> serialized
+            // as a JSON string). Preserved as-is for round-trip; re-hydrated from IdP on login.
+            .Field(u => u.MetadataJson)
             .Field(u => u.TenantId)
             .Field(u => u.CreatedAt, f => f.Format("O"))
             .Field(u => u.CreatedBy)
             .Field(u => u.ModifiedAt, f => f.Format("O"))
             .Field(u => u.ModifiedBy);
+        // Intentionally excluded: Username, Email, FirstName, LastName ([Encrypted]+[SensitiveData]),
+        // EmailHash (peppered hash — security artifact, not portable). FederatedIdentity is a
+        // cache entry re-hydrated from the IdP at login — PII export would expose plaintext
+        // (EF interceptor decrypts on read) in a file without equivalent at-rest protection.
     }
 }

--- a/tests/Granit.Identity.Federated.Tests/Exports/FederatedIdentityExportDefinitionTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Exports/FederatedIdentityExportDefinitionTests.cs
@@ -1,0 +1,52 @@
+using Granit.DataExchange.Export;
+using Granit.Identity.Federated.Exports;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.Tests.Exports;
+
+public sealed class FederatedIdentityExportDefinitionTests
+{
+    private static readonly FederatedIdentityExportDefinition Sut = new();
+    private static IReadOnlyList<ExportFieldDescriptor> Fields =>
+        ((IExportDefinitionDescriptor)Sut).GetFields();
+
+    [Fact]
+    public void Name_is_stable() =>
+        Sut.Name.ShouldBe("Granit.Identity.Federated.FederatedIdentityExport");
+
+    [Fact]
+    public void HasComplexFields_is_false() =>
+        ((IExportDefinitionDescriptor)Sut).HasComplexFields.ShouldBeFalse();
+
+    [Fact]
+    public void UserId_is_exported_as_scalar()
+    {
+        ExportFieldDescriptor field = Fields.Single(f => f.PropertyPath == "UserId");
+        field.RequiresHierarchy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void UserId_precedes_ExternalUserId()
+    {
+        int userIdOrder = Fields.Single(f => f.PropertyPath == "UserId").Order;
+        int externalOrder = Fields.Single(f => f.PropertyPath == "ExternalUserId").Order;
+        userIdOrder.ShouldBeLessThan(externalOrder);
+    }
+
+    [Fact]
+    public void MetadataJson_is_exported_as_scalar()
+    {
+        ExportFieldDescriptor field = Fields.Single(f => f.PropertyPath == "MetadataJson");
+        field.RequiresHierarchy.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("Username")]
+    [InlineData("Email")]
+    [InlineData("FirstName")]
+    [InlineData("LastName")]
+    [InlineData("EmailHash")]
+    public void Encrypted_and_hash_fields_are_not_exported(string fieldName) =>
+        Fields.ShouldNotContain(f => f.PropertyPath == fieldName);
+}


### PR DESCRIPTION
## Summary

- Add `UserId` (scalar) — FK to the canonical `User` aggregate per ADR-051 B-step 3; without it the federated→canonical link is lost on re-import
- Add `MetadataJson` (scalar) — extra IdP properties (`Dictionary<string,string>` stored as a JSON string); preserved for round-trip, re-hydrated from IdP at login anyway

## What is intentionally NOT exported

| Field | Reason |
|-------|--------|
| `Username`, `Email`, `FirstName`, `LastName` | `[Encrypted]` + `[SensitiveData]` — EF interceptor decrypts on read; exporting plaintext into a file without equivalent at-rest protection is a GDPR exposure. `FederatedIdentity` is a cache — IdP is the authoritative source and re-hydrates these on first login after migration. |
| `EmailHash` | Peppered HMAC-SHA256 lookup hash — bound to the instance's pepper key, not portable. |

## Test plan

- [ ] `Granit.Identity.Federated.Tests` — 65/65 pass including 7 new `FederatedIdentityExportDefinitionTests`
  - `Name_is_stable`
  - `HasComplexFields_is_false`
  - `UserId_is_exported_as_scalar`
  - `UserId_precedes_ExternalUserId`
  - `MetadataJson_is_exported_as_scalar`
  - `Encrypted_and_hash_fields_are_not_exported` (×5: Username, Email, FirstName, LastName, EmailHash)