### PR TITLE
feat(datalookup): QueryDefinition-backed lookup source with real cursor pagination

### DIFF
--- a/src/Granit.DataLookup.EntityFrameworkCore/Extensions/QueryDefinitionLookupExtensions.cs
+++ b/src/Granit.DataLookup.EntityFrameworkCore/Extensions/QueryDefinitionLookupExtensions.cs
@@ -1,0 +1,46 @@
+using Granit.DataLookup.EntityFrameworkCore.Sources;
+using Granit.DataLookup.Sources;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.DataLookup.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Extension methods for registering <see cref="QueryDefinitionLookupSource{TEntity}"/> instances.
+/// </summary>
+public static class QueryDefinitionLookupExtensions
+{
+    /// <summary>
+    /// Registers a scoped <see cref="QueryDefinitionLookupSource{TEntity}"/> that reuses a
+    /// <see cref="QueryDefinition{TEntity}"/> — which MUST declare <c>AsLookup</c> — and the
+    /// open-generic <see cref="IQueryEngine{TEntity}"/> to serve typeahead lookups, including
+    /// keyset/cursor pagination.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type.</typeparam>
+    /// <typeparam name="TDbContext">The DbContext exposing <c>Set&lt;TEntity&gt;()</c>.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// The host must already have registered the query definition
+    /// (<c>AddQueryDefinition&lt;TEntity, TDefinition&gt;</c>) and the query engine runtime
+    /// (<c>Granit.QueryEngine.EntityFrameworkCore</c>); both are resolved per request.
+    /// </remarks>
+    public static IServiceCollection AddQueryDefinitionLookup<TEntity, TDbContext>(
+        this IServiceCollection services)
+        where TEntity : class
+        where TDbContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<ILookupSource>(sp =>
+        {
+            IQueryEngine<TEntity> engine = sp.GetRequiredService<IQueryEngine<TEntity>>();
+            QueryDefinition<TEntity> definition = sp.GetRequiredService<QueryDefinition<TEntity>>();
+            TDbContext db = sp.GetRequiredService<TDbContext>();
+            return new QueryDefinitionLookupSource<TEntity>(engine, definition, () => db.Set<TEntity>());
+        });
+
+        return services;
+    }
+}

--- a/src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj
+++ b/src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.DataLookup.EntityFrameworkCore</PackageId>
-    <Description>Entity Framework Core adapter for Granit.DataLookup. Provides QueryableLookupSource&lt;T&gt; that wraps an IQueryable&lt;T&gt; with value/label selectors and serves paginated lookup results honoring the current culture, tenant, and scope keys.</Description>
+    <Description>Entity Framework Core adapter for Granit.DataLookup. Provides QueryableLookupSource&lt;T&gt; (wraps an IQueryable&lt;T&gt; with value/label selectors) and QueryDefinitionLookupSource&lt;T&gt; (reuses a Granit.QueryEngine QueryDefinition for search, sort, and keyset/cursor pagination), serving paginated lookup results honoring the current culture, tenant, and scope keys.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.DataLookup\Granit.DataLookup.csproj" />
     <ProjectReference Include="..\Granit.Persistence\Granit.Persistence.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.DataLookup.EntityFrameworkCore/GranitDataLookupEntityFrameworkCoreModule.cs
+++ b/src/Granit.DataLookup.EntityFrameworkCore/GranitDataLookupEntityFrameworkCoreModule.cs
@@ -1,5 +1,6 @@
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
 
 namespace Granit.DataLookup.EntityFrameworkCore;
 
@@ -7,11 +8,13 @@ namespace Granit.DataLookup.EntityFrameworkCore;
 /// Granit module for the Entity Framework Core adapter of Granit.DataLookup.
 /// </summary>
 /// <remarks>
