### PR TITLE
feat(openiddict): expose full application fields on admin endpoints

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36012,7 +36012,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs",
-      "line": 10,
+      "line": 18,
       "members": []
     },
     {
@@ -36030,7 +36030,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs",
-      "line": 11,
+      "line": 19,
       "members": []
     },
     {
@@ -36075,7 +36075,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateApplicationRequest.cs",
-      "line": 8,
+      "line": 20,
       "members": []
     },
     {

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+
 namespace Granit.OpenIddict.Endpoints.Dtos;
 
 /// <summary>
@@ -7,8 +9,20 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="DisplayName">The display name.</param>
 /// <param name="Type">The application type (confidential, public).</param>
 /// <param name="TenantId">The tenant identifier, or <see langword="null"/> for global applications.</param>
+/// <param name="Permissions">The OpenIddict permissions granted to this client (e.g. <c>ept:token</c>, <c>gt:authorization_code</c>).</param>
+/// <param name="RedirectUris">The allowed redirect URIs.</param>
+/// <param name="PostLogoutRedirectUris">The allowed post-logout redirect URIs.</param>
+/// <param name="ConsentType">The consent type (<c>implicit</c>, <c>explicit</c>, or <c>systematic</c>).</param>
+/// <param name="ClientSide">The host/tenant policy enforced at sign-in, or <see langword="null"/> for no restriction.</param>
+/// <param name="HasSigningKey">Whether a public signing key (JWK) is registered for <c>private_key_jwt</c> authentication.</param>
 public sealed record AdminOidcApplicationResponse(
     string? ClientId,
     string? DisplayName,
     string? Type,
-    Guid? TenantId);
+    Guid? TenantId,
+    string[] Permissions,
+    string[] RedirectUris,
+    string[] PostLogoutRedirectUris,
+    string? ConsentType,
+    MultiTenancySides? ClientSide,
+    bool HasSigningKey);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+
 namespace Granit.OpenIddict.Endpoints.Dtos;
 
 /// <summary>
@@ -5,12 +7,24 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// </summary>
 /// <param name="ClientId">The client identifier (unique).</param>
 /// <param name="DisplayName">A human-readable display name.</param>
-/// <param name="ClientSecret">The client secret (null for public clients).</param>
-/// <param name="Type">The application type (web, native). Default: web.</param>
+/// <param name="ClientSecret">The client secret (null for public clients). Omit or set to null for public clients.</param>
+/// <param name="Type">The application type (<c>web</c>, <c>native</c>). Default: <c>web</c>.</param>
+/// <param name="Permissions">OpenIddict permissions to grant (e.g. <c>ept:token</c>, <c>gt:authorization_code</c>). Null or omitted defaults to no permissions.</param>
+/// <param name="RedirectUris">Allowed redirect URIs. Null or omitted defaults to none.</param>
+/// <param name="PostLogoutRedirectUris">Allowed post-logout redirect URIs. Null or omitted defaults to none.</param>
+/// <param name="ConsentType">The consent type (<c>implicit</c>, <c>explicit</c>, or <c>systematic</c>). Default: <c>implicit</c>.</param>
+/// <param name="SigningKeyJwk">Public signing key as JWK JSON for <c>private_key_jwt</c> authentication (RFC 7523). Null for shared-secret clients.</param>
+/// <param name="ClientSide">Host/tenant policy enforced at sign-in. Null means no restriction.</param>
 #pragma warning disable GRSEC003 // ClientSecret is a DTO parameter, not a stored secret
 public sealed record AdminOidcCreateApplicationRequest(
     string ClientId,
     string? DisplayName = null,
     string? ClientSecret = null,
-    string? Type = null);
+    string? Type = null,
+    string[]? Permissions = null,
+    string[]? RedirectUris = null,
+    string[]? PostLogoutRedirectUris = null,
+    string? ConsentType = null,
+    string? SigningKeyJwk = null,
+    MultiTenancySides? ClientSide = null);
 #pragma warning restore GRSEC003

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateApplicationRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateApplicationRequest.cs
@@ -1,10 +1,28 @@
+using Granit.MultiTenancy;
+
 namespace Granit.OpenIddict.Endpoints.Dtos;
 
 /// <summary>
 /// Request DTO for updating an existing OIDC application.
 /// </summary>
