### PR TITLE
feat(hostnames): P3 — CertificateStatus + /certificate-status webhook

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19660,6 +19660,15 @@
       "members": []
     },
     {
+      "name": "CertificateStatus",
+      "fqn": "Granit.Hostnames.Domain.CertificateStatus",
+      "kind": "enum",
+      "project": "Granit.Hostnames",
+      "file": "src/Granit.Hostnames/Domain/CertificateStatus.cs",
+      "line": 7,
+      "members": []
+    },
+    {
       "name": "DnsConflict",
       "fqn": "Granit.Hostnames.Domain.DnsConflict",
       "kind": "record",
@@ -19684,6 +19693,24 @@
       "project": "Granit.Hostnames",
       "file": "src/Granit.Hostnames/Domain/DnsRecordType.cs",
       "line": 4,
+      "members": []
+    },
+    {
+      "name": "HostnameCertificateFailedEto",
+      "fqn": "Granit.Hostnames.Domain.Events.HostnameCertificateFailedEto",
+      "kind": "record",
+      "project": "Granit.Hostnames",
+      "file": "src/Granit.Hostnames/Domain/Events/HostnameCertificateFailedEto.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "HostnameCertificateSecuredEto",
+      "fqn": "Granit.Hostnames.Domain.Events.HostnameCertificateSecuredEto",
+      "kind": "record",
+      "project": "Granit.Hostnames",
+      "file": "src/Granit.Hostnames/Domain/Events/HostnameCertificateSecuredEto.cs",
+      "line": 15,
       "members": []
     },
     {
@@ -19789,6 +19816,12 @@
           "returnType": "DateTimeOffset?"
         },
         {
+          "name": "CertificateStatus",
+          "kind": "property",
+          "signature": "CertificateStatus CertificateStatus",
+          "returnType": "CertificateStatus"
+        },
+        {
           "name": "Create",
           "kind": "method",
           "signature": "Create(Guid id, Hostname host, string ownerType, Guid ownerId, Guid? tenantId = null, bool isPrimary = false)",
@@ -19826,7 +19859,16 @@
       "kind": "record",
       "project": "Granit.Hostnames.Endpoints",
       "file": "src/Granit.Hostnames.Endpoints/Dtos/ManagedHostnameResponse.cs",
-      "line": 25,
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "ReportCertificateStatusRequest",
+      "fqn": "Granit.Hostnames.Endpoints.Dtos.ReportCertificateStatusRequest",
+      "kind": "record",
+      "project": "Granit.Hostnames.Endpoints",
+      "file": "src/Granit.Hostnames.Endpoints/Dtos/ReportCertificateStatusRequest.cs",
+      "line": 11,
       "members": []
     },
     {
@@ -19882,6 +19924,15 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "Certificates",
+      "fqn": "Granit.Hostnames.Endpoints.Permissions.Certificates",
+      "kind": "class",
+      "project": "Granit.Hostnames.Endpoints",
+      "file": "src/Granit.Hostnames.Endpoints/Permissions/HostnamesPermissions.cs",
+      "line": 23,
+      "members": []
     },
     {
       "name": "Hostnames",

--- a/src/Granit.Hostnames.Endpoints/Dtos/ManagedHostnameResponse.cs
+++ b/src/Granit.Hostnames.Endpoints/Dtos/ManagedHostnameResponse.cs
@@ -11,13 +11,15 @@ namespace Granit.Hostnames.Endpoints.Dtos;
 /// <param name="OwnerId">Owning resource identifier.</param>
 /// <param name="TenantId">Owning tenant; <c>null</c> for global hostnames.</param>
 /// <param name="IsPrimary">Whether this is the owner's canonical hostname.</param>
-/// <param name="Status">Lifecycle state string: <c>Pending</c>, <c>Verifying</c>, <c>Active</c>, or <c>Error</c>.</param>
+/// <param name="Status">DNS verification lifecycle state: <c>Pending</c>, <c>Verifying</c>, <c>Active</c>, or <c>Error</c>.</param>
 /// <param name="VerificationToken">TXT challenge token; <c>null</c> until verification starts.</param>
 /// <param name="ExpectedDnsRecords">DNS records the owner must configure; empty until verification starts.</param>
 /// <param name="LastCheckedAt">When the last DNS check ran; <c>null</c> before any check.</param>
 /// <param name="Conflicts">DNS conflicts from the last check; empty when verified.</param>
 /// <param name="FailedCheckCount">Consecutive DNS check failure count.</param>
 /// <param name="NextCheckAt">When the poller will retry; <c>null</c> when dormant.</param>
+/// <param name="CertificateStatus">SSL/TLS certificate provisioning state: <c>Unprovisioned</c>, <c>Provisioning</c>, <c>Secured</c>, or <c>Error</c>.</param>
+/// <param name="CertExpiresAt">When the active certificate expires; <c>null</c> until a certificate is secured.</param>
 /// <param name="CreatedAt">UTC timestamp when the hostname was registered.</param>
 /// <param name="CreatedBy">Identity that registered the hostname.</param>
 /// <param name="ModifiedAt">UTC timestamp of the last change; <c>null</c> if never modified.</param>
@@ -36,6 +38,8 @@ public sealed record ManagedHostnameResponse(
     IReadOnlyList<DnsConflict> Conflicts,
     int FailedCheckCount,
     DateTimeOffset? NextCheckAt,
+    string CertificateStatus,
+    DateTimeOffset? CertExpiresAt,
     DateTimeOffset CreatedAt,
     string CreatedBy,
     DateTimeOffset? ModifiedAt,

--- a/src/Granit.Hostnames.Endpoints/Dtos/ReportCertificateStatusRequest.cs
+++ b/src/Granit.Hostnames.Endpoints/Dtos/ReportCertificateStatusRequest.cs
@@ -1,0 +1,13 @@
+using Granit.Hostnames.Domain;
+
+namespace Granit.Hostnames.Endpoints.Dtos;
+
+/// <summary>
+/// Payload for the <c>POST /hostnames/{id}/certificate-status</c> webhook endpoint.
+/// Sent by the edge provider when the SSL/TLS certificate state changes.
+/// </summary>
+/// <param name="Status">New certificate provisioning state.</param>
+/// <param name="ExpiresAt">Certificate expiry timestamp. Required when <paramref name="Status"/> is <see cref="CertificateStatus.Secured"/>.</param>
+public sealed record ReportCertificateStatusRequest(
+    CertificateStatus Status,
+    DateTimeOffset? ExpiresAt = null);

--- a/src/Granit.Hostnames.Endpoints/Extensions/HostnamesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Hostnames.Endpoints/Extensions/HostnamesEndpointRouteBuilderExtensions.cs
@@ -118,6 +118,14 @@ public static class HostnamesEndpointRouteBuilderExtensions
             .Produces<ManagedHostnameResponse>(StatusCodes.Status202Accepted)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
+
+        group.MapPost("/{id:guid}/certificate-status", HandleReportCertificateStatusAsync)
+            .RequireAuthorization(HostnamesPermissions.Certificates.Report)
+            .WithName("ReportHostnameCertificateStatus")
+            .WithSummary("Reports the SSL/TLS certificate status from the edge provider.")
+            .WithDescription("Webhook endpoint called by the edge provider (e.g. Cloudflare, AWS) when the certificate state changes. Stores the new CertificateStatus and expiry date, and dispatches the appropriate integration event (HostnameCertificateSecuredEto or HostnameCertificateFailedEto). Returns 204 on success, 404 when not found. Requires the Hostnames.Certificates.Report permission.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
     }
 
     // ── Handlers ──────────────────────────────────────────────────────────────
@@ -327,6 +335,27 @@ public static class HostnamesEndpointRouteBuilderExtensions
         return TypedResults.Accepted((string?)null, MapToResponse(hostname));
     }
 
+    private static async Task<Results<NoContent, ProblemHttpResult>> HandleReportCertificateStatusAsync(
+        Guid id,
+        ReportCertificateStatusRequest body,
+        [FromServices] IManagedHostnameReader reader,
+        [FromServices] IManagedHostnameWriter writer,
+        CancellationToken cancellationToken)
+    {
+        ManagedHostname? hostname = await reader
+            .GetByIdAsync(id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (hostname is null)
+        {
+            return HostnameNotFound(id);
+        }
+
+        hostname.ReportCertificateStatus(body.Status, body.ExpiresAt);
+        await writer.UpdateAsync(hostname, cancellationToken).ConfigureAwait(false);
+        return TypedResults.NoContent();
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static IReadOnlyList<ExpectedDnsRecord> BuildExpectedRecords(
@@ -355,6 +384,8 @@ public static class HostnamesEndpointRouteBuilderExtensions
             h.Conflicts,
             h.FailedCheckCount,
             h.NextCheckAt,
+            h.CertificateStatus.ToString(),
+            h.CertExpiresAt,
             h.CreatedAt,
             h.CreatedBy,
             h.ModifiedAt,

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/cs.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/cs.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Spravované názvy hostitelů",
     "Permission:Hostnames.Hostnames.Read": "Číst názvy hostitelů",
     "Permission:Hostnames.Hostnames.Manage": "Spravovat názvy hostitelů",
-    "PermissionGroup:Hostnames": "Názvy hostitelů"
+    "PermissionGroup:Hostnames": "Názvy hostitelů",
+    "Permission:Hostnames.Certificates.Report": "Nahlásit stav certifikátu"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/de.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/de.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Verwaltete Hostnamen",
     "Permission:Hostnames.Hostnames.Read": "Hostnamen lesen",
     "Permission:Hostnames.Hostnames.Manage": "Hostnamen verwalten",
-    "PermissionGroup:Hostnames": "Hostnamen"
+    "PermissionGroup:Hostnames": "Hostnamen",
+    "Permission:Hostnames.Certificates.Report": "Zertifikatstatus melden"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/en-GB.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/en-GB.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Managed hostnames",
     "Permission:Hostnames.Hostnames.Read": "Read hostnames",
     "Permission:Hostnames.Hostnames.Manage": "Manage hostnames",
-    "PermissionGroup:Hostnames": "Hostnames"
+    "PermissionGroup:Hostnames": "Hostnames",
+    "Permission:Hostnames.Certificates.Report": "Report certificate status"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/en.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/en.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Managed hostnames",
     "Permission:Hostnames.Hostnames.Read": "Read hostnames",
     "Permission:Hostnames.Hostnames.Manage": "Manage hostnames",
-    "PermissionGroup:Hostnames": "Hostnames"
+    "PermissionGroup:Hostnames": "Hostnames",
+    "Permission:Hostnames.Certificates.Report": "Report certificate status"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/es.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/es.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Nombres de host gestionados",
     "Permission:Hostnames.Hostnames.Read": "Leer nombres de host",
     "Permission:Hostnames.Hostnames.Manage": "Gestionar nombres de host",
-    "PermissionGroup:Hostnames": "Nombres de host"
+    "PermissionGroup:Hostnames": "Nombres de host",
+    "Permission:Hostnames.Certificates.Report": "Informar el estado del certificado"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/fr-CA.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/fr-CA.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Noms d'hôte gérés",
     "Permission:Hostnames.Hostnames.Read": "Consulter les noms d'hôte",
     "Permission:Hostnames.Hostnames.Manage": "Gérer les noms d'hôte",
-    "PermissionGroup:Hostnames": "Noms d'hôte"
+    "PermissionGroup:Hostnames": "Noms d'hôte",
+    "Permission:Hostnames.Certificates.Report": "Signaler le statut du certificat"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/fr.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/fr.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Noms d'hôte gérés",
     "Permission:Hostnames.Hostnames.Read": "Consulter les noms d'hôte",
     "Permission:Hostnames.Hostnames.Manage": "Gérer les noms d'hôte",
-    "PermissionGroup:Hostnames": "Noms d'hôte"
+    "PermissionGroup:Hostnames": "Noms d'hôte",
+    "Permission:Hostnames.Certificates.Report": "Signaler le statut du certificat"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/hi.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/hi.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "प्रबंधित होस्ट नाम",
     "Permission:Hostnames.Hostnames.Read": "होस्ट नाम पढ़ें",
     "Permission:Hostnames.Hostnames.Manage": "होस्ट नाम प्रबंधित करें",
-    "PermissionGroup:Hostnames": "होस्ट नाम"
+    "PermissionGroup:Hostnames": "होस्ट नाम",
+    "Permission:Hostnames.Certificates.Report": "प्रमाणपत्र स्थिति रिपोर्ट करें"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/it.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/it.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Nomi host gestiti",
     "Permission:Hostnames.Hostnames.Read": "Leggere i nomi host",
     "Permission:Hostnames.Hostnames.Manage": "Gestire i nomi host",
-    "PermissionGroup:Hostnames": "Nomi host"
+    "PermissionGroup:Hostnames": "Nomi host",
+    "Permission:Hostnames.Certificates.Report": "Segnalare lo stato del certificato"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/ja.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/ja.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "管理対象ホスト名",
     "Permission:Hostnames.Hostnames.Read": "ホスト名の読み取り",
     "Permission:Hostnames.Hostnames.Manage": "ホスト名の管理",
-    "PermissionGroup:Hostnames": "ホスト名"
+    "PermissionGroup:Hostnames": "ホスト名",
+    "Permission:Hostnames.Certificates.Report": "証明書ステータスを報告する"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/ko.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/ko.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "관리되는 호스트 이름",
     "Permission:Hostnames.Hostnames.Read": "호스트 이름 읽기",
     "Permission:Hostnames.Hostnames.Manage": "호스트 이름 관리",
-    "PermissionGroup:Hostnames": "호스트 이름"
+    "PermissionGroup:Hostnames": "호스트 이름",
+    "Permission:Hostnames.Certificates.Report": "인증서 상태 보고"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/nl.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/nl.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Beheerde hostnamen",
     "Permission:Hostnames.Hostnames.Read": "Hostnamen raadplegen",
     "Permission:Hostnames.Hostnames.Manage": "Hostnamen beheren",
-    "PermissionGroup:Hostnames": "Hostnamen"
+    "PermissionGroup:Hostnames": "Hostnamen",
+    "Permission:Hostnames.Certificates.Report": "Certificaatstatus rapporteren"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/pl.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/pl.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Zarządzane nazwy hostów",
     "Permission:Hostnames.Hostnames.Read": "Odczyt nazw hostów",
     "Permission:Hostnames.Hostnames.Manage": "Zarządzanie nazwami hostów",
-    "PermissionGroup:Hostnames": "Nazwy hostów"
+    "PermissionGroup:Hostnames": "Nazwy hostów",
+    "Permission:Hostnames.Certificates.Report": "Zgłoś status certyfikatu"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/pt-BR.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/pt-BR.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Nomes de host gerenciados",
     "Permission:Hostnames.Hostnames.Read": "Ler nomes de host",
     "Permission:Hostnames.Hostnames.Manage": "Gerenciar nomes de host",
-    "PermissionGroup:Hostnames": "Nomes de host"
+    "PermissionGroup:Hostnames": "Nomes de host",
+    "Permission:Hostnames.Certificates.Report": "Reportar o estado do certificado"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/pt.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/pt.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Nomes de host gerenciados",
     "Permission:Hostnames.Hostnames.Read": "Ler nomes de host",
     "Permission:Hostnames.Hostnames.Manage": "Gerenciar nomes de host",
-    "PermissionGroup:Hostnames": "Nomes de host"
+    "PermissionGroup:Hostnames": "Nomes de host",
+    "Permission:Hostnames.Certificates.Report": "Reportar o estado do certificado"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/sv.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/sv.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Hanterade värdnamn",
     "Permission:Hostnames.Hostnames.Read": "Läsa värdnamn",
     "Permission:Hostnames.Hostnames.Manage": "Hantera värdnamn",
-    "PermissionGroup:Hostnames": "Värdnamn"
+    "PermissionGroup:Hostnames": "Värdnamn",
+    "Permission:Hostnames.Certificates.Report": "Rapportera certifikatstatus"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/tr.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/tr.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "Yönetilen ana bilgisayar adları",
     "Permission:Hostnames.Hostnames.Read": "Ana bilgisayar adlarını oku",
     "Permission:Hostnames.Hostnames.Manage": "Ana bilgisayar adlarını yönet",
-    "PermissionGroup:Hostnames": "Ana Bilgisayar Adları"
+    "PermissionGroup:Hostnames": "Ana Bilgisayar Adları",
+    "Permission:Hostnames.Certificates.Report": "Sertifika durumunu bildir"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/zh.json
+++ b/src/Granit.Hostnames.Endpoints/Localization/HostnamesEndpoints/zh.json
@@ -5,6 +5,7 @@
     "HostnamesEndpoints:Workspace.Section": "托管主机名",
     "Permission:Hostnames.Hostnames.Read": "读取主机名",
     "Permission:Hostnames.Hostnames.Manage": "管理主机名",
-    "PermissionGroup:Hostnames": "主机名"
+    "PermissionGroup:Hostnames": "主机名",
+    "Permission:Hostnames.Certificates.Report": "报告证书状态"
   }
 }

--- a/src/Granit.Hostnames.Endpoints/Permissions/HostnamesPermissionDefinitionProvider.cs
+++ b/src/Granit.Hostnames.Endpoints/Permissions/HostnamesPermissionDefinitionProvider.cs
@@ -32,5 +32,12 @@ internal sealed class HostnamesPermissionDefinitionProvider : IPermissionDefinit
             LocalizableString.Create<HostnamesEndpointsLocalizationResource>(
                 "Permission:Hostnames.Hostnames.Manage"),
             MultiTenancySides.Host);
+
+        // Scoped to the edge provider API key — not shown in the admin permission UI.
+        group.AddPermission(
+            HostnamesPermissions.Certificates.Report,
+            LocalizableString.Create<HostnamesEndpointsLocalizationResource>(
+                "Permission:Hostnames.Certificates.Report"),
+            MultiTenancySides.Host);
     }
 }

