### PR TITLE
fix(dtos): optional Request-DTO defaults for the ordering-blocked cases

### DIFF
--- a/src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs
@@ -8,11 +8,11 @@ namespace Granit.AI.Endpoints.Dtos;
 /// <param name="SystemPrompt">Optional system prompt.</param>
 /// <param name="Temperature">Optional sampling temperature (0.0–2.0).</param>
 /// <param name="MaxOutputTokens">Optional maximum output tokens.</param>
-/// <param name="Activated">Whether the workspace should be active.</param>
+/// <param name="Activated">Whether the workspace should be active. Defaults to <c>false</c> when omitted.</param>
 public sealed record AIWorkspaceUpdateRequest(
     string Provider,
     string Model,
-    string? SystemPrompt,
-    float? Temperature,
-    int? MaxOutputTokens,
-    bool Activated) : IAIWorkspaceMutableFields;
+    string? SystemPrompt = null,
+    float? Temperature = null,
+    int? MaxOutputTokens = null,
+    bool Activated = false) : IAIWorkspaceMutableFields;

--- a/src/Granit.DataExchange.Endpoints/Dtos/Export/CreateExportJobRequest.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Export/CreateExportJobRequest.cs
@@ -24,8 +24,8 @@ namespace Granit.DataExchange.Endpoints.Dtos.Export;
 public sealed record CreateExportJobRequest(
     string DefinitionName,
     string Format,
-    IReadOnlyList<string>? SelectedFields,
-    bool IncludeIdForImport,
+    IReadOnlyList<string>? SelectedFields = null,
+    bool IncludeIdForImport = false,
     string? Sort = null,
     IReadOnlyDictionary<string, string>? Filter = null,
     IReadOnlyDictionary<string, string>? Presets = null,

--- a/src/Granit.Identity.Endpoints/Dtos/IdentityUserCreateRequest.cs
+++ b/src/Granit.Identity.Endpoints/Dtos/IdentityUserCreateRequest.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Endpoints.Dtos;
 public sealed record IdentityUserCreateRequest(
     string Username,
     string Email,
-    string? FirstName,
-    string? LastName,
-    bool Enabled,
+    string? FirstName = null,
+    string? LastName = null,
+    bool Enabled = false,
     string? TemporaryPassword = null);

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
@@ -6,11 +6,11 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// Request to update an existing tenant's details.
 /// </summary>
 /// <param name="Name">New display name (max 256 characters).</param>
+/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 /// <param name="ContactEmail">New contact email (or <c>null</c> to clear).</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code (or <c>null</c> to clear).</param>
-/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 public sealed record UpdateTenantRequest(
     string Name,
-    string? ContactEmail,
-    string? Jurisdiction,
-    string ConcurrencyStamp) : IConcurrencyStampRequest;
+    string ConcurrencyStamp,
+    string? ContactEmail = null,
+    string? Jurisdiction = null) : IConcurrencyStampRequest;

--- a/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentUpdateRequest.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentUpdateRequest.cs
@@ -4,13 +4,13 @@ namespace Granit.Privacy.Endpoints.Dtos;
 
 /// <summary>Request to update a legal document draft.</summary>
 /// <param name="DisplayName">Human-readable document title.</param>
+/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 /// <param name="Description">Optional admin-only changelog note.</param>
 /// <param name="TemplateName">Optional Granit.Templating template name for rendered content.</param>
 /// <param name="DocumentBlobId">Optional blob ID for a downloadable document (PDF, DOCX, etc.).</param>
-/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 public sealed record LegalDocumentUpdateRequest(
     string DisplayName,
-    string? Description,
-    string? TemplateName,
-    Guid? DocumentBlobId,
-    string ConcurrencyStamp) : IConcurrencyStampRequest;
+    string ConcurrencyStamp,
+    string? Description = null,
+    string? TemplateName = null,
+    Guid? DocumentBlobId = null) : IConcurrencyStampRequest;

