### PR TITLE
perf(persistence): AsNoTracking on EfStoreBase read helpers

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
@@ -189,6 +189,14 @@ public abstract class EfStoreBase<TEntity, TContext>
             entity, callerMember, callerFile, callerLine);
 
     // ── Read helpers ────────────────────────────────────────────────────
+    //
+    // These helpers are read-only: each opens a throwaway context that is disposed
+    // before the entity is returned, so the result is always detached. Writers
+    // re-attach explicitly via db.Set<T>().Update(entity) in a separate context, so
+    // change tracking here is pure overhead with no benefit — hence AsNoTracking().
+    // The read -> mutate -> UpdateAsync flow is unaffected (Update() works on a
+    // detached entity regardless of prior tracking state). Raw-context reads via
+    // ReadAsync(...) keep their caller-controlled tracking.
 
     /// <summary>
     /// Finds an entity by its primary key. Uses <c>FirstOrDefaultAsync</c> instead of
@@ -206,6 +214,7 @@ public abstract class EfStoreBase<TEntity, TContext>
     {
         await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await Query(db)
+            .AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == id, ct).ConfigureAwait(false);
     }
 
@@ -216,6 +225,7 @@ public abstract class EfStoreBase<TEntity, TContext>
     {
         await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await Query(db)
+            .AsNoTracking()
             .FirstOrDefaultAsync(predicate, ct).ConfigureAwait(false);
     }
 
@@ -227,6 +237,7 @@ public abstract class EfStoreBase<TEntity, TContext>
         await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await SpecificationEvaluator
             .Apply(Query(db), spec)
+            .AsNoTracking()
             .ToListAsync(ct).ConfigureAwait(false);
     }
 
@@ -240,6 +251,7 @@ public abstract class EfStoreBase<TEntity, TContext>
         await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await SpecificationEvaluator
             .Apply(Query(db), spec)
+            .AsNoTracking()
             .ToPagedResultAsync(page, pageSize, ct).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## What

Adds `AsNoTracking()` to the four dedicated read helpers of `EfStoreBase`:
`FindByIdAsync`, `FirstOrDefaultAsync`, `ListAsync`, `PagedAsync`.

## Why

Each of these helpers opens a **throwaway `DbContext`** via the factory, runs the
query, returns the entity, and disposes the context — so the result is **always
detached**. Writers re-attach explicitly via `db.Set<T>().Update(entity)` in a
**separate** context. Change tracking on these reads therefore costs CPU + memory
(change-tracker snapshots) with **no benefit**: there is never a `SaveChanges` on
the same context.

`AsNoTracking()` removes that overhead for **every store** that uses the inherited
read helpers, on all three providers (PostgreSQL / SQL Server / SQLite).

## Safety

- The `read -> mutate -> UpdateAsync` flow is unaffected: `Update()` works on a
  detached entity regardless of prior tracking state (and the context was already
  disposed between read and update).
- **Not** applied to the shared `Query()` method — writers reach it via
  `WriteAsync(db => ...)` lambdas where loaded entities are mutated and saved in the
  same context (tracking required).
- **Not** sprayed onto concrete stores — most "missing AsNoTracking" reads there are
  load-for-update inside `WriteAsync` (e.g. `EfCoreUserNotificationStore.MarkAsRead`)
  and must stay tracked.

## Tests

641 EF tests green, including read+write and tenant-filter flows:
Persistence (371), Webhooks (33), Notifications (46), MultiTenancy (55),
Auditing (136). `dotnet format` clean.

## Context

Outcome of the framework performance audit. Part of the perf-hardening Epic.

Refs #2516