### PR TITLE
fix(persistence): standardize EF Core table naming conventions across modules

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10459,6 +10459,22 @@
       ]
     },
     {
+      "name": "GranitBlobStorageDatabaseDbProperties",
+      "fqn": "Granit.BlobStorage.Database.GranitBlobStorageDatabaseDbProperties",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Database",
+      "file": "src/Granit.BlobStorage.Database/GranitBlobStorageDatabaseDbProperties.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "GranitBlobStorageDatabaseModule",
       "fqn": "Granit.BlobStorage.Database.GranitBlobStorageDatabaseModule",
       "kind": "class",
@@ -28853,6 +28869,22 @@
           "kind": "method",
           "signature": "AddGranitIndexingEntityFrameworkCore(this IServiceCollection services, Action<DbContextOptionsBuilder> configureDbContext, params Type[] indexedKeyTypes)",
           "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIndexingDbProperties",
+      "fqn": "Granit.Indexing.EntityFrameworkCore.GranitIndexingDbProperties",
+      "kind": "class",
+      "project": "Granit.Indexing.EntityFrameworkCore",
+      "file": "src/Granit.Indexing.EntityFrameworkCore/GranitIndexingDbProperties.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
         }
       ]
     },

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitApiKeysDbProperties.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitApiKeysDbProperties.cs
@@ -21,20 +21,20 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore;
 public static class GranitApiKeysDbProperties
 {
     /// <summary>
-    /// Table name prefix for all API key tables. Default: <c>"api_keys_"</c>.
+    /// Table name prefix for all API key tables. Default: <c>"authentication_api_keys_"</c>.
     /// </summary>
-    public static string DbTablePrefix { get; set; } = "api_keys_";
+    public static string DbTablePrefix { get; set; } = "authentication_api_keys_";
 
     private static string? _dbSchema;
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema. Falls back to <see cref="GranitDbDefaults.HostDbSchema"/>, then
+    /// <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.BlobStorage.Database/EntityTypeConfiguration/DatabaseBlobContentConfiguration.cs
+++ b/src/Granit.BlobStorage.Database/EntityTypeConfiguration/DatabaseBlobContentConfiguration.cs
@@ -11,7 +11,9 @@ internal sealed class DatabaseBlobContentConfiguration : IEntityTypeConfiguratio
 {
     public void Configure(EntityTypeBuilder<DatabaseBlobContent> builder)
     {
-        builder.ToTable("storage_blob_contents");
+        builder.ToTable(
+            GranitBlobStorageDatabaseDbProperties.DbTablePrefix + "contents",
+            GranitBlobStorageDatabaseDbProperties.DbSchema);
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.TenantId);
@@ -28,9 +30,9 @@ internal sealed class DatabaseBlobContentConfiguration : IEntityTypeConfiguratio
 
         builder.HasIndex(e => e.ObjectKey)
             .IsUnique()
-            .HasDatabaseName("uq_storage_blob_contents_object_key");
+            .HasDatabaseName($"uq_{GranitBlobStorageDatabaseDbProperties.DbTablePrefix}contents_object_key");
 
         builder.HasIndex(e => new { e.TenantId, e.ObjectKey })
-            .HasDatabaseName("ix_storage_blob_contents_tenant_object_key");
+            .HasDatabaseName($"ix_{GranitBlobStorageDatabaseDbProperties.DbTablePrefix}contents_tenant_object_key");
     }
 }

--- a/src/Granit.BlobStorage.Database/GranitBlobStorageDatabaseDbProperties.cs
+++ b/src/Granit.BlobStorage.Database/GranitBlobStorageDatabaseDbProperties.cs
@@ -1,0 +1,32 @@
+using Granit.Persistence.EntityFrameworkCore;
+
+namespace Granit.BlobStorage.Database;
+
+/// <summary>
+/// Provides configurable table-naming properties for the BlobStorage Database provider.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitBlobStorageDatabaseDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all BlobStorage Database tables. Default: <c>"blob_storage_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "blob_storage_";
+
+    private static string? _dbSchema;
+    private static bool _dbSchemaExplicitlySet;
+
+    /// <summary>
+    /// Database schema for BlobStorage Database tables.
+    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// </summary>
+    public static string? DbSchema
+    {
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
+    }
+}

