### PR TITLE
feat(hostnames): P2b — built-in DnsHostnameVerifier + HostnamesOptions + auto-BeginVerification

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19528,7 +19528,7 @@
       "kind": "class",
       "project": "Granit.Hostnames.BackgroundJobs",
       "file": "src/Granit.Hostnames.BackgroundJobs/Services/HostnameVerificationBatchService.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -19835,7 +19835,7 @@
       "kind": "class",
       "project": "Granit.Hostnames.Endpoints",
       "file": "src/Granit.Hostnames.Endpoints/Extensions/HostnamesEndpointRouteBuilderExtensions.cs",
-      "line": 19,
+      "line": 21,
       "members": [
         {
           "name": "MapGranitHostnames",
@@ -19916,7 +19916,7 @@
       "kind": "class",
       "project": "Granit.Hostnames.EntityFrameworkCore",
       "file": "src/Granit.Hostnames.EntityFrameworkCore/Extensions/HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitHostnamesEntityFrameworkCore",
@@ -20021,13 +20021,35 @@
       "kind": "class",
       "project": "Granit.Hostnames",
       "file": "src/Granit.Hostnames/GranitHostnamesModule.cs",
-      "line": 21,
+      "line": 24,
       "members": [
         {
           "name": "ConfigureServices",
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "HostnamesOptions",
+      "fqn": "Granit.Hostnames.Options.HostnamesOptions",
+      "kind": "class",
+      "project": "Granit.Hostnames",
+      "file": "src/Granit.Hostnames/Options/HostnamesOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IngressTarget",
+          "kind": "property",
+          "signature": "string? IngressTarget",
+          "returnType": "string?"
+        },
+        {
+          "name": "VerificationBatchSize",
+          "kind": "property",
+          "signature": "int VerificationBatchSize",
+          "returnType": "int"
         }
       ]
     },

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,6 +71,9 @@
   <ItemGroup Label="Background Jobs">
     <PackageVersion Include="Cronos" Version="0.13.*" />
   </ItemGroup>
+  <ItemGroup Label="DNS">
+    <PackageVersion Include="DnsClient" Version="1.8.*" />
+  </ItemGroup>
   <ItemGroup Label="Validation">
     <PackageVersion Include="FluentValidation" Version="12.*" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.*" />

--- a/src/Granit.Hostnames.BackgroundJobs/Services/HostnameVerificationBatchService.cs
+++ b/src/Granit.Hostnames.BackgroundJobs/Services/HostnameVerificationBatchService.cs
@@ -1,6 +1,8 @@
 using Granit.Hostnames.Contracts;
 using Granit.Hostnames.Domain;
+using Granit.Hostnames.Options;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Hostnames.BackgroundJobs.Services;
 
@@ -14,12 +16,14 @@ public sealed partial class HostnameVerificationBatchService(
     IManagedHostnameWriter writer,
     IHostnameVerifier verifier,
     TimeProvider timeProvider,
+    IOptions<HostnamesOptions> options,
     ILogger<HostnameVerificationBatchService> logger)
 {
     private readonly IManagedHostnameReader _reader = reader;
     private readonly IManagedHostnameWriter _writer = writer;
     private readonly IHostnameVerifier _verifier = verifier;
     private readonly TimeProvider _timeProvider = timeProvider;
+    private readonly HostnamesOptions _options = options.Value;
     private readonly ILogger<HostnameVerificationBatchService> _logger = logger;
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -27,7 +31,7 @@ public sealed partial class HostnameVerificationBatchService(
         DateTimeOffset now = _timeProvider.GetUtcNow();
 
         IReadOnlyList<ManagedHostname> due = await _reader
-            .ListDueForVerificationAsync(now, cancellationToken: cancellationToken)
+            .ListDueForVerificationAsync(now, _options.VerificationBatchSize, cancellationToken)
             .ConfigureAwait(false);
 
         if (due.Count == 0)

--- a/src/Granit.Hostnames.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Hostnames.BackgroundJobs/packages.lock.json
@@ -87,6 +87,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -128,6 +129,12 @@
         "requested": "[0.13.*, )",
         "resolved": "0.13.0",
         "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Hostnames.Endpoints/Extensions/HostnamesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Hostnames.Endpoints/Extensions/HostnamesEndpointRouteBuilderExtensions.cs
@@ -4,12 +4,14 @@ using Granit.Hostnames.Domain;
 using Granit.Hostnames.Endpoints.Dtos;
 using Granit.Hostnames.Endpoints.Options;
 using Granit.Hostnames.Endpoints.Permissions;
+using Granit.Hostnames.Options;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Hostnames.Endpoints.Extensions;
 
@@ -112,9 +114,10 @@ public static class HostnamesEndpointRouteBuilderExtensions
             .RequireAuthorization(HostnamesPermissions.Hostnames.Manage)
             .WithName("VerifyHostnameNow")
             .WithSummary("Manually triggers DNS verification for a hostname.")
-            .WithDescription("Resets any exponential backoff and immediately re-queues the hostname for verification (transitions to Verifying). The actual DNS check runs asynchronously via the verification poller. Returns 202 Accepted with the updated hostname record. Returns 404 when not found. Requires the Hostnames.Manage permission.")
+            .WithDescription("For Verifying, Error, or Active hostnames: resets exponential backoff and re-queues the DNS check (transitions to Verifying). For Pending hostnames: initializes verification by minting the challenge token and expected DNS records, then transitions to Verifying. Returns 409 when the hostname is Pending and the platform ingress target is not configured. Returns 202 Accepted with the updated hostname record. Returns 404 when not found. Requires the Hostnames.Manage permission.")
             .Produces<ManagedHostnameResponse>(StatusCodes.Status202Accepted)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
     }
 
     // ── Handlers ──────────────────────────────────────────────────────────────
@@ -177,6 +180,7 @@ public static class HostnamesEndpointRouteBuilderExtensions
         [FromServices] IManagedHostnameWriter writer,
         [FromServices] IManagedHostnameReader reader,
         [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IOptions<HostnamesOptions> hostnamesOptions,
         CancellationToken cancellationToken)
     {
         Hostname hostnameValue;
@@ -209,6 +213,15 @@ public static class HostnamesEndpointRouteBuilderExtensions
             body.OwnerId,
             body.TenantId,
             body.IsPrimary);
+
+        // When the platform ingress target is configured, mint the DNS challenge immediately
+        // so the API response already carries the records the customer must configure.
+        HostnamesOptions opts = hostnamesOptions.Value;
+        if (!string.IsNullOrEmpty(opts.IngressTarget))
+        {
+            string token = guidGenerator.Create().ToString("N");
+            hostname.BeginVerification(token, BuildExpectedRecords(hostname.Host.Value, token, opts));
+        }
 
         await writer.AddAsync(hostname, cancellationToken).ConfigureAwait(false);
 
@@ -279,6 +292,8 @@ public static class HostnamesEndpointRouteBuilderExtensions
         Guid id,
         [FromServices] IManagedHostnameReader reader,
         [FromServices] IManagedHostnameWriter writer,
+        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IOptions<HostnamesOptions> hostnamesOptions,
         CancellationToken cancellationToken)
     {
         ManagedHostname? hostname = await reader
@@ -290,13 +305,36 @@ public static class HostnamesEndpointRouteBuilderExtensions
             return HostnameNotFound(id);
         }
 
-        hostname.RequestRecheck();
-        await writer.UpdateAsync(hostname, cancellationToken).ConfigureAwait(false);
+        if (hostname.Status == HostnameStatus.Pending)
+        {
+            HostnamesOptions opts = hostnamesOptions.Value;
+            if (string.IsNullOrEmpty(opts.IngressTarget))
+            {
+                return TypedResults.Problem(
+                    detail: "Hostname verification has not been initialized. Configure 'Hostnames:IngressTarget' or begin verification manually.",
+                    statusCode: StatusCodes.Status409Conflict);
+            }
 
+            string token = guidGenerator.Create().ToString("N");
+            hostname.BeginVerification(token, BuildExpectedRecords(hostname.Host.Value, token, opts));
+        }
+        else
+        {
+            hostname.RequestRecheck();
+        }
+
+        await writer.UpdateAsync(hostname, cancellationToken).ConfigureAwait(false);
         return TypedResults.Accepted((string?)null, MapToResponse(hostname));
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<ExpectedDnsRecord> BuildExpectedRecords(
+        string host, string token, HostnamesOptions opts) =>
+    [
+        new(DnsRecordType.Cname, host, opts.IngressTarget!),
+        new(DnsRecordType.Txt, $"{opts.TxtChallengePrefix}.{host}", $"granit-verify={token}"),
+    ];
 
     internal static ProblemHttpResult HostnameNotFound(Guid id) =>
         TypedResults.Problem(

--- a/src/Granit.Hostnames.Endpoints/packages.lock.json
+++ b/src/Granit.Hostnames.Endpoints/packages.lock.json
@@ -84,6 +84,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -186,6 +187,12 @@
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0"
         }
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "FluentValidation": {
         "type": "CentralTransitive",

--- a/src/Granit.Hostnames.EntityFrameworkCore/Extensions/HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/Extensions/HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Hostnames.Contracts;
 using Granit.Hostnames.EntityFrameworkCore.Internal;
+using Granit.Hostnames.Options;
 using Granit.Workflow.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +35,11 @@ public static class HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions
         this IHostApplicationBuilder builder,
         Action<DbContextOptionsBuilder> configure)
     {
+        builder.Services
+            .AddOptions<HostnamesOptions>()
+            .BindConfiguration(HostnamesOptions.SectionName)
+            .ValidateOnStart();
+
         // Register WorkflowTransitionInterceptor + IWorkflowHistoryQuery + IWorkflowTransitionRecorder
         // backed by HostnamesDbContext (which implements IWorkflowDbContext).
         builder.Services.AddGranitWorkflowEntityFrameworkCore<HostnamesDbContext>();

--- a/src/Granit.Hostnames.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Hostnames.EntityFrameworkCore/packages.lock.json
@@ -109,6 +109,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -178,6 +179,12 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
         }
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/Granit.Hostnames/Granit.Hostnames.csproj
+++ b/src/Granit.Hostnames/Granit.Hostnames.csproj
@@ -7,6 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Hostnames.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DnsClient" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />

--- a/src/Granit.Hostnames/GranitHostnamesModule.cs
+++ b/src/Granit.Hostnames/GranitHostnamesModule.cs
@@ -1,9 +1,12 @@
+using DnsClient;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
+using Granit.Hostnames.Contracts;
 using Granit.Hostnames.Diagnostics;
 using Granit.Hostnames.Domain;
 using Granit.Hostnames.Exports;
 using Granit.Hostnames.Queries;
+using Granit.Hostnames.Services;
 using Granit.Modularity;
 using Granit.QueryEngine.Extensions;
 using Granit.Workflow;
@@ -31,5 +34,10 @@ public sealed class GranitHostnamesModule : GranitModule
 
         context.Services.AddQueryDefinition<ManagedHostname, ManagedHostnameQueryDefinition>();
         context.Services.AddExportDefinition<ManagedHostname, ManagedHostnameExportDefinition>();
+
+        // Default DNS verifier — uses the system resolver. Replace by registering a custom
+        // IHostnameVerifier before calling AddGranitHostnames().
+        context.Services.TryAddSingleton<ILookupClient>(_ => new LookupClient());
+        context.Services.TryAddSingleton<IHostnameVerifier, DnsHostnameVerifier>();
     }
 }

