### PR TITLE
fix(hostnames): add missing README.md for Granit.Hostnames.Notifications

### DIFF
--- a/src/Granit.Hostnames.Notifications/README.md
+++ b/src/Granit.Hostnames.Notifications/README.md
@@ -1,0 +1,25 @@
+# Granit.Hostnames.Notifications
+
+Email notifications for `Granit.Hostnames` DNS verification events.
+
+## What it does
+
+Listens to two integration events dispatched by `ManagedHostname` and sends templated emails
+to the hostname owner (`OwnerId`):
+
+| Event | Notification type |
+| ----- | ----------------- |
+| `HostnameVerifiedEto` | `hostnames.hostname_verified` |
+| `HostnameVerificationFailedEto` | `hostnames.hostname_verification_failed` |
+
+Templates ship in all 18 Granit cultures (EN + FR hand-authored; 16 auto-translated).
+Users may opt out via the standard notification preference system (`AllowUserOptOut = true`).
+
+## Registration
+
+```csharp
+builder.AddGranitModule<GranitHostnamesNotificationsModule>();
+```
+
+Requires `Granit.Notifications.Abstractions` and an `INotificationPublisher` implementation
+(e.g. `Granit.Notifications.Email.Smtp`) to be registered separately.


### PR DESCRIPTION
## Summary

- Adds `src/Granit.Hostnames.Notifications/README.md` — required by the `Every_src_package_should_have_a_README` architecture test
- Unblocks CI on the `architecture` shard (was the sole failure after the Hostnames epic merged)

## Test plan

- [ ] Architecture shard passes (`Every_src_package_should_have_a_README`)