### PR TITLE
feat(persistence): IConcurrencyStampRequest round-trip on all IConcurrencyAware update endpoints

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13127,7 +13127,7 @@
       "kind": "record",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ConfirmMappingsRequest.cs",
-      "line": 8,
+      "line": 11,
       "members": []
     },
     {
@@ -13136,7 +13136,7 @@
       "kind": "record",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs",
-      "line": 8,
+      "line": 17,
       "members": []
     },
     {
@@ -14645,6 +14645,12 @@
           "name": "UpdateAsync",
           "kind": "method",
           "signature": "UpdateAsync(ImportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(ImportJob job, string concurrencyStamp, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -30959,7 +30965,7 @@
       "kind": "record",
       "project": "Granit.MultiTenancy.Endpoints",
       "file": "src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs",
-      "line": 13,
+      "line": 14,
       "members": []
     },
     {
@@ -30968,7 +30974,7 @@
       "kind": "record",
       "project": "Granit.MultiTenancy.Endpoints",
       "file": "src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs",
-      "line": 9,
+      "line": 12,
       "members": []
     },
     {
@@ -31709,6 +31715,12 @@
           "returnType": "Task"
         },
         {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(Guid id, string name, string? contactEmail, string? jurisdiction, string concurrencyStamp, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
           "name": "ActivateAsync",
           "kind": "method",
           "signature": "ActivateAsync(Guid id, CancellationToken cancellationToken = default)",
@@ -31728,7 +31740,7 @@
       "kind": "record",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Stores/TenantData.cs",
-      "line": 16,
+      "line": 17,
       "members": []
     },
     {
@@ -40183,7 +40195,7 @@
       "kind": "record",
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/Dtos/LegalDocumentDetailResponse.cs",
-      "line": 4,
+      "line": 15,
       "members": []
     },
     {
@@ -40192,7 +40204,7 @@
       "kind": "record",
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/Dtos/LegalDocumentUpdateRequest.cs",
-      "line": 8,
+      "line": 11,
       "members": []
     },
     {
@@ -40921,6 +40933,12 @@
           "name": "UpdateAsync",
           "kind": "method",
           "signature": "UpdateAsync(LegalDocument document, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(LegalDocument document, string concurrencyStamp, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -44672,7 +44690,7 @@
       "kind": "record",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs",
-      "line": 17,
+      "line": 22,
       "members": []
     },
     {
@@ -44735,7 +44753,7 @@
       "kind": "record",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs",
-      "line": 5,
+      "line": 15,
       "members": []
     },
     {
@@ -45406,6 +45424,12 @@
           "name": "SaveDraftAsync",
           "kind": "method",
           "signature": "SaveDraftAsync(TemplateKey key, string content, string mimeType, string updatedBy, string? layoutName = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SaveDraftAsync",
+          "kind": "method",
+          "signature": "SaveDraftAsync(TemplateKey key, string content, string mimeType, string updatedBy, string? layoutName, string? concurrencyStamp, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {

--- a/src/Granit.DataExchange.Endpoints/Dtos/Import/ConfirmMappingsRequest.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Import/ConfirmMappingsRequest.cs
@@ -1,8 +1,13 @@
 using Granit.DataExchange.Import.Mapping;
+using Granit.Domain;
 
 namespace Granit.DataExchange.Endpoints.Dtos.Import;
 
 /// <summary>
 /// Request DTO for confirming column mappings on an import job.
 /// </summary>
-public sealed record ConfirmMappingsRequest(IReadOnlyList<ImportColumnMapping> Mappings);
+/// <param name="Mappings">Column-to-property mappings to confirm.</param>
+/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
+public sealed record ConfirmMappingsRequest(
+    IReadOnlyList<ImportColumnMapping> Mappings,
+    string ConcurrencyStamp) : IConcurrencyStampRequest;

--- a/src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs
@@ -5,6 +5,15 @@ namespace Granit.DataExchange.Endpoints.Dtos.Import;
 /// <summary>
 /// Response DTO for an import job summary.
 /// </summary>
+/// <param name="Id">Unique job identifier.</param>
+/// <param name="DefinitionName">Logical import definition name.</param>
+/// <param name="OriginalFileName">Original uploaded file name.</param>
+/// <param name="MimeType">MIME type of the uploaded file.</param>
+/// <param name="FileSizeBytes">File size in bytes.</param>
+/// <param name="Status">Current job status.</param>
+/// <param name="CreatedAt">UTC timestamp of creation.</param>
+/// <param name="CompletedAt">UTC timestamp of completion; <c>null</c> while in progress.</param>
+/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record ImportJobResponse(
     Guid Id,
     string DefinitionName,
@@ -13,12 +22,13 @@ public sealed record ImportJobResponse(
     long FileSizeBytes,
     ImportJobStatus Status,
     DateTimeOffset CreatedAt,
-    DateTimeOffset? CompletedAt)
+    DateTimeOffset? CompletedAt,
+    string ConcurrencyStamp)
 {
     /// <summary>
     /// Maps an <see cref="ImportJob"/> domain entity to a response DTO.
     /// </summary>
     internal static ImportJobResponse FromJob(ImportJob job) =>
         new(job.Id, job.DefinitionName, job.OriginalFileName, job.MimeType,
-            job.FileSizeBytes, job.Status, job.CreatedAt, job.CompletedAt);
+            job.FileSizeBytes, job.Status, job.CreatedAt, job.CompletedAt, job.ConcurrencyStamp);
 }

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportUploadEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportUploadEndpoints.cs
@@ -37,10 +37,11 @@ internal static class ImportUploadEndpoints
         group.MapPut("/{jobId:guid}/mappings", ConfirmMappingsAsync)
             .WithName("ConfirmImportMappings")
             .WithSummary("Confirms the column-to-property mappings for an import job.")
-            .WithDescription("Saves the user-confirmed column-to-property mappings and transitions the job to 'Mapped' status, making it eligible for execution or dry-run. At least one mapping is required. Returns 404 if the job does not exist.")
+            .WithDescription("Saves the user-confirmed column-to-property mappings and transitions the job to 'Mapped' status, making it eligible for execution or dry-run. At least one mapping is required. Returns 404 if the job does not exist. Returns 409 if the concurrency stamp does not match the stored value.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status400BadRequest);
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status409Conflict);
 
         return group;
     }
