### PR TITLE
chore(deps): align Roslyn analyzers to SDK compiler 5.3 via VersionOverride

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -198,10 +198,28 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.*" />
   </ItemGroup>
   <ItemGroup Label="Roslyn Analyzers">
-    <!-- Pinned to Roslyn 5.0 / Analyzers 3.x: bumping to 5.3 / 5.x pulls
-         System.Composition.AttributedModel 10.x, which breaks `dotnet format`
-         (the SDK ships with 9.x and fails to load the 10.x attribute assembly).
-         Revisit once dotnet format bundles a compatible System.Composition. -->
+    <!-- These central versions are the SHIPPED-package floor = the LOWEST Roslyn we support
+         (.NET 10 GA = 5.0). Granit.Analyzers and Granit.Localization.SourceGenerator ship as
+         analyzer packages (analyzers/dotnet/cs); an analyzer compiled against a newer Roslyn
+         than the consumer's SDK is rejected with CS9057. For the source generator that is a
+         HARD break (its generated code vanishes downstream), so it stays on this floor.
+
+         The dev-time analyzer/codefix projects opt UP to the SDK compiler (5.3.0) via
+         VersionOverride in their own .csproj (Granit.Analyzers, Granit.Analyzers.CodeFixes
+         and their test projects) — Granit.Analyzers only soft-disables on an older consumer
+         SDK (lint off, build fine), which we accept for the newer analyzer APIs. NEVER pin
+         the override above the running csc (SDK 10.0.201 = 5.3.0) or Granit's own build hits
+         CS9057. Keep these central entries on the floor — bumping them would also rewrite the
+         `requested` field of ~40 CentralTransitive Wolverine lockfiles for no runtime change.
+
+         System.Composition.AttributedModel is an INDEPENDENT constraint (not tied to the
+         Roslyn version): it must stay <= the System.Composition assembly bundled in the
+         running SDK's `dotnet format`, which loads our CodeFix [Export]/[Shared] attributes
+         (Granit.Analyzers.CodeFixes) from its OWN bundled copy and does not roll forward.
+         SDK 10.0.201 bundles 10.0.5; pinning AttributedModel to 10.0.8 makes `dotnet format`
+         crash with FileNotFoundException (System.Composition.AttributedModel, Version=10.0.0.8
+         at AnalyzerFinderHelpers.IsExportedForLanguage). 9.x is safe and is what
+         CodeAnalysis.CSharp.Workspaces 5.x depends on. Raise only to track the SDK's bundle. -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.*" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.*" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-05-26 (ajout de `PDFtoImage` pour `Granit.TextExtraction.Pdf.Ocr`)
+Dernière mise à jour : 2026-06-03 (alignement des analyzers Roslyn — Microsoft.CodeAnalysis.* — sur le compilateur du SDK 5.3.0 via `VersionOverride`)
 
 ---
 
