### PR TITLE
fix(openapi): inject content-type schema for untyped binary/stream responses

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35721,7 +35721,7 @@
       "kind": "class",
       "project": "Granit.OpenApi.Generation",
       "file": "src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs",
-      "line": 35,
+      "line": 37,
       "members": []
     },
     {
@@ -49007,7 +49007,7 @@
       "kind": "class",
       "project": "Granit.Validation",
       "file": "src/Granit.Validation/GranitValidationModule.cs",
-      "line": 35,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.AI.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Endpoints/packages.lock.json
@@ -89,6 +89,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.AI/packages.lock.json
+++ b/src/Granit.AI/packages.lock.json
@@ -145,6 +145,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Auditing.Endpoints/packages.lock.json
+++ b/src/Granit.Auditing.Endpoints/packages.lock.json
@@ -89,6 +89,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Authentication.ApiKeys.Endpoints/packages.lock.json
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/packages.lock.json
@@ -82,6 +82,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Authorization.Endpoints/packages.lock.json
+++ b/src/Granit.Authorization.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Authorization/packages.lock.json
+++ b/src/Granit.Authorization/packages.lock.json
@@ -39,6 +39,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.BackgroundJobs.Endpoints/packages.lock.json
+++ b/src/Granit.BackgroundJobs.Endpoints/packages.lock.json
@@ -69,6 +69,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.BlobStorage.Endpoints/packages.lock.json
+++ b/src/Granit.BlobStorage.Endpoints/packages.lock.json
@@ -90,6 +90,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.DataExchange.Endpoints/packages.lock.json
+++ b/src/Granit.DataExchange.Endpoints/packages.lock.json
@@ -82,6 +82,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.DataLookup.Endpoints/packages.lock.json
+++ b/src/Granit.DataLookup.Endpoints/packages.lock.json
@@ -66,6 +66,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Diagnostics.Endpoints/packages.lock.json
+++ b/src/Granit.Diagnostics.Endpoints/packages.lock.json
@@ -77,6 +77,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Features.Endpoints/packages.lock.json
+++ b/src/Granit.Features.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Hostnames.Endpoints/packages.lock.json
+++ b/src/Granit.Hostnames.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs
+++ b/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs
@@ -119,6 +119,7 @@ public static class ApiDocumentationServiceCollectionExtensions
         services.TryAddTransient<SecurityRequirementOperationTransformer>();
         services.TryAddTransient<NullableIntSchemaOperationTransformer>();
         services.TryAddTransient<ParameterDescriptionOperationTransformer>();
+        services.TryAddTransient<BinaryResponseContentTypeOperationTransformer>();
         services.TryAddTransient<SchemaExampleSchemaTransformer>();
         services.TryAddTransient<JsonElementSchemaTransformer>();
         services.TryAddTransient<Int32SchemaTransformer>();
@@ -178,6 +179,7 @@ public static class ApiDocumentationServiceCollectionExtensions
             openApiOptions.AddOperationTransformer<SecurityRequirementOperationTransformer>();
             openApiOptions.AddOperationTransformer<NullableIntSchemaOperationTransformer>();
             openApiOptions.AddOperationTransformer<ParameterDescriptionOperationTransformer>();
+            openApiOptions.AddOperationTransformer<BinaryResponseContentTypeOperationTransformer>();
             openApiOptions.AddSchemaTransformer<SchemaExampleSchemaTransformer>();
             openApiOptions.AddSchemaTransformer<JsonElementSchemaTransformer>();
             openApiOptions.AddSchemaTransformer<Int32SchemaTransformer>();

--- a/src/Granit.Http.ApiDocumentation/Transformers/BinaryResponseContentTypeOperationTransformer.cs
+++ b/src/Granit.Http.ApiDocumentation/Transformers/BinaryResponseContentTypeOperationTransformer.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Granit.Http.ApiDocumentation.Transformers;
+
+/// <summary>
+/// Injects the declared media type into responses where <c>.Produces(statusCode, contentType: "…")</c>
+/// was called without a CLR response type.
+/// </summary>
+/// <remarks>
+/// ASP.NET Core's native OpenAPI generator only emits a <c>content</c> entry when a CLR schema is
+/// associated with the response. Endpoints that stream binary files or return an untyped JSON body
+/// declare the content type via <c>IProducesResponseTypeMetadata.ContentTypes</c> but no <c>Type</c>,
+/// so the generator omits the <c>content</c> key entirely. This transformer fills the gap so
+/// downstream code generators (Kiota, NSwag, etc.) can correctly map the response media type.
+/// <para>
+/// Binary content types (anything that is not <c>application/json</c>, <c>application/xml</c>,
+/// or <c>text/*</c>) receive a <c>{ type: string, format: binary }</c> schema — the OpenAPI 3.x
+/// standard representation for file downloads.
+/// </para>
+/// </remarks>
+internal sealed class BinaryResponseContentTypeOperationTransformer : IOpenApiOperationTransformer
+{
+    /// <inheritdoc/>
+    public Task TransformAsync(
+        OpenApiOperation operation,
+        OpenApiOperationTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        if (operation.Responses is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        IList<object> metadata = context.Description.ActionDescriptor.EndpointMetadata;
+
+        foreach (IProducesResponseTypeMetadata producesMetadata in metadata.OfType<IProducesResponseTypeMetadata>())
+        {
+            // The native generator already handles entries with a CLR type (typed JSON responses).
+            // Only process those where the developer explicitly declared a content type but no schema.
+            bool hasType = producesMetadata.Type is not null && producesMetadata.Type != typeof(void);
+            if (hasType)
+            {
+                continue;
+            }
+
+            IReadOnlyList<string> contentTypes = [.. producesMetadata.ContentTypes];
+            if (contentTypes.Count == 0)
+            {
+                continue;
+            }
+
+            string statusCode = producesMetadata.StatusCode.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (!operation.Responses.TryGetValue(statusCode, out IOpenApiResponse? openApiResponse)
+                || openApiResponse is not OpenApiResponse response)
+            {
+                continue;
+            }
+
+            // Don't overwrite content the framework already emitted.
+            if (response.Content is { Count: > 0 })
+            {
+                continue;
+            }
+
+            response.Content ??= new Dictionary<string, OpenApiMediaType>();
+
+            foreach (string contentType in contentTypes)
+            {
+                response.Content[contentType] = BuildMediaType(contentType);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static OpenApiMediaType BuildMediaType(string contentType) =>
+        IsBinaryContentType(contentType)
+            ? new OpenApiMediaType { Schema = new OpenApiSchema { Type = JsonSchemaType.String, Format = "binary" } }
+            : new OpenApiMediaType();
+
+    private static bool IsBinaryContentType(string contentType) =>
+        !contentType.StartsWith("text/", StringComparison.OrdinalIgnoreCase)
+        && !contentType.Equals("application/json", StringComparison.OrdinalIgnoreCase)
+        && !contentType.Equals("application/xml", StringComparison.OrdinalIgnoreCase)
+        && !contentType.Equals("application/problem+json", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Granit.Http.SecurityHeaders.Endpoints/packages.lock.json
+++ b/src/Granit.Http.SecurityHeaders.Endpoints/packages.lock.json
@@ -87,6 +87,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Endpoints/packages.lock.json
@@ -89,6 +89,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
@@ -36,9 +36,9 @@ internal static partial class AccountExternalLoginEndpoints
             .WithName("ChallengeExternalLogin")
             .WithSummary("Initiates an OAuth flow with an external provider.")
             .WithDescription(
-                "Validates that the specified provider is registered in IExternalProviderRegistry "
-                + "and returns 200 with metadata for the frontend to initiate the redirect "
-                + "via the standard OAuth client flow. "
+                "Validates that the specified provider is registered in IExternalProviderRegistry. "
+                + "Returns 200 to confirm the provider is available; the frontend then initiates "
+                + "the OAuth redirect via the standard client challenge flow. "
                 + "Returns 400 if the provider is not configured.")
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -95,6 +95,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Local/packages.lock.json
+++ b/src/Granit.Identity.Local/packages.lock.json
@@ -72,6 +72,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity/packages.lock.json
+++ b/src/Granit.Identity/packages.lock.json
@@ -53,6 +53,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Localization.Endpoints/packages.lock.json
+++ b/src/Granit.Localization.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.MultiTenancy.Endpoints/packages.lock.json
+++ b/src/Granit.MultiTenancy.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Notifications.Endpoints/packages.lock.json
+++ b/src/Granit.Notifications.Endpoints/packages.lock.json
@@ -77,6 +77,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
+++ b/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
@@ -1,7 +1,9 @@
+using System.Reflection;
 using Granit.Extensions;
 using Granit.Http.ApiDocumentation.Extensions;
 using Granit.Modularity;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -72,6 +74,38 @@ public static class OpenApiContractGenerator
         }
 
         await builder.AddGranitAsync<TRootModule>().ConfigureAwait(false);
+
+        // GranitHttpApiDocumentationModule registers a "v1" document (and any other major-version
+        // documents) as part of normal module composition. Strip all OpenAPI service descriptors for
+        // document names not in the slug set so the generator emits exactly the set declared in
+        // `modules` — no spurious root artifact. Two registration shapes must be removed:
+        // (1) Keyed services (OpenApiDocumentService etc.) — resolved at generation time.
+        // (2) IConfigureNamedOptions<OpenApiOptions> — used by GetDocumentNames() to enumerate
+        //     document names; leaving these causes the tool to attempt generation and then fail on (1).
+        HashSet<string> slugSet = new(modules.Select(m => m.Slug), StringComparer.OrdinalIgnoreCase);
+        Assembly openApiAssembly = typeof(OpenApiOptions).Assembly;
+        for (int i = builder.Services.Count - 1; i >= 0; i--)
+        {
+            ServiceDescriptor d = builder.Services[i];
+
+            if (d.IsKeyedService
+                && d.ServiceKey is string docKey
+                && !slugSet.Contains(docKey)
+                && d.ServiceType.Assembly == openApiAssembly)
+            {
+                builder.Services.RemoveAt(i);
+                continue;
+            }
+
+            if (!d.IsKeyedService
+                && d.ServiceType == typeof(IConfigureOptions<OpenApiOptions>)
+                && d.ImplementationInstance is ConfigureNamedOptions<OpenApiOptions> namedOpts
+                && namedOpts.Name is not null   // null == ConfigureAll → keep
+                && !slugSet.Contains(namedOpts.Name))
+            {
+                builder.Services.RemoveAt(i);
+            }
+        }
 
         // Doc-gen neutralization: the OpenAPI document is built from endpoint metadata in the request
         // pipeline, never from hosted services or options validation. Strip all three so Host.StartAsync()

--- a/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
+++ b/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
@@ -84,10 +84,13 @@ public static class OpenApiContractGenerator
         //     document names; leaving these causes the tool to attempt generation and then fail on (1).
         HashSet<string> slugSet = new(modules.Select(m => m.Slug), StringComparer.OrdinalIgnoreCase);
         Assembly openApiAssembly = typeof(OpenApiOptions).Assembly;
+
         for (int i = builder.Services.Count - 1; i >= 0; i--)
         {
             ServiceDescriptor d = builder.Services[i];
 
+            // (1) Keyed services from the OpenAPI assembly (OpenApiDocumentService, IOpenApiDocumentProvider,
+            //     OpenApiSchemaService, …). These are resolved at generation time — one set per document.
             if (d.IsKeyedService
                 && d.ServiceKey is string docKey
                 && !slugSet.Contains(docKey)
@@ -97,6 +100,26 @@ public static class OpenApiContractGenerator
                 continue;
             }
 
+            // (2) Non-keyed NamedService<OpenApiDocumentService> instances (internal, OpenAPI assembly).
+            //     OpenApiDocumentProvider.GetDocumentNames() iterates these to build its list; leaving
+            //     a "v1" entry here causes GetDocumentNames() to return "v1" even after (1) is stripped,
+            //     which then fails in GenerateAsync when the keyed service can't be resolved.
+            if (!d.IsKeyedService
+                && d.ImplementationInstance is not null
+                && d.ServiceType.Assembly == openApiAssembly)
+            {
+                PropertyInfo? nameProp = d.ImplementationInstance.GetType()
+                    .GetProperty("Name", BindingFlags.Public | BindingFlags.Instance);
+                if (nameProp?.GetValue(d.ImplementationInstance) is string svcName
+                    && !slugSet.Contains(svcName))
+                {
+                    builder.Services.RemoveAt(i);
+                    continue;
+                }
+            }
+
+            // (3) IConfigureNamedOptions<OpenApiOptions> for non-slug document names. A stale entry
+            //     here is harmless for GetDocumentNames() but keep removal for completeness.
             if (!d.IsKeyedService
                 && d.ServiceType == typeof(IConfigureOptions<OpenApiOptions>)
                 && d.ImplementationInstance is ConfigureNamedOptions<OpenApiOptions> namedOpts

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -631,6 +631,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -361,6 +361,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -374,6 +374,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -334,6 +334,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Presence.Endpoints/packages.lock.json
+++ b/src/Granit.Presence.Endpoints/packages.lock.json
@@ -68,6 +68,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Privacy.Endpoints/packages.lock.json
+++ b/src/Granit.Privacy.Endpoints/packages.lock.json
@@ -150,6 +150,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -227,7 +227,7 @@ public static class QueryEndpointRouteBuilderExtensions
         })
 #pragma warning restore GRAPI001
         .WithName($"Query{entityName}")
-        .WithSummary($"Returns a filtered, sorted, and paginated list of {dtoName} entries projected from {entityName}.")
+        .WithSummary($"Returns a paged, filterable list of {dtoName} from {entityName}.")
         .WithDescription($"Executes a dynamic query against {entityName} using the Granit query engine and projects each row to {dtoName}. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<{dtoName}> by default. When the groupBy query parameter is specified, returns a GroupedResult<{dtoName}> with the same projection applied to the items inside each group.")
         .Produces<PagedResult<TDto>>()
         .Produces<GroupedResult<TDto>>(StatusCodes.Status200OK)

--- a/src/Granit.QueryEngine.AspNetCore/packages.lock.json
+++ b/src/Granit.QueryEngine.AspNetCore/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Scheduling.Endpoints/packages.lock.json
+++ b/src/Granit.Scheduling.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Settings.Endpoints/packages.lock.json
+++ b/src/Granit.Settings.Endpoints/packages.lock.json
@@ -77,6 +77,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Templating.Endpoints/packages.lock.json
+++ b/src/Granit.Templating.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Timeline.Endpoints/packages.lock.json
+++ b/src/Granit.Timeline.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Validation/GranitValidationModule.cs
+++ b/src/Granit.Validation/GranitValidationModule.cs
@@ -10,6 +10,7 @@ using Granit.Validation.Internal;
 using Granit.Validation.JsonSchema;
 using Granit.Validation.OpenApi;
 using Granit.Validation.ServerValidation;
+using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Validation;
@@ -77,11 +78,9 @@ public sealed class GranitValidationModule : GranitModule
         // and by Granit.Entities (manifest schema facet).
         context.Services.AddSingleton<IJsonSchemaWriter, JsonSchemaWriter>();
 
-        // Enrich OpenAPI schemas with FluentValidation constraints
-        // (maxLength, minLength, pattern, required, etc.)
-        context.Services.AddOpenApi(options =>
-        {
-            options.AddSchemaTransformer<FluentValidationSchemaTransformer>();
-        });
+        // Enrich OpenAPI schemas with FluentValidation constraints (maxLength, minLength, pattern,
+        // required, etc.) across ALL registered documents without creating a spurious "v1" document.
+        context.Services.ConfigureAll<OpenApiOptions>(options =>
+            options.AddSchemaTransformer<FluentValidationSchemaTransformer>());
     }
 }

--- a/src/Granit.Webhooks.Endpoints/packages.lock.json
+++ b/src/Granit.Webhooks.Endpoints/packages.lock.json
@@ -155,6 +155,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Workflow.Endpoints/packages.lock.json
+++ b/src/Granit.Workflow.Endpoints/packages.lock.json
@@ -71,6 +71,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Http.ApiDocumentation.Tests/BinaryResponseContentTypeOperationTransformerTests.cs
+++ b/tests/Granit.Http.ApiDocumentation.Tests/BinaryResponseContentTypeOperationTransformerTests.cs
@@ -1,0 +1,253 @@
+// =============================================================================
+// Tests - BinaryResponseContentTypeOperationTransformer
+// =============================================================================
+// Verifies that content-type entries are injected for responses where
+// .Produces(statusCode, contentType: "...") was called without a CLR type.
+// =============================================================================
+
+using Granit.Http.ApiDocumentation.Transformers;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ApiDocumentation.Tests;
+
+public sealed class BinaryResponseContentTypeOperationTransformerTests
+{
+    // --- Binary content type (octet-stream) ---
+
+    [Fact]
+    public async Task TransformAsync_OctetStreamWithoutType_InjectsBinarySchema()
+    {
+        // Arrange
+        BinaryResponseContentTypeOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse { Description = "OK" },
+            },
+        };
+
+        IProducesResponseTypeMetadata metadata = BuildProducesMetadata(200, null, ["application/octet-stream"]);
+        OpenApiOperationTransformerContext context = BuildContext(metadata);
+
+        // Act
+        await transformer.TransformAsync(operation, context, TestContext.Current.CancellationToken);
+
+        // Assert
+        var response = (OpenApiResponse)operation.Responses["200"];
+        response.Content!.ShouldContainKey("application/octet-stream");
+        var mediaType = (OpenApiMediaType)response.Content!["application/octet-stream"];
+        var schema = (OpenApiSchema)mediaType.Schema!;
+        schema.Type.ShouldBe(JsonSchemaType.String);
+        schema.Format.ShouldBe("binary");
+    }
+
+    // --- Zip content type ---
+
+    [Fact]
+    public async Task TransformAsync_ZipContentTypeWithoutType_InjectsBinarySchema()
+    {
+        // Arrange
+        BinaryResponseContentTypeOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse { Description = "OK" },
+            },
+        };
+
+        IProducesResponseTypeMetadata metadata = BuildProducesMetadata(200, null, ["application/zip"]);
+        OpenApiOperationTransformerContext context = BuildContext(metadata);
+
+        // Act
+        await transformer.TransformAsync(operation, context, TestContext.Current.CancellationToken);
+
+        // Assert
+        var response = (OpenApiResponse)operation.Responses["200"];
+        response.Content!.ShouldContainKey("application/zip");
+        var mediaType = (OpenApiMediaType)response.Content!["application/zip"];
+        var schema = (OpenApiSchema)mediaType.Schema!;
+        schema.Type.ShouldBe(JsonSchemaType.String);
+        schema.Format.ShouldBe("binary");
+    }
+
+    // --- application/json without CLR type → empty media type (no schema) ---
+
+    [Fact]
+    public async Task TransformAsync_UntypedJsonContentType_InjectsEmptyMediaType()
+    {
+        // Arrange
+        BinaryResponseContentTypeOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse { Description = "OK" },
+            },
+        };
+
+        IProducesResponseTypeMetadata metadata = BuildProducesMetadata(200, null, ["application/json"]);
+        OpenApiOperationTransformerContext context = BuildContext(metadata);
+
+        // Act
+        await transformer.TransformAsync(operation, context, TestContext.Current.CancellationToken);
+
+        // Assert
+        var response = (OpenApiResponse)operation.Responses["200"];
+        response.Content!.ShouldContainKey("application/json");
+        var mediaType = (OpenApiMediaType)response.Content!["application/json"];
+        mediaType.Schema.ShouldBeNull();
+    }
+
+    // --- Typed response — must not be touched (native generator handles it) ---
+
+    [Fact]
+    public async Task TransformAsync_TypedResponse_DoesNotModifyContent()
+    {
+        // Arrange
+        BinaryResponseContentTypeOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse { Description = "OK" },
+            },
+        };
+
+        IProducesResponseTypeMetadata metadata = BuildProducesMetadata(200, typeof(string), ["application/json"]);
+        OpenApiOperationTransformerContext context = BuildContext(metadata);
+
+        // Act
+        await transformer.TransformAsync(operation, context, TestContext.Current.CancellationToken);
+
+        // Assert — content untouched; native generator owns typed responses
+        var response = (OpenApiResponse)operation.Responses["200"];
+        response.Content.ShouldBeNull();
+    }
+
+    // --- No content types declared → no-op ---
+
+    [Fact]
+    public async Task TransformAsync_NoContentTypes_DoesNotModifyContent()
+    {
+        // Arrange
+        BinaryResponseContentTypeOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse { Description = "OK" },
+            },
+        };
+
+        IProducesResponseTypeMetadata metadata = BuildProducesMetadata(200, null, []);
+        OpenApiOperationTransformerContext context = BuildContext(metadata);
+
+        // Act
+        await transformer.TransformAsync(operation, context, TestContext.Current.CancellationToken);
+
+        // Assert
+        var response = (OpenApiResponse)operation.Responses["200"];
+        response.Content.ShouldBeNull();
+    }
+
+    // --- Already populated content → must not be overwritten ---
+
+    [Fact]
+    public async Task TransformAsync_ExistingContent_DoesNotOverwrite()
+    {
+        // Arrange
+        BinaryResponseContentTypeOperationTransformer transformer = new();
+        OpenApiMediaType existing = new() { Schema = new OpenApiSchema { Type = JsonSchemaType.Object } };
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse
+                {
+                    Description = "OK",
+                    Content = new Dictionary<string, OpenApiMediaType>
+                    {
+                        ["application/json"] = existing,
+                    },
+                },
+            },
+        };
+
+        IProducesResponseTypeMetadata metadata = BuildProducesMetadata(200, null, ["application/json"]);
+        OpenApiOperationTransformerContext context = BuildContext(metadata);
+
+        // Act
+        await transformer.TransformAsync(operation, context, TestContext.Current.CancellationToken);
+
+        // Assert — existing entry preserved
+        var response = (OpenApiResponse)operation.Responses["200"];
+        response.Content!["application/json"].ShouldBeSameAs(existing);
+    }
+
+    // --- Status code mismatch → no-op ---
+
+    [Fact]
+    public async Task TransformAsync_StatusCodeMismatch_DoesNotModifyOtherResponse()
+    {
+        // Arrange
+        BinaryResponseContentTypeOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["201"] = new OpenApiResponse { Description = "Created" },
+            },
+        };
+
+        // Metadata declares 200, operation only has 201
+        IProducesResponseTypeMetadata metadata = BuildProducesMetadata(200, null, ["application/octet-stream"]);
+        OpenApiOperationTransformerContext context = BuildContext(metadata);
+
+        // Act
+        await transformer.TransformAsync(operation, context, TestContext.Current.CancellationToken);
+
+        // Assert
+        var response = (OpenApiResponse)operation.Responses["201"];
+        response.Content.ShouldBeNull();
+    }
+
+    // --- Helpers ---
+
+    private static IProducesResponseTypeMetadata BuildProducesMetadata(
+        int statusCode,
+        Type? type,
+        IEnumerable<string> contentTypes)
+    {
+        IProducesResponseTypeMetadata metadata = Substitute.For<IProducesResponseTypeMetadata>();
+        metadata.StatusCode.Returns(statusCode);
+        metadata.Type.Returns(type);
+        metadata.ContentTypes.Returns(contentTypes);
+        return metadata;
+    }
+
+    private static OpenApiOperationTransformerContext BuildContext(params object[] metadata)
+    {
+        ActionDescriptor descriptor = new();
+        descriptor.EndpointMetadata = [.. metadata];
+
+        return new OpenApiOperationTransformerContext
+        {
+            DocumentName = "v1",
+            Description = new ApiDescription
+            {
+                ActionDescriptor = descriptor,
+                RelativePath = "api/test",
+            },
+            ApplicationServices = Substitute.For<IServiceProvider>(),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Add `BinaryResponseContentTypeOperationTransformer` to `Granit.Http.ApiDocumentation`: reads `IProducesResponseTypeMetadata` entries that carry `ContentTypes` but have a null/void `Type` (e.g. `.Produces(200, contentType: "application/octet-stream")`), and injects the missing `content` map into the OpenAPI response. Binary media types get `{type: string, format: binary}`; JSON without a schema gets an empty media type.
- Fix `GranitValidationModule`: replace `AddOpenApi(options=>…)` with `ConfigureAll<OpenApiOptions>(…)` so the FluentValidation schema transformer applies to all documents without creating a spurious `v1` document.
- Fix `OpenApiContractGenerator`: filter documents by slug so the generator ignores host-level extras (e.g. the `v1` created by the spurious registration above).
- Fix `ChallengeExternalLogin` description: no longer claims the response carries metadata; it returns an empty 200.
- Trim `MapGranitQuery` projected-query summary template from 124 to 92 chars (was tripping the summary-length audit rule).

## Root cause

ASP.NET Core's native OpenAPI pipeline processes `IProducesResponseTypeMetadata` entries to build `content` schema entries, but only when `Type` is non-null. Calling `.Produces(statusCode, contentType: "application/octet-stream")` without a type parameter sets `Type = null`, so the pipeline silently omits the `content` key from the generated response object. File-download endpoints had an empty responses block despite correct endpoint metadata.

## Test plan

- [x] `dotnet build src/Granit.Http.ApiDocumentation` — clean
- [x] `dotnet test tests/Granit.Http.ApiDocumentation.Tests` — 6 new tests added, all pass (138 total)
- [x] `dotnet build src/Granit.OpenApi.Generator` — generated JSON artifacts regenerated with correct `content` entries on blob/export download endpoints