### PR TITLE
fix(openiddict): fix 4 arch-test violations from feature-gaps PR

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -217,7 +217,7 @@ internal static partial class ConnectTokenEndpoints
 
         if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(code))
         {
-            LogTwoFactorMissingParams(logger, username ?? "(null)");
+            LogTwoFactorMissingParams(logger);
             metrics.RecordAuthenticationFailure(tenantId, "missing_params");
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
@@ -420,8 +420,8 @@ internal static partial class ConnectTokenEndpoints
     [LoggerMessage(Level = LogLevel.Error, Message = "Token endpoint: failed to write authentication audit entry — token flow continues.")]
     private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Two-factor grant: missing 'username' or 'code' parameter for user '{Username}'")]
-    private static partial void LogTwoFactorMissingParams(ILogger logger, string username);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Two-factor grant: missing required 'username' or 'code' parameter")]
+    private static partial void LogTwoFactorMissingParams(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Two-factor grant: invalid code for user '{UserId}'")]
     private static partial void LogTwoFactorFailed(ILogger logger, string userId);

--- a/tests/Granit.ArchitectureTests/ApiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ApiConventionTests.cs
@@ -27,7 +27,8 @@ public sealed class ApiConventionTests
             "ConnectAuthorizationEndpoints",
             "ConnectTokenEndpoints",
             "ConnectLogoutEndpoints",
-            "ConnectUserInfoEndpoints");
+            "ConnectUserInfoEndpoints",
+            "ConnectVerifyEndpoints");
 
     [Fact]
     public void Complex_results_unions_should_include_ProblemHttpResult() =>

--- a/tests/Granit.ArchitectureTests/EndpointAuthorizationConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/EndpointAuthorizationConventionTests.cs
@@ -24,5 +24,6 @@ public sealed class EndpointAuthorizationConventionTests
             "ConnectLogoutEndpoints",
             "ConnectUserInfoEndpoints",
             "ConnectIntrospectionEndpoints",
-            "ConnectRevocationEndpoints");
+            "ConnectRevocationEndpoints",
+            "ConnectVerifyEndpoints");
 }

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Permissions/OpenIddictPermissionDefinitionProviderTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Permissions/OpenIddictPermissionDefinitionProviderTests.cs
@@ -35,7 +35,7 @@ public sealed class OpenIddictPermissionDefinitionProviderTests
 
         provider.DefinePermissions(context);
 
-        // 3 Applications (Read, Manage, Rotate) + 2 Scopes (Read, Manage) + 2 Authorizations (Read, Revoke) = 7
-        group.Permissions.Count.ShouldBe(7);
+        // 3 Applications (Read, Manage, Rotate) + 2 Scopes (Read, Manage) + 3 Authorizations (Read, Create, Revoke) = 8
+        group.Permissions.Count.ShouldBe(8);
     }
 }


### PR DESCRIPTION
Fixes the 3 failures from the architecture shard CI run after #2572 merged, plus a related unit test count mismatch.

## Changes

- **`ConnectVerifyEndpoints` → typed-results exemption list**: OIDC protocol endpoint (same category as `ConnectAuthorizationEndpoints`, `ConnectTokenEndpoints`, etc.) — `Task<IResult>` is intentional for OpenIddict's `Results.Redirect` passthrough
- **`ConnectVerifyEndpoints` → authorization exemption list**: OpenIddict enforces auth at the protocol level; `.AllowAnonymous()` / `.RequireAuthorization()` are not applicable
- **`LogTwoFactorMissingParams` PII fix**: removed `{Username}` from the log template (GDPR Art. 5 — usernames must not appear in logs on auth failures)
- **Permission count test**: updated assertion `7 → 8` to account for the new `Authorizations.Create` permission added in #2572