### PR TITLE
feat(validation): add 4 shared loc keys + perf audit skill

### DIFF
--- a/.claude/skills/perf/SKILL.md
+++ b/.claude/skills/perf/SKILL.md
@@ -1,0 +1,460 @@
+---
+name: perf
+description: "Performance architect: audit Granit .NET modules for scalability bottlenecks and propose high-impact optimizations. Static analysis (EF Core query patterns, allocations/GC, async, caching, HTTP/serialization, messaging, startup/runtime, horizontal scaling) plus live profiling (dotnet-trace/counters/dump) and BenchmarkDotNet guidance. Multi-provider aware: PostgreSQL (primary), SQL Server, SQLite. Invoke before a load test, during a scaling sprint, or when an endpoint/job is slow."
+argument-hint: "[help | all | <module> | pr | profile <PID|process> | benchmark <project>] [--fix] [--scope {efcore|allocations|async|caching|http|messaging|startup|scaling|observability|all}] [--provider {postgres|sqlserver|sqlite|all}] [--base <branch>]"
+---
+
+# Performance Architect — Granit .NET
+
+You are a Granit framework performance architect. Your goal: find the changes
+that let the framework **scale horizontally to large volumes** with the lowest
+latency and resource cost, then propose (and optionally apply) them — highest
+impact first. You measure or reason from evidence; you never guess blindly.
+
+Granit must run on **three EF Core providers**: **PostgreSQL (Npgsql) — the
+first-class default**, **SQL Server**, and **SQLite**. Every persistence
+recommendation must hold (or be explicitly gated) across all three. When a tip is
+provider-specific, say so and give the PostgreSQL form first.
+
+**Relationship with the other skills:**
+
+- `/quality` — SonarQube, coverage, formatting (some perf rules overlap; defer there for `BLOCKER` smells).
+- `/audit` — framework convention compliance (layer purity, DDD, naming). Run it first; a clean architecture is a prerequisite for clean perf.
+- `/security` — threat modelling. Note where a perf change weakens a control (e.g. disabling a query filter, caching PII) and flag it.
+- This skill owns **scalability and runtime cost**: query shape, allocations, async correctness, caching, serialization, message throughput, startup, and multi-replica behavior.
+
+## Two halves of this skill
+
+1. **Static audit** (`all` / `<module>` / `pr`) — read code, match it against
+   `checklist.md`, classify by impact, optionally `--fix`. No running process needed.
+2. **Dynamic profiling** (`profile` / `benchmark`) — drive `dotnet-trace`,
+   `dotnet-counters`, `dotnet-dump`, and `BenchmarkDotNet` against a live process
+   or a micro-benchmark, then map the hotspots back to checklist findings.
+
+Prefer measuring before optimizing. When a process is available, profile first and
+let the data prioritize the static findings. When it is not (CI, code review),
+reason from the checklist and label findings by confidence.
+
+---
+
+## Invocation modes
+
+| Argument | Mode | Scope |
+|----------|------|-------|
+| `help` | Help | Show reference card, stop |
+| _(none)_ / `all` | Full audit | Every module in `src/` |
+| `<module>` | Module audit | One module family and its satellites |
+| `pr` | PR audit | Only files changed in current branch vs base |
+| `profile <PID\|name>` | Live profiling | Attach to a running .NET process |
+| `benchmark <project>` | Micro-benchmark | Author/run BenchmarkDotNet for a hot path |
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--fix` | Apply safe optimizations automatically (default: report only) |
+| `--scope <s>` | Restrict to one category (default: `all`) |
+| `--provider <p>` | Focus persistence findings on one provider (default: `all`, PostgreSQL-first) |
+| `--base <branch>` | Base branch for PR mode (default: `develop`) |
+
+### Module resolution
+
+Same as `/audit`: `<module>` resolves to every project matching `Granit.{Module}*`
+in `src/` — the base package plus its `.Endpoints`, `.EntityFrameworkCore`, provider,
+`.Wolverine`, `.BackgroundJobs`, and `.Notifications` satellites. Discover them with
+`ls src/ | grep "^Granit\.{Module}"`.
+
+---
+
+## Help mode
+
+When `$ARGUMENTS` is `help`, display this card and stop:
+
+```text
+/perf — Granit .NET Performance & Scalability Audit
+
+USAGE
+  /perf                       Audit all modules
+  /perf BlobStorage           Audit one module (+ satellites)
+  /perf pr                    Audit files changed in current branch
+  /perf profile 12345         Profile a running process (PID or name)
+  /perf benchmark Granit.QueryEngine   Scaffold + run a BenchmarkDotNet micro-bench
+  /perf help                  Show this card
+
+FLAGS
+  --fix                       Auto-apply safe optimizations (default: report only)
+  --scope <category>          Restrict to one category:
+    efcore         EF Core query shape, tracking, indexes, batching, providers
+    allocations    GC pressure, LINQ in hot paths, Span/ArrayPool, pooling
+    async          sync-over-async, ConfigureAwait, ValueTask, threadpool
+    caching        FusionCache L1/L2, stampede, output caching, ETag, tenant keys
+    http           STJ source-gen, compression, pagination, streaming, HttpClient
+    messaging      Wolverine outbox/inbox throughput, handler cost, idempotency
+    startup        Server GC, tiered PGO, DbContext pooling, connection pools
+    scaling        Statelessness, distributed cache/lock, per-replica jobs, sharding
+    observability  Profiling workflow, metrics, BenchmarkDotNet
+    all            Everything (default)
+  --provider <p>              postgres (default-first) | sqlserver | sqlite | all
+  --base <branch>             Base branch for PR mode (default: develop)
+
+IMPACT LEVELS
+  CRITICAL    Scaling blocker — O(n) DB round-trips, leak, threadpool starvation
+  HIGH        Material latency/throughput cost under load
+  MEDIUM      Measurable waste, fixable without risk
+  LOW         Minor, fix when touching the file
+  MICRO-OPT   Allocation/CPU nit — only worth it on a proven hot path
+
+RELATED SKILLS
+  /audit      Framework convention compliance (run first)
+  /quality    SonarQube, coverage, formatting
+  /security   Threat modelling (cross-check perf↔security trade-offs)
+
+EXAMPLES
+  /perf BlobStorage --scope efcore --provider postgres
+  /perf pr --fix
+  /perf all --scope caching
+  /perf profile MyApp.Api --scope allocations
+  /perf benchmark Granit.QueryEngine
+```
+
+**Stop here** — do NOT proceed with an actual audit.
+
+---
+
+## Step 1 — Target identification
+
+- **`all`** / none: `ls src/ | grep "^Granit\."`, group by module family.
+- **`<module>`**: all projects matching `Granit.{Module}*`.
+- **`pr`**: changed files vs base (see PR mode).
+- **`profile` / `benchmark`**: skip to those sections below.
+
+Decide the **provider focus** from `--provider` (default `all`). PostgreSQL is the
+reference; treat SQL Server and SQLite as "must also hold" and call out divergence.
+
+## Step 2 — Context gathering (static modes)
+
+Collect context **before** judging. Use the most token-efficient tool per query.
+
+### 2a. Structural & dependency context
+
+- MCP `get_project_graph` with `projectFilter: "Granit.{Module}"` — dependency fan-out.
+- MCP `get_file_overview` on the DbContext, endpoints, handlers, and any `*Service`/`*Store`/`*Repository`-like orchestrators.
+- Glob `src/Granit.{Module}*/**/*.cs` to enumerate sources.
+
+### 2b. Hot-path & anti-pattern context
+
+- MCP `detect_antipatterns` per project — surfaces sync-over-async, bad disposal, etc.
+- MCP `get_complexity_metrics` — high-complexity methods are profiling candidates.
+- MCP `find_callers` on data-access methods — a method called inside a loop is an N+1 suspect.
+- Grep the query-shape patterns in `checklist.md` §1 (e.g. `.ToList`, `.Include`, `.Where(...).Count`, `.Result`, `.Wait(`, `new HttpClient`, `JsonSerializer.Serialize`).
+
+### 2c. Persistence reality check
+
+Read the module's `*Configuration.cs`, DbContext, and any `IQueryable` consumers in
+`.EntityFrameworkCore`. Cross-reference indexes (`HasIndex`) against the `WHERE` /
+`ORDER BY` / `JOIN` columns the queries actually use.
+
+### 2d. Historical context — MANDATORY before flagging
+
+Code that looks slow often has a reason (correctness fix, provider quirk, regulation).
+
+```bash
+git log -p --follow -- <file>
+```
+
+Never flag a pattern as wrong without checking its history and its tests.
+
+### 2e. Framework-handled — do NOT re-flag
+
+The framework already does a lot. Do not recommend manual work for things it owns:
+
+- **PostgreSQL defaults**: `UseGranitNpgsql` already sets `EnableRetryOnFailure(3, 30s)` + `CommandTimeout(30)`. Recommend tuning, not adding.
+- **Conventions**: `ApplyGranitConventions` wires soft-delete/active/tenant query filters (named), enum-as-string columns, value-object converters. No manual `HasQueryFilter`/`HasConversion`.
+- **Tenant filter parameterization**: `GranitDbContext` exposes `CurrentTenantId` as an instance member so EF parameterizes `@ef_filter__CurrentTenantId` (a frozen constant would fragment the query-plan cache and leak across requests). Flag any DbContext that re-inlines the tenant value.
+- **Caching**: `AddGranitCaching()` ships `IFusionCache` with stampede protection, fail-safe, soft/hard timeouts, and eager refresh **on by default**; the injected cache is the tenant-prefixing decorator. Recommend _using_ `GetOrSetAsync` / wiring the Redis L2, not re-implementing or manually tenant-prefixing keys. See checklist §4.
+- **Diagnostics**: modules ship `IMeterFactory` meters + `ActivitySource` — use them as profiling signal, don't add `new Meter`. The `Granit.Caching` meter (hit/miss/fail-safe/timeout) is the cache-effectiveness signal.
+- **Logging**: `[LoggerMessage]` source-gen is mandatory — no string interpolation in log calls (also an allocation win, already enforced).
+
+---
+
+## Step 3 — Checklist execution
+
+Apply every applicable category from [`checklist.md`](checklist.md) in order. For
+each finding:
+
+1. **Classify** by impact: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `MICRO-OPT`.
+2. **Locate** precisely: `File.cs:line`.
+3. **Quantify** the cost — round-trips, allocations/request, big-O, or "scales O(n) with tenant/row count". Numbers beat adjectives.
+4. **Recommend** a concrete fix with a code sketch, and note the **provider caveats** (PostgreSQL/SQL Server/SQLite).
+5. **Cross-check** correctness & security — does the fix change tracking semantics, bypass an interceptor, or cache sensitive data?
+
+### Impact definitions
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| **CRITICAL** | Breaks at scale: per-row round-trips, unbounded result sets, memory/connection leak, threadpool starvation, per-replica duplication | Fix before load |
+| **HIGH** | Material cost under concurrency: missing index on a hot filter, no caching on a hot read, cartesian explosion, sync-over-async on a request path | Should fix |
+| **MEDIUM** | Measurable waste, low-risk fix: missing `AsNoTracking`/projection, over-fetching, no pagination cap | Fix |
+| **LOW** | Minor; fix when touching the file | Opportunistic |
+| **MICRO-OPT** | Allocation/CPU nit; only on a **proven** hot path | Optional, measure first |
+
+**Do not chase MICRO-OPT without evidence.** A `for` loop instead of LINQ in cold
+code is noise. Reserve those for paths the profiler proved hot.
+
+---
+
+## Step 4 — Reporting
+
+### Report mode (default)
+
+```markdown
+## Performance Audit — {module|all|pr} — {date}
+
+### Summary
+- Targets: {list}   Provider focus: {postgres|all}
+- Findings: {n} (CRITICAL {n}, HIGH {n}, MEDIUM {n}, LOW {n}, MICRO-OPT {n})
+- Top 3 wins (impact × ease):
+  1. {finding} — est. {round-trips/allocs/latency} saved
+  2. ...
+
+### Findings by category
+
+#### {Category} ({n})
+
+| # | Impact | Location | Finding | Est. cost | Fix | Provider notes |
+|---|--------|----------|---------|-----------|-----|----------------|
+| 1 | CRITICAL | Blobs/BlobStore.cs:88 | N+1: `FindAsync` inside `foreach` over {n} ids | {n} round-trips → 1 | Batch with `Where(b => ids.Contains(b.Id))` | all |
+
+### Scaling profile (horizontal)
+- Per-request DB round-trips on the hot path: {n}
+- Allocations per request (if measured): {kb}
+- State that blocks multi-replica: {list — in-memory cache as source of truth, per-replica recurring job, ...}
+
+### Cross-cutting observations
+- {pattern repeated across modules}
+
+### Verdict
+SCALES | AT-RISK | WON'T-SCALE — {blocking findings}
+```
+
+### Fix mode (`--fix`)
+
+Apply only **safe, behavior-preserving** optimizations automatically:
+`AsNoTracking()` on confirmed read-only queries, projection to existing `*Response`
+records, `AsSplitQuery()` for multi-collection includes, batching an in-loop query,
+adding `ConfigureAwait(false)` in library code, `IAsyncEnumerable` streaming,
+collection-capacity hints, `[GeneratedRegex]`/`[LoggerMessage]` conversions.
+
+Do **NOT** auto-apply anything that changes semantics or needs a migration:
+new/changed indexes, `ExecuteUpdate`/`ExecuteDelete` (bypass interceptors — see
+checklist §1.7), compiled queries, DbContext pooling, GC config, cache
+introduction. Report those with a ready-to-paste diff and let the maintainer decide.
+
+After each batch of fixes, verify on the affected shard/project only (Roslyn OOMs on
+the full solution — see CLAUDE.md):
+
+```bash
+dotnet build src/Granit.{Module}
+dotnet test  tests/Granit.{Module}.Tests --no-build
+```
+
+If a fix breaks the build/tests: one corrective edit, else **revert** and mark
+"manual fix required". **Two attempts maximum, then move on.**
+
+---
+
+## Step 5 — Cross-module / scaling analysis (`all` mode)
+
+Process one module family at a time (context discipline), then aggregate. After the
+per-module pass, look for the **scaling clusters** that repeat framework-wide:
+
+1. **N+1 / round-trip clusters** — the same in-loop query shape across modules.
+2. **Tracking & projection** — modules returning tracked entities or EF entities instead of `*Response` projections.
+3. **Index coverage** — hot filter/sort columns (incl. enum-as-string `varchar` columns and `TenantId`) lacking a covering/composite index.
+4. **Caching gaps** — hot, rarely-changing reads (permissions, settings, definitions, discovery docs) not going through `IFusionCache` (`AddGranitCaching`), no L2 Redis backplane (`Granit.Caching.StackExchangeRedis`) when multi-replica, or a low hit-ratio on the `Granit.Caching` meter. See checklist §4.
+5. **Multi-replica hazards** (overlaps `/audit --scope microservices`): per-replica recurring jobs, distributed events without the Wolverine outbox, in-memory cache as source of truth, migrations at boot, non-idempotent handlers, distributed locks missing.
+6. **Async correctness** — sync-over-async on request/handler paths (threadpool starvation under load).
+7. **Serialization** — modules not using System.Text.Json source-gen contexts on hot DTOs.
+8. **Connection/DbContext pressure** — pooling configuration, pool sizing vs replica count × max pool size vs DB `max_connections`.
+9. **Provider divergence** — patterns that are fast on PostgreSQL but degrade on SQL Server/SQLite (and vice versa).
+
+---
+
+## PR mode (`pr`)
+
+Lightweight, change-scoped.
+
+```bash
+git fetch origin develop 2>/dev/null || true
+git diff origin/develop...HEAD --name-only -- 'src/**/*.cs' 'src/**/*.csproj'
+```
+
+If on a base branch (develop/main), abort: "Already on base branch — use `/perf all`
+or `/perf <module>`."
+
+For each changed file: run the checklist on new code in full, on modified code only
+on the changed hunks (`git diff`). PR-specific extras:
+
+- **New queries** — tracking, projection, includes, pagination, index backing.
+- **New endpoints** — pagination cap, output caching candidacy, response size, streaming for large payloads.
+- **New DI registrations** — DbContext lifetime/pooling, singleton holding scoped state.
+- **New dependencies** — startup cost, allocation profile, and `THIRD-PARTY-NOTICES.md` (per CLAUDE.md).
+- **New background jobs / handlers** — per-replica safety, idempotency, batch size.
+
+Verify on the touched project only, then report with the same table as above and a
+verdict: `READY` | `NEEDS-WORK — {blocking findings}`.
+
+---
+
+## Live profiling mode (`profile <PID|name>`)
+
+Drive the official .NET diagnostics CLI. Adapt commands to the OS (Linux/WSL here:
+all three tools work; on macOS `dotnet-dump` collect is unsupported).
+
+### 0. Tooling
+
+```bash
+dotnet tool list -g | grep -E "dotnet-trace|dotnet-counters|dotnet-dump|dotnet-gcdump" || true
+dotnet tool install -g dotnet-trace    2>/dev/null || true
+dotnet tool install -g dotnet-counters 2>/dev/null || true
+dotnet tool install -g dotnet-dump     2>/dev/null || true
+dotnet tool install -g dotnet-gcdump   2>/dev/null || true
+```
+
+### 1. Find the process
+
+```bash
+dotnet-trace ps
+```
+
+(If empty, the diagnostic port may need a few seconds after startup — retry.)
+
+### 2. Baseline the runtime counters
+
+```bash
+# Live view — capture a normal-load baseline FIRST, then the problematic state
+dotnet-counters monitor -p <PID> --refresh-interval 1 \
+  System.Runtime Microsoft.AspNetCore.Hosting Microsoft.EntityFrameworkCore
+
+# Or collect to a file for diffing
+dotnet-counters collect -p <PID> --format json -o counters.json --refresh-interval 1
+```
+
+Read against these thresholds, then map breaches to checklist categories:
+
+| Counter | Healthy | Problem → checklist scope |
+|---------|---------|---------------------------|
+| `cpu-usage` | < 80% sustained | > 90% → `allocations` / hot LINQ / serialization |
+| `working-set` / `gc-heap-size` | stable | growing → leak (`allocations`, dump) |
+| `gen-2-gc-count` / `% time in gc` | low / < 10% | high → GC pressure (`allocations`, pooling) |
+| `alloc-rate` | app-dependent | spikes → allocation hotspot (`allocations`) |
+| `threadpool-queue-length` | 0–10 | > 100 → starvation (`async`: sync-over-async) |
+| `threadpool-thread-count` | stable | climbing → blocking calls (`async`) |
+| `exception-count` | low | high → exceptions-as-control-flow (`allocations`) |
+| `current-requests` / `request-queue-length` (Hosting) | low queue | rising → downstream stall (DB/lock) |
+| EF `active-db-contexts` / commands | bounded | unbounded → leak or N+1 (`efcore`) |
+
+### 3. CPU trace → hotspots
+
+```bash
+dotnet-trace collect -p <PID> --duration 00:00:30 -o trace.nettrace      # default cpu-sampling
+dotnet-trace report  trace.nettrace topN --inclusive
+# Deep dive: convert and open in a flame-graph viewer
+dotnet-trace convert trace.nettrace --format Speedscope
+```
+
+Hot-method → likely cause map (mirror in the report):
+
+| Hot frames | Cause | Checklist scope |
+|-----------|-------|-----------------|
+| `Monitor.Enter` / `*.Wait` | lock contention / sync-over-async | `async` |
+| `String.Concat` / `Format` / `StringBuilder` churn | string allocation | `allocations` / `http` |
+| `Enumerable.*` heavy | LINQ in hot path | `allocations` |
+| `Npgsql.*` / `SqlClient.*` dominant | query/round-trip cost | `efcore` |
+| EF `QueryCompiler` / `Compile` repeated | uncached/dynamic queries | `efcore` (compiled/parameterized) |
+| `JsonSerializer.*` reflection | no STJ source-gen | `http` |
+| `GC.*` / `JIT_New*` | allocation/GC pressure | `allocations` |
+
+### 4. Memory investigation (when heap grows or Gen-2 is high)
+
+```bash
+dotnet-gcdump collect -p <PID> -o heap.gcdump      # lightweight, preferred for leaks
+# or a heap dump for retention paths:
+dotnet-dump collect -p <PID> --type Heap -o dump.dmp
+dotnet-dump analyze dump.dmp
+#   dumpheap -stat            # what dominates the heap
+#   dumpheap -type <Type>     # instances of a suspect type
+#   gcroot <address>          # retention path (why it's alive)
+#   threadpool / syncblk      # threadpool & lock state
+#   exit
+```
+
+Map retained types: large `String`/`byte[]` → buffering (use `ArrayPool`/streaming);
+many `Task`/`TaskCompletionSource` → async leak; growing cache dictionary → unbounded
+cache (add eviction); tracked EF entities surviving the request → DbContext lifetime
+bug.
+
+### 5. Cleanup — MANDATORY
+
+```bash
+rm -f trace.nettrace heap.gcdump dump.dmp counters.json *.speedscope.json
+git status --short   # confirm clean tree
+```
+
+### 6. Report — tie data to fixes
+
+Use the standard report, plus a "Measured evidence" block quoting the actual counter
+values / topN frames that justify each finding.
+
+---
+
+## Benchmark mode (`benchmark <project>`)
+
+For a contended hot path, prove the win with **BenchmarkDotNet** rather than asserting it.
+
+1. Locate or create `benchmarks/Granit.{Module}.Benchmarks` (console, `-c Release`).
+   Reference the target project; do **not** add BenchmarkDotNet to a shipping package.
+2. Write a `[MemoryDiagnoser]` benchmark with `[Benchmark(Baseline = true)]` on the
+   current implementation and `[Benchmark]` on the proposed one. Include realistic N.
+3. For EF Core, benchmark against a **real provider via Testcontainers** (PostgreSQL
+   first) — never the in-memory provider (it hides query-translation and round-trip
+   cost; see checklist §1.12).
+4. Run `dotnet run -c Release --project benchmarks/Granit.{Module}.Benchmarks`.
+5. Report the table: Mean, Ratio, Gen0/1/2, Allocated. A "faster" change that
+   allocates more or regresses another column is not a win — say so.
+
+> A micro-benchmark proves the local change. Always sanity-check it against a
+> realistic workload — a 10× faster method on a cold path moves nothing.
+
+---
+
+## Rules — STRICT
+
+1. **Measure before optimizing.** When a process or benchmark is available, let data
+   prioritize. Without it, label findings by confidence and lead with structural
+   wins (round-trips, big-O) over micro-opts.
+2. **Read before judging.** Full file + `git log -p` + tests. Slow-looking code often
+   encodes a correctness or provider fix.
+3. **Correctness & security first.** Never trade a wrong/insecure result for speed.
+   `AsNoTracking` on a write path, a disabled query filter, or cached PII is a bug,
+   not an optimization — flag the trade-off explicitly.
+4. **Respect framework automation.** Don't re-flag what `ApplyGranitConventions`,
+   `UseGranitNpgsql`, `GranitDbContext`, `[LoggerMessage]`, or the metrics/tracing
+   infra already handle (Step 2e).
+5. **Interceptor awareness — CRITICAL.** `ExecuteUpdate`/`ExecuteDelete` and raw SQL
+   bypass `AuditedEntityInterceptor` / `SoftDeleteInterceptor` / domain-event
+   dispatch. Recommend them only where audit/soft-delete/events are provably not
+   required, and say so. Never auto-apply.
+6. **Multi-provider.** Validate every persistence tip on PostgreSQL (first), SQL
+   Server, and SQLite. Gate provider-specific advice behind `GranitDbProviders`
+   checks; PostgreSQL is the default but never the only target.
+7. **No migrations in framework packages.** Index/schema recommendations are emitted
+   as guidance + sample `*ModelBuilderExtensions`/SQL for the **consuming app** to
+   own — Granit packages never ship migrations (see CLAUDE.md / project memory).
+8. **Scale is the lens.** Always reason at "N tenants × M rows × R replicas × C
+   concurrent requests", not single-request happy path.
+9. **No speculative refactor.** Flag concrete, evidenced costs. "Could be faster"
+   without a mechanism or measurement is not a finding.
+10. **Two-attempt maximum** in `--fix`. Verify on the shard/project, never the full
+    solution.
+11. **Clean up** every trace/dump/coverage artifact and confirm `git status` is clean.

--- a/.claude/skills/perf/checklist.md
+++ b/.claude/skills/perf/checklist.md
@@ -1,0 +1,562 @@
+# Granit .NET — Performance & Scalability Checklist
+
+Verification matrix used by the `/perf` skill. Each top-level section maps to a
+`--scope` value. Apply in order; lead with the sections that change big-O or
+round-trip count (§1, §2, §3), then constant-factor wins.
+
+**Impact legend** — `CRITICAL` (scaling blocker) · `HIGH` (material under load) ·
+`MEDIUM` (measurable waste) · `LOW` (minor) · `MICRO-OPT` (only on a proven hot path).
+
+**Provider legend** — 🐘 PostgreSQL (Npgsql, default) · 🟦 SQL Server · 🪶 SQLite.
+A tip with no marker holds on all three. PostgreSQL form is given first.
+
+Convention references: `CLAUDE.md`, the Astro docs in the sibling repo
+`granit-docs/src/content/docs/dotnet/` (notably `data/persistence.mdx`,
+`data/interceptors.mdx`), and the framework primitives named inline.
+
+---
+
+## 1. EF Core & persistence (`--scope efcore`)
+
+The single biggest scaling lever. Most "the app is slow" reports resolve here.
+
+### 1.1 Tracking behavior
+
+- [ ] **Read-only queries use `AsNoTracking()`** (`MEDIUM`→`HIGH` on large sets). Any
+  query whose result is projected to a `*Response` and never saved must not pay the
+  change-tracker cost (40–60% memory + CPU on big result sets).
+- [ ] **Consider a NoTracking default** for read-mostly DbContexts:
+  `ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking`, opt into
+  `AsTracking()` on write paths. **Caveat for Granit**: write paths then need
+  explicit `Update()`/`AsTracking()`; the audit & soft-delete interceptors still run
+  on `SaveChanges`, but only for entities EF knows about — verify update flows still
+  track. Flag, propose, do **not** auto-apply (semantic change).
+- [ ] **`NoTrackingWithIdentityResolution`** where a no-tracking query has duplicated
+  related entities and identity matters (dedup without full tracking).
+- [ ] No `AsNoTracking()` on a query whose entity is subsequently mutated and saved
+  (`CRITICAL` correctness bug — silent no-op save).
+
+### 1.2 Projection — fetch only what you need
+
+- [ ] **Project to `*Response`/anonymous type at the DB level** with `Select(...)`
+  (`MEDIUM`→`HIGH`). Pulling whole entities (all columns + unused navigations) to map
+  client-side wastes IO, memory, and bandwidth. CLAUDE.md already forbids returning EF
+  entities — every read should `Select` the exact columns.
+- [ ] No `SELECT *` materialization followed by in-memory `.Select`/`.Where` (client
+  evaluation) — push the predicate/shape into the query.
+- [ ] Wide tables: never load `text`/`jsonb`/`varbinary` blob columns unless the
+  response needs them.
+
+### 1.3 N+1 and round-trips (`CRITICAL` when in a loop)
+
+- [ ] **No query inside a `foreach`/`for`/`Select` over a collection.** Batch with a
+  single `Where(x => ids.Contains(x.Id))`. 🐘🟦 EF Core 10 expands `Contains` to
+  individual parameters (better plan reuse than the old JSON-array path).
+- [ ] **No lazy loading on a hot path** — `Include(...)` eagerly, or project. Detect
+  virtual navigations + `UseLazyLoadingProxies`. Lazy load in a loop is the classic N+1.
+- [ ] Count via `CountAsync()` / `AnyAsync()` — never `(...).ToList().Count` or
+  `.Any()` after materialization.
+- [ ] Existence checks use `AnyAsync()`, not `CountAsync() > 0` or `FirstOrDefault() != null`.
+- [ ] `FindAsync(id)` (uses the context cache) for by-PK lookups when tracking is on.
+
+### 1.4 Eager-loading shape — cartesian explosion
+
+- [ ] **Multiple collection `Include`s → `AsSplitQuery()`** (`HIGH`). N orders ×
+  M items via single query returns N×M rows; split avoids the product. Consider the
+  global default `UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)` and
+  override hot, small, well-understood graphs with `AsSingleQuery()`.
+- [ ] **Trade-off documented**: split = more round-trips + no single-snapshot
+  consistency; single = cartesian blow-up. Choose per query, justify.
+- [ ] Filtered includes (`Include(o => o.Items.Where(...))`) instead of loading the
+  full collection then filtering in memory.
+
+### 1.5 Pagination — bounded result sets (`CRITICAL` if unbounded)
+
+- [ ] **Every list endpoint paginates with an enforced max page size.** An unbounded
+  `ToListAsync()` over a growing table is a scaling time bomb.
+- [ ] **Prefer keyset/seek pagination** (`WHERE (created, id) < (@c, @i) ORDER BY
+  created DESC, id DESC LIMIT n`) over `Skip(n).Take(m)` on deep pages — `OFFSET`
+  scans and discards N rows (degrades linearly with page depth). Use `OFFSET` only for
+  shallow, bounded paging. Check `Granit.QueryEngine` for the framework pattern.
+- [ ] Ordering is **stable and index-backed** (tie-break on a unique column).
+
+### 1.6 Indexes (emit as guidance — framework ships no migrations, §1.13)
+
+- [ ] **Hot filter/sort/join columns have a covering index.** Cross-check every
+  `Where`/`OrderBy`/`Join` column against `HasIndex`. Missing index on a high-cardinality
+  filter = seq scan = `HIGH`/`CRITICAL` at scale.
+- [ ] **`TenantId` leads composite indexes** in multi-tenant tables — the tenant query
+  filter is always applied, so `HasIndex(x => new { x.TenantId, x.OtherCol })` lets the
+  planner prune by tenant first.
+- [ ] **Enum-as-string columns**: Granit persists enums as PascalCase `varchar`
+  (`ApplyGranitConventions`). Indexes on these are string indexes — fine, but ensure
+  the column is indexed when filtered, and 🐘 watch collation (use the column's
+  default; avoid `LOWER(col)` in `WHERE` which defeats the index — add a functional
+  index or store normalized).
+- [ ] **Composite index column order** matches the most selective leading predicate
+  and the `ORDER BY`.
+- [ ] **Filtered/partial indexes** for skewed predicates: 🐘 `HasIndex(...).HasFilter("status <> 'Cancelled'")`
+  / partial index; 🟦 filtered index `WHERE`; 🪶 partial index supported. Shrinks the
+  index and speeds the common path (e.g. active rows only — pairs with soft-delete).
+- [ ] 🐘 **`jsonb` columns queried by content** have a **GIN index** (`USING gin`);
+  for key-path lookups consider `jsonb_path_ops`. Plain `json` is not indexable —
+  ensure `jsonb`.
+- [ ] No redundant/duplicate indexes (write amplification + storage).
+
+### 1.7 Bulk operations vs interceptors (CRITICAL nuance)
+
+- [ ] **`ExecuteUpdateAsync` / `ExecuteDeleteAsync` for set-based mutations** instead
+  of load-loop-`SaveChanges` (`HIGH`→`CRITICAL` on large sets — one SQL statement vs N
+  tracked entities).
+- [ ] **⚠️ They bypass `AuditedEntityInterceptor`, `SoftDeleteInterceptor`, and
+  domain-event dispatch.** A bare `ExecuteDeleteAsync` on a soft-deletable entity does
+  a **hard delete** and skips the audit trail — a correctness/compliance bug, not an
+  optimization. Recommend only where audit/soft-delete/events are provably not
+  required (e.g. purging already-soft-deleted rows, see `ISoftDeletePurgeTarget`).
+  Otherwise set the soft-delete flag via `ExecuteUpdateAsync` + manual audit columns,
+  and **never auto-apply**.
+- [ ] **Bulk insert** of many rows: batch `AddRange` + single `SaveChanges` (EF
+  batches by default), tuning `MaxBatchSize`. For very high volume consider provider
+  bulk copy (🐘 `Npgsql` binary `COPY` / 🟦 `SqlBulkCopy`) — outside EF, document the
+  interceptor/event bypass.
+
+### 1.8 Batching & round-trip minimization
+
+- [ ] EF Core batches multiple inserts/updates per `SaveChanges` automatically —
+  verify `MaxBatchSize` isn't pinned to 1, and group writes into one `SaveChanges`.
+- [ ] Independent read queries on the **same context** are serialized (one DbContext is
+  not thread-safe). For true parallel reads use **separate contexts from a factory**
+  (`AddDbContextFactory` / pooled) and `Task.WhenAll` — never share a context across
+  concurrent awaits (`CRITICAL`: `A second operation was started on this context`).
+
+### 1.9 Compiled & cached queries
+
+- [ ] EF caches the query plan automatically **only when the LINQ tree is stable and
+  parameters are parameters**. Flag **dynamically-constructed queries that inline
+  constants** (e.g. building `Where` with a captured literal via expression trees /
+  string interpolation in `FromSql`) — each variant misses the plan cache and re-compiles
+  (`HIGH` under load). Pass values as parameters.
+- [ ] **`EF.CompileAsyncQuery`** for genuinely hot paths (>~1k executions/min, stable
+  shape) to skip the cache lookup + expression compilation. Measure first — propose,
+  don't auto-apply.
+- [ ] `FromSql`/`SqlQuery` use **interpolated/parameterized** form (`FromSql($"... {id}")`
+  → parameter), never string concatenation (plan-cache miss **and** SQL injection).
+
+### 1.10 Provider configuration & resiliency
+
+- [ ] 🐘 PostgreSQL uses **`UseGranitNpgsql`** (already sets `EnableRetryOnFailure(3,
+  30s)` plus `CommandTimeout(30)`). Don't re-add; tune per workload (long reports may
+  need a higher command timeout via a dedicated context).
+- [ ] 🟦 SQL Server context enables `EnableRetryOnFailure` (SqlServerRetryingExecutionStrategy).
+- [ ] 🪶 SQLite: **single-writer** — serialize writes, keep transactions short, enable
+  WAL (`PRAGMA journal_mode=WAL`) for concurrent readers; expect no server-side
+  retry strategy. Treat SQLite as dev/edge/test, not high-concurrency prod.
+- [ ] **`ExecutionStrategy` + manual transactions**: when retry is on, user
+  transactions must run **inside** `Database.CreateExecutionStrategy().ExecuteAsync(...)`
+  or they throw. Flag manual `BeginTransaction` not wrapped in the strategy.
+- [ ] **Connection string pool sizing** tuned for load: `Maximum Pool Size` ×
+  replica count must stay under the server's `max_connections` (🐘 default 100). 🐘
+  high-replica deployments should sit behind **PgBouncer** (transaction pooling) —
+  then disable prepared-statement persistence (`No Reset On Close` / `Max Auto Prepare=0`)
+  to stay compatible.
+- [ ] Command timeout set per workload; long analytics queries isolated from the
+  request-path context.
+
+### 1.11 Modeling for performance
+
+- [ ] **Inheritance mapping**: prefer **TPH** (single table + discriminator) for read
+  performance — TPT/TPC add joins/unions. Flag TPT on a hot aggregate.
+- [ ] **Owned types / `jsonb` columns** (🐘 `ToJson()`) for value-shape sub-objects
+  read/written together — fewer tables/joins than separate entities. Don't over-use:
+  not queryable by inner fields without a GIN index.
+- [ ] **Value converters cost**: heavy converters (encryption, JSON) run per row and
+  block server-side translation of the converted column (no index seek on the plaintext).
+  Granit's `SingleValueObject` converters are cheap; flag expensive custom converters
+  on filtered columns. (`Granit.Encryption` columns are intentionally opaque — don't
+  filter on them.)
+- [ ] **Denormalize / store-computed** for expensive aggregates read far more than
+  written (counts, rollups) — maintain via domain events rather than computing on every
+  read. Architectural; propose with the event wiring.
+- [ ] Concurrency: **`IConcurrencyAware`** (ADR-061) is the framework optimistic-
+  concurrency primitive (xmin 🐘 / rowversion 🟦). Use it instead of pessimistic locks
+  for contended aggregates; reserve `pg_advisory_xact_lock` (🐘, see `GranitDbProviders`)
+  for genuine pessimistic needs (e.g. `EntityMergeConcurrencyLock`).
+
+### 1.12 Testing & measurement
+
+- [ ] **Never benchmark/perf-test on the EF in-memory provider** — it skips query
+  translation and round-trips, hiding the real cost. Use **Testcontainers** with the
+  real provider (PostgreSQL first), per CLAUDE.md testing conventions.
+- [ ] Enable SQL logging in a perf investigation (`LogTo`, `EnableSensitiveDataLogging`
+  in dev only) and read the generated SQL; 🐘 `EXPLAIN (ANALYZE, BUFFERS)` / 🟦 `SET
+  STATISTICS IO ON` to confirm index usage. Never leave sensitive-data logging on in prod.
+
+### 1.13 Migrations & schema lifecycle
+
+- [ ] **Framework packages ship NO migrations** — index/schema recommendations are
+  emitted as guidance + sample SQL / public `*ModelBuilderExtensions` for the consuming
+  app to own (CLAUDE.md, project memory).
+- [ ] **No `Database.Migrate()` at app startup in multi-replica deployments** — racing
+  replicas corrupt the schema. Use a dedicated migration job/init-container
+  (`Granit.Persistence.EntityFrameworkCore.Hosting` / `GranitMigrationRunner`) that
+  runs once and exits, gated before app rollout. (`CRITICAL` scaling/microservice hazard.)
+
+---
+
+## 2. Allocations & GC (`--scope allocations`)
+
+Reduce per-request garbage → fewer Gen-0/2 collections → lower tail latency under load.
+**Only pursue below CRITICAL/HIGH on paths the profiler proved hot (§9).**
+
+- [ ] **LINQ in proven hot paths** allocates enumerators/closures/delegates per call —
+  replace with `for`/`foreach` over the concrete collection or a `Span<T>` loop
+  (`MICRO-OPT` unless hot). Do **not** delinearize cold code.
+- [ ] **String building**: no `+=`/`String.Concat`/`String.Format` in loops → reuse a
+  `StringBuilder`, interpolation (single shot), or `string.Create`/`ISpanFormattable`.
+- [ ] **`[LoggerMessage]` everywhere** (already a Granit rule) — kills boxing +
+  interpolation allocs in logging and skips formatting when the level is disabled.
+- [ ] **`[GeneratedRegex]`** for every regex (compile once, no per-call allocation).
+- [ ] **`ArrayPool<T>` / `MemoryPool<T>`** for transient large buffers (file/stream/
+  serialization scratch) instead of `new byte[]` per request — pairs with the
+  buffer-leak pattern in dumps (§9).
+- [ ] **`Span<T>`/`ReadOnlySpan<T>`/`stackalloc`** for slicing/parsing without copies;
+  CLAUDE.md already favors `params ReadOnlySpan<T>`.
+- [ ] **Object pooling** (`ObjectPool<T>`) for expensive-to-create, reusable objects
+  (e.g. `StringBuilder`, scratch buffers) on hot paths.
+- [ ] **Avoid boxing**: generic constraints over `object` params; no value type →
+  `object`/interface in hot loops; `EqualityComparer<T>.Default` over boxing equals.
+- [ ] **Stream, don't buffer**: return `IAsyncEnumerable<T>` / write to the response
+  stream for large result sets instead of materializing a giant `List` (caps memory,
+  starts the response sooner). Pair with EF `AsAsyncEnumerable()`.
+- [ ] **Large Object Heap**: buffers/arrays > 85 KB go to the LOH (compacted rarely) —
+  pool or chunk them; flag per-request large allocations.
+- [ ] **Exceptions are not control flow** — throwing is expensive and allocates; high
+  `exception-count` (§9) means refactor to `Try*`/result types on the hot path.
+- [ ] **Capacity hints**: pre-size `List<T>`/`Dictionary<,>`/`StringBuilder` when the
+  count is known, to avoid resize-copy churn.
+- [ ] **.NET 10 wins are free** — the framework targets .NET 10; ensure projects don't
+  pin down-level langversion/runtime that forfeits JIT/GC/BCL improvements (e.g.
+  improved `LINQ`, `Span`, JSON, and GC throughput). Verify `<ServerGarbageCollection>`
+  and tiered-PGO settings (§7) so the runtime gains actually apply.
+
+---
+
+## 3. Async & concurrency (`--scope async`)
+
+Wrong async = threadpool starvation = the whole service stalls under load (`CRITICAL`).
+
+- [ ] **No sync-over-async**: `.Result`, `.Wait()`, `.GetAwaiter().GetResult()`,
+  `Task.Run(...).Result` on request/handler paths block a pool thread → starvation.
+  `await` all the way (`CRITICAL` under load). (Already a CLAUDE.md anti-pattern.)
+- [ ] **`ConfigureAwait(false)` in library code** (Granit packages are libraries) —
+  already a convention; verify on every `await` in non-ASP.NET library code.
+- [ ] **`CancellationToken` flows end-to-end** and is honored (last param, passed to
+  every async call incl. EF `*Async` and HTTP). Unhonored cancellation wastes work
+  under load/timeouts.
+- [ ] **`Task.WhenAll` for independent awaits** instead of sequential `await`s — but
+  **never** parallelize over a single shared `DbContext` (§1.8); use separate
+  contexts/clients.
+- [ ] **`ValueTask`/`ValueTask<T>`** for hot async methods that frequently complete
+  synchronously (cache hits) — fewer `Task` allocations. Don't await a `ValueTask`
+  twice.
+- [ ] **`async void`** only for event handlers — everywhere else `Task` (unobserved
+  exceptions + uncatchable).
+- [ ] **No blocking on locks across `await`**: `lock`/`Monitor` can't span awaits — use
+  `SemaphoreSlim.WaitAsync`. Prefer `System.Threading.Lock` (CLAUDE.md) for short
+  sync-only critical sections.
+- [ ] **Concurrent collections** (`ConcurrentDictionary`, `Channel<T>`) over `lock` +
+  `Dictionary` on contended shared state; producer/consumer via `System.Threading.Channels`.
+- [ ] **`IAsyncEnumerable` with `[EnumeratorCancellation]`** for async streams; consume
+  with `await foreach`.
+- [ ] **No fire-and-forget** unawaited tasks that swallow exceptions or outlive the
+  request scope (esp. capturing scoped services / `DbContext` → leak/disposed-context).
+- [ ] **Min threadpool / starvation**: if profiling shows a growing queue (§9), the fix
+  is removing blocking calls, not raising `ThreadPool.SetMinThreads` (band-aid).
+
+---
+
+## 4. Caching — `Granit.Caching` (`--scope caching`)
+
+Caching is a primary scaling lever — a cached hot read removes a DB round-trip on
+every request × every replica. Granit ships an opinionated stack; **use it correctly,
+do not hand-roll**. Know the two APIs and what the framework already does for you.
+
+### 4.0 The two cache APIs — pick the right one
+
+- **`IFusionCache`** (ZiggyCreatures FusionCache, registered by `AddGranitCaching()`)
+  is **THE cache-aside API**. Use `GetOrSetAsync(key, factory, options, tags, ct)` for
+  every read-through cache. Do **not** reach for `IConditionalCache` or a raw
+  `IMemoryCache`/`IDistributedCache` for standard caching (`MEDIUM`→`HIGH` finding:
+  re-implementing what FusionCache gives for free).
+- **`IConditionalCache`** is **only** for atomic conditional writes —
+  `SetIfAbsentAsync` (SET NX), `SetIfPresentAsync` (SET XX), `GetAsync`, `DeleteAsync`
+  — i.e. distributed locks, idempotency state machines, compare-and-swap. Flag it used
+  as a plain cache (wrong tool) **and** flag a hand-rolled lock where `SetIfAbsentAsync`
+  would do.
+
+### 4.1 What the framework already provides — do NOT re-implement (and do NOT disable)
+
+`AddGranitCaching()` + `FusionCachingOptions` (`"Cache:FusionCache"`) ship
+production-grade defaults. Re-doing these manually, or overriding them off per call, is
+the finding:
+
+- [ ] **Stampede protection is automatic** — FusionCache does per-key factory locking
+  (single-flight), so a stampede on a cold hot key rebuilds **once**, not N×. Flag any
+  hand-rolled `GetOrAdd`/`lock`+`Dictionary`/double-checked cache (`HIGH`: reinventing
+  it, usually without the lock) → replace with `GetOrSetAsync`.
+- [ ] **Fail-safe is on by default** (`FailSafeIsEnabled=true`, max 2 h, throttle 30 s)
+  — stale entries are served when the factory fails, shielding the DB during an
+  outage/spike. Flag per-call `FusionCacheEntryOptions` that set `IsFailSafeEnabled=false`
+  on a hot key without justification.
+- [ ] **Soft/hard factory timeouts** (2 s soft / 10 s hard) return stale instead of
+  hanging on a slow backend. Don't remove them; tune per workload if needed.
+- [ ] **Eager refresh at 80 % of TTL** (`EagerRefreshThreshold=0.8`) refreshes in the
+  background before expiry so requests rarely hit a cold miss. Keep it on for hot keys
+  (set to 0 only intentionally).
+- [ ] **Default durations**: absolute 1 h (`Cache:DefaultAbsoluteExpirationRelativeToNow`),
+  sliding 20 min. Set an explicit `Duration` per entry when the data's volatility
+  differs — don't leave volatile data on the 1 h default (staleness) or pin rarely-
+  changing data to a short TTL (needless misses).
+
+### 4.2 Coverage — what should be cached
+
+- [ ] **Hot, rarely-changing reads go through `IFusionCache`** (`HIGH` win): permission
+  & query/export definitions, feature flags, settings, tenant metadata, OIDC discovery
+  docs, localization, BFF/session lookups. Each uncached one is a DB round-trip per
+  request × replicas. Identify them via §9 metrics (low/no hit traffic on a hot read).
+- [ ] **Don't cache volatile or per-request-unique data** — near-zero hit ratio just
+  adds serialization + memory cost. Cache effectiveness is measured (4.6), not assumed.
+
+### 4.3 Multi-replica: L1 + L2 + backplane
+
+- [ ] **L2 Redis + backplane wired when scaling out** (`CRITICAL` at scale): default is
+  L1 in-memory only. Add **`Granit.Caching.StackExchangeRedis`** — it upgrades
+  FusionCache with `WithRegisteredDistributedCache()` + a Redis pub/sub backplane
+  (channel prefix `granit:fc`) so an eviction on one pod invalidates L1 on all pods.
+  Pure per-replica in-memory cache across R replicas = R× the misses **and** stale
+  divergence after a write on one pod.
+- [ ] **`IConditionalCache` is in-memory by default** — it only becomes cluster-wide
+  (Redis SET NX/XX) with `Granit.Caching.StackExchangeRedis`. An in-memory
+  `IConditionalCache` used as a *distributed* lock across replicas is a correctness bug
+  (`CRITICAL`) — confirm the Redis impl is registered before relying on it for
+  cross-pod mutual exclusion / idempotency.
+
+### 4.4 Tenant isolation — automatic; don't fight it
+
+- [ ] **Keys are tenant-prefixed automatically.** The injected `IFusionCache` is the
+  `TenantAwareFusionCache` decorator: it prefixes keys/tags with `t:{tenantId:N}:` (or
+  `t:host:`). So **do NOT manually concatenate the tenant id into the key** — that
+  double-prefixes and fragments the cache. Flag manual tenant prefixing on `IFusionCache`.
+- [ ] **`IConditionalCache` is NOT tenant-decorated** — for per-tenant locks/idempotency
+  you **must** include the tenant id in the key yourself. Flag a per-tenant
+  `SetIfAbsentAsync` with a bare global key (`CRITICAL` cross-tenant collision).
+- [ ] **The raw (non-decorated) cache** (`TenantAwareFusionCache.RawCacheKey`,
+  `"__granit_raw_cache__"`) bypasses tenant prefixing. Using it for per-tenant data is a
+  `CRITICAL` isolation leak — only legitimate for genuinely global/host data; justify it.
+
+### 4.5 Invalidation, sizing, encryption
+
+- [ ] **Tag-based invalidation**: pass `tags:` to `GetOrSetAsync` and evict groups with
+  `RemoveByTagAsync` instead of tracking every key. Use it for "invalidate everything
+  for entity X / tenant T" (tags are tenant-prefixed too).
+- [ ] **Invalidation is event-driven for must-be-fresh data** — wire domain events to
+  `RemoveAsync`/`RemoveByTagAsync`, don't rely on TTL alone. Document the consistency
+  window for TTL-only data.
+- [ ] **Bounded L1 size + eviction** — an unbounded in-memory cache grows into a
+  Gen-2/LOH leak (shows in dumps, §9). Confirm size limits on high-cardinality keyspaces.
+- [ ] **Encrypt sensitive cached values** (`CRITICAL`, GDPR/ISO 27001): set global
+  `Cache:EncryptValues=true` or mark the type `[CacheEncrypted]` (per-type override wins;
+  `[CacheEncrypted(false)]` opts out). AES-256 key from **Vault/ESO only**
+  (`Cache:Encryption:Key`), never committed. Note: encryption protects the **L2**
+  (serialized Redis) payload — L1 holds live objects in-process. Never cache secrets in
+  plaintext L2. Cross-check `/security`.
+
+### 4.6 Measure cache effectiveness (ties to §9)
+
+- [ ] **Watch the `Granit.Caching` meter**: `granit.caching.entry.hit` /
+  `.entry.miss` (hit ratio — a hot key with a low ratio is mis-tuned TTL or wrong key
+  shape), `granit.caching.fail_safe.activated` (rising = the backend is failing, cache
+  is masking it — investigate the source), `granit.caching.factory.timeout` (slow
+  factory — the cached read itself is slow, fix §1/§5). All tagged `tenant_id`.
+- [ ] **A new cache must move the hit-ratio / DB-round-trip metric** — verify with §9,
+  don't assume. Caching the wrong thing adds cost with no benefit.
+
+### 4.7 HTTP-level caching (complements value caching)
+
+- [ ] **HTTP output caching** (`Granit.Http.OutputCaching`, + `.StackExchangeRedis`
+  variant for multi-replica) for anonymous/cacheable GETs — skips the whole pipeline,
+  not just the DB. Vary by tenant/auth correctly (an auth-varying response cached
+  globally is a `CRITICAL` leak — cross-check `/security`).
+- [ ] **Conditional requests**: `ETag`/`Last-Modified` + `If-None-Match`/`If-Modified-Since`
+  to return `304` and skip body serialization + transfer on unchanged resources.
+
+---
+
+## 5. HTTP, serialization & API (`--scope http`)
+
+- [ ] **System.Text.Json source-gen** (`JsonSerializerContext`) for hot DTOs — avoids
+  reflection-based metadata per serialize (`HIGH` on chatty APIs); aligns with
+  Granit's native OpenAPI 3.1 stance (no Swashbuckle/NSwag).
+- [ ] **`IHttpClientFactory`** always (CLAUDE.md anti-pattern: `new HttpClient()` →
+  socket exhaustion). Typed/named clients with pooled handlers; wire
+  `Granit.Http.Resilience` (Polly) for retries/circuit-breakers, not hand-rolled.
+- [ ] **Response compression** (`Granit.Http.ResponseCompression`) for large
+  text/JSON responses (Brotli/Gzip) — big bandwidth + latency win; ensure it's not
+  applied to already-compressed payloads and is safe vs auth (BREACH — cross-check
+  `/security`).
+- [ ] **Pagination cap on every list endpoint** (`CRITICAL` if unbounded — mirrors §1.5)
+  with a hard server-side max page size, regardless of client request.
+- [ ] **Stream large payloads** (file download/export) via `FileStreamHttpResult` /
+  `IAsyncEnumerable`, not a buffered `byte[]`/`List` (caps memory, TTFB). Pairs with
+  `Granit.DataExchange` exports.
+- [ ] **Rate limiting** (`Granit.Http.RateLimiting`) + **bulkhead/concurrency limits**
+  (`Granit.Http.Bulkhead`) on expensive endpoints to protect the service and DB pool
+  under burst — a scaling safety valve, not just abuse prevention.
+- [ ] **Idempotency** (`Granit.Http.Idempotency`) on unsafe retried operations — avoids
+  duplicate work/writes under client retries.
+- [ ] **Avoid over-fetching / chatty round-trips** — collapse N small calls; use
+  `Granit.Http.ODataExposure`/`QueryEngine` for client-shaped queries instead of
+  bespoke endpoints that over-return.
+- [ ] **Minimal API** (already the Granit standard) over MVC controllers — lower
+  per-request overhead. Verify endpoint filters (validation, etc.) aren't doing heavy
+  per-request work that could be cached.
+- [ ] **OpenAPI/metadata generation** is build/startup-time, not per-request — confirm
+  no schema generation on the request path.
+
+---
+
+## 6. Messaging & Wolverine (`--scope messaging`)
+
+Granit uses WolverineFx (v6, runtime compilation pkg required — see project memory)
+with a durable outbox/inbox on 🐘 `Granit.Wolverine.Postgresql` / 🟦
+`Granit.Wolverine.SqlServer`.
+
+- [ ] **Distributed events (`*Eto`) go through the outbox** (transactional consistency,
+  at-least-once) — already a convention; flag any `IDistributedEventBus` publish that
+  bypasses it. Local `*Event` via `ILocalEventBus` stays in-process (no round trip) —
+  flag `*Eto` used where a local event suffices (wasted bus + DB write).
+- [ ] **Handler cost**: handlers are on the message-throughput path — same EF rules
+  (§1) apply. No N+1, no sync-over-async, project not load. A slow handler caps queue
+  drain rate.
+- [ ] **Idempotent handlers** (`CRITICAL` multi-replica): at-least-once delivery + N
+  replicas means a handler can run twice/concurrently. Use the inbox dedup + design
+  for re-execution; flag handlers with non-idempotent side effects (double charge,
+  double email).
+- [ ] **Batching / parallelism**: tune Wolverine listener parallelism and batch size to
+  the workload; ensure ordered processing only where required (ordering throttles
+  throughput).
+- [ ] **Outbox/inbox table growth**: confirm a cleanup/retention job exists — an
+  ever-growing outbox table degrades every publish (`HIGH` over time). Indexes on the
+  outbox status/time columns.
+- [ ] **Poison-message handling**: dead-letter + bounded retry so a bad message doesn't
+  spin a handler hot (CPU burn + queue stall).
+- [ ] **No per-message DbContext leak / no shared context across the handler chain** —
+  scoped per message.
+
+---
+
+## 7. Startup & runtime configuration (`--scope startup`)
+
+- [ ] **Server GC** enabled for server workloads: `<ServerGarbageCollection>true</ServerGarbageCollection>`
+  (+ usually `<ConcurrentGarbageCollection>true`). Workstation GC on a multi-core
+  server throttles throughput (`HIGH`). Set on the **host app** (csproj/runtimeconfig),
+  not library packages.
+- [ ] **Tiered compilation + PGO** on (default in .NET 10): `<TieredPGO>true`. Verify
+  nothing disables tiered compilation (hurts steady-state throughput). For latency-
+  sensitive startup, consider `<TieredCompilationQuickJit>` tuning + **ReadyToRun**
+  (`<PublishReadyToRun>true`) for the host.
+- [ ] **DbContext pooling** (`AddDbContextPool` / `AddPooledDbContextFactory`) for
+  high-throughput services — reuses context instances, cutting per-request allocation
+  and reset cost. **Caveat**: pooled contexts must not capture per-request state in
+  fields; Granit's `GranitDbContext` injects `ICurrentTenant`/`IDataFilter` — confirm
+  pooling is compatible (tenant resolved per-request via the scoped accessor, not
+  cached in the context). Propose, verify, don't auto-apply.
+- [ ] **Connection pool sizing** coherent with replica count (§1.10) — Min/Max pool,
+  and DB `max_connections` headroom.
+- [ ] **Lazy / deferred init**: heavy singletons built at first use, not blocking
+  startup; no synchronous IO in `ConfigureServices`/module init.
+- [ ] **Health checks are cheap** (CLAUDE.md: 10s timeout, readiness vs liveness split)
+  — a liveness probe that hits the DB couples probe load to DB and can cascade restarts
+  under load.
+- [ ] **Native AOT** is generally **not** a fit for this reflection/EF-heavy framework —
+  don't recommend it broadly; ReadyToRun is the pragmatic startup win.
+- [ ] **Compiled model** (`dotnet ef dbcontext optimize`) for very large models to cut
+  first-query/startup model-build time — app-owned, propose for big consumers.
+
+---
+
+## 8. Horizontal scaling & multi-tenancy (`--scope scaling`)
+
+Reason at "N tenants × M rows × R replicas × C concurrent". Overlaps `/audit
+--scope microservices`.
+
+- [ ] **Stateless request handling** — no per-request state in singletons / static
+  fields; session/state in distributed store (Redis), not process memory. (`CRITICAL`
+  for horizontal scale.)
+- [ ] **In-memory cache is not a source of truth** across replicas — use L2/Redis
+  backplane (§4) or accept per-replica drift only for derivable data.
+- [ ] **Distributed locks** where cross-replica mutual exclusion is needed (🐘
+  `pg_advisory_lock`, Redis lock) — never an in-process `lock` for cluster-wide
+  coordination.
+- [ ] **Recurring/background jobs run once cluster-wide**, not per replica
+  (`CRITICAL`): a `[RecurringJob]` firing on every replica multiplies load N×. Confirm
+  the scheduler (`Granit.Scheduling`/`Granit.BackgroundJobs`) dedups across replicas.
+- [ ] **Idempotent handlers/jobs** (mirror §6) — re-execution safe.
+- [ ] **No migrations at boot** (§1.13) — dedicated migration job.
+- [ ] **Tenant fan-out cost**: operations iterating all tenants (broadcast jobs,
+  per-tenant rebuilds) must batch/throttle and not hold a connection per tenant — flag
+  O(tenants) connection or round-trip patterns.
+- [ ] **Tenant filter parameterization** (§2e in SKILL) — `GranitDbContext` keeps the
+  tenant id a SQL parameter so the plan cache isn't fragmented per tenant and the value
+  can't leak across requests. Flag any re-inlining.
+- [ ] **Sharding / schema-per-tenant** (🐘 `SET search_path`, `GranitDbDefaults.HostDbSchema`):
+  if used, confirm connection reuse doesn't leak `search_path` across pooled connections
+  (reset on return) and that the schema switch is parameter-safe.
+- [ ] **Backpressure**: bulkhead/rate-limit (§5) + bounded queues so one hot tenant
+  can't starve the cluster.
+
+---
+
+## 9. Observability & profiling (`--scope observability`)
+
+The measurement layer that makes every other section evidence-based.
+
+- [ ] **Module metrics exist and are useful**: `IMeterFactory` meters
+  (`granit.{module}.{entity}.{action}`) + `ActivitySource` per module (CLAUDE.md). For
+  perf, confirm latency/throughput/error counters on the hot paths and `tenant_id` tag
+  for per-tenant breakdown. Use these as the first signal before attaching a profiler.
+- [ ] **Cache effectiveness** via the `Granit.Caching` meter —
+  `granit.caching.entry.hit`/`.miss` (hit ratio), `granit.caching.fail_safe.activated`,
+  `granit.caching.factory.timeout`, tagged `tenant_id`. Low hit ratio on a hot key,
+  rising fail-safe, or factory timeouts each point back to §4 / §1. (Detailed in §4.6.)
+- [ ] **OpenTelemetry** traces span DB/HTTP/message boundaries so slow spans are
+  attributable (Granit ships OTel 1.15+). Verify EF + HttpClient + Wolverine
+  instrumentation is enabled in the host.
+- [ ] **The profiling workflow** (see SKILL "Live profiling mode") is available:
+  `dotnet-counters` for runtime health, `dotnet-trace` for CPU hotspots,
+  `dotnet-gcdump`/`dotnet-dump` for memory/leaks. Baseline normal load, then capture
+  the problematic state, diff.
+- [ ] **BenchmarkDotNet** (`[MemoryDiagnoser]`, `Baseline = true`) for any proposed
+  hot-path micro-optimization — against a **real provider via Testcontainers** for EF
+  paths (§1.12). A change without a before/after table is a hypothesis, not a win.
+- [ ] **Logging volume**: high-throughput paths don't log at `Information` per request
+  (IO + allocation); `[LoggerMessage]` with appropriate levels, sampling for hot paths.
+- [ ] **No PII in perf logs/traces/metrics** (GDPR, cross-check `/security`).
+- [ ] **Artifacts cleaned up** after every investigation (`*.nettrace`, `*.gcdump`,
+  `*.dmp`, coverage XML) — confirm `git status` clean.
+
+---
+
+## Quick triage — where to look first by symptom
+
+| Symptom | Start at scope | Likely cause |
+|---------|---------------|--------------|
+| Endpoint slow, DB CPU high | `efcore` | N+1 (§1.3), missing index (§1.6), no projection (§1.2) |
+| Endpoint slow, app CPU high | `allocations` / `http` | LINQ/string churn (§2), reflection JSON (§5) |
+| Memory grows unbounded | `allocations` / `caching` | buffer/cache leak (§2, §4.6), tracked entities (§1.1) |
+| Threadpool queue climbs, throughput collapses | `async` | sync-over-async (§3.1) |
+| Fine on 1 replica, breaks on N | `scaling` / `caching` | per-replica jobs (§8.4), in-memory cache (§4.3) |
+| Slow only on deep pages | `efcore` | `OFFSET` pagination (§1.5) |
+| Fast on PostgreSQL, slow on SQL Server/SQLite | `efcore` (`--provider`) | provider divergence (§1.10/§1.11) |
+| Latency spikes / GC pauses | `allocations` / `startup` | Gen-2 pressure (§2), Workstation GC (§7) |
+| Message queue drains slowly | `messaging` | slow handler (§6.2), no batching (§6.4) |

--- a/src/Granit.Validation/Localization/Validation/cs.json
+++ b/src/Granit.Validation/Localization/Validation/cs.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' nemá správný formát.",
     "Validation:ReorderDeltaIllFormed": "Delta změny pořadí musí nastavit přesně jednu z hodnot BeforeFieldName / AfterFieldName.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' nesmí mít celkem více než {ExpectedPrecision} číslic, z toho {ExpectedScale} desetinných míst.",
+    "Validation:ScopeRequired": "Parametr 'scope' je povinný.",
+    "Validation:SearchTermRequired": "Vyhledávací výraz 'q' je povinný.",
+    "Validation:TargetIdRequired": "Parametr 'targetId' nesmí být prázdný.",
+    "Validation:TargetTypeRequired": "Parametr 'targetType' je povinný.",
     "Validation:TooManyDeltas": "Příliš mnoho delt v jednom požadavku.",
     "Validation:UrlMustBeHttps": "Adresa URL musí používat HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Platné do' musí být pozdější než 'Platné od'."

--- a/src/Granit.Validation/Localization/Validation/de.json
+++ b/src/Granit.Validation/Localization/Validation/de.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' hat nicht das richtige Format.",
     "Validation:ReorderDeltaIllFormed": "Reorder-Delta muss genau einen von BeforeFieldName / AfterFieldName setzen.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' darf insgesamt nicht mehr als {ExpectedPrecision} Ziffern haben, davon {ExpectedScale} Dezimalstellen.",
+    "Validation:ScopeRequired": "Der Parameter 'scope' ist erforderlich.",
+    "Validation:SearchTermRequired": "Der Suchbegriff 'q' ist erforderlich.",
+    "Validation:TargetIdRequired": "Der Parameter 'targetId' darf nicht leer sein.",
+    "Validation:TargetTypeRequired": "Der Parameter 'targetType' ist erforderlich.",
     "Validation:TooManyDeltas": "Zu viele Deltas in einer einzigen Anforderung.",
     "Validation:UrlMustBeHttps": "Die URL muss HTTPS verwenden.",
     "Validation:ValidToAfterValidFrom": "'Gültig bis' muss nach 'Gültig ab' liegen."

--- a/src/Granit.Validation/Localization/Validation/en.json
+++ b/src/Granit.Validation/Localization/Validation/en.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' is not in the correct format.",
     "Validation:ReorderDeltaIllFormed": "Reorder delta must set exactly one of BeforeFieldName / AfterFieldName.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' must not be more than {ExpectedPrecision} digits in total, with allowance for {ExpectedScale} decimals.",
+    "Validation:ScopeRequired": "The 'scope' parameter is required.",
+    "Validation:SearchTermRequired": "The search term 'q' is required.",
+    "Validation:TargetIdRequired": "The 'targetId' parameter must not be empty.",
+    "Validation:TargetTypeRequired": "The 'targetType' parameter is required.",
     "Validation:TooManyDeltas": "Too many deltas in a single request.",
     "Validation:UrlMustBeHttps": "The URL must use HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Valid to' must be after 'Valid from'."

--- a/src/Granit.Validation/Localization/Validation/es.json
+++ b/src/Granit.Validation/Localization/Validation/es.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' no tiene el formato correcto.",
     "Validation:ReorderDeltaIllFormed": "El delta de reordenación debe establecer exactamente uno de BeforeFieldName / AfterFieldName.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' no debe tener más de {ExpectedPrecision} dígitos en total, de los cuales {ExpectedScale} decimales.",
+    "Validation:ScopeRequired": "El parámetro 'scope' es obligatorio.",
+    "Validation:SearchTermRequired": "El término de búsqueda 'q' es obligatorio.",
+    "Validation:TargetIdRequired": "El parámetro 'targetId' no puede estar vacío.",
+    "Validation:TargetTypeRequired": "El parámetro 'targetType' es obligatorio.",
     "Validation:TooManyDeltas": "Demasiados deltas en una sola solicitud.",
     "Validation:UrlMustBeHttps": "La URL debe usar HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Válido hasta' debe ser posterior a 'Válido desde'."

--- a/src/Granit.Validation/Localization/Validation/fr.json
+++ b/src/Granit.Validation/Localization/Validation/fr.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' n'est pas dans le format attendu.",
     "Validation:ReorderDeltaIllFormed": "Le delta de réorganisation doit définir exactement une seule ancre (BeforeFieldName ou AfterFieldName).",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' ne doit pas avoir plus de {ExpectedPrecision} chiffres au total, dont {ExpectedScale} décimaux.",
+    "Validation:ScopeRequired": "Le paramètre 'scope' est obligatoire.",
+    "Validation:SearchTermRequired": "Le terme de recherche 'q' est obligatoire.",
+    "Validation:TargetIdRequired": "Le paramètre 'targetId' ne peut pas être vide.",
+    "Validation:TargetTypeRequired": "Le paramètre 'targetType' est obligatoire.",
     "Validation:TooManyDeltas": "Trop de deltas dans une seule requête.",
     "Validation:UrlMustBeHttps": "L'URL doit utiliser HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Valide jusqu'au' doit être postérieur à 'Valide à partir du'."

--- a/src/Granit.Validation/Localization/Validation/hi.json
+++ b/src/Granit.Validation/Localization/Validation/hi.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' सही प्रारूप में नहीं है।",
     "Validation:ReorderDeltaIllFormed": "रीऑर्डर डेल्टा को BeforeFieldName / AfterFieldName में से ठीक एक सेट करना चाहिए।",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' कुल {ExpectedPrecision} अंकों से अधिक नहीं होना चाहिए, {ExpectedScale} दशमलव की अनुमति के साथ।",
+    "Validation:ScopeRequired": "पैरामीटर 'scope' आवश्यक है।",
+    "Validation:SearchTermRequired": "खोज शब्द 'q' आवश्यक है।",
+    "Validation:TargetIdRequired": "पैरामीटर 'targetId' खाली नहीं हो सकता।",
+    "Validation:TargetTypeRequired": "पैरामीटर 'targetType' आवश्यक है।",
     "Validation:TooManyDeltas": "एकल अनुरोध में बहुत अधिक डेल्टा।",
     "Validation:UrlMustBeHttps": "URL को HTTPS का उपयोग करना चाहिए।",
     "Validation:ValidToAfterValidFrom": "'मान्य तक' 'मान्य से' के बाद होना चाहिए।"

--- a/src/Granit.Validation/Localization/Validation/it.json
+++ b/src/Granit.Validation/Localization/Validation/it.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' non è nel formato corretto.",
     "Validation:ReorderDeltaIllFormed": "Il delta di riordino deve impostare esattamente uno tra BeforeFieldName / AfterFieldName.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' non deve avere più di {ExpectedPrecision} cifre in totale, di cui {ExpectedScale} decimali.",
+    "Validation:ScopeRequired": "Il parametro 'scope' è obbligatorio.",
+    "Validation:SearchTermRequired": "Il termine di ricerca 'q' è obbligatorio.",
+    "Validation:TargetIdRequired": "Il parametro 'targetId' non può essere vuoto.",
+    "Validation:TargetTypeRequired": "Il parametro 'targetType' è obbligatorio.",
     "Validation:TooManyDeltas": "Troppi delta in una singola richiesta.",
     "Validation:UrlMustBeHttps": "L'URL deve utilizzare HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Valido fino a' deve essere successivo a 'Valido da'."

--- a/src/Granit.Validation/Localization/Validation/ja.json
+++ b/src/Granit.Validation/Localization/Validation/ja.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' の形式が正しくありません。",
     "Validation:ReorderDeltaIllFormed": "並べ替えデルタは BeforeFieldName または AfterFieldName のいずれか1つだけを設定する必要があります。",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' は合計 {ExpectedPrecision} 桁以内で、うち小数部は {ExpectedScale} 桁以内である必要があります。",
+    "Validation:ScopeRequired": "パラメータ 'scope' は必須です。",
+    "Validation:SearchTermRequired": "検索語 'q' は必須です。",
+    "Validation:TargetIdRequired": "パラメータ 'targetId' は空にできません。",
+    "Validation:TargetTypeRequired": "パラメータ 'targetType' は必須です。",
     "Validation:TooManyDeltas": "1つのリクエストにデルタが多すぎます。",
     "Validation:UrlMustBeHttps": "URL は HTTPS を使用する必要があります。",
     "Validation:ValidToAfterValidFrom": "'有効終了日' は '有効開始日' より後でなければなりません。"

--- a/src/Granit.Validation/Localization/Validation/ko.json
+++ b/src/Granit.Validation/Localization/Validation/ko.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}'의 형식이 올바르지 않습니다.",
     "Validation:ReorderDeltaIllFormed": "재정렬 델타는 BeforeFieldName 또는 AfterFieldName 중 정확히 하나를 설정해야 합니다.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}'은(는) 총 {ExpectedPrecision}자리를 초과할 수 없으며 소수점 이하 {ExpectedScale}자리까지 허용됩니다.",
+    "Validation:ScopeRequired": "'scope' 매개변수는 필수입니다.",
+    "Validation:SearchTermRequired": "검색어 'q'는 필수입니다.",
+    "Validation:TargetIdRequired": "'targetId' 매개변수는 비어 있을 수 없습니다.",
+    "Validation:TargetTypeRequired": "'targetType' 매개변수는 필수입니다.",
     "Validation:TooManyDeltas": "단일 요청에 델타가 너무 많습니다.",
     "Validation:UrlMustBeHttps": "URL은 HTTPS를 사용해야 합니다.",
     "Validation:ValidToAfterValidFrom": "'유효 종료일'은 '유효 시작일' 이후여야 합니다."

--- a/src/Granit.Validation/Localization/Validation/nl.json
+++ b/src/Granit.Validation/Localization/Validation/nl.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' heeft niet het juiste formaat.",
     "Validation:ReorderDeltaIllFormed": "Reorder-delta moet precies één van BeforeFieldName / AfterFieldName instellen.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' mag niet meer dan {ExpectedPrecision} cijfers bevatten, waarvan {ExpectedScale} decimalen.",
+    "Validation:ScopeRequired": "De parameter 'scope' is verplicht.",
+    "Validation:SearchTermRequired": "De zoekterm 'q' is verplicht.",
+    "Validation:TargetIdRequired": "De parameter 'targetId' mag niet leeg zijn.",
+    "Validation:TargetTypeRequired": "De parameter 'targetType' is verplicht.",
     "Validation:TooManyDeltas": "Te veel delta's in een enkel verzoek.",
     "Validation:UrlMustBeHttps": "De URL moet HTTPS gebruiken.",
     "Validation:ValidToAfterValidFrom": "'Geldig tot' moet na 'Geldig vanaf' liggen."

--- a/src/Granit.Validation/Localization/Validation/pl.json
+++ b/src/Granit.Validation/Localization/Validation/pl.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' ma nieprawidłowy format.",
     "Validation:ReorderDeltaIllFormed": "Delta zmiany kolejności musi ustawić dokładnie jeden z BeforeFieldName / AfterFieldName.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' nie może mieć więcej niż {ExpectedPrecision} cyfr łącznie, w tym {ExpectedScale} miejsc po przecinku.",
+    "Validation:ScopeRequired": "Parametr 'scope' jest wymagany.",
+    "Validation:SearchTermRequired": "Termin wyszukiwania 'q' jest wymagany.",
+    "Validation:TargetIdRequired": "Parametr 'targetId' nie może być pusty.",
+    "Validation:TargetTypeRequired": "Parametr 'targetType' jest wymagany.",
     "Validation:TooManyDeltas": "Zbyt wiele delt w pojedynczym żądaniu.",
     "Validation:UrlMustBeHttps": "Adres URL musi używać protokołu HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Ważne do' musi być późniejsze niż 'Ważne od'."

--- a/src/Granit.Validation/Localization/Validation/pt.json
+++ b/src/Granit.Validation/Localization/Validation/pt.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' não está no formato correto.",
     "Validation:ReorderDeltaIllFormed": "O delta de reordenação deve definir exatamente um de BeforeFieldName / AfterFieldName.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' não deve ter mais de {ExpectedPrecision} dígitos no total, dos quais {ExpectedScale} decimais.",
+    "Validation:ScopeRequired": "O parâmetro 'scope' é obrigatório.",
+    "Validation:SearchTermRequired": "O termo de pesquisa 'q' é obrigatório.",
+    "Validation:TargetIdRequired": "O parâmetro 'targetId' não pode estar vazio.",
+    "Validation:TargetTypeRequired": "O parâmetro 'targetType' é obrigatório.",
     "Validation:TooManyDeltas": "Demasiados deltas num único pedido.",
     "Validation:UrlMustBeHttps": "A URL deve usar HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Válido até' deve ser posterior a 'Válido desde'."

--- a/src/Granit.Validation/Localization/Validation/sv.json
+++ b/src/Granit.Validation/Localization/Validation/sv.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' har inte korrekt format.",
     "Validation:ReorderDeltaIllFormed": "Reorder-delta måste ange exakt en av BeforeFieldName / AfterFieldName.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' får inte ha fler än {ExpectedPrecision} siffror totalt, varav {ExpectedScale} decimaler.",
+    "Validation:ScopeRequired": "Parametern 'scope' är obligatorisk.",
+    "Validation:SearchTermRequired": "Söktermen 'q' är obligatorisk.",
+    "Validation:TargetIdRequired": "Parametern 'targetId' får inte vara tom.",
+    "Validation:TargetTypeRequired": "Parametern 'targetType' är obligatorisk.",
     "Validation:TooManyDeltas": "För många deltan i en enskild begäran.",
     "Validation:UrlMustBeHttps": "URL:en måste använda HTTPS.",
     "Validation:ValidToAfterValidFrom": "'Giltig till' måste vara efter 'Giltig från'."

--- a/src/Granit.Validation/Localization/Validation/tr.json
+++ b/src/Granit.Validation/Localization/Validation/tr.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' doğru biçimde değil.",
     "Validation:ReorderDeltaIllFormed": "Yeniden sıralama deltası BeforeFieldName veya AfterFieldName'den yalnızca birini ayarlamalıdır.",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' toplamda {ExpectedPrecision} basamaktan fazla olmamalı ve {ExpectedScale} ondalık basamağa izin verilmelidir.",
+    "Validation:ScopeRequired": "'scope' parametresi zorunludur.",
+    "Validation:SearchTermRequired": "Arama terimi 'q' zorunludur.",
+    "Validation:TargetIdRequired": "'targetId' parametresi boş olamaz.",
+    "Validation:TargetTypeRequired": "'targetType' parametresi zorunludur.",
     "Validation:TooManyDeltas": "Tek bir istekte çok fazla delta var.",
     "Validation:UrlMustBeHttps": "URL, HTTPS kullanmalıdır.",
     "Validation:ValidToAfterValidFrom": "'Geçerlilik bitiş tarihi', 'Geçerlilik başlangıç tarihi'nden sonra olmalıdır."

--- a/src/Granit.Validation/Localization/Validation/zh.json
+++ b/src/Granit.Validation/Localization/Validation/zh.json
@@ -62,6 +62,10 @@
     "Validation:RegularExpressionValidator": "'{PropertyName}' 的格式不正确。",
     "Validation:ReorderDeltaIllFormed": "重新排序增量必须仅设置 BeforeFieldName 或 AfterFieldName 之一。",
     "Validation:ScalePrecisionValidator": "'{PropertyName}' 总共不能超过 {ExpectedPrecision} 位数字，其中允许 {ExpectedScale} 位小数。",
+    "Validation:ScopeRequired": "参数 'scope' 是必需的。",
+    "Validation:SearchTermRequired": "搜索词 'q' 是必需的。",
+    "Validation:TargetIdRequired": "参数 'targetId' 不能为空。",
+    "Validation:TargetTypeRequired": "参数 'targetType' 是必需的。",
     "Validation:TooManyDeltas": "单个请求中的增量过多。",
     "Validation:UrlMustBeHttps": "URL 必须使用 HTTPS。",
     "Validation:ValidToAfterValidFrom": "'有效截止日期' 必须晚于 '有效起始日期'。"


### PR DESCRIPTION
## Summary

Lands two independent WIP items that had been sitting uncommitted in the working tree.

### 1. Validation localization keys (`feat`)
Adds four shared validation error-code keys, consumed by downstream search/sharing endpoint validators through the `Granit:Validation:*` error-code channel:

- `Validation:ScopeRequired`
- `Validation:SearchTermRequired`
- `Validation:TargetIdRequired`
- `Validation:TargetTypeRequired`

Added across the **15 base cultures**; the 3 regional files (`en-GB`, `fr-CA`, `pt-BR`) inherit from their base per the localization convention.

> Note: three billing-flavoured keys (`DueAtMustBeAfterIssuedAt`, `PeriodEndMustBeAfterStart`, `MaxMetadataEntries`) that were also in the WIP were **deliberately dropped** — those belong to `granit-business`, not the framework.

### 2. `perf` skill (`chore`)
New performance-architect skill under `.claude/skills/perf/`, alongside the existing `audit`/`quality`/`security` skills. Covers EF Core query patterns, allocations/GC, async, caching, HTTP/serialization, messaging, startup/runtime, horizontal scaling, plus live-profiling guidance.

## Validation
- All 15 base JSON files validated as well-formed.
- No in-repo validator or culture-parity test references these keys (additive, inert resources).
- Skill markdown matches the existing committed skills' table style (MD060 is a non-enforced lint-version artifact shared by all skills).

## Notes
- Two unrelated concerns bundled per request — reviewable as two commits.