### PR TITLE
feat(wolverine): configurable production codegen + native tenant id

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -51587,7 +51587,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Options/WolverineMessagingOptions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "FromSeconds",
@@ -51600,6 +51600,12 @@
           "kind": "property",
           "signature": "int MaxRetryAttempts",
           "returnType": "int"
+        },
+        {
+          "name": "CodeGenerationMode",
+          "kind": "property",
+          "signature": "TypeLoadMode CodeGenerationMode",
+          "returnType": "TypeLoadMode"
         }
       ]
     },

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -136,6 +136,12 @@ public static class WolverineHostApplicationBuilderExtensions
                 opts.Discovery.IncludeAssembly(entryAssembly);
             }
 
+            // Code-generation mode. Default Dynamic — runtime Roslyn via the transitively
+            // referenced WolverineFx.RuntimeCompilation. Consumers opt into Static for production
+            // via "Wolverine:CodeGenerationMode" AFTER running `dotnet run -- codegen write` in
+            // their build; Static has no runtime fallback, so a missing artifact throws at startup.
+            opts.CodeGeneration.TypeLoadMode = messagingOptions.CodeGenerationMode;
+
             // IDomainEvent — force local routing, never forward to external transports.
             // IIntegrationEvent routing is configured by the provider package.
             opts.PublishMessage<Events.IDomainEvent>()

--- a/src/Granit.Wolverine/Middleware/OutgoingContextMiddleware.cs
+++ b/src/Granit.Wolverine/Middleware/OutgoingContextMiddleware.cs
@@ -51,7 +51,14 @@ public sealed class OutgoingContextMiddleware(
     {
         if (currentTenant.Id.HasValue)
         {
-            envelope.Headers[TenantIdHeader] = currentTenant.Id.Value.ToString();
+            string tenantId = currentTenant.Id.Value.ToString();
+            envelope.Headers[TenantIdHeader] = tenantId;
+
+            // Mirror into Wolverine's native tenant slot (in addition to the custom header) so
+            // wolverine.* spans/metrics and any native multi-tenant routing observe the tenant
+            // without parsing X-Tenant-Id. TenantContextBehavior still restores ICurrentTenant
+            // from the header — this is purely additive for native observability.
+            envelope.TenantId = tenantId;
         }
 
         if (currentUserService.IsAuthenticated && currentUserService.UserId is { Length: > 0 } userId)

--- a/src/Granit.Wolverine/Options/WolverineMessagingOptions.cs
+++ b/src/Granit.Wolverine/Options/WolverineMessagingOptions.cs
@@ -1,3 +1,5 @@
+using JasperFx.CodeGeneration;
+
 namespace Granit.Wolverine.Options;
 
 /// <summary>
@@ -30,4 +32,24 @@ public sealed class WolverineMessagingOptions
     /// Must be ≥ 1. Default: 3.
     /// </summary>
     public int MaxRetryAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Wolverine handler/endpoint code-generation mode. Default <see cref="TypeLoadMode.Dynamic"/>:
+    /// types are generated at runtime via Roslyn (requires <c>WolverineFx.RuntimeCompilation</c>,
+    /// referenced transitively by <c>Granit.Wolverine</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set to <see cref="TypeLoadMode.Static"/> in production to remove cold-start Roslyn
+    /// compilation and its memory overhead. <b>Static requires pre-generated code</b>: run
+    /// <c>dotnet run -- codegen write</c> in the build pipeline (e.g. a Docker build stage) and
+    /// ship the generated <c>Internal/Generated/</c> output — otherwise the host throws at startup
+    /// (no runtime fallback, no environment-based switching).
+    /// </para>
+    /// <para>
+    /// Bind via <c>"Wolverine:CodeGenerationMode": "Static"</c>. <see cref="TypeLoadMode.Auto"/>
+    /// is accepted but discouraged by the Wolverine community.
+    /// </para>
+    /// </remarks>
+    public TypeLoadMode CodeGenerationMode { get; set; } = TypeLoadMode.Dynamic;
 }

--- a/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
+++ b/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
@@ -12,7 +12,9 @@ using Granit.Users;
 using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Internal;
 using Granit.Wolverine.Options;
+using JasperFx.CodeGeneration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -128,4 +130,40 @@ public sealed class GranitWolverineModuleTests
 
         callbackInvoked.ShouldBeTrue();
     }
+
+    // -------------------------------------------------------------------------
+    // Code-generation mode wiring (config → opts.CodeGeneration.TypeLoadMode).
+    // Inspects the captured WolverineOptions without building the host, so Static
+    // never triggers the missing-pre-generated-types startup throw.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AddGranitWolverine_DefaultsCodeGenerationModeToDynamic()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.AddGranitWolverine();
+
+        ResolveWolverineOptions(builder).CodeGeneration.TypeLoadMode.ShouldBe(TypeLoadMode.Dynamic);
+    }
+
+    [Fact]
+    public void AddGranitWolverine_AppliesCodeGenerationModeFromConfig()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Wolverine:CodeGenerationMode"] = "Static",
+        });
+
+        builder.AddGranitWolverine();
+
+        ResolveWolverineOptions(builder).CodeGeneration.TypeLoadMode.ShouldBe(TypeLoadMode.Static);
+    }
+
+    private static global::Wolverine.WolverineOptions ResolveWolverineOptions(HostApplicationBuilder builder) =>
+        builder.Services
+            .Select(d => d.ImplementationInstance)
+            .OfType<WolverineOptionsHolder>()
+            .First()
+            .Options;
 }

