### PR TITLE
fix(persistence): TryAddEnumerable factory throws when impl == service type

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataServiceCollectionExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataServiceCollectionExtensions.cs
@@ -25,10 +25,8 @@ public static class MetadataServiceCollectionExtensions
         services.TryAddSingleton<MetadataMappingRegistry>();
         services.TryAddSingleton<IMetadataMappingRegistry>(
             sp => sp.GetRequiredService<MetadataMappingRegistry>());
-        services.TryAddSingleton<MetadataSyncInterceptor>();
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IGranitAutoInterceptor>(
-                sp => sp.GetRequiredService<MetadataSyncInterceptor>()));
+            ServiceDescriptor.Singleton<IGranitAutoInterceptor, MetadataSyncInterceptor>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, MetadataMappingRegistryInitializer>());
 


### PR DESCRIPTION
## Summary

- `ServiceDescriptor.Singleton<TService>(factory)` sets `ImplementationType = TService`, which `TryAddEnumerable` rejects with *"Implementation type cannot be 'T' because it is indistinguishable"*
- Drop the redundant `TryAddSingleton<MetadataSyncInterceptor>()` and use the typed overload `ServiceDescriptor.Singleton<IGranitAutoInterceptor, MetadataSyncInterceptor>()` — `TryAddEnumerable` can use `MetadataSyncInterceptor` as the deduplication key
- `MetadataSyncInterceptor` is never resolved directly (only via `IEnumerable<IGranitAutoInterceptor>` in `UseGranitInterceptors`), so removing the concrete registration is safe

## Regression introduced

Commit e5bee4003 (#2508) — broke `GranitOpenIddictEntityFrameworkCoreModule` startup with `ArgumentException` at `TryAddEnumerable`.

## Test plan

- [ ] `dotnet build` passes on `Granit.Persistence.EntityFrameworkCore`
- [ ] Showcase host starts without `ArgumentException` after package bump