### PR TITLE
chore(lockfiles): regenerate packages.lock.json after Hostnames dep changes

### DIFF
--- a/src/Granit.BlobStorage.S3/packages.lock.json
+++ b/src/Granit.BlobStorage.S3/packages.lock.json
@@ -5,8 +5,8 @@
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.5",
-        "contentHash": "B7UPvqeZD/jIO1eMhCiNRfcvGChjP2yAHIj0NIIhXUVoH2u56YKkIR5CR7lmZfagJN8bCMMZpuxDbYBzgENZ0g==",
+        "resolved": "4.0.23.6",
+        "contentHash": "YIvO2mC1NQRfbjAw2MCla+GGpjOoEIYXX0hi9oGt1/Qqa4ZsSfSZVX7ohydgPPmlx2T62diZQo1MBlOBDfNFxg==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -277,8 +277,8 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.8",
-        "contentHash": "8xBHfPzBJYV27dxsV6vILcmJMTEwT5Xe1uApBdsY+ej48IAomaMZy/4k0XzyT8xQD3U2Dd7UTSVdQvaRPDKbAg==",
+        "resolved": "4.0.9",
+        "contentHash": "VuEBulOlhbl5N0hzwcYK5zdGOdeugSFts8coPpt9xHSIijwzpufYrcraOf5swVPs5vSR+Ebi8hUktV5e+88uUA==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -5,8 +5,8 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.8",
-        "contentHash": "8xBHfPzBJYV27dxsV6vILcmJMTEwT5Xe1uApBdsY+ej48IAomaMZy/4k0XzyT8xQD3U2Dd7UTSVdQvaRPDKbAg==",
+        "resolved": "4.0.9",
+        "contentHash": "VuEBulOlhbl5N0hzwcYK5zdGOdeugSFts8coPpt9xHSIijwzpufYrcraOf5swVPs5vSR+Ebi8hUktV5e+88uUA==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -5,8 +5,8 @@
       "AWSSDK.KeyManagementService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.11.2",
-        "contentHash": "XpqF7wg5gN62RlFNxAfpOLH/v1UYcyOloq0VVrNP/pOheTNhEVVxz13ysnie2WvWCoRu51kQNeemC1WVMV8leA==",
+        "resolved": "4.0.12",
+        "contentHash": "aaFvN3Wu1LFbdx57PCvyyVjg/RFwvxeCn8zCzI0F8rCNR0tNw3JkDzjyEDbry4L6KJJJXa5m/waXEXPIMTP+qg==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2225,6 +2225,7 @@
         "dependencies": {
           "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
         }
