### PR TITLE
fix(identity): make AccountRegisterRequest first/last name optional in the contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Concrete `*QueryDefinition` and `*ExportDefinition` live in **base module** `Gra
 
 - `*Request` for input, `*Response` for output. NEVER `*Dto`. Prefixed names (`WorkflowTransitionRequest`, not `TransitionRequest`) — OpenAPI flattens namespaces.
 - Errors: `TypedResults.Problem(detail, statusCode)` (RFC 7807). EF entities NEVER returned — always project to `*Response` records.
+- **Optional record params MUST have a default.** On a positional record, a constructor parameter with no default is `required` in the OpenAPI schema regardless of nullability (STJ `RespectRequiredConstructorParameters`, default on .NET 9+). So an *optional* field must be `string? FirstName = null`, not `string? FirstName` — the latter ships as `required` + `["null","string"]` and the front types it `string | null` instead of `firstName?`. Required field → non-nullable, no default (`string Email`). (#2546)
 
 ### OpenAPI endpoint metadata (5 elements MANDATORY)
 

--- a/src/Granit.Identity.Local.Endpoints/Dtos/AccountRegisterRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/AccountRegisterRequest.cs
@@ -10,5 +10,5 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 public sealed record AccountRegisterRequest(
     string Email,
     string Password,
-    string? FirstName,
-    string? LastName);
+    string? FirstName = null,
+    string? LastName = null);


### PR DESCRIPTION
First instance of #2546, surfaced by the OpenAPI generator (#2542).

## Problem

`AccountRegisterRequest.FirstName`/`LastName` are `string?`, documented "Optional", and the
validator only applies `MaximumLength(256)` — yet they were emitted as `required` in the OpenAPI
schema, because positional-record parameters without a default are treated as required by
System.Text.Json (`RespectRequiredConstructorParameters`, default on .NET 9+), independent of
nullability.

## Fix

```csharp
string? FirstName = null,
string? LastName = null
```

Generated contract now: `required: ["email","password"]` (was `[...,"firstName","lastName"]`);
the nullable `["null","string"]` type is unchanged. `openapi-typescript` will type them
`firstName?: string` instead of required `string | null`.

Also documents the convention in `CLAUDE.md` (DTOs): **optional record params must carry a default**;
required → non-nullable with no default.

## Scope

This fixes only the motivating case. The systemic sweep (~132 nullable-no-default params across
`src/*.Endpoints/Dtos`) plus a `Granit.Analyzers` rule / architecture test are tracked in **#2546**
(a blocking check can't merge until the backlog is cleared, hence the CLAUDE.md convention as interim
guidance).

## Verification

- Generator regenerated: `AccountRegisterRequest.required` = `["email","password"]`.
- `AccountRegisterRequestValidatorTests`: 7/7.
- `dotnet format` + `markdownlint CLAUDE.md`: clean.