-/// <param name="DisplayName">A human-readable display name.</param>
-/// <param name="Type">The application type (web, native). Null leaves unchanged.</param>
+/// <remarks>
+/// All fields are optional. Null values leave the corresponding field unchanged.
+/// To clear a collection, pass an empty array. To clear the signing key, pass an empty string.
+/// </remarks>
+/// <param name="DisplayName">A human-readable display name. Null leaves it unchanged.</param>
+/// <param name="Type">The application type (<c>web</c>, <c>native</c>). Null leaves it unchanged.</param>
+/// <param name="Permissions">Replaces the full permission set. Null leaves it unchanged.</param>
+/// <param name="RedirectUris">Replaces the full redirect URI list. Null leaves it unchanged.</param>
+/// <param name="PostLogoutRedirectUris">Replaces the full post-logout redirect URI list. Null leaves it unchanged.</param>
+/// <param name="ConsentType">The consent type (<c>implicit</c>, <c>explicit</c>, or <c>systematic</c>). Null leaves it unchanged.</param>
+/// <param name="SigningKeyJwk">Public signing key as JWK JSON for <c>private_key_jwt</c> authentication. Null leaves it unchanged; empty string clears the key.</param>
+/// <param name="ClientSide">Host/tenant policy enforced at sign-in. Null leaves it unchanged.</param>
 public sealed record AdminOidcUpdateApplicationRequest(
     string? DisplayName = null,
-    string? Type = null);
+    string? Type = null,
+    string[]? Permissions = null,
+    string[]? RedirectUris = null,
+    string[]? PostLogoutRedirectUris = null,
+    string? ConsentType = null,
+    string? SigningKeyJwk = null,
+    MultiTenancySides? ClientSide = null);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Entities;
 using Granit.Http.Idempotency.Attributes;
 using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.OpenIddict.Entities.OpenIddict;
+using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Permissions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Abstractions;
 
 namespace Granit.OpenIddict.Endpoints.Endpoints;
@@ -25,14 +27,14 @@ internal static class AdminOidcEndpoints
             .WithMetadata(new EntityEndpointMetadata(typeof(GranitOpenIddictApplication), EntityEndpointKind.List))
             .WithName("ListOidcApplications")
             .WithSummary("Returns all OIDC applications.")
-            .WithDescription("Returns all registered OIDC client applications with their client ID, display name, type, and tenant association. Applications are either public (SPA, mobile) or confidential (server-side). Use this list to manage the registered clients in the admin panel.")
+            .WithDescription("Returns all registered OIDC client applications with their full configuration: client ID, display name, type, tenant, permissions, redirect URIs, consent type, and signing-key presence. Use this list to manage the registered clients in the admin panel.")
             .Produces<IReadOnlyList<AdminOidcApplicationResponse>>()
             .RequireAuthorization(OpenIddictPermissions.Applications.Read);
 
         apps.MapPost("/", CreateApplicationAsync)
             .WithName("CreateOidcApplication")
             .WithSummary("Creates a new OIDC application.")
-            .WithDescription("Registers a new OIDC client with the specified permissions and redirect URIs. For confidential clients, a client secret is generated and returned once in the response. Returns 409 Conflict if a client with the same client ID already exists.")
+            .WithDescription("Registers a new OIDC client with the specified permissions, redirect URIs, and consent policy. For confidential clients, a client secret is generated and returned once in the response. Returns 409 Conflict if a client with the same client ID already exists.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<AdminOidcApplicationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
@@ -41,7 +43,7 @@ internal static class AdminOidcEndpoints
         apps.MapPut("/{clientId}", UpdateApplicationAsync)
             .WithName("UpdateOidcApplication")
             .WithSummary("Updates an OIDC application.")
-            .WithDescription("Updates the display name or type of an existing OIDC application. Null fields are left unchanged. Returns 404 if the application does not exist.")
+            .WithDescription("Updates the configuration of an existing OIDC application. Only non-null fields are applied; null leaves the existing value unchanged. Pass an empty array to clear a collection. Returns 404 if the application does not exist.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<AdminOidcApplicationResponse>()
             .ProducesValidationProblem()
@@ -159,12 +161,10 @@ internal static class AdminOidcEndpoints
 
         await foreach (object app in applicationManager.ListAsync(100, 0, cancellationToken).ConfigureAwait(false))
         {
-            string? clientId = await applicationManager.GetClientIdAsync(app, cancellationToken).ConfigureAwait(false);
-            string? displayName = await applicationManager.GetDisplayNameAsync(app, cancellationToken).ConfigureAwait(false);
-            string? type = await applicationManager.GetApplicationTypeAsync(app, cancellationToken).ConfigureAwait(false);
-
+            var descriptor = new OpenIddictApplicationDescriptor();
+            await applicationManager.PopulateAsync(descriptor, app, cancellationToken).ConfigureAwait(false);
             Guid? tenantId = app is GranitOpenIddictApplication granitApp ? granitApp.TenantId : null;
-            results.Add(new AdminOidcApplicationResponse(clientId, displayName, type, tenantId));
+            results.Add(ToResponse(descriptor, tenantId));
         }
 
         return TypedResults.Ok<IReadOnlyList<AdminOidcApplicationResponse>>(results);
@@ -180,6 +180,7 @@ internal static class AdminOidcEndpoints
             ClientId = request.ClientId,
             DisplayName = request.DisplayName,
             ApplicationType = request.Type ?? OpenIddictConstants.ApplicationTypes.Web,
+            ConsentType = request.ConsentType ?? OpenIddictConstants.ConsentTypes.Implicit,
         };
 
         if (!string.IsNullOrEmpty(request.ClientSecret))
@@ -192,16 +193,37 @@ internal static class AdminOidcEndpoints
             descriptor.ClientType = OpenIddictConstants.ClientTypes.Public;
         }
 
