### PR TITLE
fix(openiddict): disable IMultiTenant filter in OpenIddictSessionManager

### DIFF
--- a/src/Granit.OpenIddict/Services/OpenIddictSessionManager.cs
+++ b/src/Granit.OpenIddict/Services/OpenIddictSessionManager.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using System.Text.Json;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Identity;
 using Granit.Identity.Local.Services;
 using Granit.Identity.Models;
@@ -13,13 +15,18 @@ internal sealed class OpenIddictSessionManager(
     IOpenIddictTokenManager tokenManager,
     IOpenIddictApplicationManager applicationManager,
     IFusionCache cache,
-    IClock clock) : IIdentitySessionManager
+    IClock clock,
+    IDataFilter? dataFilter = null) : IIdentitySessionManager
 {
     public async Task<IReadOnlyList<IdentitySession>> GetUserSessionsAsync(
         string userId, CancellationToken cancellationToken = default)
     {
         var sessions = new List<IdentitySession>();
         var appNameCache = new Dictionary<string, string?>();
+
+        // GranitOpenIddictToken.TenantId is always null — OpenIddict never sets it.
+        // Disable the IMultiTenant filter so tenant users can see their own tokens.
+        using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
 
         await foreach (object token in tokenManager.FindBySubjectAsync(userId, cancellationToken))
         {

--- a/tests/Granit.OpenIddict.Tests/Services/OpenIddictSessionManagerTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Services/OpenIddictSessionManagerTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using System.Text.Json;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Identity.Local.Services;
 using Granit.Identity.Models;
 using Granit.OpenIddict.Services;
@@ -20,14 +22,30 @@ public sealed class OpenIddictSessionManagerTests
     private readonly IOpenIddictApplicationManager _appManager = Substitute.For<IOpenIddictApplicationManager>();
     private readonly IFusionCache _cache = Substitute.For<IFusionCache>();
     private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
 
     public OpenIddictSessionManagerTests()
     {
         _clock.Now.Returns(FixedNow);
+        _dataFilter.Disable<IMultiTenant>().Returns(Substitute.For<IDisposable>());
     }
 
     private OpenIddictSessionManager CreateSut() =>
-        new(_tokenManager, _appManager, _cache, _clock);
+        new(_tokenManager, _appManager, _cache, _clock, _dataFilter);
+
+    // ── Multi-tenant filter bypass ────────────────────────────────────────
+
+    [Fact]
+    public async Task GetUserSessionsAsync_DisablesMultiTenantFilter()
+    {
+        const string userId = "user-mt";
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>());
+
+        await CreateSut().GetUserSessionsAsync(userId, TestContext.Current.CancellationToken);
+
+        _dataFilter.Received(1).Disable<IMultiTenant>();
+    }
 
     // ── Happy path ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Root cause

`GranitOpenIddictToken` implements `IMultiTenant`, but OpenIddict's EF Core store never sets `TenantId` — it is always `null`. The `OpenIddictDbContext` multi-tenant query filter is:

```
!IsMultiTenantFilterEnabled || TenantId == CurrentTenantId
```

When a tenant user calls the sessions endpoint, `CurrentTenantId = tenantGuid` (set by the tenant middleware) while every token has `TenantId = null`. The condition `null == tenantGuid` is `false` — **all tokens are silently filtered out**, returning an empty list.

## Fix

`OpenIddictSessionManager` now accepts an optional `IDataFilter` and calls `dataFilter?.Disable<IMultiTenant>()` before `FindBySubjectAsync`. This lifts the filter for the duration of the query so tokens are visible regardless of the caller's tenant context.

`IDataFilter` is `null`-safe (optional DI parameter) — the fix degrades gracefully if the filter service is unavailable.

## Test

Added `GetUserSessionsAsync_DisablesMultiTenantFilter` — verifies `IDataFilter.Disable<IMultiTenant>()` is called exactly once per `GetUserSessionsAsync` call.

Closes #2583 regression (sessions always empty for tenant users).