### PR TITLE
fix(bff): configure cookie prefix for nested frontends

### DIFF
--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -42,9 +42,12 @@ public sealed class GranitBffEndpointsModule : GranitModule
 
         // In development (HTTP), use "." prefix instead of "__Host-" on BFF session cookies.
         // __Host- requires HTTPS — browsers silently ignore the cookie on HTTP.
-        context.Services.PostConfigureAll<BffFrontendOptions>(options =>
+        context.Services.PostConfigure<GranitBffOptions>(options =>
         {
-            options.CookiePrefix = isDevelopment ? "." : "__Host-";
+            foreach (BffFrontendOptions frontend in options.Frontends)
+            {
+                frontend.CookiePrefix = isDevelopment ? "." : "__Host-";
+            }
         });
     }
 }

--- a/tests/Granit.Bff.Endpoints.Tests/GranitBffEndpointsModuleTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/GranitBffEndpointsModuleTests.cs
@@ -1,0 +1,52 @@
+using Granit.Bff.Options;
+using Granit.Modularity;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Bff.Endpoints.Tests;
+
+public sealed class GranitBffEndpointsModuleTests
+{
+    [Fact]
+    public void ConfigureServices_UsesDevelopmentCookiePrefix_ForNestedFrontends()
+    {
+        GranitBffOptions options = ConfigureAndResolveOptions(Environments.Development);
+
+        options.Frontends.Single().SessionCookieName.ShouldBe(".bff-host");
+    }
+
+    [Fact]
+    public void ConfigureServices_UsesHostCookiePrefix_ForNestedFrontends_OutsideDevelopment()
+    {
+        GranitBffOptions options = ConfigureAndResolveOptions(Environments.Production);
+
+        options.Frontends.Single().SessionCookieName.ShouldBe("__Host-bff-host");
+    }
+
+    private static GranitBffOptions ConfigureAndResolveOptions(string environmentName)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = environmentName });
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Bff:Authority"] = "https://auth.example.com",
+            ["Bff:Frontends:0:Name"] = "host",
+            ["Bff:Frontends:0:ClientId"] = "host-client",
+            ["Bff:Frontends:0:ClientSecret"] = "host-secret",
+            ["Bff:Frontends:0:PathPrefix"] = "/host",
+        });
+
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        new GranitBffModule().ConfigureServices(context);
+        new GranitBffEndpointsModule().ConfigureServices(context);
+
+        using ServiceProvider provider = builder.Services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<GranitBffOptions>>().Value;
+    }
+}


### PR DESCRIPTION
## Summary
- apply BFF cookie prefix configuration to nested frontend options
- add regression coverage for development and production cookie prefixes

## Tests
- dotnet test tests/Granit.Bff.Endpoints.Tests/Granit.Bff.Endpoints.Tests.csproj --no-restore