+        foreach (string permission in request.Permissions ?? [])
+        {
+            descriptor.Permissions.Add(permission);
+        }
+
+        foreach (string uri in request.RedirectUris ?? [])
+        {
+            descriptor.RedirectUris.Add(new Uri(uri));
+        }
+
+        foreach (string uri in request.PostLogoutRedirectUris ?? [])
+        {
+            descriptor.PostLogoutRedirectUris.Add(new Uri(uri));
+        }
+
+        if (!string.IsNullOrEmpty(request.SigningKeyJwk))
+        {
+            descriptor.JsonWebKeySet = BuildJsonWebKeySet(request.SigningKeyJwk);
+        }
+
+        descriptor.SetClientSide(request.ClientSide);
+
         object app = await applicationManager.CreateAsync(descriptor, cancellationToken).ConfigureAwait(false);
 
-        string? clientId = await applicationManager.GetClientIdAsync(app, cancellationToken).ConfigureAwait(false);
-        string? displayName = await applicationManager.GetDisplayNameAsync(app, cancellationToken).ConfigureAwait(false);
-        string? type = await applicationManager.GetApplicationTypeAsync(app, cancellationToken).ConfigureAwait(false);
+        var responseDescriptor = new OpenIddictApplicationDescriptor();
+        await applicationManager.PopulateAsync(responseDescriptor, app, cancellationToken).ConfigureAwait(false);
         Guid? tenantId = app is GranitOpenIddictApplication granitApp ? granitApp.TenantId : null;
 
         return TypedResults.Created(
-            $"/admin/oidc/applications/{clientId}",
-            new AdminOidcApplicationResponse(clientId, displayName, type, tenantId));
+            $"/admin/oidc/applications/{request.ClientId}",
+            ToResponse(responseDescriptor, tenantId));
     }
 
     private static async Task<Results<NoContent, ProblemHttpResult>> DeleteApplicationAsync(
@@ -272,13 +294,58 @@ internal static class AdminOidcEndpoints
             descriptor.ApplicationType = request.Type;
         }
 
+        if (request.ConsentType is not null)
+        {
+            descriptor.ConsentType = request.ConsentType;
+        }
+
+        if (request.Permissions is not null)
+        {
+            descriptor.Permissions.Clear();
+            foreach (string permission in request.Permissions)
+            {
+                descriptor.Permissions.Add(permission);
+            }
+        }
+
+        if (request.RedirectUris is not null)
+        {
+            descriptor.RedirectUris.Clear();
+            foreach (string uri in request.RedirectUris)
+            {
+                descriptor.RedirectUris.Add(new Uri(uri));
+            }
+        }
+
+        if (request.PostLogoutRedirectUris is not null)
+        {
+            descriptor.PostLogoutRedirectUris.Clear();
+            foreach (string uri in request.PostLogoutRedirectUris)
+            {
+                descriptor.PostLogoutRedirectUris.Add(new Uri(uri));
+            }
+        }
+
+        if (request.SigningKeyJwk is not null)
+        {
+            // Empty string = clear the key; non-empty = update
+            descriptor.JsonWebKeySet = !string.IsNullOrEmpty(request.SigningKeyJwk)
+                ? BuildJsonWebKeySet(request.SigningKeyJwk)
+                : null;
+        }
+
+        if (request.ClientSide is not null)
+        {
+            descriptor.SetClientSide(request.ClientSide.Value);
+        }
+
         await applicationManager.UpdateAsync(app, descriptor, cancellationToken).ConfigureAwait(false);
 
