### PR TITLE
fix(analyzers): stop Roslyn leaking from analyzer/generator packages (NU1608)

### DIFF
--- a/src/Granit.Analyzers.CodeFixes/packages.lock.json
+++ b/src/Granit.Analyzers.CodeFixes/packages.lock.json
@@ -226,10 +226,7 @@
         }
       },
       "granit.analyzers": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[5.3.0, )"
-        }
+        "type": "Project"
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",

--- a/src/Granit.Analyzers/Granit.Analyzers.csproj
+++ b/src/Granit.Analyzers/Granit.Analyzers.csproj
@@ -28,7 +28,12 @@
          central pin (5.0). On a consumer SDK older than 5.3 this only soft-disables the
          analyzer (CS9057, lint off, build unaffected). Keep <= the running csc. See the
          "Roslyn Analyzers" note in Directory.Packages.props. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.3.0" />
+    <!-- PrivateAssets=all: Roslyn is a COMPILE-TIME dependency only. The analyzer runs inside
+         the host compiler, which supplies Microsoft.CodeAnalysis.*; shipping it as a package
+         dependency would force every consumer to resolve Roslyn into its app graph. Without this,
+         the 5.3.0 override leaks into the nuspec and collides with Wolverine/JasperFx's exact
+         CSharp.Workspaces 5.0.0 (Common = 5.0.0) constraint -> NU1608 in consumer restore. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="5.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Granit.Localization.SourceGenerator/Granit.Localization.SourceGenerator.csproj
+++ b/src/Granit.Localization.SourceGenerator/Granit.Localization.SourceGenerator.csproj
@@ -21,7 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <!-- PrivateAssets=all: compile-time only. A source generator runs in the host compiler, which
+         supplies Microsoft.CodeAnalysis.*. Leaking it as a package dependency drags Roslyn into
+         every consumer's graph; today it would float to the central 5.0 floor (harmless), but it
+         becomes the same NU1608 the moment that floor moves to 5.3 (see Granit.Analyzers). -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Problem

Consumers using **Wolverine + Granit.Analyzers** (granit-business, granit-showcase-dotnet) fail `dotnet restore` with **NU1608** the moment they float to `Granit 0.1.0-dev.3368`:

\`\`\`
Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0 requires Microsoft.CodeAnalysis.Common (= 5.0.0)
but version Microsoft.CodeAnalysis.Common 5.3.0 was resolved.
\`\`\`

### Root cause

\`Granit.Analyzers.csproj\` overrides Roslyn to `5.3.0` (dev-time, to match the SDK `csc`) but **omitted `PrivateAssets="all"`** on the `Microsoft.CodeAnalysis.CSharp` reference. So the packaged nuspec shipped `Microsoft.CodeAnalysis.CSharp >= 5.3.0` as a real dependency:

\`\`\`
Granit.Analyzers (dev.3368) ──► Microsoft.CodeAnalysis.CSharp 5.3.0 ──► Common 5.3.0
Granit.Wolverine ──► JasperFx.RuntimeCompiler 5.0.0 ──► CSharp.Workspaces 5.0.0  (needs Common = 5.0.0 exact)
\`\`\`

Any consumer with both in its graph has NuGet unify `Common` up to `5.3.0`, violating JasperFx's exact `= 5.0.0` → NU1608 (warn-as-error). Dormant until the override jumped 5.0→5.3 between `dev.3278` and `dev.3368`.

An analyzer/source generator runs **inside the host compiler**, which supplies `Microsoft.CodeAnalysis.*`; it must never ship a Roslyn package dependency. The sibling `Microsoft.CodeAnalysis.Analyzers` ref already had `PrivateAssets=all` — pure oversight.

## Fix

Add `PrivateAssets="all"` to the `Microsoft.CodeAnalysis.CSharp` reference in:

- **`Granit.Analyzers.csproj`** — the active break.
- **`Granit.Localization.SourceGenerator.csproj`** — same latent bug (leaks only the 5.0 floor today, harmless, but reproduces the NU1608 once the central floor moves to 5.3).

`PrivateAssets=all` keeps the compile-time reference local and strips it from the nuspec; the analyzer still compiles against 5.3.

## Verification

`dotnet pack -c Release` on both packages:

- nuspec now ships an **empty** `.NETStandard2.0` dependency group (no `Microsoft.CodeAnalysis.*`).
- analyzer + codefix DLLs under `analyzers/dotnet/cs/` intact; source generator still bundles `System.Text.Json.dll`.
- `Granit.Analyzers.CodeFixes/packages.lock.json` updated to drop the transitive propagation.

## Blast radius

Once a new dev build (`> 3368`) publishes, **granit-business** and **granit-showcase-dotnet** auto-heal on restore. `granit-microservice-template` was never affected (uses Wolverine but doesn't reference Granit.Analyzers). granit-dotnet itself was unaffected (consumes its analyzers via `ProjectReference` + `OutputItemType=Analyzer`).