--- a/src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs
@@ -3,12 +3,12 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <summary>
 /// Request body for creating or updating a template draft.
 /// </summary>
+/// <param name="Content">Template source content (Scriban HTML).</param>
 /// <param name="Name">
 /// Logical template name using <c>"Domain.Name"</c> convention (e.g. <c>"Billing.Invoice"</c>).
 /// Required for POST (create). Ignored for PUT (name comes from the route).
 /// </param>
 /// <param name="Culture">Optional BCP 47 culture tag (e.g. <c>"fr-BE"</c>). <c>null</c> for culture-neutral.</param>
-/// <param name="Content">Template source content (Scriban HTML).</param>
 /// <param name="MimeType">MIME type of the content. Default: <c>"text/html"</c>.</param>
 /// <param name="LayoutName">
 /// Layout template name assigned to this template.
@@ -20,9 +20,9 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// Omit or pass <c>null</c> when creating the first draft for this template key.
 /// </param>
 public sealed record SaveTemplateRequest(
-    string? Name,
-    string? Culture,
     string Content,
+    string? Name = null,
+    string? Culture = null,
     string MimeType = "text/html",
     string? LayoutName = null,
     string? ConcurrencyStamp = null);

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
@@ -11,7 +11,7 @@ public sealed class UpdateTenantRequestTests
     [Fact]
     public void Constructor_MapsAllFields()
     {
-        UpdateTenantRequest request = new("Updated Name", "updated@acme.com", "FR", AnyStamp);
+        UpdateTenantRequest request = new(Name: "Updated Name", ContactEmail: "updated@acme.com", Jurisdiction: "FR", ConcurrencyStamp: AnyStamp);
 
         request.Name.ShouldBe("Updated Name");
         request.ContactEmail.ShouldBe("updated@acme.com");
@@ -21,7 +21,7 @@ public sealed class UpdateTenantRequestTests
     [Fact]
     public void Constructor_NullContactEmail_IsValid()
     {
-        UpdateTenantRequest request = new("Acme", null, null, AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: null, Jurisdiction: null, ConcurrencyStamp: AnyStamp);
 
         request.ContactEmail.ShouldBeNull();
     }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
@@ -14,7 +14,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void ValidRequest_Succeeds()
     {
-        UpdateTenantRequest request = new("Updated Name", "admin@acme.com", null, AnyStamp);
+        UpdateTenantRequest request = new(Name: "Updated Name", ContactEmail: "admin@acme.com", Jurisdiction: null, ConcurrencyStamp: AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -24,7 +24,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void EmptyName_Fails()
     {
-        UpdateTenantRequest request = new("", "admin@acme.com", null, AnyStamp);
+        UpdateTenantRequest request = new(Name: "", ContactEmail: "admin@acme.com", Jurisdiction: null, ConcurrencyStamp: AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -35,7 +35,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void NameTooLong_Fails()
     {
-        UpdateTenantRequest request = new(new string('A', 257), null, null, AnyStamp);
+        UpdateTenantRequest request = new(Name: new string('A', 257), ContactEmail: null, Jurisdiction: null, ConcurrencyStamp: AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -46,7 +46,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void InvalidEmail_Fails()
     {
-        UpdateTenantRequest request = new("Acme", "not-an-email", null, AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: "not-an-email", Jurisdiction: null, ConcurrencyStamp: AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -57,7 +57,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void NullEmail_Succeeds()
     {
-        UpdateTenantRequest request = new("Acme", null, null, AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: null, Jurisdiction: null, ConcurrencyStamp: AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -67,7 +67,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void JurisdictionTooLong_Fails()
     {
-        UpdateTenantRequest request = new("Acme", null, new string('A', 17), AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: null, Jurisdiction: new string('A', 17), ConcurrencyStamp: AnyStamp);
 
         ValidationResult result = _validator.Validate(request);
 

--- a/tests/Granit.Templating.Endpoints.Tests/Dtos/TemplatingDtoTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/Dtos/TemplatingDtoTests.cs
@@ -13,7 +13,7 @@ public sealed class TemplatingDtoTests
     [Fact]
     public void SaveTemplateRequest_DefaultMimeType_IsTextHtml()
     {
-        SaveTemplateRequest request = new("Test.Template", null, "<p>Hello</p>");
+        SaveTemplateRequest request = new(Name: "Test.Template", Culture: null, Content: "<p>Hello</p>");
 
         request.MimeType.ShouldBe("text/html");
     }
@@ -21,7 +21,7 @@ public sealed class TemplatingDtoTests
     [Fact]
     public void SaveTemplateRequest_AllProperties_SetCorrectly()
     {
-        SaveTemplateRequest request = new("Billing.Invoice", "fr-BE", "<p>Facture</p>", "text/plain");
+        SaveTemplateRequest request = new(Name: "Billing.Invoice", Culture: "fr-BE", Content: "<p>Facture</p>", MimeType: "text/plain");
 
         request.Name.ShouldBe("Billing.Invoice");
         request.Culture.ShouldBe("fr-BE");

--- a/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
@@ -250,7 +250,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await client.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest("Billing.Invoice", null, "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: null, Content: "<h1>Hello</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotImplemented);
@@ -277,7 +277,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest("Billing.Invoice", "fr", "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: "fr", Content: "<h1>Hello</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
@@ -302,7 +302,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest(null, null, "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Name: null, Culture: null, Content: "<h1>Hello</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -313,7 +313,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest("invalid", null, "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Name: "invalid", Culture: null, Content: "<h1>Hello</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
@@ -324,7 +324,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest("Billing.Invoice", null, ""),
+            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: null, Content: ""),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
@@ -342,7 +342,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await client.PutAsJsonAsync(
             $"{Prefix}/Billing.Invoice",
-            new SaveTemplateRequest(null, null, "<h1>Updated</h1>"),
+            new SaveTemplateRequest(Name: null, Culture: null, Content: "<h1>Updated</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotImplemented);
@@ -369,7 +369,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await _adminClient.PutAsJsonAsync(
             $"{Prefix}/Billing.Invoice",
-            new SaveTemplateRequest(null, "fr", "<h1>Updated</h1>"),
+            new SaveTemplateRequest(Name: null, Culture: "fr", Content: "<h1>Updated</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -394,7 +394,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PutAsJsonAsync(
             $"{Prefix}/bad",
-            new SaveTemplateRequest(null, null, "<h1>Updated</h1>"),
+            new SaveTemplateRequest(Name: null, Culture: null, Content: "<h1>Updated</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -946,7 +946,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _anonClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest("Billing.Invoice", null, "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: null, Content: "<h1>Hello</h1>"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);


### PR DESCRIPTION
Part of #2546. Completes the 11 nullable params #2549 left flagged (a required no-default parameter sat after the optional candidate).

Two approaches per the blocker type:

- **`bool` blocker → default the bool** (no reorder, zero call-site impact): `AIWorkspaceUpdateRequest.Activated = false`, `IdentityUserCreateRequest.Enabled = false`, `CreateExportJobRequest.IncludeIdForImport = false`. Their nullable params get `= null`.
- **required `string`/`Guid` blocker (can't default) → reorder** the record so required params come first, optional (`= null`) last: `UpdateTenantRequest`, `LegalDocumentUpdateRequest`, `SaveTemplateRequest`. Positional test call sites converted to **named arguments** (records deserialize by name, so the reorder is contract-safe).

## Verification
- Generator regenerated: `AIWorkspaceUpdateRequest` → `required:[provider,model]`; `UpdateTenantRequest` → `[name,concurrencyStamp]`; `LegalDocumentUpdateRequest` → `[displayName,concurrencyStamp]`; `CreateExportJobRequest` → `[definitionName,format]`; `SaveTemplateRequest` → `[content]`.
- 623 tests across the 6 affected modules pass; build + format clean.

Remaining in #2546: `RoleCreateRequest.TenantId` (conditionally required — intentionally left) and the direction-aware analyzer/arch-test.