-        string? updatedDisplayName = await applicationManager.GetDisplayNameAsync(app, cancellationToken).ConfigureAwait(false);
-        string? updatedType = await applicationManager.GetApplicationTypeAsync(app, cancellationToken).ConfigureAwait(false);
-        Guid? tenantId = app is GranitOpenIddictApplication updatedGranitApp ? updatedGranitApp.TenantId : null;
+        var responseDescriptor = new OpenIddictApplicationDescriptor();
+        await applicationManager.PopulateAsync(responseDescriptor, app, cancellationToken).ConfigureAwait(false);
+        Guid? tenantId = app is GranitOpenIddictApplication granitApp ? granitApp.TenantId : null;
 
-        return TypedResults.Ok(new AdminOidcApplicationResponse(clientId, updatedDisplayName, updatedType, tenantId));
+        return TypedResults.Ok(ToResponse(responseDescriptor, tenantId));
     }
 
     // ──── Scope handlers ────
@@ -485,5 +552,44 @@ internal static class AdminOidcEndpoints
         }
 
         return TypedResults.NoContent();
+    }
+
+    // ──── Helpers ────
+
+    private static AdminOidcApplicationResponse ToResponse(
+        OpenIddictApplicationDescriptor descriptor, Guid? tenantId) =>
+        new(
+            descriptor.ClientId,
+            descriptor.DisplayName,
+            descriptor.ApplicationType,
+            tenantId,
+            [.. descriptor.Permissions],
+            [.. descriptor.RedirectUris.Select(u => u.ToString())],
+            [.. descriptor.PostLogoutRedirectUris.Select(u => u.ToString())],
+            descriptor.ConsentType,
+            descriptor.GetClientSide(),
+            descriptor.JsonWebKeySet is not null);
+
+    /// <summary>
+    /// Builds a <see cref="JsonWebKeySet"/> from a JWK JSON string,
+    /// stripping private key parameters so only the public key is stored.
+    /// </summary>
+    private static JsonWebKeySet BuildJsonWebKeySet(string jwkJson)
+    {
+        var jwk = new JsonWebKey(jwkJson);
+
+        // Strip private key parameters — only store the public key
+        jwk.D = null;
+        jwk.P = null;
+        jwk.Q = null;
+        jwk.DP = null;
+        jwk.DQ = null;
+        jwk.QI = null;
+
+        jwk.Use = JsonWebKeyUseNames.Sig;
+
+        var jwks = new JsonWebKeySet();
+        jwks.Keys.Add(jwk);
+        return jwks;
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcCreateApplicationRequestValidator.cs
+++ b/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcCreateApplicationRequestValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.Validation;
+using Granit.Validation.Extensions;
 
 namespace Granit.OpenIddict.Endpoints.Validators;
 
@@ -17,5 +18,15 @@ internal sealed class AdminOidcCreateApplicationRequestValidator : GranitValidat
 
         RuleFor(x => x.DisplayName)
             .MaximumLength(256);
+
+        RuleForEach(x => x.RedirectUris)
+            .NotEmpty()
+            .AbsoluteUri()
+            .When(x => x.RedirectUris is not null);
+
+        RuleForEach(x => x.PostLogoutRedirectUris)
+            .NotEmpty()
+            .AbsoluteUri()
+            .When(x => x.PostLogoutRedirectUris is not null);
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcUpdateApplicationRequestValidator.cs
+++ b/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcUpdateApplicationRequestValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.Validation;
+using Granit.Validation.Extensions;
 
 namespace Granit.OpenIddict.Endpoints.Validators;
 
@@ -13,5 +14,15 @@ internal sealed class AdminOidcUpdateApplicationRequestValidator : GranitValidat
     {
         RuleFor(x => x.DisplayName)
             .MaximumLength(256);
+
+        RuleForEach(x => x.RedirectUris)
+            .NotEmpty()
+            .AbsoluteUri()
+            .When(x => x.RedirectUris is not null);
+
+        RuleForEach(x => x.PostLogoutRedirectUris)
+            .NotEmpty()
+            .AbsoluteUri()
+            .When(x => x.PostLogoutRedirectUris is not null);
     }
 }