@@ -104,7 +105,7 @@ internal static class ImportUploadEndpoints
         }
 
         job.ConfirmMappings(request.Mappings);
-        await jobWriter.UpdateAsync(job, cancellationToken).ConfigureAwait(false);
+        await jobWriter.UpdateAsync(job, request.ConcurrencyStamp, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.NoContent();
     }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfImportJobStore.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfImportJobStore.cs
@@ -3,6 +3,7 @@ using Granit.DataExchange.Import.Pipeline;
 using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -44,4 +45,13 @@ internal sealed class EfImportJobStore(
     /// <inheritdoc/>
     public new Task UpdateAsync(ImportJob job, CancellationToken cancellationToken = default) =>
         base.UpdateAsync(job, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task UpdateAsync(ImportJob job, string concurrencyStamp, CancellationToken cancellationToken = default) =>
+        WriteAsync(db =>
+        {
+            db.Set<ImportJob>().Update(job);
+            db.SetConcurrencyStampOriginalValue(job, concurrencyStamp);
+            return Task.CompletedTask;
+        }, cancellationToken);
 }

--- a/src/Granit.DataExchange/Import/Internal/NullImportJobStore.cs
+++ b/src/Granit.DataExchange/Import/Internal/NullImportJobStore.cs
@@ -30,4 +30,8 @@ internal sealed class NullImportJobStore : IImportJobReader, IImportJobWriter
     /// <inheritdoc/>
     public Task UpdateAsync(ImportJob job, CancellationToken cancellationToken = default) =>
         throw new NotImplementedException(Message);
+
+    /// <inheritdoc/>
+    public Task UpdateAsync(ImportJob job, string concurrencyStamp, CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException(Message);
 }

--- a/src/Granit.DataExchange/Import/Pipeline/IImportJobWriter.cs
+++ b/src/Granit.DataExchange/Import/Pipeline/IImportJobWriter.cs
@@ -20,4 +20,12 @@ public interface IImportJobWriter
     /// <param name="job">The import job with updated state.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task UpdateAsync(ImportJob job, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing import job with optimistic concurrency check.
+    /// </summary>
+    /// <param name="job">The import job with updated state.</param>
+    /// <param name="concurrencyStamp">Client-supplied stamp from the last read; must match the stored value.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateAsync(ImportJob job, string concurrencyStamp, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
@@ -10,6 +10,7 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// <param name="Activated">Whether the tenant is active.</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
+/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record TenantResponse(
     Guid Id,
     string Name,
@@ -17,4 +18,5 @@ public sealed record TenantResponse(
     string? ContactEmail,
     bool Activated,
     string? Jurisdiction,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    string ConcurrencyStamp);

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
@@ -1,3 +1,5 @@
+using Granit.Domain;
+
 namespace Granit.MultiTenancy.Endpoints.Dtos;
 
 /// <summary>
@@ -6,7 +8,9 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// <param name="Name">New display name (max 256 characters).</param>
 /// <param name="ContactEmail">New contact email (or <c>null</c> to clear).</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code (or <c>null</c> to clear).</param>
+/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 public sealed record UpdateTenantRequest(
     string Name,
     string? ContactEmail,
-    string? Jurisdiction);
+    string? Jurisdiction,
+    string ConcurrencyStamp) : IConcurrencyStampRequest;

--- a/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
@@ -89,9 +89,10 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
              .RequireAuthorization(MultiTenancyPermissions.Tenants.Update)
              .WithName("UpdateTenant")
              .WithSummary("Updates a tenant's details.")
-             .WithDescription("Updates the display name and contact email of an existing tenant. Returns 404 if the tenant does not exist. Requires the MultiTenancy.Tenants.Update permission.")
+             .WithDescription("Updates the display name and contact email of an existing tenant. Returns 404 if the tenant does not exist. Returns 409 if the concurrency stamp does not match the stored value. Requires the MultiTenancy.Tenants.Update permission.")
              .Produces(StatusCodes.Status204NoContent)
              .ProducesProblem(StatusCodes.Status404NotFound)
+             .ProducesProblem(StatusCodes.Status409Conflict)
              .ProducesValidationProblem();
     }
 
