### PR TITLE
build: fix NU1004 — regenerate lock files for ApiKeys consumers

### DIFF
--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -429,6 +429,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
@@ -443,6 +444,7 @@
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"

--- a/tests/Granit.Authentication.ApiKeys.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Authentication.ApiKeys.Notifications.Tests/packages.lock.json
@@ -258,6 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",


### PR DESCRIPTION
## Problem

CI fails with **NU1004** on the `src-only` and `security` shards:

> The project references granit.authentication.apikeys whose dependencies has changed. The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode.

Commit #2554 (`refactor(apikeys): route key listing through QueryEngine`) changed the dependencies of `Granit.Authentication.ApiKeys` and `Granit.Authentication.ApiKeys.Endpoints` but did not regenerate the lock files of downstream consumers.

## Fix

`dotnet restore --force-evaluate` over every ApiKeys consumer. Only two lock files had genuine drift:

- **`Granit.OpenApi.Generator`** (`src-only` shard) — adds `Granit.DataExchange.Abstractions` (via ApiKeys.Endpoints) and `Granit.QueryEngine.AspNetCore` (via ApiKeys)
- **`Granit.Authentication.ApiKeys.Notifications.Tests`** (`security` shard)

Both now pass `dotnet restore --locked-mode`. Unrelated transitive drift surfaced by `--force-evaluate` (floating Azure/AWS SDK ranges) was reverted to keep the change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)