### PR TITLE
fix(wolverine): disable automatic extension scanning

### DIFF
--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -106,7 +106,7 @@ public static class WolverineHostApplicationBuilderExtensions
         // Modules without Wolverine handlers must still register manually.
         builder.Services.AddGranitValidatorsFromWolverineHandlerModules();
 
-        builder.UseWolverine(opts =>
+        builder.Services.AddWolverine(ExtensionDiscovery.ManualOnly, opts =>
         {
             // Include all Granit module assemblies passed from the module system.
             // This is the primary discovery path — no timing dependency on DI registration.


### PR DESCRIPTION
## Summary

- Replaces `builder.UseWolverine(opts => {...})` with `builder.Services.AddWolverine(ExtensionDiscovery.ManualOnly, opts => {...})`
- `IHostApplicationBuilder.UseWolverine` has no `ExtensionDiscovery` overload — it's a thin proxy to `services.AddWolverine(configure)` with `Automatic` hardcoded
- With `Automatic`, Wolverine scans all loaded assemblies at startup and prints: *"To disable automatic Wolverine extension finding, and stop these messages, see: https://wolverinefx.net/guide/extensions.html#disabling-assembly-scanning"*

## Why ManualOnly is safe

All handler assemblies are already wired explicitly:
- `opts.Discovery.IncludeAssembly(assembly)` for each Granit module assembly
- `[assembly: WolverineHandlerModule]` attribute scanning via AppDomain
- Entry assembly is always included

Skipping the automatic scan doesn't change what Wolverine discovers — it only suppresses the noisy startup output.

## Test plan

- [ ] `dotnet run` no longer prints the Wolverine extension scanning message
- [ ] All Wolverine handlers continue to be discovered and invoked correctly