### PR TITLE
feat(caching): make the L2 cache serializer domain-aware

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12592,7 +12592,7 @@
       "kind": "class",
       "project": "Granit.Caching",
       "file": "src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitCaching",
@@ -18688,7 +18688,7 @@
       "kind": "class",
       "project": "Granit",
       "file": "src/Granit/Extensions/GranitHostBuilderExtensions.cs",
-      "line": 18,
+      "line": 17,
       "members": [
         {
           "name": "AddGranit",
@@ -29217,6 +29217,22 @@
       "file": "src/Granit.Indexing/SearchRequest.cs",
       "line": 31,
       "members": []
+    },
+    {
+      "name": "GranitJsonConverters",
+      "fqn": "Granit.Json.GranitJsonConverters",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Json/GranitJsonConverters.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitJsonConverters",
+          "kind": "method",
+          "signature": "AddGranitJsonConverters(this JsonSerializerOptions options)",
+          "returnType": "JsonSerializerOptions"
+        }
+      ]
     },
     {
       "name": "SingleValueObjectJsonConverterFactory",

--- a/src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs
+++ b/src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
 using Granit.Caching.Diagnostics;
 using Granit.Caching.Internal;
 using Granit.Caching.MultiTenancy;
 using Granit.Caching.Options;
+using Granit.Json;
 using Granit.MultiTenancy;
 using Granit.Timing.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -98,12 +100,20 @@ public static class CachingServiceCollectionExtensions
                     fc.EnableAutoRecovery = true;
                 });
 
-        // Replace the serializer with the encrypting decorator (per-type via CacheEncryptionResolver)
+        // Replace the serializer with the encrypting decorator (per-type via CacheEncryptionResolver).
+        // The L2 serializer uses the same canonical Granit JSON converters as the HTTP pipeline so
+        // domain value objects (SingleValueObject<T>, enums) round-trip through L2 identically — a
+        // cached *Response/projection carrying e.g. an AbsoluteUrl deserialises correctly. The
+        // host-supplied JsonOptions are copied (never mutated) before the converters are applied.
         services.AddSingleton<ZiggyCreatures.Caching.Fusion.Serialization.IFusionCacheSerializer>(sp =>
         {
             CachingOptions cachingOpts = sp.GetRequiredService<IOptions<CachingOptions>>().Value;
             ICacheValueEncryptor encryptor = sp.GetRequiredService<ICacheValueEncryptor>();
-            var jsonSerializer = new FusionCacheSystemTextJsonSerializer(cachingOpts.JsonOptions);
+            JsonSerializerOptions jsonOptions = cachingOpts.JsonOptions is null
+                ? new JsonSerializerOptions()
+                : new JsonSerializerOptions(cachingOpts.JsonOptions);
+            jsonOptions.AddGranitJsonConverters();
+            var jsonSerializer = new FusionCacheSystemTextJsonSerializer(jsonOptions);
             return new EncryptingFusionCacheSerializer(jsonSerializer, encryptor, cachingOpts);
         });
 

--- a/src/Granit/Extensions/GranitHostBuilderExtensions.cs
+++ b/src/Granit/Extensions/GranitHostBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text.Json.Serialization;
 using Granit.Json;
 using Granit.Modularity;
 using Granit.MultiTenancy;
@@ -154,10 +153,7 @@ public static class GranitHostBuilderExtensions
         builder.Services.AddSingleton<GranitJsonDefaultsMarker>();
 
         builder.Services.ConfigureHttpJsonOptions(options =>
-        {
-            options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
-            options.SerializerOptions.Converters.Add(new SingleValueObjectJsonConverterFactory());
-        });
+            options.SerializerOptions.AddGranitJsonConverters());
     }
 
     /// <summary>

--- a/src/Granit/Json/GranitJsonConverters.cs
+++ b/src/Granit/Json/GranitJsonConverters.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Granit.Json;
+
+/// <summary>
+/// The single source of truth for "how Granit serializes JSON". Adds the canonical Granit converters
+/// to a <see cref="JsonSerializerOptions"/>: a <see cref="JsonStringEnumConverter"/> (enums as their
+/// names) and a <see cref="SingleValueObjectJsonConverterFactory"/> (flattens
+/// <see cref="Granit.Domain.SingleValueObject{T}"/> to its underlying primitive). Applied to both the
+/// minimal-API pipeline and the cache L2 serializer so a value object round-trips identically wherever
+/// it is serialized.
+/// </summary>
+public static class GranitJsonConverters
+{
+    /// <summary>
+    /// Adds the canonical Granit converters to <paramref name="options"/> and returns it. Idempotent:
+    /// a converter of the same type already present is left in place, so it is safe to call on
+    /// host-supplied options or more than once.
+    /// </summary>
+    public static JsonSerializerOptions AddGranitJsonConverters(this JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!options.Converters.Any(c => c is JsonStringEnumConverter))
+        {
+            options.Converters.Add(new JsonStringEnumConverter());
+        }
+
+        if (!options.Converters.Any(c => c is SingleValueObjectJsonConverterFactory))
+        {
+            options.Converters.Add(new SingleValueObjectJsonConverterFactory());
+        }
+
+        return options;
+    }
+}