--- a/src/Granit.Hostnames.Endpoints/Permissions/HostnamesPermissions.cs
+++ b/src/Granit.Hostnames.Endpoints/Permissions/HostnamesPermissions.cs
@@ -18,4 +18,11 @@ public static class HostnamesPermissions
         /// <summary>Grants write access: create, delete, set/clear primary, availability check.</summary>
         public const string Manage = "Hostnames.Hostnames.Manage";
     }
+
+    /// <summary>Permissions for the certificate-status webhook endpoint.</summary>
+    public static class Certificates
+    {
+        /// <summary>Grants the edge provider the right to push certificate status updates.</summary>
+        public const string Report = "Hostnames.Certificates.Report";
+    }
 }

--- a/src/Granit.Hostnames.EntityFrameworkCore/Internal/ManagedHostnameConfiguration.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/Internal/ManagedHostnameConfiguration.cs
@@ -68,6 +68,15 @@ internal sealed class ManagedHostnameConfiguration : IEntityTypeConfiguration<Ma
             nav.Property(c => c.Details).HasMaxLength(1024);
         });
 
+        // ── Certificate ───────────────────────────────────────────────────
+
+        // Persisted as varchar by the Granit enum convention ("Unprovisioned" = 13 chars + headroom).
+        builder.Property(e => e.CertificateStatus)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.CertExpiresAt);
+
         builder.Property(e => e.LastCheckedAt);
         builder.Property(e => e.FailedCheckCount).IsRequired();
         builder.Property(e => e.NextCheckAt);

