### PR TITLE
refactor(testing): add FakeTimeProvider and replace local TimeProvider stubs

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -46172,7 +46172,7 @@
       "kind": "class",
       "project": "Granit.Testing",
       "file": "src/Granit.Testing/Fakes/FakeGuidGenerator.cs",
-      "line": 28,
+      "line": 32,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -46176,6 +46176,34 @@
       "members": []
     },
     {
+      "name": "FakeTimeProvider",
+      "fqn": "Granit.Testing.Fakes.FakeTimeProvider",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeTimeProvider.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "GetUtcNow",
+          "kind": "method",
+          "signature": "GetUtcNow()",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "SetUtcNow",
+          "kind": "method",
+          "signature": "SetUtcNow(DateTimeOffset value)",
+          "returnType": "void"
+        },
+        {
+          "name": "Advance",
+          "kind": "method",
+          "signature": "Advance(TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "SharedCurrentTenant",
       "fqn": "Granit.Testing.Fakes.SharedCurrentTenant",
       "kind": "class",

--- a/src/Granit.Testing/Fakes/FakeGuidGenerator.cs
+++ b/src/Granit.Testing/Fakes/FakeGuidGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Granit.Guids;
 
 namespace Granit.Testing.Fakes;
@@ -6,11 +7,6 @@ namespace Granit.Testing.Fakes;
 /// Configurable fake implementation of <see cref="IGuidGenerator"/> for tests.
 /// </summary>
 /// <remarks>
-/// <para>
-/// All state is stored in <see cref="AsyncLocal{T}"/> so that each async context
-/// (i.e. each xUnit test) gets isolated values — safe for parallel execution
-/// and <c>IClassFixture&lt;T&gt;</c> sharing.
-/// </para>
 /// <para>
 /// Dual-mode operation:
 /// <list type="bullet">
@@ -24,10 +20,19 @@ namespace Granit.Testing.Fakes;
 ///   </item>
 /// </list>
 /// </para>
+/// <para>
+/// State is stored on the instance (not in <see cref="AsyncLocal{T}"/>), so the
+/// counter and queue survive across <c>await</c> continuations regardless of
+/// <c>ConfigureAwait(false)</c>. Isolation between parallel tests is guaranteed by
+/// each test creating its own instance — <c>AsyncLocal</c> would add no benefit here
+/// and would silently reset the counter every time a continuation resumes on a new
+/// execution context.
+/// </para>
 /// </remarks>
 public sealed class FakeGuidGenerator : IGuidGenerator
 {
-    private readonly AsyncLocal<GeneratorState?> _state = new();
+    private readonly ConcurrentQueue<Guid> _queue = new();
+    private int _counter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FakeGuidGenerator"/> class.
@@ -43,39 +48,27 @@ public sealed class FakeGuidGenerator : IGuidGenerator
     /// <param name="guids">GUIDs to return in order from <see cref="Create"/>.</param>
     public FakeGuidGenerator(params ReadOnlySpan<Guid> guids)
     {
-        GeneratorState state = EnsureState();
         foreach (Guid g in guids)
         {
-            state.Queue.Enqueue(g);
+            _queue.Enqueue(g);
         }
     }
 
     /// <inheritdoc/>
     public Guid Create()
     {
-        GeneratorState state = EnsureState();
-        return state.Queue.Count > 0
-            ? state.Queue.Dequeue()
-            : CreateSequential(state);
+        if (_queue.TryDequeue(out Guid queued))
+        {
+            return queued;
+        }
+
+        int n = Interlocked.Increment(ref _counter);
+        return new Guid(n, 0, 0, [0, 0, 0, 0, 0, 0, 0, 0]);
     }
 
     /// <summary>
     /// Enqueues a GUID to be returned by the next call to <see cref="Create"/>.
     /// </summary>
     /// <param name="value">The GUID to enqueue.</param>
-    public void Enqueue(Guid value) => EnsureState().Queue.Enqueue(value);
-
-    private static Guid CreateSequential(GeneratorState state)
-    {
-        int counter = ++state.Counter;
-        return new Guid(counter, 0, 0, [0, 0, 0, 0, 0, 0, 0, 0]);
-    }
-
-    private GeneratorState EnsureState() => _state.Value ??= new GeneratorState();
-
-    private sealed class GeneratorState
-    {
-        public Queue<Guid> Queue { get; } = new();
-        public int Counter { get; set; }
-    }
+    public void Enqueue(Guid value) => _queue.Enqueue(value);
 }

--- a/src/Granit.Testing/Fakes/FakeTimeProvider.cs
+++ b/src/Granit.Testing/Fakes/FakeTimeProvider.cs
@@ -1,0 +1,45 @@
+namespace Granit.Testing.Fakes;
+
+/// <summary>
+/// Configurable fake implementation of <see cref="TimeProvider"/> for tests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All state is stored in <see cref="AsyncLocal{T}"/> so that each async context
+/// (i.e. each xUnit test) gets isolated values — safe for parallel execution
+/// and <c>IClassFixture&lt;T&gt;</c> sharing.
+/// </para>
+/// <para>
+/// Default time is <c>2026-01-15T10:00:00Z</c>. Use <see cref="Advance"/> or
+/// <see cref="SetUtcNow"/> to control time in temporal test scenarios.
+/// </para>
+/// </remarks>
+public sealed class FakeTimeProvider : TimeProvider
+{
+    private static readonly DateTimeOffset DefaultNow = new(2026, 1, 15, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly AsyncLocal<DateTimeOffset?> _utcNow = new();
+
+    /// <summary>
+    /// Initializes a new instance with the default time (<c>2026-01-15T10:00:00Z</c>).
+    /// </summary>
+    public FakeTimeProvider() { }
+
+    /// <summary>
+    /// Initializes a new instance pinned to <paramref name="utcNow"/>.
+    /// </summary>
+    public FakeTimeProvider(DateTimeOffset utcNow) => _utcNow.Value = utcNow;
+
+    /// <inheritdoc/>
+    public override DateTimeOffset GetUtcNow() => _utcNow.Value ?? DefaultNow;
+
+    /// <summary>
+    /// Sets the current UTC time returned by <see cref="GetUtcNow"/>.
+    /// </summary>
+    public void SetUtcNow(DateTimeOffset value) => _utcNow.Value = value;
+
+    /// <summary>
+    /// Advances the current time by <paramref name="duration"/>.
+    /// </summary>
+    public void Advance(TimeSpan duration) => _utcNow.Value = GetUtcNow().Add(duration);
+}

--- a/tests/Granit.Http.Idempotency.Tests/Granit.Http.Idempotency.Tests.csproj
+++ b/tests/Granit.Http.Idempotency.Tests/Granit.Http.Idempotency.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Http.Idempotency\Granit.Http.Idempotency.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Http.Idempotency.Tests/InMemoryIdempotencyStoreTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/InMemoryIdempotencyStoreTests.cs
@@ -1,6 +1,7 @@
 using Granit.Caching.Internal;
 using Granit.Http.Idempotency.Internal;
 using Granit.Http.Idempotency.Models;
+using Granit.Testing.Fakes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using Xunit;
@@ -9,7 +10,7 @@ namespace Granit.Http.Idempotency.Tests;
 
 public sealed class ConditionalCacheIdempotencyStoreTests
 {
-    private readonly ManualTimeProvider _timeProvider = new(new DateTimeOffset(2026, 3, 21, 12, 0, 0, TimeSpan.Zero));
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 3, 21, 12, 0, 0, TimeSpan.Zero));
     private readonly ConditionalCacheIdempotencyStore _store;
 
     public ConditionalCacheIdempotencyStoreTests()
@@ -237,16 +238,4 @@ public sealed class ConditionalCacheIdempotencyStoreTests
         kept.ShouldNotBeNull();
     }
 
