### PR TITLE
fix(wolverine): relax ServiceLocationPolicy so Static codegen succeeds

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -51507,7 +51507,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs",
-      "line": 26,
+      "line": 27,
       "members": [
         {
           "name": "AddGranitWolverine",

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Granit.Wolverine.Diagnostics;
 using Granit.Wolverine.Internal;
 using Granit.Wolverine.Middleware;
 using Granit.Wolverine.Options;
+using JasperFx.CodeGeneration.Model;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -154,6 +155,18 @@ public static class WolverineHostApplicationBuilderExtensions
             // classpath) a silent fall-back to runtime Roslyn. AssertAllPreGeneratedTypesExist
             // forces fail-fast.
             opts.CodeGeneration.TypeLoadMode = messagingOptions.CodeGenerationMode;
+
+            // Service-location policy for code generation. Wolverine 6 defaults to NotAllowed,
+            // which ABORTS `codegen write` (Static) when a chain dependency can't be inlined —
+            // true for three framework registrations reached via the context-propagation
+            // middleware on every chain: ICurrentUserService + IWolverineUserContextSetter
+            // (scoped forwarding factories onto the shared WolverineCurrentUserService) and the
+            // internal INotificationPublisher impl. AllowedButWarn lets codegen fall back to
+            // runtime service location for those (everything else still inlines), so Static works
+            // without each consumer setting it. The cleaner long-term fix is to make those
+            // registrations inline-able (direct interface→concrete + InternalsVisibleTo
+            // "WolverineHandlers") so NotAllowed can be restored — tracked as a follow-up.
+            opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn;
 
             // IDomainEvent — force local routing, never forward to external transports.
             // IIntegrationEvent routing is configured by the provider package.

--- a/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
+++ b/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
@@ -13,6 +13,7 @@ using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Internal;
 using Granit.Wolverine.Options;
 using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -171,6 +172,20 @@ public sealed class GranitWolverineModuleTests
 
         ResolveWolverineOptions(builder).ApplicationAssembly
             .ShouldBe(System.Reflection.Assembly.GetEntryAssembly());
+    }
+
+    [Fact]
+    public void AddGranitWolverine_RelaxesServiceLocationPolicy_ForStaticCodegen()
+    {
+        // Wolverine 6 defaults to ServiceLocationPolicy.NotAllowed, which aborts `codegen write`
+        // because the context-propagation middleware on every chain reaches framework services
+        // that can't be inlined (ICurrentUserService / IWolverineUserContextSetter forwarding
+        // factories, internal INotificationPublisher). AllowedButWarn keeps Static codegen usable.
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.AddGranitWolverine();
+
+        ResolveWolverineOptions(builder).ServiceLocationPolicy
+            .ShouldBe(ServiceLocationPolicy.AllowedButWarn);
     }
 
     private static global::Wolverine.WolverineOptions ResolveWolverineOptions(HostApplicationBuilder builder) =>


### PR DESCRIPTION
Completes the Static-codegen enablement thread (#2533 codegen option, #2535 ApplicationAssembly). Without this, `dotnet run -- codegen write` **aborts** on Wolverine 6's stricter codegen — so Static was configurable but not usable.

## The blocker (found via the showcase)

Wolverine 6 defaults to `ServiceLocationPolicy.NotAllowed`, which forbids runtime service location in generated code. Granit's context-propagation middleware (`OutgoingContextMiddleware` / `UserContextBehavior`, added to **every** chain) reaches three registrations that can't be inlined:

- `ICurrentUserService` and `IWolverineUserContextSetter` — scoped forwarding factories (`sp => sp.GetRequiredService<WolverineCurrentUserService>()`) onto the shared `WolverineCurrentUserService`.
- the internal `INotificationPublisher` impl (`ChannelNotificationPublisher`).

Under `NotAllowed`, `codegen write` throws `InvalidServiceLocationException` and emits no registry — so Static mode silently can't deliver.

> Note: this also corrects an earlier assumption that the v6 `ServiceLocationPolicy` flip was a non-issue — it's a non-issue for **Dynamic** boot, but it blocks **Static** codegen.

## The fix

`opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn` in `AddGranitWolverine`. Codegen falls back to runtime service location for those few framework services (everything else still inlines), so Static works for **all** consumers out of the box — they no longer each need to set it.

## Verification

- **End-to-end (showcase MR #34):** with `AllowedButWarn`, `codegen write` ran clean (exit 0) and emitted the full `Internal/Generated/WolverineHandlers/` registry (98 files incl. `GeneratedHandlerRegistry.cs`) with only the expected `AllowedButWarn` warnings for exactly these three services.
- **Here:** regression test asserts `AddGranitWolverine` sets `ServiceLocationPolicy = AllowedButWarn`. 165/165 `Granit.Wolverine.Tests` · format clean · no new dependency (`JasperFx.CodeGeneration.Model` is transitive).

## Follow-up (not in this PR)

Cleaner long-term fix to restore `NotAllowed`: make the three registrations inline-able — `ICurrentUserService`/`IWolverineUserContextSetter` registered direct interface→concrete (safe: `WolverineCurrentUserService` holds only `static AsyncLocal` state) + `InternalsVisibleTo("WolverineHandlers")` on `Granit.Wolverine` and `Granit.Notifications` so Wolverine can `new` the internal types. Plus the RuntimeCompilation-footprint trim noted on #2535.