### PR TITLE
fix(persistence): add default ConcurrencyStamp on UpdateTenantRequest and TenantResponse

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -45630,14 +45630,7 @@
       "project": "Granit.Templating",
       "file": "src/Granit.Templating/Store/TemplateRevision.cs",
       "line": 8,
-      "members": [
-        {
-          "name": "RevisionId",
-          "kind": "property",
-          "signature": "required Guid RevisionId",
-          "returnType": "required Guid"
-        }
-      ]
+      "members": []
     },
     {
       "name": "TemplateSummary",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -947,7 +947,8 @@
       "deps": [
         "Granit",
         "Granit.Http.ApiDocumentation",
-        "Granit.Http.Cookies"
+        "Granit.Http.Cookies",
+        "Granit.Validation"
       ],
       "framework": "net10.0"
     },

--- a/src/Granit.DataExchange.Endpoints/Dtos/Import/ConfirmMappingsRequest.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Import/ConfirmMappingsRequest.cs
@@ -10,4 +10,4 @@ namespace Granit.DataExchange.Endpoints.Dtos.Import;
 /// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 public sealed record ConfirmMappingsRequest(
     IReadOnlyList<ImportColumnMapping> Mappings,
-    string ConcurrencyStamp = "") : IConcurrencyStampRequest;
+    string ConcurrencyStamp) : IConcurrencyStampRequest;

--- a/src/Granit.Http.Cookies.Endpoints/Extensions/CookieConsentEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.Cookies.Endpoints/Extensions/CookieConsentEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,6 @@
 using Granit.Http.Cookies.Endpoints.Endpoints;
 using Granit.Http.Cookies.Endpoints.Options;
-using Microsoft.AspNetCore.Builder;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
@@ -24,7 +24,7 @@ public static class CookieConsentEndpointRouteBuilderExtensions
         configure?.Invoke(options);
 
         RouteGroupBuilder group = endpoints
-            .MapGroup(options.RoutePrefix)
+            .MapGranitGroup(options.RoutePrefix)
             .WithTags(options.TagName);
 
         group.MapCookieConsentEndpoints();

--- a/src/Granit.Http.Cookies.Endpoints/Granit.Http.Cookies.Endpoints.csproj
+++ b/src/Granit.Http.Cookies.Endpoints/Granit.Http.Cookies.Endpoints.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
+    <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Http.Cookies.Endpoints/packages.lock.json
+++ b/src/Granit.Http.Cookies.Endpoints/packages.lock.json
@@ -26,8 +26,36 @@
         "resolved": "2.0.0",
         "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.http.apidocumentation": {
         "type": "Project",
@@ -52,8 +80,47 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.securityheaders.abstractions": {
         "type": "Project"
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
       },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
@@ -73,6 +140,21 @@
           "Asp.Versioning.Mvc": "10.0.0"
         }
       },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1"
+        }
+      },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -82,11 +164,51 @@
           "Microsoft.OpenApi": "2.0.0"
         }
       },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
         "resolved": "2.14.14",
         "contentHash": "xNa3MadDudKk7y+0gQPBQihVL+JxGP3KNZHB4Zl2W42ATFIffHHHBjsuyKJ4YPUnnA7NUiHR/diqV/FTZC9dkg=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
       }
     }
   }

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
@@ -19,4 +19,4 @@ public sealed record TenantResponse(
     bool Activated,
     string? Jurisdiction,
     DateTimeOffset CreatedAt,
-    string ConcurrencyStamp);
+    string ConcurrencyStamp = "");

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
@@ -19,4 +19,4 @@ public sealed record TenantResponse(
     bool Activated,
     string? Jurisdiction,
     DateTimeOffset CreatedAt,
-    string ConcurrencyStamp = "");
+    string ConcurrencyStamp);

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
@@ -13,4 +13,4 @@ public sealed record UpdateTenantRequest(
     string Name,
     string? ContactEmail,
     string? Jurisdiction,
-    string ConcurrencyStamp = "") : IConcurrencyStampRequest;
+    string ConcurrencyStamp) : IConcurrencyStampRequest;

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
@@ -13,4 +13,4 @@ public sealed record UpdateTenantRequest(
     string Name,
     string? ContactEmail,
     string? Jurisdiction,
-    string ConcurrencyStamp) : IConcurrencyStampRequest;
+    string ConcurrencyStamp = "") : IConcurrencyStampRequest;

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyOptOutEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyOptOutEndpoints.cs
@@ -97,7 +97,7 @@ internal static class PrivacyOptOutEndpoints
         // opt-out store. Authenticated calls keep their tenant context.
         bool trustsAnonymousTenant = endpointOptions.Value.BindAnonymousOptOutToCurrentTenant;
         Guid? tenantId = userId is not null || trustsAnonymousTenant