--- a/src/Granit.Validation/Extensions/NetworkValidatorExtensions.cs
+++ b/src/Granit.Validation/Extensions/NetworkValidatorExtensions.cs
@@ -28,6 +28,18 @@ public static partial class NetworkValidatorExtensions
     private static partial Regex MacAddressRegex();
 
     /// <summary>
+    /// Validates an absolute URI (any scheme: <c>https://</c>, <c>http://</c>, <c>myapp://</c>, etc.).
+    /// </summary>
+    /// <remarks>
+    /// Suitable for OIDC redirect and post-logout redirect URIs, which may use custom schemes
+    /// (e.g. <c>com.example.app://callback</c>) in addition to standard HTTP(S) origins.
+    /// </remarks>
+    public static IRuleBuilderOptions<T, string?> AbsoluteUri<T>(this IRuleBuilder<T, string?> ruleBuilder) =>
+        ruleBuilder
+            .Must(value => value != null && Uri.TryCreate(value.Trim(), UriKind.Absolute, out _))
+            .WithErrorCodeAndMessage("Validation:InvalidAbsoluteUri");
+
+    /// <summary>
     /// Validates a URL with a required <c>http</c> or <c>https</c> scheme per RFC 3986.
     /// </summary>
     /// <remarks>

--- a/src/Granit.Validation/Localization/Validation/cs.json
+++ b/src/Granit.Validation/Localization/Validation/cs.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "MAC adresa je neplatná (očekávaný formát: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "Identifikátor věřitele SEPA (SCI) je neplatný.",
     "Validation:InvalidSlug": "Hodnota není platný slug (povolena jsou pouze malá písmena, číslice a pomlčky).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' musí být platné absolutní URI.",
     "Validation:InvalidUrl": "URL adresa je neplatná (očekávána adresa http nebo https).",
     "Validation:InvalidUuid": "UUID je neplatné (očekávaný formát: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' musí mít délku {MinLength} až {MaxLength} znaků. Zadali jste {TotalLength} znaků.",

--- a/src/Granit.Validation/Localization/Validation/de.json
+++ b/src/Granit.Validation/Localization/Validation/de.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "Die MAC-Adresse ist ungültig (erwartetes Format: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "Die SEPA-Gläubiger-Identifikationsnummer (SCI) ist ungültig.",
     "Validation:InvalidSlug": "Der Wert ist kein gültiger Slug (nur Kleinbuchstaben, Ziffern und Bindestriche erlaubt).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' muss ein gültiger absoluter URI sein.",
     "Validation:InvalidUrl": "Die URL ist ungültig (eine http- oder https-URL wird erwartet).",
     "Validation:InvalidUuid": "Die UUID ist ungültig (erwartetes Format: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' muss zwischen {MinLength} und {MaxLength} Zeichen lang sein. Sie haben {TotalLength} Zeichen eingegeben.",

--- a/src/Granit.Validation/Localization/Validation/en.json
+++ b/src/Granit.Validation/Localization/Validation/en.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "The MAC address is invalid (expected format: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "The SEPA Creditor Identifier (SCI) is invalid.",
     "Validation:InvalidSlug": "The value is not a valid slug (only lowercase letters, digits and hyphens allowed).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' must be a valid absolute URI.",
     "Validation:InvalidUrl": "The URL is invalid (expected an http or https URL).",
     "Validation:InvalidUuid": "The UUID is invalid (expected format: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' must be between {MinLength} and {MaxLength} characters. You entered {TotalLength} characters.",

--- a/src/Granit.Validation/Localization/Validation/es.json
+++ b/src/Granit.Validation/Localization/Validation/es.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "La dirección MAC no es válida (formato esperado: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "El identificador de acreedor SEPA (SCI) no es válido.",
     "Validation:InvalidSlug": "El valor no es un slug válido (solo se permiten letras minúsculas, dígitos y guiones).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' debe ser un URI absoluto válido.",
     "Validation:InvalidUrl": "La URL no es válida (se espera una URL http o https).",
     "Validation:InvalidUuid": "El UUID no es válido (formato esperado: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' debe tener entre {MinLength} y {MaxLength} caracteres. Ha introducido {TotalLength} caracteres.",

