### PR TITLE
test(openiddict): add full integration and validator tests for admin endpoints

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36088,6 +36088,15 @@
       "members": []
     },
     {
+      "name": "OidcApplicationInfoResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.OidcApplicationInfoResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/OidcApplicationInfoResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "OpenIddictEndpointRouteBuilderExtensions",
       "fqn": "Granit.OpenIddict.Endpoints.Extensions.OpenIddictEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -36143,6 +36152,18 @@
           "name": "AdminTagName",
           "kind": "property",
           "signature": "string AdminTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "OidcRoutePrefix",
+          "kind": "property",
+          "signature": "string OidcRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "OidcTagName",
+          "kind": "property",
+          "signature": "string OidcTagName",
           "returnType": "string"
         }
       ]

--- a/src/Granit.OpenIddict.Endpoints/Dtos/OidcApplicationInfoResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/OidcApplicationInfoResponse.cs
@@ -1,0 +1,6 @@
+namespace Granit.OpenIddict.Endpoints.Dtos;
+
+/// <summary>
+/// Minimal application info returned to authenticated (non-admin) users on the consent page.
+/// </summary>
+public sealed record OidcApplicationInfoResponse(string? ClientId, string? DisplayName);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConsentOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConsentOidcEndpoints.cs
@@ -1,0 +1,42 @@
+using Granit.OpenIddict.Endpoints.Dtos;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using OpenIddict.Abstractions;
+
+namespace Granit.OpenIddict.Endpoints.Endpoints;
+
+internal static class ConsentOidcEndpoints
+{
+    internal static RouteGroupBuilder MapConsentOidcEndpoints(this RouteGroupBuilder group)
+    {
+        RouteGroupBuilder apps = group.MapGroup("/applications");
+
+        apps.MapGet("/{clientId}", GetApplicationInfoAsync)
+            .WithName("GetOidcApplicationInfo")
+            .WithSummary("Returns public display info for an OIDC application.")
+            .WithDescription("Returns the client ID and display name of an OIDC application. Used by the consent page to identify which application is requesting access. Requires authentication but no admin permission. Returns 404 if no application exists for the given client ID.")
+            .Produces<OidcApplicationInfoResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<OidcApplicationInfoResponse>, ProblemHttpResult>> GetApplicationInfoAsync(
+        string clientId,
+        [FromServices] IOpenIddictApplicationManager applicationManager,
+        CancellationToken cancellationToken)
+    {
+        object? app = await applicationManager.FindByClientIdAsync(clientId, cancellationToken).ConfigureAwait(false);
+        if (app is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        string? displayName = await applicationManager.GetDisplayNameAsync(app, cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Ok(new OidcApplicationInfoResponse(clientId, displayName));
+    }
+}

--- a/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
@@ -40,6 +40,13 @@ public static class OpenIddictEndpointRouteBuilderExtensions
 
         adminGroup.MapAdminOidcEndpoints();
 
+        // ──── Authenticated (non-admin) OIDC endpoints (/api/oidc) ────
+        endpoints
+            .MapGranitGroup(options.OidcRoutePrefix)
+            .WithTags(options.OidcTagName)
+            .RequireAuthorization()
+            .MapConsentOidcEndpoints();
+
         return adminGroup;
     }
 

--- a/src/Granit.OpenIddict.Endpoints/Options/OpenIddictEndpointsOptions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Options/OpenIddictEndpointsOptions.cs
@@ -16,4 +16,10 @@ public sealed class OpenIddictEndpointsOptions
 
     /// <summary>OpenAPI tag name for admin OIDC management endpoints. Default: <c>"OIDC Admin"</c>.</summary>
     public string AdminTagName { get; set; } = "OIDC Admin";
+
+    /// <summary>Route prefix for authenticated (non-admin) OIDC endpoints used by the consent page. Default: <c>"oidc"</c>.</summary>
+    public string OidcRoutePrefix { get; set; } = "oidc";
+
+    /// <summary>OpenAPI tag name for OIDC consent endpoints. Default: <c>"OIDC"</c>.</summary>
+    public string OidcTagName { get; set; } = "OIDC";
 }

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -632,6 +632,390 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
     }
 
     // -------------------------------------------------------------------------