--- a/src/Granit.Hostnames/Domain/CertificateStatus.cs
+++ b/src/Granit.Hostnames/Domain/CertificateStatus.cs
@@ -1,0 +1,20 @@
+namespace Granit.Hostnames.Domain;
+
+/// <summary>
+/// SSL/TLS certificate provisioning state for a <see cref="ManagedHostname"/>.
+/// Reported by the edge provider via the certificate-status webhook.
+/// </summary>
+public enum CertificateStatus
+{
+    /// <summary>No certificate has been provisioned yet. Default state.</summary>
+    Unprovisioned,
+
+    /// <summary>The edge provider is issuing the certificate (ACME challenge in progress).</summary>
+    Provisioning,
+
+    /// <summary>Certificate is active and HTTPS is live on this hostname.</summary>
+    Secured,
+
+    /// <summary>Certificate provisioning failed or the certificate expired.</summary>
+    Error,
+}

--- a/src/Granit.Hostnames/Domain/Events/HostnameCertificateFailedEto.cs
+++ b/src/Granit.Hostnames/Domain/Events/HostnameCertificateFailedEto.cs
@@ -1,0 +1,19 @@
+using Granit.Events;
+
+namespace Granit.Hostnames.Domain.Events;
+
+/// <summary>
+/// Published when an edge provider reports that SSL/TLS certificate provisioning for a
+/// <see cref="ManagedHostname"/> has failed (or that a previously active certificate has expired).
+/// </summary>
+/// <param name="HostnameId">Identifier of the affected hostname.</param>
+/// <param name="Host">The hostname value (FQDN).</param>
+/// <param name="OwnerType">Owner-resource discriminator.</param>
+/// <param name="OwnerId">Owning resource identifier.</param>
+/// <param name="TenantId">Owning tenant; <c>null</c> for a global hostname.</param>
+public sealed record HostnameCertificateFailedEto(
+    Guid HostnameId,
+    string Host,
+    string OwnerType,
+    Guid OwnerId,
+    Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Hostnames/Domain/Events/HostnameCertificateSecuredEto.cs
+++ b/src/Granit.Hostnames/Domain/Events/HostnameCertificateSecuredEto.cs
@@ -1,0 +1,21 @@
+using Granit.Events;
+
+namespace Granit.Hostnames.Domain.Events;
+
+/// <summary>
+/// Published when an edge provider reports that the SSL/TLS certificate for a
+/// <see cref="ManagedHostname"/> has been successfully issued.
+/// </summary>
+/// <param name="HostnameId">Identifier of the secured hostname.</param>
+/// <param name="Host">The hostname value (FQDN).</param>
+/// <param name="OwnerType">Owner-resource discriminator.</param>
+/// <param name="OwnerId">Owning resource identifier.</param>
+/// <param name="TenantId">Owning tenant; <c>null</c> for a global hostname.</param>
+/// <param name="ExpiresAt">When the issued certificate expires; <c>null</c> when unknown.</param>
+public sealed record HostnameCertificateSecuredEto(
+    Guid HostnameId,
+    string Host,
+    string OwnerType,
+    Guid OwnerId,
+    Guid? TenantId,
+    DateTimeOffset? ExpiresAt) : IIntegrationEvent;

--- a/src/Granit.Hostnames/Domain/ManagedHostname.cs
+++ b/src/Granit.Hostnames/Domain/ManagedHostname.cs
@@ -102,6 +102,17 @@ public sealed class ManagedHostname : AuditedAggregateRoot, IMultiTenant, IConcu
     /// <summary>DNS conflicts detected on the last check. Stored as JSON; empty when verified.</summary>
     public IReadOnlyList<DnsConflict> Conflicts { get; private set; } = [];
 
+    // ── Certificate ─────────────────────────────────────────────────────────
+
+    /// <summary>SSL/TLS certificate provisioning state. Updated by the edge provider webhook.</summary>
+    public CertificateStatus CertificateStatus { get; private set; } = CertificateStatus.Unprovisioned;
+
+    /// <summary>
+    /// When the active certificate expires; <c>null</c> until a certificate is secured.
+    /// Reset to <c>null</c> when the certificate enters <see cref="CertificateStatus.Error"/>.
+    /// </summary>
+    public DateTimeOffset? CertExpiresAt { get; private set; }
+
     // ── Backoff ─────────────────────────────────────────────────────────────
 
     /// <summary>Cumulative count of consecutive DNS check failures.</summary>
@@ -240,6 +251,32 @@ public sealed class ManagedHostname : AuditedAggregateRoot, IMultiTenant, IConcu
         Status = HostnameStatus.Verifying;
         FailedCheckCount = 0;
         NextCheckAt = null;
+    }
+
+    /// <summary>
+    /// Records a certificate status update from the edge provider.
+    /// Raises <see cref="HostnameCertificateSecuredEto"/> when <paramref name="status"/> is
+    /// <see cref="CertificateStatus.Secured"/>, or <see cref="HostnameCertificateFailedEto"/>
+    /// when it is <see cref="CertificateStatus.Error"/>.
+    /// </summary>
+    /// <param name="status">New certificate provisioning state.</param>
+    /// <param name="expiresAt">Certificate expiry timestamp (required when <paramref name="status"/> is <see cref="CertificateStatus.Secured"/>).</param>
+    public void ReportCertificateStatus(CertificateStatus status, DateTimeOffset? expiresAt = null)
+    {
+        CertificateStatus = status;
+        CertExpiresAt = status == CertificateStatus.Secured ? expiresAt : null;
+
+        switch (status)
+        {
+            case CertificateStatus.Secured:
+                AddDistributedEvent(new HostnameCertificateSecuredEto(
+                    Id, Host.Value, OwnerType, OwnerId, TenantId, expiresAt));
+                break;
+            case CertificateStatus.Error:
+                AddDistributedEvent(new HostnameCertificateFailedEto(
+                    Id, Host.Value, OwnerType, OwnerId, TenantId));
+                break;
+        }
     }
 
     /// <summary>Marks this hostname as the owner's canonical one.</summary>