-/// Provides <see cref="Sources.QueryableLookupSource{T}"/>. Module authors register
-/// sources with the <see cref="Extensions.DataLookupQueryableExtensions.AddQueryableLookup{T, TDbContext}"/>
-/// extension.
+/// Provides <see cref="Sources.QueryableLookupSource{T}"/> and
+/// <see cref="Sources.QueryDefinitionLookupSource{T}"/>. Module authors register sources with
+/// <see cref="Extensions.DataLookupQueryableExtensions.AddQueryableLookup{T, TDbContext}"/> or
+/// <see cref="Extensions.QueryDefinitionLookupExtensions.AddQueryDefinitionLookup{TEntity, TDbContext}"/>.
 /// </remarks>
 [DependsOn(
     typeof(GranitDataLookupModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitQueryEngineAbstractionsModule))]
 public sealed class GranitDataLookupEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.DataLookup.EntityFrameworkCore/README.md
+++ b/src/Granit.DataLookup.EntityFrameworkCore/README.md
@@ -18,12 +18,27 @@ services.AddQueryableLookup<Tenant, TenantsDbContext>(
     requiredPermission: "Platform.Tenants.Read");
 ```
 
-## Roadmap
+## QueryDefinition-backed lookups
 
-PR 2 will add a higher-level `QueryDefinitionLookupSource<T>` that plugs directly into
-`Granit.QueryEngine` so module authors can write:
+`QueryDefinitionLookupSource<T>` plugs directly into `Granit.QueryEngine`, reusing a
+`QueryDefinition<T>`'s global search, sort, filters, and keyset/cursor pagination. Declare the
+lookup on the definition and register the source against its `DbContext`:
 
 ```csharp