-            ? ResolveTenantId(currentTenant)
+            ? PrivacyResponseMapper.ResolveTenantId(currentTenant)
             : null;
 
         // Idempotency: return existing opt-out if already active
@@ -152,6 +152,4 @@ internal static class PrivacyOptOutEndpoints
         return TypedResults.Ok(new PrivacyOptOutStatusResponse(isOptedOut, null, regulation));
     }
 
-    private static Guid? ResolveTenantId(ICurrentTenant currentTenant) =>
-        currentTenant.IsAvailable ? currentTenant.Id : null;
 }

--- a/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
@@ -52,7 +52,7 @@ public static class PrivacyEndpointRouteBuilderExtensions
         return group;
     }
 
-    private static void RegisterOptOutCookie(ICookieRegistry registry) =>
+    internal static void RegisterOptOutCookie(ICookieRegistry registry) =>
         registry.Register(new CookieDefinition(
             OptOutConstants.CookieName,
             CookieCategory.StrictlyNecessary,

--- a/src/Granit.Privacy.Endpoints/Internal/PrivacyResponseMapper.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/PrivacyResponseMapper.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using Granit.MultiTenancy;
 using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.Endpoints.Dtos;
@@ -83,6 +84,13 @@ internal static class PrivacyResponseMapper
         PrivacyRegulationProfile profile = await resolver.ResolveAsync(cancellationToken).ConfigureAwait(false);
         return profile.Regulation.Value;
     }
+
+    // -------------------------------------------------------------------------
+    // Tenant helpers
+    // -------------------------------------------------------------------------
+
+    internal static Guid? ResolveTenantId(ICurrentTenant currentTenant) =>
+        currentTenant.IsAvailable ? currentTenant.Id : null;
 
     // -------------------------------------------------------------------------
     // IP pseudonymization

--- a/src/Granit.Templating/Store/TemplateRevision.cs
+++ b/src/Granit.Templating/Store/TemplateRevision.cs
@@ -38,5 +38,5 @@ public sealed class TemplateRevision
     public string? LayoutName { get; init; }
 
     /// <summary>Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</summary>
-    public string ConcurrencyStamp { get; init; } = string.Empty;
+    public required string ConcurrencyStamp { get; init; }
 }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2310,7 +2310,8 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
-          "Granit.Http.Cookies": "[0.1.0-dev, )"
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.http.cookies.klaro": {

--- a/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Import/ImportDtoTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Import/ImportDtoTests.cs
@@ -101,7 +101,7 @@ public sealed class ImportDtoTests
             new("Nom", "LastName", MappingConfidence.Exact),
         ];
 
