### PR TITLE
fix(dtos): default optional nullable params on Request DTOs (OpenAPI required)

### DIFF
--- a/src/Granit.AI.Endpoints/Dtos/AIWorkspaceCreateRequest.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIWorkspaceCreateRequest.cs
@@ -13,6 +13,6 @@ public sealed record AIWorkspaceCreateRequest(
     string Name,
     string Provider,
     string Model,
-    string? SystemPrompt,
-    float? Temperature,
-    int? MaxOutputTokens) : IAIWorkspaceMutableFields;
+    string? SystemPrompt = null,
+    float? Temperature = null,
+    int? MaxOutputTokens = null) : IAIWorkspaceMutableFields;

--- a/src/Granit.DataExchange.Endpoints/Dtos/Export/CreateExportJobRequest.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Export/CreateExportJobRequest.cs
@@ -26,7 +26,7 @@ public sealed record CreateExportJobRequest(
     string Format,
     IReadOnlyList<string>? SelectedFields,
     bool IncludeIdForImport,
-    string? Sort,
-    IReadOnlyDictionary<string, string>? Filter,
-    IReadOnlyDictionary<string, string>? Presets,
-    string? Search);
+    string? Sort = null,
+    IReadOnlyDictionary<string, string>? Filter = null,
+    IReadOnlyDictionary<string, string>? Presets = null,
+    string? Search = null);

--- a/src/Granit.Identity.Endpoints/Dtos/IdentityUserCreateRequest.cs
+++ b/src/Granit.Identity.Endpoints/Dtos/IdentityUserCreateRequest.cs
@@ -9,4 +9,4 @@ public sealed record IdentityUserCreateRequest(
     string? FirstName,
     string? LastName,
     bool Enabled,
-    string? TemporaryPassword);
+    string? TemporaryPassword = null);

--- a/src/Granit.Identity.Endpoints/Dtos/IdentityUserUpdateRequest.cs
+++ b/src/Granit.Identity.Endpoints/Dtos/IdentityUserUpdateRequest.cs
@@ -4,7 +4,7 @@ namespace Granit.Identity.Endpoints.Dtos;
 /// Request body for updating an existing user in the identity provider.
 /// </summary>
 public sealed record IdentityUserUpdateRequest(
-    string? Email,
-    string? FirstName,
-    string? LastName,
-    IReadOnlyDictionary<string, string?>? Attributes);
+    string? Email = null,
+    string? FirstName = null,
+    string? LastName = null,
+    IReadOnlyDictionary<string, string?>? Attributes = null);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/AccountProfileUpdateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/AccountProfileUpdateRequest.cs
@@ -6,5 +6,5 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <param name="FirstName">The new first name (max 256).</param>
 /// <param name="LastName">The new last name (max 256).</param>
 public sealed record AccountProfileUpdateRequest(
-    string? FirstName,
-    string? LastName);
+    string? FirstName = null,
+    string? LastName = null);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/PasskeyRegistrationRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/PasskeyRegistrationRequest.cs
@@ -3,4 +3,4 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <summary>Request DTO for passkey registration completion.</summary>
 /// <param name="CredentialJson">The WebAuthn AuthenticatorAttestationResponse JSON.</param>
 /// <param name="Name">Optional friendly name for the passkey.</param>
-public sealed record PasskeyRegistrationRequest(string CredentialJson, string? Name);
+public sealed record PasskeyRegistrationRequest(string CredentialJson, string? Name = null);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
@@ -19,4 +19,4 @@ public sealed record RoleCreateRequest(
     string Name,
     MultiTenancySides MultiTenancySides,
     Guid? TenantId,
-    string? Description);
+    string? Description = null);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs
@@ -3,4 +3,4 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <summary>Request to rename / update a local role's description. Side and tenant scope are immutable.</summary>
 /// <param name="Name">New display name (max 256 chars).</param>
 /// <param name="Description">New description (max 2048 chars, nullable to clear).</param>
-public sealed record RoleUpdateRequest(string Name, string? Description);
+public sealed record RoleUpdateRequest(string Name, string? Description = null);

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/CreateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/CreateTenantRequest.cs
@@ -10,5 +10,5 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 public sealed record CreateTenantRequest(
     string Name,
     string Identifier,
-    string? ContactEmail,
-    string? Jurisdiction);
+    string? ContactEmail = null,
+    string? Jurisdiction = null);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
@@ -10,7 +10,7 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 #pragma warning disable GRSEC003 // ClientSecret is a DTO parameter, not a stored secret
 public sealed record AdminOidcCreateApplicationRequest(
     string ClientId,
-    string? DisplayName,
-    string? ClientSecret,
-    string? Type);
+    string? DisplayName = null,
+    string? ClientSecret = null,
+    string? Type = null);
 #pragma warning restore GRSEC003

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs
@@ -8,5 +8,5 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="Description">An optional human-readable description.</param>
 public sealed record AdminOidcCreateScopeRequest(
     string Name,
-    string? DisplayName,
-    string? Description);
+    string? DisplayName = null,
+    string? Description = null);