@@ -179,7 +180,7 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
         }
 
         await writer
-            .UpdateAsync(id, body.Name, body.ContactEmail, body.Jurisdiction, cancellationToken)
+            .UpdateAsync(id, body.Name, body.ContactEmail, body.Jurisdiction, body.ConcurrencyStamp, cancellationToken)
             .ConfigureAwait(false);
 
         return TypedResults.NoContent();
@@ -226,7 +227,7 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
     // -------------------------------------------------------------------------
 
     private static TenantResponse ToResponse(TenantData data) =>
-        new(data.Id, data.Name, data.Identifier, data.ContactEmail, data.Activated, data.Jurisdiction, data.CreatedAt);
+        new(data.Id, data.Name, data.Identifier, data.ContactEmail, data.Activated, data.Jurisdiction, data.CreatedAt, data.ConcurrencyStamp);
 
     private static ProblemHttpResult TenantNotFound(Guid id) =>
         TypedResults.Problem(

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
@@ -1,6 +1,7 @@
 using Granit.MultiTenancy.Domain;
 using Granit.MultiTenancy.Stores;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -132,6 +133,28 @@ internal sealed partial class EfCoreTenantStore(
     }
 
     /// <inheritdoc/>
+    public async Task UpdateAsync(
+        Guid id,
+        string name,
+        string? contactEmail,
+        string? jurisdiction,
+        string concurrencyStamp,
+        CancellationToken cancellationToken = default)
+    {
+        await WriteAsync(async db =>
+        {
+            Tenant tenant = await db.Tenants
+                .FirstAsync(t => t.Id == id, cancellationToken)
+                .ConfigureAwait(false);
+
+            db.SetConcurrencyStampOriginalValue(tenant, concurrencyStamp);
+            tenant.UpdateDetails(name, contactEmail, jurisdiction);
+        }, cancellationToken).ConfigureAwait(false);
+
+        LogTenantUpdated(id);
+    }
+
+    /// <inheritdoc/>
     public async Task ActivateAsync(Guid id, CancellationToken cancellationToken = default)
     {
         await WriteAsync(async db =>
@@ -166,7 +189,7 @@ internal sealed partial class EfCoreTenantStore(
     // -------------------------------------------------------------------------
 
     private static TenantData ToData(Tenant tenant) =>
-        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.ContactEmail, tenant.Activated, tenant.Jurisdiction, tenant.CreatedAt, tenant.CustomDomain);
+        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.ContactEmail, tenant.Activated, tenant.Jurisdiction, tenant.CreatedAt, tenant.CustomDomain, tenant.ConcurrencyStamp);
 
     // -------------------------------------------------------------------------
     // Logging

--- a/src/Granit.MultiTenancy/Stores/ITenantWriter.cs
+++ b/src/Granit.MultiTenancy/Stores/ITenantWriter.cs
@@ -28,6 +28,17 @@ public interface ITenantWriter
     Task UpdateAsync(Guid id, string name, string? contactEmail, string? jurisdiction, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Updates an existing tenant's details with optimistic concurrency check.
+    /// </summary>
+    /// <param name="id">Tenant identifier.</param>
+    /// <param name="name">New display name.</param>
+    /// <param name="contactEmail">New contact email (or <c>null</c> to clear).</param>
+    /// <param name="jurisdiction">Privacy regulation code or ISO country code (or <c>null</c>).</param>
+    /// <param name="concurrencyStamp">Client-supplied stamp from the last read; must match the stored value.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateAsync(Guid id, string name, string? contactEmail, string? jurisdiction, string concurrencyStamp, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Activates a tenant.
     /// </summary>
     /// <param name="id">Tenant identifier.</param>

--- a/src/Granit.MultiTenancy/Stores/TenantData.cs
+++ b/src/Granit.MultiTenancy/Stores/TenantData.cs
@@ -13,6 +13,7 @@ namespace Granit.MultiTenancy.Stores;
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
 /// <param name="CustomDomain">Optional custom domain for outbound URL generation (e.g., <c>"app.acme-corp.com"</c>).</param>
+/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record TenantData(
     Guid Id,
     string Name,
@@ -21,4 +22,5 @@ public sealed record TenantData(
     bool Activated,
     string? Jurisdiction,
     DateTimeOffset CreatedAt,
-    string? CustomDomain = null);
+    string? CustomDomain = null,
+    string ConcurrencyStamp = "");

--- a/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentDetailResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentDetailResponse.cs
@@ -1,6 +1,17 @@
 namespace Granit.Privacy.Endpoints.Dtos;
 
 /// <summary>Detailed view of a legal document version.</summary>
+/// <param name="Id">Unique identifier of this document version.</param>
+/// <param name="DocumentId">Logical document identifier shared across all versions.</param>
+/// <param name="Version">Monotonically increasing version number.</param>
+/// <param name="LifecycleStatus">Current lifecycle status (<c>Draft</c>, <c>Published</c>, or <c>Archived</c>).</param>
+/// <param name="DisplayName">Human-readable document title.</param>
+/// <param name="Description">Optional admin-only changelog note.</param>
+/// <param name="TemplateName">Optional Granit.Templating template name for rendered content.</param>
+/// <param name="DocumentBlobId">Optional blob ID for a downloadable document.</param>
+/// <param name="CreatedAt">UTC timestamp of creation.</param>
+/// <param name="LastModifiedAt">UTC timestamp of last modification.</param>
+/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record LegalDocumentDetailResponse(
     Guid Id,
     string DocumentId,
@@ -11,4 +22,5 @@ public sealed record LegalDocumentDetailResponse(
     string? TemplateName,
     Guid? DocumentBlobId,
     DateTimeOffset CreatedAt,
-    DateTimeOffset LastModifiedAt);
+    DateTimeOffset LastModifiedAt,
+    string ConcurrencyStamp);

--- a/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentUpdateRequest.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentUpdateRequest.cs
@@ -1,3 +1,5 @@
+using Granit.Domain;
+
 namespace Granit.Privacy.Endpoints.Dtos;
 
 /// <summary>Request to update a legal document draft.</summary>
@@ -5,8 +7,10 @@ namespace Granit.Privacy.Endpoints.Dtos;
 /// <param name="Description">Optional admin-only changelog note.</param>
 /// <param name="TemplateName">Optional Granit.Templating template name for rendered content.</param>
 /// <param name="DocumentBlobId">Optional blob ID for a downloadable document (PDF, DOCX, etc.).</param>
+/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 public sealed record LegalDocumentUpdateRequest(
     string DisplayName,
     string? Description,
     string? TemplateName,
-    Guid? DocumentBlobId);
+    Guid? DocumentBlobId,
+    string ConcurrencyStamp) : IConcurrencyStampRequest;

--- a/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
@@ -50,10 +50,12 @@ internal static class LegalDocumentAdminEndpoints
             .WithSummary("Updates a legal document draft.")
             .WithDescription(
                 "Updates metadata of a legal document in Draft status. "
-                + "Returns 400 if the document is not in Draft status.")
+                + "Returns 400 if the document is not in Draft status. "
+                + "Returns 409 if the concurrency stamp does not match the stored value.")
             .Produces<LegalDocumentDetailResponse>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesValidationProblem()
             .RequireAuthorization(PrivacyPermissions.LegalDocuments.Manage);
 
@@ -148,7 +150,7 @@ internal static class LegalDocumentAdminEndpoints
             return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
         }
 