--- a/tests/Granit.Caching.FusionCache.Tests/GranitJsonCacheSerializationTests.cs
+++ b/tests/Granit.Caching.FusionCache.Tests/GranitJsonCacheSerializationTests.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using Granit.Caching.Internal;
+using Granit.Caching.Options;
+using Granit.Domain;
+using Granit.Json;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
+
+namespace Granit.Caching.FusionCache.Tests;
+
+/// <summary>
+/// Proves the cache L2 serializer is domain-aware once the canonical Granit JSON converters are
+/// applied (as <c>AddGranitCaching</c> now does): a DTO carrying a <see cref="SingleValueObject{T}"/>
+/// and an enum serializes to the same flat shape used by the HTTP pipeline and round-trips through
+/// both the bare SystemTextJson serializer and the encrypting decorator (the production path).
+/// </summary>
+public sealed class GranitJsonCacheSerializationTests
+{
+    private enum Kind { Alpha, Beta }
+
+    private sealed class TestUrl : SingleValueObject<string>
+    {
+        public override required string Value { get; init; }
+
+        public static TestUrl Of(string value) => new() { Value = value };
+    }
+
+    private sealed record CachedShape(TestUrl Canonical, Kind Kind, string Name);
+
+    private static JsonSerializerOptions GranitOptions() =>
+        new JsonSerializerOptions().AddGranitJsonConverters();
+
+    [Fact]
+    public void Value_objects_serialize_flat_and_enums_as_names()
+    {
+        string json = JsonSerializer.Serialize(
+            new CachedShape(TestUrl.Of("https://acme.test/a"), Kind.Beta, "home"),
+            GranitOptions());
+
+        json.ShouldContain("\"https://acme.test/a\"");   // flattened SingleValueObject
+        json.ShouldNotContain("\"Canonical\":{");         // not wrapped as { "Value": ... }
+        json.ShouldContain("\"Beta\"");                   // enum as name, not its ordinal
+    }
+
+    [Fact]
+    public void A_value_object_bearing_dto_round_trips_through_the_json_serializer()
+    {
+        var serializer = new FusionCacheSystemTextJsonSerializer(GranitOptions());
+        var original = new CachedShape(TestUrl.Of("https://acme.test/a"), Kind.Beta, "home");
+
+        byte[] bytes = serializer.Serialize(original);
+        CachedShape? round = serializer.Deserialize<CachedShape>(bytes);
+
+        round.ShouldNotBeNull();
+        round.Canonical.Value.ShouldBe("https://acme.test/a");
+        round.Kind.ShouldBe(Kind.Beta);
+        round.Name.ShouldBe("home");
+    }
+
+    [Fact]
+    public void A_value_object_bearing_dto_round_trips_through_the_encrypting_serializer()
+    {
+        var encryptor = new AesCacheValueEncryptor(
+            Microsoft.Extensions.Options.Options.Create(new CacheEncryptionOptions
+            {
+                Key = Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32)),
+            }));
+        var sut = new EncryptingFusionCacheSerializer(
+            new FusionCacheSystemTextJsonSerializer(GranitOptions()),
+            encryptor,
+            new CachingOptions { EncryptValues = true });
+
+        var original = new CachedShape(TestUrl.Of("https://acme.test/b"), Kind.Alpha, "about");
+        byte[] bytes = sut.Serialize(original);
+        CachedShape? round = sut.Deserialize<CachedShape>(bytes);
+
+        round.ShouldNotBeNull();
+        round.Canonical.Value.ShouldBe("https://acme.test/b");
+        round.Kind.ShouldBe(Kind.Alpha);
+        round.Name.ShouldBe("about");
+    }
+}

