### PR TITLE
fix(privacy): self-wire BlobStorage staging infra in provider builder extensions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6025,7 +6025,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Privacy",
       "file": "src/Granit.Auditing.Privacy/Extensions/PrivacyBuilderAuditingExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitAuditingPrivacyProvider",
@@ -24950,7 +24950,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Privacy",
       "file": "src/Granit.Identity.Federated.Privacy/Extensions/PrivacyBuilderIdentityFederatedExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitIdentityFederatedPrivacyProvider",
@@ -26976,7 +26976,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Privacy",
       "file": "src/Granit.Identity.Local.Privacy/Extensions/PrivacyBuilderIdentityLocalExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitIdentityLocalPrivacyProvider",
@@ -33914,7 +33914,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Privacy",
       "file": "src/Granit.Notifications.Privacy/Extensions/PrivacyBuilderNotificationsExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitNotificationsPrivacyProvider",

--- a/src/Granit.Auditing.Privacy/Extensions/PrivacyBuilderAuditingExtensions.cs
+++ b/src/Granit.Auditing.Privacy/Extensions/PrivacyBuilderAuditingExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Auditing.Privacy.DataExport;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage.Extensions;
 
 namespace Granit.Auditing.Privacy.Extensions;
 
@@ -13,13 +14,18 @@ public static class PrivacyBuilderAuditingExtensions
     /// and adds <c>"auditing"</c> to the scatter-gather registry.
     /// </summary>
     /// <remarks>
-    /// The matching Wolverine handler is discovered automatically. Requires
-    /// <see cref="GranitAuditingPrivacyModule"/> to be loaded.
+    /// The matching Wolverine handler is discovered automatically. This call also wires the
+    /// <c>Granit.Privacy.BlobStorage</c> staging infrastructure the provider depends on
+    /// (<c>IStagedFragmentBuilder</c>, uploader, assembler) — registration is idempotent
+    /// (<c>TryAdd</c>), so the host no longer needs an explicit
+    /// <c>[DependsOn(GranitPrivacyBlobStorageModule)]</c>. The provider still requires
+    /// <c>GranitAuditingModule</c> (for <c>IAuditingReader</c>) to be loaded.
     /// </remarks>
     public static GranitPrivacyBuilder AddGranitAuditingPrivacyProvider(
         this GranitPrivacyBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddGranitPrivacyBlobStorage();
         return builder.AddDataProvider<AuditingPrivacyDataProvider>();
     }
 }

--- a/src/Granit.Identity.Federated.Privacy/Extensions/PrivacyBuilderIdentityFederatedExtensions.cs
+++ b/src/Granit.Identity.Federated.Privacy/Extensions/PrivacyBuilderIdentityFederatedExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Identity.Federated.Privacy.DataExport;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage.Extensions;
 
 namespace Granit.Identity.Federated.Privacy.Extensions;
 
@@ -14,13 +15,18 @@ public static class PrivacyBuilderIdentityFederatedExtensions
     /// <c>"identity-federated"</c> to the scatter-gather registry.
     /// </summary>
     /// <remarks>
-    /// The matching Wolverine handler is discovered automatically. Requires
-    /// <see cref="GranitIdentityFederatedPrivacyModule"/> to be loaded.
+    /// The matching Wolverine handler is discovered automatically. This call also wires the
+    /// <c>Granit.Privacy.BlobStorage</c> staging infrastructure the provider depends on
+    /// (<c>IStagedFragmentBuilder</c>, uploader, assembler) — registration is idempotent
+    /// (<c>TryAdd</c>), so the host no longer needs an explicit
+    /// <c>[DependsOn(GranitPrivacyBlobStorageModule)]</c>. The provider still requires
+    /// <c>GranitIdentityFederatedModule</c> (for <c>IFederatedUserCacheReader</c>) to be loaded.
     /// </remarks>
     public static GranitPrivacyBuilder AddGranitIdentityFederatedPrivacyProvider(
         this GranitPrivacyBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddGranitPrivacyBlobStorage();
         return builder.AddDataProvider<IdentityFederatedPrivacyDataProvider>();
     }
 }