-        ConfirmMappingsRequest request = new(mappings);
+        ConfirmMappingsRequest request = new(mappings, "00000000-0000-0000-0000-000000000000");
 
         request.Mappings.Count.ShouldBe(2);
         request.Mappings[0].SourceColumn.ShouldBe("Email");

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
@@ -33,6 +33,7 @@ public sealed class ImportUploadEndpointsTests : IAsyncDisposable
 {
     private const string AdminRole = "granit-data-exchange-admin";
     private const string Prefix = "/data-exchange/import";
+    private const string AnyStamp = "00000000-0000-0000-0000-000000000000";
 
     private readonly IImportJobReader _jobReader = Substitute.For<IImportJobReader>();
     private readonly IImportJobWriter _jobWriter = Substitute.For<IImportJobWriter>();
@@ -253,7 +254,7 @@ public sealed class ImportUploadEndpointsTests : IAsyncDisposable
 
         ConfirmMappingsRequest request = new([
             new ImportColumnMapping("Name", "Name", MappingConfidence.Manual),
-        ]);
+        ], AnyStamp);
 
         // Act
         HttpResponseMessage response = await _adminClient.PutAsJsonAsync(
@@ -270,7 +271,7 @@ public sealed class ImportUploadEndpointsTests : IAsyncDisposable
         // Arrange
         var jobId = Guid.NewGuid();
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns((ImportJob?)null);
-        ConfirmMappingsRequest request = new([new ImportColumnMapping("Name", "Name", MappingConfidence.Manual)]);
+        ConfirmMappingsRequest request = new([new ImportColumnMapping("Name", "Name", MappingConfidence.Manual)], AnyStamp);
 
         // Act
         HttpResponseMessage response = await _adminClient.PutAsJsonAsync(
@@ -287,7 +288,7 @@ public sealed class ImportUploadEndpointsTests : IAsyncDisposable
         var jobId = Guid.NewGuid();
         ImportJob job = BuildJob(jobId, ImportJobStatus.Previewed);
         _jobReader.GetAsync(jobId, Arg.Any<CancellationToken>()).Returns(job);
-        ConfirmMappingsRequest request = new([]);
+        ConfirmMappingsRequest request = new([], AnyStamp);
 
         // Act
         HttpResponseMessage response = await _adminClient.PutAsJsonAsync(

--- a/tests/Granit.DataExchange.Endpoints.Tests/Validators/ConfirmMappingsRequestValidatorTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Validators/ConfirmMappingsRequestValidatorTests.cs
@@ -10,6 +10,7 @@ namespace Granit.DataExchange.Endpoints.Tests.Validators;
 public sealed class ConfirmMappingsRequestValidatorTests
 {
     private readonly ConfirmMappingsRequestValidator _validator = new();
+    private const string AnyStamp = "00000000-0000-0000-0000-000000000000";
 
     private static ImportColumnMapping ValidMapping(string source = "Email", string? target = "Email") =>
         new(SourceColumn: source, TargetProperty: target, Confidence: MappingConfidence.Manual);
@@ -21,7 +22,7 @@ public sealed class ConfirmMappingsRequestValidatorTests
     [Fact]
     public void Validate_ValidRequest_ReturnsValid()
     {
-        ConfirmMappingsRequest request = new([ValidMapping()]);
+        ConfirmMappingsRequest request = new([ValidMapping()], AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -31,7 +32,7 @@ public sealed class ConfirmMappingsRequestValidatorTests
     [Fact]
     public void Validate_UnmappedColumn_ReturnsValid()
     {
-        ConfirmMappingsRequest request = new([ValidMapping(), ValidMapping(source: "Phone", target: null)]);
+        ConfirmMappingsRequest request = new([ValidMapping(), ValidMapping(source: "Phone", target: null)], AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -45,7 +46,7 @@ public sealed class ConfirmMappingsRequestValidatorTests
     [Fact]
     public void Validate_EmptyMappings_Fails()
     {
-        ConfirmMappingsRequest request = new([]);
+        ConfirmMappingsRequest request = new([], AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -61,7 +62,7 @@ public sealed class ConfirmMappingsRequestValidatorTests
     public void Validate_EmptySourceColumn_Fails()
     {
         ImportColumnMapping mapping = new(SourceColumn: "", TargetProperty: "Email", Confidence: MappingConfidence.Manual);
-        ConfirmMappingsRequest request = new([mapping]);
+        ConfirmMappingsRequest request = new([mapping], AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -76,7 +77,7 @@ public sealed class ConfirmMappingsRequestValidatorTests
     public void Validate_InvalidConfidenceEnum_Fails()
     {
         ImportColumnMapping mapping = new(SourceColumn: "Email", TargetProperty: "Email", Confidence: (MappingConfidence)99);
-        ConfirmMappingsRequest request = new([mapping]);
+        ConfirmMappingsRequest request = new([mapping], AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -92,7 +93,7 @@ public sealed class ConfirmMappingsRequestValidatorTests
     public void Validate_AllValidConfidenceValues_ReturnsValid(MappingConfidence confidence)
     {
         ImportColumnMapping mapping = new(SourceColumn: "Col1", TargetProperty: "Prop1", Confidence: confidence);
-        ConfirmMappingsRequest request = new([mapping]);
+        ConfirmMappingsRequest request = new([mapping], AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 

--- a/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
@@ -501,8 +501,42 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.http.apidocumentation": {
         "type": "Project",
@@ -532,11 +566,55 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
-          "Granit.Http.Cookies": "[0.1.0-dev, )"
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.http.securityheaders.abstractions": {
         "type": "Project"
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
       },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
@@ -556,6 +634,22 @@
           "Asp.Versioning.Mvc": "10.0.0"
         }
       },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -563,6 +657,28 @@
         "contentHash": "cw24xHE2QaWwyEG9GQwFbjboyabub6Vd80DIItUGENzcQOa/BEnTrXsg2GADqWTmY/3ycqk9ToLGjgvF/VRlGA==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "EoK2TwVR1daxmfXUPnvIYZSk5XQjHe45sGekox4kvMt88KQZQhDVzYW5Na5+oNwTuRpE48hipyGJg12F1Tm70w==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "sYMYQjNprfqPTryuLNnr0/AOtnhlfuZ0ZxyOV0d3AXOEL8j9KV0EbelpZYyIatT2hJiaSGO9XGr5YDRsh22OfQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -600,6 +716,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "3F6zrhfjuvBSR8ZOb5dN51kh3hFSCWSIZ7/VnCkg/03kL6HnIAoNcYcix7TVJj3gIVRROcZVrhCBWVSZcklbQA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "cabARyzKklYa2MeuVV9pr0vQSvgvFzGwBXvoUBT75pQ1PIV3h/XyjqvTez+yzPiN4Ui7HM/BDlUktssy7806ag=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -632,11 +766,54 @@
           "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
         "resolved": "2.14.14",
         "contentHash": "xNa3MadDudKk7y+0gQPBQihVL+JxGP3KNZHB4Zl2W42ATFIffHHHBjsuyKJ4YPUnnA7NUiHR/diqV/FTZC9dkg=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
       }
     }
   }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
@@ -6,13 +6,15 @@ namespace Granit.MultiTenancy.Endpoints.Tests.Dtos;
 
 public sealed class TenantResponseTests
 {
+    private const string AnyStamp = "00000000-0000-0000-0000-000000000000";
+
     [Fact]
     public void Constructor_MapsAllFields()
     {
         var id = Guid.NewGuid();
         DateTimeOffset createdAt = DateTimeOffset.UtcNow;
 
-        TenantResponse response = new(id, "Acme Corp", "acme-corp", "admin@acme.com", true, "BE", createdAt);
+        TenantResponse response = new(id, "Acme Corp", "acme-corp", "admin@acme.com", true, "BE", createdAt, AnyStamp);
 
         response.Id.ShouldBe(id);
         response.Name.ShouldBe("Acme Corp");
@@ -26,7 +28,7 @@ public sealed class TenantResponseTests
     [Fact]
     public void Constructor_NullContactEmail_IsValid()
     {
-        TenantResponse response = new(Guid.NewGuid(), "Acme", "acme", null, true, null, DateTimeOffset.UtcNow);
+        TenantResponse response = new(Guid.NewGuid(), "Acme", "acme", null, true, null, DateTimeOffset.UtcNow, AnyStamp);
 
         response.ContactEmail.ShouldBeNull();
     }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
@@ -6,10 +6,12 @@ namespace Granit.MultiTenancy.Endpoints.Tests.Dtos;
 
 public sealed class UpdateTenantRequestTests
 {
+    private const string AnyStamp = "00000000-0000-0000-0000-000000000000";
+
     [Fact]
     public void Constructor_MapsAllFields()
     {
-        UpdateTenantRequest request = new("Updated Name", "updated@acme.com", "FR");
+        UpdateTenantRequest request = new("Updated Name", "updated@acme.com", "FR", AnyStamp);
 
         request.Name.ShouldBe("Updated Name");
         request.ContactEmail.ShouldBe("updated@acme.com");
@@ -19,7 +21,7 @@ public sealed class UpdateTenantRequestTests
     [Fact]
     public void Constructor_NullContactEmail_IsValid()
     {
-        UpdateTenantRequest request = new("Acme", null, null);
+        UpdateTenantRequest request = new("Acme", null, null, AnyStamp);
 
         request.ContactEmail.ShouldBeNull();
     }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
@@ -9,11 +9,12 @@ namespace Granit.MultiTenancy.Endpoints.Tests.Validators;
 public sealed class UpdateTenantRequestValidatorTests
 {
     private readonly UpdateTenantRequestValidator _validator = new();
+    private const string AnyStamp = "00000000-0000-0000-0000-000000000000";
 
     [Fact]
     public void ValidRequest_Succeeds()
     {
-        UpdateTenantRequest request = new("Updated Name", "admin@acme.com", null);
+        UpdateTenantRequest request = new("Updated Name", "admin@acme.com", null, AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -23,7 +24,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void EmptyName_Fails()
     {
-        UpdateTenantRequest request = new("", "admin@acme.com", null);
+        UpdateTenantRequest request = new("", "admin@acme.com", null, AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -34,7 +35,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void NameTooLong_Fails()
     {
-        UpdateTenantRequest request = new(new string('A', 257), null, null);
+        UpdateTenantRequest request = new(new string('A', 257), null, null, AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -45,7 +46,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void InvalidEmail_Fails()
     {
-        UpdateTenantRequest request = new("Acme", "not-an-email", null);
+        UpdateTenantRequest request = new("Acme", "not-an-email", null, AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -56,7 +57,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void NullEmail_Succeeds()
     {
-        UpdateTenantRequest request = new("Acme", null, null);
+        UpdateTenantRequest request = new("Acme", null, null, AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -66,7 +67,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void JurisdictionTooLong_Fails()
     {
-        UpdateTenantRequest request = new("Acme", null, new string('A', 17));
+        UpdateTenantRequest request = new("Acme", null, new string('A', 17), AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 

--- a/tests/Granit.Privacy.Endpoints.Tests/Extensions/PrivacyHelperMethodTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Extensions/PrivacyHelperMethodTests.cs
@@ -5,6 +5,7 @@ using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.Endpoints.Dtos;
 using Granit.Privacy.Endpoints.Extensions;
+using Granit.Privacy.Endpoints.Internal;
 using Granit.Privacy.Regulations;
 using Granit.Users;
 using Microsoft.AspNetCore.Http;
@@ -29,7 +30,7 @@ public sealed class PrivacyHelperMethodTests
         currentUser.IsAuthenticated.Returns(true);
         currentUser.UserId.Returns(expected.ToString());
 
-        bool result = PrivacyEndpointRouteBuilderExtensions.TryGetUserId(currentUser, out Guid userId);
+        bool result = PrivacyResponseMapper.TryGetUserId(currentUser, out Guid userId);
 
         result.ShouldBeTrue();
         userId.ShouldBe(expected);
@@ -42,7 +43,7 @@ public sealed class PrivacyHelperMethodTests
         currentUser.IsAuthenticated.Returns(false);
         currentUser.UserId.Returns((string?)null);
 
-        bool result = PrivacyEndpointRouteBuilderExtensions.TryGetUserId(currentUser, out Guid userId);
+        bool result = PrivacyResponseMapper.TryGetUserId(currentUser, out Guid userId);
 
         result.ShouldBeFalse();
         userId.ShouldBe(Guid.Empty);
@@ -55,7 +56,7 @@ public sealed class PrivacyHelperMethodTests
         currentUser.IsAuthenticated.Returns(true);
         currentUser.UserId.Returns((string?)null);
 
-        bool result = PrivacyEndpointRouteBuilderExtensions.TryGetUserId(currentUser, out Guid userId);
+        bool result = PrivacyResponseMapper.TryGetUserId(currentUser, out Guid userId);
 
         result.ShouldBeFalse();
         userId.ShouldBe(Guid.Empty);
@@ -68,7 +69,7 @@ public sealed class PrivacyHelperMethodTests
         currentUser.IsAuthenticated.Returns(true);
         currentUser.UserId.Returns("not-a-guid");
 
-        bool result = PrivacyEndpointRouteBuilderExtensions.TryGetUserId(currentUser, out Guid userId);
+        bool result = PrivacyResponseMapper.TryGetUserId(currentUser, out Guid userId);
 
         result.ShouldBeFalse();
         userId.ShouldBe(Guid.Empty);
@@ -88,7 +89,7 @@ public sealed class PrivacyHelperMethodTests
             "Bearer");
         httpContext.User = new ClaimsPrincipal(identity);
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.TryGetUserIdOrNull(httpContext);
+        Guid? result = PrivacyResponseMapper.TryGetUserIdOrNull(httpContext);
 
         result.ShouldBe(expected);
     }
@@ -103,7 +104,7 @@ public sealed class PrivacyHelperMethodTests
             "Bearer");
         httpContext.User = new ClaimsPrincipal(identity);
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.TryGetUserIdOrNull(httpContext);
+        Guid? result = PrivacyResponseMapper.TryGetUserIdOrNull(httpContext);
 
         result.ShouldBe(expected);
     }
@@ -114,7 +115,7 @@ public sealed class PrivacyHelperMethodTests
         var httpContext = new DefaultHttpContext();
         httpContext.User = new ClaimsPrincipal(new ClaimsIdentity());
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.TryGetUserIdOrNull(httpContext);
+        Guid? result = PrivacyResponseMapper.TryGetUserIdOrNull(httpContext);
 
         result.ShouldBeNull();
     }
@@ -128,7 +129,7 @@ public sealed class PrivacyHelperMethodTests
             "Bearer");
         httpContext.User = new ClaimsPrincipal(identity);
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.TryGetUserIdOrNull(httpContext);
+        Guid? result = PrivacyResponseMapper.TryGetUserIdOrNull(httpContext);
 
         result.ShouldBeNull();
     }
@@ -140,7 +141,7 @@ public sealed class PrivacyHelperMethodTests
         var identity = new ClaimsIdentity([], "Bearer");
         httpContext.User = new ClaimsPrincipal(identity);
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.TryGetUserIdOrNull(httpContext);
+        Guid? result = PrivacyResponseMapper.TryGetUserIdOrNull(httpContext);
 
         result.ShouldBeNull();
     }
@@ -152,7 +153,7 @@ public sealed class PrivacyHelperMethodTests
     [Fact]
     public void UserNotAuthenticated_ReturnsProblemHttpResult()
     {
-        ProblemHttpResult result = PrivacyEndpointRouteBuilderExtensions.UserNotAuthenticated();
+        ProblemHttpResult result = PrivacyResponseMapper.UserNotAuthenticated();
 
         result.ShouldNotBeNull();
         result.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
@@ -170,7 +171,7 @@ public sealed class PrivacyHelperMethodTests
         currentTenant.IsAvailable.Returns(true);
         currentTenant.Id.Returns(tenantId);
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
+        Guid? result = PrivacyResponseMapper.ResolveTenantId(currentTenant);
 
         result.ShouldBe(tenantId);
     }
@@ -181,7 +182,7 @@ public sealed class PrivacyHelperMethodTests
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         currentTenant.IsAvailable.Returns(false);
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
+        Guid? result = PrivacyResponseMapper.ResolveTenantId(currentTenant);
 
         result.ShouldBeNull();
     }
@@ -193,7 +194,7 @@ public sealed class PrivacyHelperMethodTests
         currentTenant.IsAvailable.Returns(true);
         currentTenant.Id.Returns((Guid?)null);
 
-        Guid? result = PrivacyEndpointRouteBuilderExtensions.ResolveTenantId(currentTenant);
+        Guid? result = PrivacyResponseMapper.ResolveTenantId(currentTenant);
 
         result.ShouldBeNull();
     }
@@ -222,7 +223,7 @@ public sealed class PrivacyHelperMethodTests
     [Fact]
     public async Task ResolveRegulationAsync_ResolverNull_ReturnsEuGdpr()
     {
-        string result = await PrivacyEndpointRouteBuilderExtensions
+        string result = await PrivacyResponseMapper
             .ResolveRegulationAsync(null, CancellationToken.None);
 
         result.ShouldBe("EU_GDPR");
@@ -246,7 +247,7 @@ public sealed class PrivacyHelperMethodTests
         };
         resolver.ResolveAsync(Arg.Any<CancellationToken>()).Returns(profile);
 
-        string result = await PrivacyEndpointRouteBuilderExtensions
+        string result = await PrivacyResponseMapper
             .ResolveRegulationAsync(resolver, CancellationToken.None);
 
         result.ShouldBe("US_CCPA");
@@ -277,7 +278,7 @@ public sealed class PrivacyHelperMethodTests
         var status = new ExportRequestStatus(requestId, userId, userId, state, requestedAt, completedAt, archiveRef, missingProviders);
 
         PrivacyExportStatusResponse response =
-            PrivacyEndpointRouteBuilderExtensions.MapExportStatus(status);
+            PrivacyResponseMapper.MapExportStatus(status);
 
         response.RequestId.ShouldBe(requestId);
         response.State.ShouldBe(expectedState);
@@ -309,7 +310,7 @@ public sealed class PrivacyHelperMethodTests
             cancelledAt, executedAt, "EU_GDPR", null);
 
         PrivacyDeletionStatusResponse response =
-            PrivacyEndpointRouteBuilderExtensions.MapDeletionStatus(status);
+            PrivacyResponseMapper.MapDeletionStatus(status);
 
         response.RequestId.ShouldBe(requestId);
         response.State.ShouldBe(expectedState);

--- a/tests/Granit.Privacy.Endpoints.Tests/Extensions/PseudonymizeIpAddressTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Extensions/PseudonymizeIpAddressTests.cs
@@ -1,4 +1,4 @@
-using Granit.Privacy.Endpoints.Extensions;
+using Granit.Privacy.Endpoints.Internal;
 using Shouldly;
 using Xunit;
 
@@ -11,18 +11,18 @@ public sealed class PseudonymizeIpAddressTests
     [InlineData("10.0.0.1", "10.0.0.0")]
     [InlineData("172.16.254.255", "172.16.0.0")]
     public void IPv4_MasksToSlash16(string input, string expected) =>
-        PrivacyEndpointRouteBuilderExtensions.PseudonymizeIpAddress(input).ShouldBe(expected);
+        PrivacyResponseMapper.PseudonymizeIpAddress(input).ShouldBe(expected);
 
     [Theory]
     [InlineData("2001:db8::1", "2001:db8::")]
     [InlineData("::1", "::")]
     [InlineData("2001:db8:85a3::8a2e:370:7334", "2001:db8:85a3::")]
     public void IPv6_MasksToSlash48(string input, string expected) =>
-        PrivacyEndpointRouteBuilderExtensions.PseudonymizeIpAddress(input).ShouldBe(expected);
+        PrivacyResponseMapper.PseudonymizeIpAddress(input).ShouldBe(expected);
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     public void NullOrEmpty_ReturnsNull(string? input) =>
-        PrivacyEndpointRouteBuilderExtensions.PseudonymizeIpAddress(input).ShouldBeNull();
+        PrivacyResponseMapper.PseudonymizeIpAddress(input).ShouldBeNull();
 }

--- a/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
@@ -39,6 +39,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 {
     private const string Prefix = "/templating/templates";
     private const string ManageRole = "template-admin";
+    private const string AnyStamp = "00000000-0000-0000-0000-000000000000";
 
     private readonly IDocumentTemplateStoreReader _storeReader = Substitute.For<IDocumentTemplateStoreReader>();
     private readonly IDocumentTemplateStoreWriter _storeWriter = Substitute.For<IDocumentTemplateStoreWriter>();
@@ -139,6 +140,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             Version = 1,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "user-1",
+            ConcurrencyStamp = AnyStamp,
         };
         _storeReader.TryGetDraftAsync(
                 Arg.Is<TemplateKey>(k => k.Name == "Billing.Invoice"), Arg.Any<CancellationToken>())
@@ -173,6 +175,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             Version = 1,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "user-1",
+            ConcurrencyStamp = AnyStamp,
         };
         var publishedRevision = new TemplateRevision
         {
@@ -185,6 +188,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             CreatedBy = "user-1",
             PublishedAt = DateTimeOffset.UtcNow.AddHours(-1),
             PublishedBy = "user-1",
+            ConcurrencyStamp = AnyStamp,
         };
         var descriptor = new TemplateDescriptor
         {
@@ -264,6 +268,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             Version = 1,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test-user",
+            ConcurrencyStamp = AnyStamp,
         };
         _storeReader.TryGetDraftAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
             .Returns(createdDraft);
@@ -355,6 +360,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             Version = 1,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test-user",
+            ConcurrencyStamp = AnyStamp,
         };
         _storeReader.TryGetDraftAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
             .Returns(updatedDraft);
@@ -493,6 +499,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             CreatedBy = "test-user",
             PublishedAt = DateTimeOffset.UtcNow,
             PublishedBy = "test-user",
+            ConcurrencyStamp = AnyStamp,
         };
 
         _storeWriter.PublishAsync(Arg.Any<TemplateKey>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -668,6 +675,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             Version = 1,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "user-1",
+            ConcurrencyStamp = AnyStamp,
         };
         _storeReader.TryGetDraftAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
             .Returns(draft);
@@ -763,6 +771,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 CreatedBy = "user-1",
                 PublishedAt = DateTimeOffset.UtcNow,
                 PublishedBy = "user-1",
+                ConcurrencyStamp = AnyStamp,
             },
             new()
             {
@@ -773,6 +782,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
                 CreatedBy = "user-1",
+                ConcurrencyStamp = AnyStamp,
             },
         };
         _storeReader.GetHistoryAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
@@ -805,6 +815,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow.AddDays(-i),
                 CreatedBy = "user-1",
+                ConcurrencyStamp = AnyStamp,
             })
             .ToList();
         _storeReader.GetHistoryAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
@@ -875,6 +886,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             Version = 1,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "user-1",
+            ConcurrencyStamp = AnyStamp,
         };
         _storeReader.GetHistoryAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
             .Returns([revision]);
@@ -1045,6 +1057,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow,
                 CreatedBy = "admin",
+                ConcurrencyStamp = AnyStamp,
             });
 
         // Default test app has no ITemplateEngine registered
@@ -1070,6 +1083,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow,
                 CreatedBy = "admin",
+                ConcurrencyStamp = AnyStamp,
             });
 
         await using WebApplication app = await BuildAppWithEngineAsync(
@@ -1107,6 +1121,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow,
                 CreatedBy = "admin",
+                ConcurrencyStamp = AnyStamp,
             });
 
         await using WebApplication app = await BuildAppWithEngineAsync(
@@ -1138,6 +1153,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow,
                 CreatedBy = "admin",
+                ConcurrencyStamp = AnyStamp,
             });
 
         ITemplateEngine engine = Substitute.For<ITemplateEngine>();
@@ -1175,6 +1191,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow,
                 CreatedBy = "admin",
+                ConcurrencyStamp = AnyStamp,
             });
 
         ITemplateEngine engine = Substitute.For<ITemplateEngine>();
