### PR TITLE
feat(multi-tenancy): add Tenant.Jurisdiction (ISO 3166) with IPrivacyJurisdictionResolver

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40630,7 +40630,7 @@
       "kind": "record",
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyRegulationProfileResponse.cs",
-      "line": 6,
+      "line": 8,
       "members": []
     },
     {
@@ -41920,7 +41920,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Regulations",
       "file": "src/Granit.Privacy.Regulations/Extensions/PrivacyRegulationsServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitPrivacyRegulations",
@@ -41936,7 +41936,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Regulations",
       "file": "src/Granit.Privacy.Regulations/GranitPrivacyRegulationsBuilder.cs",
-      "line": 11,
+      "line": 12,
       "members": []
     },
     {
@@ -41967,6 +41967,38 @@
           "kind": "method",
           "signature": "ResolveAllAsync(CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<PrivacyRegulationProfile>>"
+        }
+      ]
+    },
+    {
+      "name": "IPrivacyJurisdictionMapProvider",
+      "fqn": "Granit.Privacy.Regulations.Jurisdiction.IPrivacyJurisdictionMapProvider",
+      "kind": "interface",
+      "project": "Granit.Privacy.Regulations",
+      "file": "src/Granit.Privacy.Regulations/Jurisdiction/IPrivacyJurisdictionMapProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(IDictionary<string, IReadOnlyList<PrivacyRegulation>> countryMap, IDictionary<string, IReadOnlyList<PrivacyRegulation>> regionMap)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IPrivacyJurisdictionResolver",
+      "fqn": "Granit.Privacy.Regulations.Jurisdiction.IPrivacyJurisdictionResolver",
+      "kind": "interface",
+      "project": "Granit.Privacy.Regulations",
+      "file": "src/Granit.Privacy.Regulations/Jurisdiction/IPrivacyJurisdictionResolver.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(string countryCode, string? regionCode = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<PrivacyRegulation>>"
         }
       ]
     },

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/CreateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/CreateTenantRequest.cs
@@ -6,7 +6,7 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// <param name="Name">Display name of the tenant (max 256 characters).</param>
 /// <param name="Identifier">Unique slug/subdomain identifier (max 64 characters, lowercase alphanumeric + hyphens).</param>
 /// <param name="ContactEmail">Optional contact email address.</param>
-/// <param name="Jurisdiction">Privacy regulation code or ISO country code (e.g. <c>"BE"</c>, <c>"FR"</c>), or <c>null</c>.</param>
+/// <param name="Jurisdiction">ISO 3166 jurisdiction code (e.g. <c>"FR"</c>, <c>"CA-QC"</c>, <c>"US-CA"</c>). Omit or pass <c>null</c> to leave unconfigured.</param>
 public sealed record CreateTenantRequest(
     string Name,
     string Identifier,

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
@@ -8,7 +8,7 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// <param name="Identifier">Unique slug/subdomain identifier.</param>
 /// <param name="ContactEmail">Optional contact email address.</param>
 /// <param name="Activated">Whether the tenant is active.</param>
-/// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
+/// <param name="Jurisdiction">ISO 3166 jurisdiction code (e.g. <c>"FR"</c>, <c>"CA-QC"</c>). <c>null</c> when not configured.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
 /// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record TenantResponse(

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
@@ -8,7 +8,7 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// <param name="Name">New display name (max 256 characters).</param>
 /// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates).</param>
 /// <param name="ContactEmail">New contact email (or <c>null</c> to clear).</param>
-/// <param name="Jurisdiction">Privacy regulation code or ISO country code (or <c>null</c> to clear).</param>
+/// <param name="Jurisdiction">ISO 3166 jurisdiction code (e.g. <c>"FR"</c>, <c>"CA-QC"</c>). Pass <c>null</c> to clear.</param>
 public sealed record UpdateTenantRequest(
     string Name,
     string ConcurrencyStamp,

--- a/src/Granit.MultiTenancy.Endpoints/Validators/CreateTenantRequestValidator.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Validators/CreateTenantRequestValidator.cs
@@ -12,7 +12,7 @@ internal sealed class CreateTenantRequestValidator : GranitValidator<CreateTenan
     internal const int MaxNameLength = 256;
     internal const int MaxIdentifierLength = 64;
     internal const int MaxEmailLength = 256;
-    internal const int MaxJurisdictionLength = 16;
+    internal const int MaxJurisdictionCodeLength = 16;
     internal const string IdentifierPattern = @"^[a-z0-9-]+$";
 
     public CreateTenantRequestValidator()
@@ -32,7 +32,7 @@ internal sealed class CreateTenantRequestValidator : GranitValidator<CreateTenan
             .When(x => x.ContactEmail is not null);
 
         RuleFor(x => x.Jurisdiction)
-            .MaximumLength(MaxJurisdictionLength)
+            .MaximumLength(MaxJurisdictionCodeLength)
             .When(x => x.Jurisdiction is not null);
     }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Validators/UpdateTenantRequestValidator.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Validators/UpdateTenantRequestValidator.cs
@@ -11,7 +11,7 @@ internal sealed class UpdateTenantRequestValidator : GranitValidator<UpdateTenan
 {
     internal const int MaxNameLength = 256;
     internal const int MaxEmailLength = 256;
-    internal const int MaxJurisdictionLength = 16;
+    internal const int MaxJurisdictionCodeLength = 16;
 
     public UpdateTenantRequestValidator()
     {
@@ -25,7 +25,7 @@ internal sealed class UpdateTenantRequestValidator : GranitValidator<UpdateTenan
             .When(x => x.ContactEmail is not null);
 
         RuleFor(x => x.Jurisdiction)
-            .MaximumLength(MaxJurisdictionLength)
+            .MaximumLength(MaxJurisdictionCodeLength)
             .When(x => x.Jurisdiction is not null);
     }
 }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
@@ -33,6 +33,7 @@ internal sealed class TenantEntityTypeConfiguration : IEntityTypeConfiguration<T
         builder.Property(e => e.Jurisdiction)
                .HasMaxLength(16);
 
+
         builder.Property(e => e.Activated)
                .IsRequired();
 

--- a/src/Granit.MultiTenancy/Domain/Tenant.cs
+++ b/src/Granit.MultiTenancy/Domain/Tenant.cs
@@ -62,7 +62,7 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo, IConcurrency
     /// <param name="name">Display name (max 256 characters).</param>
     /// <param name="identifier">Unique slug/subdomain identifier (max 64 characters).</param>
     /// <param name="contactEmail">Optional contact email address.</param>
-    /// <param name="jurisdiction">Privacy regulation code or ISO country code (or <c>null</c>).</param>
+    /// <param name="jurisdiction">ISO 3166 jurisdiction code (e.g. <c>"FR"</c>, <c>"CA-QC"</c>), or <c>null</c> when not configured.</param>
     /// <returns>A new active <see cref="Tenant"/> instance.</returns>
     public static Tenant Create(
         Guid id,
@@ -89,11 +89,11 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo, IConcurrency
     }
 
     /// <summary>
-    /// Updates the tenant's display name, contact email, and jurisdiction.
+    /// Updates the tenant's display name, contact email, and jurisdictions.
     /// </summary>
     /// <param name="name">New display name.</param>
     /// <param name="contactEmail">New contact email (or <c>null</c> to clear).</param>
-    /// <param name="jurisdiction">Privacy regulation code or ISO country code (or <c>null</c>).</param>
+    /// <param name="jurisdiction">ISO 3166 jurisdiction code, or <c>null</c> to clear.</param>
     public void UpdateDetails(string name, string? contactEmail, string? jurisdiction)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);

--- a/src/Granit.MultiTenancy/ITenantInfo.cs
+++ b/src/Granit.MultiTenancy/ITenantInfo.cs
@@ -19,9 +19,9 @@ public interface ITenantInfo
     string? Identifier { get; }
 
     /// <summary>
-    /// Privacy regulation code or ISO country code for this tenant.
-    /// Used by <c>IPrivacyRegulationResolver</c> to determine the applicable regulation.
-    /// Null when no jurisdiction is configured.
+    /// ISO 3166 jurisdiction code for this tenant (e.g. <c>"FR"</c>, <c>"CA-QC"</c>, <c>"US-CA"</c>).
+    /// Used by <c>IPrivacyRegulationResolver</c> to determine the applicable regulation(s).
+    /// <c>null</c> when no jurisdiction is configured.
     /// </summary>
     string? Jurisdiction { get; }
 }

--- a/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
+++ b/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
@@ -19,7 +19,7 @@ public sealed class TenantQueryDefinition : QueryDefinition<Tenant>
             .Column(t => t.Name, c => c.Label("Name").LabelKey("MultiTenancy.Columns.Name").Filterable().Sortable())
             .Column(t => t.Identifier, c => c.Label("Identifier").LabelKey("MultiTenancy.Columns.Identifier").Filterable().Sortable())
             .Column(t => t.ContactEmail, c => c.Label("Party Email").LabelKey("MultiTenancy.Columns.ContactEmail").Filterable())
