### PR TITLE
fix(identity): enable WebAuthn/passkey support via IdentitySchemaVersions.Version3

### DIFF
--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -58,6 +58,8 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
                 options.Lockout.MaxFailedAccessAttempts = lockoutOptions.MaxFailedAccessAttempts;
                 options.Lockout.DefaultLockoutTimeSpan = lockoutOptions.BaseLockoutDuration;
                 options.SignIn.RequireConfirmedEmail = true;
+                // Version3 adds IdentityUserPasskey — required for WebAuthn/passkey support.
+                options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
             })
             .AddEntityFrameworkStores<OpenIddictDbContext>()
             .AddDefaultTokenProviders();

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -125,6 +125,25 @@ public static class OpenIddictModelBuilderExtensions
             b.HasKey(c => c.Id);
         });
 
+        // AspNetCore Identity Version3: passkey (WebAuthn/FIDO2) credentials.
+        // IdentityDbContext.OnModelCreating adds this entity when SchemaVersion = Version3;
+        // we add it here too so that host DbContexts that do not inherit from IdentityDbContext
+        // (e.g. ShowcaseHostDbContext) include the table in their migration.
+        // For OpenIddictDbContext the ToTable call below overrides the default AspNetUserPasskeys name.
+        modelBuilder.Entity<IdentityUserPasskey<Guid>>(b =>
+        {
+            b.ToTable(prefix + "user_passkeys", schema);
+            b.HasKey(p => p.CredentialId);
+            b.HasOne<LocalIdentity>()
+                .WithMany()
+                .HasForeignKey(p => p.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            b.OwnsOne(p => p.Data, data =>
+            {
+                data.ToJson();
+            });
+        });
+
         // ──── OpenIddict conventions + table remapping ────
         // UseOpenIddict registers key/index conventions for the custom OpenIddict entities.
         // Must be called before ToTable remapping.


### PR DESCRIPTION
## Summary

- **Root cause:** ASP.NET Core Identity 10 introduced `IdentitySchemaVersions.Version3` to gate WebAuthn/passkey store operations. Without `options.Stores.SchemaVersion = IdentitySchemaVersions.Version3`, `UserStore<T>` throws `InvalidOperationException` on every call to `GetPasskeysAsync` / `AddPasskeyAsync`, producing a 500 on `/api/v1/account/passkeys`.
- **`AddGranitOpenIddict`:** sets `SchemaVersion = Version3` on Identity store options.
- **`ConfigureOpenIddictModule`:** adds explicit `IdentityUserPasskey<Guid>` model configuration so host DbContexts not inheriting from `IdentityDbContext` (e.g. Showcase's `ShowcaseHostDbContext`) include the `openiddict_user_passkeys` table in their EF Core migration. `OpenIddictDbContext` (which does inherit `IdentityDbContext`) already gets this entity via `OnModelCreatingVersion3`; the config here is defensive and canonicalises the table name for both paths.

## Table mapping

| Property | Configuration |
|---|---|
| Table | `openiddict_user_passkeys` (via `GranitOpenIddictDbProperties` prefix) |
| PK | `CredentialId` (`byte[]`) |
| FK | `UserId → openiddict_users.Id` with `DeleteBehavior.Cascade` |
| `Data` | Owned type mapped as JSON (`jsonb` on PostgreSQL) |

## Test plan

- [ ] Build `src/Granit.OpenIddict.EntityFrameworkCore/` — 0 errors, 0 warnings
- [ ] Showcase: after NuGet update, regenerate `AddPasskeySchema` migration — `openiddict_user_passkeys` table appears in `Up()`
- [ ] Showcase: `GET /api/v1/account/passkeys` returns 200 (no more 500)
- [ ] Showcase: passkey registration and authentication flows end-to-end