### PR TITLE
feat(openapi): shared Granit.OpenApi.Generation helper + GRAPI003=Error

### DIFF
--- a/Granit.slnx
+++ b/Granit.slnx
@@ -318,6 +318,7 @@
   <Folder Name="/src/Tooling/">
     <Project Path="src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj" />
     <Project Path="src/Granit.Analyzers/Granit.Analyzers.csproj" />
+    <Project Path="src/Granit.OpenApi.Generation/Granit.OpenApi.Generation.csproj" />
     <Project Path="src/Granit.OpenApi.Generator/Granit.OpenApi.Generator.csproj" />
     <Project Path="src/Granit.Testing.EntityFrameworkCore/Granit.Testing.EntityFrameworkCore.csproj" />
     <Project Path="src/Granit.Testing/Granit.Testing.csproj" />

--- a/src/Granit.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Granit.Analyzers/AnalyzerReleases.Unshipped.md
@@ -17,7 +17,7 @@ GRSEC005 | Security | Warning | PrivacyExportSubjectSubstitutionAnalyzer, IsEnab
 GREF001 | EntityFramework | Warning | SynchronousSaveChangesAnalyzer, IsEnabledByDefault=True
 GRAPI001 | Api | Warning | UntypedResultsAnalyzer, IsEnabledByDefault=True
 GRAPI002 | Api | Warning | TypedResultsBadRequestAnalyzer, IsEnabledByDefault=True
-GRAPI003 | Api | Warning | MinimalApiServiceParameterAnalyzer, IsEnabledByDefault=True
+GRAPI003 | Api | Error | MinimalApiServiceParameterAnalyzer, IsEnabledByDefault=True
 GRMOD001 | Architecture | Error | CrossModuleReferenceAnalyzer, IsEnabledByDefault=True
 GRSEC010 | Security | Error | TagListPiiAnalyzer, IsEnabledByDefault=True
 GRSEC011 | Security | Error | LoggerMessagePiiAnalyzer, IsEnabledByDefault=True

--- a/src/Granit.Analyzers/MinimalApiServiceParameterAnalyzer.cs
+++ b/src/Granit.Analyzers/MinimalApiServiceParameterAnalyzer.cs
@@ -6,9 +6,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Granit.Analyzers;
 
 /// <summary>
-/// GRAPI003 — Reports a warning when a minimal API endpoint handler has an interface-typed
+/// GRAPI003 — Reports an error when a minimal API endpoint handler has an interface-typed
 /// parameter without an explicit binding attribute (<c>[FromServices]</c>,
-/// <c>[FromQuery]</c>, <c>[FromBody]</c>, etc.).
+/// <c>[FromQuery]</c>, <c>[FromBody]</c>, etc.). The unbound parameter is mis-inferred as
+/// <c>[FromBody]</c> and throws at startup on GET/DELETE — a latent crash, not a style nit,
+/// hence error severity (on par with the data-loss and security rules).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -59,7 +61,7 @@ public sealed class MinimalApiServiceParameterAnalyzer : SingleRuleAnalyzerBase
         messageFormat: "Parameter '{0}' of interface type '{1}' must be decorated with [FromServices]. "
             + "Without it, ASP.NET Core may infer the parameter as [FromBody] and throw at startup.",
         category: "Api",
-        defaultSeverity: DiagnosticSeverity.Warning,
+        defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "In minimal API endpoint handlers (static methods returning an IResult-derived type), "
             + "parameters of interface type must have [FromServices] so that ASP.NET Core resolves them "

