### PR TITLE
fix(hostnames): apply security audit findings (VULN-200–400)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19666,7 +19666,7 @@
         {
           "name": "ListByOwnerAsync",
           "kind": "method",
-          "signature": "ListByOwnerAsync(string ownerType, Guid ownerId, CancellationToken cancellationToken = default)",
+          "signature": "ListByOwnerAsync(string ownerType, Guid ownerId, int maxResults = 500, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<ManagedHostname>>"
         },
         {
@@ -20154,7 +20154,7 @@
       "kind": "class",
       "project": "Granit.Hostnames",
       "file": "src/Granit.Hostnames/GranitHostnamesModule.cs",
-      "line": 25,
+      "line": 27,
       "members": [
         {
           "name": "ConfigureServices",
@@ -20293,6 +20293,24 @@
           "kind": "property",
           "signature": "int VerificationBatchSize",
           "returnType": "int"
+        },
+        {
+          "name": "VerificationConcurrency",
+          "kind": "property",
+          "signature": "int VerificationConcurrency",
+          "returnType": "int"
+        },
+        {
+          "name": "DnsQueryTimeoutSeconds",
+          "kind": "property",
+          "signature": "int DnsQueryTimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "CertificateWebhookSecret",
+          "kind": "property",
+          "signature": "string? CertificateWebhookSecret",
+          "returnType": "string?"
         }
       ]
     },

--- a/src/Granit.Hostnames.BackgroundJobs/Services/HostnameVerificationBatchService.cs
+++ b/src/Granit.Hostnames.BackgroundJobs/Services/HostnameVerificationBatchService.cs
@@ -42,15 +42,15 @@ public sealed partial class HostnameVerificationBatchService(
 
         LogStartingBatch(due.Count);
 
-        foreach (ManagedHostname hostname in due)
-        {
-            if (cancellationToken.IsCancellationRequested)
+        await Parallel.ForEachAsync(
+            due,
+            new ParallelOptions
             {
-                break;
-            }
-
-            await VerifyOneAsync(hostname, now, cancellationToken).ConfigureAwait(false);
-        }
+                MaxDegreeOfParallelism = _options.VerificationConcurrency,
+                CancellationToken = cancellationToken,
+            },
+            (hostname, ct) => new ValueTask(VerifyOneAsync(hostname, now, ct)))
+            .ConfigureAwait(false);
     }
 
     private async Task VerifyOneAsync(

--- a/src/Granit.Hostnames.Endpoints/Endpoints/HostnamesReadEndpoints.cs
+++ b/src/Granit.Hostnames.Endpoints/Endpoints/HostnamesReadEndpoints.cs
@@ -19,7 +19,7 @@ internal static class HostnamesReadEndpoints
             .RequireAuthorization(HostnamesPermissions.Hostnames.Read)
             .WithName("ListManagedHostnames")
             .WithSummary("Lists the hostnames registered for an owning resource.")
-            .WithDescription("Returns all hostnames registered for the specified owner (ownerType + ownerId pair), ordered by host name. An empty list is returned when the owner has no registered hostnames. Requires the Hostnames.Read permission.")
+            .WithDescription("Returns hostnames registered for the specified owner (ownerType + ownerId pair), ordered by host name. At most maxResults entries are returned (capped at 500). An empty list is returned when the owner has no registered hostnames. Requires the Hostnames.Read permission.")
             .Produces<IReadOnlyList<ManagedHostnameResponse>>();
 
         group.MapGet("/availability", HandleAvailabilityAsync)
@@ -41,14 +41,20 @@ internal static class HostnamesReadEndpoints
         return group;
     }
 
