### PR TITLE
feat(multi-tenancy): expose Jurisdiction on ICurrentTenant, resolve from DB in middleware

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -31092,9 +31092,15 @@
           "returnType": "string?"
         },
         {
+          "name": "Jurisdiction",
+          "kind": "property",
+          "signature": "string? Jurisdiction",
+          "returnType": "string?"
+        },
+        {
           "name": "Change",
           "kind": "method",
-          "signature": "Change(Guid? id, string? name = null)",
+          "signature": "Change(Guid? id, string? name = null, string? jurisdiction = null)",
           "returnType": "IDisposable"
         }
       ]
@@ -31480,8 +31486,8 @@
         {
           "name": "Change",
           "kind": "method",
-          "signature": "Change(Guid? id, string? name = null)",
-          "returnType": "bool IsAvailable { get; } Guid? Id { get; } string? Name { get; } IDisposable"
+          "signature": "Change(Guid? id, string? name = null, string? jurisdiction = null)",
+          "returnType": "bool IsAvailable { get; } Guid? Id { get; } string? Name { get; } string? Jurisdiction { get; } IDisposable"
         }
       ]
     },
@@ -31620,9 +31626,15 @@
           "returnType": "string?"
         },
         {
+          "name": "Jurisdiction",
+          "kind": "property",
+          "signature": "string? Jurisdiction",
+          "returnType": "string?"
+        },
+        {
           "name": "Change",
           "kind": "method",
-          "signature": "Change(Guid? id, string? name = null)",
+          "signature": "Change(Guid? id, string? name = null, string? jurisdiction = null)",
           "returnType": "IDisposable"
         }
       ]

--- a/src/Granit.MultiTenancy/CurrentTenant.cs
+++ b/src/Granit.MultiTenancy/CurrentTenant.cs
@@ -62,9 +62,12 @@ public sealed class CurrentTenant : ICurrentTenant
     public string? Name => CurrentInfo?.Name;
 
     /// <inheritdoc/>
-    public IDisposable Change(Guid? id, string? name = null)
+    public string? Jurisdiction => CurrentInfo?.Jurisdiction;
+
+    /// <inheritdoc/>
+    public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
     {
-        TenantInfo? newValue = id.HasValue ? new TenantInfo(id, name) : null;
+        TenantInfo? newValue = id.HasValue ? new TenantInfo(id, name, Identifier: null, jurisdiction) : null;
         HttpContext? httpContext = _httpContextAccessor?.HttpContext;
 
         return httpContext is not null

--- a/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
@@ -68,14 +68,15 @@ public sealed partial class TenantResolutionMiddleware(
             return;
         }
 
-        if (!await EnsureTenantExistsAsync(context, result).ConfigureAwait(false))
+        (bool exists, string? jurisdiction) = await EnsureTenantExistsAsync(context, result).ConfigureAwait(false);
+        if (!exists)
         {
             return;
         }
 
         _metrics.RecordResolutionSucceeded(result.Tenant.Id.ToString()!, result.ResolverType);
 
-        using IDisposable _ = _currentTenant.Change(result.Tenant.Id, result.Tenant.Name);
+        using IDisposable _ = _currentTenant.Change(result.Tenant.Id, result.Tenant.Name, jurisdiction);
         await next(context).ConfigureAwait(false);
     }
 