-        await writer.UpdateAsync(document, cancellationToken).ConfigureAwait(false);
+        await writer.UpdateAsync(document, request.ConcurrencyStamp, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Ok(ToResponse(document));
     }
@@ -185,5 +187,6 @@ internal static class LegalDocumentAdminEndpoints
             doc.TemplateName,
             doc.DocumentBlobId,
             doc.CreatedAt,
-            doc.ModifiedAt ?? doc.CreatedAt);
+            doc.ModifiedAt ?? doc.CreatedAt,
+            doc.ConcurrencyStamp);
 }

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/EfLegalDocumentStore.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/EfLegalDocumentStore.cs
@@ -3,6 +3,7 @@ using Granit.Domain;
 using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Privacy.LegalAgreements;
 using Granit.Privacy.LegalAgreements.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -53,4 +54,13 @@ internal sealed class EfLegalDocumentStore(
     Task ILegalDocumentWriter.UpdateAsync(
         LegalDocument document, CancellationToken cancellationToken) =>
         base.UpdateAsync(document, cancellationToken);
+
+    Task ILegalDocumentWriter.UpdateAsync(
+        LegalDocument document, string concurrencyStamp, CancellationToken cancellationToken) =>
+        WriteAsync(db =>
+        {
+            db.Set<LegalDocument>().Update(document);
+            db.SetConcurrencyStampOriginalValue(document, concurrencyStamp);
+            return Task.CompletedTask;
+        }, cancellationToken);
 }

