### PR TITLE
fix(testing): replace AsyncLocal with instance field in FakeTimeProvider

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -46181,7 +46181,7 @@
       "kind": "class",
       "project": "Granit.Testing",
       "file": "src/Granit.Testing/Fakes/FakeTimeProvider.cs",
-      "line": 17,
+      "line": 20,
       "members": [
         {
           "name": "GetUtcNow",

--- a/src/Granit.Testing/Fakes/FakeTimeProvider.cs
+++ b/src/Granit.Testing/Fakes/FakeTimeProvider.cs
@@ -5,9 +5,12 @@ namespace Granit.Testing.Fakes;
 /// </summary>
 /// <remarks>
 /// <para>
-/// All state is stored in <see cref="AsyncLocal{T}"/> so that each async context
-/// (i.e. each xUnit test) gets isolated values — safe for parallel execution
-/// and <c>IClassFixture&lt;T&gt;</c> sharing.
+/// State is stored on the instance (not in <see cref="AsyncLocal{T}"/>), so the time
+/// value survives across <c>await</c> continuations regardless of
+/// <c>ConfigureAwait(false)</c> and is visible from sibling execution contexts
+/// (e.g. xUnit v3 where <c>IAsyncLifetime.InitializeAsync</c> and the test method
+/// run in independent contexts, not parent-child). Isolation between parallel tests
+/// is guaranteed by each test creating its own instance.
 /// </para>
 /// <para>
 /// Default time is <c>2026-01-15T10:00:00Z</c>. Use <see cref="Advance"/> or
@@ -18,28 +21,28 @@ public sealed class FakeTimeProvider : TimeProvider
 {
     private static readonly DateTimeOffset DefaultNow = new(2026, 1, 15, 10, 0, 0, TimeSpan.Zero);
 
-    private readonly AsyncLocal<DateTimeOffset?> _utcNow = new();
+    private DateTimeOffset _utcNow;
 
     /// <summary>
     /// Initializes a new instance with the default time (<c>2026-01-15T10:00:00Z</c>).
     /// </summary>
-    public FakeTimeProvider() { }
+    public FakeTimeProvider() => _utcNow = DefaultNow;
 
     /// <summary>
     /// Initializes a new instance pinned to <paramref name="utcNow"/>.
     /// </summary>
-    public FakeTimeProvider(DateTimeOffset utcNow) => _utcNow.Value = utcNow;
+    public FakeTimeProvider(DateTimeOffset utcNow) => _utcNow = utcNow;
 
     /// <inheritdoc/>
-    public override DateTimeOffset GetUtcNow() => _utcNow.Value ?? DefaultNow;
+    public override DateTimeOffset GetUtcNow() => _utcNow;
 
     /// <summary>
     /// Sets the current UTC time returned by <see cref="GetUtcNow"/>.
     /// </summary>
-    public void SetUtcNow(DateTimeOffset value) => _utcNow.Value = value;
+    public void SetUtcNow(DateTimeOffset value) => _utcNow = value;
 
     /// <summary>
     /// Advances the current time by <paramref name="duration"/>.
     /// </summary>
-    public void Advance(TimeSpan duration) => _utcNow.Value = GetUtcNow().Add(duration);
+    public void Advance(TimeSpan duration) => _utcNow += duration;
 }

--- a/tests/Granit.Testing.Tests/FakeTimeProviderTests.cs
+++ b/tests/Granit.Testing.Tests/FakeTimeProviderTests.cs
@@ -1,0 +1,98 @@
+using Granit.Testing.Fakes;
+using Shouldly;
+
+namespace Granit.Testing.Tests;
+
+public sealed class FakeTimeProviderTests
+{
+    private static readonly DateTimeOffset DefaultNow = new(2026, 1, 15, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Default_Constructor_Returns_DefaultNow()
+    {
+        FakeTimeProvider sut = new();
+
+        sut.GetUtcNow().ShouldBe(DefaultNow);
+    }
+
+    [Fact]
+    public void Constructor_With_DateTimeOffset_Pins_Time()
+    {
+        DateTimeOffset pinned = new(2024, 6, 1, 8, 0, 0, TimeSpan.Zero);
+        FakeTimeProvider sut = new(pinned);
+
+        sut.GetUtcNow().ShouldBe(pinned);
+    }
+
+    [Fact]
+    public void SetUtcNow_Updates_Time()
+    {
+        FakeTimeProvider sut = new();
+        DateTimeOffset newTime = new(2025, 12, 31, 23, 59, 59, TimeSpan.Zero);
+
+        sut.SetUtcNow(newTime);
+
+        sut.GetUtcNow().ShouldBe(newTime);
+    }
+
+    [Fact]
+    public void Advance_Increments_Time()
+    {
+        DateTimeOffset start = new(2026, 5, 12, 10, 0, 0, TimeSpan.Zero);
+        FakeTimeProvider sut = new(start);
+
+        sut.Advance(TimeSpan.FromHours(2));
+
+        sut.GetUtcNow().ShouldBe(start.AddHours(2));
+    }
+
+    [Fact]
+    public void Advance_Multiple_Times_Accumulates()
+    {
+        DateTimeOffset start = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        FakeTimeProvider sut = new(start);
+
+        sut.Advance(TimeSpan.FromDays(1));
+        sut.Advance(TimeSpan.FromHours(3));
+
+        sut.GetUtcNow().ShouldBe(start.AddDays(1).AddHours(3));
+    }
+
+    [Fact]
+    public void Separate_Instances_Are_Independent()
+    {
+        FakeTimeProvider sut1 = new();
+        FakeTimeProvider sut2 = new();
+
+        sut1.Advance(TimeSpan.FromDays(30));
+
+        sut2.GetUtcNow().ShouldBe(DefaultNow, "sut2 must not be affected by sut1 mutations");
+    }
+
+    [Fact]
+    public async Task Time_PersistsAcross_Awaits()
+    {
+        // AsyncLocal loses its value when an async continuation resumes in a sibling
+        // execution context (e.g. xUnit v3 IAsyncLifetime.InitializeAsync vs test method).
+        // Instance fields survive across all contexts — this test documents that contract.
+        DateTimeOffset pinned = new(2026, 5, 12, 10, 0, 0, TimeSpan.Zero);
+        FakeTimeProvider sut = new(pinned);
+
+        await Task.Delay(1, TestContext.Current.CancellationToken);
+        DateTimeOffset after = sut.GetUtcNow();
+
+        after.ShouldBe(pinned, "time must be unchanged after await — not reset to default");
+    }
+
+    [Fact]
+    public async Task SetUtcNow_PersistsAcross_Awaits()
+    {
+        FakeTimeProvider sut = new();
+        DateTimeOffset updated = new(2026, 5, 12, 10, 0, 0, TimeSpan.Zero);
+
+        sut.SetUtcNow(updated);
+        await Task.Delay(1, TestContext.Current.CancellationToken);
+
+        sut.GetUtcNow().ShouldBe(updated, "SetUtcNow must persist after await continuation");
+    }
+}


### PR DESCRIPTION
## Summary

- `FakeTimeProvider` stored its time value in `AsyncLocal<DateTimeOffset?>`, which is invisible across sibling execution contexts
- xUnit v3 runs `IAsyncLifetime.InitializeAsync` and the test method as siblings (not parent-child), so a value written in `InitializeAsync` was not visible in the test — `GetUtcNow()` silently returned the default `2026-01-15T10:00:00Z` instead of the configured time
- Fixed by switching to a plain instance field, same root cause as `FakeGuidGenerator` (fixed in #2575 via `Interlocked.Increment`)

## Why

Per-test isolation is guaranteed by each test creating its own `FakeTimeProvider` instance — `AsyncLocal` adds no value and actively breaks the contract in xUnit v3 / `IAsyncLifetime` scenarios.

## Test plan

- [ ] New `FakeTimeProviderTests` (8 tests): default time, pinned constructor, `SetUtcNow`, `Advance`, multiple advances, instance independence, persistence across awaits, `SetUtcNow` persistence across awaits
- [ ] Existing 98 tests in `Granit.Testing.Tests` still green