-builder.AsLookup("tenants", value: t => t.Id, label: t => t.Name)
-       .WithRequiredPermission("Platform.Tenants.Read");
+// In the QueryDefinition (base module):
+protected override void Configure(QueryDefinitionBuilder<Tenant> builder) =>
+    builder
+        .Column(t => t.Name, c => c.Sortable().Filterable())
+        .GlobalSearch(t => t.Name)
+        .DefaultSort("Name")
+        .SupportsCursorPagination(t => t.Id)   // enables infinite-scroll (NextCursor)
+        .AsLookup("tenants", value: t => t.Id, label: t => t.Name,
+            requiredPermission: "Platform.Tenants.Read");
+
+// In the host/EF module:
+services.AddQueryDefinitionLookup<Tenant, TenantsDbContext>();
 ```
+
+`ContinuationToken` round-trips to the engine's keyset cursor, so paging through
+`GET /lookups/tenants?continuationToken=…` yields a true infinite-scroll feed. Scope keys map
+to equality filters on the matching filterable columns (cascading pickers).

--- a/src/Granit.DataLookup.EntityFrameworkCore/Sources/QueryDefinitionLookupSource.cs
+++ b/src/Granit.DataLookup.EntityFrameworkCore/Sources/QueryDefinitionLookupSource.cs
@@ -1,0 +1,184 @@
+using System.Globalization;
+using System.Linq.Expressions;
+using Granit.DataLookup.Descriptors;
+using Granit.DataLookup.Registry;
+using Granit.DataLookup.Sources;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.DataLookup.EntityFrameworkCore.Sources;
+
+/// <summary>
+/// Lookup source backed by a <see cref="QueryDefinition{TEntity}"/> that declared
+/// <see cref="QueryDefinitionBuilder{TEntity}.AsLookup{TValue}"/>. Delegates search, sort,
+/// pagination, and keyset/cursor handling to <see cref="IQueryEngine{TEntity}"/>, then
+/// projects the materialized page to the canonical <see cref="LookupItem"/> shape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The non-projecting <see cref="IQueryEngine{TEntity}.ExecuteAsync(IQueryable{TEntity}, QueryRequest, CancellationToken)"/>
+/// overload is used on purpose: it is the only engine path that returns a <c>NextCursor</c>,
+/// so the lookup transparently supports infinite-scroll for definitions that opt into cursor
+/// pagination (<c>SupportsCursorPagination</c>). Only the requested page of entities is
+/// materialized (default 25 rows) and then projected in-memory — negligible over a typeahead
+/// page, and it keeps cursor support that server-side projection would forfeit.
+/// </para>
+/// <para>
+/// Scope keys are mapped to equality filters on the matching filterable columns, so a scoped
+/// lookup (e.g. <c>meter-definitions</c> scoped by <c>tenantId</c>) filters server-side via the
+/// definition's own filter pipeline.
+/// </para>
+/// </remarks>
+/// <typeparam name="TEntity">The entity type exposed by the definition.</typeparam>
+public sealed class QueryDefinitionLookupSource<TEntity> : ILookupSource, IKindProviderLookupSource
+    where TEntity : class
+{
+    private readonly IQueryEngine<TEntity> _engine;
+    private readonly Func<IQueryable<TEntity>> _queryableFactory;
+    private readonly Func<TEntity, object> _valueSelector;
+    private readonly Func<TEntity, string> _labelSelector;
+    private readonly LambdaExpression _valueExpression;
+    private readonly Type _valueType;
+    private readonly string[] _filterableColumns;
+
+    /// <summary>Initializes a new <see cref="QueryDefinitionLookupSource{TEntity}"/>.</summary>
+    /// <param name="engine">The query engine bound to <typeparamref name="TEntity"/>.</param>
+    /// <param name="definition">The query definition; MUST declare <c>AsLookup</c>.</param>
+    /// <param name="queryableFactory">Factory returning the base queryable (e.g. <c>() =&gt; db.Set&lt;TEntity&gt;()</c>).</param>
+    /// <exception cref="InvalidOperationException">Thrown when the definition did not declare <c>AsLookup</c>.</exception>
+    public QueryDefinitionLookupSource(
+        IQueryEngine<TEntity> engine,
+        QueryDefinition<TEntity> definition,
+        Func<IQueryable<TEntity>> queryableFactory)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(queryableFactory);
+
+        LookupSourceDescriptor descriptor = definition.GetLookupSource()
+            ?? throw new InvalidOperationException(
+                $"Query definition '{definition.Name}' does not declare a lookup source. Call " +
+                "builder.AsLookup(...) in its Configure method before registering it with AddQueryDefinitionLookup.");
+
+        _engine = engine;
+        _queryableFactory = queryableFactory;
+        _valueSelector = ((Expression<Func<TEntity, object>>)descriptor.BoxedValueSelector).Compile();
+        _labelSelector = ((Expression<Func<TEntity, string>>)descriptor.LabelSelector).Compile();
+        _valueExpression = descriptor.ValueSelector;
+        _valueType = descriptor.ValueType;
+        Name = descriptor.Name;
+        RequiredPermission = descriptor.RequiredPermission;
+        ScopeKeys = descriptor.ScopeKeys;
+        _filterableColumns = [.. definition.GetColumns().Where(c => c.IsFilterable).Select(c => c.PropertyName)];
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string? RequiredPermission { get; }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> ScopeKeys { get; }
+
+    LookupKind IKindProviderLookupSource.Kind => LookupKind.QueryEngine;
+
+    /// <inheritdoc/>
+    public async ValueTask<LookupResult> SearchAsync(LookupQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        QueryRequest request = new()
+        {
+            Search = query.Search,
+            PageSize = query.PageSize,
+            Cursor = query.ContinuationToken,
+            Page = query.ContinuationToken is null ? query.Page : null,
+            Filter = BuildScopeFilter(query.Scope),
+        };
+
+        PagedResult<TEntity> result = await _engine
+            .ExecuteAsync(_queryableFactory(), request, cancellationToken)
+            .ConfigureAwait(false);
+
+        LookupItem[] items = [.. result.Items.Select(e => new LookupItem(_valueSelector(e), _labelSelector(e)))];
+        return new LookupResult(items, result.TotalCount, result.NextCursor);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<LookupItem?> ResolveByValueAsync(object value, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        Expression<Func<TEntity, bool>> predicate = BuildEqualityPredicate(value);
+
+        TEntity? entity = await _queryableFactory()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(predicate, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : new LookupItem(_valueSelector(entity), _labelSelector(entity));
+    }
+
+    private Dictionary<string, string>? BuildScopeFilter(IReadOnlyDictionary<string, string?>? scope)
+    {
+        if (scope is null || scope.Count == 0)
+        {
+            return null;
+        }
+
+        Dictionary<string, string> filter = new(StringComparer.Ordinal);
+        foreach ((string key, string? value) in scope)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            string? column = Array.Find(_filterableColumns, c => string.Equals(c, key, StringComparison.OrdinalIgnoreCase));
+            if (column is not null)
+            {
+                filter[$"{column}.eq"] = value;
+            }
+        }
+
+        return filter.Count == 0 ? null : filter;
+    }
+
+    private Expression<Func<TEntity, bool>> BuildEqualityPredicate(object value)
+    {
+        ParameterExpression parameter = _valueExpression.Parameters[0];
+        Expression body = _valueExpression.Body;
+        object converted = ConvertToValueType(value);
+        BinaryExpression equality = Expression.Equal(body, Expression.Constant(converted, body.Type));
+        return Expression.Lambda<Func<TEntity, bool>>(equality, parameter);
+    }
+
+    private object ConvertToValueType(object value)
+    {
+        if (_valueType.IsInstanceOfType(value))
+        {
+            return value;
+        }
+
+        string text = value.ToString()
+            ?? throw new InvalidOperationException("Lookup value cannot be converted to a string.");
+
+        if (_valueType == typeof(Guid))
+        {
+            return Guid.Parse(text);
+        }
+
+        if (_valueType == typeof(string))
+        {
+            return text;
+        }
+
+        if (_valueType.IsEnum)
+        {
+            return Enum.Parse(_valueType, text, ignoreCase: true);
+        }
+
+        return Convert.ChangeType(text, _valueType, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Granit.DataLookup.EntityFrameworkCore/Sources/QueryableLookupSource.cs
+++ b/src/Granit.DataLookup.EntityFrameworkCore/Sources/QueryableLookupSource.cs
@@ -17,9 +17,9 @@ namespace Granit.DataLookup.EntityFrameworkCore.Sources;
 /// filters declared on the underlying <c>DbContext</c>.
 /// </para>
 /// <para>
-/// PR 2 will introduce a higher-level <c>QueryDefinitionLookupSource&lt;T&gt;</c> that
-/// layers on top of this primitive, reuses the QueryEngine search + sort infrastructure,
-/// and projects values server-side without materializing full entities.
+/// For lookups that should reuse an existing <c>Granit.QueryEngine</c> definition (its global
+/// search, sort, filters, and keyset/cursor pagination), prefer
+/// <see cref="QueryDefinitionLookupSource{T}"/> over this lower-level primitive.
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The entity type exposed by this source.</typeparam>

--- a/src/Granit.QueryEngine.Abstractions/LookupSourceDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/LookupSourceDescriptor.cs
@@ -1,0 +1,45 @@
+using System.Linq.Expressions;
+
+namespace Granit.QueryEngine;
+
+/// <summary>
+/// Declares that a <see cref="QueryDefinition{TEntity}"/> also serves as a data-lookup
+/// source (typeahead picker) registered under <see cref="Name"/>. Produced by
+/// <see cref="QueryDefinitionBuilder{TEntity}.AsLookup{TValue}"/> and consumed by
+/// <c>Granit.DataLookup.EntityFrameworkCore</c>'s <c>QueryDefinitionLookupSource&lt;TEntity&gt;</c>,
+/// which reuses the query engine's search, sort, and keyset-pagination pipeline.
+/// </summary>
+public sealed record LookupSourceDescriptor
+{
+    /// <summary>Unique lookup registry key (e.g. <c>"tenants"</c>).</summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Selector for the lookup value, typed as declared (<c>Func&lt;TEntity, TValue&gt;</c>).
+    /// Used to build the resolve-by-value equality predicate.
+    /// </summary>
+    public required LambdaExpression ValueSelector { get; init; }
+
+    /// <summary>
+    /// Selector for the lookup value boxed to <see cref="object"/>
+    /// (<c>Func&lt;TEntity, object&gt;</c>). Used to project a materialized row to
+    /// <c>LookupItem.Value</c>.
+    /// </summary>
+    public required LambdaExpression BoxedValueSelector { get; init; }
+
+    /// <summary>Selector for the display label (<c>Func&lt;TEntity, string&gt;</c>).</summary>
+    public required LambdaExpression LabelSelector { get; init; }
+
+    /// <summary>The CLR type of the lookup value, used for resolve-by-value conversion.</summary>
+    public required Type ValueType { get; init; }
+
+    /// <summary>Optional permission the caller must hold to invoke the lookup.</summary>
+    public string? RequiredPermission { get; init; }
+
+    /// <summary>
+    /// Scope keys the caller must supply with every search. Each key SHOULD match a
+    /// filterable column on the definition so its value is applied as an equality filter
+    /// (the mechanism behind cascading pickers).
+    /// </summary>
+    public IReadOnlyList<string> ScopeKeys { get; init; } = [];
+}

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinition.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinition.cs
@@ -163,4 +163,12 @@ public abstract class QueryDefinition<TEntity> : IQueryDefinitionDescriptor wher
     /// </summary>
     public LambdaExpression? GetProjectionExpression() =>
         GetBuilder().ProjectionExpression;
+
+    /// <summary>
+    /// Gets the lookup-source declaration (via
+    /// <see cref="QueryDefinitionBuilder{TEntity}.AsLookup{TValue}"/>), or <c>null</c> when
+    /// this definition is not exposed as a data-lookup source.
+    /// </summary>
+    public LookupSourceDescriptor? GetLookupSource() =>
+        GetBuilder().LookupSourceValue;
 }

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -39,6 +39,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
     internal string? DefaultSortValue { get; private set; }
     internal LambdaExpression? ProjectionExpression { get; private set; }
     internal Type? ProjectionType { get; private set; }
+    internal LookupSourceDescriptor? LookupSourceValue { get; private set; }
 
     /// <summary>
     /// Declares a column on the target entity. Only explicitly declared columns are
@@ -409,6 +410,51 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
 
         ProjectionExpression = projection;
         ProjectionType = typeof(TDto);
+        return this;
+    }
+
+    /// <summary>
+    /// Declares that this query definition doubles as a data-lookup source — a typeahead
+    /// picker registered under <paramref name="name"/> in <c>Granit.DataLookup</c>. The
+    /// generated <c>QueryDefinitionLookupSource&lt;TEntity&gt;</c> reuses this definition's
+    /// global search, default sort, and pagination (including keyset/cursor) via
+    /// <see cref="IQueryEngine{TEntity}"/>, projecting each row to <c>{ value, label }</c>.
+    /// </summary>
+    /// <typeparam name="TValue">The lookup value type (typically the entity key).</typeparam>
+    /// <param name="name">Unique lookup registry key (e.g. <c>"tenants"</c>).</param>
+    /// <param name="value">Selector for the lookup value (typically the primary key).</param>
+    /// <param name="label">Selector for the human-readable, already-localized label.</param>
+    /// <param name="requiredPermission">Optional permission the caller must hold.</param>
+    /// <param name="scopeKeys">
+    /// Scope keys the caller must supply. Each SHOULD match a filterable column so its value
+    /// is applied as an equality filter (cascading pickers).
+    /// </param>
+    public QueryDefinitionBuilder<TEntity> AsLookup<TValue>(
+        string name,
+        Expression<Func<TEntity, TValue>> value,
+        Expression<Func<TEntity, string>> label,
+        string? requiredPermission = null,
+        IReadOnlyList<string>? scopeKeys = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(label);
+
+        var boxed = Expression.Lambda<Func<TEntity, object>>(
+            Expression.Convert(value.Body, typeof(object)),
+            value.Parameters);
+
+        LookupSourceValue = new LookupSourceDescriptor
+        {
+            Name = name,
+            ValueSelector = value,
+            BoxedValueSelector = boxed,
+            LabelSelector = label,
+            ValueType = typeof(TValue),
+            RequiredPermission = requiredPermission,
+            ScopeKeys = scopeKeys ?? [],
+        };
+
         return this;
     }
 

--- a/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryDefinitionLookupSourceTests.cs
+++ b/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryDefinitionLookupSourceTests.cs
@@ -1,0 +1,180 @@
+using Granit.DataLookup.Descriptors;
+using Granit.DataLookup.EntityFrameworkCore.Sources;
+using Granit.DataLookup.Registry;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.DataLookup.EntityFrameworkCore.Tests;
+
+public sealed class QueryDefinitionLookupSourceTests : IDisposable
+{
+    private readonly SampleDbContext _db;
+    private readonly Guid _acmeId = Guid.NewGuid();
+
+    public QueryDefinitionLookupSourceTests()
+    {
+        DbContextOptions<SampleDbContext> options = new DbContextOptionsBuilder<SampleDbContext>()
+            .UseInMemoryDatabase($"test-{Guid.NewGuid()}")
+            .Options;
+        _db = new SampleDbContext(options);
+
+        _db.Tenants.AddRange(
+            new Tenant(_acmeId, "Acme", "EU"),
+            new Tenant(Guid.NewGuid(), "Initech", "US"));
+        _db.SaveChanges();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public void Ctor_throws_when_definition_declares_no_lookup()
+    {
+        IQueryEngine<Tenant> engine = Substitute.For<IQueryEngine<Tenant>>();
+
+        Should.Throw<InvalidOperationException>(() =>
+            new QueryDefinitionLookupSource<Tenant>(engine, new NoLookupDefinition(), () => _db.Tenants));
+    }
+
+    [Fact]
+    public void Exposes_name_permission_scope_and_kind()
+    {
+        QueryDefinitionLookupSource<Tenant> source = BuildSource(out _);
+
+        source.Name.ShouldBe("tenants");
+        source.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+        source.ScopeKeys.ShouldBe(["region"]);
+        ((IKindProviderLookupSource)source).Kind.ShouldBe(LookupKind.QueryEngine);
+    }
+
+    [Fact]
+    public async Task Search_maps_query_and_projects_items()
+    {
+        QueryDefinitionLookupSource<Tenant> source = BuildSource(out IQueryEngine<Tenant> engine);
+        QueryRequest? captured = null;
+        engine.ExecuteAsync(Arg.Any<IQueryable<Tenant>>(), Arg.Do<QueryRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new PagedResult<Tenant>([new Tenant(_acmeId, "Acme", "EU")], TotalCount: 1, HasMore: false)));
+
+        LookupResult result = await source.SearchAsync(
+            new LookupQuery(Search: "ac", Page: 2, PageSize: 10),
+            TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured!.Search.ShouldBe("ac");
+        captured.Page.ShouldBe(2);
+        captured.PageSize.ShouldBe(10);
+        captured.Cursor.ShouldBeNull();
+        result.Items.Single().Value.ShouldBe(_acmeId);
+        result.Items.Single().Label.ShouldBe("Acme");
+        result.TotalCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Search_passes_continuation_token_as_cursor_and_returns_next_cursor()
+    {
+        QueryDefinitionLookupSource<Tenant> source = BuildSource(out IQueryEngine<Tenant> engine);
+        QueryRequest? captured = null;
+        engine.ExecuteAsync(Arg.Any<IQueryable<Tenant>>(), Arg.Do<QueryRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new PagedResult<Tenant>([], TotalCount: null, HasMore: true, NextCursor: "next-cursor")));
+
+        LookupResult result = await source.SearchAsync(
+            new LookupQuery(ContinuationToken: "cur-1", Page: 5),
+            TestContext.Current.CancellationToken);
+
+        captured!.Cursor.ShouldBe("cur-1");
+        captured.Page.ShouldBeNull();
+        result.ContinuationToken.ShouldBe("next-cursor");
+    }
+
+    [Fact]
+    public async Task Search_maps_scope_to_equality_filter_only_for_filterable_columns()
+    {
+        QueryDefinitionLookupSource<Tenant> source = BuildSource(out IQueryEngine<Tenant> engine);
+        QueryRequest? captured = null;
+        engine.ExecuteAsync(Arg.Any<IQueryable<Tenant>>(), Arg.Do<QueryRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new PagedResult<Tenant>([], TotalCount: 0, HasMore: false)));
+
+        Dictionary<string, string?> scope = new() { ["region"] = "EU", ["unknown"] = "x", ["blank"] = "  " };
+        await source.SearchAsync(new LookupQuery(Scope: scope), TestContext.Current.CancellationToken);
+
+        captured!.Filter.ShouldNotBeNull();
+        captured.Filter!.Count.ShouldBe(1);
+        captured.Filter["Region.eq"].ShouldBe("EU");
+        captured.Filter.ContainsKey("unknown.eq").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Resolve_returns_item_by_value()
+    {
+        QueryDefinitionLookupSource<Tenant> source = BuildSource(out _);
+
+        LookupItem? item = await source.ResolveByValueAsync(_acmeId, TestContext.Current.CancellationToken);
+
+        item.ShouldNotBeNull();
+        item!.Value.ShouldBe(_acmeId);
+        item.Label.ShouldBe("Acme");
+    }
+
+    [Fact]
+    public async Task Resolve_accepts_string_form_of_value()
+    {
+        QueryDefinitionLookupSource<Tenant> source = BuildSource(out _);
+
+        LookupItem? item = await source.ResolveByValueAsync(_acmeId.ToString(), TestContext.Current.CancellationToken);
+
+        item.ShouldNotBeNull();
+        item!.Label.ShouldBe("Acme");
+    }
+
+    [Fact]
+    public async Task Resolve_returns_null_for_unknown_value()
+    {
+        QueryDefinitionLookupSource<Tenant> source = BuildSource(out _);
+
+        LookupItem? item = await source.ResolveByValueAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        item.ShouldBeNull();
+    }
+
+    private QueryDefinitionLookupSource<Tenant> BuildSource(out IQueryEngine<Tenant> engine)
+    {
+        engine = Substitute.For<IQueryEngine<Tenant>>();
+        return new QueryDefinitionLookupSource<Tenant>(engine, new TenantLookupDefinition(), () => _db.Tenants);
+    }
+
+    public sealed record Tenant(Guid Id, string Name, string Region);
+
+    private sealed class TenantLookupDefinition : QueryDefinition<Tenant>
+    {
+        public override string Name => "Test.Tenants";
+
+        protected override void Configure(QueryDefinitionBuilder<Tenant> builder) =>
+            builder
+                .Column(t => t.Name, c => c.Sortable().Filterable())
+                .Column(t => t.Region, c => c.Filterable())
+                .GlobalSearch(t => t.Name!)
+                .DefaultSort("Name")
+                .SupportsCursorPagination(t => t.Id)
+                .AsLookup("tenants", t => t.Id, t => t.Name,
+                    requiredPermission: "Platform.Tenants.Read",
+                    scopeKeys: ["region"]);
+    }
+
+    private sealed class NoLookupDefinition : QueryDefinition<Tenant>
+    {
+        public override string Name => "Test.NoLookup";
+
+        protected override void Configure(QueryDefinitionBuilder<Tenant> builder) =>
+            builder.Column(t => t.Name);
+    }
+
+    internal sealed class SampleDbContext(DbContextOptions<SampleDbContext> options) : DbContext(options)
+    {
+        public DbSet<Tenant> Tenants => Set<Tenant>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Tenant>().HasKey(t => t.Id);
+    }
+}

--- a/tests/Granit.DataLookup.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.DataLookup.EntityFrameworkCore.Tests/packages.lock.json
@@ -375,6 +375,7 @@
           "Granit.DataLookup": "[0.1.0-dev, )",
           "Granit.Persistence": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionLookupTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionLookupTests.cs
@@ -1,0 +1,73 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.Abstractions.Tests;
+
+public sealed class QueryDefinitionLookupTests
+{
+    [Fact]
+    public void AsLookup_stores_descriptor_with_name_type_permission_and_scope()
+    {
+        TenantLookupDefinition definition = new();
+
+        LookupSourceDescriptor? descriptor = definition.GetLookupSource();
+
+        descriptor.ShouldNotBeNull();
+        descriptor!.Name.ShouldBe("tenants");
+        descriptor.ValueType.ShouldBe(typeof(Guid));
+        descriptor.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+        descriptor.ScopeKeys.ShouldBe(["region"]);
+    }
+
+    [Fact]
+    public void AsLookup_boxed_value_selector_compiles_and_boxes_value()
+    {
+        TenantLookupDefinition definition = new();
+        LookupSourceDescriptor descriptor = definition.GetLookupSource()!;
+        var id = Guid.NewGuid();
+
+        var boxed = (System.Linq.Expressions.Expression<Func<Tenant, object>>)descriptor.BoxedValueSelector;
+        object value = boxed.Compile()(new Tenant(id, "Acme"));
+
+        value.ShouldBeOfType<Guid>().ShouldBe(id);
+    }
+
+    [Fact]
+    public void GetLookupSource_returns_null_when_not_declared()
+    {
+        NoLookupDefinition definition = new();
+
+        definition.GetLookupSource().ShouldBeNull();
+    }
+
+    [Fact]
+    public void AsLookup_blank_name_throws()
+    {
+        QueryDefinitionBuilder<Tenant> builder = new();
+
+        Should.Throw<ArgumentException>(() => builder.AsLookup(" ", t => t.Id, t => t.Name));
+    }
+
+    public sealed record Tenant(Guid Id, string Name);
+
+    private sealed class TenantLookupDefinition : QueryDefinition<Tenant>
+    {
+        public override string Name => "Test.Tenants";
+
+        protected override void Configure(QueryDefinitionBuilder<Tenant> builder) =>
+            builder
+                .Column(t => t.Name, c => c.Sortable().Filterable())
+                .GlobalSearch(t => t.Name!)
+                .AsLookup("tenants", t => t.Id, t => t.Name,
+                    requiredPermission: "Platform.Tenants.Read",
+                    scopeKeys: ["region"]);
+    }
+
+    private sealed class NoLookupDefinition : QueryDefinition<Tenant>
+    {
+        public override string Name => "Test.NoLookup";
+
+        protected override void Configure(QueryDefinitionBuilder<Tenant> builder) =>
+            builder.Column(t => t.Name);
+    }
+}


### PR DESCRIPTION
Finalizes the long-deferred "PR 2" of ADR-028: a `QueryDefinitionLookupSource<T>` bridging `Granit.DataLookup` onto `Granit.QueryEngine`, so a single `QueryDefinition` powers both the grid and its typeahead pickers.

## What
- `QueryDefinitionBuilder<TEntity>.AsLookup<TValue>(name, value, label, requiredPermission?, scopeKeys?)` + `LookupSourceDescriptor`, exposed via `QueryDefinition.GetLookupSource()`.
- `QueryDefinitionLookupSource<T>` delegates search/sort/pagination to `IQueryEngine<T>`.
- `AddQueryDefinitionLookup<TEntity, TDbContext>()` registration.

## Why the non-projecting engine overload
`ExecuteAsync<TProjection>` returns no `NextCursor` in cursor mode (`QueryEngine.cs` ~L432). For **real infinite-scroll** the source uses the non-projecting `ExecuteAsync` (which returns `NextCursor`) and projects the ~25-row page to `LookupItem` in memory. `ContinuationToken` round-trips to the keyset cursor; scope keys map to equality filters on matching filterable columns (cascading pickers).

## Tests
8 source tests + 4 builder tests. Engine cursor mechanics are covered by the engine's own suite; end-to-end HTTP coverage is in the endpoint-integration PR.

## Notes
- Purely additive to `Granit.QueryEngine.Abstractions` (widely referenced) — no breaking changes.
- ADR-028 delivery status corrected in a separate granit-docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)