### PR TITLE
fix(openiddict): complete admin endpoint and seeding gaps

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36021,7 +36021,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcAuthorizationResponse.cs",
-      "line": 11,
+      "line": 12,
       "members": []
     },
     {
@@ -36575,7 +36575,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 36,
+      "line": 37,
       "members": []
     },
     {
@@ -36584,7 +36584,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 53,
+      "line": 56,
       "members": []
     },
     {

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcAuthorizationResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcAuthorizationResponse.cs
@@ -8,9 +8,11 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="ClientId">The client identifier.</param>
 /// <param name="Status">The authorization status.</param>
 /// <param name="Type">The authorization type (permanent, ad-hoc).</param>
+/// <param name="Scopes">The granted scopes.</param>
 public sealed record AdminOidcAuthorizationResponse(
     Guid Id,
     string? Subject,
     string? ClientId,
     string? Status,
-    string? Type);
+    string? Type,
+    string[] Scopes);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -31,6 +31,14 @@ internal static class AdminOidcEndpoints
             .Produces<IReadOnlyList<AdminOidcApplicationResponse>>()
             .RequireAuthorization(OpenIddictPermissions.Applications.Read);
 
+        apps.MapGet("/{clientId}", GetApplicationAsync)
+            .WithName("GetOidcApplication")
+            .WithSummary("Returns a single OIDC application by client ID.")
+            .WithDescription("Returns the full configuration of the specified OIDC client application. Returns 404 if no application with the given client ID exists.")
+            .Produces<AdminOidcApplicationResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(OpenIddictPermissions.Applications.Read);
+
         apps.MapPost("/", CreateApplicationAsync)
             .WithName("CreateOidcApplication")
             .WithSummary("Creates a new OIDC application.")
@@ -152,6 +160,24 @@ internal static class AdminOidcEndpoints
     }
 
     // ──── Application handlers ────
