### PR TITLE
chore(caching): drop direct ZiggyCreatures.FusionCache ref from Localization.Endpoints tests

### DIFF
--- a/tests/Granit.Localization.Endpoints.Tests/Granit.Localization.Endpoints.Tests.csproj
+++ b/tests/Granit.Localization.Endpoints.Tests/Granit.Localization.Endpoints.Tests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.Localization.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Localization.Endpoints.Tests/packages.lock.json
@@ -75,15 +75,6 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
-      "ZiggyCreatures.FusionCache": {
-        "type": "Direct",
-        "requested": "[2.*, )",
-        "resolved": "2.6.0",
-        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Memory": "10.0.1"
-        }
-      },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -837,6 +828,15 @@
         "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
         "dependencies": {
           "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
         }
       },
       "ZiggyCreatures.FusionCache.OpenTelemetry": {


### PR DESCRIPTION
## What

Removes the direct `<PackageReference Include="ZiggyCreatures.FusionCache" />` from `Granit.Localization.Endpoints.Tests`.

## Why

The repo convention is to reference **Granit.Caching**, which re-exposes `IFusionCache` (and `AddFusionCache()`) transitively — only `Granit.Caching` (owner) and `Granit.Caching.StackExchangeRedis` (backplane provider) may reference `ZiggyCreatures.*` directly.

This test project was the only place bypassing that convention. The reference was also **redundant**: the symbol already flows in transitively via

```
Granit.Localization.Endpoints.Tests
  └─ Granit.Localization.Endpoints
       └─ Granit.Localization        (ProjectReference Granit.Caching)
            └─ Granit.Caching         (PackageReference ZiggyCreatures.FusionCache)
```

Three other test projects already call `AddFusionCache()` with no direct reference (Presence, Settings, Identity.Local.AspNetIdentity) — empirical proof the transitive path works.

## Changes

- Drop the direct package reference.
- Regenerate `packages.lock.json` (`--force-evaluate`): `ZiggyCreatures.*` entries are now `CentralTransitive`.

## Verification

- `dotnet build tests/Granit.Localization.Endpoints.Tests` → **Build succeeded. 0 Warning(s), 0 Error(s)** — `AddFusionCache()` resolves transitively via Granit.Caching.