--- a/src/Granit.OpenApi.Generation/Granit.OpenApi.Generation.csproj
+++ b/src/Granit.OpenApi.Generation/Granit.OpenApi.Generation.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.OpenApi.Generation</PackageId>
+    <Description>Build-time OpenAPI contract generator shared across Granit bounded contexts (framework and downstream repos). Composes Granit.*.Endpoints modules through the Granit module system and emits one OpenAPI 3.1 document per module — no running host, no infrastructure. Consumed by per-repo *.OpenApi.Generator build projects.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Granit umbrella (AddGranitAsync, the module-system bootstrap) + the ApiDocumentation
+         transformer chain (AddGranitOpenApiDocument drives per-module slicing). -->
+    <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
+++ b/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
@@ -1,0 +1,102 @@
+using Granit.Extensions;
+using Granit.Http.ApiDocumentation.Extensions;
+using Granit.Modularity;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Granit.OpenApi.Generation;
+
+/// <summary>
+/// Build-time OpenAPI contract generator shared by every Granit bounded context (the framework and
+/// every downstream repo). Composes the supplied <see cref="OpenApiContractModule"/> set through the
+/// Granit module system and emits one OpenAPI 3.1 document per module — no running host, no
+/// infrastructure. The single home for the doc-gen quirks every generator would otherwise re-discover.
+/// </summary>
+/// <remarks>
+/// Drive it from a <c>Microsoft.NET.Sdk.Web</c> project with <c>OpenApiGenerateDocuments=true</c>: the
+/// build invokes <c>GetDocument.Insider</c>, which runs <c>Host.StartAsync()</c> against an inert
+/// server. All <see cref="IHostedService"/>, <see cref="IStartupValidator"/> and
+/// <see cref="IValidateOptions{T}"/> registrations are stripped so that start-up is a no-op and no
+/// module reaches for real infrastructure (DB / Vault / object store / message bus).
+/// <para>
+/// This helper deliberately does <b>not</b> work around handler-injected application services. A
+/// contract-only generator composes only the <c>.Endpoints</c> layer, so services whose impl lives in
+/// a persistence/caching/provider module are unregistered; minimal-API binding then mis-infers such an
+/// interface parameter as a request body and throws on GET/DELETE. The correct fix is at the source —
+/// annotate every application-service handler parameter with <c>[FromServices]</c>, which forces service
+/// binding regardless of registration. Where that discipline is not yet in place, pass the leaking
+/// contracts to <see cref="OpenApiContractServiceCollectionExtensions.AddContractServiceStubs"/> from
+/// the <paramref name="configure"/> hook — an explicit, self-documenting list, never a blanket mask.
+/// </para>
+/// </remarks>
+public static class OpenApiContractGenerator
+{
+    /// <summary>Composes <paramref name="modules"/> under <typeparamref name="TRootModule"/> and runs the doc-gen host.</summary>
+    /// <typeparam name="TRootModule">Root Granit module whose <c>[DependsOn]</c> graph pulls in every endpoint module.</typeparam>
+    /// <param name="args">Process arguments forwarded to <see cref="WebApplication.CreateBuilder(string[])"/>.</param>
+    /// <param name="modules">The slug-to-route-mapping pairs; one generated document each.</param>
+    /// <param name="configure">
+    /// Optional hook run after the base services are registered and before module composition — for
+    /// modules that expose an explicit <c>AddGranit*Endpoints</c> service registration, to stub a
+    /// service the contract needs (e.g. a frontend entry so BFF emits paths), or to declare leaking
+    /// application-service contracts via <c>AddContractServiceStubs</c>.
+    /// </param>
+    public static async Task RunAsync<TRootModule>(
+        string[] args,
+        IReadOnlyList<OpenApiContractModule> modules,
+        Action<WebApplicationBuilder>? configure = null)
+        where TRootModule : GranitModule
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(modules);
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+        // Cheap, infra-free ASP.NET services the Granit OpenAPI transformers assume a host wires
+        // (e.g. JwtBearerSecuritySchemeTransformer constructor-injects IAuthenticationSchemeProvider).
+        builder.Services.AddAuthentication();
+        builder.Services.AddAuthorizationBuilder();
+
+        configure?.Invoke(builder);
+
+        // One OpenAPI document per module, sliced by the GroupName stamped on its routes below, each
+        // carrying the full Granit transformer chain so the artifacts match the framework's served
+        // output (int32 normalized, int64 string-union kept, problem-details enriched, tags sorted).
+        foreach (OpenApiContractModule module in modules)
+        {
+            string slug = module.Slug;
+            builder.AddGranitOpenApiDocument(slug, slug, description => description.GroupName == slug);
+        }
+
+        await builder.AddGranitAsync<TRootModule>().ConfigureAwait(false);
+
+        // Doc-gen neutralization: the OpenAPI document is built from endpoint metadata in the request
+        // pipeline, never from hosted services or options validation. Strip all three so Host.StartAsync()
+        // is a no-op and no module reaches for real infrastructure (DB / Vault / object store / messaging).
+        builder.Services.RemoveAll<IHostedService>();
+        builder.Services.RemoveAll<IStartupValidator>();
+        foreach (ServiceDescriptor validator in builder.Services
+            .Where(d => d.ServiceType.IsGenericType
+                && d.ServiceType.GetGenericTypeDefinition() == typeof(IValidateOptions<>))
+            .ToList())
+        {
+            builder.Services.Remove(validator);
+        }
+
+        WebApplication app = builder.Build();
+
+        // Each module's routes are mounted under an empty-prefix group stamped with the module slug.
+        // WithGroupName propagates to nested groups, so shared-helper endpoints (e.g. MapGranitQuery<T>)
+        // still land in the owning module's document.
+        foreach (OpenApiContractModule module in modules)
+        {
+            module.Map(app.MapGroup(string.Empty).WithGroupName(module.Slug));
+        }
+
+        await app.RunAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Granit.OpenApi.Generation/OpenApiContractModule.cs
+++ b/src/Granit.OpenApi.Generation/OpenApiContractModule.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.OpenApi.Generation;
+
+/// <summary>One generated OpenAPI document: a module slug and the routes mounted under it.</summary>
+/// <param name="Slug">Document name and <c>GroupName</c> stamped on the module's routes.</param>
+/// <param name="Map">Mounts the module's <c>MapGranit*</c> endpoints onto the supplied builder.</param>
+public sealed record OpenApiContractModule(string Slug, Action<IEndpointRouteBuilder> Map);

--- a/src/Granit.OpenApi.Generation/OpenApiContractServiceCollectionExtensions.cs
+++ b/src/Granit.OpenApi.Generation/OpenApiContractServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.OpenApi.Generation;
+
+/// <summary>Service-collection helpers for build-time OpenAPI contract generation.</summary>
+public static class OpenApiContractServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers each contract as an inert <c>null</c> singleton so the minimal-API binder classifies it
+    /// as a service (not a request body) during doc-gen. Use sparingly, for application-service
+    /// parameters a contract-only generator cannot compose and that are <b>not</b> annotated with
+    /// <c>[FromServices]</c> — the proper fix is the attribute, which makes this unnecessary. The stubs
+    /// are never resolved (handlers do not run during generation), so <c>null</c> is safe and the
+    /// explicit list documents exactly which services leak through the endpoints layer.
+    /// </summary>
+    /// <param name="services">The doc-gen service collection.</param>
+    /// <param name="contracts">The application-service contract types to stub.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddContractServiceStubs(
+        this IServiceCollection services,
+        params ReadOnlySpan<Type> contracts)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        foreach (Type contract in contracts)
+        {
+            ArgumentNullException.ThrowIfNull(contract);
+            services.AddSingleton(contract, _ => null!);
+        }
+
+        return services;
+    }
+}