@@ -3723,8 +3724,8 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.8",
-        "contentHash": "8xBHfPzBJYV27dxsV6vILcmJMTEwT5Xe1uApBdsY+ej48IAomaMZy/4k0XzyT8xQD3U2Dd7UTSVdQvaRPDKbAg==",
+        "resolved": "4.0.9",
+        "contentHash": "VuEBulOlhbl5N0hzwcYK5zdGOdeugSFts8coPpt9xHSIijwzpufYrcraOf5swVPs5vSR+Ebi8hUktV5e+88uUA==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }
@@ -3732,8 +3733,8 @@
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.11.2",
-        "contentHash": "XpqF7wg5gN62RlFNxAfpOLH/v1UYcyOloq0VVrNP/pOheTNhEVVxz13ysnie2WvWCoRu51kQNeemC1WVMV8leA==",
+        "resolved": "4.0.12",
+        "contentHash": "aaFvN3Wu1LFbdx57PCvyyVjg/RFwvxeCn8zCzI0F8rCNR0tNw3JkDzjyEDbry4L6KJJJXa5m/waXEXPIMTP+qg==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }
@@ -3741,8 +3742,8 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.5",
-        "contentHash": "B7UPvqeZD/jIO1eMhCiNRfcvGChjP2yAHIj0NIIhXUVoH2u56YKkIR5CR7lmZfagJN8bCMMZpuxDbYBzgENZ0g==",
+        "resolved": "4.0.23.6",
+        "contentHash": "YIvO2mC1NQRfbjAw2MCla+GGpjOoEIYXX0hi9oGt1/Qqa4ZsSfSZVX7ohydgPPmlx2T62diZQo1MBlOBDfNFxg==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
@@ -541,8 +541,8 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.23.5",
-        "contentHash": "B7UPvqeZD/jIO1eMhCiNRfcvGChjP2yAHIj0NIIhXUVoH2u56YKkIR5CR7lmZfagJN8bCMMZpuxDbYBzgENZ0g==",
+        "resolved": "4.0.23.6",
+        "contentHash": "YIvO2mC1NQRfbjAw2MCla+GGpjOoEIYXX0hi9oGt1/Qqa4ZsSfSZVX7ohydgPPmlx2T62diZQo1MBlOBDfNFxg==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -429,6 +429,7 @@
         "dependencies": {
           "DnsClient": "[1.8.*, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -516,8 +516,8 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.8",
-        "contentHash": "8xBHfPzBJYV27dxsV6vILcmJMTEwT5Xe1uApBdsY+ej48IAomaMZy/4k0XzyT8xQD3U2Dd7UTSVdQvaRPDKbAg==",
+        "resolved": "4.0.9",
+        "contentHash": "VuEBulOlhbl5N0hzwcYK5zdGOdeugSFts8coPpt9xHSIijwzpufYrcraOf5swVPs5vSR+Ebi8hUktV5e+88uUA==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -5,8 +5,8 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.8",
-        "contentHash": "8xBHfPzBJYV27dxsV6vILcmJMTEwT5Xe1uApBdsY+ej48IAomaMZy/4k0XzyT8xQD3U2Dd7UTSVdQvaRPDKbAg==",
+        "resolved": "4.0.9",
+        "contentHash": "VuEBulOlhbl5N0hzwcYK5zdGOdeugSFts8coPpt9xHSIijwzpufYrcraOf5swVPs5vSR+Ebi8hUktV5e+88uUA==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -495,8 +495,8 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.8",
-        "contentHash": "8xBHfPzBJYV27dxsV6vILcmJMTEwT5Xe1uApBdsY+ej48IAomaMZy/4k0XzyT8xQD3U2Dd7UTSVdQvaRPDKbAg==",
+        "resolved": "4.0.9",
+        "contentHash": "VuEBulOlhbl5N0hzwcYK5zdGOdeugSFts8coPpt9xHSIijwzpufYrcraOf5swVPs5vSR+Ebi8hUktV5e+88uUA==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }

--- a/tests/Granit.Vault.Aws.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Aws.Tests/packages.lock.json
@@ -407,8 +407,8 @@
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.11.2",
-        "contentHash": "XpqF7wg5gN62RlFNxAfpOLH/v1UYcyOloq0VVrNP/pOheTNhEVVxz13ysnie2WvWCoRu51kQNeemC1WVMV8leA==",
+        "resolved": "4.0.12",
+        "contentHash": "aaFvN3Wu1LFbdx57PCvyyVjg/RFwvxeCn8zCzI0F8rCNR0tNw3JkDzjyEDbry4L6KJJJXa5m/waXEXPIMTP+qg==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.7.4, 5.0.0)"
         }


### PR DESCRIPTION
## Summary
- Fixes CI `NU1004` error on `Granit.Hostnames.EntityFrameworkCore.Tests.Integration` caused by stale lock file after recent Hostnames dependency changes
- Regenerated all 11 out-of-date `packages.lock.json` files via `dotnet restore --force-evaluate`

## Affected lock files
- `Granit.Hostnames.EntityFrameworkCore.Tests.Integration` (root cause of CI failure)
- `Granit.BlobStorage.S3` + tests
- `Granit.Identity.Federated.Cognito` + BackgroundJobs + tests
- `Granit.Vault.Aws` + tests
- `Granit.ArchitectureTests`

## Test plan
- [ ] CI passes on all shards (no more NU1004)