-            .Column(t => t.Jurisdiction, c => c.Label("Jurisdiction").LabelKey("MultiTenancy.Columns.Jurisdiction").Filterable().Sortable())
+            .Column(t => t.Jurisdiction, c => c.Label("Jurisdiction").LabelKey("MultiTenancy.Columns.Jurisdiction").Filterable())
             .Column(t => t.Activated, c => c.Label("Activated").LabelKey("MultiTenancy.Columns.Activated").Filterable().Sortable())
             .Column(t => t.CustomDomain, c => c.Label("Custom Domain").LabelKey("MultiTenancy.Columns.CustomDomain").Filterable())
             .Column(t => t.IsDeleted, c => c.Label("Deleted").LabelKey("MultiTenancy.Columns.IsDeleted").Filterable().Sortable())

--- a/src/Granit.MultiTenancy/Stores/ITenantWriter.cs
+++ b/src/Granit.MultiTenancy/Stores/ITenantWriter.cs
@@ -13,7 +13,7 @@ public interface ITenantWriter
     /// <param name="name">Display name (max 256 characters).</param>
     /// <param name="identifier">Unique slug/subdomain identifier (max 64 characters).</param>
     /// <param name="contactEmail">Optional contact email address.</param>
-    /// <param name="jurisdiction">Privacy regulation code or ISO country code (or <c>null</c>).</param>
+    /// <param name="jurisdiction">ISO 3166 jurisdiction code, or <c>null</c>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task CreateAsync(Guid id, string name, string identifier, string? contactEmail, string? jurisdiction, CancellationToken cancellationToken = default);
 
@@ -23,7 +23,7 @@ public interface ITenantWriter
     /// <param name="id">Tenant identifier.</param>
     /// <param name="name">New display name.</param>
     /// <param name="contactEmail">New contact email (or <c>null</c> to clear).</param>
-    /// <param name="jurisdiction">Privacy regulation code or ISO country code (or <c>null</c>).</param>
+    /// <param name="jurisdiction">ISO 3166 jurisdiction code, or <c>null</c> to clear.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task UpdateAsync(Guid id, string name, string? contactEmail, string? jurisdiction, CancellationToken cancellationToken = default);
 
@@ -33,7 +33,7 @@ public interface ITenantWriter
     /// <param name="id">Tenant identifier.</param>
     /// <param name="name">New display name.</param>
     /// <param name="contactEmail">New contact email (or <c>null</c> to clear).</param>
-    /// <param name="jurisdiction">Privacy regulation code or ISO country code (or <c>null</c>).</param>
+    /// <param name="jurisdiction">ISO 3166 jurisdiction code, or <c>null</c> to clear.</param>
     /// <param name="concurrencyStamp">Client-supplied stamp from the last read; must match the stored value.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task UpdateAsync(Guid id, string name, string? contactEmail, string? jurisdiction, string concurrencyStamp, CancellationToken cancellationToken = default);

--- a/src/Granit.MultiTenancy/Stores/TenantData.cs
+++ b/src/Granit.MultiTenancy/Stores/TenantData.cs
@@ -10,7 +10,7 @@ namespace Granit.MultiTenancy.Stores;
 /// <param name="Identifier">Unique slug/subdomain identifier.</param>
 /// <param name="ContactEmail">Optional contact email address.</param>
 /// <param name="Activated">Whether the tenant is active.</param>
-/// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
+/// <param name="Jurisdiction">ISO 3166 jurisdiction code (e.g. <c>"FR"</c>, <c>"CA-QC"</c>), or <c>null</c> when not configured.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
 /// <param name="CustomDomain">Optional custom domain for outbound URL generation (e.g., <c>"app.acme-corp.com"</c>).</param>
 /// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyRegulationProfileResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyRegulationProfileResponse.cs
@@ -1,12 +1,15 @@
 namespace Granit.Privacy.Endpoints.Dtos;
 
 /// <summary>
