### PR TITLE
fix(openiddict): harden key rotation concurrency + audit findings

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35901,7 +35901,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.BackgroundJobs",
       "file": "src/Granit.OpenIddict.BackgroundJobs/Services/KeyRotationExecutionService.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -35982,6 +35982,12 @@
       "line": 22,
       "members": [
         {
+          "name": "ConcurrencyStamp",
+          "kind": "property",
+          "signature": "string ConcurrencyStamp",
+          "returnType": "string"
+        },
+        {
           "name": "KeyId",
           "kind": "property",
           "signature": "string KeyId",
@@ -36037,7 +36043,7 @@
       "kind": "enum",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Domain/SigningKey.cs",
-      "line": 97,
+      "line": 100,
       "members": []
     },
     {
@@ -36453,7 +36459,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
-      "line": 41,
+      "line": 47,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36904,7 +36910,7 @@
           "name": "UpdateAsync",
           "kind": "method",
           "signature": "UpdateAsync(SigningKey key, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
+          "returnType": "Task<bool>"
         },
         {
           "name": "PruneRevokedAsync",

--- a/src/Granit.OpenIddict.BackgroundJobs/Services/KeyRotationExecutionService.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Services/KeyRotationExecutionService.cs
@@ -1,3 +1,4 @@
+using Granit.OpenIddict.Diagnostics;
 using Granit.OpenIddict.Services;
 using Microsoft.Extensions.Logging;
 
@@ -8,12 +9,17 @@ namespace Granit.OpenIddict.BackgroundJobs.Services;
 /// </summary>
 public sealed partial class KeyRotationExecutionService(
     IKeyRotationService keyRotationService,
+    OpenIddictMetrics metrics,
     ILogger<KeyRotationExecutionService> logger)
 {
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         KeyRotationResult result = await keyRotationService
             .RotateAsync(cancellationToken).ConfigureAwait(false);
+
+        // Signing keys are global (not tenant-scoped) — record under the "global" tenant.
+        metrics.RecordKeyRotation(
+            tenantId: null, result.KeysGenerated, result.KeysRetired, result.KeysRevoked);
 
         Log.KeyRotationCompleted(logger,
             result.KeysGenerated, result.KeysRetired, result.KeysRevoked, result.KeysPruned);

--- a/src/Granit.OpenIddict.Endpoints/Options/OpenIddictEndpointsOptions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Options/OpenIddictEndpointsOptions.cs
@@ -14,8 +14,8 @@ public sealed class OpenIddictEndpointsOptions
     /// <summary>Route prefix for admin management endpoints. Default: <c>"admin"</c>.</summary>
     public string AdminRoutePrefix { get; set; } = "admin";
 
-    /// <summary>OpenAPI tag name for admin OIDC management endpoints. Default: <c>"OIDC Admin"</c>.</summary>
-    public string AdminTagName { get; set; } = "OIDC Admin";
+    /// <summary>OpenAPI tag name for admin OIDC management endpoints. Default: <c>"OIDC - Admin"</c>.</summary>
+    public string AdminTagName { get; set; } = "OIDC - Admin";
 
     /// <summary>Route prefix for authenticated (non-admin) OIDC endpoints used by the consent page. Default: <c>"oidc"</c>.</summary>
     public string OidcRoutePrefix { get; set; } = "oidc";

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfSigningKeyStore.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfSigningKeyStore.cs
@@ -46,12 +46,27 @@ internal sealed class EfSigningKeyStore(
         AddAsync(key, cancellationToken);
 
     /// <inheritdoc/>
-    public new Task UpdateAsync(SigningKey key, CancellationToken cancellationToken = default) =>
-        base.UpdateAsync(key, cancellationToken);
+    public new async Task<bool> UpdateAsync(SigningKey key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await base.UpdateAsync(key, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Another rotation already transitioned this key (its ConcurrencyStamp moved).
+            // Report the lost race to the caller so it aborts instead of minting a duplicate key.
+            return false;
+        }
+    }
 
     /// <inheritdoc/>
     public Task<int> PruneRevokedAsync(
         DateTimeOffset olderThan, CancellationToken cancellationToken = default) =>
+        // Deliberate interceptor bypass: revoked keys are hard-deleted. SigningKey is not
+        // ISoftDeletable (no soft-delete to preserve) and pruning is a maintenance operation,
+        // so ExecuteDelete (which skips SaveChanges interceptors) is the intended path.
         WriteAsync(
             db => db.SigningKeys
                 .Where(k => k.Status == SigningKeyStatus.Revoked && k.RetiredAt < olderThan)

--- a/src/Granit.OpenIddict/Domain/SigningKey.cs
+++ b/src/Granit.OpenIddict/Domain/SigningKey.cs
@@ -19,10 +19,13 @@ namespace Granit.OpenIddict.Domain;
 /// and <see cref="SigningKeyStatus.Retired"/> public keys.
 /// </para>
 /// </remarks>
-public sealed class SigningKey : CreationAuditedEntity
+public sealed class SigningKey : CreationAuditedEntity, IConcurrencyAware
 {
     /// <summary>EF Core materialization constructor.</summary>
     private SigningKey() { }
+
+    /// <inheritdoc/>
+    public string ConcurrencyStamp { get; set; } = string.Empty;
 
     /// <summary>The key identifier (kid), used in JWT headers to identify the signing key.</summary>
     public string KeyId { get; private set; } = string.Empty;

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -1,6 +1,9 @@
 using Granit.Caching;
+using Granit.DataExchange;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
+using Granit.Encryption;
+using Granit.Entities;
 using Granit.Entities.Extensions;
 using Granit.Http.Cookies;
 using Granit.Identity;
@@ -34,6 +37,9 @@ namespace Granit.OpenIddict;
 /// </summary>
 [DependsOn(
     typeof(GranitCachingModule),
+    typeof(GranitDataExchangeAbstractionsModule),
+    typeof(GranitEncryptionModule),
+    typeof(GranitEntitiesAbstractionsModule),
     typeof(GranitHttpCookiesModule),
     typeof(GranitIdentityLocalAspNetIdentityModule),
     typeof(GranitIdentityLocalModule),

--- a/src/Granit.OpenIddict/Internal/KeyRotationService.cs
+++ b/src/Granit.OpenIddict/Internal/KeyRotationService.cs
@@ -36,10 +36,14 @@ internal sealed partial class KeyRotationService(
         int revoked = 0;
 
         // 1. Ensure active signing key exists, rotate if expiring soon
-        generated += await EnsureActiveKeyAsync("signing", options, now, cancellationToken).ConfigureAwait(false);
+        (int g, int r) = await EnsureActiveKeyAsync("signing", options, now, cancellationToken).ConfigureAwait(false);
+        generated += g;
+        retired += r;
 
         // 2. Ensure active encryption key exists, rotate if expiring soon
-        generated += await EnsureActiveKeyAsync("encryption", options, now, cancellationToken).ConfigureAwait(false);
+        (g, r) = await EnsureActiveKeyAsync("encryption", options, now, cancellationToken).ConfigureAwait(false);
+        generated += g;
+        retired += r;
 
         // 3. Revoke keys whose grace period has expired
         IReadOnlyList<SigningKey> retiredKeys = await keyStore
@@ -49,7 +53,13 @@ internal sealed partial class KeyRotationService(
             k.RetiredAt.HasValue && now - k.RetiredAt.Value > options.GracePeriod))
         {
             retiredKey.Revoke();
-            await keyStore.UpdateAsync(retiredKey, cancellationToken).ConfigureAwait(false);
+
+            // A concurrent rotation may already have revoked this key — skip on a lost race.
+            if (!await keyStore.UpdateAsync(retiredKey, cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
+
             Log.KeyRevoked(logger, retiredKey.KeyId);
             revoked++;
         }
@@ -66,7 +76,18 @@ internal sealed partial class KeyRotationService(
         return new KeyRotationResult(generated, retired, revoked, pruned);
     }
 
-    private async Task<int> EnsureActiveKeyAsync(
+    /// <summary>
+    /// Ensures an active key exists for <paramref name="keyType"/>, rotating it when it nears
+    /// expiry. Returns the number of keys generated and retired in this cycle.
+    /// </summary>
+    /// <remarks>
+    /// Rotation retires the current key <b>before</b> generating its replacement. The retire is
+    /// an optimistic-concurrency update on <see cref="SigningKey.ConcurrencyStamp"/>: when two
+    /// rotations race (cron + manual trigger, message redelivery, or per-replica scheduling), only
+    /// one wins the retire and proceeds to generate. The loser observes a lost race and aborts,
+    /// guaranteeing a single new active key per type instead of two.
+    /// </remarks>
+    private async Task<(int Generated, int Retired)> EnsureActiveKeyAsync(
         string keyType,
         GranitKeyRotationOptions options,
         DateTimeOffset now,
@@ -78,23 +99,30 @@ internal sealed partial class KeyRotationService(
         if (activeKey is null)
         {
             await GenerateKeyAsync(keyType, options, now, cancellationToken).ConfigureAwait(false);
-            return 1;
+            return (1, 0);
         }
 
         if (activeKey.ExpiresAt - now <= options.RotationLeadTime)
         {
             Log.KeyRotationStarted(logger, activeKey.KeyId, activeKey.ExpiresAt);
 
-            await GenerateKeyAsync(keyType, options, now, cancellationToken).ConfigureAwait(false);
-
+            // Retire first: this is the concurrency gate. If a competing rotation already
+            // retired this key, our update loses the race and we MUST NOT generate a duplicate.
             activeKey.Retire(now);
-            await keyStore.UpdateAsync(activeKey, cancellationToken).ConfigureAwait(false);
+            if (!await keyStore.UpdateAsync(activeKey, cancellationToken).ConfigureAwait(false))
+            {
+                Log.ConcurrentRotationSkipped(logger, activeKey.KeyId);
+                return (0, 0);
+            }
+
             Log.KeyRetired(logger, activeKey.KeyId);
 
-            return 1;
+            await GenerateKeyAsync(keyType, options, now, cancellationToken).ConfigureAwait(false);
+
+            return (1, 1);
         }
 
-        return 0;
+        return (0, 0);
     }
 
     private async Task GenerateKeyAsync(
@@ -147,6 +175,9 @@ internal sealed partial class KeyRotationService(
 
         [LoggerMessage(Level = LogLevel.Information, Message = "Key {KeyId} retired (grace period started).")]
         public static partial void KeyRetired(ILogger logger, string keyId);
+
+        [LoggerMessage(Level = LogLevel.Information, Message = "Key rotation for {KeyId} skipped — a concurrent rotation already retired it.")]
+        public static partial void ConcurrentRotationSkipped(ILogger logger, string keyId);
 
         [LoggerMessage(Level = LogLevel.Information, Message = "Key {KeyId} revoked (grace period expired).")]
         public static partial void KeyRevoked(ILogger logger, string keyId);

--- a/src/Granit.OpenIddict/Services/ISigningKeyStore.cs
+++ b/src/Granit.OpenIddict/Services/ISigningKeyStore.cs
@@ -34,7 +34,13 @@ public interface ISigningKeyStore
     /// <summary>
     /// Updates an existing key (e.g., status change on rotation).
     /// </summary>
-    Task UpdateAsync(SigningKey key, CancellationToken cancellationToken = default);
+    /// <returns>
+    /// <c>true</c> if the update was applied; <c>false</c> if it lost an optimistic-concurrency
+    /// race (another rotation already transitioned this key). Callers must treat <c>false</c> as
+    /// "another runner won" and abort the dependent step rather than retrying — this is the
+    /// guard against a double key rotation minting two active keys across replicas.
+    /// </returns>
+    Task<bool> UpdateAsync(SigningKey key, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes keys older than the specified cutoff (cleanup of revoked keys).

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictKeyRotationHandlerTests.cs
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictKeyRotationHandlerTests.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics.Metrics;
 using Granit.OpenIddict.BackgroundJobs.Jobs;
 using Granit.OpenIddict.BackgroundJobs.Services;
+using Granit.OpenIddict.Diagnostics;
 using Granit.OpenIddict.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
@@ -8,8 +11,17 @@ using Xunit;
 
 namespace Granit.OpenIddict.BackgroundJobs.Tests.Jobs;
 
-public sealed class OpenIddictKeyRotationHandlerTests
+public sealed class OpenIddictKeyRotationHandlerTests : IDisposable
 {
+    private readonly ServiceProvider _serviceProvider = new ServiceCollection()
+        .AddMetrics()
+        .BuildServiceProvider();
+
+    private OpenIddictMetrics CreateMetrics() =>
+        new(_serviceProvider.GetRequiredService<IMeterFactory>());
+
+    public void Dispose() => _serviceProvider.Dispose();
+
     [Fact]
     public async Task HandleAsync_DelegatesToKeyRotationService()
     {
@@ -17,7 +29,7 @@ public sealed class OpenIddictKeyRotationHandlerTests
         keyRotationService.RotateAsync(Arg.Any<CancellationToken>())
             .Returns(new KeyRotationResult(1, 1, 0, 0));
         var service = new KeyRotationExecutionService(
-            keyRotationService, NullLogger<KeyRotationExecutionService>.Instance);
+            keyRotationService, CreateMetrics(), NullLogger<KeyRotationExecutionService>.Instance);
 
         await OpenIddictKeyRotationHandler.HandleAsync(
             new OpenIddictKeyRotationJob(),
@@ -34,7 +46,7 @@ public sealed class OpenIddictKeyRotationHandlerTests
         keyRotationService.RotateAsync(Arg.Any<CancellationToken>())
             .Returns(new KeyRotationResult(0, 0, 0, 0));
         var service = new KeyRotationExecutionService(
-            keyRotationService, NullLogger<KeyRotationExecutionService>.Instance);
+            keyRotationService, CreateMetrics(), NullLogger<KeyRotationExecutionService>.Instance);
 
         await Should.NotThrowAsync(() => OpenIddictKeyRotationHandler.HandleAsync(
             new OpenIddictKeyRotationJob(),

--- a/tests/Granit.OpenIddict.Tests/KeyRotationServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/KeyRotationServiceTests.cs
@@ -30,6 +30,10 @@ public sealed class KeyRotationServiceTests
             .Returns([]);
         _keyStore.PruneRevokedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
             .Returns(0);
+
+        // Default: updates win the optimistic-concurrency race.
+        _keyStore.UpdateAsync(Arg.Any<SigningKey>(), Arg.Any<CancellationToken>())
+            .Returns(true);
     }
 
     private KeyRotationService CreateSut(GranitKeyRotationOptions? options = null)
@@ -172,6 +176,25 @@ public sealed class KeyRotationServiceTests
         await _keyStore.Received().UpdateAsync(signingKey, Arg.Any<CancellationToken>());
         signingKey.Status.ShouldBe(SigningKeyStatus.Retired);
         signingKey.RetiredAt.ShouldBe(Now);
+    }
+
+    [Fact]
+    public async Task RotateAsync_WhenRetireLosesConcurrencyRace_DoesNotGenerateReplacement()
+    {
+        // Signing key is expiring → rotation is attempted, but the retire update loses the
+        // optimistic-concurrency race (a competing rotation already retired this key).
+        SigningKey signingKey = SetupActiveKey("signing", Now.AddDays(10));
+        SetupActiveKey("encryption", Now.AddDays(60));
+        _keyStore.UpdateAsync(signingKey, Arg.Any<CancellationToken>()).Returns(false);
+
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        // Fail closed: no replacement key is minted when the retire was not applied.
+        result.KeysGenerated.ShouldBe(0);
+        result.KeysRetired.ShouldBe(0);
+        await _keyStore.DidNotReceive().CreateAsync(Arg.Any<SigningKey>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Context

`/audit Granit.OpenIddict.*` flagged one security-relevant hazard plus several convention deviations. This PR fixes all of them.

## Security — key rotation concurrency (the blocking finding)

`KeyRotationService` had no single-runner guarantee. Two racing rotations — cron racing a manual `TriggerNowAsync`, Wolverine redelivery, or the default in-memory **per-replica** scheduler — could each generate a new active signing key and retire the original, leaving **multiple active keys** advertised in the JWKS. Signing keys are global (not tenant-scoped), so any double-execution is a token-validation hazard.

**Fix (portable, ADR-061-idiomatic — no provider-specific SQL):**
- `SigningKey` implements `IConcurrencyAware`; `ApplyGranitConventions` configures `ConcurrencyStamp` as the EF concurrency token and `ConcurrencyStampInterceptor` regenerates it on save.
- Rotation **retires the current key before generating** the replacement. The retire is the concurrency gate: a losing rotation observes the lost race and aborts — guaranteeing a single new active key per type.
- `ISigningKeyStore.UpdateAsync` now returns `bool` (`false` = lost race). `EfSigningKeyStore` maps `DbUpdateConcurrencyException` to it, keeping EF types out of the base module (layer purity).
- New fail-closed unit test: when the retire loses the race, no replacement key is minted.

## Convention findings
- **Dead metric**: `granit.openiddict.keys.rotated` was defined but never emitted — wired into `KeyRotationExecutionService` (key-lifecycle observability, ISO 27001). `EnsureActiveKeyAsync` now reports the retired count so the metric is accurate.
- **`[DependsOn]`**: added the 3 missing modules with a `*Module` + direct project ref (`DataExchangeAbstractions`, `Encryption`, `EntitiesAbstractions`); restored alphabetical order.
- **OpenAPI tag**: admin tag `"OIDC Admin"` → `"OIDC - Admin"` (`<Module> - <SubGroup>` format).
- **Doc**: documented the deliberate `ExecuteDelete` interceptor bypass in `PruneRevokedAsync`.

## Audit findings intentionally NOT changed
- **GroupStore `TenantId`** (flagged CONVENTION): verified false positive — `AuditedEntityInterceptor` stamps `TenantId` on insert for `IMultiTenant` entities and is auto-wired into `OpenIddictDbContext`.
- **`SigningKey.KeyType`/`Algorithm` as `string`** (IMPROVEMENT): left as-is — they interop with `Microsoft.IdentityModel` string constants; converting to enums adds interop risk for marginal gain.

## Verification
- Builds clean: base, `.EntityFrameworkCore`, `.BackgroundJobs`, `.Endpoints`.
- Tests green: `Granit.OpenIddict.Tests` (287), `.BackgroundJobs.Tests` (14), `.EntityFrameworkCore.Tests` (8), `.Endpoints.Tests` (121), **architecture shard** (216).
- `dotnet format --verify-no-changes` clean on all touched projects.

> Note: `SigningKey` gains a `ConcurrencyStamp varchar(36)` column. Consuming apps own migrations (framework ships none) and will pick it up on regeneration. Concurrent-rotation behaviour is unit-covered via the fail-closed test; a live multi-replica integration test would require the `integration` shard's database.