--- a/src/Granit.Hostnames/Options/HostnamesOptions.cs
+++ b/src/Granit.Hostnames/Options/HostnamesOptions.cs
@@ -1,0 +1,32 @@
+namespace Granit.Hostnames.Options;
+
+/// <summary>
+/// Platform-level options for the custom hostname feature.
+/// Bind from the <c>"Hostnames"</c> configuration section.
+/// </summary>
+public sealed class HostnamesOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Hostnames";
+
+    /// <summary>
+    /// The platform's ingress CNAME target that customers must point their hostname to.
+    /// When set, <c>BeginVerification</c> is called automatically on hostname creation,
+    /// so the response immediately carries the DNS records the customer must configure.
+    /// Example: <c>"customers.platform.example.com"</c>
+    /// </summary>
+    public string? IngressTarget { get; set; }
+
+    /// <summary>
+    /// DNS label prefix used for the TXT ownership-challenge record.
+    /// The full challenge name is <c>{TxtChallengePrefix}.{host}</c>.
+    /// Default: <c>"_granit-challenge"</c>.
+    /// </summary>
+    public string TxtChallengePrefix { get; set; } = "_granit-challenge";
+
+    /// <summary>
+    /// Maximum number of hostnames the poller fetches per tick.
+    /// Default: <c>100</c>.
+    /// </summary>
+    public int VerificationBatchSize { get; set; } = 100;
+}

