### PR TITLE
fix(hostnames): add ReportCertificateStatusRequestValidator

### DIFF
--- a/src/Granit.Hostnames.Endpoints/Validators/ReportCertificateStatusRequestValidator.cs
+++ b/src/Granit.Hostnames.Endpoints/Validators/ReportCertificateStatusRequestValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using Granit.Hostnames.Domain;
+using Granit.Hostnames.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Hostnames.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="ReportCertificateStatusRequest"/>.
+/// Enforces that <see cref="ReportCertificateStatusRequest.ExpiresAt"/> is provided
+/// when <see cref="CertificateStatus.Secured"/> is reported.
+/// </summary>
+internal sealed class ReportCertificateStatusRequestValidator
+    : GranitValidator<ReportCertificateStatusRequest>
+{
+    public ReportCertificateStatusRequestValidator()
+    {
+        RuleFor(x => x.ExpiresAt)
+            .NotNull()
+            .When(x => x.Status == CertificateStatus.Secured);
+    }
+}


### PR DESCRIPTION
Architecture test requires every `*Request` type in `.Endpoints` assemblies to have a corresponding `IValidator<T>`. `ReportCertificateStatusRequest` was missing one.

Adds `ReportCertificateStatusRequestValidator` which enforces that `ExpiresAt` is non-null when `Status == CertificateStatus.Secured`.