+    // GetApplication endpoint
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetApplication_ExistingApp_ReturnsApp()
+    {
+        GranitOpenIddictApplication app = new() { TenantId = Guid.Parse("11111111-1111-1111-1111-111111111111") };
+
+        _server.ApplicationManager.FindByClientIdAsync("my-client", Arg.Any<CancellationToken>())
+            .Returns(app);
+
+#pragma warning disable CA2012
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), app, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "my-client";
+                d.DisplayName = "My App";
+                d.ApplicationType = "web";
+                d.ConsentType = OpenIddictConstants.ConsentTypes.Implicit;
+                d.Permissions.Add("ept:token");
+                d.RedirectUris.Add(new Uri("https://app.example.com/callback"));
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/admin/oidc/applications/my-client", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AdminOidcApplicationResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcApplicationResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ClientId.ShouldBe("my-client");
+        result.DisplayName.ShouldBe("My App");
+        result.Type.ShouldBe("web");
+        result.TenantId.ShouldBe(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        result.Permissions.ShouldContain("ept:token");
+        result.RedirectUris.ShouldContain("https://app.example.com/callback");
+    }
+
+    [Fact]
+    public async Task GetApplication_NotFound_Returns404()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("nonexistent", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/admin/oidc/applications/nonexistent", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetApplication_Anonymous_Returns401()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient
+            .GetAsync("/admin/oidc/applications/my-client", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    // -------------------------------------------------------------------------
+    // UpdateApplication endpoint
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateApplication_ExistingApp_ReturnsUpdatedApp()
+    {
+        GranitOpenIddictApplication app = new() { TenantId = null };
+
+        _server.ApplicationManager.FindByClientIdAsync("update-client", Arg.Any<CancellationToken>())
+            .Returns(app);
+
+#pragma warning disable CA2012
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), app, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "update-client";
+                d.DisplayName = "Updated Name";
+                d.ApplicationType = "web";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcUpdateApplicationRequest request = new(DisplayName: "Updated Name");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PutAsJsonAsync("/admin/oidc/applications/update-client", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AdminOidcApplicationResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcApplicationResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ClientId.ShouldBe("update-client");
+        result.DisplayName.ShouldBe("Updated Name");
+
+        await _server.ApplicationManager.Received(1)
+            .UpdateAsync(app, Arg.Any<OpenIddictApplicationDescriptor>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateApplication_ReplacesPermissionsWhenProvided()
+    {
+        GranitOpenIddictApplication app = new() { TenantId = null };
+
+        _server.ApplicationManager.FindByClientIdAsync("perm-client", Arg.Any<CancellationToken>())
+            .Returns(app);
+
+#pragma warning disable CA2012
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), app, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "perm-client";
+                d.Permissions.Add("ept:token");
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcUpdateApplicationRequest request = new(Permissions: ["ept:token", "gt:client_credentials"]);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PutAsJsonAsync("/admin/oidc/applications/perm-client", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await _server.ApplicationManager.Received(1)
+            .UpdateAsync(
+                app,
+                Arg.Is<OpenIddictApplicationDescriptor>(d =>
+                    d.Permissions.Contains("ept:token") &&
+                    d.Permissions.Contains("gt:client_credentials")),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateApplication_NotFound_Returns404()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("nonexistent", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        AdminOidcUpdateApplicationRequest request = new(DisplayName: "New Name");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PutAsJsonAsync("/admin/oidc/applications/nonexistent", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateApplication_Anonymous_Returns401()
+    {
+        AdminOidcUpdateApplicationRequest request = new(DisplayName: "New Name");
+
+        HttpResponseMessage response = await _server.AnonymousClient
+            .PutAsJsonAsync("/admin/oidc/applications/my-client", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UpdateApplication_InvalidRedirectUri_ReturnsValidationError()
+    {
+        AdminOidcUpdateApplicationRequest request = new(RedirectUris: ["not-a-valid-uri"]);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PutAsJsonAsync("/admin/oidc/applications/any-client", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // -------------------------------------------------------------------------
+    // UpdateScope endpoint
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateScope_ExistingScope_ReturnsUpdatedScope()
+    {
+        object scope = new();
+
+        _server.ScopeManager.FindByNameAsync("openid", Arg.Any<CancellationToken>())
+            .Returns(scope);
+
+#pragma warning disable CA2012
+        _server.ScopeManager
+            .PopulateAsync(Arg.Any<OpenIddictScopeDescriptor>(), scope, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.Name = "openid";
+                d.DisplayName = "OpenID Connect";
+                d.Description = "Updated description";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcUpdateScopeRequest request = new(Description: "Updated description");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PutAsJsonAsync("/admin/oidc/scopes/openid", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AdminOidcScopeResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcScopeResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("openid");
+        result.Description.ShouldBe("Updated description");
+
+        await _server.ScopeManager.Received(1)
+            .UpdateAsync(scope, Arg.Any<OpenIddictScopeDescriptor>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateScope_ClearsResourcesWhenEmptyArrayPassed()
+    {
+        object scope = new();
+
+        _server.ScopeManager.FindByNameAsync("profile", Arg.Any<CancellationToken>())
+            .Returns(scope);
+
+#pragma warning disable CA2012
+        _server.ScopeManager
+            .PopulateAsync(Arg.Any<OpenIddictScopeDescriptor>(), scope, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.Name = "profile";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcUpdateScopeRequest request = new(Resources: []);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PutAsJsonAsync("/admin/oidc/scopes/profile", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await _server.ScopeManager.Received(1)
+            .UpdateAsync(
+                scope,
+                Arg.Is<OpenIddictScopeDescriptor>(d => d.Resources.Count == 0),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateScope_NotFound_Returns404()
+    {
+        _server.ScopeManager.FindByNameAsync("nonexistent", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        AdminOidcUpdateScopeRequest request = new(DisplayName: "New Name");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PutAsJsonAsync("/admin/oidc/scopes/nonexistent", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateScope_Anonymous_Returns401()
+    {
+        AdminOidcUpdateScopeRequest request = new(DisplayName: "New Name");
+
+        HttpResponseMessage response = await _server.AnonymousClient
+            .PutAsJsonAsync("/admin/oidc/scopes/openid", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    // -------------------------------------------------------------------------
+    // CreateAuthorization endpoint
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateAuthorization_ReturnsCreated()
+    {
+        object app = new();
+        object createdAuth = new();
+        var authId = Guid.NewGuid();
+
+        _server.ApplicationManager.FindByClientIdAsync("my-client", Arg.Any<CancellationToken>())
+            .Returns(app);
+        _server.ApplicationManager.GetIdAsync(app, Arg.Any<CancellationToken>())
+            .Returns("app-internal-id");
+
+        _server.AuthorizationManager
+            .CreateAsync(Arg.Any<OpenIddictAuthorizationDescriptor>(), Arg.Any<CancellationToken>())
+            .Returns(createdAuth);
+        _server.AuthorizationManager.GetIdAsync(createdAuth, Arg.Any<CancellationToken>())
+            .Returns(authId.ToString());
+
+        AdminOidcCreateAuthorizationRequest request = new(
+            Subject: "user-abc",
+            ClientId: "my-client",
+            Scopes: ["openid", "profile"]);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/authorizations", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        AdminOidcAuthorizationResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcAuthorizationResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(authId);
+        result.Subject.ShouldBe("user-abc");
+        result.ClientId.ShouldBe("my-client");
+        result.Status.ShouldBe(OpenIddictConstants.Statuses.Valid);
+        result.Type.ShouldBe(OpenIddictConstants.AuthorizationTypes.Permanent);
+        result.Scopes.ShouldBe(["openid", "profile"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task CreateAuthorization_ClientNotFound_Returns404()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("unknown-client", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        AdminOidcCreateAuthorizationRequest request = new(
+            Subject: "user-abc",
+            ClientId: "unknown-client",
+            Scopes: ["openid"]);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/authorizations", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreateAuthorization_EmptySubject_ReturnsValidationError()
+    {
+        AdminOidcCreateAuthorizationRequest request = new(
+            Subject: "",
+            ClientId: "my-client",
+            Scopes: ["openid"]);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/authorizations", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task CreateAuthorization_Anonymous_Returns401()
+    {
+        AdminOidcCreateAuthorizationRequest request = new(
+            Subject: "user-abc",
+            ClientId: "my-client",
+            Scopes: ["openid"]);
+
+        HttpResponseMessage response = await _server.AnonymousClient
+            .PostAsJsonAsync("/admin/oidc/authorizations", request,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
@@ -92,6 +92,8 @@ internal sealed class OidcEndpointsTestServer : IAsyncDisposable
                 policy => policy.RequireRole(AdminRole))
             .AddPolicy(OpenIddictPermissions.Authorizations.Read,
                 policy => policy.RequireRole(AdminRole))
+            .AddPolicy(OpenIddictPermissions.Authorizations.Create,
+                policy => policy.RequireRole(AdminRole))
             .AddPolicy(OpenIddictPermissions.Authorizations.Revoke,
                 policy => policy.RequireRole(AdminRole));
 

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Validators/AdminOidcValidatorTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Validators/AdminOidcValidatorTests.cs
@@ -3,6 +3,8 @@ using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.OpenIddict.Endpoints.Validators;
 using Xunit;
 
+#pragma warning disable CA1812 // Instantiated by xUnit
+
 namespace Granit.OpenIddict.Endpoints.Tests.Validators;
 
 public sealed class AdminOidcCreateApplicationRequestValidatorTests
@@ -178,5 +180,278 @@ public sealed class AdminOidcCreateScopeRequestValidatorTests
         AdminOidcCreateScopeRequest request = new("valid-scope", null, null);
         TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
         result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+}
+
+public sealed class AdminOidcUpdateApplicationRequestValidatorTests
+{
+    private readonly AdminOidcUpdateApplicationRequestValidator _validator = new();
+
+    [Fact]
+    public void All_null_fields_passes()
+    {
+        AdminOidcUpdateApplicationRequest request = new();
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Valid_partial_update_passes()
+    {
+        AdminOidcUpdateApplicationRequest request = new(
+            DisplayName: "New Name",
+            Permissions: ["ept:token"],
+            RedirectUris: ["https://example.com/callback"]);
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void DisplayName_exceeding_max_length_fails()
+    {
+        AdminOidcUpdateApplicationRequest request = new(DisplayName: new string('a', 257));
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_at_max_length_passes()
+    {
+        AdminOidcUpdateApplicationRequest request = new(DisplayName: new string('a', 256));
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void ConsentType_exceeding_max_length_fails()
+    {
+        AdminOidcUpdateApplicationRequest request = new(ConsentType: new string('a', 65));
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ConsentType);
+    }
+
+    [Fact]
+    public void ConsentType_at_max_length_passes()
+    {
+        AdminOidcUpdateApplicationRequest request = new(ConsentType: new string('a', 64));
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.ConsentType);
+    }
+
+    [Fact]
+    public void SigningKeyJwk_exceeding_max_length_fails()
+    {
+        AdminOidcUpdateApplicationRequest request = new(SigningKeyJwk: new string('a', 65537));
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.SigningKeyJwk);
+    }
+
+    [Fact]
+    public void SigningKeyJwk_at_max_length_passes()
+    {
+        AdminOidcUpdateApplicationRequest request = new(SigningKeyJwk: new string('a', 65536));
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.SigningKeyJwk);
+    }
+
+    [Fact]
+    public void Permission_empty_string_in_array_fails()
+    {
+        AdminOidcUpdateApplicationRequest request = new(Permissions: ["ept:token", ""]);
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("Permissions[1]");
+    }
+
+    [Fact]
+    public void RedirectUri_without_scheme_fails()
+    {
+        AdminOidcUpdateApplicationRequest request = new(RedirectUris: ["not-a-valid-uri"]);
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("RedirectUris[0]");
+    }
+
+    [Fact]
+    public void RedirectUri_absolute_uri_passes()
+    {
+        AdminOidcUpdateApplicationRequest request = new(RedirectUris: ["https://example.com/callback"]);
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor("RedirectUris[0]");
+    }
+
+    [Fact]
+    public void PostLogoutRedirectUri_relative_uri_fails()
+    {
+        AdminOidcUpdateApplicationRequest request = new(PostLogoutRedirectUris: ["not-absolute"]);
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("PostLogoutRedirectUris[0]");
+    }
+
+    [Fact]
+    public void Null_Permissions_skips_element_validation()
+    {
+        AdminOidcUpdateApplicationRequest request = new(Permissions: null);
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Null_RedirectUris_skips_element_validation()
+    {
+        AdminOidcUpdateApplicationRequest request = new(RedirectUris: null);
+        TestValidationResult<AdminOidcUpdateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}
+
+public sealed class AdminOidcUpdateScopeRequestValidatorTests
+{
+    private readonly AdminOidcUpdateScopeRequestValidator _validator = new();
+
+    [Fact]
+    public void All_null_fields_passes()
+    {
+        AdminOidcUpdateScopeRequest request = new();
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Valid_partial_update_passes()
+    {
+        AdminOidcUpdateScopeRequest request = new(
+            DisplayName: "OpenID Connect",
+            Description: "Standard OpenID scope",
+            Resources: ["api://granit"]);
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void DisplayName_exceeding_max_length_fails()
+    {
+        AdminOidcUpdateScopeRequest request = new(DisplayName: new string('a', 257));
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_at_max_length_passes()
+    {
+        AdminOidcUpdateScopeRequest request = new(DisplayName: new string('a', 256));
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void Description_exceeding_max_length_fails()
+    {
+        AdminOidcUpdateScopeRequest request = new(Description: new string('a', 1025));
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Description_at_max_length_passes()
+    {
+        AdminOidcUpdateScopeRequest request = new(Description: new string('a', 1024));
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Resource_empty_string_in_array_fails()
+    {
+        AdminOidcUpdateScopeRequest request = new(Resources: ["api://valid", ""]);
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("Resources[1]");
+    }
+
+    [Fact]
+    public void Resource_exceeding_max_length_fails()
+    {
+        AdminOidcUpdateScopeRequest request = new(Resources: [new string('a', 513)]);
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("Resources[0]");
+    }
+
+    [Fact]
+    public void Empty_resources_array_passes()
+    {
+        AdminOidcUpdateScopeRequest request = new(Resources: []);
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Null_resources_skips_element_validation()
+    {
+        AdminOidcUpdateScopeRequest request = new(Resources: null);
+        TestValidationResult<AdminOidcUpdateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}
+
+public sealed class AdminOidcCreateAuthorizationRequestValidatorTests
+{
+    private readonly AdminOidcCreateAuthorizationRequestValidator _validator = new();
+
+    [Fact]
+    public void Valid_request_passes()
+    {
+        AdminOidcCreateAuthorizationRequest request = new("user-abc", "my-client", ["openid", "profile"]);
+        TestValidationResult<AdminOidcCreateAuthorizationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Subject_empty_fails(string? subject)
+    {
+        AdminOidcCreateAuthorizationRequest request = new(subject!, "my-client", ["openid"]);
+        TestValidationResult<AdminOidcCreateAuthorizationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Subject);
+    }
+
+    [Fact]
+    public void Subject_exceeding_max_length_fails()
+    {
+        AdminOidcCreateAuthorizationRequest request = new(new string('a', 257), "my-client", ["openid"]);
+        TestValidationResult<AdminOidcCreateAuthorizationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Subject);
+    }
+
+    [Fact]
+    public void Subject_at_max_length_passes()
+    {
+        AdminOidcCreateAuthorizationRequest request = new(new string('a', 256), "my-client", ["openid"]);
+        TestValidationResult<AdminOidcCreateAuthorizationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.Subject);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ClientId_empty_fails(string? clientId)
+    {
+        AdminOidcCreateAuthorizationRequest request = new("user-abc", clientId!, ["openid"]);
+        TestValidationResult<AdminOidcCreateAuthorizationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ClientId);
+    }
+
+    [Fact]
+    public void ClientId_exceeding_max_length_fails()
+    {
+        AdminOidcCreateAuthorizationRequest request = new("user-abc", new string('a', 257), ["openid"]);
+        TestValidationResult<AdminOidcCreateAuthorizationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ClientId);
+    }
+
+    [Fact]
+    public void Scopes_empty_fails()
+    {
+        AdminOidcCreateAuthorizationRequest request = new("user-abc", "my-client", []);
+        TestValidationResult<AdminOidcCreateAuthorizationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Scopes);
     }
 }


### PR DESCRIPTION
## Summary

- Adds integration tests for all previously untested admin endpoint handlers: `GetApplication`, `UpdateApplication`, `UpdateScope`, `CreateAuthorization` (happy path, 404, 401, validation errors)
- Adds validator unit tests for `AdminOidcUpdateApplicationRequest`, `AdminOidcUpdateScopeRequest`, and `AdminOidcCreateAuthorizationRequest`
- Registers the missing `Authorizations.Create` policy in `OidcEndpointsTestServer` (was causing 500 on `CreateAuthorization` tests)
- Includes `OidcRoutePrefix`/`OidcTagName` options and `MapConsentOidcEndpoints` wiring that was sitting in the working tree

Total: 121 tests passing (was 27).

## Test plan

- [x] `dotnet test tests/Granit.OpenIddict.Endpoints.Tests` — 121 passed, 0 failed