--- a/tests/Granit.Hostnames.Endpoints.Tests/HostnamesEndpointTests.cs
+++ b/tests/Granit.Hostnames.Endpoints.Tests/HostnamesEndpointTests.cs
@@ -40,7 +40,8 @@ public sealed class HostnamesEndpointTests : IAsyncDisposable
             {
                 services.AddAuthorizationBuilder()
                     .AddPolicy(HostnamesPermissions.Hostnames.Read, p => p.RequireAuthenticatedUser())
-                    .AddPolicy(HostnamesPermissions.Hostnames.Manage, p => p.RequireAuthenticatedUser());
+                    .AddPolicy(HostnamesPermissions.Hostnames.Manage, p => p.RequireAuthenticatedUser())
+                    .AddPolicy(HostnamesPermissions.Certificates.Report, p => p.RequireAuthenticatedUser());
 
                 services.AddSingleton(_reader);
                 services.AddSingleton(_writer);
@@ -346,5 +347,66 @@ public sealed class HostnamesEndpointTests : IAsyncDisposable
             $"{Prefix}/{FixedId}/verify-now", null, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ── POST /{id}/certificate-status ─────────────────────────────────────────
+
+    [Fact]
+    public async Task ReportCertificateStatus_Secured_Returns_204_And_Updates_Hostname()
+    {
+        ManagedHostname hostname = MakeHostname();
+        _reader.GetByIdAsync(FixedId, Arg.Any<CancellationToken>()).Returns(hostname);
+
+        var request = new ReportCertificateStatusRequest(
+            CertificateStatus.Secured,
+            new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero));
+
+        HttpResponseMessage response = await _authClient.PostAsJsonAsync(
+            $"{Prefix}/{FixedId}/certificate-status", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        hostname.CertificateStatus.ShouldBe(CertificateStatus.Secured);
+        await _writer.Received(1).UpdateAsync(hostname, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReportCertificateStatus_Error_Returns_204_And_Updates_Hostname()
+    {
+        ManagedHostname hostname = MakeHostname();
+        _reader.GetByIdAsync(FixedId, Arg.Any<CancellationToken>()).Returns(hostname);
+
+        var request = new ReportCertificateStatusRequest(CertificateStatus.Error);
+
+        HttpResponseMessage response = await _authClient.PostAsJsonAsync(
+            $"{Prefix}/{FixedId}/certificate-status", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        hostname.CertificateStatus.ShouldBe(CertificateStatus.Error);
+        await _writer.Received(1).UpdateAsync(hostname, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReportCertificateStatus_Unknown_Returns_404()
+    {
+        _reader.GetByIdAsync(FixedId, Arg.Any<CancellationToken>())
+            .Returns((ManagedHostname?)null);
+
+        var request = new ReportCertificateStatusRequest(CertificateStatus.Provisioning);
+
+        HttpResponseMessage response = await _authClient.PostAsJsonAsync(
+            $"{Prefix}/{FixedId}/certificate-status", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReportCertificateStatus_Unauthenticated_Returns_401()
+    {
+        var request = new ReportCertificateStatusRequest(CertificateStatus.Provisioning);
+
+        HttpResponseMessage response = await _anonClient.PostAsJsonAsync(
+            $"{Prefix}/{FixedId}/certificate-status", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/Granit.Hostnames.Tests/Domain/ManagedHostnameTests.cs
+++ b/tests/Granit.Hostnames.Tests/Domain/ManagedHostnameTests.cs
@@ -218,4 +218,71 @@ public sealed class ManagedHostnameTests
         h2.RequestRecheck();
         h2.Status.ShouldBe(HostnameStatus.Verifying);
     }
+
+    // ── ReportCertificateStatus ───────────────────────────────────────────────
+
+    [Fact]
+    public void Create_defaults_certificate_status_to_unprovisioned()
+    {
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+
+        hostname.CertificateStatus.ShouldBe(CertificateStatus.Unprovisioned);
+        hostname.CertExpiresAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReportCertificateStatus_Secured_sets_status_and_expiry()
+    {
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        DateTimeOffset expires = Now.AddDays(90);
+
+        hostname.ReportCertificateStatus(CertificateStatus.Secured, expires);
+
+        hostname.CertificateStatus.ShouldBe(CertificateStatus.Secured);
+        hostname.CertExpiresAt.ShouldBe(expires);
+    }
+
+    [Fact]
+    public void ReportCertificateStatus_Secured_raises_HostnameCertificateSecuredEto()
+    {
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId, TenantId);
+        DateTimeOffset expires = Now.AddDays(90);
+
+        hostname.ReportCertificateStatus(CertificateStatus.Secured, expires);
+
+        Granit.Hostnames.Domain.Events.HostnameCertificateSecuredEto eto = hostname.IntegrationEvents
+            .OfType<Granit.Hostnames.Domain.Events.HostnameCertificateSecuredEto>()
+            .ShouldHaveSingleItem();
+        eto.HostnameId.ShouldBe(Id);
+        eto.Host.ShouldBe("acme.com");
+        eto.ExpiresAt.ShouldBe(expires);
+    }
+
+    [Fact]
+    public void ReportCertificateStatus_Error_clears_expiry_and_raises_HostnameCertificateFailedEto()
+    {
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId, TenantId);
+        hostname.ReportCertificateStatus(CertificateStatus.Secured, Now.AddDays(90));
+
+        hostname.ReportCertificateStatus(CertificateStatus.Error);
+
+        hostname.CertificateStatus.ShouldBe(CertificateStatus.Error);
+        hostname.CertExpiresAt.ShouldBeNull();
+        hostname.IntegrationEvents
+            .OfType<Granit.Hostnames.Domain.Events.HostnameCertificateFailedEto>()
+            .ShouldHaveSingleItem()
+            .HostnameId.ShouldBe(Id);
+    }
+
+    [Fact]
+    public void ReportCertificateStatus_Provisioning_raises_no_event()
+    {
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+
+        hostname.ReportCertificateStatus(CertificateStatus.Provisioning);
+
+        hostname.CertificateStatus.ShouldBe(CertificateStatus.Provisioning);
+        hostname.CertExpiresAt.ShouldBeNull();
+        hostname.IntegrationEvents.ShouldBeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `CertificateStatus` enum (`Unprovisioned | Provisioning | Secured | Error`) to `ManagedHostname`
- `CertExpiresAt` property tracks the certificate expiry date; cleared automatically on `Error`
- `ReportCertificateStatus(status, expiresAt)` behavior method dispatches `HostnameCertificateSecuredEto` or `HostnameCertificateFailedEto`
- `POST /hostnames/{id}/certificate-status` — provider-agnostic webhook receiver guarded by the new `Hostnames.Certificates.Report` permission
- `ManagedHostnameResponse` extended with `CertificateStatus` + `CertExpiresAt`
- EF Core configuration for both new columns (`CertificateStatus` persisted as `varchar(20)` per Granit enum convention)
- New permission + 18 locale translations

## Test plan

- [ ] 5 new domain tests: `Create_defaults_certificate_status_to_unprovisioned`, Secured sets status + expiry + fires ETO, Error clears expiry + fires ETO, Provisioning raises no event
- [ ] 4 new endpoint tests: Secured→204, Error→204, Unknown→404, Unauthenticated→401
- [ ] All 91 tests across the Hostnames suites pass locally
- [ ] CI — Architecture Tests should pass (no new single-segment section names added)