### PR TITLE
feat(openiddict): expose Resources field on admin scope endpoints

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36048,7 +36048,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs",
-      "line": 9,
+      "line": 10,
       "members": []
     },
     {
@@ -36066,7 +36066,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcScopeResponse.cs",
-      "line": 9,
+      "line": 10,
       "members": []
     },
     {
@@ -36084,7 +36084,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateScopeRequest.cs",
-      "line": 8,
+      "line": 9,
       "members": []
     },
     {

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs
@@ -6,7 +6,9 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="Name">The scope name (unique).</param>
 /// <param name="DisplayName">A human-readable display name.</param>
 /// <param name="Description">An optional human-readable description.</param>
+/// <param name="Resources">Resource server identifiers associated with this scope.</param>
 public sealed record AdminOidcCreateScopeRequest(
     string Name,
     string? DisplayName = null,
-    string? Description = null);
+    string? Description = null,
+    string[]? Resources = null);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcScopeResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcScopeResponse.cs
@@ -6,7 +6,9 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="Name">The scope name.</param>
 /// <param name="DisplayName">The display name.</param>
 /// <param name="Description">Human-readable description.</param>
+/// <param name="Resources">Resource server identifiers associated with this scope.</param>
 public sealed record AdminOidcScopeResponse(
     string? Name,
     string? DisplayName,
-    string? Description);
+    string? Description,
+    string[] Resources);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateScopeRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateScopeRequest.cs
@@ -5,6 +5,8 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// </summary>
 /// <param name="DisplayName">A human-readable display name. Null leaves unchanged.</param>
 /// <param name="Description">An optional human-readable description. Null leaves unchanged.</param>
+/// <param name="Resources">Resource server identifiers. Null leaves unchanged; empty array clears all.</param>
 public sealed record AdminOidcUpdateScopeRequest(
     string? DisplayName = null,
-    string? Description = null);
+    string? Description = null,
+    string[]? Resources = null);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -358,10 +358,9 @@ internal static class AdminOidcEndpoints
 
         await foreach (object scope in scopeManager.ListAsync(100, 0, cancellationToken).ConfigureAwait(false))
         {
-            string? name = await scopeManager.GetNameAsync(scope, cancellationToken).ConfigureAwait(false);
-            string? displayName = await scopeManager.GetDisplayNameAsync(scope, cancellationToken).ConfigureAwait(false);
-            string? description = await scopeManager.GetDescriptionAsync(scope, cancellationToken).ConfigureAwait(false);
-            results.Add(new AdminOidcScopeResponse(name, displayName, description));
+            var descriptor = new OpenIddictScopeDescriptor();
+            await scopeManager.PopulateAsync(descriptor, scope, cancellationToken).ConfigureAwait(false);
+            results.Add(ToScopeResponse(descriptor));
         }
 
         return TypedResults.Ok<IReadOnlyList<AdminOidcScopeResponse>>(results);
@@ -379,15 +378,19 @@ internal static class AdminOidcEndpoints
             Description = request.Description,
         };
 
+        foreach (string resource in request.Resources ?? [])
+        {
+            descriptor.Resources.Add(resource);
+        }
+
         object scope = await scopeManager.CreateAsync(descriptor, cancellationToken).ConfigureAwait(false);
 
-        string? name = await scopeManager.GetNameAsync(scope, cancellationToken).ConfigureAwait(false);
-        string? displayName = await scopeManager.GetDisplayNameAsync(scope, cancellationToken).ConfigureAwait(false);
-        string? description = await scopeManager.GetDescriptionAsync(scope, cancellationToken).ConfigureAwait(false);
+        var responseDescriptor = new OpenIddictScopeDescriptor();
+        await scopeManager.PopulateAsync(responseDescriptor, scope, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Created(
-            $"/admin/oidc/scopes/{name}",
-            new AdminOidcScopeResponse(name, displayName, description));
+            $"/admin/oidc/scopes/{responseDescriptor.Name}",
+            ToScopeResponse(responseDescriptor));
     }
 
     private static async Task<Results<Ok<AdminOidcScopeResponse>, ProblemHttpResult>> UpdateScopeAsync(
@@ -415,13 +418,21 @@ internal static class AdminOidcEndpoints
             descriptor.Description = request.Description;
         }
 
+        if (request.Resources is not null)
+        {
+            descriptor.Resources.Clear();
+            foreach (string resource in request.Resources)
+            {
+                descriptor.Resources.Add(resource);
+            }
+        }
+
         await scopeManager.UpdateAsync(scope, descriptor, cancellationToken).ConfigureAwait(false);
 
-        string? name = await scopeManager.GetNameAsync(scope, cancellationToken).ConfigureAwait(false);
-        string? displayName = await scopeManager.GetDisplayNameAsync(scope, cancellationToken).ConfigureAwait(false);
-        string? description = await scopeManager.GetDescriptionAsync(scope, cancellationToken).ConfigureAwait(false);
+        var responseDescriptor = new OpenIddictScopeDescriptor();
+        await scopeManager.PopulateAsync(responseDescriptor, scope, cancellationToken).ConfigureAwait(false);
 
-        return TypedResults.Ok(new AdminOidcScopeResponse(name, displayName, description));
+        return TypedResults.Ok(ToScopeResponse(responseDescriptor));
     }
 
     private static async Task<Results<NoContent, ProblemHttpResult>> DeleteScopeAsync(
@@ -555,6 +566,13 @@ internal static class AdminOidcEndpoints
     }
 
     // ──── Helpers ────