--- a/src/Granit.Identity.Local.Privacy/Extensions/PrivacyBuilderIdentityLocalExtensions.cs
+++ b/src/Granit.Identity.Local.Privacy/Extensions/PrivacyBuilderIdentityLocalExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Identity.Local.Privacy.DataExport;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage.Extensions;
 
 namespace Granit.Identity.Local.Privacy.Extensions;
 
@@ -15,13 +16,18 @@ public static class PrivacyBuilderIdentityLocalExtensions
     /// the export saga expects fragments from.
     /// </summary>
     /// <remarks>
-    /// The matching Wolverine handler is discovered automatically. Requires
-    /// <see cref="GranitIdentityLocalPrivacyModule"/> to be loaded.
+    /// The matching Wolverine handler is discovered automatically. This call also wires the
+    /// <c>Granit.Privacy.BlobStorage</c> staging infrastructure the provider depends on
+    /// (<c>IStagedFragmentBuilder</c>, uploader, assembler) — registration is idempotent
+    /// (<c>TryAdd</c>), so the host no longer needs an explicit
+    /// <c>[DependsOn(GranitPrivacyBlobStorageModule)]</c>. The provider still requires the
+    /// <c>Granit.Identity.Local</c> identity stack (for <c>UserManager&lt;LocalIdentity&gt;</c>) to be loaded.
     /// </remarks>
     public static GranitPrivacyBuilder AddGranitIdentityLocalPrivacyProvider(
         this GranitPrivacyBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddGranitPrivacyBlobStorage();
         return builder.AddDataProvider<IdentityLocalPrivacyDataProvider>();
     }
 }

--- a/src/Granit.Notifications.Privacy/Extensions/PrivacyBuilderNotificationsExtensions.cs
+++ b/src/Granit.Notifications.Privacy/Extensions/PrivacyBuilderNotificationsExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Notifications.Privacy.DataExport;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage.Extensions;
 
 namespace Granit.Notifications.Privacy.Extensions;
 
@@ -13,13 +14,18 @@ public static class PrivacyBuilderNotificationsExtensions
     /// to the scatter-gather registry.
     /// </summary>
     /// <remarks>
-    /// The matching Wolverine handler is discovered automatically. Requires
-    /// <see cref="GranitNotificationsPrivacyModule"/> to be loaded.
+    /// The matching Wolverine handler is discovered automatically. This call also wires the
+    /// <c>Granit.Privacy.BlobStorage</c> staging infrastructure the provider depends on
+    /// (<c>IStagedFragmentBuilder</c>, uploader, assembler) — registration is idempotent
+    /// (<c>TryAdd</c>), so the host no longer needs an explicit
+    /// <c>[DependsOn(GranitPrivacyBlobStorageModule)]</c>. The provider still requires
+    /// <c>GranitNotificationsModule</c> (for the notification readers) to be loaded.
     /// </remarks>
     public static GranitPrivacyBuilder AddGranitNotificationsPrivacyProvider(
         this GranitPrivacyBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddGranitPrivacyBlobStorage();
         return builder.AddDataProvider<NotificationsPrivacyDataProvider>();
     }
 }

--- a/tests/Granit.Auditing.Privacy.Tests/Extensions/PrivacyBuilderAuditingExtensionsTests.cs
+++ b/tests/Granit.Auditing.Privacy.Tests/Extensions/PrivacyBuilderAuditingExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Granit.Auditing.Privacy.DataExport;
 using Granit.Auditing.Privacy.Extensions;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
@@ -18,8 +19,21 @@ public sealed class PrivacyBuilderAuditingExtensionsTests
         GranitPrivacyBuilder returned = builder.AddGranitAuditingPrivacyProvider();
 
         returned.ShouldBeSameAs(builder);
-        ServiceDescriptor descriptor = services.ShouldHaveSingleItem();
-        descriptor.ServiceType.ShouldBe(typeof(AuditingPrivacyDataProvider));
+        ServiceDescriptor descriptor = services.Single(d => d.ServiceType == typeof(AuditingPrivacyDataProvider));
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitAuditingPrivacyProvider_WiresBlobStorageStagingInfrastructure()
+    {
+        // The provider's ctor hard-depends on IStagedFragmentBuilder; the builder call must
+        // register the Granit.Privacy.BlobStorage staging infra so a host does not need a
+        // separate [DependsOn(GranitPrivacyBlobStorageModule)].
+        ServiceCollection services = new();
+        GranitPrivacyBuilder builder = new(services);
+
+        builder.AddGranitAuditingPrivacyProvider();
+
+        services.ShouldContain(d => d.ServiceType == typeof(IStagedFragmentBuilder));
     }
 }

