### PR TITLE
fix(caching): drop unsupported DefaultSlidingExpiration option

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12814,12 +12814,6 @@
           "kind": "method",
           "signature": "FromHours(1)",
           "returnType": "TimeSpan? DefaultAbsoluteExpirationRelativeToNow { get; set; } = TimeSpan."
-        },
-        {
-          "name": "FromMinutes",
-          "kind": "method",
-          "signature": "FromMinutes(20)",
-          "returnType": "TimeSpan? DefaultSlidingExpiration { get; set; } = TimeSpan."
         }
       ]
     },

--- a/src/Granit.Caching/Options/CachingOptions.cs
+++ b/src/Granit.Caching/Options/CachingOptions.cs
@@ -18,17 +18,12 @@ public sealed class CachingOptions
     public string KeyPrefix { get; set; } = "dd";
 
     /// <summary>
-    /// Default absolute expiration relative to the time of caching.
-    /// Used when no options are passed to <c>SetAsync</c> or <c>GetOrAddAsync</c>.
+    /// Default absolute expiration relative to the time of caching, applied as the
+    /// FusionCache default entry <c>Duration</c> when no per-entry options are passed.
+    /// FusionCache has no sliding expiration — absolute duration is the only default.
     /// Default: 1 hour.
     /// </summary>
     public TimeSpan? DefaultAbsoluteExpirationRelativeToNow { get; set; } = TimeSpan.FromHours(1);
-
-    /// <summary>
-    /// Default sliding expiration (reset on each access).
-    /// Default: 20 minutes.
-    /// </summary>
-    public TimeSpan? DefaultSlidingExpiration { get; set; } = TimeSpan.FromMinutes(20);
 
     /// <summary>
     /// Enables AES-256 encryption for all types without a <see cref="CacheEncryptedAttribute"/>.

--- a/tests/Granit.Caching.Tests/CachingOptionsTests.cs
+++ b/tests/Granit.Caching.Tests/CachingOptionsTests.cs
@@ -26,14 +26,6 @@ public sealed class CachingOptionsTests
     }
 
     [Fact]
-    public void Defaults_DefaultSlidingExpiration_IsTwentyMinutes()
-    {
-        CachingOptions options = new();
-
-        options.DefaultSlidingExpiration.ShouldBe(TimeSpan.FromMinutes(20));
-    }
-
-    [Fact]
     public void Defaults_EncryptValues_IsFalse()
     {
         CachingOptions options = new();
@@ -63,13 +55,5 @@ public sealed class CachingOptionsTests
         CachingOptions options = new() { DefaultAbsoluteExpirationRelativeToNow = null };
 
         options.DefaultAbsoluteExpirationRelativeToNow.ShouldBeNull();
-    }
-
-    [Fact]
-    public void DefaultSlidingExpiration_CanBeSetToNull()
-    {
-        CachingOptions options = new() { DefaultSlidingExpiration = null };
-
-        options.DefaultSlidingExpiration.ShouldBeNull();
     }
 }


### PR DESCRIPTION
## Summary

`CachingOptions.DefaultSlidingExpiration` was dead configuration. FusionCache (the caching provider) has **no sliding expiration** — absolute duration is the only default entry policy — so the option was never wired into the FusionCache registration and silently did nothing.

- Removes the `DefaultSlidingExpiration` property and its two tests.
- Clarifies the `DefaultAbsoluteExpirationRelativeToNow` doc comment to state it maps to the FusionCache default entry `Duration`.

Pre-1.0 clean break (no `[Obsolete]` graduation). Verified no consumer in the repo references the property — remaining `SlidingExpiration` hits are unrelated (`MemoryCacheEntryOptions` in AI client caches, `GranitBffOptions.UseSessionSlidingExpiration`).

## Verification
- `dotnet build src/Granit.Caching` clean.
- `dotnet test tests/Granit.Caching.Tests` — 62 passed.