### PR TITLE
test(vault): de-flake VerifyAsync_RejectsTamperedTag

### DIFF
--- a/tests/Granit.Vault.Tests/Services/SecretBackedMacServiceTests.cs
+++ b/tests/Granit.Vault.Tests/Services/SecretBackedMacServiceTests.cs
@@ -78,9 +78,15 @@ public sealed class SecretBackedMacServiceTests : IDisposable
         byte[] input = Encoding.UTF8.GetBytes("hello");
 
         TransitMacResult tag = await sut.MacAsync("k", input, TestContext.Current.CancellationToken);
-        // Flip the last char of the base64 payload
-        char last = tag.Mac[^1];
-        string flipped = string.Concat(tag.Mac.AsSpan(0, tag.Mac.Length - 1), last == 'A' ? "B" : "A");
+        // Tamper a *significant* base64url character — NOT the last one. A 32-byte MAC encodes to 43
+        // base64url chars whose final char carries only 4 significant bits + 2 padding bits, so the
+        // 'A'<->'B' flip there toggles only a padding bit and decodes to the same MAC (~1/16 flake when
+        // the last char is 'A'). The first body char is fully significant, so flipping it always changes
+        // the decoded bytes.
+        int bodyStart = tag.Mac.LastIndexOf(':') + 1;
+        char original = tag.Mac[bodyStart];
+        string flipped = string.Concat(
+            tag.Mac.AsSpan(0, bodyStart), original == 'A' ? "B" : "A", tag.Mac.AsSpan(bodyStart + 1));
 
         (await sut.VerifyAsync("k", input, flipped, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }


### PR DESCRIPTION
## Problem

`SecretBackedMacServiceTests.VerifyAsync_RejectsTamperedTag` is flaky (~1/16 failure rate, random key per run). It surfaced as a red CI run unrelated to the change under test.

## Root cause

The test tampers the MAC by flipping the **last** base64url character (`'A'`↔`'B'`). A 32-byte MAC (HMAC-SHA256) encodes to 43 base64url chars (no padding), and the **final char carries only 4 significant bits + 2 padding bits**. `'A'`=0 and `'B'`=1 differ solely in the lowest bit — a *padding* bit. So when the last char happens to be `'A'`, the `'A'`→`'B'` flip toggles a dropped bit: the "tampered" tag **decodes to the same MAC**, `VerifyAsync` correctly returns `true`, and `ShouldBeFalse()` fails. The last char is one of 16 padding-aligned values, so this hits ~1/16 of runs.

## Fix

Tamper the **first** body character instead. The first base64url char is fully significant (top 6 bits of MAC byte 0), so flipping it always changes the decoded bytes and the tampered tag is reliably rejected. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)