--- a/src/Granit.Hostnames/Services/DnsHostnameVerifier.cs
+++ b/src/Granit.Hostnames/Services/DnsHostnameVerifier.cs
@@ -1,0 +1,178 @@
+using DnsClient;
+using DnsClient.Protocol;
+using Granit.Hostnames.Contracts;
+using Granit.Hostnames.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Hostnames.Services;
+
+/// <summary>
+/// Default <see cref="IHostnameVerifier"/> implementation. Resolves each
+/// <see cref="ManagedHostname.ExpectedDnsRecords"/> entry against live DNS and
+/// maps failures to typed <see cref="DnsConflict"/> instances.
+/// Replace this by registering a custom <see cref="IHostnameVerifier"/> before
+/// calling <c>AddGranitHostnames</c>.
+/// </summary>
+internal sealed partial class DnsHostnameVerifier(
+    ILookupClient dns,
+    ILogger<DnsHostnameVerifier> logger) : IHostnameVerifier
+{
+    public async Task<HostnameVerificationResult> VerifyAsync(
+        ManagedHostname hostname,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(hostname);
+
+        if (hostname.ExpectedDnsRecords.Count == 0)
+        {
+            return new HostnameVerificationResult(IsVerified: false,
+                [new DnsConflict(DnsConflictType.ResolutionFailure, "No expected DNS records are configured.")]);
+        }
+
+        var conflicts = new List<DnsConflict>();
+
+        foreach (ExpectedDnsRecord record in hostname.ExpectedDnsRecords)
+        {
+            await CheckRecordAsync(record, conflicts, cancellationToken).ConfigureAwait(false);
+        }
+
+        return new HostnameVerificationResult(conflicts.Count == 0, conflicts);
+    }
+
+    private async Task CheckRecordAsync(
+        ExpectedDnsRecord record,
+        List<DnsConflict> conflicts,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            switch (record.RecordType)
+            {
+                case DnsRecordType.Cname:
+                    await CheckCnameAsync(record, conflicts, cancellationToken).ConfigureAwait(false);
+                    break;
+                case DnsRecordType.Txt:
+                    await CheckTxtAsync(record, conflicts, cancellationToken).ConfigureAwait(false);
+                    break;
+                case DnsRecordType.A:
+                    await CheckAAsync(record, conflicts, cancellationToken).ConfigureAwait(false);
+                    break;
+                case DnsRecordType.Aaaa:
+                    await CheckAaaaAsync(record, conflicts, cancellationToken).ConfigureAwait(false);
+                    break;
+            }
+        }
+        catch (DnsResponseException ex)
+        {
+            LogResolutionFailure(record.Name, ex);
+            conflicts.Add(new DnsConflict(
+                DnsConflictType.ResolutionFailure,
+                $"DNS resolution failed for '{record.Name}': {ex.Code}"));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogResolutionFailure(record.Name, ex);
+            conflicts.Add(new DnsConflict(
+                DnsConflictType.ResolutionFailure,
+                $"Unexpected error resolving '{record.Name}'."));
+        }
+    }
+
+    private async Task CheckCnameAsync(
+        ExpectedDnsRecord record,
+        List<DnsConflict> conflicts,
+        CancellationToken cancellationToken)
+    {
+        IDnsQueryResponse response = await dns
+            .QueryAsync(record.Name, QueryType.CNAME, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        CNameRecord? cname = response.Answers.CnameRecords().FirstOrDefault();
+
+        if (cname is null)
+        {
+            conflicts.Add(new DnsConflict(
+                DnsConflictType.MissingCname,
+                $"No CNAME found for '{record.Name}'."));
+            return;
+        }
+
+        string actual = cname.CanonicalName.Value.TrimEnd('.');
+        string expected = record.Value.TrimEnd('.');
+
+        if (!string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase))
+        {
+            conflicts.Add(new DnsConflict(
+                DnsConflictType.DivergentCname,
+                $"CNAME '{record.Name}' points to '{actual}', expected '{expected}'."));
+        }
+    }
+
+    private async Task CheckTxtAsync(
+        ExpectedDnsRecord record,
+        List<DnsConflict> conflicts,
+        CancellationToken cancellationToken)
+    {
+        IDnsQueryResponse response = await dns
+            .QueryAsync(record.Name, QueryType.TXT, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        bool found = response.Answers.TxtRecords()
+            .SelectMany(r => r.Text)
+            .Any(t => string.Equals(t, record.Value, StringComparison.Ordinal));
+
+        if (!found)
+        {
+            conflicts.Add(new DnsConflict(
+                DnsConflictType.MissingTxt,
+                $"TXT record '{record.Name}' does not contain the expected value."));
+        }
+    }
+
+    private async Task CheckAAsync(
+        ExpectedDnsRecord record,
+        List<DnsConflict> conflicts,
+        CancellationToken cancellationToken)
+    {
+        IDnsQueryResponse response = await dns
+            .QueryAsync(record.Name, QueryType.A, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        bool found = response.Answers.ARecords()
+            .Any(r => string.Equals(r.Address.ToString(), record.Value, StringComparison.OrdinalIgnoreCase));
+
+        if (!found)
+        {
+            conflicts.Add(new DnsConflict(
+                DnsConflictType.UnexpectedA,
+                $"A record for '{record.Name}' does not contain expected address '{record.Value}'."));
+        }
+    }
+
+    private async Task CheckAaaaAsync(
+        ExpectedDnsRecord record,
+        List<DnsConflict> conflicts,
+        CancellationToken cancellationToken)
+    {
+        IDnsQueryResponse response = await dns
+            .QueryAsync(record.Name, QueryType.AAAA, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        bool found = response.Answers.AaaaRecords()
+            .Any(r => string.Equals(r.Address.ToString(), record.Value, StringComparison.OrdinalIgnoreCase));
+
+        if (!found)
+        {
+            conflicts.Add(new DnsConflict(
+                DnsConflictType.UnexpectedAaaa,
+                $"AAAA record for '{record.Name}' does not contain expected address '{record.Value}'."));
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "DNS resolution error for '{Name}'.")]
+    private partial void LogResolutionFailure(string name, Exception ex);
+}

--- a/src/Granit.Hostnames/packages.lock.json
+++ b/src/Granit.Hostnames/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "DnsClient": {
+        "type": "Direct",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",

--- a/tests/Granit.ArchitectureTests/SectionNameConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SectionNameConventionTests.cs
@@ -39,6 +39,7 @@ public sealed partial class SectionNameConventionTests
         "Indexing",
         "Mcp",
         "EntityMerge",
+        "Hostnames",
         "MultiTenancy",
         "Notifications",
         "Observability",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2223,6 +2223,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -3862,6 +3863,12 @@
         "requested": "[0.13.*, )",
         "resolved": "0.13.0",
         "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "DocumentFormat.OpenXml": {
         "type": "CentralTransitive",

--- a/tests/Granit.Hostnames.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Hostnames.BackgroundJobs.Tests/packages.lock.json
@@ -319,6 +319,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -367,6 +368,12 @@
         "requested": "[0.13.*, )",
         "resolved": "0.13.0",
         "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Hostnames.Endpoints.Tests/HostnamesEndpointTests.cs
+++ b/tests/Granit.Hostnames.Endpoints.Tests/HostnamesEndpointTests.cs
@@ -324,6 +324,8 @@ public sealed class HostnamesEndpointTests : IAsyncDisposable
     public async Task VerifyNow_Known_Returns_202_And_Transitions_To_Verifying()
     {
         ManagedHostname hostname = MakeHostname();
+        hostname.BeginVerification("tok", [new ExpectedDnsRecord(DnsRecordType.Cname, "acme.com", "ingress.platform.example.com")]);
+        hostname.MarkFailed([], DateTimeOffset.UtcNow); // Error → verify-now calls RequestRecheck
         _reader.GetByIdAsync(FixedId, Arg.Any<CancellationToken>()).Returns(hostname);
 
         HttpResponseMessage response = await _authClient.PostAsync(

--- a/tests/Granit.Hostnames.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Hostnames.Endpoints.Tests/packages.lock.json
@@ -567,6 +567,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -701,6 +702,12 @@
         "requested": "[35.*, )",
         "resolved": "35.6.5",
         "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "FluentValidation": {
         "type": "CentralTransitive",

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -427,6 +427,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -505,6 +506,12 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
         }
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.Metrics;
+using Granit.Hostnames.Diagnostics;
 using Granit.Hostnames.Domain;
 using Granit.Hostnames.EntityFrameworkCore.Internal;
 using Granit.MultiTenancy;
@@ -44,7 +46,10 @@ public sealed class EfManagedHostnameStoreTests
     private static EfManagedHostnameStore CreateStore(string dbName, Guid? tenantId = null)
     {
         ICurrentTenant tenant = MakeTenant(tenantId ?? TenantA);
-        return new(new InMemoryContextFactory(dbName, tenant), tenant);
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>()).Returns(new Meter("test"));
+        var metrics = new HostnamesMetrics(meterFactory);
+        return new(new InMemoryContextFactory(dbName, tenant), tenant, metrics);
     }
 
     private static ManagedHostname MakeHostname(

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/packages.lock.json
@@ -340,6 +340,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -418,6 +419,12 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
         }
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Hostnames.Tests/Granit.Hostnames.Tests.csproj
+++ b/tests/Granit.Hostnames.Tests/Granit.Hostnames.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Hostnames.Tests/Services/DnsHostnameVerifierTests.cs
+++ b/tests/Granit.Hostnames.Tests/Services/DnsHostnameVerifierTests.cs
@@ -1,0 +1,226 @@
+using DnsClient;
+using DnsClient.Protocol;
+using Granit.Hostnames.Contracts;
+using Granit.Hostnames.Domain;
+using Granit.Hostnames.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Hostnames.Tests.Services;
+
+public sealed class DnsHostnameVerifierTests
+{
+    private static readonly Guid Id = new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid OwnerId = new("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private static ManagedHostname PendingHostname(string host = "acme.com")
+    {
+        var h = ManagedHostname.Create(Id, host, "cms.site", OwnerId);
+        h.BeginVerification("token123",
+        [
+            new ExpectedDnsRecord(DnsRecordType.Cname, host, "ingress.platform.example.com"),
+            new ExpectedDnsRecord(DnsRecordType.Txt, $"_granit-challenge.{host}", "granit-verify=token123"),
+        ]);
+        return h;
+    }
+
+    // ── No expected records ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NoExpectedRecords_ReturnsNotVerified()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeFalse();
+        result.Conflicts.ShouldHaveSingleItem();
+        result.Conflicts[0].ConflictType.ShouldBe(DnsConflictType.ResolutionFailure);
+    }
+
+    // ── CNAME checks ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Cname_MatchesExpected_ReturnsVerified()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        hostname.BeginVerification("token", [new(DnsRecordType.Cname, "acme.com", "ingress.platform.example.com")]);
+
+        SetupCname(dns, "acme.com", "ingress.platform.example.com.");
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeTrue();
+        result.Conflicts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Cname_Missing_ReturnsMissingCnameConflict()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        hostname.BeginVerification("token", [new(DnsRecordType.Cname, "acme.com", "ingress.platform.example.com")]);
+
+        SetupEmptyResponse(dns, "acme.com", QueryType.CNAME);
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeFalse();
+        result.Conflicts.ShouldHaveSingleItem();
+        result.Conflicts[0].ConflictType.ShouldBe(DnsConflictType.MissingCname);
+    }
+
+    [Fact]
+    public async Task Cname_PointsToWrongTarget_ReturnsDivergentCnameConflict()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        hostname.BeginVerification("token", [new(DnsRecordType.Cname, "acme.com", "ingress.platform.example.com")]);
+
+        SetupCname(dns, "acme.com", "other-target.example.com.");
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeFalse();
+        result.Conflicts.ShouldHaveSingleItem();
+        result.Conflicts[0].ConflictType.ShouldBe(DnsConflictType.DivergentCname);
+    }
+
+    // ── TXT checks ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Txt_MatchesExpected_ReturnsVerified()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        hostname.BeginVerification("tok", [new(DnsRecordType.Txt, "_granit-challenge.acme.com", "granit-verify=tok")]);
+
+        SetupTxt(dns, "_granit-challenge.acme.com", "granit-verify=tok");
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeTrue();
+        result.Conflicts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Txt_Missing_ReturnsMissingTxtConflict()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        hostname.BeginVerification("tok", [new(DnsRecordType.Txt, "_granit-challenge.acme.com", "granit-verify=tok")]);
+
+        SetupEmptyResponse(dns, "_granit-challenge.acme.com", QueryType.TXT);
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeFalse();
+        result.Conflicts.ShouldHaveSingleItem();
+        result.Conflicts[0].ConflictType.ShouldBe(DnsConflictType.MissingTxt);
+    }
+
+    // ── DNS failure ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DnsException_ReturnsResolutionFailureConflict()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        hostname.BeginVerification("tok", [new(DnsRecordType.Cname, "acme.com", "ingress.platform.example.com")]);
+
+        dns.QueryAsync("acme.com", QueryType.CNAME, cancellationToken: Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DnsResponseException(DnsResponseCode.ServerFailure));
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeFalse();
+        result.Conflicts.ShouldHaveSingleItem();
+        result.Conflicts[0].ConflictType.ShouldBe(DnsConflictType.ResolutionFailure);
+    }
+
+    // ── Multiple records ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllRecordsMatch_ReturnsVerified()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        ManagedHostname hostname = PendingHostname();
+
+        SetupCname(dns, "acme.com", "ingress.platform.example.com.");
+        SetupTxt(dns, "_granit-challenge.acme.com", "granit-verify=token123");
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeTrue();
+        result.Conflicts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task OneRecordFails_ReturnsNotVerified_WithConflict()
+    {
+        ILookupClient dns = Substitute.For<ILookupClient>();
+        var sut = new DnsHostnameVerifier(dns, NullLogger<DnsHostnameVerifier>.Instance);
+        ManagedHostname hostname = PendingHostname();
+
+        SetupCname(dns, "acme.com", "ingress.platform.example.com.");
+        SetupEmptyResponse(dns, "_granit-challenge.acme.com", QueryType.TXT);
+
+        HostnameVerificationResult result = await sut.VerifyAsync(hostname, TestContext.Current.CancellationToken);
+
+        result.IsVerified.ShouldBeFalse();
+        result.Conflicts.ShouldHaveSingleItem();
+        result.Conflicts[0].ConflictType.ShouldBe(DnsConflictType.MissingTxt);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static void SetupCname(ILookupClient dns, string name, string canonicalName)
+    {
+        var record = new CNameRecord(
+            new ResourceRecordInfo(name, ResourceRecordType.CNAME, QueryClass.IN, 300, 0),
+            DnsString.Parse(canonicalName));
+
+        IDnsQueryResponse response = BuildResponse([record]);
+        dns.QueryAsync(name, QueryType.CNAME, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private static void SetupTxt(ILookupClient dns, string name, params string[] values)
+    {
+        var record = new TxtRecord(
+            new ResourceRecordInfo(name, ResourceRecordType.TXT, QueryClass.IN, 300, 0),
+            values,
+            values);
+
+        IDnsQueryResponse response = BuildResponse([record]);
+        dns.QueryAsync(name, QueryType.TXT, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private static void SetupEmptyResponse(ILookupClient dns, string name, QueryType queryType)
+    {
+        IDnsQueryResponse response = BuildResponse([]);
+        dns.QueryAsync(name, queryType, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private static IDnsQueryResponse BuildResponse(IReadOnlyList<DnsResourceRecord> answers)
+    {
+        IDnsQueryResponse response = Substitute.For<IDnsQueryResponse>();
+        response.Answers.Returns(answers);
+        return response;
+    }
+}

--- a/tests/Granit.Hostnames.Tests/packages.lock.json
+++ b/tests/Granit.Hostnames.Tests/packages.lock.json
@@ -30,6 +30,15 @@
           "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "Shouldly": {
         "type": "Direct",
         "requested": "[4.*, )",
@@ -53,6 +62,14 @@
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
           "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "DiffEngine": {
@@ -148,6 +165,11 @@
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
       },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "6.0.1",
@@ -241,6 +263,7 @@
       "granit.hostnames": {
         "type": "Project",
         "dependencies": {
+          "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -276,6 +299,12 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
+      },
+      "DnsClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.*, )",
+        "resolved": "1.8.0",
+        "contentHash": "RRwtaCXkXWsx0mmsReGDqCbRLtItfUbkRJlet1FpdciVhyMGKcPd57T1+8Jki9ojHlq9fntVhXQroOOgRak8DQ=="
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Completes the DNS verification loop for `Granit.Hostnames` so hostnames can be verified end-to-end without any external dependency or custom provider.

- **`HostnamesOptions`** — new `Hostnames:IngressTarget`, `TxtChallengePrefix`, `VerificationBatchSize` configuration bound in `AddGranitHostnamesEntityFrameworkCore`
- **`DnsHostnameVerifier`** — built-in `IHostnameVerifier` using `DnsClient 1.8`; checks CNAME, TXT, A, AAAA records against `ExpectedDnsRecords`; maps failures to typed `DnsConflict`; registered as default via `TryAddSingleton` (replaceable by custom providers)
- **`ILookupClient`** — registered with the system DNS resolver; injected into `DnsHostnameVerifier`
- **`POST /hostnames`** — auto-calls `BeginVerification` on create when `IngressTarget` is configured, so the 201 response immediately carries the DNS records the customer must set
- **`POST /hostnames/{id}/verify-now`** — initializes `Pending` hostnames when `IngressTarget` is set; 409 when not configured; `RequestRecheck` for all other states
- **`HostnameVerificationBatchService`** — reads `VerificationBatchSize` from options (was hardcoded at 100)
- **9 new `DnsHostnameVerifierTests`** (CNAME match/missing/divergent, TXT match/missing, DNS exception, multi-record pass/fail)
- **CI fix** — `EfManagedHostnameStoreTests.CreateStore` missing `HostnamesMetrics` parameter

## Test plan

- [ ] All 43 `Granit.Hostnames.Tests` pass (34 domain + 9 DNS verifier)
- [ ] All 28 `Granit.Hostnames.Endpoints.Tests` pass
- [ ] All 10 `Granit.Hostnames.EntityFrameworkCore.Tests` pass
- [ ] All 1 `Granit.Hostnames.BackgroundJobs.Tests` pass
- [ ] `dotnet format --verify-no-changes` clean on all modified packages
- [ ] CI integration tests pass (`Granit.Hostnames.EntityFrameworkCore.Tests.Integration`)