### PR TITLE
test(arch): guard analyzer packages against leaking Roslyn dependencies

### DIFF
--- a/tests/Granit.ArchitectureTests/AnalyzerPackageDependencyTests.cs
+++ b/tests/Granit.ArchitectureTests/AnalyzerPackageDependencyTests.cs
@@ -1,0 +1,137 @@
+using System.Xml.Linq;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Guards against analyzer / source-generator packages leaking compile-time dependencies
+/// (Roslyn, System.Composition, …) into consumer package graphs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Analyzer and source-generator packages run inside the host compiler, which already supplies
+/// <c>Microsoft.CodeAnalysis.*</c>. They ship their DLLs under <c>analyzers/</c> and must declare
+/// <b>zero</b> NuGet dependencies: every <c>&lt;PackageReference&gt;</c> carries
+/// <c>PrivateAssets="all"</c> so it never reaches the produced <c>.nuspec</c>.
+/// </para>
+/// <para>
+/// Regression this prevents: <c>Granit.Analyzers</c> dev.3360–3368 dropped <c>PrivateAssets="all"</c>
+/// from <c>Microsoft.CodeAnalysis.CSharp</c>, so the <c>VersionOverride="5.3.0"</c> leaked into the
+/// nuspec and pulled <c>Microsoft.CodeAnalysis.Common 5.3.0</c> into every consumer's app graph —
+/// colliding with Wolverine/JasperFx's exact <c>[5.0.0]</c> constraint → <c>NU1608</c> "warning as
+/// error" on every project referencing <c>Granit.Wolverine</c> (broke granit-business). Note:
+/// <c>&lt;DevelopmentDependency&gt;true&lt;/DevelopmentDependency&gt;</c> alone does NOT suppress the
+/// dependency — <c>PrivateAssets="all"</c> on the reference does.
+/// </para>
+/// <para>
+/// Mechanism: a static csproj check rather than pack-and-inspect-nuspec. It catches the exact
+/// regression (a dropped <c>PrivateAssets</c>), runs offline and deterministically, and matches the
+/// existing csproj-scanning ArchitectureTests style. The packed-artifact guarantee (empty
+/// <c>&lt;dependencies&gt;</c> in the real <c>.nuspec</c>) is verified manually when these packages
+/// change — pack-at-test-time was rejected: no precedent in the suite, and it requires a fragile
+/// build ordering (<c>Granit.Analyzers</c> packs the pre-built <c>Granit.Analyzers.CodeFixes</c> DLL).
+/// </para>
+/// </remarks>
+public sealed class AnalyzerPackageDependencyTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void Analyzer_and_source_generator_packages_must_keep_PrivateAssets_all_on_every_PackageReference()
+    {
+        IReadOnlyList<string> projects = DiscoverPackableAnalyzerProjects();
+
+        // Anti-vacuous guard: if discovery breaks, the test must fail loudly rather than pass empty.
+        IEnumerable<string> names = projects.Select(p => Path.GetFileNameWithoutExtension(p)!);
+        names.ShouldContain("Granit.Analyzers",
+            "Discovery of packable analyzer packages is broken — expected Granit.Analyzers.");
+        names.ShouldContain("Granit.Localization.SourceGenerator",
+            "Discovery of packable analyzer packages is broken — expected Granit.Localization.SourceGenerator.");
+
+        List<string> violations = [];
+
+        foreach (string csproj in projects)
+        {
+            string packageName = Path.GetFileNameWithoutExtension(csproj);
+            var doc = XDocument.Load(csproj);
+
+            foreach (XElement reference in doc.Descendants("PackageReference"))
+            {
+                string? id = (string?)reference.Attribute("Include") ?? (string?)reference.Attribute("Update");
+                if (id is null)
+                {
+                    continue;
+                }
+
+                if (!HasPrivateAssetsAll(reference))
+                {
+                    violations.Add($"{packageName}: PackageReference '{id}' is missing PrivateAssets=\"all\"");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Analyzer/source-generator packages must declare PrivateAssets=\"all\" on EVERY PackageReference so the " +
+            "packed .nuspec carries zero dependencies. A leaking reference drags compile-time Roslyn into consumer " +
+            "package graphs and triggers NU1608 against Wolverine/JasperFx's pinned Microsoft.CodeAnalysis versions.\n"
+            + string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// True when the reference declares <c>PrivateAssets="all"</c> in either the attribute form
+    /// (<c>PrivateAssets="all"</c>) or the child-element form
+    /// (<c>&lt;PrivateAssets&gt;all&lt;/PrivateAssets&gt;</c>). Case-insensitive.
+    /// </summary>
+    private static bool HasPrivateAssetsAll(XElement reference)
+    {
+        string? attribute = (string?)reference.Attribute("PrivateAssets");
+        if (string.Equals(attribute, "all", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        XElement? element = reference.Elements("PrivateAssets").FirstOrDefault();
+        return string.Equals(element?.Value.Trim(), "all", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Discovers packable analyzer / source-generator projects under <c>src/</c>: those marked both
+    /// <c>IsPackable=true</c> and <c>DevelopmentDependency=true</c> — the convention for packages
+    /// whose DLLs ship under <c>analyzers/</c> and must carry no NuGet dependencies. Enumerated
+    /// dynamically so any future analyzer/source-gen package is covered automatically.
+    /// </summary>
+    private static IReadOnlyList<string> DiscoverPackableAnalyzerProjects()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+
+        return
+        [
+            .. Directory.GetFiles(srcDir, "*.csproj", SearchOption.AllDirectories)
+                .Where(csproj =>
+                {
+                    string content = File.ReadAllText(csproj);
+                    return content.Contains("<IsPackable>true</IsPackable>", StringComparison.OrdinalIgnoreCase)
+                        && content.Contains("<DevelopmentDependency>true</DevelopmentDependency>", StringComparison.OrdinalIgnoreCase);
+                })
+                .OrderBy(path => path, StringComparer.Ordinal),
+        ];
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(AnalyzerPackageDependencyTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+}


### PR DESCRIPTION
Durable framework-side guard for the NU1608 leak fixed in #2538. The source fix is done; nothing prevented it from regressing — this adds the missing test.

## The regression it prevents

`Granit.Analyzers` dev.3360–3368 shipped a nuspec dependency on `Microsoft.CodeAnalysis.CSharp 5.3.0` because a `PackageReference` lost its `PrivateAssets="all"`. The runtime/compile assets then flowed into consumer app graphs, pulling `Microsoft.CodeAnalysis.Common 5.3.0`, which collided with Wolverine/JasperFx's exact `[5.0.0]` constraint → **NU1608 "warning as error"** on every project referencing `Granit.Wolverine` (broke granit-business MR !92, would break granit-website). `DevelopmentDependency=true` alone does **not** suppress the dependency — `PrivateAssets="all"` on the reference does.

## The guard

`AnalyzerPackageDependencyTests` discovers packable analyzer/source-generator projects (`IsPackable` + `DevelopmentDependency=true`, enumerated dynamically) and asserts **every `<PackageReference>` carries `PrivateAssets="all"`** (both attribute and child-element forms). It fails the moment someone drops it. Covers `Granit.Analyzers` and `Granit.Localization.SourceGenerator`; an anti-vacuous assertion makes it fail loudly if discovery ever breaks.

## Mechanism — static csproj check, not pack-and-inspect

Chose the static check over pack-at-test-time because:
- **No precedent** for spawning `dotnet pack`/`Process` in the test suite; ArchitectureTests already scans `.csproj`/project deps, so this fits.
- Pack-at-test-time needs a **fragile build ordering** (`Granit.Analyzers` packs the pre-built `Granit.Analyzers.CodeFixes` DLL — confirmed: pack fails if CodeFixes isn't built first) and a nested SDK invocation = slow/flaky in CI.
- The static check catches the exact regression (a dropped `PrivateAssets`), offline and deterministically.

The real-artifact guarantee was verified manually for this change: packing both packages produces an **empty `<dependencies>` group** (zero `Microsoft.CodeAnalysis.*` / `System.Composition.*`), DLLs under `analyzers/`, nothing in `lib/`.

## Verification

- Passes on the current (fixed) tree.
- **Fails** when `PrivateAssets="all"` is removed from a Roslyn ref — verified by a temporary mutation (`Granit.Analyzers: PackageReference 'Microsoft.CodeAnalysis.CSharp' is missing PrivateAssets="all"`), then restored.
- `dotnet format --verify-no-changes` clean. Test-only; no Roslyn version change (the `VersionOverride="5.3.0"` opt-up is intentional and untouched). Lives in the existing `architecture` shard — no sharding change needed.

Cross-ref: granit-business MR !92 is the consumer-side cache-bust onto dev.3370; this is the framework-side durable guard.