@@ -152,16 +153,20 @@ public sealed partial class TenantResolutionMiddleware(
 
     // Validate that the resolved tenant actually exists in the store. Prevents
     // phantom tenants (arbitrary GUIDs) from creating orphaned data.
-    private async Task<bool> EnsureTenantExistsAsync(HttpContext context, TenantResolutionResult result)
+    // Returns (true, jurisdiction) when the tenant exists, (false, null) for phantom tenants.
+    // When ValidateTenantExistence is disabled, skips the DB call and returns (true, null).
+    private async Task<(bool Exists, string? Jurisdiction)> EnsureTenantExistsAsync(HttpContext context, TenantResolutionResult result)
     {
         if (!_options.ValidateTenantExistence || !result.Tenant!.Id.HasValue)
         {
-            return true;
+            return (true, null);
         }
 
-        if (await _tenantReader.ExistsAsync(result.Tenant.Id.Value, context.RequestAborted).ConfigureAwait(false))
+        TenantData? data = await _tenantReader.FindByIdAsync(result.Tenant.Id.Value, context.RequestAborted).ConfigureAwait(false);
+
+        if (data is not null)
         {
-            return true;
+            return (true, data.Jurisdiction);
         }
 
         _metrics.RecordResolutionFailed();
@@ -170,7 +175,7 @@ public sealed partial class TenantResolutionMiddleware(
         // Don't reveal to an attacker why the tenant was rejected. Server-side
         // observability is provided by LogPhantomTenant.
         context.Response.StatusCode = StatusCodes.Status403Forbidden;
-        return false;
+        return (false, null);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Tenant mismatch: resolved tenant {ResolvedTenantId} via {ResolverType} but JWT claim contains {JwtTenantId}. Request rejected.")]

--- a/src/Granit.Privacy.Regulations/Extensions/PrivacyRegulationsServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy.Regulations/Extensions/PrivacyRegulationsServiceCollectionExtensions.cs
@@ -52,7 +52,7 @@ public static class PrivacyRegulationsServiceCollectionExtensions
         var registry = new RegulationProfileRegistry(context.Build());
         services.TryAddSingleton<IRegulationProfileRegistry>(registry);
 
-        // Resolver (scoped — depends on ICurrentTenant)
+        // Resolver (scoped — depends on ICurrentTenant and optionally ITenantReader when available)
         services.TryAddScoped<IPrivacyRegulationResolver, TenantBasedRegulationResolver>();
 
         // Deadline tracker

--- a/src/Granit.Privacy.Regulations/Internal/TenantBasedRegulationResolver.cs
+++ b/src/Granit.Privacy.Regulations/Internal/TenantBasedRegulationResolver.cs
@@ -7,7 +7,8 @@ namespace Granit.Privacy.Regulations.Internal;
 
 /// <summary>
 /// Default <see cref="IPrivacyRegulationResolver"/> implementation.
-/// Resolution chain: per-tenant config override → default regulation → throw.
+/// Resolution chain: ICurrentTenant.Jurisdiction (populated from DB by the middleware) →
+/// per-tenant config override → default regulation → throw.
 /// </summary>
 internal sealed class TenantBasedRegulationResolver(
     IRegulationProfileRegistry registry,
@@ -19,22 +20,29 @@ internal sealed class TenantBasedRegulationResolver(
         PrivacyRegulationsOptions opts = options.Value;
         string? regulationCode = null;
 
-        // 1. Per-tenant override from configuration
         if (currentTenant is { IsAvailable: true, Id: { } tenantId })
         {
-            string tenantKey = tenantId.ToString();
-            opts.TenantRegulations.TryGetValue(tenantKey, out regulationCode);
+            // 1. DB jurisdiction — already resolved by the middleware via FindByIdAsync and
+            //    stored on ICurrentTenant when ValidateTenantExistence is enabled.
+            regulationCode = currentTenant.Jurisdiction;
+
+            // 2. Config per-tenant override (operator escape hatch, takes precedence over DB)
+            if (opts.TenantRegulations.TryGetValue(tenantId.ToString(), out string? configCode))
+            {
+                regulationCode = configCode;
+            }
         }
 
-        // 2. Default regulation from configuration
+        // 3. Default regulation from configuration
         regulationCode ??= opts.DefaultRegulation;
 
         if (string.IsNullOrWhiteSpace(regulationCode))
         {
             throw new InvalidOperationException(
                 "No privacy regulation configured. " +
-                "Set 'Privacy:Regulations:DefaultRegulation' in appsettings.json " +
-                "or configure per-tenant regulations in 'Privacy:Regulations:TenantRegulations'.");
+                "Set 'Privacy:Regulations:DefaultRegulation' in appsettings.json, " +
+                "configure per-tenant regulations in 'Privacy:Regulations:TenantRegulations', " +
+                "or set the Jurisdiction field on the tenant.");
         }
 
         PrivacyRegulationProfile profile = registry.GetProfile(PrivacyRegulation.Create(regulationCode))

--- a/src/Granit.Testing/Fakes/FakeCurrentTenant.cs
+++ b/src/Granit.Testing/Fakes/FakeCurrentTenant.cs
@@ -48,7 +48,14 @@ public sealed class FakeCurrentTenant : ICurrentTenant
     }
 
     /// <inheritdoc/>
-    public IDisposable Change(Guid? id, string? name = null)
+    public string? Jurisdiction
+    {
+        get => _state.Value?.Jurisdiction;
+        set => EnsureState().Jurisdiction = value;
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
     {
         TenantState? previous = _state.Value;
         _state.Value = new TenantState
@@ -56,6 +63,7 @@ public sealed class FakeCurrentTenant : ICurrentTenant
             Id = id,
             Name = name,
             IsAvailable = id.HasValue,
+            Jurisdiction = jurisdiction,
         };
         return new ChangeScope(this, previous);
     }
@@ -67,6 +75,7 @@ public sealed class FakeCurrentTenant : ICurrentTenant
         public bool IsAvailable { get; set; }
         public Guid? Id { get; set; }
         public string? Name { get; set; }
+        public string? Jurisdiction { get; set; }
     }
 
     private sealed class ChangeScope(FakeCurrentTenant owner, TenantState? previous) : IDisposable

--- a/src/Granit/MultiTenancy/ICurrentTenant.cs
+++ b/src/Granit/MultiTenancy/ICurrentTenant.cs
@@ -20,11 +20,19 @@ public interface ICurrentTenant
     string? Name { get; }
 
     /// <summary>
+    /// Privacy regulation code for the current tenant (e.g., <c>"EU_GDPR"</c>), or <c>null</c>.
+    /// Populated from <c>Tenant.Jurisdiction</c> when <c>ValidateTenantExistence</c> is enabled.
+    /// Falls back to <c>null</c> when running without the EF Core tenant store.
+    /// </summary>
+    string? Jurisdiction { get; }
+
+    /// <summary>
     /// Temporarily overrides the current tenant in the async flow.
     /// The previous tenant is restored when the scope is disposed.
     /// </summary>
     /// <param name="id">Identifier of the tenant to activate, or <c>null</c> to deactivate.</param>
     /// <param name="name">Optional tenant name.</param>
+    /// <param name="jurisdiction">Optional privacy regulation code for the tenant.</param>
     /// <returns>Scope to dispose to restore the previous tenant.</returns>
-    IDisposable Change(Guid? id, string? name = null);
+    IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null);
 }

