### PR TITLE
fix(auditing): add [AuditIgnore] to audit domain entities to prevent infinite recursion

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1823,11 +1823,13 @@
     {
       "name": "Granit.OpenIddict",
       "deps": [
+        "Granit.Caching",
         "Granit.DataExchange.Abstractions",
         "Granit.Encryption",
+        "Granit.Entities.Abstractions",
         "Granit.Http.Cookies",
         "Granit.Identity.Local",
-        "Granit.Entities.Abstractions",
+        "Granit.Identity.Local.AspNetIdentity",
         "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
@@ -5277,7 +5279,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Abstractions",
       "file": "src/Granit.Auditing.Abstractions/Domain/AuditEntityChange.cs",
-      "line": 8,
+      "line": 10,
       "members": [
         {
           "name": "AuditEntryId",
@@ -5305,7 +5307,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Abstractions",
       "file": "src/Granit.Auditing.Abstractions/Domain/AuditEntry.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "Timestamp",
@@ -5336,7 +5338,7 @@
       "kind": "class",
       "project": "Granit.Auditing.Abstractions",
       "file": "src/Granit.Auditing.Abstractions/Domain/AuditPropertyChange.cs",
-      "line": 8,
+      "line": 10,
       "members": [
         {
           "name": "AuditEntityChangeId",
@@ -36419,7 +36421,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
-      "line": 36,
+      "line": 41,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Auditing.Abstractions/Domain/AuditEntityChange.cs
+++ b/src/Granit.Auditing.Abstractions/Domain/AuditEntityChange.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing.Attributes;
 using Granit.Domain;
 
 namespace Granit.Auditing.Domain;
@@ -5,6 +6,7 @@ namespace Granit.Auditing.Domain;
 /// <summary>
 /// Records a single entity change within an <see cref="AuditEntry"/>.
 /// </summary>
+[AuditIgnore]
 public class AuditEntityChange : Entity
 {
     /// <summary>Foreign key to the parent <see cref="AuditEntry"/>.</summary>

--- a/src/Granit.Auditing.Abstractions/Domain/AuditEntry.cs
+++ b/src/Granit.Auditing.Abstractions/Domain/AuditEntry.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing.Attributes;
 using Granit.Domain;
 
 namespace Granit.Auditing.Domain;
@@ -11,6 +12,7 @@ namespace Granit.Auditing.Domain;
 /// (auto-populated by <c>AuditedEntityInterceptor</c>). Audit entries are immutable —
 /// no modification audit fields needed.
 /// </remarks>
+[AuditIgnore]
 public class AuditEntry : CreationAuditedEntity, IMultiTenant
 {
     /// <summary>Operation timestamp (UTC).</summary>

--- a/src/Granit.Auditing.Abstractions/Domain/AuditPropertyChange.cs
+++ b/src/Granit.Auditing.Abstractions/Domain/AuditPropertyChange.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing.Attributes;
 using Granit.Domain;
 
 namespace Granit.Auditing.Domain;
@@ -5,6 +6,7 @@ namespace Granit.Auditing.Domain;
 /// <summary>
 /// Records a single property change within an <see cref="AuditEntityChange"/>.
 /// </summary>
+[AuditIgnore]
 public class AuditPropertyChange : Entity
 {
     /// <summary>Foreign key to the parent <see cref="AuditEntityChange"/>.</summary>

--- a/tests/Granit.Auditing.Abstractions.Tests/Domain/AuditDomainEntitiesTests.cs
+++ b/tests/Granit.Auditing.Abstractions.Tests/Domain/AuditDomainEntitiesTests.cs
@@ -1,0 +1,27 @@
+using Granit.Auditing.Attributes;
+using Granit.Auditing.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Auditing.Abstractions.Tests.Domain;
+
+/// <summary>
+/// Guards that audit domain entities carry [AuditIgnore] so they are skipped
+/// by AuditingChangeTrackingInterceptor when AuditingDbContext saves them.
+/// Without this attribute, saving an AuditEntry triggers the interceptor again,
+/// which calls StrictAuditingPublisher, which saves another AuditEntry — infinite recursion.
+/// </summary>
+public sealed class AuditDomainEntitiesTests
+{
+    [Fact]
+    public void AuditEntry_HasAuditIgnoreAttribute() =>
+        typeof(AuditEntry).IsDefined(typeof(AuditIgnoreAttribute), inherit: false).ShouldBeTrue();
+
+    [Fact]
+    public void AuditEntityChange_HasAuditIgnoreAttribute() =>
+        typeof(AuditEntityChange).IsDefined(typeof(AuditIgnoreAttribute), inherit: false).ShouldBeTrue();
+
+    [Fact]
+    public void AuditPropertyChange_HasAuditIgnoreAttribute() =>
+        typeof(AuditPropertyChange).IsDefined(typeof(AuditIgnoreAttribute), inherit: false).ShouldBeTrue();
+}


### PR DESCRIPTION
## Summary

- **Root cause:** PR #1017 registered `AuditingChangeTrackingInterceptor` as `IGranitAutoInterceptor`, which wires it automatically on every DbContext via `UseGranitInterceptors` — including `AuditingDbContext` itself.
- **Recursion loop:** `SaveChanges(Product)` → `StrictAuditingPublisher` saves `AuditEntry1` → interceptor captures `AuditEntry1` → `StrictAuditingPublisher` saves `AuditEntry2` → … until connection pool exhaustion → exception propagates back → **no audit entry persisted** → Timeline empty.
- **Fix:** `[AuditIgnore]` on `AuditEntry`, `AuditEntityChange`, `AuditPropertyChange`. The capture service skips them (`entityChanges.Count == 0` → batch null → no publish). Semantically correct: audit entries should not be audited.
- **Guard:** 3 regression tests in `AuditDomainEntitiesTests` to prevent accidental removal.

## Test plan

- [ ] `dotnet test tests/Granit.Auditing.Abstractions.Tests` — 10 tests pass (3 new)
- [ ] `dotnet test tests/Granit.Auditing.EntityFrameworkCore.Tests` — 136 tests pass
- [ ] `dotnet test tests/Granit.Timeline.Auditing.Tests` — 11 tests pass
- [ ] Showcase: créer une entité → vérifier qu'une entrée apparaît dans la Timeline