-/// Response returning the privacy regulation profile applicable to the current tenant.
+/// Response returning the effective privacy regulation profile for the current tenant.
+/// When multiple jurisdictions are declared, the profile represents the merged composite
+/// (most restrictive rules win). <see cref="ContributingRegulations"/> lists the source regulations.
 /// </summary>
 public sealed record PrivacyRegulationProfileResponse(
     string Regulation,
     string DisplayName,
     string JurisdictionCode,
+    IReadOnlyList<string> ContributingRegulations,
     string ConsentModel,
     IReadOnlyList<string> AvailableLegalBases,
     int SubjectAccessRequestDays,

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyRegulationEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyRegulationEndpoints.cs
@@ -14,11 +14,12 @@ internal static class PrivacyRegulationEndpoints
     {
         group.MapGet("/regulation", HandleGetRegulationAsync)
              .WithName("GetApplicableRegulation")
-             .WithSummary("Returns the privacy regulation profile applicable to the current tenant.")
+             .WithSummary("Returns the effective privacy regulation profile for the current tenant.")
              .WithDescription(
-                 "Resolves the privacy regulation for the current tenant context via IPrivacyRegulationResolver. "
-                 + "Returns the full regulation profile including consent model, response timelines, breach notification "
-                 + "deadlines, age thresholds, cookie consent rules, and cross-border transfer requirements.")
+                 "Resolves the effective privacy regulation for the current tenant via IPrivacyRegulationResolver. "
+                 + "For multi-jurisdiction tenants, returns a composite profile (most restrictive rules win) "
+                 + "with contributingRegulations listing the source regulations. "
+                 + "Single-jurisdiction response is backward-compatible: contributingRegulations contains one entry.")
              .Produces<PrivacyRegulationProfileResponse>();
 
         return group;
@@ -28,12 +29,16 @@ internal static class PrivacyRegulationEndpoints
         [FromServices] IPrivacyRegulationResolver resolver,
         CancellationToken cancellationToken)
     {
+        IReadOnlyList<PrivacyRegulationProfile> contributing =
+            await resolver.ResolveAllAsync(cancellationToken).ConfigureAwait(false);
+
         PrivacyRegulationProfile profile = await resolver.ResolveAsync(cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Ok(new PrivacyRegulationProfileResponse(
             profile.Regulation.Value,
             profile.DisplayName,
             profile.JurisdictionCode,
+            contributing.Select(p => p.Regulation.Value).ToList(),
             profile.ConsentModel.ToString(),
             profile.AvailableLegalBases.Select(b => b.Value).ToList(),
             profile.SubjectAccessRequestDays,

--- a/src/Granit.Privacy.Regulations/Extensions/PrivacyRegulationsServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy.Regulations/Extensions/PrivacyRegulationsServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Granit.Privacy.Regulations.Internal;
+using Granit.Privacy.Regulations.Jurisdiction;
+using Granit.Privacy.Regulations.Jurisdiction.Internal;
 using Granit.Privacy.Regulations.Options;
 using Granit.Privacy.Regulations.Profiles;
 using Granit.Privacy.Regulations.Profiles.Internal;
@@ -57,6 +59,19 @@ public static class PrivacyRegulationsServiceCollectionExtensions
 
         // Deadline tracker
         services.TryAddSingleton<IResponseDeadlineTracker, DefaultResponseDeadlineTracker>();
+
+        // Jurisdiction resolver — built-in map + custom Tier 3 providers
+        var jurisdictionMapProviders = new List<IPrivacyJurisdictionMapProvider>
+        {
+            new BuiltInPrivacyJurisdictionMapProvider(),
+        };
+        foreach (IPrivacyJurisdictionMapProvider provider in builder.JurisdictionMapProviders)
+        {
+            jurisdictionMapProviders.Add(provider);
+        }
+
+        services.TryAddSingleton<IPrivacyJurisdictionResolver>(
+            new DefaultPrivacyJurisdictionResolver(jurisdictionMapProviders));
 
         return services;
     }

--- a/src/Granit.Privacy.Regulations/GranitPrivacyRegulationsBuilder.cs
+++ b/src/Granit.Privacy.Regulations/GranitPrivacyRegulationsBuilder.cs
@@ -1,3 +1,4 @@
+using Granit.Privacy.Regulations.Jurisdiction;
 using Granit.Privacy.Regulations.Profiles;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -6,7 +7,7 @@ namespace Granit.Privacy.Regulations;
 /// <summary>
 /// Builder for customizing the <c>Granit.Privacy.Regulations</c> module.
 /// Used within <see cref="Extensions.PrivacyRegulationsServiceCollectionExtensions.AddGranitPrivacyRegulations"/>
-/// to register custom Tier 3 regulation profile providers.
+/// to register custom Tier 3 regulation profile providers and jurisdiction map providers.
 /// </summary>
 public sealed class GranitPrivacyRegulationsBuilder(IServiceCollection services)
 {
@@ -15,6 +16,9 @@ public sealed class GranitPrivacyRegulationsBuilder(IServiceCollection services)
 
     /// <summary>Custom regulation profile providers (Tier 3).</summary>
     internal List<IRegulationProfileProvider> Providers { get; } = [];
+
+    /// <summary>Custom jurisdiction map providers.</summary>
+    internal List<IPrivacyJurisdictionMapProvider> JurisdictionMapProviders { get; } = [];
 
     /// <summary>
     /// Adds a custom regulation profile provider (Tier 3).
@@ -35,6 +39,29 @@ public sealed class GranitPrivacyRegulationsBuilder(IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(provider);
         Providers.Add(provider);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom ISO 3166 → regulation mapping provider.
+    /// Custom entries take precedence over the built-in map for the same country/region codes.
+    /// </summary>
+    /// <typeparam name="TProvider">The provider type.</typeparam>
+    public GranitPrivacyRegulationsBuilder AddJurisdictionMapProvider<TProvider>()
+        where TProvider : IPrivacyJurisdictionMapProvider, new()
+    {
+        JurisdictionMapProviders.Add(new TProvider());
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom ISO 3166 → regulation mapping provider instance.
+    /// </summary>
+    /// <param name="provider">The provider instance.</param>
+    public GranitPrivacyRegulationsBuilder AddJurisdictionMapProvider(IPrivacyJurisdictionMapProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        JurisdictionMapProviders.Add(provider);
         return this;
     }
 }

--- a/src/Granit.Privacy.Regulations/Internal/CompositeRegulationProfileMerger.cs
+++ b/src/Granit.Privacy.Regulations/Internal/CompositeRegulationProfileMerger.cs
@@ -1,0 +1,119 @@
+namespace Granit.Privacy.Regulations.Internal;
+
+/// <summary>
+/// Merges multiple <see cref="PrivacyRegulationProfile"/> instances into a single
+/// composite effective profile using deterministic "most restrictive wins" rules.
+/// </summary>
+/// <remarks>
+/// Merge rules applied per field:
+/// <list type="bullet">
+///   <item>Consent model — lowest enum value wins (<see cref="ConsentModel.OptIn"/> = 0 is strictest).</item>
+///   <item>Response SLA — minimum calendar days; null ("prompt/reasonable") treated as unbounded.</item>
+///   <item>Breach notification deadlines — minimum hours; null ignored (use other's value).</item>
+///   <item>Legal bases — union of all contributing profiles.</item>
+///   <item>Export formats — union of all contributing profiles.</item>
+///   <item>Transfer mechanisms — union (each profile's available mechanisms listed).</item>
+///   <item>Boolean safety flags — OR (true if any profile requires it).</item>
+///   <item>Minimum consent age — maximum (most protective).</item>
+/// </list>
+/// Passing a single-element list returns that profile unchanged.
+/// </remarks>
+internal static class CompositeRegulationProfileMerger
+{
+    /// <summary>
+    /// Merges <paramref name="profiles"/> into a single composite profile.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="profiles"/> is empty.</exception>
+    public static PrivacyRegulationProfile Merge(IReadOnlyList<PrivacyRegulationProfile> profiles)
+    {
+        ArgumentNullException.ThrowIfNull(profiles);
+
+        if (profiles.Count == 0)
+        {
+            throw new ArgumentException("At least one profile is required for merging.", nameof(profiles));
+        }
+
+        if (profiles.Count == 1)
+        {
+            return profiles[0];
+        }
+
+        string compositeCode = string.Join("+", profiles.Select(p => p.Regulation.Value));
+        string compositeDisplay = string.Join(", ", profiles.Select(p => p.DisplayName));
+        string compositeJurisdiction = string.Join("+", profiles.Select(p => p.JurisdictionCode));
+
+        return new PrivacyRegulationProfile
+        {
+            Regulation = PrivacyRegulation.Create(compositeCode),
+            DisplayName = compositeDisplay,
+            JurisdictionCode = compositeJurisdiction,
+
+            // Consent — strictest (lowest enum value)
+            ConsentModel = profiles.Min(p => p.ConsentModel),
+            CookieConsentModel = profiles.Min(p => p.CookieConsentModel),
+
+            // Legal bases — union
+            AvailableLegalBases = profiles
+                .SelectMany(p => p.AvailableLegalBases)
+                .Distinct()
+                .ToList(),
+
+            // Response timelines — minimum (null = unbounded, skipped in min)
+            SubjectAccessRequestDays = profiles.Min(p => p.SubjectAccessRequestDays),
+            SubjectAccessRequestExtensionDays = MinNullable(profiles.Select(p => p.SubjectAccessRequestExtensionDays)),
+            DeletionRequestDays = MinNullable(profiles.Select(p => p.DeletionRequestDays)),
+            RectificationRequestDays = MinNullable(profiles.Select(p => p.RectificationRequestDays)),
+
+            // Deletion grace period — minimum
+            DefaultDeletionGracePeriodDays = profiles.Min(p => p.DefaultDeletionGracePeriodDays),
+            MaxDeletionGracePeriodDays = profiles.Min(p => p.MaxDeletionGracePeriodDays),
+            ReminderDaysBefore = profiles.Min(p => p.ReminderDaysBefore),
+
+            // Breach notification — minimum non-null deadline
+            BreachNotifyAuthorityHours = MinNullable(profiles.Select(p => p.BreachNotifyAuthorityHours)),
+            BreachNotifyIndividualsHours = MinNullable(profiles.Select(p => p.BreachNotifyIndividualsHours)),
+            BreachSeverityNotes = CombineNotes(profiles.Select(p => p.BreachSeverityNotes)),
+
+            // Age verification — strictest
+            MinimumConsentAge = profiles.Max(p => p.MinimumConsentAge),
+            RequiresParentalIdentityVerification = profiles.Any(p => p.RequiresParentalIdentityVerification),
+
+            // Cookie & GPC
+            HonorGlobalPrivacyControl = profiles.Any(p => p.HonorGlobalPrivacyControl),
+
+            // Cross-border — most restrictive
+            RequiresCrossBorderAssessment = profiles.Any(p => p.RequiresCrossBorderAssessment),
+            TransferMechanisms = profiles.SelectMany(p => p.TransferMechanisms).Distinct().ToList(),
+
+            // Data localization — most restrictive
+            DataLocalizationRequired = profiles.Any(p => p.DataLocalizationRequired),
+            DataLocalizationNotes = CombineNotes(profiles.Select(p => p.DataLocalizationNotes)),
+
+            // DPO — most restrictive
+            RequiresDpoOrRepresentative = profiles.Any(p => p.RequiresDpoOrRepresentative),
+            DpoNotes = CombineNotes(profiles.Select(p => p.DpoNotes)),
+
+            // Export formats — union
+            RequiredExportFormats = profiles.SelectMany(p => p.RequiredExportFormats).Distinct().ToList(),
+        };
+    }
+
+    private static int? MinNullable(IEnumerable<int?> values)
+    {
+        int? result = null;
+        foreach (int? v in values)
+        {
+            if (v.HasValue && (result is null || v.Value < result.Value))
+            {
+                result = v;
+            }
+        }
+        return result;
+    }
+
+    private static string? CombineNotes(IEnumerable<string?> notes)
+    {
+        string combined = string.Join(" | ", notes.Where(n => !string.IsNullOrWhiteSpace(n))!);
+        return string.IsNullOrEmpty(combined) ? null : combined;
+    }
+}

--- a/src/Granit.Privacy.Regulations/Internal/TenantBasedRegulationResolver.cs
+++ b/src/Granit.Privacy.Regulations/Internal/TenantBasedRegulationResolver.cs
@@ -1,4 +1,5 @@
 using Granit.MultiTenancy;
+using Granit.Privacy.Regulations.Jurisdiction;
 using Granit.Privacy.Regulations.Options;
 using Granit.Privacy.Regulations.Profiles;
 using Microsoft.Extensions.Options;
@@ -7,58 +8,88 @@ namespace Granit.Privacy.Regulations.Internal;
 
 /// <summary>
 /// Default <see cref="IPrivacyRegulationResolver"/> implementation.
-/// Resolution chain: ICurrentTenant.Jurisdiction (populated from DB by the middleware) →
-/// per-tenant config override → default regulation → throw.
+/// Resolution chain (highest to lowest precedence):
+/// 1. Config per-tenant override (regulation code — operator escape hatch).
+/// 2. Tenant <c>Jurisdiction</c> (ISO 3166 code) resolved via <see cref="IPrivacyJurisdictionResolver"/>.
+///    A single ISO code may map to multiple regulations (e.g. <c>"CH"</c> → CH_NFADP + EU_GDPR).
+///    Falls through to step 3 when the code resolves to nothing (e.g. <c>"US"</c>).
+/// 3. Default regulation from configuration.
 /// </summary>
 internal sealed class TenantBasedRegulationResolver(
     IRegulationProfileRegistry registry,
     IOptions<PrivacyRegulationsOptions> options,
+    IPrivacyJurisdictionResolver jurisdictionResolver,
     ICurrentTenant? currentTenant = null) : IPrivacyRegulationResolver
 {
-    public Task<PrivacyRegulationProfile> ResolveAsync(CancellationToken cancellationToken = default)
+    public async Task<PrivacyRegulationProfile> ResolveAsync(CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<PrivacyRegulationProfile> profiles =
+            await ResolveAllAsync(cancellationToken).ConfigureAwait(false);
+
+        return CompositeRegulationProfileMerger.Merge(profiles);
+    }
+
+    public async Task<IReadOnlyList<PrivacyRegulationProfile>> ResolveAllAsync(CancellationToken cancellationToken = default)
     {
         PrivacyRegulationsOptions opts = options.Value;
-        string? regulationCode = null;
 
         if (currentTenant is { IsAvailable: true, Id: { } tenantId })
         {
-            // 1. DB jurisdiction — already resolved by the middleware via FindByIdAsync and
-            //    stored on ICurrentTenant when ValidateTenantExistence is enabled.
-            regulationCode = currentTenant.Jurisdiction;
-
-            // 2. Config per-tenant override (operator escape hatch, takes precedence over DB)
-            if (opts.TenantRegulations.TryGetValue(tenantId.ToString(), out string? configCode))
+            // 1. Config per-tenant override — explicit regulation code, takes precedence over ISO resolution
+            if (opts.TenantRegulations.TryGetValue(tenantId.ToString(), out string? configCode)
+                && !string.IsNullOrWhiteSpace(configCode))
             {
-                regulationCode = configCode;
+                return [LookupRequired(configCode)];
+            }
+
+            // 2. ISO 3166 jurisdiction code from DB
+            string? isoCode = currentTenant.Jurisdiction;
+            if (!string.IsNullOrWhiteSpace(isoCode))
+            {
+                (string country, string? region) = ParseIsoCode(isoCode);
+                IReadOnlyList<PrivacyRegulation> resolved =
+                    await jurisdictionResolver.ResolveAsync(country, region, cancellationToken)
+                        .ConfigureAwait(false);
+
+                if (resolved.Count > 0)
+                {
+                    return resolved.Select(r => LookupRequired(r.Value)).ToList();
+                }
+
+                // ISO code resolved to nothing (e.g. "US" — no federal general privacy law)
+                // → fall through to default
             }
         }
 
         // 3. Default regulation from configuration
-        regulationCode ??= opts.DefaultRegulation;
+        string? defaultCode = opts.DefaultRegulation;
 
-        if (string.IsNullOrWhiteSpace(regulationCode))
+        if (string.IsNullOrWhiteSpace(defaultCode))
         {
             throw new InvalidOperationException(
                 "No privacy regulation configured. " +
                 "Set 'Privacy:Regulations:DefaultRegulation' in appsettings.json, " +
                 "configure per-tenant regulations in 'Privacy:Regulations:TenantRegulations', " +
-                "or set the Jurisdiction field on the tenant.");
+                "or set an ISO 3166 jurisdiction code on the tenant.");
         }
 
-        PrivacyRegulationProfile profile = registry.GetProfile(PrivacyRegulation.Create(regulationCode))
+        return [LookupRequired(defaultCode)];
+    }
+
+    private PrivacyRegulationProfile LookupRequired(string regulationCode) =>
+        registry.GetProfile(PrivacyRegulation.Create(regulationCode))
             ?? throw new InvalidOperationException(
                 $"Privacy regulation '{regulationCode}' is not registered. " +
                 $"Ensure a matching IRegulationProfileProvider is loaded. " +
                 $"Available regulations: {string.Join(", ", registry.GetAll().Select(p => p.Regulation.Value))}.");
 
-        return Task.FromResult(profile);
-    }
-
-    public async Task<IReadOnlyList<PrivacyRegulationProfile>> ResolveAllAsync(CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Parses an ISO 3166 code into country + optional region.
+    /// <c>"FR"</c> → <c>("FR", null)</c>. <c>"CA-QC"</c> → <c>("CA", "CA-QC")</c>.
+    /// </summary>
+    private static (string Country, string? Region) ParseIsoCode(string code)
     {
-        // For now, returns only the primary regulation.
-        // Composite multi-regulation support is handled via explicit composite profiles.
-        PrivacyRegulationProfile primary = await ResolveAsync(cancellationToken).ConfigureAwait(false);
-        return [primary];
+        int dash = code.IndexOf('-');
+        return dash > 0 ? (code[..dash], code) : (code, null);
     }
 }

--- a/src/Granit.Privacy.Regulations/Jurisdiction/IPrivacyJurisdictionMapProvider.cs
+++ b/src/Granit.Privacy.Regulations/Jurisdiction/IPrivacyJurisdictionMapProvider.cs
@@ -1,0 +1,17 @@
+namespace Granit.Privacy.Regulations.Jurisdiction;
+
+/// <summary>
+/// Extension point for contributing ISO 3166 → regulation code mappings to <see cref="IPrivacyJurisdictionResolver"/>.
+/// Register additional providers via <see cref="GranitPrivacyRegulationsBuilder.AddJurisdictionMapProvider"/>.
+/// </summary>
+public interface IPrivacyJurisdictionMapProvider
+{
+    /// <summary>
+    /// Populates <paramref name="countryMap"/> (ISO 3166-1 alpha-2 → regulations)
+    /// and <paramref name="regionMap"/> (ISO 3166-2 → regulations).
+    /// Region entries take precedence over country entries in the resolver.
+    /// </summary>
+    void Define(
+        IDictionary<string, IReadOnlyList<PrivacyRegulation>> countryMap,
+        IDictionary<string, IReadOnlyList<PrivacyRegulation>> regionMap);
+}

--- a/src/Granit.Privacy.Regulations/Jurisdiction/IPrivacyJurisdictionResolver.cs
+++ b/src/Granit.Privacy.Regulations/Jurisdiction/IPrivacyJurisdictionResolver.cs
@@ -1,0 +1,28 @@
+namespace Granit.Privacy.Regulations.Jurisdiction;
+
+/// <summary>
+/// Advisory resolver that maps ISO 3166 country/region codes to applicable privacy regulation codes.
+/// The result is a suggestion — the tenant administrator confirms or overrides before it is persisted.
+/// </summary>
+/// <remarks>
+/// Sector-specific regulations (HIPAA, FERPA, COPPA) are excluded — they are not universally applicable
+/// within a geography and carry a high false-positive risk. Add them manually when required.
+/// </remarks>
+public interface IPrivacyJurisdictionResolver
+{
+    /// <summary>
+    /// Returns the privacy regulation codes applicable to the given country and optional region.
+    /// Region code takes precedence over country-level mapping when both exist.
+    /// Returns an empty list for unknown countries or regions.
+    /// </summary>
+    /// <param name="countryCode">ISO 3166-1 alpha-2 country code (e.g. <c>"FR"</c>, <c>"CA"</c>).</param>
+    /// <param name="regionCode">
+    /// Optional ISO 3166-2 subdivision code (e.g. <c>"CA-QC"</c> for Quebec, <c>"US-CA"</c> for California).
+    /// When provided, takes precedence over the country-level entry.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<PrivacyRegulation>> ResolveAsync(
+        string countryCode,
+        string? regionCode = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Privacy.Regulations/Jurisdiction/Internal/BuiltInPrivacyJurisdictionMapProvider.cs
+++ b/src/Granit.Privacy.Regulations/Jurisdiction/Internal/BuiltInPrivacyJurisdictionMapProvider.cs
@@ -1,0 +1,50 @@
+namespace Granit.Privacy.Regulations.Jurisdiction.Internal;
+
+/// <summary>
+/// Built-in ISO 3166 → regulation mapping for all Tier 1 and Tier 2 regulations.
+/// </summary>
+internal sealed class BuiltInPrivacyJurisdictionMapProvider : IPrivacyJurisdictionMapProvider
+{
+    // EU member states (ISO 3166-1 alpha-2) — all subject to EU GDPR
+    private static readonly string[] EuMemberStates =
+    [
+        "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI",
+        "FR", "GR", "HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT",
+        "NL", "PL", "PT", "RO", "SE", "SI", "SK",
+    ];
+
+    public void Define(
+        IDictionary<string, IReadOnlyList<PrivacyRegulation>> countryMap,
+        IDictionary<string, IReadOnlyList<PrivacyRegulation>> regionMap)
+    {
+        // ── EU member states → EU GDPR ────────────────────────────────────
+        foreach (string code in EuMemberStates)
+        {
+            countryMap[code] = [PrivacyRegulation.EuGdpr];
+        }
+
+        // ── Tier 1 country-level mappings ─────────────────────────────────
+        countryMap["GB"] = [PrivacyRegulation.UkGdpr];
+        countryMap["BR"] = [PrivacyRegulation.BrLgpd];
+        countryMap["CH"] = [PrivacyRegulation.ChNfadp, PrivacyRegulation.EuGdpr]; // CH processes EU data subjects
+        countryMap["CA"] = [PrivacyRegulation.CaPipeda];
+
+        // US: no federal general privacy law — empty at country level
+        countryMap["US"] = [];
+
+        // ── Tier 1 region-level mappings ──────────────────────────────────
+        regionMap["CA-QC"] = [PrivacyRegulation.CaQuebec25, PrivacyRegulation.CaPipeda]; // Quebec Law 25 + PIPEDA
+        regionMap["CA-BC"] = [PrivacyRegulation.CaPipeda]; // BC PIPA is advisory; PIPEDA applies for cross-border
+        regionMap["CA-AB"] = [PrivacyRegulation.CaPipeda]; // AB PIPA — same note
+        regionMap["US-CA"] = [PrivacyRegulation.UsCcpa];   // California CCPA
+
+        // ── Tier 2 country-level mappings ─────────────────────────────────
+        countryMap["CN"] = [PrivacyRegulation.CnPipl];
+        countryMap["IN"] = [PrivacyRegulation.InDpdpa];
+        countryMap["JP"] = [PrivacyRegulation.JpAppi];
+        countryMap["KR"] = [PrivacyRegulation.KrPipa];
+        countryMap["AU"] = [PrivacyRegulation.AuPrivacyAct];
+        countryMap["ZA"] = [PrivacyRegulation.ZaPopia];
+        countryMap["TH"] = [PrivacyRegulation.ThPdpa];
+    }
+}

--- a/src/Granit.Privacy.Regulations/Jurisdiction/Internal/DefaultPrivacyJurisdictionResolver.cs
+++ b/src/Granit.Privacy.Regulations/Jurisdiction/Internal/DefaultPrivacyJurisdictionResolver.cs
@@ -1,0 +1,50 @@
+using System.Collections.Frozen;
+
+namespace Granit.Privacy.Regulations.Jurisdiction.Internal;
+
+/// <summary>
+/// Default implementation of <see cref="IPrivacyJurisdictionResolver"/>.
+/// Built from all registered <see cref="IPrivacyJurisdictionMapProvider"/> instances at startup.
+/// Region lookup takes precedence over country-level mapping.
+/// Returns empty list for unknown codes — never throws.
+/// </summary>
+internal sealed class DefaultPrivacyJurisdictionResolver : IPrivacyJurisdictionResolver
+{
+    private readonly FrozenDictionary<string, IReadOnlyList<PrivacyRegulation>> _countryMap;
+    private readonly FrozenDictionary<string, IReadOnlyList<PrivacyRegulation>> _regionMap;
+
+    public DefaultPrivacyJurisdictionResolver(IEnumerable<IPrivacyJurisdictionMapProvider> providers)
+    {
+        Dictionary<string, IReadOnlyList<PrivacyRegulation>> countryMap = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, IReadOnlyList<PrivacyRegulation>> regionMap = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (IPrivacyJurisdictionMapProvider provider in providers)
+        {
+            provider.Define(countryMap, regionMap);
+        }
+
+        _countryMap = countryMap.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        _regionMap = regionMap.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public Task<IReadOnlyList<PrivacyRegulation>> ResolveAsync(
+        string countryCode,
+        string? regionCode = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Region takes precedence over country
+        if (!string.IsNullOrWhiteSpace(regionCode)
+            && _regionMap.TryGetValue(regionCode, out IReadOnlyList<PrivacyRegulation>? regionResult))
+        {
+            return Task.FromResult(regionResult);
+        }
+
+        if (!string.IsNullOrWhiteSpace(countryCode)
+            && _countryMap.TryGetValue(countryCode, out IReadOnlyList<PrivacyRegulation>? countryResult))
+        {
+            return Task.FromResult(countryResult);
+        }
+
+        return Task.FromResult<IReadOnlyList<PrivacyRegulation>>([]);
+    }
+}

--- a/src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs
+++ b/src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs
@@ -12,7 +12,7 @@ namespace Granit.Wolverine.Behaviors;
 /// <para>
 /// Reads the <c>X-Tenant-Id</c> header set by
 /// <see cref="Granit.Wolverine.Middleware.OutgoingContextMiddleware"/> on the publisher
-/// side and calls <see cref="ICurrentTenant.Change(Guid?, string?)"/> to activate the
+/// side and calls <see cref="ICurrentTenant.Change(Guid?, string?, string?)"/> to activate the
 /// tenant for the duration of the handler invocation.
 /// </para>
 /// <para>

--- a/src/Granit/MultiTenancy/ICurrentTenant.cs
+++ b/src/Granit/MultiTenancy/ICurrentTenant.cs
@@ -20,9 +20,9 @@ public interface ICurrentTenant
     string? Name { get; }
 
     /// <summary>
-    /// Privacy regulation code for the current tenant (e.g., <c>"EU_GDPR"</c>), or <c>null</c>.
+    /// ISO 3166 jurisdiction code for the current tenant (e.g. <c>"FR"</c>, <c>"CA-QC"</c>).
     /// Populated from <c>Tenant.Jurisdiction</c> when <c>ValidateTenantExistence</c> is enabled.
-    /// Falls back to <c>null</c> when running without the EF Core tenant store.
+    /// <c>null</c> when running without the EF Core tenant store or when no jurisdiction is configured.
     /// </summary>
     string? Jurisdiction { get; }
 
@@ -32,7 +32,7 @@ public interface ICurrentTenant
     /// </summary>
     /// <param name="id">Identifier of the tenant to activate, or <c>null</c> to deactivate.</param>
     /// <param name="name">Optional tenant name.</param>
-    /// <param name="jurisdiction">Optional privacy regulation code for the tenant.</param>
+    /// <param name="jurisdiction">Optional ISO 3166 jurisdiction code for the tenant.</param>
     /// <returns>Scope to dispose to restore the previous tenant.</returns>
     IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null);
 }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/CreateTenantRequestTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/CreateTenantRequestTests.cs
@@ -9,12 +9,12 @@ public sealed class CreateTenantRequestTests
     [Fact]
     public void Constructor_MapsAllFields()
     {
-        CreateTenantRequest request = new("Acme Corp", "acme-corp", "admin@acme.com", "BE");
+        CreateTenantRequest request = new("Acme Corp", "acme-corp", "admin@acme.com", "FR");
 
         request.Name.ShouldBe("Acme Corp");
         request.Identifier.ShouldBe("acme-corp");
         request.ContactEmail.ShouldBe("admin@acme.com");
-        request.Jurisdiction.ShouldBe("BE");
+        request.Jurisdiction.ShouldBe("FR");
     }
 
     [Fact]

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
@@ -14,14 +14,14 @@ public sealed class TenantResponseTests
         var id = Guid.NewGuid();
         DateTimeOffset createdAt = DateTimeOffset.UtcNow;
 
-        TenantResponse response = new(id, "Acme Corp", "acme-corp", "admin@acme.com", true, "BE", createdAt, AnyStamp);
+        TenantResponse response = new(id, "Acme Corp", "acme-corp", "admin@acme.com", true, "FR", createdAt, AnyStamp);
 
         response.Id.ShouldBe(id);
         response.Name.ShouldBe("Acme Corp");
         response.Identifier.ShouldBe("acme-corp");
         response.ContactEmail.ShouldBe("admin@acme.com");
         response.Activated.ShouldBeTrue();
-        response.Jurisdiction.ShouldBe("BE");
+        response.Jurisdiction.ShouldBe("FR");
         response.CreatedAt.ShouldBe(createdAt);
     }
 

--- a/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
@@ -109,7 +109,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
 
         nextCalled.ShouldBeTrue();
-        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public sealed class TenantResolutionMiddlewareTests
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
         var tenantId = Guid.NewGuid();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
 
         TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(tenantId, "Acme"));
         TenantResolutionMiddleware middleware = CreateMiddleware(currentTenant, pipeline);
@@ -128,7 +128,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
 
         nextCalled.ShouldBeTrue();
-        currentTenant.Received(1).Change(tenantId, "Acme");
+        currentTenant.Received(1).Change(tenantId, "Acme", Arg.Any<string?>());
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public sealed class TenantResolutionMiddlewareTests
     {
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
 
         TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(Guid.NewGuid()));
         TenantResolutionMiddleware middleware = CreateMiddleware(currentTenant, pipeline);
@@ -159,7 +159,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
 
         nextCalled.ShouldBeTrue();
-        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public sealed class TenantResolutionMiddlewareTests
     {
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var tenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(tenantId));
         TenantResolutionMiddleware middleware = CreateMiddleware(
@@ -192,7 +192,7 @@ public sealed class TenantResolutionMiddlewareTests
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>());
+        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
         context.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
-        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     [Fact]
@@ -216,7 +216,7 @@ public sealed class TenantResolutionMiddlewareTests
     {
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var phantomId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(phantomId));
         TenantResolutionMiddleware middleware = CreateMiddleware(
@@ -225,7 +225,7 @@ public sealed class TenantResolutionMiddlewareTests
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        currentTenant.Received(1).Change(phantomId, Arg.Any<string?>());
+        currentTenant.Received(1).Change(phantomId, Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     private static TenantResolutionMiddleware CreateMiddlewareWithPhantomRejection(
@@ -324,7 +324,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
         context.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
-        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>());
         await gate.Received(1).CanImpersonateAsync(
             Arg.Any<ClaimsPrincipal>(), targetTenantId, Arg.Any<CancellationToken>());
     }
@@ -334,7 +334,7 @@ public sealed class TenantResolutionMiddlewareTests
     {
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var targetTenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineWithResolver(
             nameof(HeaderTenantResolver), new TenantInfo(targetTenantId));
@@ -355,7 +355,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
         context.Response.StatusCode.ShouldNotBe(StatusCodes.Status403Forbidden);
-        currentTenant.Received(1).Change(targetTenantId, Arg.Any<string?>());
+        currentTenant.Received(1).Change(targetTenantId, Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     [Fact]
@@ -364,7 +364,7 @@ public sealed class TenantResolutionMiddlewareTests
         // JWT-only resolution is authoritative — no impersonation is taking place.
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var tenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineWithResolver(
             nameof(JwtClaimTenantResolver), new TenantInfo(tenantId));
@@ -392,7 +392,7 @@ public sealed class TenantResolutionMiddlewareTests
     {
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var tenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineWithResolver(
             nameof(HeaderTenantResolver), new TenantInfo(tenantId));
@@ -410,7 +410,7 @@ public sealed class TenantResolutionMiddlewareTests
 
         await gate.DidNotReceive().CanImpersonateAsync(
             Arg.Any<ClaimsPrincipal>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
-        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>());
+        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     [Fact]
@@ -465,7 +465,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
         context.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
-        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>());
         await gate.Received(1).CanImpersonateAsync(
             Arg.Any<ClaimsPrincipal>(), targetTenantId, Arg.Any<CancellationToken>());
     }
@@ -477,7 +477,7 @@ public sealed class TenantResolutionMiddlewareTests
         // cross-check is intentionally skipped for Tenant users.
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var headerTenantId = Guid.NewGuid();
         var claimTenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineWithResolver(
@@ -495,7 +495,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
         context.Response.StatusCode.ShouldNotBe(StatusCodes.Status403Forbidden);
-        currentTenant.Received(1).Change(headerTenantId, Arg.Any<string?>());
+        currentTenant.Received(1).Change(headerTenantId, Arg.Any<string?>(), Arg.Any<string?>());
         await gate.DidNotReceive().CanImpersonateAsync(
             Arg.Any<ClaimsPrincipal>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
@@ -506,7 +506,7 @@ public sealed class TenantResolutionMiddlewareTests
         // The gate is only consulted for authenticated principals with no tenant_id claim.
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var tenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineWithResolver(
             nameof(HeaderTenantResolver), new TenantInfo(tenantId));
@@ -604,7 +604,7 @@ public sealed class TenantResolutionMiddlewareTests
     {
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var tenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineWithResolver(
             nameof(HeaderTenantResolver), new TenantInfo(tenantId));
@@ -676,7 +676,7 @@ public sealed class TenantResolutionMiddlewareTests
         // Audit failure must NOT propagate. Request still proceeds (gate said allow).
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         IDisposable scope = Substitute.For<IDisposable>();
-        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>()).Returns(scope);
         var tenantId = Guid.NewGuid();
         TenantResolverPipeline pipeline = PipelineWithResolver(
             nameof(HeaderTenantResolver), new TenantInfo(tenantId));
@@ -705,7 +705,7 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
 
         nextCalled.ShouldBeTrue();
-        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>());
+        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>(), Arg.Any<string?>());
     }
 
     private static TenantResolutionMiddleware CreateMiddlewareWithAudit(

--- a/tests/Granit.Privacy.Regulations.Tests/Internal/CompositeRegulationProfileMergerTests.cs
+++ b/tests/Granit.Privacy.Regulations.Tests/Internal/CompositeRegulationProfileMergerTests.cs
@@ -1,0 +1,151 @@
+using Granit.Privacy.Regulations.Internal;
+using Granit.Privacy.Regulations.Profiles.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Regulations.Tests.Internal;
+
+public sealed class CompositeRegulationProfileMergerTests
+{
+    private static PrivacyRegulationProfile Gdpr { get; } = BuildRegistry().GetProfile(PrivacyRegulation.EuGdpr)!;
+    private static PrivacyRegulationProfile Ccpa { get; } = BuildRegistry().GetProfile(PrivacyRegulation.UsCcpa)!;
+    private static PrivacyRegulationProfile Quebec25 { get; } = BuildRegistry().GetProfile(PrivacyRegulation.CaQuebec25)!;
+    private static PrivacyRegulationProfile Pipeda { get; } = BuildRegistry().GetProfile(PrivacyRegulation.CaPipeda)!;
+    private static PrivacyRegulationProfile Lgpd { get; } = BuildRegistry().GetProfile(PrivacyRegulation.BrLgpd)!;
+
+    [Fact]
+    public void Merge_SingleProfile_ReturnsUnchanged()
+    {
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr]);
+
+        result.ShouldBeSameAs(Gdpr);
+    }
+
+    [Fact]
+    public void Merge_EmptyList_Throws()
+    {
+        Should.Throw<ArgumentException>(() => CompositeRegulationProfileMerger.Merge([]));
+    }
+
+    [Fact]
+    public void Merge_GdprPlusCcpa_OptInWins()
+    {
+        // GDPR = OptIn (strictest), CCPA = OptOut
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, Ccpa]);
+
+        result.ConsentModel.ShouldBe(ConsentModel.OptIn);
+        result.CookieConsentModel.ShouldBe(ConsentModel.OptIn);
+    }
+
+    [Fact]
+    public void Merge_GdprPlusCcpa_MinimumSarDeadline()
+    {
+        // GDPR = 30 days, CCPA = 45 days → merged = 30
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, Ccpa]);
+
+        result.SubjectAccessRequestDays.ShouldBe(
+            Math.Min(Gdpr.SubjectAccessRequestDays, Ccpa.SubjectAccessRequestDays));
+    }
+
+    [Fact]
+    public void Merge_GdprPlusCcpa_MinimumBreachDeadline()
+    {
+        // GDPR = 72h, CCPA = null (not specified) → merged = 72h
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, Ccpa]);
+
+        result.BreachNotifyAuthorityHours.ShouldBe(Gdpr.BreachNotifyAuthorityHours);
+    }
+
+    [Fact]
+    public void Merge_LegalBasesAreUnioned()
+    {
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, Lgpd]);
+
+        foreach (LegalBasis basis in Gdpr.AvailableLegalBases)
+        {
+            result.AvailableLegalBases.ShouldContain(basis);
+        }
+        foreach (LegalBasis basis in Lgpd.AvailableLegalBases)
+        {
+            result.AvailableLegalBases.ShouldContain(basis);
+        }
+    }
+
+    [Fact]
+    public void Merge_ExportFormatsAreUnioned()
+    {
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, Lgpd]);
+
+        foreach (string fmt in Gdpr.RequiredExportFormats)
+        {
+            result.RequiredExportFormats.ShouldContain(fmt);
+        }
+        foreach (string fmt in Lgpd.RequiredExportFormats)
+        {
+            result.RequiredExportFormats.ShouldContain(fmt);
+        }
+    }
+
+    [Fact]
+    public void Merge_CompositeRegulationCodeIsJoined()
+    {
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, Ccpa]);
+
+        result.Regulation.Value.ShouldBe("EU_GDPR+US_CCPA");
+    }
+
+    [Fact]
+    public void Merge_OrderIndependent()
+    {
+        PrivacyRegulationProfile ab = CompositeRegulationProfileMerger.Merge([Gdpr, Ccpa]);
+        PrivacyRegulationProfile ba = CompositeRegulationProfileMerger.Merge([Ccpa, Gdpr]);
+
+        // Merged fields that should be order-independent
+        ab.ConsentModel.ShouldBe(ba.ConsentModel);
+        ab.SubjectAccessRequestDays.ShouldBe(ba.SubjectAccessRequestDays);
+        ab.DataLocalizationRequired.ShouldBe(ba.DataLocalizationRequired);
+        ab.RequiresDpoOrRepresentative.ShouldBe(ba.RequiresDpoOrRepresentative);
+        ab.MinimumConsentAge.ShouldBe(ba.MinimumConsentAge);
+    }
+
+    [Fact]
+    public void Merge_QuebecPlusPipeda_BothOptIn_NoChange()
+    {
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Quebec25, Pipeda]);
+
+        result.ConsentModel.ShouldBe(ConsentModel.OptIn);
+    }
+
+    [Fact]
+    public void Merge_DataLocalizationRequired_TrueIfAnyRequires()
+    {
+        // GDPR = false, CN_PIPL = true (data localization required in China)
+        // We use GDPR + any profile that has DataLocalizationRequired = true
+        // Build a synthetic profile with data localization
+        PrivacyRegulationProfile withLocalization = Gdpr with
+        {
+            Regulation = PrivacyRegulation.Create("TEST_LOC"),
+            DataLocalizationRequired = true,
+        };
+
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, withLocalization]);
+
+        result.DataLocalizationRequired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Merge_ThreeRegulations_Works()
+    {
+        PrivacyRegulationProfile result = CompositeRegulationProfileMerger.Merge([Gdpr, Ccpa, Lgpd]);
+
+        result.Regulation.Value.ShouldBe("EU_GDPR+US_CCPA+BR_LGPD");
+        result.ConsentModel.ShouldBe(ConsentModel.OptIn);
+    }
+
+    private static RegulationProfileRegistry BuildRegistry()
+    {
+        var context = new RegulationProfileContext();
+        new BuiltInRegulationProfileProvider().Define(context);
+        return new RegulationProfileRegistry(context.Build());
+    }
+}