--- a/src/Granit.Privacy/LegalAgreements/ILegalDocumentWriter.cs
+++ b/src/Granit.Privacy/LegalAgreements/ILegalDocumentWriter.cs
@@ -12,4 +12,10 @@ public interface ILegalDocumentWriter
 
     /// <summary>Updates an existing legal document.</summary>
     Task UpdateAsync(LegalDocument document, CancellationToken cancellationToken = default);
+
+    /// <summary>Updates an existing legal document with optimistic concurrency check.</summary>
+    /// <param name="document">The modified document entity.</param>
+    /// <param name="concurrencyStamp">Client-supplied stamp from the last read; must match the stored value.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateAsync(LegalDocument document, string concurrencyStamp, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs
@@ -14,9 +14,15 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// Layout template name assigned to this template.
 /// <c>null</c> means the code-level <c>ILayoutRegistry</c> default applies.
 /// </param>
+/// <param name="ConcurrencyStamp">
+/// Stamp from the last read of the draft revision.
+/// Provide when updating an existing draft to detect concurrent modifications (HTTP 409).
+/// Omit or pass <c>null</c> when creating the first draft for this template key.
+/// </param>
 public sealed record SaveTemplateRequest(
     string? Name,
     string? Culture,
     string Content,
     string MimeType = "text/html",
-    string? LayoutName = null);
+    string? LayoutName = null,
+    string? ConcurrencyStamp = null);

