### PR TITLE
test(datalookup): HTTP integration tests for the lookup endpoints

### DIFF
--- a/tests/Granit.DataLookup.Endpoints.Tests/Granit.DataLookup.Endpoints.Tests.csproj
+++ b/tests/Granit.DataLookup.Endpoints.Tests/Granit.DataLookup.Endpoints.Tests.csproj
@@ -12,10 +12,12 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.DataLookup.Endpoints\Granit.DataLookup.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.DataLookup.Endpoints.Tests/LookupEndpointsHttpTests.cs
+++ b/tests/Granit.DataLookup.Endpoints.Tests/LookupEndpointsHttpTests.cs
@@ -1,0 +1,247 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Authorization;
+using Granit.DataLookup.Descriptors;
+using Granit.DataLookup.Endpoints.Dtos;
+using Granit.DataLookup.Endpoints.Extensions;
+using Granit.DataLookup.Endpoints.Permissions;
+using Granit.DataLookup.Extensions;
+using Granit.DataLookup.Registry;
+using Granit.DataLookup.Sources;
+using Granit.MultiTenancy;
+using Granit.Testing.Endpoints;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.DataLookup.Endpoints.Tests;
+
+public sealed class LookupEndpointsHttpTests : IAsyncDisposable
+{
+    private const string Prefix = "/lookups";
+
+    private readonly FakeLookupSource _colors = new("colors", LookupKind.Enum,
+        items: [new LookupItem("red", "Red"), new LookupItem("green", "Green")]);
+    private readonly FakeLookupSource _scoped = new("meter-definitions", LookupKind.QueryEngine,
+        items: [new LookupItem(Guid.Empty, "Main meter")], scopeKeys: ["tenantId"]);
+    private readonly FakeLookupSource _secured = new("tenants", LookupKind.QueryEngine,
+        items: [new LookupItem(Guid.Empty, "Acme")], requiredPermission: "Platform.Tenants.Read");
+
+    private readonly IPermissionChecker _permissionChecker = Substitute.For<IPermissionChecker>();
+    private readonly GranitEndpointTestHost _host;
+    private readonly HttpClient _client;
+    private readonly HttpClient _anon;
+
+    public LookupEndpointsHttpTests()
+    {
+        _host = GranitEndpointTestHost.StartAsync(
+            configureServices: services =>
+            {
+                services.AddAuthorizationBuilder()
+                    .AddPolicy(DataLookupPermissions.Lookups.Read, p => p.RequireAuthenticatedUser());
+
+                services.AddMetrics();
+                services.AddGranitDataLookup();
+                services.AddSingleton<ILookupSource>(_colors);
+                services.AddSingleton<ILookupSource>(_scoped);
+                services.AddSingleton<ILookupSource>(_secured);
+                services.AddSingleton(_permissionChecker);
+                services.AddSingleton(Substitute.For<ICurrentTenant>());
+            },
+            configureEndpoints: app => app.MapGranitDataLookups())
+            .GetAwaiter().GetResult();
+
+        _client = _host.CreateAuthenticatedClient();
+        _anon = _host.CreateAnonymousClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        _anon.Dispose();
+        await _host.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task Manifest_lists_sources_with_kind_permission_and_scope()
+    {
+        LookupManifestResponse? body = await _client.GetFromJsonAsync<LookupManifestResponse>(
+            Prefix, TestContext.Current.CancellationToken);
+
+        body.ShouldNotBeNull();
+        body.Lookups.Select(l => l.Name).ShouldBe(["colors", "meter-definitions", "tenants"]);
+
+        LookupManifestEntryResponse colors = body.Lookups.First(l => l.Name == "colors");
+        colors.Kind.ShouldBe(LookupKind.Enum);
+
+        LookupManifestEntryResponse scoped = body.Lookups.First(l => l.Name == "meter-definitions");
+        scoped.ScopeKeys.ShouldBe(["tenantId"]);
+
+        body.Lookups.First(l => l.Name == "tenants").RequiredPermission.ShouldBe("Platform.Tenants.Read");
+    }
+
+    [Fact]
+    public async Task Anonymous_request_is_rejected()
+    {
+        HttpResponseMessage response = await _anon.GetAsync(Prefix, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Search_unknown_source_returns_404()
+    {
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/does-not-exist", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Search_returns_items_and_forwards_query()
+    {
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/colors?search=re&page=2&pageSize=5", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        LookupResultResponse? body = await response.Content
+            .ReadFromJsonAsync<LookupResultResponse>(TestContext.Current.CancellationToken);
+
+        body.ShouldNotBeNull();
+        body.Items.Select(i => i.Label).ShouldBe(["Red", "Green"]);
+        body.TotalCount.ShouldBe(2);
+
+        _colors.LastQuery.ShouldNotBeNull();
+        _colors.LastQuery!.Search.ShouldBe("re");
+        _colors.LastQuery.Page.ShouldBe(2);
+        _colors.LastQuery.PageSize.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task Search_round_trips_continuation_token()
+    {
+        _colors.NextContinuationToken = "cursor-2";
+
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/colors?continuationToken=cursor-1", TestContext.Current.CancellationToken);
+
+        LookupResultResponse? body = await response.Content
+            .ReadFromJsonAsync<LookupResultResponse>(TestContext.Current.CancellationToken);
+
+        _colors.LastQuery!.ContinuationToken.ShouldBe("cursor-1");
+        body!.ContinuationToken.ShouldBe("cursor-2");
+    }
+
+    [Fact]
+    public async Task Search_missing_required_scope_key_returns_400()
+    {
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/meter-definitions", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("tenantId");
+    }
+
+    [Fact]
+    public async Task Search_with_scope_satisfied_returns_200_and_forwards_scope()
+    {
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/meter-definitions?scope.tenantId=acme", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _scoped.LastQuery!.Scope.ShouldNotBeNull();
+        _scoped.LastQuery.Scope!["tenantId"].ShouldBe("acme");
+    }
+
+    [Fact]
+    public async Task Search_forbidden_when_permission_denied_returns_403()
+    {
+        _permissionChecker.IsGrantedAsync("Platform.Tenants.Read", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/tenants", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Search_allowed_when_permission_granted_returns_200()
+    {
+        _permissionChecker.IsGrantedAsync("Platform.Tenants.Read", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/tenants", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Resolve_returns_item()
+    {
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/colors/resolve?value=red", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        LookupItemResponse? body = await response.Content
+            .ReadFromJsonAsync<LookupItemResponse>(TestContext.Current.CancellationToken);
+
+        body!.Label.ShouldBe("Red");
+    }
+
+    [Fact]
+    public async Task Resolve_missing_value_returns_400()
+    {
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/colors/resolve", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Resolve_unknown_value_returns_404()
+    {
+        HttpResponseMessage response = await _client.GetAsync(
+            $"{Prefix}/colors/resolve?value=purple", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>
+    /// Configurable in-memory lookup source: records the last query it received and returns
+    /// canned items, so the endpoint contract (routing, scope/permission gating, query
+    /// forwarding, response shape) can be asserted without a database or localizer.
+    /// </summary>
+    private sealed class FakeLookupSource(
+        string name,
+        LookupKind kind,
+        IReadOnlyList<LookupItem> items,
+        string? requiredPermission = null,
+        IReadOnlyList<string>? scopeKeys = null) : ILookupSource, IKindProviderLookupSource
+    {
+        private readonly IReadOnlyList<LookupItem> _items = items;
+
+        public string Name => name;
+        public string? RequiredPermission => requiredPermission;
+        public IReadOnlyList<string> ScopeKeys => scopeKeys ?? [];
+        LookupKind IKindProviderLookupSource.Kind => kind;
+
+        public LookupQuery? LastQuery { get; private set; }
+        public string? NextContinuationToken { get; set; }
+
+        public ValueTask<LookupResult> SearchAsync(LookupQuery query, CancellationToken cancellationToken)
+        {
+            LastQuery = query;
+            return ValueTask.FromResult(new LookupResult(_items, _items.Count, NextContinuationToken));
+        }
+
+        public ValueTask<LookupItem?> ResolveByValueAsync(object value, CancellationToken cancellationToken)
+        {
+            LookupItem? match = _items.FirstOrDefault(i => string.Equals(i.Value.ToString(), value.ToString(), StringComparison.OrdinalIgnoreCase));
+            return ValueTask.FromResult(match);
+        }
+    }
+}

--- a/tests/Granit.DataLookup.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.DataLookup.Endpoints.Tests/packages.lock.json
@@ -14,6 +14,17 @@
         "resolved": "7.1.0",
         "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "C9kMpUciPgx7ObqoO6W+eXEf3zHFWb7XpQgFJBzdO8GsmmVYrgcErTLMuki6e3EihycGpHbcJECYHDgM7XRMkg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.8",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Extensions.Hosting": "10.0.8"
+        }
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
@@ -91,6 +102,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HRH/XAke90wkHv9ykCsrvpVqvKOUt53jQzvHHIXrPIPZWAjyPq6B5/InCmPYWvme+WKMXD10rplMAitzNMtC3w=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -115,6 +131,208 @@
         "resolved": "10.0.8",
         "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
         "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "nQXq1a4MiInYh+0VF9fguxAl06q2ftmOyYQ+5e933s4rk57xjgkbTjUdFUySzjrcrvDeWsSqlZB+TE8+TbM2HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "bVGqctAfPGfTxJvNp8pMshtvpsUj6r6JkeiCNVIGVYO5gBxuxdN0Lbr25kEvE/zXdctkEc44g8HssnPgDnFGVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "1g9mzuu8gIHkjYb0jLxOTQVl/QDG5nn0b0JzgT/gbgNKr6gXZzxOHRAsdYRc1eDApB7LdHR8uK5vQrNjIQdRrQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "KLtAZ6A38s1pIfCO2ns6aG14NNGMYNZ4PBYfFK4M+R4A+xuSc6oklhqDcpHZxvDpyBWeFtR5C8iQBw2ng8tUHQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "6XTfFOnf27WY8kEeZkTZ4YNn0t+imgvdQ0YaAdR4vgURKATo9bCaVJ1KB71IOJAQtJP7Elb53VHlTNXg2CtSsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Json": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "uduyw9d3Fi+sbredO5drA1S44AQS2FRNFyn72UmB2vmQIO1qaXprpp1U/2lYhYi8yFdVERfY9sy/pxw/qPOU9w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "U+oquaPxFdY8lYeEIWO/AD7jDIl9sPW6aVWMQRHU/pZ/SWpLcOrAj2fcLe1HwXl4sYw1ONI56K/eELT3xr4RRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "GkPvQe6IdidLu6Q3Lw6+B8NJpW8feW8czZ5mBKt5rXM/x8MvZfEp5WvAsjznzDGd23chIDrW0b2mmt+ScnEgiw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "VfEyM2BipThcSd0GG/FS2ZPCVCTiosVq2zLKEDsfeMIg78sOVZPEmS7CgWlb+dqTlgXvLSL4OG2q6sM4xRhHNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.8",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Json": "10.0.8",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
+          "Microsoft.Extensions.Logging.Console": "10.0.8",
+          "Microsoft.Extensions.Logging.Debug": "10.0.8",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.8",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "K60JhWC2hN/Gi7TP68tBxSzk5ACWOs7lkmPzsfA8Bcf/IXTajujt2ORMf9rSMk1bsng6Lv4Y3fuxp3bm1+15ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "rxSLTO7xTbcC3DuEJHNEijBr8g14Jj62zQ+DeFu68bsoTYoU8jLcMhc1735PV21bESXsATlL5LsfaWH71FOWAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "6cv53sHsPnFS56PJw8X4GbNcjeX1KGyFJRxJWvxOgK63cnqeSB1k1eRwjUdkse0tBhwlH6qc9EOYDlan+CYTuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "4HW3M1lGHHDwEYcDZHRNptBQ48LCI2yW+XV4vuxdfQUqafTpVT8j9RqAsez08krZKhIiaArWu8iQq5uRKZ9Ffg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "kK/C3SLIoGrcZvddYQw4eMm6YaROiSYBO7YgUR5Hdv5l+GIjBmbvQK5cST2FqjeubiAOPqFEimBT2N/8wVI+3A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "System.Diagnostics.EventLog": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HX2M0MgzwQM8jpLe3AYAEMd0YsUfOP5RgGrDuk+Ki9n7HSuMbvLm9TEV3qRI3Pg9aqxc56GfgK/KdMRBhfWwKw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
           "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
@@ -189,8 +407,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.8",
+        "contentHash": "+Ro7WgIom+BDNH+YhTuZKL6QJ0ctfOpTyfUG/h3aU5KwXt3OaNf0wYWrTvoBUj+34Dy5V8dN9yCco1hAJQ4txw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -339,6 +557,14 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.http.abstractions": {
         "type": "Project"
       },
@@ -367,6 +593,16 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
@@ -390,6 +626,12 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
+      },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
       },
       "FluentValidation": {
         "type": "CentralTransitive",
@@ -453,6 +695,25 @@
         "requested": "[10.*, )",
         "resolved": "10.0.8",
         "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Fills a documented gap — the lookup endpoints had **zero** HTTP-level coverage. Drives the real Minimal API through `GranitEndpointTestHost` with controllable fake sources (no DB/localizer).

## Coverage (12 tests)
- **Manifest** — name / kind / permission / scope projection.
- **Authorization** — anonymous request rejected (group policy).
- **Search** — unknown source → 404; items + query forwarding (search/page/pageSize); continuation-token round-trip.
- **Scope** — missing required key → 400; satisfied → 200 with scope forwarded.
- **Per-source permission** — denied → 403; granted → 200.
- **Resolve** — hit → 200; missing value → 400; unknown value → 404.

## Merge order
Independent of the QueryDefinition source, but logically lands after #2556 (end-to-end QueryEngine-backed lookup behavior is unit-covered there). Part of finalizing ADR-028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)