--- a/src/Granit.Validation/Localization/Validation/fr.json
+++ b/src/Granit.Validation/Localization/Validation/fr.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "L'adresse MAC est invalide (format attendu : 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "L'identifiant créancier SEPA (SCI) est invalide.",
     "Validation:InvalidSlug": "La valeur n'est pas un slug valide (seuls les lettres minuscules, chiffres et tirets sont autorisés).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' doit être un URI absolu valide.",
     "Validation:InvalidUrl": "L'URL est invalide (URL http ou https attendue).",
     "Validation:InvalidUuid": "L'UUID est invalide (format attendu : 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' doit contenir entre {MinLength} et {MaxLength} caractères. Vous avez saisi {TotalLength} caractères.",

--- a/src/Granit.Validation/Localization/Validation/hi.json
+++ b/src/Granit.Validation/Localization/Validation/hi.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "MAC पता अमान्य है (अपेक्षित प्रारूप: 00:1A:2B:3C:4D:5E)।",
     "Validation:InvalidSepaCreditorIdentifier": "SEPA क्रेडिटर आइडेंटिफ़ायर (SCI) अमान्य है।",
     "Validation:InvalidSlug": "यह मान एक मान्य स्लग नहीं है (केवल लोअरकेस अक्षर, अंक और हाइफ़न अनुमत हैं)।",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' एक मान्य पूर्ण URI होना चाहिए।",
     "Validation:InvalidUrl": "URL अमान्य है (http या https URL अपेक्षित है)।",
     "Validation:InvalidUuid": "UUID अमान्य है (अपेक्षित प्रारूप: 550e8400-e29b-41d4-a716-446655440000)।",
     "Validation:LengthValidator": "'{PropertyName}' {MinLength} और {MaxLength} अक्षरों के बीच होना चाहिए। आपने {TotalLength} अक्षर दर्ज किए।",

--- a/src/Granit.Validation/Localization/Validation/it.json
+++ b/src/Granit.Validation/Localization/Validation/it.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "L'indirizzo MAC non è valido (formato previsto: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "L'identificativo creditore SEPA (SCI) non è valido.",
     "Validation:InvalidSlug": "Il valore non è uno slug valido (sono ammessi solo lettere minuscole, cifre e trattini).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' deve essere un URI assoluto valido.",
     "Validation:InvalidUrl": "L'URL non è valido (URL http o https previsto).",
     "Validation:InvalidUuid": "L'UUID non è valido (formato previsto: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' deve contenere tra {MinLength} e {MaxLength} caratteri. Sono stati inseriti {TotalLength} caratteri.",

--- a/src/Granit.Validation/Localization/Validation/ja.json
+++ b/src/Granit.Validation/Localization/Validation/ja.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "MACアドレスが無効です（例：00:1A:2B:3C:4D:5E）。",
     "Validation:InvalidSepaCreditorIdentifier": "SEPA 債権者識別子（SCI）が無効です。",
     "Validation:InvalidSlug": "値が有効なスラッグではありません（小文字、数字、ハイフンのみ使用可能です）。",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' は有効な絶対 URI でなければなりません。",
     "Validation:InvalidUrl": "URLが無効です（httpまたはhttpsのURLが必要です）。",
     "Validation:InvalidUuid": "UUIDが無効です（例：550e8400-e29b-41d4-a716-446655440000）。",
     "Validation:LengthValidator": "'{PropertyName}' は {MinLength} 文字以上 {MaxLength} 文字以下である必要があります。{TotalLength} 文字入力されました。",

--- a/src/Granit.Validation/Localization/Validation/ko.json
+++ b/src/Granit.Validation/Localization/Validation/ko.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "MAC 주소가 유효하지 않습니다(예: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "SEPA 채권자 식별자(SCI)가 유효하지 않습니다.",
     "Validation:InvalidSlug": "값이 유효한 슬러그가 아닙니다(소문자, 숫자, 하이픈만 허용됩니다).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}'은(는) 유효한 절대 URI여야 합니다.",
     "Validation:InvalidUrl": "URL이 유효하지 않습니다(http 또는 https URL 필요).",
     "Validation:InvalidUuid": "UUID가 유효하지 않습니다(예: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}'은(는) {MinLength}자에서 {MaxLength}자 사이여야 합니다. {TotalLength}자를 입력하셨습니다.",