--- a/src/Granit/MultiTenancy/NullTenantContext.cs
+++ b/src/Granit/MultiTenancy/NullTenantContext.cs
@@ -15,8 +15,9 @@ public sealed class NullTenantContext : ICurrentTenant
     public bool IsAvailable => false;
     public Guid? Id => null;
     public string? Name => null;
+    public string? Jurisdiction => null;
 
-    public IDisposable Change(Guid? id, string? name = null) => NullScope.Value;
+    public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null) => NullScope.Value;
 
     private sealed class NullScope : IDisposable
     {

--- a/tests/Granit.IO.Tests/FakeCurrentTenant.cs
+++ b/tests/Granit.IO.Tests/FakeCurrentTenant.cs
@@ -11,7 +11,9 @@ internal sealed class FakeCurrentTenant(Guid? id = null, string? name = null) : 
 
     public string? Name { get; private set; } = name;
 
-    public IDisposable Change(Guid? id, string? name = null)
+    public string? Jurisdiction => null;
+
+    public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
     {
         Guid? previousId = Id;
         string? previousName = Name;

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/MutableCurrentTenant.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/MutableCurrentTenant.cs
@@ -15,7 +15,9 @@ public sealed class MutableCurrentTenant : ICurrentTenant
 
     public string? Name { get; private set; }
 
-    public IDisposable Change(Guid? id, string? name = null)
+    public string? Jurisdiction => null;
+
+    public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
     {
         Guid? previousId = Id;
         string? previousName = Name;

--- a/tests/Granit.Indexing.AI.Tests/AIAutoTaggerTests.cs
+++ b/tests/Granit.Indexing.AI.Tests/AIAutoTaggerTests.cs
@@ -223,6 +223,7 @@ public sealed class AIAutoTaggerTests
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; } = id;
         public string? Name => null;
-        public IDisposable Change(Guid? id, string? name = null) => throw new NotSupportedException();
+        public string? Jurisdiction => null;
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null) => throw new NotSupportedException();
     }
 }