+    private const int DefaultMaxResults = 100;
+    private const int AbsoluteMaxResults = 500;
+
     private static async Task<Ok<IReadOnlyList<ManagedHostnameResponse>>> HandleListByOwnerAsync(
         [FromQuery] string ownerType,
         [FromQuery] Guid ownerId,
         [FromServices] IManagedHostnameReader reader,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        [FromQuery] int maxResults = DefaultMaxResults)
     {
+        int capped = Math.Clamp(maxResults, 1, AbsoluteMaxResults);
+
         IReadOnlyList<ManagedHostname> hostnames = await reader
-            .ListByOwnerAsync(ownerType, ownerId, cancellationToken)
+            .ListByOwnerAsync(ownerType, ownerId, capped, cancellationToken)
             .ConfigureAwait(false);
 
         return TypedResults.Ok<IReadOnlyList<ManagedHostnameResponse>>(

--- a/src/Granit.Hostnames.Endpoints/Endpoints/HostnamesWriteEndpoints.cs
+++ b/src/Granit.Hostnames.Endpoints/Endpoints/HostnamesWriteEndpoints.cs
@@ -60,10 +60,12 @@ internal static class HostnamesWriteEndpoints
 
         group.MapPost("/{id:guid}/certificate-status", HandleReportCertificateStatusAsync)
             .RequireAuthorization(HostnamesPermissions.Certificates.Report)
+            .AddEndpointFilter<CertificateWebhookSignatureFilter>()
             .WithName("ReportHostnameCertificateStatus")
             .WithSummary("Reports the SSL/TLS certificate status from the edge provider.")
-            .WithDescription("Webhook endpoint called by the edge provider (e.g. Cloudflare, AWS) when the certificate state changes. Stores the new CertificateStatus and expiry date, and dispatches the appropriate integration event (HostnameCertificateSecuredEto or HostnameCertificateFailedEto). Returns 204 on success, 404 when not found. Requires the Hostnames.Certificates.Report permission.")
+            .WithDescription("Webhook endpoint called by the edge provider (e.g. Cloudflare, AWS) when the certificate state changes. The request must carry a valid HMAC-SHA-256 signature in the configured header when Hostnames:CertificateWebhookSecret is set. Stores the new CertificateStatus and expiry date, and dispatches the appropriate integration event (HostnameCertificateSecuredEto or HostnameCertificateFailedEto). Idempotent: repeated delivery of the same status does not re-raise events. Returns 204 on success, 404 when not found. Requires the Hostnames.Certificates.Report permission.")
             .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;

--- a/src/Granit.Hostnames.Endpoints/Internal/CertificateWebhookSignatureFilter.cs
+++ b/src/Granit.Hostnames.Endpoints/Internal/CertificateWebhookSignatureFilter.cs
@@ -1,0 +1,66 @@
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Hostnames.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Granit.Hostnames.Endpoints.Internal;
+
+/// <summary>
+/// Endpoint filter that validates the HMAC-SHA-256 signature on the
+/// <c>POST /{id}/certificate-status</c> webhook before the handler runs.
+/// Skipped when <see cref="HostnamesOptions.CertificateWebhookSecret"/> is not configured
+/// (useful for local development / integration tests).
+/// </summary>
+internal sealed class CertificateWebhookSignatureFilter(IOptions<HostnamesOptions> options) : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        string? secret = options.Value.CertificateWebhookSecret;
+        if (string.IsNullOrEmpty(secret))
+        {
+            return await next(context);
+        }
+
+        HttpContext httpContext = context.HttpContext;
+        string headerName = options.Value.CertificateWebhookSignatureHeader;
+
+        if (!httpContext.Request.Headers.TryGetValue(headerName, out StringValues sigHeader)
+            || StringValues.IsNullOrEmpty(sigHeader))
+        {
+            return TypedResults.Problem(
+                detail: $"Missing webhook signature header '{headerName}'.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        // Buffer the body so model binding can still read it after we verify the signature.
+        httpContext.Request.EnableBuffering();
+        string body = await new StreamReader(httpContext.Request.Body, Encoding.UTF8, leaveOpen: true)
+            .ReadToEndAsync(httpContext.RequestAborted)
+            .ConfigureAwait(false);
+        httpContext.Request.Body.Position = 0;
+
+        byte[] secretBytes = Encoding.UTF8.GetBytes(secret);
+        byte[] bodyBytes = Encoding.UTF8.GetBytes(body);
+        byte[] expectedHash = HMACSHA256.HashData(secretBytes, bodyBytes);
+        string expectedSig = $"sha256={Convert.ToHexString(expectedHash).ToLowerInvariant()}";
+
+        string receivedSig = sigHeader.ToString();
+
+        // Constant-time comparison prevents timing-based signature oracle attacks.
+        // The expected length is always fixed (71 chars: "sha256=" + 64 hex digits).
+        bool valid = CryptographicOperations.FixedTimeEquals(
+            Encoding.ASCII.GetBytes(expectedSig),
+            Encoding.ASCII.GetBytes(receivedSig));
+
+        if (!valid)
+        {
+            return TypedResults.Problem(
+                detail: "Invalid webhook signature.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        return await next(context);
+    }
+}

--- a/src/Granit.Hostnames.EntityFrameworkCore/Internal/EfManagedHostnameStore.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/Internal/EfManagedHostnameStore.cs
@@ -59,15 +59,19 @@ internal sealed class EfManagedHostnameStore(
             cancellationToken);
     }
 
+    private const int MaxListByOwnerResults = 500;
+
     /// <inheritdoc/>
     public Task<IReadOnlyList<ManagedHostname>> ListByOwnerAsync(
         string ownerType,
         Guid ownerId,
+        int maxResults = MaxListByOwnerResults,
         CancellationToken cancellationToken = default) =>
         ListAsync(
             Spec.For<ManagedHostname>()
                 .Where(h => h.OwnerType == ownerType && h.OwnerId == ownerId)
-                .OrderBy(h => (object)h.Host.Value),
+                .OrderBy(h => (object)h.Host.Value)
+                .Limit(Math.Min(maxResults, MaxListByOwnerResults)),
             cancellationToken);
 
     /// <inheritdoc/>

--- a/src/Granit.Hostnames/Contracts/IManagedHostnameReader.cs
+++ b/src/Granit.Hostnames/Contracts/IManagedHostnameReader.cs
@@ -13,10 +13,21 @@ public interface IManagedHostnameReader
     /// </summary>
     Task<ManagedHostname?> FindByHostAsync(string host, CancellationToken cancellationToken = default);
 
-    /// <summary>Lists the hostnames registered for an owning resource.</summary>
+    /// <summary>
+    /// Lists the hostnames registered for an owning resource.
+    /// Results are ordered by host name. At most <paramref name="maxResults"/> entries are returned.
+    /// </summary>
+    /// <param name="ownerType">Owner-resource discriminator.</param>
+    /// <param name="ownerId">Owning resource identifier.</param>
+    /// <param name="maxResults">
+    /// Upper bound on the number of entries returned. Capped at <c>500</c> by the EF store
+    /// regardless of the value passed here. Default: <c>500</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<IReadOnlyList<ManagedHostname>> ListByOwnerAsync(
         string ownerType,
         Guid ownerId,
+        int maxResults = 500,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Granit.Hostnames/Domain/Hostname.cs
+++ b/src/Granit.Hostnames/Domain/Hostname.cs
@@ -45,7 +45,9 @@ public sealed partial class Hostname : SingleValueObject<string>
     /// <summary>Implicit conversion from <see cref="string"/> (validates + normalises).</summary>
     public static implicit operator Hostname(string value) => Create(value);
 
-    [GeneratedRegex(@"^[a-z0-9]+(-[a-z0-9]+)*(\.[a-z0-9]+(-[a-z0-9]+)*)+$",
+    // Requires the TLD (last label) to start with a letter — rejects IPv4 literals such as
+    // 169.254.169.254 or 10.0.0.1 whose final label is all-numeric (RFC 1123 §2.1).
+    [GeneratedRegex(@"^[a-z0-9]+(-[a-z0-9]+)*(\.[a-z0-9]+(-[a-z0-9]+)*)*\.[a-z]([a-z0-9-]*[a-z0-9])?$",
         RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 1000)]
     private static partial Regex FqdnPattern();
 }

--- a/src/Granit.Hostnames/Domain/ManagedHostname.cs
+++ b/src/Granit.Hostnames/Domain/ManagedHostname.cs
@@ -210,6 +210,9 @@ public sealed class ManagedHostname : AuditedAggregateRoot, IMultiTenant, IConcu
         Conflicts = [];
         FailedCheckCount = 0;
         NextCheckAt = null;
+        // Challenge token served its purpose — clear to avoid retaining it indefinitely.
+        VerificationToken = null;
+        ExpectedDnsRecords = [];
 
         AddDistributedEvent(new HostnameVerifiedEto(
             Id, Host.Value, OwnerType, OwnerId, TenantId));
@@ -263,8 +266,17 @@ public sealed class ManagedHostname : AuditedAggregateRoot, IMultiTenant, IConcu
     /// <param name="expiresAt">Certificate expiry timestamp (required when <paramref name="status"/> is <see cref="CertificateStatus.Secured"/>).</param>
     public void ReportCertificateStatus(CertificateStatus status, DateTimeOffset? expiresAt = null)
     {
+        bool statusChanged = CertificateStatus != status;
+
         CertificateStatus = status;
         CertExpiresAt = status == CertificateStatus.Secured ? expiresAt : null;
+
+        // Guard: edge providers commonly retry webhook delivery. Only raise an integration
+        // event when the status actually changes to avoid duplicate downstream notifications.
+        if (!statusChanged)
+        {
+            return;
+        }
 
         switch (status)
         {

--- a/src/Granit.Hostnames/GranitHostnamesModule.cs
+++ b/src/Granit.Hostnames/GranitHostnamesModule.cs
@@ -5,6 +5,7 @@ using Granit.Hostnames.Contracts;
 using Granit.Hostnames.Diagnostics;
 using Granit.Hostnames.Domain;
 using Granit.Hostnames.Exports;
+using Granit.Hostnames.Options;
 using Granit.Hostnames.Queries;
 using Granit.Hostnames.Services;
 using Granit.Modularity;
@@ -12,6 +13,7 @@ using Granit.QueryEngine.Extensions;
 using Granit.Workflow;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Hostnames;
 
@@ -36,9 +38,21 @@ public sealed class GranitHostnamesModule : GranitModule
         context.Services.AddQueryDefinition<ManagedHostname, ManagedHostnameQueryDefinition>();
         context.Services.AddExportDefinition<ManagedHostname, ManagedHostnameExportDefinition>();
 
-        // Default DNS verifier — uses the system resolver. Replace by registering a custom
-        // IHostnameVerifier before calling AddGranitHostnames().
-        context.Services.TryAddSingleton<ILookupClient>(_ => new LookupClient());
+        // Default DNS verifier — uses the system resolver with explicit bounds.
+        // Replace by registering a custom IHostnameVerifier before calling AddGranitHostnames().
+        context.Services.TryAddSingleton<ILookupClient>(sp =>
+        {
+            HostnamesOptions opts = sp.GetRequiredService<IOptions<HostnamesOptions>>().Value;
+            return new LookupClient(new LookupClientOptions
+            {
+                Timeout = TimeSpan.FromSeconds(opts.DnsQueryTimeoutSeconds),
+                Retries = 1,
+                UseCache = false,         // always query live — verification must see real DNS state
+                ThrowDnsErrors = false,   // DnsResponseException is handled in DnsHostnameVerifier
+                ContinueOnDnsError = true,
+                UseTcpFallback = true,    // required for TXT records that exceed UDP payload limits
+            });
+        });
         context.Services.TryAddSingleton<IHostnameVerifier, DnsHostnameVerifier>();
 
         context.Services.AddScoped<IHostnameRegistrationService, HostnameRegistrationService>();

--- a/src/Granit.Hostnames/Options/HostnamesOptions.cs
+++ b/src/Granit.Hostnames/Options/HostnamesOptions.cs
@@ -29,4 +29,33 @@ public sealed class HostnamesOptions
     /// Default: <c>100</c>.
     /// </summary>
     public int VerificationBatchSize { get; set; } = 100;
+
+    /// <summary>
+    /// Maximum degree of parallelism for the per-tick DNS verification batch.
+    /// Prevents a single slow DNS delegation chain from blocking all other domains.
+    /// Default: <c>10</c>.
+    /// </summary>
+    public int VerificationConcurrency { get; set; } = 10;
+
+    /// <summary>
+    /// Per-query DNS resolution timeout. Applied to each individual record lookup.
+    /// Default: <c>3</c> seconds.
+    /// </summary>
+    public int DnsQueryTimeoutSeconds { get; set; } = 3;
+
+    /// <summary>
+    /// Shared secret used to validate HMAC-SHA-256 signatures on the
+    /// <c>POST /{id}/certificate-status</c> webhook. When <c>null</c> or empty,
+    /// signature verification is skipped (useful for local development).
+    /// Set via <c>Hostnames:CertificateWebhookSecret</c> — use a Vault secret or
+    /// environment variable, never a hardcoded value.
+    /// </summary>
+    public string? CertificateWebhookSecret { get; set; }
+
+    /// <summary>
+    /// HTTP header carrying the HMAC-SHA-256 signature sent by the edge provider.
+    /// Default: <c>"X-Webhook-Signature-256"</c>.
+    /// Override to match your provider (e.g. <c>"CF-Webhook-Signature"</c>).
+    /// </summary>
+    public string CertificateWebhookSignatureHeader { get; set; } = "X-Webhook-Signature-256";
 }

--- a/tests/Granit.Hostnames.Endpoints.Tests/HostnamesEndpointTests.cs
+++ b/tests/Granit.Hostnames.Endpoints.Tests/HostnamesEndpointTests.cs
@@ -113,7 +113,7 @@ public sealed class HostnamesEndpointTests : IAsyncDisposable
     [Fact]
     public async Task ListByOwner_Returns_200_With_List()
     {
-        _reader.ListByOwnerAsync("cms.site", OwnerId, Arg.Any<CancellationToken>())
+        _reader.ListByOwnerAsync("cms.site", OwnerId, Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([MakeHostname(), MakeHostname("alias.acme.com")]);
 
         HttpResponseMessage response = await _authClient.GetAsync(

--- a/tests/Granit.Hostnames.Tests/Domain/HostnameTests.cs
+++ b/tests/Granit.Hostnames.Tests/Domain/HostnameTests.cs
@@ -30,6 +30,18 @@ public sealed class HostnameTests
         Should.Throw<ArgumentException>(() => Hostname.Create(input));
     }
 
+    [Theory]
+    [InlineData("169.254.169.254")] // AWS metadata endpoint
+    [InlineData("10.0.0.1")]        // RFC-1918 private
+    [InlineData("192.168.1.100")]   // RFC-1918 private
+    [InlineData("127.0.0.1")]       // loopback
+    [InlineData("8.8.8.8")]         // any all-numeric labels
+    public void Create_rejects_ip_address_literals(string input)
+    {
+        // RFC 1123 §2.1: the TLD must not be all-numeric.
+        Should.Throw<ArgumentException>(() => Hostname.Create(input));
+    }
+
     [Fact]
     public void Create_rejects_hostnames_over_253_characters()
     {

--- a/tests/Granit.Hostnames.Tests/Domain/ManagedHostnameTests.cs
+++ b/tests/Granit.Hostnames.Tests/Domain/ManagedHostnameTests.cs
@@ -132,6 +132,18 @@ public sealed class ManagedHostnameTests
         hostname.IntegrationEvents.ShouldContain(e => e is Granit.Hostnames.Domain.Events.HostnameVerifiedEto);
     }
 
+    [Fact]
+    public void MarkVerified_clears_verification_token_and_expected_records()
+    {
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId);
+        hostname.BeginVerification("secret-token", SampleRecords);
+
+        hostname.MarkVerified(Now);
+
+        hostname.VerificationToken.ShouldBeNull();
+        hostname.ExpectedDnsRecords.ShouldBeEmpty();
+    }
+
     // ── MarkFailed ────────────────────────────────────────────────────────────
 
     [Fact]
@@ -284,5 +296,20 @@ public sealed class ManagedHostnameTests
         hostname.CertificateStatus.ShouldBe(CertificateStatus.Provisioning);
         hostname.CertExpiresAt.ShouldBeNull();
         hostname.IntegrationEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ReportCertificateStatus_is_idempotent_for_repeated_identical_status()
+    {
+        var hostname = ManagedHostname.Create(Id, "acme.com", "cms.site", OwnerId, TenantId);
+        DateTimeOffset expires = Now.AddDays(90);
+
+        hostname.ReportCertificateStatus(CertificateStatus.Secured, expires);
+        hostname.ReportCertificateStatus(CertificateStatus.Secured, expires); // duplicate delivery
+
+        // Only one SecuredEto should have been raised, not two.
+        hostname.IntegrationEvents
+            .OfType<Granit.Hostnames.Domain.Events.HostnameCertificateSecuredEto>()
+            .ShouldHaveSingleItem();
     }
 }


### PR DESCRIPTION
## Summary

Security audit of the `Granit.Hostnames.*` modules revealed 6 medium/low findings.
This PR applies all recommended fixes from the `/security` report.

| Finding | Severity | Description |
|---------|----------|-------------|
| VULN-200 | Medium | FQDN regex accepted IPv4 literals — TLD must now start with a letter |
| VULN-201 | Medium | Certificate webhook had no HMAC signature — `CertificateWebhookSignatureFilter` added |
| VULN-202 | Medium | `LookupClient` used system-default DNS settings — now explicit bounded options |
| VULN-300 | Low | `ListByOwnerAsync` had no result cap — `maxResults` param added (default 100, cap 500) |
| VULN-301 | Low | `VerificationToken` persisted after verification — cleared in `MarkVerified()` |
| VULN-302 | Low | DNS verification batch was sequential — replaced with `Parallel.ForEachAsync` |
| VULN-400 | Info | Certificate webhook idempotency not enforced — status-change guard added |

## Changes

- **`Hostname.cs`** — regex `\.[a-z]([a-z0-9-]*[a-z0-9])?$` at TLD position rejects `169.254.169.254`, `10.0.0.1`, etc.
- **`ManagedHostname.cs`** — `MarkVerified()` clears token + expected records; `ReportCertificateStatus()` is now idempotent
- **`HostnamesOptions.cs`** — 4 new options: `DnsQueryTimeoutSeconds`, `VerificationConcurrency`, `CertificateWebhookSecret`, `CertificateWebhookSignatureHeader`
- **`GranitHostnamesModule.cs`** — `LookupClient` constructed with explicit `LookupClientOptions`
- **`IManagedHostnameReader.cs`** / **`EfManagedHostnameStore.cs`** — `maxResults` added to `ListByOwnerAsync` with `.Limit()` on `Spec`
- **`HostnameVerificationBatchService.cs`** — `Parallel.ForEachAsync` with configurable `MaxDegreeOfParallelism`
- **`CertificateWebhookSignatureFilter.cs`** *(new)* — HMAC-SHA-256 endpoint filter with constant-time comparison
- **`HostnamesWriteEndpoints.cs`** — filter wired on `POST /{id}/certificate-status`
- **`HostnamesReadEndpoints.cs`** — `maxResults` query param (default 100, clamped to 500)

## Test plan

- [ ] `dotnet test tests/Granit.Hostnames.Tests` — 65 tests pass (7 new: IP rejection ×5, token cleared, idempotency)
- [ ] `dotnet test tests/Granit.Hostnames.Endpoints.Tests` — 33 tests pass
- [ ] Verify `CertificateWebhookSignatureFilter` is skipped when `CertificateWebhookSecret` is null (existing tests pass without configuring the secret)
- [ ] Verify `169.254.169.254` is rejected by `Hostname.Create` (new test `Create_rejects_ip_address_literals`)