-    // =========================================================================
-    // Manual TimeProvider for testing
-    // =========================================================================
-
-    private sealed class ManualTimeProvider(DateTimeOffset startTime) : TimeProvider
-    {
-        private DateTimeOffset _utcNow = startTime;
-
-        public override DateTimeOffset GetUtcNow() => _utcNow;
-
-        public void Advance(TimeSpan delta) => _utcNow += delta;
-    }
 }

--- a/tests/Granit.Http.Idempotency.Tests/packages.lock.json
+++ b/tests/Granit.Http.Idempotency.Tests/packages.lock.json
@@ -266,6 +266,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.abstractions": {
         "type": "Project"
       },
@@ -277,11 +283,27 @@
           "Microsoft.IO.RecyclableMemoryStream": "[3.*, )"
         }
       },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
+      },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
       },
       "Microsoft.IO.RecyclableMemoryStream": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStatsTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStatsTests.cs
@@ -2,6 +2,7 @@ using Granit.Identity.Federated.EntityFrameworkCore.Internal;
 using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.Options;
 using Granit.MultiTenancy;
+using Granit.Testing.Fakes;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -81,12 +82,4 @@ public sealed class EfCoreUserCacheStatsTests
         resultNewest.ShouldBe(newest);
     }
 
-    private sealed class FakeTimeProvider : TimeProvider
-    {
-        private DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
-
-        public void SetUtcNow(DateTimeOffset value) => _utcNow = value;
-
-        public override DateTimeOffset GetUtcNow() => _utcNow;
-    }
 }

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/Granit.Identity.Federated.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/Granit.Identity.Federated.EntityFrameworkCore.Tests.csproj
@@ -22,5 +22,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Identity.Federated.EntityFrameworkCore\Granit.Identity.Federated.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
@@ -108,6 +108,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HRH/XAke90wkHv9ykCsrvpVqvKOUt53jQzvHHIXrPIPZWAjyPq6B5/InCmPYWvme+WKMXD10rplMAitzNMtC3w=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -145,12 +150,79 @@
           "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "nQXq1a4MiInYh+0VF9fguxAl06q2ftmOyYQ+5e933s4rk57xjgkbTjUdFUySzjrcrvDeWsSqlZB+TE8+TbM2HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "bVGqctAfPGfTxJvNp8pMshtvpsUj6r6JkeiCNVIGVYO5gBxuxdN0Lbr25kEvE/zXdctkEc44g8HssnPgDnFGVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "1g9mzuu8gIHkjYb0jLxOTQVl/QDG5nn0b0JzgT/gbgNKr6gXZzxOHRAsdYRc1eDApB7LdHR8uK5vQrNjIQdRrQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "KLtAZ6A38s1pIfCO2ns6aG14NNGMYNZ4PBYfFK4M+R4A+xuSc6oklhqDcpHZxvDpyBWeFtR5C8iQBw2ng8tUHQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "6XTfFOnf27WY8kEeZkTZ4YNn0t+imgvdQ0YaAdR4vgURKATo9bCaVJ1KB71IOJAQtJP7Elb53VHlTNXg2CtSsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Json": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.8"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.8",
         "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "uduyw9d3Fi+sbredO5drA1S44AQS2FRNFyn72UmB2vmQIO1qaXprpp1U/2lYhYi8yFdVERfY9sy/pxw/qPOU9w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