+
+    private static async Task<Results<Ok<AdminOidcApplicationResponse>, ProblemHttpResult>> GetApplicationAsync(
+        string clientId,
+        [FromServices] IOpenIddictApplicationManager applicationManager,
+        CancellationToken cancellationToken)
+    {
+        object? app = await applicationManager.FindByClientIdAsync(clientId, cancellationToken).ConfigureAwait(false);
+        if (app is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        var descriptor = new OpenIddictApplicationDescriptor();
+        await applicationManager.PopulateAsync(descriptor, app, cancellationToken).ConfigureAwait(false);
+        Guid? tenantId = app is GranitOpenIddictApplication granitApp ? granitApp.TenantId : null;
+
+        return TypedResults.Ok(ToResponse(descriptor, tenantId));
+    }
 
     private static async Task<Ok<IReadOnlyList<AdminOidcApplicationResponse>>> ListApplicationsAsync(
         [FromServices] IOpenIddictApplicationManager applicationManager,

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -95,7 +95,7 @@ internal static class AdminOidcEndpoints
         scopes.MapPut("/{scopeName}", UpdateScopeAsync)
             .WithName("UpdateOidcScope")
             .WithSummary("Updates an OIDC scope.")
-            .WithDescription("Updates the display name or description of an existing OIDC scope. Null fields are left unchanged. Returns 404 if the scope does not exist.")
+            .WithDescription("Updates the display name, description, or resource server identifiers of an existing OIDC scope. Null fields are left unchanged; an empty Resources array clears all resources. Returns 404 if the scope does not exist.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<AdminOidcScopeResponse>()
             .ProducesValidationProblem()
@@ -484,32 +484,47 @@ internal static class AdminOidcEndpoints
         object auth = await authorizationManager.CreateAsync(descriptor, cancellationToken).ConfigureAwait(false);
 
         string? id = await authorizationManager.GetIdAsync(auth, cancellationToken).ConfigureAwait(false);
-        string? status = await authorizationManager.GetStatusAsync(auth, cancellationToken).ConfigureAwait(false);
-        string? type = await authorizationManager.GetTypeAsync(auth, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Created(
             $"/admin/oidc/authorizations/{id}",
             new AdminOidcAuthorizationResponse(
                 Guid.TryParse(id, out Guid parsedId) ? parsedId : Guid.Empty,
-                request.Subject, request.ClientId, status, type));
+                request.Subject, request.ClientId,
+                descriptor.Status, descriptor.Type,
+                [.. descriptor.Scopes]));
     }
 
     private static async Task<Ok<IReadOnlyList<AdminOidcAuthorizationResponse>>> ListAuthorizationsAsync(
         [FromServices] IOpenIddictAuthorizationManager authorizationManager,
+        [FromServices] IOpenIddictApplicationManager applicationManager,
         CancellationToken cancellationToken)
     {
         var results = new List<AdminOidcAuthorizationResponse>();
+        var clientIdCache = new Dictionary<string, string?>(StringComparer.Ordinal);
 
         await foreach (object auth in authorizationManager.ListAsync(100, 0, cancellationToken).ConfigureAwait(false))
         {
             string? id = await authorizationManager.GetIdAsync(auth, cancellationToken).ConfigureAwait(false);
-            string? subject = await authorizationManager.GetSubjectAsync(auth, cancellationToken).ConfigureAwait(false);
-            string? status = await authorizationManager.GetStatusAsync(auth, cancellationToken).ConfigureAwait(false);
-            string? type = await authorizationManager.GetTypeAsync(auth, cancellationToken).ConfigureAwait(false);
+            var descriptor = new OpenIddictAuthorizationDescriptor();
+            await authorizationManager.PopulateAsync(descriptor, auth, cancellationToken).ConfigureAwait(false);
+
+            string? clientId = null;
+            if (descriptor.ApplicationId is not null)
+            {
+                if (!clientIdCache.TryGetValue(descriptor.ApplicationId, out clientId))
+                {
+                    object? app = await applicationManager.FindByIdAsync(descriptor.ApplicationId, cancellationToken).ConfigureAwait(false);
+                    clientId = app is not null
+                        ? await applicationManager.GetClientIdAsync(app, cancellationToken).ConfigureAwait(false)
+                        : null;
+                    clientIdCache[descriptor.ApplicationId] = clientId;
+                }
+            }
 
             results.Add(new AdminOidcAuthorizationResponse(
                 Guid.TryParse(id, out Guid parsedId) ? parsedId : Guid.Empty,
-                subject, null, status, type));
+                descriptor.Subject, clientId, descriptor.Status, descriptor.Type,
+                [.. descriptor.Scopes]));
         }
 
         return TypedResults.Ok<IReadOnlyList<AdminOidcAuthorizationResponse>>(results);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectVerifyEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectVerifyEndpoints.cs
@@ -1,11 +1,20 @@
+using System.Collections.Immutable;
+using System.Security.Claims;
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Endpoints.Internal;
 using Granit.OpenIddict.Endpoints.Options;
 using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
 
 namespace Granit.OpenIddict.Endpoints.Endpoints;
 
@@ -20,12 +29,16 @@ namespace Granit.OpenIddict.Endpoints.Endpoints;
 /// <c>/connect/verify</c>, enters the code, and authorizes the device.
 /// </para>
 /// <para>
-/// By default this endpoint redirects to a configurable verification page
-/// (<see cref="OpenIddictServerEndpointsOptions.DeviceVerificationPath"/>)
-/// where the host application can render the code-entry UI.
+/// Flow:
+/// <list type="number">
+///   <item>No <c>user_code</c> → redirect to <see cref="OpenIddictServerEndpointsOptions.DeviceVerificationPath"/>.</item>
+///   <item>Invalid/expired <c>user_code</c> → OpenID Connect error response (400).</item>
+///   <item>Valid <c>user_code</c> but user not authenticated → redirect to login, preserving <c>user_code</c> in returnUrl.</item>
+///   <item>Valid <c>user_code</c> + authenticated user → build principal, call SignIn to mark the device as authorized.</item>
+/// </list>
 /// </para>
 /// </remarks>
