### PR TITLE
refactor(core): add SafeTypeLoader to harden assembly type-scans

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -8435,7 +8435,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/GranitAuthorizationModule.cs",
-      "line": 25,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -15448,7 +15448,7 @@
       "kind": "class",
       "project": "Granit",
       "file": "src/Granit/DataProtection/SensitivePropertyRegistry.cs",
-      "line": 28,
+      "line": 29,
       "members": [
         {
           "name": "IsSensitiveAtLevel",
@@ -15473,7 +15473,7 @@
       "kind": "record",
       "project": "Granit",
       "file": "src/Granit/DataProtection/SensitivePropertyRegistry.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "IsSensitiveAtLevel",
@@ -20494,7 +20494,7 @@
       "kind": "class",
       "project": "Granit.Http.ApiDocumentation",
       "file": "src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitApiDocumentation",
@@ -30430,7 +30430,7 @@
       "kind": "class",
       "project": "Granit.Mcp",
       "file": "src/Granit.Mcp/McpToolTypeRegistry.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "Register",
@@ -43870,7 +43870,7 @@
       "kind": "class",
       "project": "Granit.Scheduling",
       "file": "src/Granit.Scheduling/ScheduledPayloadTypeRegistry.cs",
-      "line": 21,
+      "line": 22,
       "members": [
         {
           "name": "Resolve",
@@ -44377,7 +44377,7 @@
       "kind": "class",
       "project": "Granit.Settings",
       "file": "src/Granit.Settings/GranitSettingsModule.cs",
-      "line": 25,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -48872,7 +48872,7 @@
       "kind": "class",
       "project": "Granit.Validation",
       "file": "src/Granit.Validation/GranitValidationModule.cs",
-      "line": 34,
+      "line": 35,
       "members": [
         {
           "name": "ConfigureServices",
@@ -51051,7 +51051,7 @@
       "kind": "class",
       "project": "Granit.Webhooks",
       "file": "src/Granit.Webhooks/GranitWebhooksModule.cs",
-      "line": 35,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Authorization/GranitAuthorizationModule.cs
+++ b/src/Granit.Authorization/GranitAuthorizationModule.cs
@@ -9,6 +9,7 @@ using Granit.DataExchange.Extensions;
 using Granit.Entities.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine.Extensions;
+using Granit.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Authorization;
@@ -41,7 +42,7 @@ public sealed class GranitAuthorizationModule : GranitModule
 
         foreach (Assembly assembly in context.ModuleAssemblies)
         {
-            IEnumerable<Type> providerTypes = assembly.GetTypes()
+            IEnumerable<Type> providerTypes = assembly.GetLoadableTypes()
                 .Where(t => t is { IsAbstract: false, IsInterface: false }
                     && typeof(IPermissionDefinitionProvider).IsAssignableFrom(t));
 

--- a/src/Granit.BackgroundJobs/Internal/RecurringJobDiscovery.cs
+++ b/src/Granit.BackgroundJobs/Internal/RecurringJobDiscovery.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Granit.BackgroundJobs.Domain;
+using Granit.Reflection;
 
 namespace Granit.BackgroundJobs.Internal;
 
@@ -18,7 +19,7 @@ internal static class RecurringJobDiscovery
 
         foreach (Assembly assembly in assemblies)
         {
-            foreach (Type type in GetLoadableTypes(assembly))
+            foreach (Type type in assembly.GetLoadableTypes())
             {
                 RecurringJobAttribute? attr = type.GetCustomAttribute<RecurringJobAttribute>();
                 if (attr is null)
@@ -40,17 +41,5 @@ internal static class RecurringJobDiscovery
         }
 
         return registrations;
-    }
-
-    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            return ex.Types.Where(t => t is not null)!;
-        }
     }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/DbContextAutoExportDefinitionSource.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/DbContextAutoExportDefinitionSource.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reflection;
 using Granit.DataExchange.Export;
+using Granit.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
@@ -109,20 +109,8 @@ internal sealed partial class DbContextAutoExportDefinitionSource(
     private static IEnumerable<Type> ScanAssembliesForDbContexts() =>
         AppDomain.CurrentDomain.GetAssemblies()
             .Where(a => a.GetName().Name?.StartsWith("Granit", StringComparison.Ordinal) == true)
-            .SelectMany(GetAssemblyTypes)
+            .SelectMany(SafeTypeLoader.GetLoadableTypes)
             .Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(DbContext)));
-
-    private static IEnumerable<Type> GetAssemblyTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            return ex.Types.Where(t => t is not null).Cast<Type>();
-        }
-    }
 
     [LoggerMessage(1, LogLevel.Warning, "Failed to scan DbContext '{DbContextName}' for entity types")]
     private static partial void LogDbContextScanFailed(ILogger logger, string dbContextName, Exception ex);

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/DbContextResolver.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/DbContextResolver.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using Granit.Reflection;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.DataExchange.EntityFrameworkCore.Internal.Export;
@@ -19,14 +19,7 @@ internal static class DbContextResolver
     {
         IEnumerable<Type> dbContextTypes = AppDomain.CurrentDomain.GetAssemblies()
             .Where(a => a.GetName().Name?.StartsWith("Granit", StringComparison.Ordinal) == true)
-            .SelectMany(a =>
-            {
-                try { return a.GetTypes(); }
-                catch (ReflectionTypeLoadException ex)
-                {
-                    return ex.Types.Where(t => t is not null).Cast<Type>();
-                }
-            })
+            .SelectMany(SafeTypeLoader.GetLoadableTypes)
             .Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(DbContext)));
 
         foreach (Type dbContextType in dbContextTypes)

--- a/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs
+++ b/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Nodes;
 using Asp.Versioning;
 using Granit.Http.ApiDocumentation.Options;
 using Granit.Http.ApiDocumentation.Transformers;
+using Granit.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -189,25 +190,7 @@ public static class ApiDocumentationServiceCollectionExtensions
 
         foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
-            if (assembly.IsDynamic)
-            {
-                continue;
-            }
-
-            Type[] types;
-            try
-            {
-                types = assembly.GetExportedTypes();
-            }
-            catch (Exception ex) when (ex is ReflectionTypeLoadException or FileNotFoundException or FileLoadException or TypeLoadException)
-            {
-                // An assembly in the load context references a dependency that is not present
-                // (e.g. a module exposing Wolverine-derived types when Wolverine is not flowed).
-                // Skip it — its example providers, if any, simply will not be discovered.
-                continue;
-            }
-
-            foreach (Type type in types.Where(t =>
+            foreach (Type type in assembly.GetLoadableExportedTypes().Where(t =>
                          t is { IsAbstract: false, IsInterface: false }
                          && interfaceType.IsAssignableFrom(t)))
             {

--- a/src/Granit.Localization/Internal/LocalizationAutoDiscovery.cs
+++ b/src/Granit.Localization/Internal/LocalizationAutoDiscovery.cs
@@ -12,6 +12,7 @@
 
 using System.Reflection;
 using Granit.Localization.Options;
+using Granit.Reflection;
 
 namespace Granit.Localization.Internal;
 
@@ -54,15 +55,7 @@ internal static class LocalizationAutoDiscovery
             return;
         }
 
-        Type[] types;
-        try
-        {
-            types = assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            types = [.. ex.Types.OfType<Type>()];
-        }
+        IReadOnlyList<Type> types = assembly.GetLoadableTypes();
 
         foreach (Type type in types)
         {

--- a/src/Granit.Mcp/McpToolTypeRegistry.cs
+++ b/src/Granit.Mcp/McpToolTypeRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Granit.Reflection;
 using ModelContextProtocol.Server;
 
 namespace Granit.Mcp;
@@ -40,7 +41,7 @@ public sealed class McpToolTypeRegistry
 
         foreach (System.Reflection.Assembly assembly in assemblies)
         {
-            foreach (Type type in assembly.GetTypes())
+            foreach (Type type in assembly.GetLoadableTypes())
             {
                 if (type is { IsAbstract: true } or { IsInterface: true })
                 {

--- a/src/Granit.Scheduling/ScheduledPayloadTypeRegistry.cs
+++ b/src/Granit.Scheduling/ScheduledPayloadTypeRegistry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
+using Granit.Reflection;
 
 namespace Granit.Scheduling;
 
@@ -29,12 +30,7 @@ public sealed class ScheduledPayloadTypeRegistry
     public ScheduledPayloadTypeRegistry()
     {
         _typesByName = AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => !a.IsDynamic)
-            .SelectMany(a =>
-            {
-                try { return a.GetTypes(); }
-                catch { return []; }
-            })
+            .SelectMany(SafeTypeLoader.GetLoadableTypes)
             .Where(t => t.IsAssignableTo(typeof(IScheduledPayload))
                          && t is { IsAbstract: false, IsInterface: false })
             .ToFrozenDictionary(t => t.AssemblyQualifiedName!, t => t);

--- a/src/Granit.Settings/GranitSettingsModule.cs
+++ b/src/Granit.Settings/GranitSettingsModule.cs
@@ -5,6 +5,7 @@ using Granit.Encryption;
 using Granit.Events;
 using Granit.Modularity;
 using Granit.QueryEngine.Extensions;
+using Granit.Reflection;
 using Granit.Settings.Definitions;
 using Granit.Settings.Domain;
 using Granit.Settings.Exports;
@@ -34,7 +35,7 @@ public sealed class GranitSettingsModule : GranitModule
 
         foreach (Assembly assembly in context.ModuleAssemblies)
         {
-            IEnumerable<Type> providerTypes = assembly.GetTypes()
+            IEnumerable<Type> providerTypes = assembly.GetLoadableTypes()
                 .Where(t => t is { IsAbstract: false, IsInterface: false }
                     && typeof(ISettingDefinitionProvider).IsAssignableFrom(t));
 

--- a/src/Granit.Validation/GranitValidationModule.cs
+++ b/src/Granit.Validation/GranitValidationModule.cs
@@ -4,6 +4,7 @@ using Granit.Http.ExceptionHandling;
 using Granit.Localization;
 using Granit.Localization.Options;
 using Granit.Modularity;
+using Granit.Reflection;
 using Granit.Validation.Extensions;
 using Granit.Validation.Internal;
 using Granit.Validation.JsonSchema;
@@ -59,7 +60,7 @@ public sealed class GranitValidationModule : GranitModule
         // Auto-discover IServerValidatorContributor from all loaded module assemblies.
         foreach (Assembly assembly in context.ModuleAssemblies)
         {
-            IEnumerable<Type> contributorTypes = assembly.GetTypes()
+            IEnumerable<Type> contributorTypes = assembly.GetLoadableTypes()
                 .Where(t => t is { IsAbstract: false, IsInterface: false }
                     && typeof(IServerValidatorContributor).IsAssignableFrom(t));
 

--- a/src/Granit.Webhooks/GranitWebhooksModule.cs
+++ b/src/Granit.Webhooks/GranitWebhooksModule.cs
@@ -4,6 +4,7 @@ using Granit.Guids;
 using Granit.Http.Resilience;
 using Granit.Http.Security;
 using Granit.Modularity;
+using Granit.Reflection;
 using Granit.Timing;
 using Granit.Webhooks.Definitions;
 using Granit.Webhooks.Extensions;
@@ -41,7 +42,7 @@ public sealed class GranitWebhooksModule : GranitModule
 
         foreach (Assembly assembly in context.ModuleAssemblies)
         {
-            IEnumerable<Type> providerTypes = assembly.GetTypes()
+            IEnumerable<Type> providerTypes = assembly.GetLoadableTypes()
                 .Where(t => t is { IsAbstract: false, IsInterface: false }
                     && typeof(IWebhookEventTypeDefinitionProvider).IsAssignableFrom(t));
 

--- a/src/Granit/DataProtection/SensitivePropertyRegistry.cs
+++ b/src/Granit/DataProtection/SensitivePropertyRegistry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Reflection;
+using Granit.Reflection;
 
 namespace Granit.DataProtection;
 
@@ -72,17 +73,7 @@ public sealed class SensitivePropertyRegistry
 
     private static void ScanAssembly(Assembly assembly, Dictionary<string, SensitivePropertyEntry> map)
     {
-        Type[] types;
-        try
-        {
-            types = assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            types = ex.Types.Where(t => t is not null).ToArray()!;
-        }
-
-        foreach (Type type in types)
+        foreach (Type type in assembly.GetLoadableTypes())
         {
             ScanType(type, map);
         }

--- a/src/Granit/Reflection/SafeTypeLoader.cs
+++ b/src/Granit/Reflection/SafeTypeLoader.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+
+namespace Granit.Reflection;
+
+/// <summary>
+/// Resilient assembly type enumeration for discovery scans. <see cref="Assembly.GetTypes"/> and
+/// <see cref="Assembly.GetExportedTypes"/> throw when an assembly's surface references a type from
+/// a dependency that is not loaded: <see cref="ReflectionTypeLoadException"/> for non-public types,
+/// but <see cref="FileNotFoundException"/> / <see cref="TypeLoadException"/> for the public surface
+/// (e.g. a module exporting Wolverine-derived types when <c>Wolverine.dll</c> did not flow). These
+/// helpers return the loadable subset instead of letting one such assembly take down an unrelated
+/// "scan every loaded assembly" discovery site.
+/// </summary>
+public static class SafeTypeLoader
+{
+    /// <summary>
+    /// Returns the loadable types of <paramref name="assembly"/> (public and non-public), never throwing
+    /// for missing-dependency failures. Dynamic assemblies return empty.
+    /// </summary>
+    public static IReadOnlyList<Type> GetLoadableTypes(this Assembly assembly) =>
+        Load(assembly, static a => a.GetTypes());
+
+    /// <summary>
+    /// Returns the loadable <em>exported</em> (public) types of <paramref name="assembly"/>, never throwing
+    /// for missing-dependency failures. Dynamic assemblies return empty.
+    /// </summary>
+    public static IReadOnlyList<Type> GetLoadableExportedTypes(this Assembly assembly) =>
+        Load(assembly, static a => a.GetExportedTypes());
+
+    /// <summary>
+    /// Shared resilience core. On <see cref="ReflectionTypeLoadException"/> returns the partial set that
+    /// did load; on a missing-dependency load failure returns empty; any other exception propagates.
+    /// </summary>
+    internal static IReadOnlyList<Type> Load(Assembly assembly, Func<Assembly, Type[]> getTypes)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        if (assembly.IsDynamic)
+        {
+            return [];
+        }
+
+        try
+        {
+            return getTypes(assembly);
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            // Keep the types that did load; the rest reference an unresolved dependency.
+            return [.. ex.Types.OfType<Type>()];
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or TypeLoadException)
+        {
+            // The assembly's public surface references a type from a dependency that is not present.
+            return [];
+        }
+    }
+}

--- a/tests/Granit.Tests/SafeTypeLoaderTests.cs
+++ b/tests/Granit.Tests/SafeTypeLoaderTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using Granit.Reflection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests;
+
+/// <summary>
+/// Verifies <see cref="SafeTypeLoader"/> returns the loadable subset instead of throwing when an
+/// assembly references an unloaded dependency — the failure mode that crashed framework-wide
+/// discovery scans (see issue #2541 / #2540).
+/// </summary>
+public sealed class SafeTypeLoaderTests
+{
+    [Fact]
+    public void GetLoadableTypes_on_a_real_assembly_returns_its_types()
+    {
+        IReadOnlyList<Type> types = typeof(SafeTypeLoader).Assembly.GetLoadableTypes();
+
+        types.ShouldNotBeEmpty();
+        types.ShouldContain(typeof(SafeTypeLoader));
+    }
+
+    [Fact]
+    public void GetLoadableExportedTypes_returns_only_public_types()
+    {
+        IReadOnlyList<Type> types = typeof(SafeTypeLoader).Assembly.GetLoadableExportedTypes();
+
+        types.ShouldNotBeEmpty();
+        types.ShouldAllBe(t => t.IsPublic || t.IsNestedPublic);
+    }
+
+    [Fact]
+    public void Dynamic_assemblies_return_empty()
+    {
+        var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("Granit.Tests.Dynamic"), AssemblyBuilderAccess.Run);
+
+        dynamicAssembly.IsDynamic.ShouldBeTrue();
+        dynamicAssembly.GetLoadableTypes().ShouldBeEmpty();
+        dynamicAssembly.GetLoadableExportedTypes().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ReflectionTypeLoadException_returns_the_partial_loadable_set()
+    {
+        IReadOnlyList<Type> result = SafeTypeLoader.Load(
+            typeof(SafeTypeLoader).Assembly,
+            _ => throw new ReflectionTypeLoadException(
+                [typeof(int), null, typeof(string)],
+                new Exception?[3]));
+
+        result.ShouldBe(new[] { typeof(int), typeof(string) });
+    }
+
+    [Theory]
+    [MemberData(nameof(MissingDependencyExceptions))]
+    public void Missing_dependency_failures_return_empty(Exception exception)
+    {
+        IReadOnlyList<Type> result = SafeTypeLoader.Load(
+            typeof(SafeTypeLoader).Assembly, _ => throw exception);
+
+        result.ShouldBeEmpty();
+    }
+
+    public static TheoryData<Exception> MissingDependencyExceptions() => new()
+    {
+        new FileNotFoundException(),
+        new FileLoadException(),
+        new TypeLoadException(),
+    };
+
+    [Fact]
+    public void Unexpected_exceptions_propagate()
+    {
+        Should.Throw<InvalidOperationException>(() => SafeTypeLoader.Load(
+            typeof(SafeTypeLoader).Assembly, _ => throw new InvalidOperationException("boom")));
+    }
+
+    [Fact]
+    public void Null_assembly_throws()
+    {
+        Should.Throw<ArgumentNullException>(() => ((Assembly)null!).GetLoadableTypes());
+    }
+}


### PR DESCRIPTION
Closes #2541. Related: #2540.

## What

Adds `Granit.Reflection.SafeTypeLoader` in the base `Granit` package and retrofits every
"scan loaded assemblies → `GetTypes()`/`GetExportedTypes()` → filter" discovery site onto it.

```csharp
assembly.GetLoadableTypes();          // resilient GetTypes()
assembly.GetLoadableExportedTypes();  // resilient GetExportedTypes()
```

The helper skips dynamic assemblies, returns the **partial set** on `ReflectionTypeLoadException`,
and returns the **loadable subset** on `FileNotFoundException` / `FileLoadException` /
`TypeLoadException` — the failure mode when an assembly's *public* surface references a type from a
dependency that is not loaded (e.g. `Granit.Privacy`'s Wolverine sagas while `WolverineFx` is
`PrivateAssets=all`). Any other exception still propagates.

## Sites retrofitted (12)

Previously caught only `ReflectionTypeLoadException` — or nothing:

- `Granit.Localization` auto-discovery
- `Granit.Http.ApiDocumentation` schema-example providers
- `Granit.DataExchange.EntityFrameworkCore` (DbContext export source + resolver)
- `Granit/DataProtection/SensitivePropertyRegistry`
- `Granit.BackgroundJobs` recurring-job discovery
- `Granit.Validation` / `Granit.Webhooks` / `Granit.Settings` / `Granit.Authorization` provider scans
- `Granit.Mcp` tool-type registry
- `Granit.Scheduling` payload registry (now keeps partial types on RTLE instead of discarding all)

Deterministic unit test forces each branch (RTLE → partial, missing-dependency → empty,
unexpected → propagate, dynamic → empty).

## ⚠️ Does NOT drop the generator's WolverineFx band-aid

The issue proposed tying off the loop by removing `WolverineFx` from `Granit.OpenApi.Generator`.
**Verified empirically that this is not achievable:** with all 12 Granit sites hardened, the
generator still crashes with `FileNotFoundException: Wolverine` — the residual scan is
**`FluentValidation.AddValidatorsFromAssembly`** (and, by the same mechanism, the OpenAPI schema
generator and Wolverine's own discovery). These are third-party reflections over the module graph
and cannot be wrapped by our helper. The generator's `WolverineFx PrivateAssets=all` reference and
its allow-list entry therefore stay.

The framework value here is independent of the generator: Granit's own discovery no longer takes an
opaque `FileNotFound` at startup when any assembly's public surface references an unflowed
dependency, and the inconsistent RTLE-only / no-try-catch handling is unified on one helper.

## Verification

- `Granit.Tests` (base): 528/528, incl. 9 new `SafeTypeLoaderTests`.
- `Granit.Http.ApiDocumentation` tests: 131/131.
- All 12 retrofitted modules build clean (analyzers, `TreatWarningsAsErrors`, format).