@@ -175,6 +247,45 @@
           "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "GkPvQe6IdidLu6Q3Lw6+B8NJpW8feW8czZ5mBKt5rXM/x8MvZfEp5WvAsjznzDGd23chIDrW0b2mmt+ScnEgiw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "VfEyM2BipThcSd0GG/FS2ZPCVCTiosVq2zLKEDsfeMIg78sOVZPEmS7CgWlb+dqTlgXvLSL4OG2q6sM4xRhHNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.8",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Json": "10.0.8",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
+          "Microsoft.Extensions.Logging.Console": "10.0.8",
+          "Microsoft.Extensions.Logging.Debug": "10.0.8",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.8",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "10.0.8",
@@ -183,6 +294,67 @@
           "Microsoft.Extensions.DependencyInjection": "10.0.8",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
           "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "rxSLTO7xTbcC3DuEJHNEijBr8g14Jj62zQ+DeFu68bsoTYoU8jLcMhc1735PV21bESXsATlL5LsfaWH71FOWAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "6cv53sHsPnFS56PJw8X4GbNcjeX1KGyFJRxJWvxOgK63cnqeSB1k1eRwjUdkse0tBhwlH6qc9EOYDlan+CYTuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "4HW3M1lGHHDwEYcDZHRNptBQ48LCI2yW+XV4vuxdfQUqafTpVT8j9RqAsez08krZKhIiaArWu8iQq5uRKZ9Ffg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "kK/C3SLIoGrcZvddYQw4eMm6YaROiSYBO7YgUR5Hdv5l+GIjBmbvQK5cST2FqjeubiAOPqFEimBT2N/8wVI+3A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "System.Diagnostics.EventLog": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HX2M0MgzwQM8jpLe3AYAEMd0YsUfOP5RgGrDuk+Ki9n7HSuMbvLm9TEV3qRI3Pg9aqxc56GfgK/KdMRBhfWwKw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -251,8 +423,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.8",