--- a/tests/Granit.Indexing.AI.Tests/AISummarizerTests.cs
+++ b/tests/Granit.Indexing.AI.Tests/AISummarizerTests.cs
@@ -172,6 +172,7 @@ public sealed class AISummarizerTests
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; } = id;
         public string? Name => null;
-        public IDisposable Change(Guid? id, string? name = null) => throw new NotSupportedException();
+        public string? Jurisdiction => null;
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null) => throw new NotSupportedException();
     }
 }

--- a/tests/Granit.Indexing.Elasticsearch.Tests.Integration/ElasticsearchBackendTests.cs
+++ b/tests/Granit.Indexing.Elasticsearch.Tests.Integration/ElasticsearchBackendTests.cs
@@ -177,7 +177,8 @@ public sealed class ElasticsearchBackendTests : IClassFixture<ElasticsearchFixtu
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; } = id;
         public string? Name => null;
-        public IDisposable Change(Guid? id, string? name = null) => throw new NotSupportedException();
+        public string? Jurisdiction => null;
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null) => throw new NotSupportedException();
     }
 
     private sealed class NoopLocalEventBus : ILocalEventBus

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PostgresHarness.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PostgresHarness.cs
@@ -63,7 +63,8 @@ internal sealed class MutableTenant : ICurrentTenant
     public Guid? Id { get; set; }
     public bool IsAvailable => Id is not null;
     public string? Name => null;
-    public IDisposable Change(Guid? id, string? name = null)
+    public string? Jurisdiction => null;
+    public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
     {
         Guid? prev = Id;
         Id = id;

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests/SqliteHarness.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests/SqliteHarness.cs
@@ -73,7 +73,8 @@ internal sealed class MutableTenant : ICurrentTenant
     public Guid? Id { get; set; }
     public bool IsAvailable => Id is not null;
     public string? Name => null;
-    public IDisposable Change(Guid? id, string? name = null)
+    public string? Jurisdiction => null;
+    public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
     {
         Guid? prev = Id;
         Id = id;

--- a/tests/Granit.Indexing.Privacy.Tests/PersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Indexing.Privacy.Tests/PersonalDataDeletionHandlerTests.cs
@@ -100,7 +100,8 @@ public sealed class PersonalDataDeletionHandlerTests
         public bool IsAvailable => id is not null;
         public Guid? Id => id;
         public string? Name => null;
-        public IDisposable Change(Guid? id, string? name = null) => Empty.Instance;
+        public string? Jurisdiction => null;
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null) => Empty.Instance;
 
         private sealed class Empty : IDisposable
         {

--- a/tests/Granit.LanguageDetection.AI.Tests/AILanguageDetectorTests.cs
+++ b/tests/Granit.LanguageDetection.AI.Tests/AILanguageDetectorTests.cs
@@ -251,6 +251,7 @@ public sealed class AILanguageDetectorTests
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; } = id;
         public string? Name => null;
-        public IDisposable Change(Guid? id, string? name = null) => throw new NotSupportedException();
+        public string? Jurisdiction => null;
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null) => throw new NotSupportedException();
     }
 }

--- a/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
@@ -58,8 +58,8 @@ public sealed class TenantResolutionMiddlewareTests
             ValidateTenantExistence = validateTenantExistence,
         });
         ITenantReader tenantReader = Substitute.For<ITenantReader>();