--- a/src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs
@@ -2,6 +2,16 @@ using Granit.Workflow.Domain;
 
 namespace Granit.Templating.Endpoints.Dtos;
 
+/// <param name="RevisionId">Unique identifier of this revision.</param>
+/// <param name="Content">Raw template source content.</param>
+/// <param name="MimeType">MIME type of the content (e.g. <c>text/html</c>).</param>
+/// <param name="Status">Lifecycle status (<c>Draft</c>, <c>Published</c>, or <c>Archived</c>).</param>
+/// <param name="CreatedAt">UTC timestamp of creation.</param>
+/// <param name="CreatedBy">Identity of the user who created this revision.</param>
+/// <param name="PublishedAt">UTC timestamp of publication; <c>null</c> for drafts.</param>
+/// <param name="PublishedBy">Identity of the user who published; <c>null</c> for drafts.</param>
+/// <param name="LayoutName">Assigned layout template name; <c>null</c> uses the registry default.</param>
+/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record TemplateRevisionResponse(
     Guid RevisionId,
     string Content,
@@ -11,4 +21,5 @@ public sealed record TemplateRevisionResponse(
     string CreatedBy,
     DateTimeOffset? PublishedAt,
     string? PublishedBy,
-    string? LayoutName);
+    string? LayoutName,
+    string ConcurrencyStamp);

--- a/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
@@ -153,10 +153,11 @@ public static class TemplatingEndpointRouteBuilderExtensions
              .RequireAuthorization(TemplatingPermissions.Templates.Manage)
              .WithName("UpdateTemplateDraft")
              .WithSummary("Updates an existing template draft.")
-             .WithDescription("Replaces the draft revision content and metadata. Only the draft revision is affected — published and archived revisions are immutable. Creates a new draft if none exists. Returns 404 if the template does not exist.")
+             .WithDescription("Replaces the draft revision content and metadata. Only the draft revision is affected — published and archived revisions are immutable. Creates a new draft if none exists. Returns 409 if the concurrency stamp does not match the stored draft. Returns 404 if the template does not exist.")
              .Produces<TemplateDetailResponse>()
              .ProducesValidationProblem()
              .ProducesProblem(StatusCodes.Status400BadRequest)
+             .ProducesProblem(StatusCodes.Status409Conflict)
              .ProducesProblem(StatusCodes.Status501NotImplemented);
 
         templateGroup.MapDelete("/{name}/draft", HandleDeleteDraftAsync)
@@ -414,7 +415,7 @@ public static class TemplatingEndpointRouteBuilderExtensions
         string userId = GetCurrentUserId(context);
         TemplateKey key = new(name, body.Culture);
 