--- a/src/Granit.Validation/Localization/Validation/nl.json
+++ b/src/Granit.Validation/Localization/Validation/nl.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "Het MAC-adres is ongeldig (verwacht formaat: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "De SEPA Creditor Identifier (SCI) is ongeldig.",
     "Validation:InvalidSlug": "De waarde is geen geldige slug (alleen kleine letters, cijfers en koppeltekens toegestaan).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' moet een geldige absolute URI zijn.",
     "Validation:InvalidUrl": "De URL is ongeldig (een http- of https-URL wordt verwacht).",
     "Validation:InvalidUuid": "De UUID is ongeldig (verwacht formaat: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' moet tussen {MinLength} en {MaxLength} tekens bevatten. U hebt {TotalLength} tekens ingevoerd.",

--- a/src/Granit.Validation/Localization/Validation/pl.json
+++ b/src/Granit.Validation/Localization/Validation/pl.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "Adres MAC jest nieprawidłowy (oczekiwany format: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "Identyfikator wierzyciela SEPA (SCI) jest nieprawidłowy.",
     "Validation:InvalidSlug": "Wartość nie jest prawidłowym slugiem (dozwolone są tylko małe litery, cyfry i myślniki).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' musi być prawidłowym bezwzględnym identyfikatorem URI.",
     "Validation:InvalidUrl": "Adres URL jest nieprawidłowy (oczekiwano adresu http lub https).",
     "Validation:InvalidUuid": "UUID jest nieprawidłowy (oczekiwany format: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' musi mieć od {MinLength} do {MaxLength} znaków. Wprowadzono {TotalLength} znaków.",

--- a/src/Granit.Validation/Localization/Validation/pt.json
+++ b/src/Granit.Validation/Localization/Validation/pt.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "O endereço MAC é inválido (formato esperado: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "O identificador de credor SEPA (SCI) é inválido.",
     "Validation:InvalidSlug": "O valor não é um slug válido (apenas letras minúsculas, dígitos e hífens são permitidos).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' deve ser um URI absoluto válido.",
     "Validation:InvalidUrl": "O URL é inválido (URL http ou https esperado).",
     "Validation:InvalidUuid": "O UUID é inválido (formato esperado: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' deve ter entre {MinLength} e {MaxLength} caracteres. Foram introduzidos {TotalLength} caracteres.",

--- a/src/Granit.Validation/Localization/Validation/sv.json
+++ b/src/Granit.Validation/Localization/Validation/sv.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "MAC-adressen är ogiltig (förväntat format: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "SEPA-borgenärsidentifieraren (SCI) är ogiltig.",
     "Validation:InvalidSlug": "Värdet är inte en giltig slug (bara små bokstäver, siffror och bindestreck tillåtna).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' måste vara en giltig absolut URI.",
     "Validation:InvalidUrl": "URL:en är ogiltig (en http- eller https-URL förväntas).",
     "Validation:InvalidUuid": "UUID är ogiltigt (förväntat format: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' måste vara mellan {MinLength} och {MaxLength} tecken. Du angav {TotalLength} tecken.",

--- a/src/Granit.Validation/Localization/Validation/tr.json
+++ b/src/Granit.Validation/Localization/Validation/tr.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "MAC adresi geçersiz (beklenen biçim: 00:1A:2B:3C:4D:5E).",
     "Validation:InvalidSepaCreditorIdentifier": "SEPA Alacaklı Tanımlayıcısı (SCI) geçersiz.",
     "Validation:InvalidSlug": "Değer geçerli bir slug değil (yalnızca küçük harfler, rakamlar ve kısa çizgiler kullanılabilir).",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' geçerli bir mutlak URI olmalıdır.",
     "Validation:InvalidUrl": "URL geçersiz (http veya https URL bekleniyor).",
     "Validation:InvalidUuid": "UUID geçersiz (beklenen biçim: 550e8400-e29b-41d4-a716-446655440000).",
     "Validation:LengthValidator": "'{PropertyName}' {MinLength} ile {MaxLength} karakter arasında olmalıdır. {TotalLength} karakter girdiniz.",

--- a/src/Granit.Validation/Localization/Validation/zh.json
+++ b/src/Granit.Validation/Localization/Validation/zh.json
@@ -38,6 +38,7 @@
     "Validation:InvalidMacAddress": "MAC 地址无效（格式示例：00:1A:2B:3C:4D:5E）。",
     "Validation:InvalidSepaCreditorIdentifier": "SEPA 债权人标识符（SCI）无效。",
     "Validation:InvalidSlug": "值不是有效的 slug（仅允许小写字母、数字和连字符）。",