--- a/tests/Granit.Privacy.Regulations.Tests/Internal/TenantBasedRegulationResolverTests.cs
+++ b/tests/Granit.Privacy.Regulations.Tests/Internal/TenantBasedRegulationResolverTests.cs
@@ -1,5 +1,7 @@
 using Granit.MultiTenancy;
 using Granit.Privacy.Regulations.Internal;
+using Granit.Privacy.Regulations.Jurisdiction;
+using Granit.Privacy.Regulations.Jurisdiction.Internal;
 using Granit.Privacy.Regulations.Options;
 using Granit.Privacy.Regulations.Profiles;
 using Granit.Privacy.Regulations.Profiles.Internal;
@@ -13,6 +15,8 @@ namespace Granit.Privacy.Regulations.Tests.Internal;
 public sealed class TenantBasedRegulationResolverTests
 {
     private readonly IRegulationProfileRegistry _registry;
+    private readonly DefaultPrivacyJurisdictionResolver _jurisdictionResolver =
+        new([new BuiltInPrivacyJurisdictionMapProvider()]);
 
     public TenantBasedRegulationResolverTests()
     {
@@ -36,7 +40,7 @@ public sealed class TenantBasedRegulationResolverTests
     public async Task ResolveAsync_PerTenantConfigOverride_TakesPrecedence()
     {
         var tenantId = Guid.NewGuid();
-        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: null);
+        ICurrentTenant tenant = CreateTenant(tenantId, null);
 
         TenantBasedRegulationResolver resolver = CreateResolver(
             new PrivacyRegulationsOptions
@@ -55,10 +59,10 @@ public sealed class TenantBasedRegulationResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_TenantJurisdiction_UsedWhenNoConfigOverride()
+    public async Task ResolveAsync_IsoJurisdiction_ResolvesToMatchingRegulation()
     {
         var tenantId = Guid.NewGuid();
-        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: "BR_LGPD");
+        ICurrentTenant tenant = CreateTenant(tenantId, "BR");
 
         TenantBasedRegulationResolver resolver = CreateResolver(
             new PrivacyRegulationsOptions { DefaultRegulation = "EU_GDPR" },
@@ -66,14 +70,15 @@ public sealed class TenantBasedRegulationResolverTests
 
         PrivacyRegulationProfile profile = await resolver.ResolveAsync(TestContext.Current.CancellationToken);
 
+        // "BR" → BR_LGPD via IPrivacyJurisdictionResolver
         profile.Regulation.Value.ShouldBe("BR_LGPD");
     }
 
     [Fact]
-    public async Task ResolveAsync_ConfigOverrideTakesPrecedenceOverJurisdiction()
+    public async Task ResolveAsync_ConfigOverrideTakesPrecedenceOverIsoJurisdiction()
     {
         var tenantId = Guid.NewGuid();
-        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: "BR_LGPD");
+        ICurrentTenant tenant = CreateTenant(tenantId, "BR");
 
         TenantBasedRegulationResolver resolver = CreateResolver(
             new PrivacyRegulationsOptions
@@ -95,7 +100,7 @@ public sealed class TenantBasedRegulationResolverTests
     public async Task ResolveAsync_NullJurisdiction_FallsBackToConfigDefault()
     {
         var tenantId = Guid.NewGuid();
-        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: null);
+        ICurrentTenant tenant = CreateTenant(tenantId, null);
 
         TenantBasedRegulationResolver resolver = CreateResolver(
             new PrivacyRegulationsOptions { DefaultRegulation = "CH_NFADP" },
@@ -107,18 +112,92 @@ public sealed class TenantBasedRegulationResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_NoTenantOverride_FallsBackToDefault()
+    public async Task ResolveAsync_IsoCodeResolvesToNothing_FallsBackToDefault()
     {
+        // "US" has no federal general privacy law → resolver returns [] → fallback to default
         var tenantId = Guid.NewGuid();
-        ICurrentTenant tenant = CreateTenant(tenantId, jurisdiction: null);
+        ICurrentTenant tenant = CreateTenant(tenantId, "US");
 
         TenantBasedRegulationResolver resolver = CreateResolver(
-            new PrivacyRegulationsOptions { DefaultRegulation = "US_CCPA" },
+            new PrivacyRegulationsOptions { DefaultRegulation = "EU_GDPR" },
             tenant);
 
         PrivacyRegulationProfile profile = await resolver.ResolveAsync(TestContext.Current.CancellationToken);
 
-        profile.Regulation.Value.ShouldBe("US_CCPA");
+        profile.Regulation.Value.ShouldBe("EU_GDPR");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_RegionCode_TakesPrecedenceOverCountry()
+    {
+        // "CA-QC" → CA_QUEBEC_25 + CA_PIPEDA (region match)
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = CreateTenant(tenantId, "CA-QC");
+
+        TenantBasedRegulationResolver resolver = CreateResolver(
+            new PrivacyRegulationsOptions { DefaultRegulation = "EU_GDPR" },
+            tenant);
+
+        IReadOnlyList<PrivacyRegulationProfile> profiles =
+            await resolver.ResolveAllAsync(TestContext.Current.CancellationToken);
+
+        profiles.Count.ShouldBe(2);
+        profiles.Select(p => p.Regulation.Value).ShouldContain("CA_QUEBEC_25");
+        profiles.Select(p => p.Regulation.Value).ShouldContain("CA_PIPEDA");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SwitzerlandIsoCode_MergesIntoCompositeProfile()
+    {
+        // "CH" → CH_NFADP + EU_GDPR; ResolveAsync merges them into a single composite
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = CreateTenant(tenantId, "CH");
+
+        TenantBasedRegulationResolver resolver = CreateResolver(
+            new PrivacyRegulationsOptions { DefaultRegulation = "EU_GDPR" },
+            tenant);
+
+        PrivacyRegulationProfile profile = await resolver.ResolveAsync(TestContext.Current.CancellationToken);
+
+        // Merged profile covers both CH_NFADP and EU_GDPR
+        profile.ConsentModel.ShouldBe(ConsentModel.OptIn);
+    }
+
+    [Fact]
+    public async Task ResolveAllAsync_FranceIsoCode_ReturnsSingleProfile()
+    {
+        // "FR" → EU_GDPR only; ResolveAllAsync returns a single-element list
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = CreateTenant(tenantId, "FR");
+
+        TenantBasedRegulationResolver resolver = CreateResolver(
+            new PrivacyRegulationsOptions { DefaultRegulation = "CH_NFADP" },
+            tenant);
+
+        IReadOnlyList<PrivacyRegulationProfile> profiles =
+            await resolver.ResolveAllAsync(TestContext.Current.CancellationToken);
+
+        profiles.Count.ShouldBe(1);
+        profiles[0].Regulation.Value.ShouldBe("EU_GDPR");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SwitzerlandIsoCode_ReturnsDualRegulation()
+    {
+        // "CH" → CH_NFADP + EU_GDPR (for EU data subjects)
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = CreateTenant(tenantId, "CH");
+
+        TenantBasedRegulationResolver resolver = CreateResolver(
+            new PrivacyRegulationsOptions { DefaultRegulation = "EU_GDPR" },
+            tenant);
+
+        IReadOnlyList<PrivacyRegulationProfile> profiles =
+            await resolver.ResolveAllAsync(TestContext.Current.CancellationToken);
+
+        profiles.Count.ShouldBe(2);
+        profiles.Select(p => p.Regulation.Value).ShouldContain("CH_NFADP");
+        profiles.Select(p => p.Regulation.Value).ShouldContain("EU_GDPR");
     }
 
     [Fact]
@@ -159,7 +238,7 @@ public sealed class TenantBasedRegulationResolverTests
     }
 
     [Fact]
-    public async Task ResolveAllAsync_ReturnsSingleProfile()
+    public async Task ResolveAllAsync_SingleJurisdiction_ReturnsSingleProfile()
     {
         TenantBasedRegulationResolver resolver = CreateResolver(
             new PrivacyRegulationsOptions { DefaultRegulation = "EU_GDPR" });
@@ -172,10 +251,11 @@ public sealed class TenantBasedRegulationResolverTests
 
     private TenantBasedRegulationResolver CreateResolver(
         PrivacyRegulationsOptions options,
-        ICurrentTenant? currentTenant = null)
+        ICurrentTenant? currentTenant = null,
+        IPrivacyJurisdictionResolver? jurisdictionResolver = null)
     {
         IOptions<PrivacyRegulationsOptions> opts = Microsoft.Extensions.Options.Options.Create(options);
-        return new TenantBasedRegulationResolver(_registry, opts, currentTenant);
+        return new TenantBasedRegulationResolver(_registry, opts, jurisdictionResolver ?? _jurisdictionResolver, currentTenant);
     }
 
     private static ICurrentTenant CreateTenant(Guid tenantId, string? jurisdiction)

--- a/tests/Granit.Privacy.Regulations.Tests/Jurisdiction/DefaultPrivacyJurisdictionResolverTests.cs
+++ b/tests/Granit.Privacy.Regulations.Tests/Jurisdiction/DefaultPrivacyJurisdictionResolverTests.cs
@@ -1,0 +1,165 @@
+using Granit.Privacy.Regulations.Jurisdiction.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Regulations.Tests.Jurisdiction;
+
+public sealed class DefaultPrivacyJurisdictionResolverTests
+{
+    private readonly DefaultPrivacyJurisdictionResolver _resolver =
+        new DefaultPrivacyJurisdictionResolver([new BuiltInPrivacyJurisdictionMapProvider()]);
+
+    // ── EU member states ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("FR")]
+    [InlineData("DE")]
+    [InlineData("BE")]
+    [InlineData("NL")]
+    [InlineData("IT")]
+    [InlineData("ES")]
+    [InlineData("PL")]
+    public async Task Resolve_EuMemberState_ReturnsEuGdpr(string countryCode)
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync(countryCode, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Value.ShouldBe("EU_GDPR");
+    }
+
+    // ── Tier 1 country mappings ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Resolve_UnitedKingdom_ReturnsUkGdpr()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("GB", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Value.ShouldBe("UK_GDPR");
+    }
+
+    [Fact]
+    public async Task Resolve_Brazil_ReturnsLgpd()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("BR", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Value.ShouldBe("BR_LGPD");
+    }
+
+    [Fact]
+    public async Task Resolve_Switzerland_ReturnsNfadpAndEuGdpr()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("CH", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(2);
+        result.Select(r => r.Value).ShouldBe(["CH_NFADP", "EU_GDPR"], ignoreOrder: false);
+    }
+
+    [Fact]
+    public async Task Resolve_Canada_CountryLevel_ReturnsPipeda()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("CA", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Value.ShouldBe("CA_PIPEDA");
+    }
+
+    // ── Region overrides (Canada) ────────────────────────────────────────
+
+    [Fact]
+    public async Task Resolve_QuebecRegion_ReturnsQuebec25AndPipeda()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("CA", "CA-QC", TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(2);
+        result.Select(r => r.Value).ShouldContain("CA_QUEBEC_25");
+        result.Select(r => r.Value).ShouldContain("CA_PIPEDA");
+    }
+
+    [Fact]
+    public async Task Resolve_QuebecRegion_TakesPrecedenceOverCountry()
+    {
+        IReadOnlyList<PrivacyRegulation> withRegion =
+            await _resolver.ResolveAsync("CA", "CA-QC", TestContext.Current.CancellationToken);
+
+        IReadOnlyList<PrivacyRegulation> withoutRegion =
+            await _resolver.ResolveAsync("CA", cancellationToken: TestContext.Current.CancellationToken);
+
+        withRegion.Count.ShouldBeGreaterThan(withoutRegion.Count);
+    }
+
+    // ── US ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Resolve_UsCountryLevel_ReturnsEmpty()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("US", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_CaliforniaRegion_ReturnsCcpa()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("US", "US-CA", TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Value.ShouldBe("US_CCPA");
+    }
+
+    // ── Tier 2 ───────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("CN", "CN_PIPL")]
+    [InlineData("IN", "IN_DPDPA")]
+    [InlineData("JP", "JP_APPI")]
+    [InlineData("KR", "KR_PIPA")]
+    [InlineData("AU", "AU_PRIVACY_ACT")]
+    [InlineData("ZA", "ZA_POPIA")]
+    [InlineData("TH", "TH_PDPA")]
+    public async Task Resolve_Tier2Country_ReturnsExpectedRegulation(string countryCode, string expectedCode)
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync(countryCode, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Value.ShouldBe(expectedCode);
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Resolve_UnknownCountry_ReturnsEmpty()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("XX", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_UnknownRegion_FallsBackToCountry()
+    {
+        IReadOnlyList<PrivacyRegulation> result =
+            await _resolver.ResolveAsync("FR", "FR-XX", TestContext.Current.CancellationToken);
+
+        // No FR-XX region → falls back to country FR → EU_GDPR
+        result.ShouldHaveSingleItem().Value.ShouldBe("EU_GDPR");
+    }
+
+    [Fact]
+    public async Task Resolve_LookupIsCaseInsensitive()
+    {
+        IReadOnlyList<PrivacyRegulation> upper =
+            await _resolver.ResolveAsync("FR", cancellationToken: TestContext.Current.CancellationToken);
+
+        IReadOnlyList<PrivacyRegulation> lower =
+            await _resolver.ResolveAsync("fr", cancellationToken: TestContext.Current.CancellationToken);
+
+        upper.Count.ShouldBe(lower.Count);
+        upper[0].Value.ShouldBe(lower[0].Value);
+    }
+}

--- a/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
@@ -378,21 +378,24 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         public bool IsAvailable => Id.HasValue;
         public Guid? Id { get; private set; }
         public string? Name { get; private set; }
+        public string? Jurisdiction { get; private set; }
 
-        public IDisposable Change(Guid? id, string? name = null)
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
         {
-            (Guid? previousId, string? previousName) = (Id, Name);
+            (Guid? previousId, string? previousName, string? previousJurisdiction) = (Id, Name, Jurisdiction);
             Id = id;
             Name = name;
-            return new Restore(this, previousId, previousName);
+            Jurisdiction = jurisdiction;
+            return new Restore(this, previousId, previousName, previousJurisdiction);
         }
 
-        private sealed class Restore(RecordingCurrentTenant owner, Guid? previousId, string? previousName) : IDisposable
+        private sealed class Restore(RecordingCurrentTenant owner, Guid? previousId, string? previousName, string? previousJurisdiction) : IDisposable
         {
             public void Dispose()
             {
                 owner.Id = previousId;
                 owner.Name = previousName;
+                owner.Jurisdiction = previousJurisdiction;
             }
         }
     }


### PR DESCRIPTION
## Summary

Follows from #2563. Stores a single ISO 3166 country/region code on `Tenant.Jurisdiction` and introduces `IPrivacyJurisdictionResolver` to map it to one or more `PrivacyRegulation` values at runtime — no list, no regulation code hard-coded in the DB.

**Key decisions:**
- **One tenant = one country of establishment = one ISO 3166 code** (`varchar(16)`, e.g. `"FR"`, `"CA-QC"`, `"US-CA"`). The DB stores geography, not legal interpretation.
- A single ISO code can still resolve to multiple regulations: `"CH"` → CH_NFADP + EU_GDPR; `"CA-QC"` → CA_QUEBEC_25 + CA_PIPEDA. `CompositeRegulationProfileMerger` merges them for `ResolveAsync`.
- `"US"` intentionally maps to nothing (no federal general privacy law) → falls back to `DefaultRegulation`.

**Changes:**
- `Tenant.Jurisdiction: string?` replaces `Jurisdictions: List<string>` (scalar column)
- `IPrivacyJurisdictionResolver` / `IPrivacyJurisdictionMapProvider` — extensible ISO → regulation bridge
- `BuiltInPrivacyJurisdictionMapProvider` — EU/EEA, CH, BR, CA-QC, CA, AU, NZ, JP, KR, IN, SG, GB, US-CA
- `CompositeRegulationProfileMerger` — merges multiple profiles from one ISO code
- `TenantBasedRegulationResolver` updated: (1) per-tenant config override, (2) ISO code → resolver → profiles, (3) DefaultRegulation fallback
- `GranitPrivacyRegulationsBuilder.ConfigureJurisdictionResolver()` for app-level custom mappings
- All DTOs, validators, EF config (`varchar(16)`), mappers, query/export definitions updated

## Test plan

- [ ] `Granit.Privacy.Regulations.Tests` — 86 tests including `TenantBasedRegulationResolverTests`, `CompositeRegulationProfileMergerTests`, `DefaultPrivacyJurisdictionResolverTests` (all ISO mappings, CH dual, CA-QC dual, US fallback)
- [ ] `Granit.MultiTenancy.Tests` — 113 tests
- [ ] `Granit.MultiTenancy.Endpoints.Tests` — 38 tests
- [ ] `Granit.Privacy.Tests` — 282 tests
- [ ] `Granit.Wolverine.Tests` — 165 tests
- [ ] `Granit.ArchitectureTests` — 215 tests
- [ ] `dotnet format --verify-no-changes` clean on all modified source projects

Closes #2568