--- a/tests/Granit.Tests/Json/GranitJsonConvertersTests.cs
+++ b/tests/Granit.Tests/Json/GranitJsonConvertersTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Json;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Json;
+
+public sealed class GranitJsonConvertersTests
+{
+    private static int Count<T>(JsonSerializerOptions options) =>
+        options.Converters.Count(c => c is T);
+
+    [Fact]
+    public void AddGranitJsonConverters_OnEmptyOptions_AddsBothConverters()
+    {
+        JsonSerializerOptions options = new();
+
+        options.AddGranitJsonConverters();
+
+        Count<JsonStringEnumConverter>(options).ShouldBe(1);
+        Count<SingleValueObjectJsonConverterFactory>(options).ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddGranitJsonConverters_ReturnsSameInstance()
+    {
+        JsonSerializerOptions options = new();
+
+        options.AddGranitJsonConverters().ShouldBeSameAs(options);
+    }
+
+    [Fact]
+    public void AddGranitJsonConverters_CalledTwice_DoesNotDuplicate()
+    {
+        JsonSerializerOptions options = new();
+
+        options.AddGranitJsonConverters();
+        options.AddGranitJsonConverters();
+
+        Count<JsonStringEnumConverter>(options).ShouldBe(1);
+        Count<SingleValueObjectJsonConverterFactory>(options).ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddGranitJsonConverters_PreservesPreexistingEnumConverter()
+    {
+        JsonSerializerOptions options = new();
+        var hostConverter = new JsonStringEnumConverter(JsonNamingPolicy.CamelCase);
+        options.Converters.Add(hostConverter);
+
+        options.AddGranitJsonConverters();
+
+        // The host's converter is left in place (not duplicated, not replaced)...
+        Count<JsonStringEnumConverter>(options).ShouldBe(1);
+        options.Converters.OfType<JsonStringEnumConverter>().Single().ShouldBeSameAs(hostConverter);
+        // ...while the still-missing factory is added.
+        Count<SingleValueObjectJsonConverterFactory>(options).ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddGranitJsonConverters_PreservesPreexistingFactory()
+    {
+        JsonSerializerOptions options = new();
+        var hostFactory = new SingleValueObjectJsonConverterFactory();
+        options.Converters.Add(hostFactory);
+
+        options.AddGranitJsonConverters();
+
+        Count<SingleValueObjectJsonConverterFactory>(options).ShouldBe(1);
+        options.Converters.OfType<SingleValueObjectJsonConverterFactory>().Single().ShouldBeSameAs(hostFactory);
+        Count<JsonStringEnumConverter>(options).ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddGranitJsonConverters_NullOptions_Throws()
+    {
+        JsonSerializerOptions options = null!;
+
+        Should.Throw<ArgumentNullException>(() => options.AddGranitJsonConverters());
+    }
+}


### PR DESCRIPTION
## Summary

The FusionCache L2 serializer was built from `CachingOptions.JsonOptions` (null by default) with vanilla `System.Text.Json`, so it could not round-trip DTOs containing a `SingleValueObject<T>` (e.g. `AbsoluteUrl`) — the `SingleValueObjectJsonConverterFactory` was wired only into the ASP.NET HTTP pipeline. Cachers were therefore limited to primitive-shaped DTOs.

This extracts the canonical converter set into `Granit.Json.AddGranitJsonConverters` (`JsonStringEnumConverter` + `SingleValueObjectJsonConverterFactory`, idempotent) and applies it in **both** the HTTP defaults and the `AddGranitCaching` serializer registration. A value object now serialises to the same flat shape and round-trips identically over HTTP and L2, so cachers can store domain `*Response`/projection DTOs.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Changes

- **New** `Granit.Json.GranitJsonConverters.AddGranitJsonConverters(this JsonSerializerOptions)` — the single source of truth for the Granit converter set. Idempotent: a converter of the same type already present is preserved, so it is safe on host-supplied options or when called more than once.
- `AddGranitCaching` now applies the converters to the L2 serializer. Host-supplied `JsonOptions` are **copied** (never mutated) before the converters are added — avoids mutating frozen `System.Text.Json` options.
- HTTP `ConfigureHttpJsonOptions` refactored onto the same helper (behaviour-equivalent, now idempotent).
- Tests: SVO+enum DTO round-trips through both the bare `SystemTextJson` serializer and the encrypting decorator (the production path); a dedicated suite locks down the `AddGranitJsonConverters` idempotency contract.

## Checklist

- [x] Tests pass — FusionCache serializer **18**, base Json **18**, caching unit **64**, Redis L2 integration **7** (real Testcontainers), StackExchangeRedis **33**
- [x] Build succeeds (0 warnings)
- [x] Format verified (`dotnet format --verify-no-changes` clean on changed projects)
- [x] Markdownlint — N/A (no `.md` modified)
- [ ] Documentation — the new public API note ships separately against `granit-docs` (code/docs decoupled per CLAUDE.md)
- [x] No hardcoded secrets