### PR TITLE
fix(persistence): three audit findings — DI wiring + [DependsOn] order

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37361,7 +37361,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddMetadataInfrastructure",

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -42,7 +42,8 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
 
         // LocalIdentity implements IHasMetadata — apps can extend user properties
         // by calling AddMetadataMappings<LocalIdentity> in their own module.
-        // The MetadataSyncInterceptor in Granit.Persistence handles sync automatically.
+        // AddMetadataInfrastructure registers MetadataSyncInterceptor as IGranitAutoInterceptor
+        // so UseGranitInterceptors picks it up on every DbContext automatically.
         context.Services.AddMetadataInfrastructure();
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs
@@ -89,7 +89,7 @@ public static class PersistenceMigrationsHostApplicationBuilderExtensions
 
         // Migration batch executor. Commands are dispatched via ICommandSender (Granit.Wolverine
         // or another provider) and handled by RunMigrationBatchHandler.
-        builder.Services.AddScoped<MigrationBatchExecutor>();
+        builder.Services.AddScoped<IMigrationBatchExecutor, MigrationBatchExecutor>();
 
         // Hosted service — resumes pending and in-progress cycles at startup.
         builder.Services.AddHostedService<MigrationStartupService>();

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs
@@ -13,8 +13,8 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// is not a direct dependency of this module.
 /// </summary>
 [DependsOn(
-    typeof(GranitHttpExceptionHandlingModule),
     typeof(GranitGuidsModule),
+    typeof(GranitHttpExceptionHandlingModule),
     typeof(GranitTimingModule))]
 public sealed class GranitPersistenceEntityFrameworkCoreModule : GranitModule
 {

--- a/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataServiceCollectionExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Domain;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -25,6 +26,9 @@ public static class MetadataServiceCollectionExtensions
         services.TryAddSingleton<IMetadataMappingRegistry>(
             sp => sp.GetRequiredService<MetadataMappingRegistry>());
         services.TryAddSingleton<MetadataSyncInterceptor>();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IGranitAutoInterceptor>(
+                sp => sp.GetRequiredService<MetadataSyncInterceptor>()));
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, MetadataMappingRegistryInitializer>());
 

--- a/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataSyncInterceptor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataSyncInterceptor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Granit.Domain;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -24,7 +25,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Metadata;
 /// </para>
 /// </remarks>
 internal sealed class MetadataSyncInterceptor(
-    IMetadataMappingRegistry registry) : SaveChangesInterceptor
+    IMetadataMappingRegistry registry) : SaveChangesInterceptor, IGranitAutoInterceptor
 {
     private readonly ConcurrentDictionary<Type, HashSet<string>> _cache = new();
 


### PR DESCRIPTION
## Summary

Three findings from `/audit Granit.Persistence.*`:

- **`IMigrationBatchExecutor` missing from DI** (`PersistenceMigrationsHostApplicationBuilderExtensions.cs:92`) — `AddScoped<MigrationBatchExecutor>()` registered the concrete type only; `RunMigrationBatchHandler.HandleAsync` injects `IMigrationBatchExecutor` as a Wolverine parameter which would throw at first migration batch dispatch. Fixed to `AddScoped<IMigrationBatchExecutor, MigrationBatchExecutor>()`.

- **`MetadataSyncInterceptor` never wired into DbContexts** (`MetadataServiceCollectionExtensions.cs`, `MetadataSyncInterceptor.cs`) — the interceptor was registered as a singleton but not as `IGranitAutoInterceptor`, so `UseGranitInterceptors` never included it in any DbContext pipeline. Shadow properties mapped via `ApplyMetadataMappings` were permanently null on write. Fixed by implementing `IGranitAutoInterceptor` on the class and adding the corresponding `TryAddEnumerable` registration. Updated stale OpenIddict comment.

- **`[DependsOn]` not alphabetical** (`GranitPersistenceEntityFrameworkCoreModule.cs`) — reordered `Guids → HttpExceptionHandling → Timing`.

## Test plan

- [ ] `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Tests` — 371 tests pass
- [ ] `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests` — 69 tests pass
- [ ] CI `api-data` shard green