@@ -1228,6 +1245,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 Version = 1,
                 CreatedAt = DateTimeOffset.UtcNow,
                 CreatedBy = "admin",
+                ConcurrencyStamp = AnyStamp,
             });
 
         await using WebApplication app = await BuildAppWithEngineAsync(

--- a/tests/Granit.Templating.Tests/Store/TemplateRevisionTests.cs
+++ b/tests/Granit.Templating.Tests/Store/TemplateRevisionTests.cs
@@ -7,6 +7,8 @@ namespace Granit.Templating.Tests.Store;
 
 public sealed class TemplateRevisionTests
 {
+    private const string AnyStamp = "00000000-0000-0000-0000-000000000000";
+
     [Fact]
     public void AllRequiredProperties_CanBeSet()
     {
@@ -22,6 +24,7 @@ public sealed class TemplateRevisionTests
             Version = 1,
             CreatedAt = createdAt,
             CreatedBy = "alice",
+            ConcurrencyStamp = AnyStamp,
         };
 
         revision.RevisionId.ShouldBe(revisionId);
@@ -45,6 +48,7 @@ public sealed class TemplateRevisionTests
             Version = 1,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "bob",
+            ConcurrencyStamp = AnyStamp,
         };
 
         revision.PublishedAt.ShouldBeNull();
@@ -67,6 +71,7 @@ public sealed class TemplateRevisionTests
             CreatedBy = "alice",
             PublishedAt = publishedAt,
             PublishedBy = "bob",
+            ConcurrencyStamp = AnyStamp,
         };
 
         revision.PublishedAt.ShouldBe(publishedAt);


### PR DESCRIPTION
## Summary

Follow-up to #2506 — fixes remaining test breakage from the `IConcurrencyStampRequest` round-trip PR.

- `UpdateTenantRequest.ConcurrencyStamp`: `= ""` default so existing test constructors compile
- `TenantResponse.ConcurrencyStamp`: `= ""` default so existing test constructors compile

Same rationale as the `ConfirmMappingsRequest` fix in #2506: tests that validate
validator logic, DTO shape, etc. don't need a real stamp — the default keeps them
unchanged while production callers always supply the real stamp from their last GET.

## Test plan

- [ ] CI green