### PR TITLE
fix(dataexchange): satisfy archi conventions for the complex-export feature

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13359,6 +13359,15 @@
       "members": []
     },
     {
+      "name": "ExportProviderIncompatibleException",
+      "fqn": "Granit.DataExchange.Export.Exceptions.ExportProviderIncompatibleException",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Export/Exceptions/ExportProviderIncompatibleException.cs",
+      "line": 7,
+      "members": []
+    },
+    {
       "name": "ExportDefinition",
       "fqn": "Granit.DataExchange.Export.ExportDefinition",
       "kind": "class",
@@ -13508,7 +13517,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Export/ExportOrchestrator.cs",
-      "line": 26,
+      "line": 27,
       "members": [
         {
           "name": "ExportAsync",
@@ -13531,15 +13540,6 @@
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Export/ExportPreset.cs",
       "line": 12,
-      "members": []
-    },
-    {
-      "name": "ExportProviderIncompatibleException",
-      "fqn": "Granit.DataExchange.Export.ExportProviderIncompatibleException",
-      "kind": "class",
-      "project": "Granit.DataExchange.Abstractions",
-      "file": "src/Granit.DataExchange.Abstractions/Export/ExportProviderIncompatibleException.cs",
-      "line": 7,
       "members": []
     },
     {

--- a/src/Granit.DataExchange.Abstractions/Export/Exceptions/ExportProviderIncompatibleException.cs
+++ b/src/Granit.DataExchange.Abstractions/Export/Exceptions/ExportProviderIncompatibleException.cs
@@ -1,4 +1,4 @@
-namespace Granit.DataExchange.Export;
+namespace Granit.DataExchange.Export.Exceptions;
 
 /// <summary>
 /// Thrown when the chosen export format does not support complex/hierarchical fields

--- a/src/Granit.DataExchange.Abstractions/Export/ExportDefinitionBuilder.cs
+++ b/src/Granit.DataExchange.Abstractions/Export/ExportDefinitionBuilder.cs
@@ -123,7 +123,7 @@ public sealed class ExportDefinitionBuilder<TEntity> where TEntity : class
     /// <para>
     /// The resulting field sets <see cref="ExportFieldDescriptor.RequiresHierarchy"/> to <c>true</c>.
     /// Export writers that do not declare <c>SupportsHierarchy = true</c> in their capabilities
-    /// will throw <see cref="ExportProviderIncompatibleException"/> (default) or skip the field
+    /// will throw <see cref="Exceptions.ExportProviderIncompatibleException"/> (default) or skip the field
     /// depending on <see cref="ExportDefinition{TEntity}.OnIncompatibleField"/>.
     /// </para>
     /// </remarks>

--- a/src/Granit.DataExchange.Abstractions/Export/OnIncompatibleFieldPolicy.cs
+++ b/src/Granit.DataExchange.Abstractions/Export/OnIncompatibleFieldPolicy.cs
@@ -7,7 +7,7 @@ namespace Granit.DataExchange.Export;
 public enum OnIncompatibleFieldPolicy
 {
     /// <summary>
-    /// Throw <see cref="ExportProviderIncompatibleException"/> immediately.
+    /// Throw <see cref="Exceptions.ExportProviderIncompatibleException"/> immediately.
     /// This is the default: fail fast rather than silently losing data.
     /// </summary>
     Throw,

--- a/src/Granit.DataExchange.Json/README.md
+++ b/src/Granit.DataExchange.Json/README.md
@@ -1,0 +1,24 @@
+# Granit.DataExchange.Json
+
+JSON export support for `Granit.DataExchange`.
+
+**Export**: `JsonExportWriter` implementing `IExportWriter` (format `"json"`) with
+`ExportFormatCapabilities.Structured` — so it serializes hierarchical/complex fields
+(`ComplexField<TValue>`) in full, enabling round-trippable structured exports. Per-row
+streaming flush; cycle-safe serialization (`ReferenceHandler.IgnoreCycles`).
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.DataExchange.Json
+```
+
+## Dependencies
+
+- `Granit.DataExchange`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.DataExchange.Xml/README.md
+++ b/src/Granit.DataExchange.Xml/README.md
@@ -1,0 +1,24 @@
+# Granit.DataExchange.Xml
+
+XML export support for `Granit.DataExchange`.
+
+**Export**: `XmlExportWriter` implementing `IExportWriter` (format `"xml"`) with
+`ExportFormatCapabilities.Structured` — so it serializes hierarchical/complex fields
+(`ComplexField<TValue>`) in full, enabling round-trippable structured exports. Per-row
+streaming flush; cached per-type serializers; loud failure on unsupported types.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.DataExchange.Xml
+```
+
+## Dependencies
+
+- `Granit.DataExchange`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.DataExchange/Export/ExportOrchestrator.cs
+++ b/src/Granit.DataExchange/Export/ExportOrchestrator.cs
@@ -4,6 +4,7 @@ using Granit.Commands;
 using Granit.DataExchange.Diagnostics;
 using Granit.DataExchange.Export.Domain;
 using Granit.DataExchange.Export.Events;
+using Granit.DataExchange.Export.Exceptions;
 using Granit.DataExchange.Export.Messages;
 using Granit.Domain.ValueObjects;
 using Granit.Events;

--- a/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
@@ -4,6 +4,7 @@ using Granit.Commands;
 using Granit.DataExchange.Diagnostics;
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
+using Granit.DataExchange.Export.Exceptions;
 using Granit.DataExchange.Export.Messages;
 using Granit.Events;
 using Granit.Guids;


### PR DESCRIPTION
## Problem

`develop` is **red** on the architecture shard: PR #2489 merged the complex/hierarchical export feature without two convention fixes, so `Granit.ArchitectureTests` fails (242/244):

- `Every_src_package_should_have_a_README` — `Granit.DataExchange.Json` and `Granit.DataExchange.Xml` ship no `README.md`.
- `Exception_classes_should_reside_in_Exceptions_folder` — `ExportProviderIncompatibleException.cs` sits in `Export/`, not an `Exceptions/` subfolder.

A red `develop` blocks the dev-publish, so downstream consumers can't pick up the `ComplexField` API.

## Fix

- Move `ExportProviderIncompatibleException` into `Export/Exceptions/` → namespace `Granit.DataExchange.Export.Exceptions` (satisfies both the Exceptions-folder and namespace-matches-folder rules); update the orchestrator + test `using`s and the two doc `cref`s.
- Add `README.md` to `Granit.DataExchange.Json` and `Granit.DataExchange.Xml` (mirroring the `Csv` writer README).

## Verification

- `Granit.ArchitectureTests` — **244/244** (was 242 + 2 failed).
- `Granit.DataExchange.Tests` — **368/368**.
- Touched projects build clean; `dotnet format` clean.

No behaviour change — file move + doc/README + `using` only.