### PR TITLE
feat(entities): bind form fields to data-lookup sources via FieldBuilder.Lookup

### DIFF
--- a/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
+using Granit.DataLookup.Descriptors;
 using Granit.Entities.Visibility;
 
 namespace Granit.Entities.Forms;
@@ -24,6 +25,7 @@ public sealed class FieldBuilder<TEntity, TProperty>
     private string? _requiresPermission;
     private bool _readOnly;
     private VisibilityCondition? _visibleIf;
+    private LookupDescriptor? _lookup;
 
     internal FieldBuilder(Expression<Func<TEntity, TProperty>> propertySelector, int order)
     {
@@ -108,6 +110,43 @@ public sealed class FieldBuilder<TEntity, TProperty>
         return this;
     }
 
+    /// <summary>
+    /// Binds this field to a data-lookup source (typeahead picker) by registry name. The form
+    /// renders a server-backed picker instead of a free-text or plain <c>select</c> control.
+    /// Mirrors <c>ColumnBuilder.Lookup</c> on the query side, so a foreign-key field
+    /// (<c>tenantId</c>, <c>ownerId</c>…) resolves the same source in both the grid filter and
+    /// the edit form.
+    /// </summary>
+    /// <param name="name">Lookup registry key (e.g. <c>"tenants"</c>).</param>
+    /// <param name="kind">The lookup kind. Defaults to <see cref="LookupKind.QueryEngine"/>.</param>
+    /// <param name="requiredPermission">Optional permission the caller must hold.</param>
+    /// <param name="scopeKeys">Scope keys the picker must supply (cascading pickers).</param>
+    public FieldBuilder<TEntity, TProperty> Lookup(
+        string name,
+        LookupKind kind = LookupKind.QueryEngine,
+        string? requiredPermission = null,
+        IReadOnlyList<string>? scopeKeys = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _lookup = new LookupDescriptor(
+            Name: name,
+            Kind: kind,
+            RequiredPermission: requiredPermission,
+            ScopeKeys: scopeKeys);
+        return this;
+    }
+
+    /// <summary>
+    /// Binds this field to a data-lookup source via a full <see cref="LookupDescriptor"/>. Use
+    /// when pointing to a custom URL or overriding the default search parameter.
+    /// </summary>
+    public FieldBuilder<TEntity, TProperty> Lookup(LookupDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        _lookup = descriptor;
+        return this;
+    }
+
     internal FieldDescriptor Build() =>
         new()
         {
@@ -121,6 +160,7 @@ public sealed class FieldBuilder<TEntity, TProperty>
             Order = _order,
             ReadOnly = _readOnly,
             VisibleIf = _visibleIf,
+            Lookup = _lookup,
         };
 
     /// <summary>

--- a/src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs
@@ -1,3 +1,4 @@
+using Granit.DataLookup.Descriptors;
 using Granit.Entities.Visibility;
 
 namespace Granit.Entities.Forms;
@@ -54,4 +55,13 @@ public sealed record FieldDescriptor
     /// happens server-side.
     /// </summary>
     public VisibilityCondition? VisibleIf { get; init; }
+
+    /// <summary>
+    /// Optional data-lookup source (see <c>Granit.DataLookup</c>). When set, the form renders
+    /// a server-backed typeahead picker instead of a free-text/select control — the same
+    /// source a query column binds via <c>ColumnBuilder.Lookup</c>, so a foreign-key field
+    /// resolves consistently in both the grid filter and the edit form. <c>null</c> for
+    /// fields without a declared lookup.
+    /// </summary>
+    public LookupDescriptor? Lookup { get; init; }
 }

--- a/src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj
+++ b/src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.DataLookup.Abstractions\Granit.DataLookup.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Workflow.Abstractions\Granit.Workflow.Abstractions.csproj" />
   </ItemGroup>

--- a/tests/Granit.Entities.Abstractions.Tests/FieldLookupTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/FieldLookupTests.cs
@@ -1,0 +1,74 @@
+using Granit.DataLookup.Descriptors;
+using Granit.Entities.Forms;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests;
+
+public sealed class FieldLookupTests
+{
+    [Fact]
+    public void Field_without_lookup_has_null_lookup()
+    {
+        FieldDescriptor title = FieldsOf(new SampleEntityDefinition())["Title"];
+
+        title.Lookup.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Lookup_by_name_captures_descriptor_with_defaults()
+    {
+        FieldDescriptor tenant = FieldsOf(new SampleEntityDefinition())["TenantId"];
+
+        tenant.Lookup.ShouldNotBeNull();
+        tenant.Lookup!.Name.ShouldBe("tenants");
+        tenant.Lookup.Kind.ShouldBe(LookupKind.QueryEngine);
+        tenant.Lookup.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+        tenant.Lookup.ScopeKeys.ShouldBe(["region"]);
+    }
+
+    [Fact]
+    public void Lookup_by_descriptor_is_stored_verbatim()
+    {
+        FieldDescriptor owner = FieldsOf(new SampleEntityDefinition())["OwnerId"];
+
+        owner.Lookup.ShouldNotBeNull();
+        owner.Lookup!.Kind.ShouldBe(LookupKind.Simple);
+        owner.Lookup.Endpoint.ShouldBe("/custom/owners");
+    }
+
+    [Fact]
+    public void Lookup_blank_name_throws()
+    {
+        EntityDefinitionBuilder<SampleEntity> builder = new();
+
+        Should.Throw<ArgumentException>(() =>
+            builder.Form("f", f => f.Section("s", s => s.Field(x => x.TenantId, fld => fld.Lookup(" ")))));
+    }
+
+    private static Dictionary<string, FieldDescriptor> FieldsOf(SampleEntityDefinition definition) =>
+        definition.Descriptor.Forms[0].Sections
+            .SelectMany(s => s.Fields)
+            .ToDictionary(f => f.PropertyName);
+
+    private sealed class SampleEntity
+    {
+        public string Title { get; set; } = "";
+        public Guid TenantId { get; set; }
+        public Guid OwnerId { get; set; }
+    }
+
+    private sealed class SampleEntityDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.LookupEntity";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b) =>
+            b.Form("default", f => f
+                .Section("general", s => s
+                    .Field(x => x.Title)
+                    .Field(x => x.TenantId, fld => fld
+                        .Lookup("tenants", requiredPermission: "Platform.Tenants.Read", scopeKeys: ["region"]))
+                    .Field(x => x.OwnerId, fld => fld
+                        .Lookup(new LookupDescriptor(Endpoint: "/custom/owners", Kind: LookupKind.Simple)))));
+    }
+}

--- a/tests/Granit.Entities.Abstractions.Tests/packages.lock.json
+++ b/tests/Granit.Entities.Abstractions.Tests/packages.lock.json
@@ -260,6 +260,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }


### PR DESCRIPTION
EntityDefinition form fields can now declare a data-lookup source, mirroring `ColumnBuilder.Lookup` on the query side — so a foreign-key field (`tenantId`, `ownerId`…) resolves the **same** lookup in both the grid filter and the edit form instead of rendering a free-text/plain-select control.

## What
- `FieldBuilder<TEntity, TProperty>.Lookup(name, kind?, requiredPermission?, scopeKeys?)` and `Lookup(LookupDescriptor)` overloads.
- `FieldDescriptor.Lookup` carries the descriptor into the manifest.
- Direct `ProjectReference` to `Granit.DataLookup.Abstractions` (the types were only reachable transitively before).

## Tests
4 covering by-name defaults, full-descriptor, no-lookup, and the blank-name guard.

Part of finalizing ADR-028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)