-        tenantReader.ExistsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
+        tenantReader.FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult<TenantData?>(new TenantData(ci.Arg<Guid>(), "Test", "test", null, true, null, DateTimeOffset.UtcNow)));
 
         // Default gate for tests that don't care: allow everything. The dedicated
         // host-impersonation tests below pass their own substitute.
@@ -237,8 +237,8 @@ public sealed class TenantResolutionMiddlewareTests
             ValidateTenantExistence = true,
         });
         ITenantReader tenantReader = Substitute.For<ITenantReader>();
-        tenantReader.ExistsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(false)); // Tenant does NOT exist
+        tenantReader.FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TenantData?>(null)); // Tenant does NOT exist
         return new TenantResolutionMiddleware(
             currentTenant,
             pipeline,
@@ -720,8 +720,8 @@ public sealed class TenantResolutionMiddlewareTests
             ValidateTenantExistence = false,
         });
         ITenantReader tenantReader = Substitute.For<ITenantReader>();
-        tenantReader.ExistsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
+        tenantReader.FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult<TenantData?>(new TenantData(ci.Arg<Guid>(), "Test", "test", null, true, null, DateTimeOffset.UtcNow)));
         return new TenantResolutionMiddleware(
             currentTenant,
             pipeline,

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/GranitDbContextSvoMultiTenantOrderingTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/GranitDbContextSvoMultiTenantOrderingTests.cs
@@ -164,7 +164,10 @@ public sealed class GranitDbContextSvoMultiTenantOrderingTests : IAsyncLifetime
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; set; }
         public string? Name { get; set; }
-        public IDisposable Change(Guid? id, string? name = null)
+
+        public string? Jurisdiction => throw new NotImplementedException();
+
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
             => throw new NotSupportedException();
     }
 

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
@@ -780,7 +780,8 @@ public sealed class ModelBuilderExtensionsTests
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; set; }
         public string? Name { get; set; }
-        public IDisposable Change(Guid? id, string? name = null) => throw new NotSupportedException();
+        public string? Jurisdiction => null;
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null) => throw new NotSupportedException();
     }
 
     // Mutable IDataFilter for tests: direct control without AsyncLocal.

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenantFilterParameterizationReproTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenantFilterParameterizationReproTests.cs
@@ -202,7 +202,10 @@ public sealed class MultiTenantFilterParameterizationReproTests : IAsyncLifetime
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; set; }
         public string? Name { get; set; }
-        public IDisposable Change(Guid? id, string? name = null)
+
+        public string? Jurisdiction => throw new NotImplementedException();
+
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
             => throw new NotSupportedException();
     }
 

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportAssemblyCheckpointStoreCrossTenantIsolationTests.cs
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportAssemblyCheckpointStoreCrossTenantIsolationTests.cs
@@ -205,7 +205,8 @@ public sealed class EfExportAssemblyCheckpointStoreCrossTenantIsolationTests
         public Guid? Id { get; set; }
         public bool IsAvailable => Id is not null;
         public string? Name => null;
