### PR TITLE
fix(persistence): mirror ISoftDeletable / IActive filters onto ITranslation entities

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -192,7 +192,7 @@ public static class ModelBuilderExtensions
             typeof(ModelBuilderExtensions)
                 .GetMethod(nameof(ConfigureTranslation), BindingFlags.Static | BindingFlags.NonPublic)! // NOSONAR S3011 - intentional: generic EF Core convention pattern requires reflection
                 .MakeGenericMethod(clrType, parentType)
-                .Invoke(null, [modelBuilder]);
+                .Invoke(null, [modelBuilder, proxy]);
         }
 
         // --- Value object conventions ---
@@ -467,11 +467,32 @@ public static class ModelBuilderExtensions
         // SingleValueObject<T> must stay visible as a scalar property so the next pass
         // (ApplySingleValueObjectConverters) can wrap it with its primitive converter —
         // Ignore(type) would hide that property and drop the column.
+        //
+        // Exception: when a module author explicitly mapped the VO as a property column in a
+        // custom IEntityTypeConfiguration (e.g. WebManifest via HasConversion in
+        // SiteSeoDefaultsConfiguration), the navigation loop above found no raw navigation to
+        // process. No navigation → no risk of re-discovery during finalization → RemoveEntityType
+        // is sufficient and avoids the EF Core warning "entity type was first mapped explicitly
+        // and then ignored" that Ignore() emits in this scenario.
         foreach (Type valueObjectClrType in valueObjectClrTypes)
         {
             if (GetSingleValueObjectBase(valueObjectClrType) is null)
             {
-                modelBuilder.Ignore(valueObjectClrType);                 // multi-field VO → keep it out for good
+                // Check whether any non-VO entity still has a raw navigation to this VO type.
+                // If so, a later convention could re-discover it → Ignore() is needed.
+                // If not, the VO was already handled as a property column → RemoveEntityType suffices.
+                bool hasRemainingNavigation = modelBuilder.Model.GetEntityTypes()
+                    .Any(et => !valueObjectClrTypes.Contains(et.ClrType)
+                        && et.GetNavigations().Any(nav => nav.TargetEntityType.ClrType == valueObjectClrType));
+
+                if (hasRemainingNavigation)
+                {
+                    modelBuilder.Ignore(valueObjectClrType);                 // multi-field VO with live navigations → keep it out for good
+                }
+                else
+                {
+                    modelBuilder.Model.RemoveEntityType(valueObjectClrType); // no live navigations → RemoveEntityType is safe
+                }
             }
             else
             {
@@ -541,7 +562,11 @@ public static class ModelBuilderExtensions
     }
 
     // Configures a translation entity type: FK, cascade delete, unique index, Culture max length.
-    private static void ConfigureTranslation<TTranslation, TParent>(ModelBuilder modelBuilder)
+    // Also mirrors the parent's ISoftDeletable / IActive query filters onto the translation so
+    // that EF Core's filter consistency check (required principal end with a global query filter)
+    // is satisfied. Without these mirrors, EF Core warns that querying translations directly may
+    // return rows whose parent would be filtered out.
+    private static void ConfigureTranslation<TTranslation, TParent>(ModelBuilder modelBuilder, FilterProxy proxy)
         where TTranslation : class, ITranslation<TParent>
         where TParent : Entity
     {
@@ -562,6 +587,36 @@ public static class ModelBuilderExtensions
         // Unique index: one translation per (parent, culture)
         builder.HasIndex(t => new { t.ParentId, t.Culture })
             .IsUnique();
+
+        // Mirror the parent's filter interfaces on the translation entity. EF Core requires
+        // matching filters on both ends of a required relationship when the principal end has
+        // a global query filter. The filters navigate through the Parent reference so that
+        // direct DbSet<TTranslation> queries apply the same visibility rules as the parent.
+        ParameterExpression param = Expression.Parameter(typeof(TTranslation), "t");
+        MemberExpression parentProp = Expression.Property(param, nameof(ITranslation<TParent>.Parent));
+        // Guard against a null navigation in the SQL expression tree (required FK in practice,
+        // but EF Core needs the null branch to generate a valid SQL predicate).
+        Expression parentNull = Expression.Equal(parentProp, Expression.Constant(null, typeof(TParent)));
+
+        if (typeof(ISoftDeletable).IsAssignableFrom(typeof(TParent)))
+        {
+            Expression bypass = Expression.Not(Expression.Property(Expression.Constant(proxy), nameof(FilterProxy.SoftDeleteEnabled)));
+            PropertyInfo isDeletedProp = typeof(TParent).GetProperty(nameof(ISoftDeletable.IsDeleted))!; // NOSONAR S3011 - accessing a property known to exist on TParent via ISoftDeletable contract
+            Expression notDeleted = Expression.Not(Expression.Property(parentProp, isDeletedProp));
+            builder.HasQueryFilter(GranitFilterNames.SoftDelete,
+                Expression.Lambda<Func<TTranslation, bool>>(
+                    Expression.OrElse(bypass, Expression.OrElse(parentNull, notDeleted)), param));
+        }
+
+        if (typeof(IActive).IsAssignableFrom(typeof(TParent)))
+        {
+            Expression bypass = Expression.Not(Expression.Property(Expression.Constant(proxy), nameof(FilterProxy.ActiveEnabled)));
+            PropertyInfo activatedProp = typeof(TParent).GetProperty(nameof(IActive.Activated))!; // NOSONAR S3011 - accessing a property known to exist on TParent via IActive contract
+            Expression activated = Expression.Property(parentProp, activatedProp);
+            builder.HasQueryFilter(GranitFilterNames.Active,
+                Expression.Lambda<Func<TTranslation, bool>>(
+                    Expression.OrElse(bypass, Expression.OrElse(parentNull, activated)), param));
+        }
     }
 
     // Registers one named HasQueryFilter per applicable filter interface for TEntity (EF Core 10).

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslationConventionTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslationConventionTests.cs
@@ -3,12 +3,14 @@
 // =============================================================================
 // Verifies that ApplyGranitConventions detects ITranslation<TParent> and
 // configures: FK with cascade delete, unique index (ParentId, Culture),
-// Culture max length 20.
+// Culture max length 20, and mirrors parent ISoftDeletable / IActive filters.
 //
 // Uses InMemory database. Unique index enforcement is verified via model
 // metadata (InMemory does not enforce unique indexes at runtime).
 // =============================================================================
 
+using System.Linq.Expressions;
+using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +22,11 @@ namespace Granit.Persistence.EntityFrameworkCore.Tests;
 
 public sealed class TranslationConventionTests
 {
+    // EF Core caches the model per DbContext type. The filter proxy captures the IDataFilter
+    // instance at model-build time — subsequent filter evaluations read from that same instance.
+    // Static instances guarantee that the captured proxy references the object mutated by tests.
+    private static readonly TranslationTestDataFilter SharedTranslationDataFilter = new();
+
     // -------------------------------------------------------------------------
     // Convention detection — Translation<T>
     // -------------------------------------------------------------------------
@@ -158,6 +165,134 @@ public sealed class TranslationConventionTests
     }
 
     // -------------------------------------------------------------------------
+    // Filter mirrors — ISoftDeletable parent
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ApplyGranitConventions_SoftDeletableParent_TranslationHasSoftDeleteFilter()
+    {
+        using TestSoftDeletableTranslationDbContext context = CreateSoftDeletableContext();
+
+        IEntityType? entityType = context.Model.FindEntityType(typeof(TestSoftDeletableDocTranslation));
+
+        entityType.ShouldNotBeNull();
+        entityType!.GetDeclaredQueryFilters()
+            .ShouldContain(f => f.Key == GranitFilterNames.SoftDelete,
+                "translation of a soft-deletable parent must inherit the SoftDelete filter");
+    }
+
+    [Fact]
+    public void ApplyGranitConventions_SoftDeletableParent_TranslationFilter_ExcludesWhenParentDeleted()
+    {
+        SharedTranslationDataFilter.SetEnabled<ISoftDeletable>(true);
+
+        using TestSoftDeletableTranslationDbContextWithFilter context = CreateSoftDeletableContextWithFilter();
+        LambdaExpression? filter = context.Model
+            .FindEntityType(typeof(TestFilteredSoftDeletableDocTranslation))
+            ?.GetDeclaredQueryFilters()
+            .FirstOrDefault(f => f.Key == GranitFilterNames.SoftDelete)?.Expression;
+        filter.ShouldNotBeNull();
+
+        var compiled = (Func<TestFilteredSoftDeletableDocTranslation, bool>)filter!.Compile();
+
+        // Null parent → passes (null guard)
+        compiled(new TestFilteredSoftDeletableDocTranslation { Parent = null }).ShouldBeTrue("null parent must pass null guard");
+
+        // Non-deleted parent → passes
+        compiled(new TestFilteredSoftDeletableDocTranslation
+        {
+            Parent = new TestFilteredSoftDeletableDocument { IsDeleted = false },
+        }).ShouldBeTrue("translation of non-deleted parent must pass");
+
+        // Deleted parent → filtered
+        compiled(new TestFilteredSoftDeletableDocTranslation
+        {
+            Parent = new TestFilteredSoftDeletableDocument { IsDeleted = true, DeletedAt = DateTimeOffset.UtcNow, DeletedBy = "dpo" },
+        }).ShouldBeFalse("translation of deleted parent must be filtered");
+
+        // Bypass via IDataFilter
+        SharedTranslationDataFilter.SetEnabled<ISoftDeletable>(false);
+        compiled(new TestFilteredSoftDeletableDocTranslation
+        {
+            Parent = new TestFilteredSoftDeletableDocument { IsDeleted = true, DeletedAt = DateTimeOffset.UtcNow, DeletedBy = "dpo" },
+        }).ShouldBeTrue("filter disabled via IDataFilter — deleted parent must pass");
+
+        SharedTranslationDataFilter.SetEnabled<ISoftDeletable>(true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Filter mirrors — IActive parent
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ApplyGranitConventions_ActiveParent_TranslationHasActiveFilter()
+    {
+        using TestActiveTranslationDbContext context = CreateActiveContext();
+
+        IEntityType? entityType = context.Model.FindEntityType(typeof(TestActiveDocTranslation));
+
+        entityType.ShouldNotBeNull();
+        entityType!.GetDeclaredQueryFilters()
+            .ShouldContain(f => f.Key == GranitFilterNames.Active,
+                "translation of an active-filtered parent must inherit the Active filter");
+    }
+
+    [Fact]
+    public void ApplyGranitConventions_ActiveParent_TranslationFilter_ExcludesWhenParentInactive()
+    {
+        SharedTranslationDataFilter.SetEnabled<IActive>(true);
+
+        using TestActiveTranslationDbContextWithFilter context = CreateActiveContextWithFilter();
+        LambdaExpression? filter = context.Model
+            .FindEntityType(typeof(TestFilteredActiveDocTranslation))
+            ?.GetDeclaredQueryFilters()
+            .FirstOrDefault(f => f.Key == GranitFilterNames.Active)?.Expression;
+        filter.ShouldNotBeNull();
+
+        var compiled = (Func<TestFilteredActiveDocTranslation, bool>)filter!.Compile();
+
+        // Null parent → passes
+        compiled(new TestFilteredActiveDocTranslation { Parent = null }).ShouldBeTrue("null parent must pass null guard");
+
+        // Active parent → passes
+        compiled(new TestFilteredActiveDocTranslation
+        {
+            Parent = new TestFilteredActiveDocument { Activated = true },
+        }).ShouldBeTrue("translation of active parent must pass");
+
+        // Inactive parent → filtered
+        compiled(new TestFilteredActiveDocTranslation
+        {
+            Parent = new TestFilteredActiveDocument { Activated = false },
+        }).ShouldBeFalse("translation of inactive parent must be filtered");
+
+        // Bypass via IDataFilter
+        SharedTranslationDataFilter.SetEnabled<IActive>(false);
+        compiled(new TestFilteredActiveDocTranslation
+        {
+            Parent = new TestFilteredActiveDocument { Activated = false },
+        }).ShouldBeTrue("filter disabled via IDataFilter — inactive parent must pass");
+
+        SharedTranslationDataFilter.SetEnabled<IActive>(true);
+    }
+
+    // -------------------------------------------------------------------------
+    // No filter mirror when parent is a plain entity
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ApplyGranitConventions_PlainParent_TranslationHasNoQueryFilters()
+    {
+        using TestTranslationDbContext context = CreateContext();
+
+        IEntityType? entityType = context.Model.FindEntityType(typeof(TestDocTranslation));
+
+        entityType.ShouldNotBeNull();
+        entityType!.GetDeclaredQueryFilters().ShouldBeEmpty(
+            "translation of a plain entity should not have any query filters");
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -179,6 +314,46 @@ public sealed class TranslationConventionTests
                 .Options;
 
         return new TestAuditedTranslationDbContext(options);
+    }
+
+    private static TestSoftDeletableTranslationDbContext CreateSoftDeletableContext()
+    {
+        DbContextOptions<TestSoftDeletableTranslationDbContext> options =
+            new DbContextOptionsBuilder<TestSoftDeletableTranslationDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+        return new TestSoftDeletableTranslationDbContext(options);
+    }
+
+    private static TestSoftDeletableTranslationDbContextWithFilter CreateSoftDeletableContextWithFilter()
+    {
+        DbContextOptions<TestSoftDeletableTranslationDbContextWithFilter> options =
+            new DbContextOptionsBuilder<TestSoftDeletableTranslationDbContextWithFilter>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+        return new TestSoftDeletableTranslationDbContextWithFilter(options, SharedTranslationDataFilter);
+    }
+
+    private static TestActiveTranslationDbContext CreateActiveContext()
+    {
+        DbContextOptions<TestActiveTranslationDbContext> options =
+            new DbContextOptionsBuilder<TestActiveTranslationDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+        return new TestActiveTranslationDbContext(options);
+    }
+
+    private static TestActiveTranslationDbContextWithFilter CreateActiveContextWithFilter()
+    {
+        DbContextOptions<TestActiveTranslationDbContextWithFilter> options =
+            new DbContextOptionsBuilder<TestActiveTranslationDbContextWithFilter>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+        return new TestActiveTranslationDbContextWithFilter(options, SharedTranslationDataFilter);
     }
 }
 
@@ -218,6 +393,131 @@ internal sealed class TestAuditedTranslationDbContext(DbContextOptions<TestAudit
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
         modelBuilder.ApplyGranitConventions();
+}
+
+// --- ISoftDeletable parent (metadata test — no dataFilter) ---
+
+internal sealed class TestSoftDeletableDocument : Entity, ISoftDeletable
+{
+    public ICollection<TestSoftDeletableDocTranslation> Translations { get; set; } = [];
+    public bool IsDeleted { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
+    public string? DeletedBy { get; set; }
+}
+
+internal sealed class TestSoftDeletableDocTranslation : Translation<TestSoftDeletableDocument>
+{
+    public string Title { get; set; } = string.Empty;
+}
+
+internal sealed class TestSoftDeletableTranslationDbContext(DbContextOptions<TestSoftDeletableTranslationDbContext> options) : DbContext(options)
+{
+    public DbSet<TestSoftDeletableDocument> Documents => Set<TestSoftDeletableDocument>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyGranitConventions();
+}
+
+// --- ISoftDeletable parent (compiled filter test — with dataFilter) ---
+
+internal sealed class TestFilteredSoftDeletableDocument : Entity, ISoftDeletable
+{
+    public ICollection<TestFilteredSoftDeletableDocTranslation> Translations { get; set; } = [];
+    public bool IsDeleted { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
+    public string? DeletedBy { get; set; }
+}
+
+internal sealed class TestFilteredSoftDeletableDocTranslation : Translation<TestFilteredSoftDeletableDocument>
+{
+    public string Title { get; set; } = string.Empty;
+}
+
+internal sealed class TestSoftDeletableTranslationDbContextWithFilter(
+    DbContextOptions<TestSoftDeletableTranslationDbContextWithFilter> options,
+    IDataFilter dataFilter) : DbContext(options)
+{
+    private readonly IDataFilter _dataFilter = dataFilter;
+
+    public DbSet<TestFilteredSoftDeletableDocument> Documents => Set<TestFilteredSoftDeletableDocument>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyGranitConventions(dataFilter: _dataFilter);
+}
+
+// --- IActive parent (metadata test — no dataFilter) ---
+
+internal sealed class TestActiveDocument : Entity, IActive
+{
+    public ICollection<TestActiveDocTranslation> Translations { get; set; } = [];
+    public bool Activated { get; set; }
+}
+
+internal sealed class TestActiveDocTranslation : Translation<TestActiveDocument>
+{
+    public string Title { get; set; } = string.Empty;
+}
+
+internal sealed class TestActiveTranslationDbContext(DbContextOptions<TestActiveTranslationDbContext> options) : DbContext(options)
+{
+    public DbSet<TestActiveDocument> Documents => Set<TestActiveDocument>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyGranitConventions();
+}
+
+// --- IActive parent (compiled filter test — with dataFilter) ---
+
+internal sealed class TestFilteredActiveDocument : Entity, IActive
+{
+    public ICollection<TestFilteredActiveDocTranslation> Translations { get; set; } = [];
+    public bool Activated { get; set; }
+}
+
+internal sealed class TestFilteredActiveDocTranslation : Translation<TestFilteredActiveDocument>
+{
+    public string Title { get; set; } = string.Empty;
+}
+
+internal sealed class TestActiveTranslationDbContextWithFilter(
+    DbContextOptions<TestActiveTranslationDbContextWithFilter> options,
+    IDataFilter dataFilter) : DbContext(options)
+{
+    private readonly IDataFilter _dataFilter = dataFilter;
+
+    public DbSet<TestFilteredActiveDocument> Documents => Set<TestFilteredActiveDocument>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyGranitConventions(dataFilter: _dataFilter);
+}
+
+// Minimal IDataFilter for filter expression tests — direct state control without AsyncLocal.
+internal sealed class TranslationTestDataFilter : IDataFilter
+{
+    private readonly Dictionary<Type, bool> _state = [];
+
+    public void SetEnabled<TFilter>(bool enabled) => _state[typeof(TFilter)] = enabled;
+
+    public IDisposable Disable<TFilter>() where TFilter : class
+    {
+        _state[typeof(TFilter)] = false;
+        return NullScope.Instance;
+    }
+
+    public IDisposable Enable<TFilter>() where TFilter : class
+    {
+        _state[typeof(TFilter)] = true;
+        return NullScope.Instance;
+    }
+
+    public bool IsEnabled<TFilter>() where TFilter : class =>
+        !_state.TryGetValue(typeof(TFilter), out bool value) || value;
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
 }
 
 #endregion

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportRequestTrackerTests.cs
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfExportRequestTrackerTests.cs
@@ -3,6 +3,7 @@ using Granit.MultiTenancy;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
 using Granit.Privacy.EntityFrameworkCore.Internal;
+using Granit.Testing.Fakes;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;

--- a/tests/Granit.Testing.Tests/FakeGuidGeneratorTests.cs
+++ b/tests/Granit.Testing.Tests/FakeGuidGeneratorTests.cs
@@ -69,28 +69,37 @@ public sealed class FakeGuidGeneratorTests
     }
 
     [Fact]
-    public async Task AsyncLocal_Isolates_State_Across_Tasks()
+    public async Task Counter_PersistsAcross_Awaits()
     {
+        // AsyncLocal resets to 0 on each continuation — that was the bug.
+        // Interlocked.Increment advances the counter monotonically regardless of the
+        // synchronization context, so sequential calls always produce distinct GUIDs.
         FakeGuidGenerator generator = new();
-        var specificGuid = Guid.NewGuid();
 
-#pragma warning disable xUnit1051
-        var task1 = Task.Run(async () =>
-        {
-            generator.Enqueue(specificGuid);
-            await Task.Delay(50);
-            generator.Create().ShouldBe(specificGuid);
-        });
+        Guid first = generator.Create();
+        await Task.Delay(1, TestContext.Current.CancellationToken);
+        Guid second = generator.Create();
+        await Task.Delay(1, TestContext.Current.CancellationToken);
+        Guid third = generator.Create();
 
-        var task2 = Task.Run(async () =>
-        {
-            await Task.Delay(50);
-            // Should NOT see specificGuid from task1
-            Guid result = generator.Create();
-            result.ShouldNotBe(specificGuid);
-        });
+        first.ShouldNotBe(second, "counter must advance after await");
+        second.ShouldNotBe(third, "counter must continue advancing across awaits");
+        first.ShouldNotBe(third);
+    }
 
-        await Task.WhenAll(task1, task2);
-#pragma warning restore xUnit1051
+    [Fact]
+    public void Separate_Instances_Are_Independent()
+    {
+        // Isolation is guaranteed by each test creating its own instance, not by AsyncLocal.
+        FakeGuidGenerator gen1 = new();
+        FakeGuidGenerator gen2 = new();
+
+        gen1.Create(); // advance gen1 counter to 1
+        gen1.Create(); // advance gen1 counter to 2
+
+        Guid fromGen2 = gen2.Create(); // gen2 counter starts at 0 independently → 1
+
+        fromGen2.ShouldBe(new Guid(1, 0, 0, [0, 0, 0, 0, 0, 0, 0, 0]),
+            "gen2 counter is independent of gen1");
     }
 }


### PR DESCRIPTION
## Summary

- `ConfigureTranslation` now wires named query filters on the translation entity that mirror the parent's `ISoftDeletable` and `IActive` filters, navigating through `t.Parent`
- The filter short-circuits on a null parent navigation (null guard) and respects `IDataFilter` bypass — identical semantics to the parent filter
- Multi-field VO removal switches from `Ignore()` to `RemoveEntityType()` when the VO was already explicitly mapped as a property column (no remaining raw navigation), eliminating a spurious EF Core "entity type was first mapped explicitly and then ignored" warning

## Why

EF Core 10 requires matching named query filters on both ends of a required relationship when the principal end carries a global query filter. Without this, querying a translation `DbSet` directly can return rows whose soft-deleted or inactive parent would normally be excluded.

## Test plan

- [ ] `TranslationConventionTests` — 5 new tests:
  - `ApplyGranitConventions_SoftDeletableParent_TranslationHasSoftDeleteFilter` — model metadata
  - `ApplyGranitConventions_SoftDeletableParent_TranslationFilter_ExcludesWhenParentDeleted` — compiled expression + `IDataFilter` bypass
  - `ApplyGranitConventions_ActiveParent_TranslationHasActiveFilter` — model metadata
  - `ApplyGranitConventions_ActiveParent_TranslationFilter_ExcludesWhenParentInactive` — compiled expression + `IDataFilter` bypass
  - `ApplyGranitConventions_PlainParent_TranslationHasNoQueryFilters` — regression guard
- [ ] All 376 existing Persistence.EntityFrameworkCore tests still green