--- a/src/Granit.OpenApi.Generation/packages.lock.json
+++ b/src/Granit.OpenApi.Generation/packages.lock.json
@@ -1,0 +1,87 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Granit.Http.SecurityHeaders.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.securityheaders.abstractions": {
+        "type": "Project"
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "cw24xHE2QaWwyEG9GQwFbjboyabub6Vd80DIItUGENzcQOa/BEnTrXsg2GADqWTmY/3ycqk9ToLGjgvF/VRlGA==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.14.14",
+        "contentHash": "xNa3MadDudKk7y+0gQPBQihVL+JxGP3KNZHB4Zl2W42ATFIffHHHBjsuyKJ4YPUnnA7NUiHR/diqV/FTZC9dkg=="
+      }
+    }
+  }
+}

--- a/src/Granit.OpenApi.Generator/GeneratorEndpoints.cs
+++ b/src/Granit.OpenApi.Generator/GeneratorEndpoints.cs
@@ -27,14 +27,10 @@ using Granit.Templating.Endpoints.Extensions;
 using Granit.Timeline.Endpoints.Extensions;
 using Granit.Validation.Endpoints.Extensions;
 using Granit.Webhooks.Endpoints.Extensions;
+using Granit.OpenApi.Generation;
 using Granit.Workflow.Endpoints.Extensions;
 
 namespace Granit.OpenApi.Generator;