--- a/src/Granit.EntityMerge.EntityFrameworkCore/GranitEntityMergeDbProperties.cs
+++ b/src/Granit.EntityMerge.EntityFrameworkCore/GranitEntityMergeDbProperties.cs
@@ -8,7 +8,7 @@ namespace Granit.EntityMerge.EntityFrameworkCore;
 /// <remarks>
 /// <para>
 /// The merge orchestrator owns a single host-level bookkeeping table
-/// (<c>merge_idempotency</c>). Both the isolated <c>EntityMergeDbContext</c> and host
+/// (<c>entity_merge_idempotency</c>). Both the isolated <c>EntityMergeDbContext</c> and host
 /// applications that fold the table into their own <c>DbContext</c> via
 /// <c>modelBuilder.ConfigureEntityMergeModule()</c> read these same static values, ensuring
 /// migration-time and runtime SQL stay in sync.
@@ -22,9 +22,9 @@ namespace Granit.EntityMerge.EntityFrameworkCore;
 public static class GranitEntityMergeDbProperties
 {
     /// <summary>
-    /// Table name prefix for the EntityMerge tables. Default: <c>"merge_"</c>.
+    /// Table name prefix for the EntityMerge tables. Default: <c>"entity_merge_"</c>.
     /// </summary>
-    public static string DbTablePrefix { get; set; } = "merge_";
+    public static string DbTablePrefix { get; set; } = "entity_merge_";
 
     private static string? _dbSchema;
     private static bool _dbSchemaExplicitlySet;

--- a/src/Granit.Hostnames.EntityFrameworkCore/GranitHostnamesDbProperties.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/GranitHostnamesDbProperties.cs
@@ -11,8 +11,8 @@ namespace Granit.Hostnames.EntityFrameworkCore;
 /// </remarks>
 public static class GranitHostnamesDbProperties
 {
-    /// <summary>Table name prefix for all hostname tables. Default: <c>"hostname_"</c>.</summary>
-    public static string DbTablePrefix { get; set; } = "hostname_";
+    /// <summary>Table name prefix for all hostname tables. Default: <c>"hostnames_"</c>.</summary>
+    public static string DbTablePrefix { get; set; } = "hostnames_";
 
     private static string? _dbSchema;
     private static bool _dbSchemaExplicitlySet;

--- a/src/Granit.Hostnames.EntityFrameworkCore/GranitHostnamesDbProperties.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/GranitHostnamesDbProperties.cs
@@ -18,11 +18,12 @@ public static class GranitHostnamesDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema. Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema. Falls back to <see cref="GranitDbDefaults.HostDbSchema"/>, then
+    /// <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs
@@ -15,11 +15,9 @@ namespace Granit.Identity.EntityFrameworkCore;
 public static class GranitIdentityDbProperties
 {
     /// <summary>
-    /// Table-name prefix applied to every Identity-owned table. Mirrors the
-    /// per-module prefix convention (<c>granit_</c>, <c>granit_apikeys_</c>,
-    /// etc.). Default: <c>"granit_identity_"</c>.
+    /// Table-name prefix applied to every Identity-owned table. Default: <c>"identity_"</c>.
     /// </summary>
-    public static string DbTablePrefix { get; set; } = "granit_identity_";
+    public static string DbTablePrefix { get; set; } = "identity_";
 
     private static string? _dbSchema;
     private static bool _dbSchemaExplicitlySet;

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/GranitIdentityDbProperties.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/GranitIdentityDbProperties.cs
@@ -13,9 +13,9 @@ namespace Granit.Identity.Federated.EntityFrameworkCore;
 public static class GranitIdentityDbProperties
 {
     /// <summary>
-    /// Table name prefix for all identity tables. Default: <c>"identity_"</c>.
+    /// Table name prefix for all federated identity tables. Default: <c>"identity_federated_"</c>.
     /// </summary>
-    public static string DbTablePrefix { get; set; } = "identity_";
+    public static string DbTablePrefix { get; set; } = "identity_federated_";
 
     private static string? _dbSchema;
     private static bool _dbSchemaExplicitlySet;

--- a/src/Granit.Indexing.Embeddings/GranitIndexingEmbeddingsModule.cs
+++ b/src/Granit.Indexing.Embeddings/GranitIndexingEmbeddingsModule.cs
@@ -14,7 +14,7 @@ namespace Granit.Indexing.Embeddings;
 /// pgvector, Elasticsearch dense_vector) are wired by the host via their per-key
 /// extensions, NOT by module discovery — embeddings stay opt-in.
 /// </remarks>
-[DependsOn(typeof(GranitIndexingModule), typeof(GranitAIModule))]
+[DependsOn(typeof(GranitAIModule), typeof(GranitIndexingModule))]
 public sealed class GranitIndexingEmbeddingsModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Indexing.EntityFrameworkCore/Configurations/IndexedEntryRowConfiguration.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/Configurations/IndexedEntryRowConfiguration.cs
@@ -17,7 +17,9 @@ internal sealed class IndexedEntryRowConfiguration<TKey> : IEntityTypeConfigurat
 {
     public void Configure(EntityTypeBuilder<IndexedEntryRow<TKey>> builder)
     {
-        builder.ToTable($"IndexedEntry_{typeof(TKey).Name}");
+        builder.ToTable(
+            GranitIndexingDbProperties.DbTablePrefix + $"indexed_entry_{typeof(TKey).Name.ToLowerInvariant()}",
+            GranitIndexingDbProperties.DbSchema);
 
         builder.HasKey(e => new { e.TenantId, e.Key });
 
@@ -29,6 +31,6 @@ internal sealed class IndexedEntryRowConfiguration<TKey> : IEntityTypeConfigurat
 
         // Hot-path lookup: GDPR Art. 17 handler deletes by (TenantId, DataSubjectId).
         builder.HasIndex(e => new { e.TenantId, e.DataSubjectId })
-            .HasDatabaseName($"IX_IndexedEntry_{typeof(TKey).Name}_DataSubject");
+            .HasDatabaseName($"ix_{GranitIndexingDbProperties.DbTablePrefix}indexed_entry_{typeof(TKey).Name.ToLowerInvariant()}_data_subject");
     }
 }

--- a/src/Granit.Indexing.EntityFrameworkCore/Configurations/IndexingRebuildCheckpointRowConfiguration.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/Configurations/IndexingRebuildCheckpointRowConfiguration.cs
@@ -8,7 +8,9 @@ internal sealed class IndexingRebuildCheckpointRowConfiguration : IEntityTypeCon
 {
     public void Configure(EntityTypeBuilder<IndexingRebuildCheckpointRow> builder)
     {
-        builder.ToTable("IndexingRebuildCheckpoint");
+        builder.ToTable(
+            GranitIndexingDbProperties.DbTablePrefix + "rebuild_checkpoint",
+            GranitIndexingDbProperties.DbSchema);
 
         // (TenantId, SourceName) is the natural key. We deliberately don't add a
         // surrogate Id — checkpoints are upsert-by-tuple.

--- a/src/Granit.Indexing.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -199,7 +199,7 @@ public static class ModelBuilderExtensions
 
         entity.HasIndex(e => e.SearchVector)
             .HasMethod("GIN")
-            .HasDatabaseName($"IX_IndexedEntry_{typeof(TKey).Name}_SearchVector_GIN");
+            .HasDatabaseName($"ix_{GranitIndexingDbProperties.DbTablePrefix}indexed_entry_{typeof(TKey).Name.ToLowerInvariant()}_search_vector_gin");
 
         return entity;
     }
@@ -237,7 +237,7 @@ public static class ModelBuilderExtensions
         entity.HasIndex(e => e.Embedding)
             .HasMethod("hnsw")
             .HasOperators("vector_cosine_ops")
-            .HasDatabaseName($"IX_IndexedEntry_{typeof(TKey).Name}_Embedding_HNSW");
+            .HasDatabaseName($"ix_{GranitIndexingDbProperties.DbTablePrefix}indexed_entry_{typeof(TKey).Name.ToLowerInvariant()}_embedding_hnsw");
 
         return entity;
     }

--- a/src/Granit.Indexing.EntityFrameworkCore/GranitIndexingDbProperties.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/GranitIndexingDbProperties.cs
@@ -1,0 +1,32 @@
+using Granit.Persistence.EntityFrameworkCore;
+
+namespace Granit.Indexing.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Indexing EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitIndexingDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all indexing tables. Default: <c>"indexing_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "indexing_";
+
+    private static string? _dbSchema;
+    private static bool _dbSchemaExplicitlySet;
+
+    /// <summary>
+    /// Database schema for indexing tables.
+    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// </summary>
+    public static string? DbSchema
+    {
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
+    }
+}

--- a/src/Granit.QueryEngine.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
+++ b/src/Granit.QueryEngine.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
@@ -183,6 +183,21 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
         return sb.ToString();
     }
 
+    // Used by the fuzz harness (Granit.QueryEngine.AI.Fuzz) to exercise the
+    // JSON-parse + whitelist-validation path without going through the LLM.
+    internal static bool TryDeserializeAndConvert(string json, QueryMetadata metadata, out QueryRequest? result)
+    {
+        LlmQueryPayload? dto = System.Text.Json.JsonSerializer.Deserialize<LlmQueryPayload>(json);
+        if (dto is null)
+        {
+            result = null;
+            return false;
+        }
+
+        result = ValidateAndConvert(dto, metadata);
+        return true;
+    }
+
     private static QueryRequest ValidateAndConvert(LlmQueryPayload dto, QueryMetadata metadata)
     {
         // Build whitelist of allowed filter keys from metadata (CWE-20, LLM02)

--- a/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/GranitApiKeysDbPropertiesTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/GranitApiKeysDbPropertiesTests.cs
@@ -6,12 +6,12 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests;
 public sealed class GranitApiKeysDbPropertiesTests
 {
     [Fact]
-    public void DbTablePrefix_DefaultIsApiKeys()
+    public void DbTablePrefix_DefaultIsAuthenticationApiKeys()
     {
         // Reset to default in case other tests modified it
-        GranitApiKeysDbProperties.DbTablePrefix = "api_keys_";
+        GranitApiKeysDbProperties.DbTablePrefix = "authentication_api_keys_";
 
-        GranitApiKeysDbProperties.DbTablePrefix.ShouldBe("api_keys_");
+        GranitApiKeysDbProperties.DbTablePrefix.ShouldBe("authentication_api_keys_");
     }
 
     [Fact]

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
@@ -30,7 +30,7 @@ public sealed class HostnamesPostgresTests : IClassFixture<PostgresFixture>, IAs
 
         // Table name uses the default prefix — tests always run with defaults.
         await _context.Database.ExecuteSqlAsync(
-            $"TRUNCATE TABLE hostname_managed_hostnames RESTART IDENTITY CASCADE;",
+            $"TRUNCATE TABLE {GranitHostnamesDbProperties.DbTablePrefix}managed_hostnames RESTART IDENTITY CASCADE;",
             TestContext.Current.CancellationToken);
     }
 

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
@@ -113,7 +113,7 @@ public sealed class HostnamesPostgresTests : IClassFixture<PostgresFixture>, IAs
         // Column/table names use PascalCase — EF Core default without snake_case conventions.
         Guid id = hostname.Id;
         string? rawStatus = await _context.Database
-            .SqlQuery<string>($"""SELECT "Status" AS "Value" FROM hostname_managed_hostnames WHERE "Id" = {id}""")
+            .SqlQuery<string>($"""SELECT "Status" AS "Value" FROM {GranitHostnamesDbProperties.DbTablePrefix}managed_hostnames WHERE "Id" = {id}""")
             .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
 
         // Create() sets Status = Pending; Active is only reached after DNS verification.

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
@@ -29,9 +29,8 @@ public sealed class HostnamesPostgresTests : IClassFixture<PostgresFixture>, IAs
         await _context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 
         // Table name uses the default prefix — tests always run with defaults.
-        await _context.Database.ExecuteSqlAsync(
-            $"TRUNCATE TABLE {GranitHostnamesDbProperties.DbTablePrefix}managed_hostnames RESTART IDENTITY CASCADE;",
-            TestContext.Current.CancellationToken);
+        string truncateSql = $"TRUNCATE TABLE {GranitHostnamesDbProperties.DbTablePrefix}managed_hostnames RESTART IDENTITY CASCADE";
+        await _context.Database.ExecuteSqlRawAsync(truncateSql, TestContext.Current.CancellationToken);
     }
 
     public ValueTask DisposeAsync() => _context.DisposeAsync();

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests.Integration/HostnamesPostgresTests.cs
@@ -112,8 +112,9 @@ public sealed class HostnamesPostgresTests : IClassFixture<PostgresFixture>, IAs
         // SqlQuery<string> uses a parameterised query (safe from SQL injection).
         // Column/table names use PascalCase — EF Core default without snake_case conventions.
         Guid id = hostname.Id;
+        string sql = $"""SELECT "Status" AS "Value" FROM {GranitHostnamesDbProperties.DbTablePrefix}managed_hostnames WHERE "Id" = @id""";
         string? rawStatus = await _context.Database
-            .SqlQuery<string>($"""SELECT "Status" AS "Value" FROM {GranitHostnamesDbProperties.DbTablePrefix}managed_hostnames WHERE "Id" = {id}""")
+            .SqlQueryRaw<string>(sql, new NpgsqlParameter("id", id))
             .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
 
         // Create() sets Status = Pending; Active is only reached after DNS verification.

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/GranitIdentityDbPropertiesTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/GranitIdentityDbPropertiesTests.cs
@@ -6,14 +6,14 @@ namespace Granit.Identity.EntityFrameworkCore.Tests;
 public sealed class GranitIdentityDbPropertiesTests
 {
     [Fact]
-    public void DbTablePrefix_DefaultsToGranitIdentityUnderscore()
+    public void DbTablePrefix_DefaultsToIdentityUnderscore()
     {
         string original = GranitIdentityDbProperties.DbTablePrefix;
         try
         {
-            GranitIdentityDbProperties.DbTablePrefix = "granit_identity_";
+            GranitIdentityDbProperties.DbTablePrefix = "identity_";
 
-            GranitIdentityDbProperties.DbTablePrefix.ShouldBe("granit_identity_");
+            GranitIdentityDbProperties.DbTablePrefix.ShouldBe("identity_");
         }
         finally
         {

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/GranitIdentityDbPropertiesTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/GranitIdentityDbPropertiesTests.cs
@@ -6,16 +6,16 @@ namespace Granit.Identity.Federated.EntityFrameworkCore.Tests;
 public sealed class GranitIdentityDbPropertiesTests
 {
     [Fact]
-    public void DbTablePrefix_DefaultsToIdentityUnderscore()
+    public void DbTablePrefix_DefaultsToIdentityFederatedUnderscore()
     {
         // Save original to restore after test
         string original = GranitIdentityDbProperties.DbTablePrefix;
         try
         {
             // Reset to default
-            GranitIdentityDbProperties.DbTablePrefix = "identity_";
+            GranitIdentityDbProperties.DbTablePrefix = "identity_federated_";
 
-            GranitIdentityDbProperties.DbTablePrefix.ShouldBe("identity_");
+            GranitIdentityDbProperties.DbTablePrefix.ShouldBe("identity_federated_");
         }
         finally
         {

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PostgresHarness.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PostgresHarness.cs
@@ -46,7 +46,8 @@ internal sealed class PostgresHarness : IAsyncDisposable
             // Idempotent across tests sharing the same container — schema is created once,
             // rows are truncated below to guarantee isolation.
             await db.Database.EnsureCreatedAsync(ct);
-            await db.Database.ExecuteSqlRawAsync("TRUNCATE TABLE \"IndexedEntry_Guid\"", ct);
+            await db.Database.ExecuteSqlRawAsync(
+                $"TRUNCATE TABLE \"{GranitIndexingDbProperties.DbTablePrefix}indexed_entry_guid\"", ct);
         }
 
         return new PostgresHarness(sp);


### PR DESCRIPTION
## Summary

- **Granit.Indexing**: add `GranitIndexingDbProperties` (prefix `indexing_`), rename `IndexedEntry_{TKey}` → `indexing_indexed_entry_{key}`, `IndexingRebuildCheckpoint` → `indexing_rebuild_checkpoint`, fix PascalCase `IX_` index names to snake_case `ix_`
- **Granit.Indexing.Embeddings**: fix `[DependsOn]` alphabetical order (`GranitAIModule` before `GranitIndexingModule`)
- **Granit.Identity**: drop redundant `granit_` from prefix (`granit_identity_` → `identity_`)
- **Granit.Identity.Federated**: disambiguate prefix (`identity_` → `identity_federated_`) to avoid collision with `Granit.Identity`
- **Granit.EntityMerge**: widen prefix (`merge_` → `entity_merge_`) to avoid ambiguity
- **Granit.Hostnames**: pluralise prefix (`hostname_` → `hostnames_`) to match module name
- **Granit.BlobStorage.Database**: add `GranitBlobStorageDatabaseDbProperties` (prefix `blob_storage_`), replace hardcoded `storage_blob_contents` with prefixed + configurable name

## Test plan

- [ ] `dotnet build` on all modified modules passes
- [ ] Consuming apps must update their EF Core migrations to rename the affected tables