+        "contentHash": "+Ro7WgIom+BDNH+YhTuZKL6QJ0ctfOpTyfUG/h3aU5KwXt3OaNf0wYWrTvoBUj+34Dy5V8dN9yCco1hAJQ4txw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -479,6 +651,16 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
@@ -491,6 +673,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "C9kMpUciPgx7ObqoO6W+eXEf3zHFWb7XpQgFJBzdO8GsmmVYrgcErTLMuki6e3EihycGpHbcJECYHDgM7XRMkg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.8",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Extensions.Hosting": "10.0.8"
         }
       },
       "Microsoft.EntityFrameworkCore": {
@@ -577,6 +770,12 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.8",
           "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.8"
         }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportRequestTrackerTests.cs
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportRequestTrackerTests.cs
@@ -116,7 +116,7 @@ public sealed class EfExportRequestTrackerTests : IAsyncDisposable
         var userId = Guid.NewGuid();
         await _sut.RecordRequestAsync(requestId, userId, userId, Now, TestContext.Current.CancellationToken);
 
-        _time.Set(Now.AddMinutes(5));
+        _time.SetUtcNow(Now.AddMinutes(5));
         await _sut.MarkCompletedAsync(
             requestId,
             ExportRequestState.Completed,
@@ -175,10 +175,4 @@ public sealed class EfExportRequestTrackerTests : IAsyncDisposable
         }
     }
 
-    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
-    {
-        private DateTimeOffset _now = now;
-        public override DateTimeOffset GetUtcNow() => _now;
-        public void Set(DateTimeOffset value) => _now = value;
-    }
 }


### PR DESCRIPTION
## Summary

- Add `Granit.Testing.Fakes.FakeTimeProvider : TimeProvider` with `AsyncLocal` isolation (same pattern as `FakeClock`), `Advance(TimeSpan)` and `SetUtcNow(DateTimeOffset)` methods, default time `2026-01-15T10:00:00Z`.
- Replace 3 local `TimeProvider` stubs (`ManualTimeProvider`, `FakeTimeProvider`) across `Granit.Http.Idempotency.Tests`, `Granit.Identity.Federated.EntityFrameworkCore.Tests`, and `Granit.Privacy.EntityFrameworkCore.Tests`.
- Add `Granit.Testing` project reference to the 2 projects that didn't have it yet.
- The `UuidV7GuidGeneratorTests` stub is intentionally left — its `Func<int>? incrementFunc` behaviour is specific to UUID v7 timestamp testing.

## Test plan

- [ ] `Granit.Http.Idempotency.Tests` — 110 tests pass
- [ ] `Granit.Identity.Federated.EntityFrameworkCore.Tests` — 32 tests pass
- [ ] `Granit.Privacy.EntityFrameworkCore.Tests` — 29 tests pass