+    "Validation:InvalidAbsoluteUri": "'{PropertyName}' 必须是有效的绝对 URI。",
     "Validation:InvalidUrl": "URL 无效（需要 http 或 https URL）。",
     "Validation:InvalidUuid": "UUID 无效（格式示例：550e8400-e29b-41d4-a716-446655440000）。",
     "Validation:LengthValidator": "'{PropertyName}' 必须在 {MinLength} 到 {MaxLength} 个字符之间。您输入了 {TotalLength} 个字符。",

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -47,19 +47,29 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         _server.ApplicationManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable<object>(app1, app2));
 
-        _server.ApplicationManager.GetClientIdAsync(app1, Arg.Any<CancellationToken>())
-            .Returns("client-1");
-        _server.ApplicationManager.GetDisplayNameAsync(app1, Arg.Any<CancellationToken>())
-            .Returns("App One");
-        _server.ApplicationManager.GetApplicationTypeAsync(app1, Arg.Any<CancellationToken>())
-            .Returns("web");
+#pragma warning disable CA2012 // NSubstitute mock setup intentionally doesn't await ValueTask
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), app1, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "client-1";
+                d.DisplayName = "App One";
+                d.ApplicationType = "web";
+                return new ValueTask();
+            });
 
-        _server.ApplicationManager.GetClientIdAsync(app2, Arg.Any<CancellationToken>())
-            .Returns("client-2");
-        _server.ApplicationManager.GetDisplayNameAsync(app2, Arg.Any<CancellationToken>())
-            .Returns("App Two");
-        _server.ApplicationManager.GetApplicationTypeAsync(app2, Arg.Any<CancellationToken>())
-            .Returns("native");
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), app2, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "client-2";
+                d.DisplayName = "App Two";
+                d.ApplicationType = "native";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
 
         HttpResponseMessage response = await _server.AuthenticatedClient
             .GetAsync("/admin/oidc/applications", TestContext.Current.CancellationToken);
@@ -101,12 +111,18 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
             Arg.Any<OpenIddictApplicationDescriptor>(),
             Arg.Any<CancellationToken>())
             .Returns(createdApp);
-        _server.ApplicationManager.GetClientIdAsync(createdApp, Arg.Any<CancellationToken>())
-            .Returns("new-client");
-        _server.ApplicationManager.GetDisplayNameAsync(createdApp, Arg.Any<CancellationToken>())
-            .Returns("New App");
-        _server.ApplicationManager.GetApplicationTypeAsync(createdApp, Arg.Any<CancellationToken>())
-            .Returns("web");
+#pragma warning disable CA2012 // NSubstitute mock setup intentionally doesn't await ValueTask
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), createdApp, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "new-client";
+                d.DisplayName = "New App";
+                d.ApplicationType = "web";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
 
         AdminOidcCreateApplicationRequest request = new("new-client", "New App", null, "web");
 


### PR DESCRIPTION
## Summary

- Adds `Permissions`, `RedirectUris`, `PostLogoutRedirectUris`, `ConsentType`, `SigningKeyJwk`, and `ClientSide` to create/update request DTOs and `AdminOidcApplicationResponse`, bringing the admin API to parity with `OidcApplicationSeedDescriptor`
- Uses `PopulateAsync` for all read paths (list + post-create/update) to populate all fields in a single manager call instead of multiple individual `Get*Async` calls
- Adds `AbsoluteUri()` FluentValidation extension to `Granit.Validation` (accepts any absolute URI scheme — custom OIDC schemes like `myapp://` are valid redirect URIs) with locale keys in all 15 base language files

## Notable behaviour

- `SigningKeyJwk` on create/update strips private key params (D, P, Q, DP, DQ, QI) and sets `Use = "sig"` before storage — mirrors `OpenIddictSeedContributor` logic
- Empty string `SigningKeyJwk` on update clears the key (null = leave unchanged)
- `HasSigningKey` on the response avoids serialising `JsonWebKeySet` back to JSON; callers know a key is configured without receiving key material

## Test plan

- [ ] `ListApplications_ReturnsApplications` — updated to mock `PopulateAsync` instead of individual `Get*Async` calls
- [ ] `CreateApplication_ReturnsCreated` — updated to mock `PopulateAsync`
- [ ] All 72 tests pass (`Granit.OpenIddict.Endpoints.Tests`)
- [ ] Build clean: 0 warnings, 0 errors on `Granit.OpenIddict.Endpoints` and `Granit.Validation`