### PR TITLE
fix(wolverine): set ApplicationAssembly to host entry assembly for Static codegen

### DIFF
--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -134,12 +134,25 @@ public static class WolverineHostApplicationBuilderExtensions
             if (entryAssembly is not null)
             {
                 opts.Discovery.IncludeAssembly(entryAssembly);
+
+                // Point Wolverine's ApplicationAssembly at the host's entry assembly. UseWolverine()
+                // is invoked from THIS library, so Wolverine would otherwise infer
+                // ApplicationAssembly = Granit.Wolverine. `dotnet run -- codegen write` emits the
+                // handlers + HandlerRegistry into the ENTRY assembly, and Static mode loads
+                // pre-generated types from ApplicationAssembly — the two must point at the same
+                // assembly or Static never finds the registry (see the CodeGenerationMode note
+                // below for how that failure surfaces).
+                opts.ApplicationAssembly = entryAssembly;
             }
 
             // Code-generation mode. Default Dynamic — runtime Roslyn via the transitively
             // referenced WolverineFx.RuntimeCompilation. Consumers opt into Static for production
             // via "Wolverine:CodeGenerationMode" AFTER running `dotnet run -- codegen write` in
-            // their build; Static has no runtime fallback, so a missing artifact throws at startup.
+            // their build. Static loads pre-generated types only and does not regenerate them
+            // itself; a missing or misplaced artifact therefore breaks the optimization —
+            // surfacing as a startup failure, or (because RuntimeCompilation stays on the
+            // classpath) a silent fall-back to runtime Roslyn. AssertAllPreGeneratedTypesExist
+            // forces fail-fast.
             opts.CodeGeneration.TypeLoadMode = messagingOptions.CodeGenerationMode;
 
             // IDomainEvent — force local routing, never forward to external transports.

--- a/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
+++ b/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
@@ -160,6 +160,19 @@ public sealed class GranitWolverineModuleTests
         ResolveWolverineOptions(builder).CodeGeneration.TypeLoadMode.ShouldBe(TypeLoadMode.Static);
     }
 
+    [Fact]
+    public void AddGranitWolverine_SetsApplicationAssembly_ToEntryAssembly()
+    {
+        // UseWolverine() runs from inside Granit.Wolverine, so without the explicit override
+        // Wolverine would infer ApplicationAssembly = Granit.Wolverine — and Static codegen
+        // would look for the pre-generated registry in the wrong assembly.
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.AddGranitWolverine();
+
+        ResolveWolverineOptions(builder).ApplicationAssembly
+            .ShouldBe(System.Reflection.Assembly.GetEntryAssembly());
+    }
+
     private static global::Wolverine.WolverineOptions ResolveWolverineOptions(HostApplicationBuilder builder) =>
         builder.Services
             .Select(d => d.ImplementationInstance)


### PR DESCRIPTION
Follow-up to #2533 (configurable production codegen). That PR added `Wolverine:CodeGenerationMode=Static` but, on its own, Static would not actually find the pre-generated code.

## The fix

`AddGranitWolverine` calls `UseWolverine()` from inside the `Granit.Wolverine` library, so Wolverine infers `ApplicationAssembly = Granit.Wolverine`. But `dotnet run -- codegen write` emits the generated handlers + `HandlerRegistry` into the **host's entry assembly**, and Static mode loads pre-generated types from `ApplicationAssembly`. The two must point at the same assembly or Static never finds the registry.

- Set `opts.ApplicationAssembly = entryAssembly` (inside the existing `entryAssembly is not null` guard; overridable via the `configure` callback which runs later).
- Reconcile the two code-gen failure-mode comments that previously contradicted each other (one said "silent Roslyn fall-back", the other "throws at startup"). They now agree: Static loads pre-generated types only and does not regenerate them, so a missing/misplaced artifact surfaces as a startup failure — or, because `WolverineFx.RuntimeCompilation` stays on the classpath, a silent Roslyn fall-back.
- Regression test: `AddGranitWolverine` sets `ApplicationAssembly` to the entry assembly.

✅ 164/164 `Granit.Wolverine.Tests` · format clean · no new dependency.

## Known limitation / follow-up (not in this PR)

`Granit.Wolverine.csproj` references `WolverineFx.RuntimeCompilation` **unconditionally**, so the Roslyn generator (~100 MB) ships in every consumer image even under Static — and a missing pre-generated artifact silently falls back to runtime Roslyn instead of failing fast. To fully realize Static's footprint/cold-start benefit, the framework should let consumers drop RuntimeCompilation in production (e.g. `PrivateAssets`/`ExcludeAssets` or a Debug-only reference pattern), and/or set `AssertAllPreGeneratedTypesExist` so a stale artifact fails fast. Tension with the reason RuntimeCompilation is transitive today (so Dynamic works out of the box) — to be decided separately.

> Note: full end-to-end verification (run `codegen write`, start under Static, confirm the registry loads) requires a host with the JasperFx CLI wired (`RunJasperFxCommands`) — tracked in the granit-docs + showcase follow-ups.