@@ -184,9 +184,9 @@ Dernière mise à jour : 2026-05-26 (ajout de `PDFtoImage` pour `Granit.TextExtr
 | coverlet.collector | 10.0.1 | (c) 2018 Toni Solarin-Sodara |
 | JunitXml.TestLogger | 7.1.0 | JunitXml.TestLogger Contributors |
 | Microsoft.AspNetCore.Mvc.Testing | 10.0.8 | (c) Microsoft Corporation |
-| Microsoft.CodeAnalysis.Analyzers | 3.11.0 | (c) Microsoft Corporation |
-| Microsoft.CodeAnalysis.CSharp | 5.0.0 | (c) Microsoft Corporation |
-| Microsoft.CodeAnalysis.CSharp.Workspaces | 5.0.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.Analyzers | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.CSharp | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.CSharp.Workspaces | 5.3.0 | (c) Microsoft Corporation |
 | Microsoft.EntityFrameworkCore.InMemory | 10.0.8 | (c) Microsoft Corporation |
 | Microsoft.EntityFrameworkCore.Sqlite | 10.0.8 | (c) Microsoft Corporation |
 | Microsoft.Extensions.TimeProvider.Testing | 10.6.0 | (c) Microsoft Corporation |

--- a/src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj
+++ b/src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj
@@ -10,8 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Dev-only (IsPackable=false, loaded by `dotnet format`): opt up to the SDK compiler
+         (5.3.0) above the shipped-floor central pin. System.Composition.AttributedModel is
+         deliberately NOT overridden — it must track the central 9.x pin so `dotnet format`
+         can load these [Export]/[Shared] CodeFixes. See Directory.Packages.props. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="5.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Granit.Analyzers.CodeFixes/packages.lock.json
+++ b/src/Granit.Analyzers.CodeFixes/packages.lock.json
@@ -4,22 +4,22 @@
     ".NETStandard,Version=v2.0": {
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Direct",
-        "requested": "[3.*, )",
-        "resolved": "3.11.0",
-        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "KuLhbZwB0L8JikL86AE5VWEp3RLNjIcp+j8yz9EJ/UBgRz4+qDEjHg/tluRFbpYpD/e37BqaaNFbQ0vqawBwWQ=="
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "Direct",
-        "requested": "[5.0.*, )",
-        "resolved": "5.0.0",
-        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "mRwxchBs3ewXK4dqK4R/eVCx99VIq1k/lhwArlu+fJuV0uzmbkTTRw4jR9gN9sOcAQfX0uV9KQlmCk1yC0JNog==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.CSharp": "[5.3.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.3.0]",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "9.0.0",
           "System.Composition": "9.0.0",
@@ -63,10 +63,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.3.0",
+        "contentHash": "uC0qk3jzTQY7i90ehfnCqaOZpBUGJyPMiHJ3c0jOb8yaPBjWzIhVdNxPbeVzI74DB0C+YgBKPLqUkgFZzua5Mg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "9.0.0",
           "System.Memory": "4.6.0",
@@ -79,13 +79,13 @@
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "resolved": "5.3.0",
+        "contentHash": "QSf1ge9A+XFZbGL+gIqXYBIKlm8QdQVLvHDPZiydG11W6mJY7XBMusrsgIEz6L8GYMzGJKTM78m9icliGMF7NA==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "9.0.0",
           "System.Composition": "9.0.0",
@@ -228,17 +228,17 @@
       "granit.analyzers": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.*, )"
+          "Microsoft.CodeAnalysis.CSharp": "[5.3.0, )"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
         "requested": "[5.0.*, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "resolved": "5.3.0",
+        "contentHash": "SQFNGQF4f7UfDXKxMzzGNMr3fjrPDIjLfmRvvVgDCw+dyvEHDaRfHuKA5q0Pr0/JW0Gcw89TxrxrS/MjwBvluQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "9.0.0",
           "System.Memory": "4.6.0",

--- a/src/Granit.Analyzers/Granit.Analyzers.csproj
+++ b/src/Granit.Analyzers/Granit.Analyzers.csproj
@@ -24,8 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Opt this dev-time analyzer up to the SDK compiler (5.3.0) above the shipped-floor
+         central pin (5.0). On a consumer SDK older than 5.3 this only soft-disables the
+         analyzer (CS9057, lint off, build unaffected). Keep <= the running csc. See the
+         "Roslyn Analyzers" note in Directory.Packages.props. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="5.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Granit.Analyzers/packages.lock.json
+++ b/src/Granit.Analyzers/packages.lock.json
@@ -4,18 +4,18 @@
     ".NETStandard,Version=v2.0": {
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Direct",
-        "requested": "[3.*, )",
-        "resolved": "3.11.0",
-        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "KuLhbZwB0L8JikL86AE5VWEp3RLNjIcp+j8yz9EJ/UBgRz4+qDEjHg/tluRFbpYpD/e37BqaaNFbQ0vqawBwWQ=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.*, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "SQFNGQF4f7UfDXKxMzzGNMr3fjrPDIjLfmRvvVgDCw+dyvEHDaRfHuKA5q0Pr0/JW0Gcw89TxrxrS/MjwBvluQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "9.0.0",
           "System.Memory": "4.6.0",
@@ -37,10 +37,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.3.0",
+        "contentHash": "uC0qk3jzTQY7i90ehfnCqaOZpBUGJyPMiHJ3c0jOb8yaPBjWzIhVdNxPbeVzI74DB0C+YgBKPLqUkgFZzua5Mg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "9.0.0",
           "System.Memory": "4.6.0",

--- a/tests/Granit.Analyzers.CodeFixes.Tests/Granit.Analyzers.CodeFixes.Tests.csproj
+++ b/tests/Granit.Analyzers.CodeFixes.Tests/Granit.Analyzers.CodeFixes.Tests.csproj
@@ -11,8 +11,10 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <!-- Match the CodeFix Roslyn (5.3.0 override in Granit.Analyzers.CodeFixes) so the test
+         harness loads the same compiler version. See Directory.Packages.props. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.Analyzers.CodeFixes.Tests/packages.lock.json
+++ b/tests/Granit.Analyzers.CodeFixes.Tests/packages.lock.json
@@ -16,25 +16,25 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.*, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "SQFNGQF4f7UfDXKxMzzGNMr3fjrPDIjLfmRvvVgDCw+dyvEHDaRfHuKA5q0Pr0/JW0Gcw89TxrxrS/MjwBvluQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]"
         }
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "Direct",
-        "requested": "[5.0.*, )",
-        "resolved": "5.0.0",
-        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "mRwxchBs3ewXK4dqK4R/eVCx99VIq1k/lhwArlu+fJuV0uzmbkTTRw4jR9gN9sOcAQfX0uV9KQlmCk1yC0JNog==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.CSharp": "[5.3.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.3.0]",
           "System.Composition": "9.0.0"
         }
       },
@@ -104,20 +104,20 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.3.0",
+        "contentHash": "uC0qk3jzTQY7i90ehfnCqaOZpBUGJyPMiHJ3c0jOb8yaPBjWzIhVdNxPbeVzI74DB0C+YgBKPLqUkgFZzua5Mg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "resolved": "5.3.0",
+        "contentHash": "QSf1ge9A+XFZbGL+gIqXYBIKlm8QdQVLvHDPZiydG11W6mJY7XBMusrsgIEz6L8GYMzGJKTM78m9icliGMF7NA==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]",
           "System.Composition": "9.0.0"
         }
       },
@@ -306,13 +306,13 @@
       "granit.analyzers": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.*, )"
+          "Microsoft.CodeAnalysis.CSharp": "[5.3.0, )"
         }
       },
       "granit.analyzers.codefixes": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.*, )",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.3.0, )",
           "System.Composition.AttributedModel": "[9.*, )"
         }
       },
@@ -321,7 +321,7 @@
         "dependencies": {
           "Granit.Analyzers": "[0.1.0-dev, )",
           "JunitXml.TestLogger": "[7.*, )",
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.*, )",
+          "Microsoft.CodeAnalysis.CSharp": "[5.3.0, )",
           "Microsoft.NET.Test.Sdk": "[18.*, )",
           "Shouldly": "[4.*, )",
           "coverlet.collector": "[10.*, )",
@@ -332,8 +332,8 @@
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "CentralTransitive",
         "requested": "[3.*, )",
-        "resolved": "3.11.0",
-        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+        "resolved": "5.3.0-2.25625.1",
+        "contentHash": "4Yhh2fnu3G+J0J1lDc8WZVgMjgbynSeTfkl5IFJMFrmiIO0sc7Tjx+f3sFVV8Sd35PrIUWfof0RWc3lAMl7Azg=="
       },
       "System.Composition.AttributedModel": {
         "type": "CentralTransitive",

--- a/tests/Granit.Analyzers.Tests/Granit.Analyzers.Tests.csproj
+++ b/tests/Granit.Analyzers.Tests/Granit.Analyzers.Tests.csproj
@@ -11,7 +11,9 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <!-- Match the analyzer-under-test Roslyn (5.3.0 override in Granit.Analyzers) so the
+         test harness loads the same compiler version. See Directory.Packages.props. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.Analyzers.Tests/packages.lock.json
+++ b/tests/Granit.Analyzers.Tests/packages.lock.json
@@ -16,12 +16,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.*, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "SQFNGQF4f7UfDXKxMzzGNMr3fjrPDIjLfmRvvVgDCw+dyvEHDaRfHuKA5q0Pr0/JW0Gcw89TxrxrS/MjwBvluQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1",
+          "Microsoft.CodeAnalysis.Common": "[5.3.0]"
         }
       },
       "Microsoft.NET.Test.Sdk": {
@@ -85,10 +85,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.3.0",
+        "contentHash": "uC0qk3jzTQY7i90ehfnCqaOZpBUGJyPMiHJ3c0jOb8yaPBjWzIhVdNxPbeVzI74DB0C+YgBKPLqUkgFZzua5Mg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0-2.25625.1"
         }
       },
       "Microsoft.CodeCoverage": {
@@ -233,14 +233,14 @@
       "granit.analyzers": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.*, )"
+          "Microsoft.CodeAnalysis.CSharp": "[5.3.0, )"
         }
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "CentralTransitive",
         "requested": "[3.*, )",
-        "resolved": "3.11.0",
-        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+        "resolved": "5.3.0-2.25625.1",
+        "contentHash": "4Yhh2fnu3G+J0J1lDc8WZVgMjgbynSeTfkl5IFJMFrmiIO0sc7Tjx+f3sFVV8Sd35PrIUWfof0RWc3lAMl7Azg=="
       }
     }
   }


### PR DESCRIPTION
## What

Corrects the misleading `Directory.Packages.props` "Roslyn Analyzers" pin comment and aligns the **dev-time** analyzer/codefix projects with the SDK compiler (5.3.0), without raising the floor of the **shipped** analyzer packages.

## Why — the old comment was false

The old comment claimed bumping Roslyn to 5.3 pulls `System.Composition.AttributedModel` 10.x and breaks `dotnet format` "because the SDK ships 9.x". Verified false on SDK **10.0.201**: its bundled `dotnet-format` ships **System.Composition 10.0.5** and **Microsoft.CodeAnalysis 5.3.0**. The Roslyn version and the System.Composition pin are **two independent constraints**:

1. **Roslyn version is unrelated to the format break.** Building + `dotnet format --verify-no-changes` + the analyzer/source-gen test suites are all green on 5.3.0 (with `AttributedModel` at 9.x).
2. **The real format constraint is `System.Composition.AttributedModel`:** it must stay `<=` the copy `dotnet format` bundles. `dotnet format` loads our CodeFix `[Export]/[Shared]` attributes (`Granit.Analyzers.CodeFixes`) from its **own** bundled copy and does not roll forward. Pinning `AttributedModel` to `10.0.8` (> bundled `10.0.5`) crashes it:
   ```
   System.IO.FileNotFoundException: Could not load file or assembly
   'System.Composition.AttributedModel, Version=10.0.0.8'
     at AnalyzerFinderHelpers.IsExportedForLanguage
   ```

## How

- **Central pins stay on the shipped-package floor** (`5.0.*` / `3.*` = lowest supported Roslyn). `Granit.Analyzers` and `Granit.Localization.SourceGenerator` ship as analyzer packages; an analyzer compiled against a newer Roslyn than the consumer's SDK is rejected with **CS9057**. For the source generator that is a hard break downstream, so it stays on the floor.
- **Dev-time analyzer/codefix projects opt up to 5.3.0 via `VersionOverride`** (`Granit.Analyzers`, `Granit.Analyzers.CodeFixes` and their two test projects). `Granit.Analyzers` only soft-disables on an older consumer SDK (lint off, build fine).
- **`System.Composition.AttributedModel` stays `9.*`** (independent constraint; also what `Workspaces` 5.x depends on).
- `VersionOverride` is used instead of a central bump to avoid rewriting the `requested` field of ~40 `CentralTransitive` Wolverine lockfiles for **no runtime change** (transitive pinning is off; `resolved` stays 5.0.0 there).
- Comment in `Directory.Packages.props` rewritten with the two real constraints + the exact repro.
- `THIRD-PARTY-NOTICES.md` updated for the bumped versions.

## Verification (SDK 10.0.201)

- `dotnet restore --locked-mode` on all 4 overridden projects ✓
- `dotnet build` analyzers/codefixes — 0 warnings, 0 errors ✓
- `dotnet format --verify-no-changes` (the historical break vector) — exit 0 ✓
- Test suites: `Granit.Analyzers.Tests` **116**, `Granit.Analyzers.CodeFixes.Tests` **32**, `Granit.Localization.SourceGenerator.Tests` **10** — all green ✓
- Blast radius: 4 analyzer lockfiles only; source-generator and the ~40 Wolverine lockfiles untouched.

## Notes

This pin block was cargo-culted into `granit-business` where it was **inert** (no source-gen/analyzer projects) and correctly removed there. Here it is real — do not mirror that removal.