### PR TITLE
fix(indexing): fix EF1002 — build TRUNCATE sql string before ExecuteSqlRawAsync

### DIFF
--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PostgresHarness.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/PostgresHarness.cs
@@ -46,8 +46,8 @@ internal sealed class PostgresHarness : IAsyncDisposable
             // Idempotent across tests sharing the same container — schema is created once,
             // rows are truncated below to guarantee isolation.
             await db.Database.EnsureCreatedAsync(ct);
-            await db.Database.ExecuteSqlRawAsync(
-                $"TRUNCATE TABLE \"{GranitIndexingDbProperties.DbTablePrefix}indexed_entry_guid\"", ct);
+            string truncateSql = $"TRUNCATE TABLE \"{GranitIndexingDbProperties.DbTablePrefix}indexed_entry_guid\"";
+            await db.Database.ExecuteSqlRawAsync(truncateSql, ct);
         }
 
         return new PostgresHarness(sp);


### PR DESCRIPTION
## Summary

- Fixes EF1002 build error in `PostgresHarness.cs`: `ExecuteSqlRawAsync` with an interpolated string literal at the call site triggers the analyzer. Building the SQL string in a local variable first avoids the warning-as-error.

Same pattern already applied in `Granit.Hostnames.EntityFrameworkCore.Tests.Integration`.

## Test plan

- [ ] CI build passes on `Granit.Indexing.EntityFrameworkCore.Tests.Integration`