--- a/tests/Granit.Identity.Federated.Privacy.Tests/Extensions/PrivacyBuilderIdentityFederatedExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/Extensions/PrivacyBuilderIdentityFederatedExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Granit.Identity.Federated.Privacy.DataExport;
 using Granit.Identity.Federated.Privacy.Extensions;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
@@ -18,8 +19,21 @@ public sealed class PrivacyBuilderIdentityFederatedExtensionsTests
         GranitPrivacyBuilder returned = builder.AddGranitIdentityFederatedPrivacyProvider();
 
         returned.ShouldBeSameAs(builder);
-        ServiceDescriptor descriptor = services.ShouldHaveSingleItem();
-        descriptor.ServiceType.ShouldBe(typeof(IdentityFederatedPrivacyDataProvider));
+        ServiceDescriptor descriptor = services.Single(d => d.ServiceType == typeof(IdentityFederatedPrivacyDataProvider));
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitIdentityFederatedPrivacyProvider_WiresBlobStorageStagingInfrastructure()
+    {
+        // The provider's ctor hard-depends on IStagedFragmentBuilder; the builder call must
+        // register the Granit.Privacy.BlobStorage staging infra so a host does not need a
+        // separate [DependsOn(GranitPrivacyBlobStorageModule)].
+        ServiceCollection services = new();
+        GranitPrivacyBuilder builder = new(services);
+
+        builder.AddGranitIdentityFederatedPrivacyProvider();
+
+        services.ShouldContain(d => d.ServiceType == typeof(IStagedFragmentBuilder));
     }
 }

--- a/tests/Granit.Identity.Local.Privacy.Tests/Extensions/PrivacyBuilderIdentityLocalExtensionsTests.cs
+++ b/tests/Granit.Identity.Local.Privacy.Tests/Extensions/PrivacyBuilderIdentityLocalExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Granit.Identity.Local.Privacy.DataExport;
 using Granit.Identity.Local.Privacy.Extensions;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
@@ -18,8 +19,21 @@ public sealed class PrivacyBuilderIdentityLocalExtensionsTests
         GranitPrivacyBuilder returned = builder.AddGranitIdentityLocalPrivacyProvider();
 
         returned.ShouldBeSameAs(builder);
-        ServiceDescriptor descriptor = services.ShouldHaveSingleItem();
-        descriptor.ServiceType.ShouldBe(typeof(IdentityLocalPrivacyDataProvider));
+        ServiceDescriptor descriptor = services.Single(d => d.ServiceType == typeof(IdentityLocalPrivacyDataProvider));
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitIdentityLocalPrivacyProvider_WiresBlobStorageStagingInfrastructure()
+    {
+        // The provider's ctor hard-depends on IStagedFragmentBuilder; the builder call must
+        // register the Granit.Privacy.BlobStorage staging infra so a host does not need a
+        // separate [DependsOn(GranitPrivacyBlobStorageModule)].
+        ServiceCollection services = new();
+        GranitPrivacyBuilder builder = new(services);
+
+        builder.AddGranitIdentityLocalPrivacyProvider();
+
+        services.ShouldContain(d => d.ServiceType == typeof(IStagedFragmentBuilder));
     }
 }

--- a/tests/Granit.Notifications.Privacy.Tests/Extensions/PrivacyBuilderNotificationsExtensionsTests.cs
+++ b/tests/Granit.Notifications.Privacy.Tests/Extensions/PrivacyBuilderNotificationsExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Granit.Notifications.Privacy.DataExport;
 using Granit.Notifications.Privacy.Extensions;
 using Granit.Privacy;
+using Granit.Privacy.BlobStorage;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
@@ -18,8 +19,21 @@ public sealed class PrivacyBuilderNotificationsExtensionsTests
         GranitPrivacyBuilder returned = builder.AddGranitNotificationsPrivacyProvider();
 
         returned.ShouldBeSameAs(builder);