--- a/tests/Granit.Wolverine.Tests/OutgoingContextMiddlewareTests.cs
+++ b/tests/Granit.Wolverine.Tests/OutgoingContextMiddlewareTests.cs
@@ -167,6 +167,43 @@ public sealed class OutgoingContextMiddlewareTests : IDisposable
     }
 
     // -------------------------------------------------------------------------
+    // Native Wolverine tenant slot (mirrored in addition to X-Tenant-Id)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Before_WithTenant_SetsNativeEnvelopeTenantId()
+    {
+        var tenantId = Guid.NewGuid();
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.Id.Returns(tenantId);
+
+        ICurrentUserService userService = Substitute.For<ICurrentUserService>();
+        userService.IsAuthenticated.Returns(false);
+
+        OutgoingContextMiddleware middleware = new(tenant, userService);
+        Envelope envelope = CreateEnvelope();
+
+        middleware.Before(envelope);
+
+        envelope.TenantId.ShouldBe(tenantId.ToString());
+        envelope.Headers[OutgoingContextMiddleware.TenantIdHeader].ShouldBe(tenantId.ToString());
+    }
+
+    [Fact]
+    public void Before_WithNoTenant_DoesNotSetNativeEnvelopeTenantId()
+    {
+        (ICurrentTenant tenant, ICurrentUserService userService) = CreateNullContext();
+
+        OutgoingContextMiddleware middleware = new(tenant, userService);
+        Envelope envelope = CreateEnvelope();
+
+        middleware.Before(envelope);
+
+        envelope.TenantId.ShouldBeNull();
+    }
+
+    // -------------------------------------------------------------------------
     // traceparent header (W3C Trace Context propagation)
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Wolverine.Tests/WolverineMessagingOptionsTests.cs
+++ b/tests/Granit.Wolverine.Tests/WolverineMessagingOptionsTests.cs
@@ -7,6 +7,7 @@
 
 using Granit.Wolverine.Internal;
 using Granit.Wolverine.Options;
+using JasperFx.CodeGeneration;
 using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
@@ -26,6 +27,10 @@ public sealed class WolverineMessagingOptionsTests
     [Fact]
     public void DefaultMaxRetryAttempts_IsThree() =>
         new WolverineMessagingOptions().MaxRetryAttempts.ShouldBe(3);
+
+    [Fact]
+    public void DefaultCodeGenerationMode_IsDynamic() =>
+        new WolverineMessagingOptions().CodeGenerationMode.ShouldBe(TypeLoadMode.Dynamic);
 
     [Fact]
     public void DefaultRetryDelays_AreFiveThirtyAndFiveMin()


### PR DESCRIPTION
Two small production-hardening changes from the Wolverine best-practices review (items 1 & 2 of the prioritized synthesis). Independent commits.

## 1. Configurable code-generation mode (`feat`)

Granit runs `TypeLoadMode.Dynamic` (runtime Roslyn codegen), so every cold start recompiles handler/endpoint chains — costly in RAM and startup time at scale.

- New `WolverineMessagingOptions.CodeGenerationMode` (default **Dynamic** = current behaviour), wired to `opts.CodeGeneration.TypeLoadMode` in `AddGranitWolverine`.
- Consumers opt into **Static** for production via `"Wolverine:CodeGenerationMode": "Static"`.

**Why an opt-in, not a default:** `Static` requires pre-generated code (`dotnet run -- codegen write` in the build + shipped `Internal/Generated/`) and has **no runtime fallback** — forcing it framework-wide would crash every consumer app that doesn't pre-generate. The framework can't enforce the build step, so the default stays Dynamic. A consumer-side `configure` callback still overrides the config value.

> Follow-ups (separate, not in this PR): granit-docs production-codegen recipe + showcase Dockerfile `codegen write` stage (cross-repo).

## 2. Mirror tenant into native `Envelope.TenantId` (`feat`)

`OutgoingContextMiddleware` injects the custom `X-Tenant-Id` header (consumed by `TenantContextBehavior` to restore `ICurrentTenant`). It now **also** sets Wolverine's native `Envelope.TenantId`, so `wolverine.*` spans/metrics and any native multi-tenant routing observe the tenant without parsing the header.

Purely additive — the custom header remains the source of truth for `ICurrentTenant` restoration (Granit uses `Guid?` tenancy with a single-DB row filter; the native slot is for observability).

## Tests

- `envelope.TenantId` set when a tenant is active, null otherwise.
- `CodeGenerationMode` default is Dynamic; config `"Static"` flows through to `opts.CodeGeneration.TypeLoadMode` (asserted on the captured `WolverineOptions` **without** building the host, so `Static` never triggers the missing-artifact startup throw).

✅ 163/163 `Granit.Wolverine.Tests` · format clean · no new package dependency (`JasperFx.CodeGeneration` is transitive).

## Not in this PR
Item 3 of the synthesis (Minimal API endpoints with a non-atomic DB-write + outbox-publish) is a confirmed cross-module gap — tracked as a separate issue/ADR.