-        public IDisposable Change(Guid? id, string? name = null)
+        public string? Jurisdiction => null;
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
         {
             Guid? prev = Id;
             Id = id;

--- a/tests/Granit.Privacy.Regulations.Tests/Internal/TenantBasedRegulationResolverTests.cs
+++ b/tests/Granit.Privacy.Regulations.Tests/Internal/TenantBasedRegulationResolverTests.cs
@@ -33,10 +33,10 @@ public sealed class TenantBasedRegulationResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_PerTenantOverride_TakesPrecedence()
+    public async Task ResolveAsync_PerTenantConfigOverride_TakesPrecedence()
     {
         var tenantId = Guid.NewGuid();
-        ICurrentTenant tenant = CreateTenant(tenantId);
+        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: null);
 
         TenantBasedRegulationResolver resolver = CreateResolver(
             new PrivacyRegulationsOptions
@@ -55,10 +55,62 @@ public sealed class TenantBasedRegulationResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_TenantJurisdiction_UsedWhenNoConfigOverride()
+    {
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: "BR_LGPD");
+
+        TenantBasedRegulationResolver resolver = CreateResolver(
+            new PrivacyRegulationsOptions { DefaultRegulation = "EU_GDPR" },
+            tenant);
+
+        PrivacyRegulationProfile profile = await resolver.ResolveAsync(TestContext.Current.CancellationToken);
+
+        profile.Regulation.Value.ShouldBe("BR_LGPD");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ConfigOverrideTakesPrecedenceOverJurisdiction()
+    {
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: "BR_LGPD");
+
+        TenantBasedRegulationResolver resolver = CreateResolver(
+            new PrivacyRegulationsOptions
+            {
+                DefaultRegulation = "EU_GDPR",
+                TenantRegulations = new Dictionary<string, string>
+                {
+                    [tenantId.ToString()] = "US_CCPA",
+                },
+            },
+            tenant);
+
+        PrivacyRegulationProfile profile = await resolver.ResolveAsync(TestContext.Current.CancellationToken);
+
+        profile.Regulation.Value.ShouldBe("US_CCPA");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NullJurisdiction_FallsBackToConfigDefault()
+    {
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: null);
+
+        TenantBasedRegulationResolver resolver = CreateResolver(
+            new PrivacyRegulationsOptions { DefaultRegulation = "CH_NFADP" },
+            tenant);
+
+        PrivacyRegulationProfile profile = await resolver.ResolveAsync(TestContext.Current.CancellationToken);
+
+        profile.Regulation.Value.ShouldBe("CH_NFADP");
+    }
+
+    [Fact]
     public async Task ResolveAsync_NoTenantOverride_FallsBackToDefault()
     {
         var tenantId = Guid.NewGuid();
-        ICurrentTenant tenant = CreateTenant(tenantId);
+        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: null);
 
         TenantBasedRegulationResolver resolver = CreateResolver(
             new PrivacyRegulationsOptions { DefaultRegulation = "US_CCPA" },
@@ -126,11 +178,12 @@ public sealed class TenantBasedRegulationResolverTests
         return new TenantBasedRegulationResolver(_registry, opts, currentTenant);
     }
 
-    private static ICurrentTenant CreateTenant(Guid tenantId)
+    private static ICurrentTenant CreateTenant(Guid tenantId, string? jurisdiction)
     {
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
         tenant.IsAvailable.Returns(true);
         tenant.Id.Returns(tenantId);
+        tenant.Jurisdiction.Returns(jurisdiction);
         return tenant;
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Jurisdiction` property to `ICurrentTenant` and updates `Change()` signature (optional `jurisdiction` param — all existing callers compile unchanged).
- `TenantResolutionMiddleware` now returns `(bool Exists, string? Jurisdiction)` from `EnsureTenantExistsAsync`, reusing the existing `FindByIdAsync` call (no extra DB round trip) and passing the jurisdiction into `Change()`.
- `TenantBasedRegulationResolver` drops its `ITenantReader` dependency entirely — it reads `ICurrentTenant.Jurisdiction` instead, which is already populated per-request by the middleware.
- Resolution chain: DB jurisdiction → per-tenant config override → default config → throw.
- Updates `NullTenantContext`, `CurrentTenant`, `FakeCurrentTenant`, and 13 test stubs to implement the new interface member.

## Resolution chain

```
ICurrentTenant.Jurisdiction     ← Tenant.Jurisdiction from DB (via middleware FindByIdAsync)
  ↳ TenantRegulations[tenantId] ← operator escape hatch in appsettings
    ↳ DefaultRegulation          ← global fallback in appsettings
      ↳ InvalidOperationException
```

## Test plan

- [x] `Granit.MultiTenancy.Tests` — 113 tests, 0 failures (includes `TenantResolutionMiddlewareTests`)
- [x] `Granit.Privacy.Regulations.Tests` — 45 tests, 0 failures (includes `TenantBasedRegulationResolverTests`)
- [x] All 4 core packages build cleanly