-        ServiceDescriptor descriptor = services.ShouldHaveSingleItem();
-        descriptor.ServiceType.ShouldBe(typeof(NotificationsPrivacyDataProvider));
+        ServiceDescriptor descriptor = services.Single(d => d.ServiceType == typeof(NotificationsPrivacyDataProvider));
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitNotificationsPrivacyProvider_WiresBlobStorageStagingInfrastructure()
+    {
+        // The provider's ctor hard-depends on IStagedFragmentBuilder; the builder call must
+        // register the Granit.Privacy.BlobStorage staging infra so a host does not need a
+        // separate [DependsOn(GranitPrivacyBlobStorageModule)].
+        ServiceCollection services = new();
+        GranitPrivacyBuilder builder = new(services);
+
+        builder.AddGranitNotificationsPrivacyProvider();
+
+        services.ShouldContain(d => d.ServiceType == typeof(IStagedFragmentBuilder));
     }
 }


### PR DESCRIPTION
## Problem

A host that opts a privacy data provider in via the documented builder entry point — `AddGranitPrivacy(p => p.AddGranitAuditingPrivacyProvider())` — but does **not** also `[DependsOn(GranitPrivacyBlobStorageModule)]` (directly or transitively) fails DI validation at startup:

```
Unable to resolve service for type 'Granit.Privacy.BlobStorage.IStagedFragmentBuilder'
while attempting to activate 'Granit.Auditing.Privacy.DataExport.AuditingPrivacyDataProvider'.
```

Reproduced in the IoT showcase, which loads no other privacy module that pulls in BlobStorage. The main showcase only avoids the crash *by chance*, because `GranitPartiesPrivacyModule` happens to `[DependsOn(GranitPrivacyBlobStorageModule)]`.

## Root cause

Each provider has **two** registration paths that diverge:

| Path | Effect |
| --- | --- |
| `[DependsOn(GranitAuditingPrivacyModule)]` (module) | loads the module **and** its `GranitPrivacyBlobStorageModule` dependency → `IStagedFragmentBuilder` registered |
| `AddGranitAuditingPrivacyProvider()` (builder) | registers the provider only, **bypassing module loading** → BlobStorage never wired |

The module chain is correct; the builder extension — the path hosts actually use — was not self-sufficient. The hard `IStagedFragmentBuilder` ctor dependency was left implicit and only mentioned in an XML-doc remark, producing a cryptic startup failure when forgotten.

## Fix

Each builder extension now calls `builder.Services.AddGranitPrivacyBlobStorage()` before `AddDataProvider<T>()`. That registration is idempotent (`TryAdd*` throughout; `AddHostedService` via `TryAddEnumerable`), so:

- a single `AddGranitXxxPrivacyProvider()` call is self-sufficient — no `[DependsOn(GranitPrivacyBlobStorageModule)]` required on the host;
- safe to call multiple times (the IoT host registers 3 providers → 3× call, no duplicate registrations);
- safe to combine with the module path (no double-registration).

Affected packages: `Granit.Auditing.Privacy`, `Granit.Notifications.Privacy`, `Granit.Identity.Federated.Privacy`, `Granit.Identity.Local.Privacy`. XML-doc remarks updated (the BlobStorage infra is now auto-wired; only the underlying domain module — for the provider's readers — remains required).

## Tests

The 4 builder-extension tests previously pinned `ShouldHaveSingleItem()` (the old single-descriptor contract). Each now finds the provider descriptor explicitly + asserts it is Scoped, plus a new fact asserting `IStagedFragmentBuilder` is registered by the builder call. All green (10 / 9 / 9 / 9). Build clean (0 warnings, `TreatWarningsAsErrors`), `dotnet format --verify-no-changes` clean.

## Follow-ups (out of scope here)

- **granit-business**: `Granit.Parties.Privacy`'s `AddGranitPartiesPrivacyProvider()` has the same latent gap — same one-line fix needed there (separate repo / PR).
- **Showcases**: their explicit `[DependsOn(GranitPrivacyBlobStorageModule)]` becomes redundant (but harmless) once they consume a dev package with this fix.