-
-/// <summary>One generated OpenAPI document: a module slug and the routes mounted under it.</summary>
-/// <param name="Slug">Document name and <c>GroupName</c> stamped on the module's routes.</param>
-/// <param name="Map">Mounts the module's <c>MapGranit*</c> endpoints onto the supplied builder.</param>
-internal sealed record EndpointModule(string Slug, Action<IEndpointRouteBuilder> Map);
 
 /// <summary>
 /// The single source of truth pairing each <c>Granit.*.Endpoints</c> module with its slug and
@@ -43,7 +39,7 @@ internal sealed record EndpointModule(string Slug, Action<IEndpointRouteBuilder>
 /// </summary>
 internal static class GeneratorEndpoints
 {
-    public static readonly IReadOnlyList<EndpointModule> All =
+    public static readonly IReadOnlyList<OpenApiContractModule> All =
     [
         new("ai", e => e.MapGranitAI()),
         new("auditing", e => e.MapGranitAuditing()),

--- a/src/Granit.OpenApi.Generator/Granit.OpenApi.Generator.csproj
+++ b/src/Granit.OpenApi.Generator/Granit.OpenApi.Generator.csproj
@@ -19,8 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Direct dependency: AddGranitOpenApiDocument drives per-module slicing + the transformer chain. -->
-    <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
+    <!-- Shared doc-gen orchestration: OpenApiContractGenerator.RunAsync (per-module slicing, infra
+         neutralization, the minimal-API binding probe). Brings Granit + Granit.Http.ApiDocumentation. -->
+    <ProjectReference Include="..\Granit.OpenApi.Generation\Granit.OpenApi.Generation.csproj" />
     <ProjectReference Include="..\Granit.AI.Endpoints\Granit.AI.Endpoints.csproj" />
     <ProjectReference Include="..\Granit.Auditing.Endpoints\Granit.Auditing.Endpoints.csproj" />
     <ProjectReference Include="..\Granit.Authentication.ApiKeys.Endpoints\Granit.Authentication.ApiKeys.Endpoints.csproj" />

--- a/src/Granit.OpenApi.Generator/Program.cs
+++ b/src/Granit.OpenApi.Generator/Program.cs
@@ -1,59 +1,22 @@
 using Granit.Authentication.ApiKeys.Endpoints.Extensions;
 using Granit.BlobStorage.Endpoints.Extensions;
-using Granit.Extensions;
-using Granit.Http.ApiDocumentation.Extensions;
 using Granit.Identity.Endpoints.Extensions;
+using Granit.OpenApi.Generation;
 using Granit.OpenApi.Generator;
 using Granit.Workflow.Endpoints.Extensions;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-
-// Cheap, infra-free ASP.NET services the Granit OpenAPI transformers assume a host wires
-// (e.g. JwtBearerSecuritySchemeTransformer constructor-injects IAuthenticationSchemeProvider).
-builder.Services.AddAuthentication();
-builder.Services.AddAuthorizationBuilder();
-
-// The four endpoint modules that expose a host-builder/service registration method.
-builder.AddGranitBlobStorageEndpoints();
-builder.Services.AddGranitApiKeysEndpoints();
-builder.Services.AddGranitIdentityEndpoints();
-builder.Services.AddGranitWorkflowEndpoints();
-
-// One OpenAPI document per module, sliced by the GroupName stamped on its routes below, each
-// carrying the full Granit transformer chain so the artifacts match the framework's served output
-// (int32 normalized, int64 string-union kept, problem-details enriched, tags sorted).
-foreach (EndpointModule module in GeneratorEndpoints.All)
-{
-    string slug = module.Slug;
-    builder.AddGranitOpenApiDocument(slug, slug, description => description.GroupName == slug);
-}
-
-await builder.AddGranitAsync<GeneratorModule>();
-
-// Doc-gen neutralization: the OpenAPI document is built from endpoint metadata in the request
-// pipeline, never from hosted services or options validation. Strip all three so Host.StartAsync()
-// is a no-op and no module reaches for real infrastructure (DB / Vault / object store / messaging).
-// This keeps the generator config-free and independent of how many modules are composed.
-builder.Services.RemoveAll<IHostedService>();
-builder.Services.RemoveAll<IStartupValidator>();
-foreach (ServiceDescriptor validator in builder.Services
-    .Where(d => d.ServiceType.IsGenericType
-        && d.ServiceType.GetGenericTypeDefinition() == typeof(IValidateOptions<>))
-    .ToList())
-{
-    builder.Services.Remove(validator);
-}
-
-WebApplication app = builder.Build();
-
-// Each module's routes are mounted under an empty-prefix group stamped with the module slug.
-// WithGroupName propagates to nested groups, so shared-helper endpoints (e.g. MapGranitQuery<T>,
-// whose handler lives in Granit.QueryEngine.AspNetCore) still land in the owning module's document.
-foreach (EndpointModule module in GeneratorEndpoints.All)
-{
-    module.Map(app.MapGroup(string.Empty).WithGroupName(module.Slug));
-}
-
-await app.RunAsync();
+// All doc-gen orchestration (per-module document slicing, infra neutralization, the minimal-API
+// binding probe) lives in the shared Granit.OpenApi.Generation helper, so this entry point only
+// declares what is specific to the framework's own contract: the module graph (GeneratorModule),
+// the slug-to-routes pairing (GeneratorEndpoints.All), and the four modules that expose an explicit
+// service-registration method rather than registering purely via [DependsOn].
+await OpenApiContractGenerator.RunAsync<GeneratorModule>(
+    args,
+    GeneratorEndpoints.All,
+    builder =>
+    {
+        builder.AddGranitBlobStorageEndpoints();
+        builder.Services.AddGranitApiKeysEndpoints();
+        builder.Services.AddGranitIdentityEndpoints();
+        builder.Services.AddGranitWorkflowEndpoints();
+    });


### PR DESCRIPTION
## Why

Build-time OpenAPI contract generation (one document per `Granit.*.Endpoints` module, consumed by granit-front) was **copy-pasted per repo** — the orchestration in `Program.cs` is byte-for-byte identical between granit-dotnet and granit-website, and would be a third copy in granit-iot. This PR extracts it once and codifies the service-binding gotcha that every downstream generator otherwise re-discovers.

## What

### New package `Granit.OpenApi.Generation` (packable)
- `OpenApiContractGenerator.RunAsync<TRootModule>(args, modules, configure)` — owns all doc-gen mechanics: per-module slicing (`AddGranitOpenApiDocument`), infra neutralization (strips `IHostedService` / `IStartupValidator` / `IValidateOptions<>` so `Host.StartAsync()` is a no-op), and mounting each module under `WithGroupName(slug)`.
- `OpenApiContractModule(Slug, Map)` — public slug↔routes record.
- `AddContractServiceStubs(params Type[])` — **explicit, last-resort** escape hatch for application-service interfaces a contract-only generator cannot compose. **No blanket masking by default** — the real fix is `[FromServices]` (see below).

### `Granit.OpenApi.Generator` migrated (the proof)
`Program.cs` collapses from ~50 lines to a single `RunAsync` call (the four `AddGranit*Endpoints` registrations move into the `configure` hook). It needs **zero stubs** because it composes the full module graph.

### `GRAPI003` promoted `Warning` → `Error`
`MinimalApiServiceParameterAnalyzer` flags interface-typed minimal-API handler params lacking an explicit binding attribute — ASP.NET Core mis-infers them as `[FromBody]` and **throws at startup on GET/DELETE**. That is a latent crash, not a style nit (on par with `GRMIGA001/002`, `GRSEC003`, already Error). Making it build-breaking at the source is what lets downstream generators (which compose only the `.Endpoints` layer) drop their service-stub workarounds. A code fix already auto-adds the attribute; existing false positives stay suppressed via `#pragma`; tests assert by id, not severity.

## Downstream (follow-up PRs, after this publishes to the dev feed)
- **granit-website**: migrate its generator to the helper, bump `Granit.Analyzers`, drop its 12-entry stub list (`TreatWarningsAsErrors=true` surfaces any remaining un-annotated handler param → code-fix).
- **granit-iot**: scaffold a generator (3 modules: `iot`, `iot-ingestion`, `iot-fleet-provisioning`).

## Notes / validation
- Docs ship separately in granit-docs.
- ⚠️ Local builds in WSL hit pre-existing `CS9057` (Granit.Analyzers.dll built against Roslyn 5.3, SDK 10.0.108 ships compiler 5.0) — **needs CI to validate the build**, including that granit-dotnet is `GRAPI003`-clean under the new Error severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)