--- a/src/Granit.Presence.Endpoints/Dtos/SetPresenceRequest.cs
+++ b/src/Granit.Presence.Endpoints/Dtos/SetPresenceRequest.cs
@@ -9,4 +9,4 @@ namespace Granit.Presence.Endpoints.Dtos;
 /// <param name="UntilUtc">Optional override expiration (UTC). Past values are rejected.</param>
 public sealed record SetPresenceRequest(
     ManualPresenceStatus ManualStatus,
-    DateTimeOffset? UntilUtc);
+    DateTimeOffset? UntilUtc = null);

--- a/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentCreateRequest.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentCreateRequest.cs
@@ -8,5 +8,5 @@ namespace Granit.Privacy.Endpoints.Dtos;
 public sealed record LegalDocumentCreateRequest(
     string DocumentId,
     string DisplayName,
-    string? Description,
-    string? TemplateName);
+    string? Description = null,
+    string? TemplateName = null);

--- a/src/Granit.Settings.Endpoints/Dtos/UpdateSettingValueRequest.cs
+++ b/src/Granit.Settings.Endpoints/Dtos/UpdateSettingValueRequest.cs
@@ -4,4 +4,4 @@ namespace Granit.Settings.Endpoints.Dtos;
 /// Request to update a setting value.
 /// </summary>
 /// <param name="Value">The new value, or <c>null</c> to clear.</param>
-public sealed record UpdateSettingValueRequest(string? Value);
+public sealed record UpdateSettingValueRequest(string? Value = null);

--- a/src/Granit.Templating.Endpoints/Dtos/SaveTemplateCategoryRequest.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/SaveTemplateCategoryRequest.cs
@@ -9,6 +9,6 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <param name="SortOrder">Display order (default 0).</param>
 public sealed record SaveTemplateCategoryRequest(
     string Name,
-    string? Description,
-    string? Icon,
+    string? Description = null,
+    string? Icon = null,
     int SortOrder = 0);

--- a/src/Granit.Templating.Endpoints/Dtos/TemplatePreviewRequest.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/TemplatePreviewRequest.cs
@@ -8,5 +8,5 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <param name="Culture">Optional BCP 47 culture tag to select the template variant.</param>
 /// <param name="Data">Optional JSON data model to merge into the template.</param>
 public sealed record TemplatePreviewRequest(
-    string? Culture,
-    JsonElement? Data);
+    string? Culture = null,
+    JsonElement? Data = null);

--- a/src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateRequest.cs
+++ b/src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateRequest.cs
@@ -8,4 +8,4 @@ namespace Granit.Validation.Endpoints.Dtos;
 /// Must match the <c>x-granit-validator</c> extension in the OpenAPI schema.
 /// </param>
 /// <param name="Value">The value to validate.</param>
-public sealed record ValidationFieldValidateRequest(string ErrorCode, string? Value);
+public sealed record ValidationFieldValidateRequest(string ErrorCode, string? Value = null);

--- a/src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionRequest.cs
+++ b/src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionRequest.cs
@@ -7,4 +7,4 @@ namespace Granit.Workflow.Endpoints.Dtos;
 /// <param name="Comment">Optional regulatory comment or justification (ISO 27001 audit trail).</param>
 public sealed record WorkflowTransitionRequest(
     string TargetState,
-    string? Comment);
+    string? Comment = null);


### PR DESCRIPTION
Part of #2546. Follows the AccountRegisterRequest fix (#2547) and the convention (#2548).

## What

Adds `= null` to **27 optional nullable constructor parameters** across **18 `*Request` DTOs**, so they stop being emitted as `required` in the generated OpenAPI (a positional-record param with no default is required-by-constructor in STJ, independent of nullability). The nullable value type is unchanged.

Optionality was confirmed **per parameter** against the FluentValidation validator: a member with an unconditional `NotEmpty()`/`NotNull()` would stay required — none of the 27 had one (rules were length/format/conditional only, or no rule).

## Verification

- Generator regenerated: `AccountProfileUpdateRequest` → `required: []`; `RoleUpdateRequest` → `[name]`; `AIWorkspaceCreateRequest` → `[name, provider, model]`; `AdminOidcCreateApplicationRequest` → `[clientId]`.
- All 29 `.Endpoints` compile (no C# optional-after-required errors); `Granit.Identity.Local.Endpoints.Tests` 147/147; `dotnet format` clean.

## Deliberately NOT changed (12 params, tracked in #2546)

- **11 ordering-blocked**: a required (no-default) param sits *after* the optional candidate (`UpdateTenantRequest`/`LegalDocumentUpdateRequest`: trailing `ConcurrencyStamp`; `SaveTemplateRequest`: `Content`; `AIWorkspaceUpdateRequest`/`IdentityUserCreateRequest`: trailing `bool` flag; `CreateExportJobRequest`: `IncludeIdForImport`). Adding a default would violate C#'s optional-after-required rule — these need the record params reordered or the field made non-nullable (per-DTO judgment, breaking positional call sites).
- **1 conditional**: `RoleCreateRequest.TenantId` is required only on the tenant side (`.Must(... is not null)`), so it stays required.

The remaining `*Response` DTOs (~158 nullable-no-default) are intentionally untouched — `required` + nullable is the correct contract for always-present-but-nullable output.