+
+    private static AdminOidcScopeResponse ToScopeResponse(OpenIddictScopeDescriptor descriptor) =>
+        new(
+            descriptor.Name,
+            descriptor.DisplayName,
+            descriptor.Description,
+            [.. descriptor.Resources]);
 
     private static AdminOidcApplicationResponse ToResponse(
         OpenIddictApplicationDescriptor descriptor, Guid? tenantId) =>

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -330,19 +330,26 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         _server.ScopeManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable<object>(scope1, scope2));
 
-        _server.ScopeManager.GetNameAsync(scope1, Arg.Any<CancellationToken>())
-            .Returns("openid");
-        _server.ScopeManager.GetDisplayNameAsync(scope1, Arg.Any<CancellationToken>())
-            .Returns("OpenID");
-        _server.ScopeManager.GetDescriptionAsync(scope1, Arg.Any<CancellationToken>())
-            .Returns("OpenID Connect scope");
+#pragma warning disable CA2012
+        _server.ScopeManager
+            .PopulateAsync(Arg.Any<OpenIddictScopeDescriptor>(), scope1, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.Name = "openid"; d.DisplayName = "OpenID"; d.Description = "OpenID Connect scope";
+                return new ValueTask();
+            });
 
-        _server.ScopeManager.GetNameAsync(scope2, Arg.Any<CancellationToken>())
-            .Returns("profile");
-        _server.ScopeManager.GetDisplayNameAsync(scope2, Arg.Any<CancellationToken>())
-            .Returns("Profile");
-        _server.ScopeManager.GetDescriptionAsync(scope2, Arg.Any<CancellationToken>())
-            .Returns("User profile scope");
+        _server.ScopeManager
+            .PopulateAsync(Arg.Any<OpenIddictScopeDescriptor>(), scope2, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.Name = "profile"; d.DisplayName = "Profile"; d.Description = "User profile scope";
+                d.Resources.Add("api://granit");
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
 
         HttpResponseMessage response = await _server.AuthenticatedClient
             .GetAsync("/admin/oidc/scopes", TestContext.Current.CancellationToken);
@@ -358,10 +365,12 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         result[0].Name.ShouldBe("openid");
         result[0].DisplayName.ShouldBe("OpenID");
         result[0].Description.ShouldBe("OpenID Connect scope");
+        result[0].Resources.ShouldBeEmpty();
 
         result[1].Name.ShouldBe("profile");
         result[1].DisplayName.ShouldBe("Profile");
         result[1].Description.ShouldBe("User profile scope");
+        result[1].Resources.ShouldBe(["api://granit"]);
     }
 
     [Fact]
@@ -382,14 +391,23 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
             Arg.Any<OpenIddictScopeDescriptor>(),
             Arg.Any<CancellationToken>())
             .Returns(createdScope);
-        _server.ScopeManager.GetNameAsync(createdScope, Arg.Any<CancellationToken>())
-            .Returns("custom_scope");
-        _server.ScopeManager.GetDisplayNameAsync(createdScope, Arg.Any<CancellationToken>())
-            .Returns("Custom Scope");
-        _server.ScopeManager.GetDescriptionAsync(createdScope, Arg.Any<CancellationToken>())
-            .Returns("A custom OIDC scope");
 
-        AdminOidcCreateScopeRequest request = new("custom_scope", "Custom Scope", "A custom OIDC scope");
+#pragma warning disable CA2012
+        _server.ScopeManager
+            .PopulateAsync(Arg.Any<OpenIddictScopeDescriptor>(), createdScope, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.Name = "custom_scope"; d.DisplayName = "Custom Scope";
+                d.Description = "A custom OIDC scope";
+                d.Resources.Add("api://my-resource");
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcCreateScopeRequest request = new(
+            "custom_scope", "Custom Scope", "A custom OIDC scope",
+            Resources: ["api://my-resource"]);
 
         HttpResponseMessage response = await _server.AuthenticatedClient
             .PostAsJsonAsync("/admin/oidc/scopes", request, TestContext.Current.CancellationToken);
@@ -404,6 +422,7 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         result.Name.ShouldBe("custom_scope");
         result.DisplayName.ShouldBe("Custom Scope");
         result.Description.ShouldBe("A custom OIDC scope");
+        result.Resources.ShouldBe(["api://my-resource"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Adds `Resources` (resource server identifiers) to `AdminOidcScopeResponse`, `AdminOidcCreateScopeRequest`, and `AdminOidcUpdateScopeRequest`
- Brings scope endpoints to parity with `OidcScopeSeedDescriptor` — the field was used in seeding and the export definition, but never surfaced on the admin API
- Refactors scope read paths (`ListScopesAsync`, `CreateScopeAsync`, `UpdateScopeAsync`) to use `PopulateAsync` instead of individual `Get*Async` calls, mirroring the pattern introduced for applications in #2578

## Behaviour

- `Resources: null` on update → leaves resources unchanged
- `Resources: []` on update → clears all resources
- Response always includes `resources: []` (never null)

## Test plan

- [ ] `ListScopes_ReturnsScopes` — updated to mock `PopulateAsync`, verifies `Resources` on each scope
- [ ] `CreateScope_ReturnsCreated` — updated to mock `PopulateAsync`, verifies `Resources` in response
- [ ] All 72 tests pass
- [ ] Build clean: 0 warnings, 0 errors