-#pragma warning disable GRAPI001 // OpenIddict requires Results.SignIn/Forbid/Challenge with explicit auth scheme
+#pragma warning disable GRAPI001 // OpenIddict requires Results.SignIn/Challenge with explicit auth scheme
 #pragma warning disable GRAPI003 // Private handler methods — not exposed as endpoint parameters
 internal static partial class ConnectVerifyEndpoints
 {
@@ -35,10 +48,12 @@ internal static partial class ConnectVerifyEndpoints
     {
         endpoints.MapGet("/connect/verify",
                 (Delegate)((HttpContext context) => HandleVerifyAsync(context, options)))
+            .AllowAnonymous()
             .ExcludeFromDescription();
 
         endpoints.MapPost("/connect/verify",
                 (Delegate)((HttpContext context) => HandleVerifyAsync(context, options)))
+            .AllowAnonymous()
             .ExcludeFromDescription();
 
         return endpoints;
@@ -62,13 +77,93 @@ internal static partial class ConnectVerifyEndpoints
             return Results.Redirect(path);
         }
 
-        // Redirect with the user_code so the verification page can pre-fill the input.
         string userCode = (string?)request["user_code"] ?? string.Empty;
-        string redirectUrl = $"{options.DeviceVerificationPath}?user_code={Uri.EscapeDataString(userCode)}";
-        LogDeviceVerificationRedirect(logger, redirectUrl);
-        return await Task.FromResult(Results.Redirect(redirectUrl)).ConfigureAwait(false);
+
+        // Validate the user_code by authenticating with the OpenIddict scheme.
+        // OpenIddict looks up the device authorization in the store.
+        // If the code is invalid or expired, authentication fails.
+        AuthenticateResult oidcResult = await context.AuthenticateAsync(
+            OpenIddictServerAspNetCoreDefaults.AuthenticationScheme).ConfigureAwait(false);
+
+        if (!oidcResult.Succeeded || oidcResult.Principal is null)
+        {
+            LogInvalidUserCode(logger, userCode);
+            return Results.Challenge(
+                new AuthenticationProperties(new Dictionary<string, string?>
+                {
+                    [OpenIddictServerAspNetCoreConstants.Properties.Error] =
+                        OpenIddictConstants.Errors.InvalidToken,
+                    [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] =
+                        "The specified user code is invalid or has expired."
+                }),
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        // Require the end-user to be authenticated before authorizing the device (RFC 8628 §3.3).
+        AuthenticateResult identityResult = await context.AuthenticateAsync(
+            IdentityConstants.ApplicationScheme).ConfigureAwait(false);
+
+        if (!identityResult.Succeeded || identityResult.Principal is null)
+        {
+            string verifyReturnUrl = $"{options.DeviceVerificationPath}?user_code={Uri.EscapeDataString(userCode)}";
+            string loginUrl = $"{options.LoginPath}?returnUrl={Uri.EscapeDataString(verifyReturnUrl)}";
+            LogUnauthenticatedDeviceVerification(logger, loginUrl);
+            return Results.Redirect(loginUrl);
+        }
+
+        // Resolve the user — bypass the multi-tenant filter: the authenticated user ID is globally
+        // unique and the cookie signature already guarantees authenticity.
+        UserManager<LocalIdentity> userManager = context.RequestServices
+            .GetRequiredService<UserManager<LocalIdentity>>();
+        IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
+
+        LocalIdentity? user;
+        IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
+        try
+        {
+            user = await userManager.GetUserAsync(identityResult.Principal).ConfigureAwait(false);
+        }
+        finally
+        {
+            filterScope?.Dispose();
+        }
+
+        if (user is null)
+        {
+            // Stale cookie — clear and redirect to login.
+            await context.SignOutAsync(IdentityConstants.ApplicationScheme).ConfigureAwait(false);
+            string verifyReturnUrl = $"{options.DeviceVerificationPath}?user_code={Uri.EscapeDataString(userCode)}";
+            return Results.Redirect($"{options.LoginPath}?returnUrl={Uri.EscapeDataString(verifyReturnUrl)}");
+        }
+
+        // Build a principal from the authenticated user with the device authorization's requested scopes.
+        // The principal from oidcResult carries the scopes originally requested by the device.
+        ImmutableArray<string> scopes = oidcResult.Principal.GetScopes();
+        OidcPrincipalFactory principalFactory = context.RequestServices
+            .GetRequiredService<OidcPrincipalFactory>();
+
+        ClaimsPrincipal principal = await principalFactory.CreateUserPrincipalAsync(
+            user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+            context.RequestAborted).ConfigureAwait(false);
+
+        LogDeviceAuthorizationApproved(logger, user.Id.ToString());
+
+        // SignIn marks the device authorization as approved for this user.
+        // OpenIddict updates the pending device authorization so the device can exchange it for tokens
+        // via POST /connect/token with grant_type=urn:ietf:params:oauth:grant-type:device_code.
+        return Results.SignIn(principal,
+            authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Device verification: redirecting to '{Path}'")]
     private static partial void LogDeviceVerificationRedirect(ILogger logger, string path);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Device verification: invalid or expired user code '{UserCode}'")]
+    private static partial void LogInvalidUserCode(ILogger logger, string userCode);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Device verification: unauthenticated user redirected to login at '{LoginUrl}'")]
+    private static partial void LogUnauthenticatedDeviceVerification(ILogger logger, string loginUrl);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Device verification: approved for user '{UserId}'")]
+    private static partial void LogDeviceAuthorizationApproved(ILogger logger, string userId);
 }

--- a/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcCreateApplicationRequestValidator.cs
+++ b/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcCreateApplicationRequestValidator.cs
@@ -19,6 +19,17 @@ internal sealed class AdminOidcCreateApplicationRequestValidator : GranitValidat
         RuleFor(x => x.DisplayName)
             .MaximumLength(256);
 
+        RuleFor(x => x.ConsentType)
+            .MaximumLength(64);
+
+        RuleFor(x => x.SigningKeyJwk)
+            .MaximumLength(65536);
+
+        RuleForEach(x => x.Permissions)
+            .NotEmpty()
+            .MaximumLength(512)
+            .When(x => x.Permissions is not null);
+
         RuleForEach(x => x.RedirectUris)
             .NotEmpty()
             .AbsoluteUri()

--- a/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcCreateScopeRequestValidator.cs
+++ b/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcCreateScopeRequestValidator.cs
@@ -20,5 +20,10 @@ internal sealed class AdminOidcCreateScopeRequestValidator : GranitValidator<Adm
 
         RuleFor(x => x.Description)
             .MaximumLength(1024);
+
+        RuleForEach(x => x.Resources)
+            .NotEmpty()
+            .MaximumLength(512)
+            .When(x => x.Resources is not null);
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcUpdateApplicationRequestValidator.cs
+++ b/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcUpdateApplicationRequestValidator.cs
@@ -15,6 +15,17 @@ internal sealed class AdminOidcUpdateApplicationRequestValidator : GranitValidat
         RuleFor(x => x.DisplayName)
             .MaximumLength(256);
 
+        RuleFor(x => x.ConsentType)
+            .MaximumLength(64);
+
+        RuleFor(x => x.SigningKeyJwk)
+            .MaximumLength(65536);
+
+        RuleForEach(x => x.Permissions)
+            .NotEmpty()
+            .MaximumLength(512)
+            .When(x => x.Permissions is not null);
+
         RuleForEach(x => x.RedirectUris)
             .NotEmpty()
             .AbsoluteUri()

--- a/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcUpdateScopeRequestValidator.cs
+++ b/src/Granit.OpenIddict.Endpoints/Validators/AdminOidcUpdateScopeRequestValidator.cs
@@ -16,5 +16,10 @@ internal sealed class AdminOidcUpdateScopeRequestValidator : GranitValidator<Adm
 
         RuleFor(x => x.Description)
             .MaximumLength(1024);
+
+        RuleForEach(x => x.Resources)
+            .NotEmpty()
+            .MaximumLength(512)
+            .When(x => x.Resources is not null);
     }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -134,6 +134,12 @@ internal sealed partial class OpenIddictSeedContributor(
             return true;
         }
 
+        if ((current.ApplicationType ?? OpenIddictConstants.ApplicationTypes.Web) !=
+            (desired.ApplicationType ?? OpenIddictConstants.ApplicationTypes.Web))
+        {
+            return true;
+        }
+
         return current.GetClientSide() != desired.ClientSide;
     }
 
@@ -200,6 +206,8 @@ internal sealed partial class OpenIddictSeedContributor(
             ? BuildJsonWebKeySet(source.SigningKeyJwk)
             : null;
 
+        appDescriptor.ApplicationType = source.ApplicationType ?? OpenIddictConstants.ApplicationTypes.Web;
+
         // Consent type (default: implicit — auto-grant for first-party apps)
         appDescriptor.ConsentType = source.ConsentType ?? OpenIddictConstants.ConsentTypes.Implicit;
 
@@ -220,6 +228,7 @@ internal sealed partial class OpenIddictSeedContributor(
             {
                 Name = descriptor.Name,
                 DisplayName = descriptor.DisplayName,
+                Description = descriptor.Description,
             };
 
             foreach (string resource in descriptor.Resources)
@@ -239,6 +248,7 @@ internal sealed partial class OpenIddictSeedContributor(
             // Skip update when values are already up to date — prevents ConcurrencyException
             // when migrator and API both execute seeders concurrently at startup.
             if (scopeDescriptor.DisplayName == descriptor.DisplayName
+                && scopeDescriptor.Description == descriptor.Description
                 && scopeDescriptor.Resources.SetEquals(descriptor.Resources))
             {
                 Log.ScopeUnchanged(logger, descriptor.Name);
@@ -246,6 +256,7 @@ internal sealed partial class OpenIddictSeedContributor(
             }
 
             scopeDescriptor.DisplayName = descriptor.DisplayName;
+            scopeDescriptor.Description = descriptor.Description;
 
             scopeDescriptor.Resources.Clear();
             foreach (string resource in descriptor.Resources)

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
@@ -32,6 +32,7 @@ public sealed class GranitOpenIddictSeedingOptions
 /// <param name="PostLogoutRedirectUris">Allowed post-logout redirect URIs.</param>
 /// <param name="SigningKeyJwk">Optional public signing key as JWK JSON for <c>private_key_jwt</c> client authentication (RFC 7523). When set, the client authenticates with a signed JWT assertion instead of a shared secret.</param>
 /// <param name="ConsentType">The consent type for the application (<c>"implicit"</c>, <c>"explicit"</c>, or <c>"systematic"</c>). Default: <c>"implicit"</c> (auto-grant for first-party apps).</param>
+/// <param name="ApplicationType">The application type (<c>"web"</c> or <c>"native"</c>). Default: <c>"web"</c>.</param>
 /// <param name="ClientSide">Optional host/tenant policy enforced at sign-in. <see cref="MultiTenancySides.Host"/> = only users with <c>TenantId = null</c> may obtain tokens for this client; <see cref="MultiTenancySides.Tenant"/> = only users with a non-null <c>TenantId</c>; <see cref="MultiTenancySides.Both"/> or <see langword="null"/> = no restriction. Stored on the OIDC application's <c>Properties</c> bag and enforced by <c>ClientSideAuthorizationHandler</c>.</param>
 public sealed record OidcApplicationSeedDescriptor(
     string ClientId,
@@ -42,6 +43,7 @@ public sealed record OidcApplicationSeedDescriptor(
     string[] PostLogoutRedirectUris,
     string? SigningKeyJwk = null,
     string? ConsentType = null,
+    string? ApplicationType = null,
     MultiTenancySides? ClientSide = null);
 
 /// <summary>
@@ -50,7 +52,9 @@ public sealed record OidcApplicationSeedDescriptor(
 /// <param name="Name">The scope name (unique key for upsert).</param>
 /// <param name="DisplayName">A human-readable display name.</param>
 /// <param name="Resources">Resources associated with this scope.</param>
+/// <param name="Description">An optional human-readable description.</param>
 public sealed record OidcScopeSeedDescriptor(
     string Name,
     string DisplayName,
-    string[] Resources);
+    string[] Resources,
+    string? Description = null);

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -489,18 +489,34 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
     {
         var authId = Guid.NewGuid();
         object auth1 = new();
+        object app1 = new();
 
         _server.AuthorizationManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable<object>(auth1));
 
         _server.AuthorizationManager.GetIdAsync(auth1, Arg.Any<CancellationToken>())
             .Returns(authId.ToString());
-        _server.AuthorizationManager.GetSubjectAsync(auth1, Arg.Any<CancellationToken>())
-            .Returns("user-123");
-        _server.AuthorizationManager.GetStatusAsync(auth1, Arg.Any<CancellationToken>())
-            .Returns("valid");
-        _server.AuthorizationManager.GetTypeAsync(auth1, Arg.Any<CancellationToken>())
-            .Returns("permanent");
+
+#pragma warning disable CA2012
+        _server.AuthorizationManager
+            .PopulateAsync(Arg.Any<OpenIddictAuthorizationDescriptor>(), auth1, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictAuthorizationDescriptor d = ci.ArgAt<OpenIddictAuthorizationDescriptor>(0);
+                d.Subject = "user-123";
+                d.Status = "valid";
+                d.Type = "permanent";
+                d.ApplicationId = "app-internal-id";
+                d.Scopes.Add("openid");
+                d.Scopes.Add("profile");
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        _server.ApplicationManager.FindByIdAsync("app-internal-id", Arg.Any<CancellationToken>())
+            .Returns(app1);
+        _server.ApplicationManager.GetClientIdAsync(app1, Arg.Any<CancellationToken>())
+            .Returns("my-client");
 
         HttpResponseMessage response = await _server.AuthenticatedClient
             .GetAsync("/admin/oidc/authorizations", TestContext.Current.CancellationToken);
@@ -514,8 +530,10 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         result.Count.ShouldBe(1);
         result[0].Id.ShouldBe(authId);
         result[0].Subject.ShouldBe("user-123");
+        result[0].ClientId.ShouldBe("my-client");
         result[0].Status.ShouldBe("valid");
         result[0].Type.ShouldBe("permanent");
+        result[0].Scopes.ShouldBe(["openid", "profile"], ignoreOrder: true);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Full audit of OpenIddict admin endpoints and seeding configuration — completes the remaining gaps identified after PR #2578 and #2579.

### Authorization endpoints
- `AdminOidcAuthorizationResponse` now includes `Scopes: string[]`
- `ListAuthorizationsAsync`: switched from individual `Get*Async` calls to `PopulateAsync`; resolves `ClientId` from `applicationManager.FindByIdAsync` with a per-request cache to avoid N+1 lookups
- `CreateAuthorizationAsync`: populates `Status`, `Type`, `Scopes` from descriptor instead of re-querying manager methods

### Seeding descriptors
- `OidcApplicationSeedDescriptor`: new optional `ApplicationType` field (defaults to `"web"`; null-coalesced on both sides of the equality check to avoid spurious updates for existing apps)
- `OidcScopeSeedDescriptor`: new optional `Description` field
- `OpenIddictSeedContributor`: propagates both new fields in create/update paths and includes them in the up-to-date equality check

### Validators
- Applications (create + update): `Permissions` (`NotEmpty`, `MaxLength 512`), `ConsentType` (`MaxLength 64`), `SigningKeyJwk` (`MaxLength 65536`)
- Scopes (create + update): `Resources` (`NotEmpty`, `MaxLength 512`)

## Test plan
- [x] `Granit.OpenIddict.Endpoints.Tests` — 72/72 passed
- [x] `Granit.OpenIddict.EntityFrameworkCore.Tests` — 8/8 passed (including `ApplicationType` null-coalescing fix)