-        await storeWriter.SaveDraftAsync(key, body.Content, body.MimeType, userId, body.LayoutName, cancellationToken).ConfigureAwait(false);
+        await storeWriter.SaveDraftAsync(key, body.Content, body.MimeType, userId, body.LayoutName, body.ConcurrencyStamp, cancellationToken).ConfigureAwait(false);
 
         TemplateRevision? draft = await storeReader.TryGetDraftAsync(key, cancellationToken).ConfigureAwait(false);
         Pipeline.TemplateDescriptor? published = await storeReader.TryGetPublishedAsync(key, cancellationToken).ConfigureAwait(false);
@@ -1140,7 +1141,8 @@ public static class TemplatingEndpointRouteBuilderExtensions
             revision.CreatedBy,
             revision.PublishedAt,
             revision.PublishedBy,
-            revision.LayoutName);
+            revision.LayoutName,
+            revision.ConcurrencyStamp);
 
     private static async Task<TemplateDetailResponse> BuildDetailResponseAsync(
         IDocumentTemplateStoreReader storeReader,

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
@@ -2,6 +2,7 @@ using Granit.Exceptions;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.Exceptions;
 using Granit.Templating.Keys;
@@ -66,13 +67,34 @@ internal sealed class EfDocumentTemplateStore(
     }
 
     /// <inheritdoc/>
-    public async Task SaveDraftAsync(
+    public Task SaveDraftAsync(
         TemplateKey key,
         string content,
         string mimeType,
         string updatedBy,
         string? layoutName = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        SaveDraftCoreAsync(key, content, mimeType, updatedBy, layoutName, null, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task SaveDraftAsync(
+        TemplateKey key,
+        string content,
+        string mimeType,
+        string updatedBy,
+        string? layoutName,
+        string? concurrencyStamp,
+        CancellationToken cancellationToken = default) =>
+        SaveDraftCoreAsync(key, content, mimeType, updatedBy, layoutName, concurrencyStamp, cancellationToken);
+
+    private async Task SaveDraftCoreAsync(
+        TemplateKey key,
+        string content,
+        string mimeType,
+        string updatedBy,
+        string? layoutName,
+        string? concurrencyStamp,
+        CancellationToken cancellationToken)
     {
         await using TemplatingDbContext ctx = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         TemplateRevisionEntity? existing = await ctx.TemplateRevisions
@@ -84,6 +106,11 @@ internal sealed class EfDocumentTemplateStore(
 
         if (existing is not null)
         {
+            if (concurrencyStamp is not null)
+            {
+                ctx.SetConcurrencyStampOriginalValue(existing, concurrencyStamp);
+            }
+
             // Update existing draft in place (only one draft per key)
             existing.UpdateDraft(content, mimeType, layoutName);
         }
@@ -280,6 +307,7 @@ internal sealed class EfDocumentTemplateStore(
                 PublishedAt = r.PublishedAt,
                 PublishedBy = r.PublishedBy,
                 LayoutName = r.LayoutName,
+                ConcurrencyStamp = r.ConcurrencyStamp,
             })
             .ToListAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -311,6 +339,7 @@ internal sealed class EfDocumentTemplateStore(
             PublishedAt = entity.PublishedAt,
             PublishedBy = entity.PublishedBy,
             LayoutName = entity.LayoutName,
+            ConcurrencyStamp = entity.ConcurrencyStamp,
         };
 
     private string CacheKey(TemplateKey key)

--- a/src/Granit.Templating/Store/IDocumentTemplateStoreWriter.cs
+++ b/src/Granit.Templating/Store/IDocumentTemplateStoreWriter.cs
@@ -8,7 +8,7 @@ namespace Granit.Templating.Store;
 /// <remarks>
 /// Lifecycle:
 /// <list type="number">
-///   <item><see cref="SaveDraftAsync"/> — create or update the editable draft for a key.</item>
+///   <item><c>SaveDraftAsync</c> — create or update the editable draft for a key.</item>
 ///   <item><see cref="PublishAsync"/> — promote the current draft to <c>Published</c>,
 ///     archiving any previous published revision.</item>
 ///   <item><see cref="UnpublishAsync"/> — archive the published revision without promoting a new one.</item>
@@ -40,6 +40,29 @@ public interface IDocumentTemplateStoreWriter
         string mimeType,
         string updatedBy,
         string? layoutName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates or replaces the draft for the given key with optimistic concurrency check.
+    /// </summary>
+    /// <remarks>
+    /// The stamp is validated only when an existing draft is found (update path).
+    /// When no draft exists yet (create path) the stamp is ignored.
+    /// </remarks>
+    /// <param name="key">Template key.</param>
+    /// <param name="content">Template source (HTML).</param>
+    /// <param name="mimeType">MIME type (e.g. <c>"text/html"</c>).</param>
+    /// <param name="updatedBy">Identity of the user saving the draft.</param>
+    /// <param name="layoutName">Optional layout template name.</param>
+    /// <param name="concurrencyStamp">Client-supplied stamp from the last read; validated against the stored draft.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SaveDraftAsync(
+        TemplateKey key,
+        string content,
+        string mimeType,
+        string updatedBy,
+        string? layoutName,
+        string? concurrencyStamp,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Granit.Templating/Store/TemplateRevision.cs
+++ b/src/Granit.Templating/Store/TemplateRevision.cs
@@ -36,4 +36,7 @@ public sealed class TemplateRevision
 
     /// <summary>Layout template name assigned by an administrator.</summary>
     public string? LayoutName { get; init; }
+
+    /// <summary>Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</summary>
+    public required string ConcurrencyStamp { get; init; }
 }


### PR DESCRIPTION
## Summary

- **Writer interfaces**: additive overloads with `concurrencyStamp` parameter on `ITenantWriter`, `ILegalDocumentWriter`, `IImportJobWriter`, `IDocumentTemplateStoreWriter` — existing callers (orchestrators, background jobs) are unaffected.
- **EFC stores**: each new overload calls `SetConcurrencyStampOriginalValue` so the client-supplied stamp is used as the EF Core original value in the `WHERE` clause. `DbUpdateConcurrencyException` → HTTP 409 via the existing `EfCoreExceptionStatusCodeMapper`.
- **Request DTOs** now implement `IConcurrencyStampRequest`: `UpdateTenantRequest`, `LegalDocumentUpdateRequest`, `ConfirmMappingsRequest`. `SaveTemplateRequest` uses `string?` (nullable) because `SaveDraftAsync` is an upsert — stamp is ignored on first-draft creation.
- **Response DTOs** now expose `ConcurrencyStamp` for round-trip: `TenantData`, `TenantResponse`, `LegalDocumentDetailResponse`, `TemplateRevision`, `TemplateRevisionResponse`, `ImportJobResponse`.
- **OpenAPI**: `ProducesProblem(409)` declared on all four mutating endpoints.

## Modules touched

| Module | Entity | Request DTO | Response DTO |
|--------|--------|-------------|--------------|
| MultiTenancy | `Tenant` | `UpdateTenantRequest : IConcurrencyStampRequest` | `TenantResponse` + `TenantData` |
| Privacy | `LegalDocument` | `LegalDocumentUpdateRequest : IConcurrencyStampRequest` | `LegalDocumentDetailResponse` |
| DataExchange | `ImportJob` | `ConfirmMappingsRequest : IConcurrencyStampRequest` | `ImportJobResponse` |
| Templating | `TemplateRevisionEntity` | `SaveTemplateRequest.ConcurrencyStamp?` | `TemplateRevisionResponse` + `TemplateRevision` |

## Test plan

- [ ] `PUT /multi-tenancy/tenants/{id}` with a stale stamp returns 409
- [ ] `PUT /legal-documents/{id}` with a stale stamp returns 409
- [ ] `PUT /import/jobs/{id}/mappings` with a stale stamp returns 409
- [ ] `PUT /templates/{name}` with a stale stamp returns 409 (update path only)
- [ ] `PUT /templates/{name}` without stamp on first-draft creation succeeds (upsert path)
- [ ] All existing callers of the old `UpdateAsync(entity, ct)` overloads continue to compile and run