### PR TITLE
chore(agents): expand audit/perf/security skills, add AGENTS.md

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: audit
 description: "Framework architect: audit Granit .NET modules against framework conventions, architecture rules, and CLAUDE.md standards. Checks module anatomy, DDD, naming, OpenAPI, persistence, validation, events, metrics, localization, documentation, and cross-cutting concerns. Invoke to verify convention compliance before merge or during tech-debt sprints."
-argument-hint: "[help | all | <module> | pr] [--fix] [--scope {anatomy|code|naming|http|openapi|persistence|ddd|validation|events|metrics|localization|deps|compliance|microservices|all}] [--base <branch>]"
+argument-hint: "[help | all | <module> | pr] [--fix] [--scope {anatomy|layer-purity|code|naming|http|openapi|persistence|ddd|validation|events|metrics|localization|deps|compliance|microservices|docs|all}] [--base <branch>]"
 ---
 
 # Framework Audit — Granit .NET
 
 You are a Granit framework architect. Your goal: ensure every module respects the
 conventions, architecture rules, and patterns defined in `CLAUDE.md` and the
-Astro documentation site (`docs-site/src/content/docs/dotnet/`). You analyze,
-classify findings by severity, then optionally fix — in that order.
+Astro documentation site (sibling repo `../granit-docs/`,
+`src/content/docs/dotnet/`). You analyze, classify findings by severity, then
+optionally fix — in that order.
 
 **Relationship with `/quality`**: the quality skill handles SonarQube, test
 coverage, and formatting. This skill handles **framework convention compliance** —
@@ -20,7 +21,7 @@ They are complementary; run both for a full picture.
 ## Invocation modes
 
 | Argument | Mode | Scope |
-|----------|------|-------|
+| -------- | ---- | ----- |
 | `help` | Help | Show reference card, stop |
 | _(none)_ / `all` | Full audit | All modules in `src/` |
 | `<module>` | Module audit | Single module and its satellite projects |
@@ -29,7 +30,7 @@ They are complementary; run both for a full picture.
 ### Flags
 
 | Flag | Effect |
-|------|--------|
+| ---- | ------ |
 | `--fix` | Apply fixes automatically (default: report only) |
 | `--scope <s>` | Restrict to one checklist category (default: `all`) |
 | `--base <branch>` | Override base branch for PR mode (default: `develop`) |
@@ -49,7 +50,7 @@ They are complementary; run both for a full picture.
 
 When `$ARGUMENTS` is `help`, display this reference card and stop:
 
-```
+```text
 /audit — Granit .NET Framework Convention Audit
 
 USAGE
@@ -72,8 +73,8 @@ FLAGS
     validation    FluentValidation, localization, MapGranitGroup
     events        Domain events (*Event) and integration events (*Eto)
     metrics       Meters, ActivitySource, health checks, diagnostics
-    localization  17-culture JSON completeness
-    deps          [DependsOn], project references, circular refs
+    localization  18-culture JSON completeness (15 base + 3 regional)
+    deps          [DependsOn], project refs, circular refs, vendor SDK confinement
     compliance    GDPR, ISO 27001, security, analyzers
     microservices Multi-replica safety, k8s probes/lifecycle, outbox, config/secrets
     docs          Module doc pages, code samples, cross-refs, counters
@@ -116,7 +117,7 @@ Resolve the audit target:
 For each module family, identify the **satellite projects**:
 
 | Suffix | Layer |
-|--------|-------|
+| ------ | ----- |
 | `Granit.{Module}` | Abstractions (interfaces, options, DI, Module class) |
 | `.Endpoints` | Minimal API endpoints, DTOs |
 | `.EntityFrameworkCore` | Isolated DbContext, entity configs, migrations |
@@ -134,6 +135,8 @@ token-efficient tool for each query.
 - **MCP `get_file_overview`** on key files (Module class, endpoints, DbContext)
 - **MCP `get_public_api`** for the abstractions project
 - **MCP `get_project_graph`** with `projectFilter: "Granit.{Module}"` for dependencies
+- **MCP granit-tools `code_search`** for broad symbol discovery across the
+  pre-built index (cheaper than Glob+Read for "where does X live?")
 - **Glob** `src/Granit.{Module}*/**/*.cs` to enumerate all source files
 
 ### 2b. Convention context
@@ -175,7 +178,7 @@ Apply every applicable category from `checklist.md` in order. For each finding:
 ### Severity definitions
 
 | Level | Meaning | Action |
-|-------|---------|--------|
+| ----- | ------- | ------ |
 | **BREAKING** | Runtime failure, data loss, security hole | Must fix before merge |
 | **ARCHITECTURE** | Module boundary violation, DDD rule break, circular dep | Must fix |
 | **CONVENTION** | Naming deviation, missing metadata, wrong pattern | Should fix |
@@ -217,17 +220,41 @@ COMPLIANT | NON-COMPLIANT — {n} blocking findings ({severity breakdown})
 
 ### Fix mode (`--fix`)
 
+**Mandatory planning for structural fixes.** Before the first `Edit` of any
+BREAKING or ARCHITECTURE finding — and any fix that moves a file between
+projects (layer-purity) — write down the complete refactoring plan first:
+
+- which file moves where (source → target project/folder)
+- the new namespace and every consumer `using` that must change
+  (enumerate consumers via `find_references` BEFORE moving)
+- DI registration moves (`Add{Module}Endpoints()` → `Add{Module}()`)
+- `[DependsOn]` / `<ProjectReference>` adjustments on both sides
+- test impact: moved/new test projects must be registered in
+  `.github/test-shards.json` + `python3 scripts/generate-shard-filters.py`
+
+Then apply the whole plan as one batch and build once. An unplanned multi-file
+move loops on build errors and burns the two-attempt budget on symptoms.
+
 For each finding with severity BREAKING, ARCHITECTURE, or CONVENTION:
 
 1. Read the full file
 2. Apply the fix via `Edit`
 3. Log the fix in the report under "Actions taken"
 
-After all fixes:
+After all fixes, build each touched project **individually** (NEVER the full
+solution — Roslyn OOMs; and `dotnet build A B C` silently builds only A,
+MSB1008):
 
 ```bash
-dotnet build src/Granit.{Module}
+for p in src/Granit.{Module} src/Granit.{Module}.Endpoints ...; do dotnet build "$p"; done
 dotnet test tests/Granit.{Module}.Tests
+```
+
+After any structural fix (file move, namespace change, `[DependsOn]` change),
+also run the architecture shard — those conventions are CI-enforced there:
+
+```bash
+dotnet test .github/shard-filters/architecture.slnf
 ```
 
 If a fix causes a build error:
@@ -240,6 +267,11 @@ If a fix causes a build error:
 
 For CLEANUP and IMPROVEMENT findings: report only, do not auto-fix unless
 `--scope` explicitly targets them.
+
+**Docs findings are never auto-fixed here.** The documentation site lives in
+the sibling `granit-docs` repo and doc updates ship in a separate PR. Report
+the finding and emit a self-contained handoff prompt for a granit-docs session
+(file path, old text, expected text) instead of editing cross-repo.
 
 ---
 
@@ -268,8 +300,9 @@ After auditing individual modules, perform cross-cutting checks:
 9. **Interceptor awareness** — no `ExecuteUpdate`/`ExecuteDelete` bypassing audit/soft-delete
 10. **Roslyn analyzer compliance** — GRMOD, GRSEC, GREF, GRAPI violations resolved
 11. **Architecture test coverage** — verify `Granit.ArchitectureTests` covers the module
-12. **Documentation coverage** — every module has a doc page in `docs-site/`,
-   code samples use current names, `PACKAGE_COUNT` in `constants.ts` is accurate
+12. **Documentation coverage** — every module has a doc page in
+   `../granit-docs/src/content/docs/dotnet/`, code samples use current names,
+   `PACKAGE_COUNT` in `../granit-docs/src/data/constants.ts` is accurate
 13. **Microservices/k8s readiness** — across modules, look for the recurring
    multi-replica hazards (`--scope microservices`, checklist §15): per-replica
    scheduled work, distributed events without an outbox, non-idempotent handlers,
@@ -315,23 +348,29 @@ In addition to the standard checklist:
 - **New public API surface**: any new `public` types or methods must follow naming
   conventions and have XML docs
 - **New dependencies**: check `<PackageReference>` additions for license compliance
-  and `THIRD-PARTY-NOTICES.md` update
+  and `THIRD-PARTY-NOTICES.md` update; vendor SDKs (`AWSSDK.*`, `Azure.*`,
+  `Google.Cloud.*`, …) only in `.{Provider}` packages (checklist §12e)
 - **New endpoints**: must have all 5 OpenAPI metadata elements
 - **New entities**: must follow DDD conventions (factory method, private setters if
   aggregate root)
 - **New events**: correct suffix (`*Event` or `*Eto`)
 - **New permissions**: three-segment naming
 - **New metrics**: correct naming and `TagList` usage
-- **New localization keys**: present in all 17 JSON files
+- **New localization keys**: present in all 18 culture files (15 base +
+  fr-CA, en-GB, pt-BR); new validation error codes in all 18 JSON files under
+  `src/Granit.Validation/Localization/Validation/`
 - **Documentation**: module doc page exists and references current names
-  (check `docs-site/src/content/docs/dotnet/` for the module)
+  (check `../granit-docs/src/content/docs/dotnet/` for the module)
 
 ### 4. Verification gate
 
+NEVER build/test/format the full solution (Roslyn OOMs). Match each changed
+file's directory against `.github/test-shards.json` to find its shard(s):
+
 ```bash
-dotnet build
-dotnet test tests/Granit.{Module}.Tests
-dotnet format --verify-no-changes
+dotnet build  .github/shard-filters/<shard>.slnf
+dotnet test   .github/shard-filters/<shard>.slnf --no-build
+dotnet format .github/shard-filters/<shard>.slnf --verify-no-changes
 ```
 
 ### 5. PR report
@@ -361,8 +400,8 @@ COMPLIANT | NON-COMPLIANT — {reasons}
 1. **Read before judging** — always read the full file and git history before
    flagging. Code that looks wrong often has a reason.
 2. **Documentation is the source of truth** — conventions come from `CLAUDE.md`,
-   `docs-site/src/content/docs/dotnet/` (Astro docs), and architecture tests.
-   Do not invent new rules.
+   the Astro docs in the sibling repo (`../granit-docs/src/content/docs/dotnet/`),
+   and architecture tests. Do not invent new rules.
 3. **MCP first** — use Roslyn MCP tools for type inspection, not file reading.
    Fall back to `Read` only for implementation logic and non-C# files.
 4. **No speculative refactoring** — flag only concrete violations of documented

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -6,7 +6,9 @@ Verification matrix used by the `/audit` skill. Each category maps to a
 Convention references point to:
 
 - `CLAUDE.md` — project conventions (root of repo)
-- `docs-site/…/dotnet/` — Astro documentation site
+- `docs-site/…/dotnet/` — Astro documentation site, now the **sibling repo**
+  `../granit-docs/` — resolve any `docs-site/…/X` reference as
+  `../granit-docs/src/content/docs/dotnet/…/X`
 - `GRXXXX` — Roslyn analyzer rule
 
 ---
@@ -663,7 +665,15 @@ What the endpoint MUST still declare:
 
 - [ ] `ISchemaExampleProvider<TRequest>` implemented for each non-trivial
   `*Request` DTO with realistic values (no `"string"`, `0`, `00000000-0000-...`)
-- [ ] Enum JSON serialization uses `JsonStringEnumConverter` (PascalCase)
+- [ ] Enum JSON serialization uses `JsonStringEnumConverter` (PascalCase) —
+  never raw integers; an opaque `type: integer` enum is useless to TypeScript
+  codegen and to anyone reading the payload
+- [ ] **Polymorphic DTOs declare their hierarchy explicitly** — any `*Request`/
+  `*Response` base type with derived wire types carries
+  `[JsonDerivedType(typeof(Derived), "discriminatorValue")]` (one per derived
+  type) so the OpenAPI document emits a `discriminator` mapping. Without it,
+  TypeScript generators (openapi-ts, Orval) silently degrade the union to
+  `any` or an unusable intersection — flag as BREAKING, not style
 - [ ] Date/time properties are `DateTime` / `DateTimeOffset` → ISO 8601 with
   timezone in OpenAPI
 - [ ] Identifiers are `Guid` → `string` with `format: uuid` in OpenAPI
@@ -772,6 +782,8 @@ When auditing a module's endpoints:
 | Swashbuckle / NSwag reference | ARCHITECTURE |
 | Wrong route constraint type | BREAKING (binding fails at runtime) |
 | Missing `.DisableAntiforgery()` on multipart | BREAKING (endpoint rejects requests) |
+| Polymorphic DTO base without `[JsonDerivedType]` discriminator | BREAKING (TS codegen emits `any`) |
+| Enum exposed as raw integer in a wire DTO | CONVENTION |
 
 Ref: `CLAUDE.md §OpenAPI metadata`, `docs-site/…/api/api-documentation.mdx`,
 `docs-site/…/architecture/http-conventions.md`
@@ -802,6 +814,15 @@ Ref: `docs-site/…/data/persistence.mdx`, `docs-site/…/data/query-filters.mdx
   `Guid`, never `string`)
 - [ ] Entity type configurations in `EntityTypeConfiguration/` folder
 - [ ] Each configuration in its own file
+- [ ] **Enum persistence**: no manual `.HasConversion<string>()` on enum
+  properties — `ApplyGranitConventions` already persists every enum as its
+  PascalCase string name in a `varchar` column (CLAUDE.md §Enum persistence)
+- [ ] `[PersistAsInt]` opt-outs are justified inline — reserved for `[Flags]`
+  bitmasks (auto-skipped anyway), high-write tables, or pre-existing DB
+  contracts; an undocumented `[PersistAsInt]` is a CONVENTION finding
+- [ ] Int→string enum migrations in consuming apps use
+  `MigrationBuilderExtensions.AlterEnumColumnIntToString<TEnum>` (emits the
+  mandatory PostgreSQL `USING CASE` clause)
 
 ### 6c. Interceptor pipeline awareness
 
@@ -928,8 +949,9 @@ Verify correct base class selection:
   (`GranitErrorCodeLanguageManager`)
 - [ ] Custom `.Must()` validators use
   `.WithErrorCodeAndMessage("Granit:Validation:XxxCode")`
-- [ ] Error code present in all 17 JSON files in
-  `src/Granit.Validation/Localization/Validation/`
+- [ ] Error code present in all 18 JSON files in
+  `src/Granit.Validation/Localization/Validation/` (15 base + fr-CA, en-GB,
+  pt-BR)
 
 Ref: `CLAUDE.md §Validation`
 
@@ -1065,6 +1087,36 @@ Ref: `CLAUDE.md §Localization`
 
 Ref: `docs-site/…/concepts/multi-tenancy.mdx`
 
+### 12e. Provider SDK confinement (cloud agnosticism / vendor lock-in)
+
+Granit must stay deployable on any infrastructure (sovereign EU clouds, on-prem
+K8s) — vendor SDKs are confined to `.{Provider}` packages and must never leak
+into the base module, `.Endpoints`, or `.EntityFrameworkCore`:
+
+- [ ] No `<PackageReference>` to a vendor SDK (`AWSSDK.*`, `Azure.*`,
+  `Google.Cloud.*`, `Amazon.*`, `Twilio*`, `SendGrid*`, vendor `*.Sdk`)
+  outside `src/Granit.{Module}.{Provider}/` projects
+- [ ] No vendor type (`AmazonS3Client`, `BlobServiceClient`, …) in the public
+  API or method signatures of the base module — abstractions speak in framework
+  types and primitives only
+- [ ] No vendor-specific configuration key (`AccessKeyId`, `ConnectionString`
+  with vendor scheme, region names) in base-module `*Options` — provider
+  options live in the provider package with their own `SectionName`
+  (`{Module}:{Provider}` or `Notifications:{Channel}:{Provider}`)
+- [ ] The base module compiles and runs with zero provider packages installed
+  (provider chosen by the host via DI)
+
+**How to detect:**
+
+```bash
+# Vendor SDK leaking outside provider packages
+grep -lE 'AWSSDK|Azure\.|Google\.Cloud|Amazon\.' src/Granit.*/[!.]*.csproj \
+  | grep -vE 'Granit\.[^.]+\.(S3|AzureBlob|GoogleCloud|Aws|Azure|Cognito|EntraId|Keycloak|AwsSes|AwsSns|AzureCommunicationServices|AzureNotificationHubs|AzureOpenAI)'
+```
+
+Severity: ARCHITECTURE (a vendor type in an abstraction welds every consumer
+to that vendor).
+
 ---
 
 ## 13. Compliance (`--scope compliance`)
@@ -1135,8 +1187,10 @@ Ref: `CLAUDE.md §Security`, `docs-site/…/concepts/security-model.mdx`
 ### 14a. Module documentation page
 
 Every module with public API surface MUST have a documentation page in
-`docs-site/src/content/docs/dotnet/`. The page lives under the appropriate
-domain subdirectory:
+`../granit-docs/src/content/docs/dotnet/` (sibling repo). Doc fixes ship in a
+**separate PR against granit-docs** — in `--fix` mode, report the finding with
+a self-contained handoff prompt instead of editing cross-repo. The page lives
+under the appropriate domain subdirectory:
 
 | Domain | Directory | Example modules |
 | ------ | --------- | --------------- |
@@ -1181,7 +1235,7 @@ domain subdirectory:
 
 ### 14e. Counters
 
-- [ ] `PACKAGE_COUNT` in `docs-site/src/data/constants.ts` matches
+- [ ] `PACKAGE_COUNT` in `../granit-docs/src/data/constants.ts` matches
   actual count: `ls src/ | grep "^Granit\." | wc -l`
 - [ ] `PATTERN_COUNT` and `ADR_COUNT` are current (check only in `all` mode)
 
@@ -1200,7 +1254,7 @@ After a module rename, verify:
 
 1. Check recent renames: `git log --diff-filter=R --name-status -20 -- 'src/'`
 2. For each renamed module, grep docs for old name:
-   `grep -r "OldModuleName" docs-site/src/content/`
+   `grep -r "OldModuleName" ../granit-docs/src/content/`
 3. Flag any occurrence as CONVENTION severity
 
 Ref: `CLAUDE.md §Documentation site`
@@ -1324,6 +1378,13 @@ Config and secrets must be injectable per environment without rebuilding the ima
 - [ ] No `localhost`/`127.0.0.1`/`file://` defaults that only work on a dev box
 - [ ] Feature toggles / endpoints overridable via `*Options` (e.g. `TagName`,
   health paths) rather than constants
+- [ ] **Options shapes are env-var-overridable** — prefer dictionaries
+  (`"Providers": { "Smtp": { … } }` → `…__Providers__Smtp__Host`) over arrays
+  of objects (`"Providers": [ { "Name": "Smtp", … } ]` →
+  `…__Providers__0__Name`): ordinal indices are fragile under Helm/ArgoCD
+  overlays (an override targets a position, not an identity, and removing an
+  element from the base config silently shifts every override). Flag a
+  `List<T>`-of-records option where the elements have a natural key
 
 **How to detect:** `grep -nE 'https?://(localhost|127\.0\.0\.1)|Password=|ApiKey|/home/|C:\\\\'`
 across the module's `src` and `appsettings*.json`.
@@ -1361,6 +1422,13 @@ Builds on §10c/§10d, but from the _probe-correctness_ angle:
   that is a readiness concern); only deadlock/unrecoverable state fails liveness
 - [ ] Startup probe covers slow init (migrations) so liveness doesn't kill a
   still-booting pod
+- [ ] **The app survives an un-migrated database** — when the schema is not yet
+  in place (the K8s migration job/init container is still running), the module
+  must fail its readiness/startup probe gracefully, NOT throw during
+  `Program.cs`/module init. A startup-path schema query (`ValidateOnStart`
+  hitting the DB, eager warmup, seeding) that throws turns "waiting for the
+  migration job" into a CrashLoopBackOff — and on a fresh environment the
+  migration job and the app race each other forever
 - [ ] Probes are cheap + time-bounded (10s defensive timeout, `CachedHealthCheck`
   to avoid stampede across rapid kubelet polls) and leak **no PII/secrets/connection
   strings** (ISO 27001 / GDPR)
@@ -1492,6 +1560,8 @@ two modules; check whether any two DbContexts map the same table name.
 | `new HttpClient()` / no resilience on external call | CONVENTION |
 | Module ships no health check for its own critical dependency | CONVENTION |
 | Liveness probe depends on an external dependency | CONVENTION |
+| Startup throws on un-migrated DB (CrashLoopBackOff instead of failing readiness) | ARCHITECTURE |
+| Array-of-objects options shape where elements have a natural key | CONVENTION |
 | Hardcoded `localhost`/path/URL default | CONVENTION |
 | Missing trace-context propagation on outbound call | CLEANUP |
 | No graceful-shutdown drain on a hosted service | CONVENTION |

--- a/.claude/skills/perf/SKILL.md
+++ b/.claude/skills/perf/SKILL.md
@@ -40,7 +40,7 @@ reason from the checklist and label findings by confidence.
 ## Invocation modes
 
 | Argument | Mode | Scope |
-|----------|------|-------|
+| ---------- | ------ | ------- |
 | `help` | Help | Show reference card, stop |
 | _(none)_ / `all` | Full audit | Every module in `src/` |
 | `<module>` | Module audit | One module family and its satellites |
@@ -51,7 +51,7 @@ reason from the checklist and label findings by confidence.
 ### Flags
 
 | Flag | Effect |
-|------|--------|
+| ------ | -------- |
 | `--fix` | Apply safe optimizations automatically (default: report only) |
 | `--scope <s>` | Restrict to one category (default: `all`) |
 | `--provider <p>` | Focus persistence findings on one provider (default: `all`, PostgreSQL-first) |
@@ -139,6 +139,7 @@ Collect context **before** judging. Use the most token-efficient tool per query.
 
 - MCP `get_project_graph` with `projectFilter: "Granit.{Module}"` — dependency fan-out.
 - MCP `get_file_overview` on the DbContext, endpoints, handlers, and any `*Service`/`*Store`/`*Repository`-like orchestrators.
+- MCP `code_search` (granit-tools pre-built index) for broad symbol discovery; roslyn-lens stays the tool for live analysis (callers, refs, impls).
 - Glob `src/Granit.{Module}*/**/*.cs` to enumerate sources.
 
 ### 2b. Hot-path & anti-pattern context
@@ -191,7 +192,7 @@ each finding:
 ### Impact definitions
 
 | Level | Meaning | Action |
-|-------|---------|--------|
+| ------- | --------- | -------- |
 | **CRITICAL** | Breaks at scale: per-row round-trips, unbounded result sets, memory/connection leak, threadpool starvation, per-replica duplication | Fix before load |
 | **HIGH** | Material cost under concurrency: missing index on a hot filter, no caching on a hot read, cartesian explosion, sync-over-async on a request path | Should fix |
 | **MEDIUM** | Measurable waste, low-risk fix: missing `AsNoTracking`/projection, over-fetching, no pagination cap | Fix |
@@ -222,7 +223,7 @@ code is noise. Reserve those for paths the profiler proved hot.
 #### {Category} ({n})
 
 | # | Impact | Location | Finding | Est. cost | Fix | Provider notes |
-|---|--------|----------|---------|-----------|-----|----------------|
+| --- | -------- | ---------- | --------- | ----------- | ----- | ---------------- |
 | 1 | CRITICAL | Blobs/BlobStore.cs:88 | N+1: `FindAsync` inside `foreach` over {n} ids | {n} round-trips → 1 | Batch with `Where(b => ids.Contains(b.Id))` | all |
 
 ### Scaling profile (horizontal)
@@ -255,7 +256,7 @@ the full solution — see CLAUDE.md):
 
 ```bash
 dotnet build src/Granit.{Module}
-dotnet test  tests/Granit.{Module}.Tests --no-build
+dotnet test  tests/Granit.{Module}.Tests   # no --no-build after src edits — stale test DLL
 ```
 
 If a fix breaks the build/tests: one corrective edit, else **revert** and mark
@@ -265,8 +266,11 @@ If a fix breaks the build/tests: one corrective edit, else **revert** and mark
 
 ## Step 5 — Cross-module / scaling analysis (`all` mode)
 
-Process one module family at a time (context discipline), then aggregate. After the
-per-module pass, look for the **scaling clusters** that repeat framework-wide:
+Process one module family at a time (context discipline), then aggregate — ~128
+packages do not fit one context. Fan the per-module passes out to subagents (one
+per module family, each returning **only** its findings table, never file dumps)
+and aggregate centrally. After the per-module pass, look for the **scaling
+clusters** that repeat framework-wide:
 
 1. **N+1 / round-trip clusters** — the same in-loop query shape across modules.
 2. **Tracking & projection** — modules returning tracked entities or EF entities instead of `*Response` projections.
@@ -343,7 +347,7 @@ dotnet-counters collect -p <PID> --format json -o counters.json --refresh-interv
 Read against these thresholds, then map breaches to checklist categories:
 
 | Counter | Healthy | Problem → checklist scope |
-|---------|---------|---------------------------|
+| --------- | --------- | --------------------------- |
 | `cpu-usage` | < 80% sustained | > 90% → `allocations` / hot LINQ / serialization |
 | `working-set` / `gc-heap-size` | stable | growing → leak (`allocations`, dump) |
 | `gen-2-gc-count` / `% time in gc` | low / < 10% | high → GC pressure (`allocations`, pooling) |
@@ -366,7 +370,7 @@ dotnet-trace convert trace.nettrace --format Speedscope
 Hot-method → likely cause map (mirror in the report):
 
 | Hot frames | Cause | Checklist scope |
-|-----------|-------|-----------------|
+| ----------- | ------- | ----------------- |
 | `Monitor.Enter` / `*.Wait` | lock contention / sync-over-async | `async` |
 | `String.Concat` / `Format` / `StringBuilder` churn | string allocation | `allocations` / `http` |
 | `Enumerable.*` heavy | LINQ in hot path | `allocations` |
@@ -412,8 +416,11 @@ values / topN frames that justify each finding.
 
 For a contended hot path, prove the win with **BenchmarkDotNet** rather than asserting it.
 
-1. Locate or create `benchmarks/Granit.{Module}.Benchmarks` (console, `-c Release`).
-   Reference the target project; do **not** add BenchmarkDotNet to a shipping package.
+1. Locate or create `benchmarks/Granit.{Module}.Benchmarks` (console, `-c Release`) —
+   the repo has no `benchmarks/` directory yet; the first benchmark creates it.
+   Reference the target project; do **not** add BenchmarkDotNet to a shipping package,
+   and do **not** register the project in `.github/test-shards.json` (it is not a
+   test project).
 2. Write a `[MemoryDiagnoser]` benchmark with `[Benchmark(Baseline = true)]` on the
    current implementation and `[Benchmark]` on the proposed one. Include realistic N.
 3. For EF Core, benchmark against a **real provider via Testcontainers** (PostgreSQL
@@ -422,6 +429,11 @@ For a contended hot path, prove the win with **BenchmarkDotNet** rather than ass
 4. Run `dotnet run -c Release --project benchmarks/Granit.{Module}.Benchmarks`.
 5. Report the table: Mean, Ratio, Gen0/1/2, Allocated. A "faster" change that
    allocates more or regresses another column is not a win — say so.
+
+6. Decide the artifact's fate explicitly: a one-off benchmark is **deleted** after
+   its table is captured in the report (clean-tree rule); a benchmark worth keeping
+   is committed **with** a `THIRD-PARTY-NOTICES.md` entry for BenchmarkDotNet
+   (CLAUDE.md dependency rule).
 
 > A micro-benchmark proves the local change. Always sanity-check it against a
 > realistic workload — a 10× faster method on a cold path moves nothing.

--- a/.claude/skills/perf/checklist.md
+++ b/.claude/skills/perf/checklist.md
@@ -313,10 +313,12 @@ the finding:
 - [ ] **Eager refresh at 80 % of TTL** (`EagerRefreshThreshold=0.8`) refreshes in the
   background before expiry so requests rarely hit a cold miss. Keep it on for hot keys
   (set to 0 only intentionally).
-- [ ] **Default durations**: absolute 1 h (`Cache:DefaultAbsoluteExpirationRelativeToNow`),
-  sliding 20 min. Set an explicit `Duration` per entry when the data's volatility
-  differs — don't leave volatile data on the 1 h default (staleness) or pin rarely-
-  changing data to a short TTL (needless misses).
+- [ ] **Default duration**: absolute 1 h (`Cache:DefaultAbsoluteExpirationRelativeToNow`)
+  wired into `FusionCacheEntryOptions.Duration`. FusionCache has **no sliding
+  expiration** (by design — it doesn't compose with L2/backplane); do not assume or
+  recommend sliding behavior. Set an explicit `Duration` per entry when the data's
+  volatility differs — don't leave volatile data on the 1 h default (staleness) or
+  pin rarely-changing data to a short TTL (needless misses).
 
 ### 4.2 Coverage — what should be cached
 
@@ -550,13 +552,13 @@ The measurement layer that makes every other section evidence-based.
 ## Quick triage — where to look first by symptom
 
 | Symptom | Start at scope | Likely cause |
-|---------|---------------|--------------|
+| --------- | --------------- | -------------- |
 | Endpoint slow, DB CPU high | `efcore` | N+1 (§1.3), missing index (§1.6), no projection (§1.2) |
 | Endpoint slow, app CPU high | `allocations` / `http` | LINQ/string churn (§2), reflection JSON (§5) |
-| Memory grows unbounded | `allocations` / `caching` | buffer/cache leak (§2, §4.6), tracked entities (§1.1) |
-| Threadpool queue climbs, throughput collapses | `async` | sync-over-async (§3.1) |
-| Fine on 1 replica, breaks on N | `scaling` / `caching` | per-replica jobs (§8.4), in-memory cache (§4.3) |
+| Memory grows unbounded | `allocations` / `caching` | buffer/cache leak (§2, §4.5), tracked entities (§1.1) |
+| Threadpool queue climbs, throughput collapses | `async` | sync-over-async (§3) |
+| Fine on 1 replica, breaks on N | `scaling` / `caching` | per-replica jobs (§8), in-memory cache (§4.3) |
 | Slow only on deep pages | `efcore` | `OFFSET` pagination (§1.5) |
 | Fast on PostgreSQL, slow on SQL Server/SQLite | `efcore` (`--provider`) | provider divergence (§1.10/§1.11) |
 | Latency spikes / GC pauses | `allocations` / `startup` | Gen-2 pressure (§2), Workstation GC (§7) |
-| Message queue drains slowly | `messaging` | slow handler (§6.2), no batching (§6.4) |
+| Message queue drains slowly | `messaging` | slow handler, no batching (§6) |

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security
 description: "Principal Application Security Architect: exhaustive security audit of the Granit framework. Covers IAM (BFF, DPoP, OIDC), AI/MCP security, data protection, multi-tenancy isolation, infrastructure resilience, and supply chain. Produces STRIDE threat models, CVSS-scored findings, FAPI/ISO 27001/GDPR gap analysis, and a prioritized remediation roadmap."
-argument-hint: "[help | full | <domain> | diff] [--severity {critical|high|medium|all}] [--base <branch>]"
+argument-hint: "[help | full | quick | <domain> | diff] [--severity {critical|high|medium|all}] [--base <branch>] [--format {full|exec}] [--output <path>]"
 ---
 
 # Security Audit — Granit .NET Framework
@@ -24,9 +24,14 @@ framework "Granit" (un Modular Application Framework .NET 10 de 200+ packages).
   "Cross-Tenant Data", et les failles de "Confused Deputy" dans l'integration
   IA (MCP).
 - **Standards stricts :** Tu evalues l'architecture a l'aune des normes
-  ISO 27001 (A.9, A.10, A.12, A.14), FAPI 2.0 (Financial-grade API),
-  RFC 9449 (DPoP), RFC 9126 (PAR), OWASP ASVS 4.0, OWASP API Security
-  Top 10, et OWASP LLM Top 10.
+  ISO 27001:2022 (Annex A — A.5, A.8), FAPI 2.0 (Financial-grade API),
+  RFC 9449 (DPoP), RFC 9126 (PAR), RFC 9700 (OAuth 2.0 Security BCP),
+  RFC 8725 (JWT BCP), OWASP ASVS 4.0, OWASP API Security Top 10 (2023),
+  et OWASP LLM Top 10 (2025).
+- **Rigueur avant verdict :** Tu ne formules JAMAIS un finding ni un score
+  CVSS sans avoir d'abord raisonne dans un bloc `<scratchpad>` interne
+  (menace STRIDE, vecteur CVSS metrique par metrique, controles
+  compensatoires). Voir « Rules — STRICT », regle 1.
 
 **Relationship with other skills:**
 
@@ -40,23 +45,26 @@ framework "Granit" (un Modular Application Framework .NET 10 de 200+ packages).
 ## Invocation modes
 
 | Argument | Mode | Scope |
-|----------|------|-------|
+| ---------- | ------ | ------- |
 | `help` | Help | Show reference card, stop |
 | _(none)_ / `full` | Full audit | All security domains — the "Matrice Granit" |
+| `quick` | Triage | Fast pass: perimeter + secret scan + top STRIDE questions per boundary. CRITICAL/HIGH only, no compliance matrices |
 | `<domain>` | Domain audit | Single security domain (see list below) |
 | `diff` | Diff audit | Security-relevant changes in current branch vs base |
 
 ### Flags
 
 | Flag | Effect |
-|------|--------|
+| ------ | -------- |
 | `--severity <s>` | Filter findings: `critical`, `high`, `medium`, `all` (default: `all`) |
 | `--base <branch>` | Override base branch for diff mode (default: `develop`) |
+| `--format <f>` | Report format: `full` (default) or `exec` (Executive Summary + Residual Risk Register + Roadmap only — the CISO deliverable) |
+| `--output <path>` | Write the final report to `<path>` instead of printing it in the conversation (intermediate per-domain files still go to `/tmp/security-{domain}.md`) |
 
 ### Security domains
 
 | Domain keyword | Scope |
-|----------------|-------|
+| ---------------- | ------- |
 | `iam` | Authentication, Authorization, Identity, BFF, OIDC, DPoP, API Keys |
 | `ai` | MCP Server/Client, AI modules, prompt injection, tool visibility, SSRF |
 | `data` | Encryption, Privacy/GDPR, Data Protection, Vault, Caching encryption |
@@ -67,6 +75,8 @@ framework "Granit" (un Modular Application Framework .NET 10 de 200+ packages).
 | `observability` | Audit logging, PII in logs, metrics cardinality, tracing leaks |
 | `headers` | HTTP security headers (CSP, HSTS, CORS, X-Frame-Options, Referrer-Policy) |
 | `deserialization` | JSON/binary deserialization safety across Wolverine, Cache, MCP, Claim Check |
+| `injection` | Input injection: raw SQL (`FromSqlRaw`/`ExecuteSqlRaw`), path traversal (blob keys), template injection (Scriban), log/CRLF injection, ReDoS |
+| `secrets` | Focused secret hunt: working tree + git history + CI config (Step 0d run as a standalone audit, checklist 6.11-6.14 + 11.1-11.3) |
 
 ---
 
@@ -74,11 +84,12 @@ framework "Granit" (un Modular Application Framework .NET 10 de 200+ packages).
 
 When `$ARGUMENTS` is `help`, display this reference card and stop:
 
-```
+```text
 /security — Granit .NET Security Audit (Principal AppSec Architect)
 
 USAGE
   /security                     Full security audit (all domains)
+  /security quick               Fast triage: perimeter + secrets + top risks
   /security iam                 Audit Identity & Access Management
   /security ai                  Audit AI/MCP security
   /security data                Audit data protection & encryption
@@ -89,6 +100,8 @@ USAGE
   /security observability       Audit logging, tracing, metrics security
   /security headers             Audit HTTP security headers (CSP, HSTS, CORS)
   /security deserialization     Audit deserialization safety
+  /security injection           Audit input injection (SQL, path, template, log)
+  /security secrets             Focused secret hunt (tree + git history + CI)
   /security diff                Audit security-relevant changes in branch
   /security help                Show this reference card
 
@@ -98,23 +111,31 @@ FLAGS
   --severity medium             Critical + High + Medium
   --severity all                All findings (default)
   --base <branch>               Base branch for diff mode (default: develop)
+  --format full                 Complete technical report (default)
+  --format exec                 CISO deliverable only (summary + risk register
+                                + roadmap, no technical finding bodies)
+  --output <path>               Write final report to file instead of chat
 
-SEVERITY LEVELS (aligned with CVSS 3.1)
-  CRITICAL (9.0-10.0)   Exploitable remotely, no auth required, data breach
-  HIGH     (7.0-8.9)    Exploitable with low complexity, significant impact
-  MEDIUM   (4.0-6.9)    Requires specific conditions, moderate impact
-  LOW      (0.1-3.9)    Theoretical, minimal impact, defense-in-depth
-  INFO                   Observation, hardening suggestion, best practice
+SEVERITY LEVELS (aligned with CVSS 3.1) + REMEDIATION SLA
+  CRITICAL (9.0-10.0)   Exploitable remotely, no auth, data breach    — 7 days
+  HIGH     (7.0-8.9)    Low complexity, significant impact            — 30 days
+  MEDIUM   (4.0-6.9)    Specific conditions, moderate impact          — 90 days
+  LOW      (0.1-3.9)    Theoretical, defense-in-depth                 — 180 days
+  INFO                  Observation, hardening, best practice         — backlog
 
 STANDARDS EVALUATED
   OWASP ASVS 4.0        Application Security Verification Standard
-  OWASP API Top 10      API Security Top 10 (2023)
-  OWASP LLM Top 10      AI/LLM-specific threats
+  OWASP API Top 10      API Security Top 10 (2023) — incl. API7 SSRF
+  OWASP LLM Top 10      AI/LLM threats (2025 edition numbering)
   FAPI 2.0              Financial-grade API Security Profile
   RFC 9449              DPoP (Demonstrating Proof-of-Possession)
   RFC 9126              PAR (Pushed Authorization Requests)
-  ISO 27001             Information Security Management (A.9, A.10, A.14)
-  GDPR                  Data Protection (Art. 25, 32, 17)
+  RFC 9700              OAuth 2.0 Security Best Current Practice
+  RFC 8725              JSON Web Token Best Current Practices
+  ISO 27001:2022        Annex A controls (A.5 organizational, A.8 technical)
+  GDPR                  Art. 5, 7, 17, 20, 25, 32
+  NIST SP 800-57        Key management & algorithm strength
+  CWE                   Weakness classification on every finding
 
 RELATED SKILLS
   /audit                Framework convention compliance
@@ -122,8 +143,9 @@ RELATED SKILLS
   /review               Pre-landing MR diff review
 
 EXAMPLES
+  /security quick
   /security iam --severity critical
-  /security ai
+  /security ai --format exec --output /tmp/security-ai-report.md
   /security diff --base main
   /security full --severity high
 ```
@@ -157,39 +179,117 @@ Find all HTTP-exposed endpoints:
 
 ### 0c. Trust boundary diagram
 
-Mentally construct the trust boundaries:
+Construct the trust boundary map. Zones align with `threat-models.md`
+("Trust Boundaries" section); every **numbered crossing (B1-B7)** is an attack
+vector. Findings MUST reference the crossing they exploit (e.g., `Boundary: B5`).
 
 ```text
-[Browser/SPA] <--HTTPS--> [BFF/YARP Proxy] <--internal--> [API Modules]
-                                                              |
-                                                   [Wolverine Outbox] --> [External Systems]
-                                                              |
-[AI Agent] <--MCP/stdio--> [MCP Server] <--internal--> [Tool Implementations]
-                                                              |
-                                                   [Vault] <-- Key Management
-                                                   [Redis] <-- Session/Cache/Rate Limiting
-                                                   [PostgreSQL] <-- Persistence + Outbox
+ZONE 1 — UNTRUSTED (Internet)          ZONE 5 — EXTERNAL IDENTITY
+  Browser / SPA                          Keycloak / EntraId / Cognito / Google
+  External AI agents (MCP clients)       OpenIddict (self-hosted IdP)
+  Webhook callers                        ACME / Certificate authorities
+       │                                      ▲
+       │ B1  HTTPS + session cookie /         │ B4  OIDC code flow, JWKS,
+       │     DPoP proof / API key / HMAC      │     back-channel logout,
+       ▼                                      │     token introspection
+ZONE 2 — EDGE (DMZ)                           │
+  Granit.Bff + Granit.Bff.Yarp ───────────────┘
+  Granit.Mcp.Server (stdio/SSE/HTTP)
+  Granit.RateLimiting / Granit.Http.RateLimiting
+  Security headers / CORS middleware
+       │
+       │ B2  YARP token injection, MCP tool dispatch,
+       │     tenant resolution (header vs JWT claim)
+       ▼
+ZONE 3 — APPLICATION (internal)
+  *.Endpoints modules · Authorization engine · MCP tool implementations
+  Wolverine handlers & sagas · Background jobs
+       │                                  │
+       │ B3  EF Core (tenant filters),    │ B5  EGRESS: webhooks, SMTP/SMS
+       │     Redis protocol, Vault API,   │     providers, MCP *client*
+       │     blob SDK                     │     (SSRF!), AI provider APIs
+       ▼                                  ▼
+ZONE 4 — DATA (trusted)               EXTERNAL THIRD PARTIES (untrusted again)
+  PostgreSQL (persistence + outbox)
+  Redis (sessions, cache, rate limits)
+  Vault (secrets, transit encryption)
+  Blob storage (S3/Azure/GCS/FS)
+
+CROSS-CUTTING CROSSINGS
+  B6  Outbox → Wolverine agent → consumer handler (deferred trust:
+      message was serialized in a PAST security context)
+  B7  Build/CI → NuGet feeds → published packages (supply chain)
 ```
 
-Each arrow crossing a trust boundary is an attack vector.
+Boundary review rules:
+
+- **B1/B2 asymmetry** — headers trusted at B2 (e.g., `X-Tenant-Id`,
+  `X-Forwarded-For`) must NEVER be trusted at B1. Verify the edge strips them.
+- **B5 is a boundary back into untrusted territory** — egress is where SSRF,
+  credential leakage, and webhook abuse live. Treat responses from B5 as
+  hostile input re-entering Zone 3.
+- **B6 is a time-shifted boundary** — tenant/user context, permissions, and
+  even message schema may have changed between produce and consume.
 
 ### 0d. Secret scanning
 
-Systematically search for hardcoded secrets before diving into domain analysis:
+Systematically hunt for hardcoded secrets before domain analysis. This step
+also runs standalone as `/security secrets`.
 
-- **Connection strings** — `Grep` for `Password=`, `Server=`, `Data Source=` in
-  `appsettings*.json` and C# files (exclude placeholder values like `{VAULT}`)
-- **Cryptographic keys** — `Grep` for `-----BEGIN`, base64 patterns >40 chars
-  assigned to `const`/`static` fields, `SigningKey`, `HmacKey`, `Secret`
-- **Cloud credentials** — `Grep` for `AKIA` (AWS), `AccountKey=` (Azure),
-  `private_key_id` (GCP) across all file types
-- **Test fixtures** — verify that secrets in test projects are synthetic and do not
-  mirror production values (`grep -r "appsettings" tests/`)
-- **Git history** — `git log -p --all -S "password" -- "*.cs" "*.json"` for
-  secrets that were committed then removed (still in history)
+**Phase 1 — Tooling first.** If `gitleaks` is available
+(`command -v gitleaks`), prefer it over manual greps:
 
-Findings from this step use checklist items 11.1-11.3 and are classified
-CRITICAL by default (CWE-798).
+```bash
+gitleaks detect --source . --no-banner --report-format json --report-path /tmp/gitleaks.json
+gitleaks detect --source . --log-opts="--all" --no-banner   # full git history
+```
+
+Review any `.gitleaksignore` / baseline file: each suppression must be
+individually justified — a blanket suppression is itself a finding (6.14).
+
+**Phase 2 — Manual pattern sweep** (always run, even after gitleaks —
+tools miss context-dependent secrets):
+
+| Category | Patterns (Grep, case-sensitive unless noted) | CWE |
+| ---------- | ----------------------------------------------- | ----- |
+| Connection strings | `Password=`, `Pwd=`, `User Id=.*Password`, `AccountKey=`, `SharedAccessSignature=` | CWE-798 |
+| Private keys | `-----BEGIN (RSA \|EC \|OPENSSH \|PGP )?PRIVATE KEY` | CWE-321 |
+| AWS | `AKIA[0-9A-Z]{16}`, `ASIA[0-9A-Z]{16}`, `aws_secret_access_key` (i) | CWE-798 |
+| GitHub / GitLab | `ghp_`, `gho_`, `ghs_`, `github_pat_`, `glpat-` | CWE-798 |
+| Other SaaS | `sk_live_` (Stripe), `SG\.` (SendGrid), `xox[bpars]-` (Slack), `npm_` (npm) | CWE-798 |
+| GCP | `"type": "service_account"`, `private_key_id` | CWE-798 |
+| JWT / signing material | hardcoded `eyJ[A-Za-z0-9_-]+\.eyJ` outside test fixtures; `SigningKey`, `HmacKey`, `ClientSecret`, `SymmetricSecurityKey(` with literal args | CWE-798 |
+| Generic high-entropy | base64/hex literals > 32 chars assigned to `const`/`static`/json values whose key contains `secret\|key\|token\|password` (i) | CWE-798 |
+
+Scope: `src/`, `tests/`, `.github/`, `scripts/`, `docker-compose*`, `*.props`,
+`appsettings*.json`. **Exclude from matching:** `packages.lock.json` (content
+hashes), `*.snap`, public keys (`-----BEGIN PUBLIC KEY-----` / `BEGIN CERTIFICATE`
+are not secrets).
+
+**Phase 3 — Git history** (a removed secret is still compromised):
+
+```bash
+git log -p --all -S "PRIVATE KEY" -- . | head -100
+git log -p --all -S "Password=" -- "*.json" "*.cs" "*.yml" | head -100
+```
+
+**Phase 4 — Triage protocol (MANDATORY before reporting).** For every hit,
+work through this in the `<scratchpad>` (see Rules):
+
+1. **Placeholder?** `{VAULT}`, `<your-key>`, `changeme`, `dummy`, `example`,
+   `REPLACE_ME`, obvious sequential values (`0123...`) → not a finding.
+2. **Synthetic test fixture?** Located in `tests/`, value never appears in any
+   deployable config path, and clearly fake → INFO at most (note: test secrets
+   must not mirror production patterns).
+3. **Reachable in production?** A secret in `appsettings.Development.json` for
+   a localhost-only service is HIGH, not CRITICAL; the same value in a deployed
+   config or CI file is CRITICAL.
+4. **Still active?** Do NOT probe external services to verify. Report as
+   "assume compromised — rotate" regardless of whether it was since removed.
+
+Confirmed live secrets: CRITICAL (CWE-798), checklist 11.1-11.3 + 6.11-6.14.
+The recommendation MUST include **rotation**, not just removal — removal
+without rotation leaves the credential valid and in history.
 
 ---
 
@@ -202,7 +302,7 @@ Apply STRIDE systematically on the trust boundaries identified in Step 0.
 For each boundary crossing, evaluate:
 
 | Threat | Question | Where to look |
-|--------|----------|---------------|
+| -------- | ---------- | --------------- |
 | **Spoofing** | Can an attacker impersonate a user, tenant, or service? | BFF token handling, JWT validation, API key auth, MCP client identity, tenant resolution |
 | **Tampering** | Can data be modified in transit or at rest without detection? | CSRF tokens, signed cookies, outbox messages, cache values, MCP tool responses |
 | **Repudiation** | Can actions be performed without audit trail? | Audit interceptors, GDPR deletion logs, permission changes, MCP tool invocations |
@@ -278,7 +378,7 @@ Key areas:
   - `McpExposedAttribute` — is opt-in enforced? Can a tool leak without explicit exposure?
   - `ExplicitDiscoveryFilter` vs implicit discovery — default posture
 
-- **Output sanitization (OWASP LLM06 — Sensitive Information Disclosure):**
+- **Output sanitization (OWASP LLM02:2025 — Sensitive Information Disclosure):**
   - `IMcpOutputSanitizer` — what does it redact? Is it applied to ALL tool responses?
   - `[SensitiveData]` coverage — are all PII/secret DTO properties annotated?
     `SensitivePropertyRegistry` auto-discovers `[SensitiveData]` on entity properties
@@ -288,18 +388,18 @@ Key areas:
     used to hide security-relevant changes (privilege escalation, key rotation).
   - Error sanitizer — does it leak stack traces, connection strings, internal paths?
 
-- **Prompt injection (OWASP LLM01):**
+- **Prompt injection (OWASP LLM01:2025):**
   - Can user-controlled data flow into MCP tool descriptions or parameters?
   - Are tool inputs validated before execution?
   - Is there a content security policy for MCP responses?
 
-- **Confused Deputy (OWASP LLM08):**
+- **Confused Deputy (OWASP LLM06:2025 — Excessive Agency):**
   - Does the MCP server validate that a tool call is authorized for the CALLING
     user, not just the tool's existence?
   - `McpTenantScopeAttribute` — is tenant context propagated and enforced?
   - Are MCP tool calls audited?
 
-- **Denial of Wallet:**
+- **Denial of Wallet (OWASP LLM10:2025 — Unbounded Consumption):**
   - Are MCP tool calls rate-limited per user/tenant?
   - Is there a cost ceiling for AI operations?
   - Can a malicious prompt trigger expensive operations in a loop?
@@ -539,19 +639,110 @@ Key areas:
     inject types that trigger instantiation?
   - Structured content responses — validated against schema before processing
 
+### Domain: Input Injection (`injection`)
+
+**Target modules:** all `*.EntityFrameworkCore` projects, `Granit.BlobStorage.*`,
+`Granit.Notifications.*` (Scriban templates), `Granit.Indexing.*`,
+`Granit.DataExchange.*`, all `*.Endpoints` projects
+
+**Checklist — see `checklist.md` section 12**
+
+Key areas:
+
+- **SQL injection (CWE-89):**
+  - `Grep` for `FromSqlRaw`, `ExecuteSqlRaw`, `SqlQueryRaw` — every occurrence
+    must use parameter placeholders or the `*Interpolated` variant; string
+    concatenation/`string.Format` into SQL is CRITICAL
+  - Dynamic identifiers (table/column names built from input — e.g., TRUNCATE
+    helpers, indexing executors) — must be validated against a closed allowlist,
+    parameters cannot help here
+  - Npgsql-specific: `jsonb` path queries, full-text `to_tsquery` built from
+    user input
+
+- **Path traversal (CWE-22):**
+  - Blob keys / file names from user input — `..`, absolute paths, drive
+    letters, URL-encoded variants rejected before reaching
+    `Granit.BlobStorage.FileSystem`
+  - Export/import file naming in `Granit.DataExchange` — archive entry names
+    (zip-slip) validated on extraction
+
+- **Template injection (CWE-1336):**
+  - Scriban templates in `*.Notifications` — user data must enter as model
+    values only, NEVER concatenated into template source
+  - Template source loading — embedded resources only, or tenant-supplied
+    templates rendered in a sandboxed/limited Scriban context
+
+- **Log & header injection:**
+  - CRLF in values echoed into response headers (CWE-113)
+  - User input in log templates — `[LoggerMessage]` parameters are safe by
+    structure; flag any string interpolation into log messages (CWE-117)
+
+- **ReDoS (CWE-1333):**
+  - User-input-facing regexes — `[GeneratedRegex]` with `RegexOptions.NonBacktracking`
+    or a `matchTimeout`; flag nested quantifiers on unbounded input
+
+- **CSV/Excel formula injection (CWE-1236):**
+  - `Granit.DataExchange.Csv` / `.Excel` exports — cell values starting with
+    `=`, `+`, `-`, `@` must be escaped (`'` prefix) when exporting user data
+
+### Domain: Secrets (`secrets`)
+
+Standalone execution of **Step 0d** with full git-history depth, plus CI/CD
+configuration review (`.github/workflows/*.yml`: secrets passed as env vars
+not inline, no `echo` of secret-bearing variables, OIDC federation preferred).
+Checklist items 6.11-6.14 and 11.1-11.3. Report uses the standard findings
+format; severity per the Step 0d triage protocol.
+
 ---
 
 ## Step 3 — Findings format
 
-For each finding, use this strict format:
+### 3a. Pre-finding scratchpad — MANDATORY
 
-```markdown
+Before writing ANY finding (and before assigning its VULN number), reason
+through this worksheet in a `<scratchpad>` block. The scratchpad is internal
+working memory: it NEVER appears in the report, the per-domain `/tmp` files,
+or any user-facing output — only its conclusions do.
+
+```text
+<scratchpad>
+1. STRIDE     : which threat category? which boundary crossing (B1-B7)?
+2. Preconditions: what must the attacker already control/know? Is each
+                precondition realistic in a deployed Granit app?
+3. Evidence   : did I READ the vulnerable code path (file:line) or am I
+                inferring from naming/conventions? Inference alone → INFO.
+4. Compensating controls: what did I actively search for (grep pattern,
+                find_callers, architecture test, ApplyGranitConventions,
+                Roslyn analyzer)? Found / not found?
+5. CVSS 3.1, metric by metric, each with one line of justification:
+                AV → AC → PR → UI → S → C → I → A
+                (use the scoring discipline table in threat-models.md;
+                cross-tenant impact ⇒ S:C)
+6. Severity sanity check: does the computed score match the narrative?
+                If the story says "catastrophic" but the vector says 5.1,
+                one of them is wrong — fix it now.
+7. Confidence : Confirmed (exploit path read end-to-end) |
+                Probable (code read, one precondition unverified) |
+                Needs investigation (pattern-level suspicion)
+8. Verdict    : report at severity X / downgrade to INFO / discard (why).
+</scratchpad>
+```
+
+A finding may only be written once the scratchpad reaches step 8. Findings
+that never get a scratchpad do not exist.
+
+### 3b. Finding template
+
+````markdown
 ### [SEV: CRITICAL|HIGH|MEDIUM|LOW|INFO] VULN-{nnn}: {Title}
 
 **Component:** `Granit.{Module}` — `{ClassName}` / `{MethodName}`
 **File:** [{file}:{line}]({relative-path}#L{line})
+**Boundary:** {B1-B7 from Step 0c}
 **CVSS 3.1:** {score} ({vector-string}) *(omit for INFO)*
-**Standard:** {OWASP ASVS x.y.z | FAPI 2.0 §x | ISO 27001 A.x.y | RFC xxxx §y | OWASP LLM-xx}
+**CWE:** CWE-{nnn} {name}
+**Standard:** {OWASP ASVS x.y.z | FAPI 2.0 §x | ISO 27001 A.x.y | RFC xxxx §y | OWASP LLM{xx}:2025 | API{x}:2023}
+**Confidence:** {Confirmed | Probable | Needs investigation}
 
 **Description:**
 {What the vulnerability is, in precise technical terms.}
@@ -568,10 +759,15 @@ For each finding, use this strict format:
 {Precise .NET 10 / C# 14 fix. Show code when possible.}
 
 **Compensating controls:**
-{Existing mitigations that reduce the risk, if any.}
-```
+{Existing mitigations that reduce the risk, if any — name what was searched
+and found (architecture test, convention, middleware), or state "none found
+after searching X".}
+````
 
 ### Finding numbering
+
+Assign numbers only AFTER the scratchpad has fixed the final severity
+(post-compensating-controls) — renumbering mid-report is forbidden:
 
 - `VULN-001` to `VULN-099`: Critical
 - `VULN-100` to `VULN-199`: High
@@ -588,7 +784,7 @@ For each finding, use this strict format:
 Use MCP tools for efficient analysis — **never read entire files blindly**:
 
 | Goal | Tool | Why |
-|------|------|-----|
+| ------ | ------ | ----- |
 | Understand a module's API surface | `get_public_api` / `get_public_api_batch` | Token-efficient overview |
 | Inspect a specific type | `get_type_overview` | Members + hierarchy |
 | Analyze a security-critical method | `analyze_method` | Complexity + data flow + control flow |
@@ -628,18 +824,21 @@ Evaluate against these standards and produce a matrix:
 ### FAPI 2.0 Security Profile
 
 | Requirement | Status | Evidence |
-|-------------|--------|----------|
+| ------------- | -------- | ---------- |
 | PKCE with S256 (mandatory) | | |
 | mTLS or DPoP for token binding | | |
 | PAR (RFC 9126) support | | |
 | Signed request objects (JAR) | | |
 | Response mode `jwt` | | |
 | Sender-constrained access tokens | | |
+| Exact `redirect_uri` string matching (RFC 9700 §2.1) | | |
+| Refresh token rotation OR sender-constraining (RFC 9700 §2.2.2) | | |
+| No bearer tokens in URLs/query strings (RFC 9700 §2.3) | | |
 
 ### OWASP ASVS 4.0 (relevant sections)
 
 | Section | Area | Status | Gap |
-|---------|------|--------|-----|
+| --------- | ------ | -------- | ----- |
 | V2 | Authentication | | |
 | V3 | Session Management | | |
 | V4 | Access Control | | |
@@ -652,7 +851,7 @@ Evaluate against these standards and produce a matrix:
 ### ISO 27001:2022 (Annex A controls)
 
 | Control | Description | Status | Gap |
-|---------|-------------|--------|-----|
+| --------- | ------------- | -------- | ----- |
 | A.5.15 | Access control | | |
 | A.5.17 | Authentication information | | |
 | A.5.34 | Privacy and PII protection | | |
@@ -662,40 +861,71 @@ Evaluate against these standards and produce a matrix:
 | A.8.24 | Use of cryptography | | |
 | A.8.25 | Secure development lifecycle | | |
 
-### OWASP LLM Top 10 (2025)
+### OWASP LLM Top 10 (2025 edition — official numbering)
 
 | Risk | Description | Status | Gap |
-|------|-------------|--------|-----|
+| ------ | ------------- | -------- | ----- |
 | LLM01 | Prompt Injection | | |
-| LLM02 | Insecure Output Handling | | |
-| LLM03 | Training Data Poisoning | | |
+| LLM02 | Sensitive Information Disclosure | | |
+| LLM03 | Supply Chain (models, embeddings, plugins) | | |
+| LLM04 | Data and Model Poisoning | | |
 | LLM05 | Improper Output Handling | | |
-| LLM06 | Sensitive Information Disclosure | | |
-| LLM07 | Insecure Plugin/Tool Design | | |
-| LLM08 | Excessive Agency | | |
-| LLM09 | Overreliance | | |
-| LLM10 | Model Theft | | |
+| LLM06 | Excessive Agency (incl. confused deputy, tool design) | | |
+| LLM07 | System Prompt Leakage | | |
+| LLM08 | Vector and Embedding Weaknesses | | |
+| LLM09 | Misinformation | | |
+| LLM10 | Unbounded Consumption (DoS, denial of wallet) | | |
 
 ### OWASP API Security Top 10 (2023)
 
 | Risk | Description | Status | Gap |
-|------|-------------|--------|-----|
+| ------ | ------------- | -------- | ----- |
 | API1 | Broken Object Level Authorization (BOLA/IDOR) | | |
 | API2 | Broken Authentication | | |
 | API3 | Broken Object Property Level Authorization | | |
 | API4 | Unrestricted Resource Consumption | | |
 | API5 | Broken Function Level Authorization | | |
 | API6 | Unrestricted Access to Sensitive Business Flows | | |
+| API7 | Server Side Request Forgery (MCP client, webhooks, blob proxy) | | |
 | API8 | Security Misconfiguration | | |
 | API9 | Improper Inventory Management | | |
+| API10 | Unsafe Consumption of APIs (IdP responses, AI providers, webhook payloads) | | |
 
 ---
 
 ## Step 6 — Report generation
 
+Two formats, selected by `--format`:
+
+- **`full`** (default) — the complete structure below.
+- **`exec`** — CISO deliverable only: sections 1 (Executive Summary),
+  5 (Residual Risk Register), 6 (Remediation Roadmap), plus Appendix C
+  (Out of scope). Technical finding bodies are replaced by one-line entries
+  in the summary table. Written for a non-technical executive: business
+  impact phrasing, no code, no CVSS vector strings (scores only).
+
+If `--output <path>` is set, `Write` the final report there and print only
+the Executive Summary in the conversation.
+
+### Posture grading — deterministic rubric
+
+`Overall security posture` is NOT a judgment call. Apply top-down, first
+match wins (count findings at their FINAL severity, after compensating
+controls, Confidence = Confirmed or Probable only):
+
+| Grade | Criteria |
+| ------- | ---------- |
+| CRITICAL | ≥ 1 Critical finding open |
+| NEEDS IMPROVEMENT | ≥ 3 High findings, OR ≥ 1 High in `iam`/`tenancy`/`crypto` |
+| ADEQUATE | ≤ 2 High findings, none in `iam`/`tenancy`/`crypto` |
+| STRONG | 0 Critical, 0 High; Medium findings all have compensating controls |
+
+"Needs investigation" findings never degrade the grade — list them in a
+dedicated follow-up table instead.
+
 ### Full report structure
 
-```markdown
+````markdown
 # Security Audit Report: Granit Framework
 
 **Auditor:** Principal Application Security Architect (AI-assisted)
@@ -710,12 +940,24 @@ Evaluate against these standards and produce a matrix:
 
 ## 1. Executive Summary
 
+> Written for a non-technical executive: lead with business impact
+> (data breach, tenant trust, regulatory exposure), not mechanisms.
+
 **Overall security posture:** {STRONG | ADEQUATE | NEEDS IMPROVEMENT | CRITICAL}
+*(per the deterministic rubric — state which criterion triggered)*
+
+**In one paragraph:** {What an attacker can and cannot do to a deployed
+Granit application today, and what it would cost the business.}
 
 **Key strengths:**
 1. {strength}
 2. {strength}
 3. {strength}
+
+**Top findings at a glance:**
+| # | Severity | Finding (one line, business terms) | Boundary | SLA |
+| --- | ---------- | ----------------------------------- | ---------- | ----- |
+| VULN-xxx | | | | |
 
 **Top 3 systemic risks:**
 1. {risk — one sentence with impact}
@@ -723,13 +965,26 @@ Evaluate against these standards and produce a matrix:
 3. {risk}
 
 **Finding summary:**
-| Severity | Count | Remediated | Remaining |
-|----------|-------|------------|-----------|
-| Critical | | | |
-| High | | | |
-| Medium | | | |
-| Low | | | |
-| Info | | | |
+| Severity | Confirmed | Probable | Needs investigation | Total | SLA |
+| ---------- | ----------- | ---------- | -------------------- | ------- | ----- |
+| Critical | | | | | 7 days |
+| High | | | | | 30 days |
+| Medium | | | | | 90 days |
+| Low | | | | | 180 days |
+| Info | | | | | backlog |
+
+**Risk heat map** (count of findings per cell, Probability x Impact from
+the Residual Risk Register):
+
+```text
+              Impact →   Negligible  Minor  Moderate  Major  Catastrophic
+Almost certain (5)           .         .       .        .         .
+Likely         (4)           .         .       .        .         .
+Possible       (3)           .         .       .        .         .
+Unlikely       (2)           .         .       .        .         .
+Rare           (1)           .         .       .        .         .
+```
+{Replace `.` with finding counts; bold the cells in the High/Critical band.}
 
 ---
 
@@ -779,6 +1034,14 @@ exploitation paths and required preconditions}
 ### 3.10 Deserialization Safety
 {Findings}
 
+### 3.11 Input Injection
+{Findings}
+
+### 3.12 Needs-investigation follow-ups
+{Findings with Confidence = Needs investigation — listed separately so they
+do not pollute the risk register; each with the question to answer and the
+code location to inspect.}
+
 ---
 
 ## 4. Compliance Gap Analysis
@@ -800,7 +1063,7 @@ exploitation paths and required preconditions}
 
 ### 4.6 GDPR — Privacy by Design (Art. 25)
 | Principle | Implementation | Gap |
-|-----------|---------------|-----|
+| ----------- | --------------- | ----- |
 | Data minimization | | |
 | Purpose limitation | | |
 | Storage limitation | | |
@@ -817,7 +1080,7 @@ exploitation paths and required preconditions}
 remediations, assess the residual risk. This is the CISO's primary deliverable.}
 
 | # | Risk description | Inherent risk (P x I) | Compensating controls | Residual risk | Risk owner | Accept / Mitigate / Transfer |
-|---|-----------------|----------------------|----------------------|---------------|------------|------------------------------|
+| --- | ----------------- | ---------------------- | ---------------------- | --------------- | ------------ | ------------------------------ |
 | | | | | | | |
 
 **Probability scale:** Rare (1) — Unlikely (2) — Possible (3) — Likely (4) — Almost certain (5)
@@ -831,27 +1094,32 @@ For each "Accept" decision, document the justification and review date.}
 
 ## 6. Remediation Roadmap
 
+{Every Critical/High finding MUST appear in a wave whose deadline respects
+its SLA (Critical 7d, High 30d, Medium 90d, Low 180d). If a fix cannot meet
+its SLA, say so explicitly and require an interim compensating control with
+its own entry.}
+
 ### Quick Wins (Immediate — 0-2 weeks)
 {Low effort, high impact fixes. Configuration changes, missing attributes,
 default hardening.}
 
-| # | Finding | Effort | Impact | Owner |
-|---|---------|--------|--------|-------|
-| | | | | |
+| # | Finding | Effort | Impact | SLA deadline | Owner |
+| --- | --------- | -------- | -------- | -------------- | ------- |
+| | | | | | |
 
 ### Tactical (1-3 months)
 {Medium effort fixes requiring code changes but no architecture redesign.}
 
-| # | Finding | Effort | Impact | Owner |
-|---|---------|--------|--------|-------|
-| | | | | |
+| # | Finding | Effort | Impact | SLA deadline | Owner |
+| --- | --------- | -------- | -------- | -------------- | ------- |
+| | | | | | |
 
 ### Strategic (3-6 months — architecture evolution)
 {Major changes requiring design, implementation, and migration.}
 
-| # | Finding | Effort | Impact | Owner |
-|---|---------|--------|--------|-------|
-| | | | | |
+| # | Finding | Effort | Impact | SLA deadline | Owner |
+| --- | --------- | -------- | -------- | -------------- | ------- |
+| | | | | | |
 
 ---
 
@@ -868,7 +1136,7 @@ default hardening.}
 
 ### D. Glossary
 {Security terms used in this report}
-```
+````
 
 ---
 
@@ -910,7 +1178,7 @@ For each changed file in security-relevant modules:
 
 ### Security-relevant files changed
 | File | Module | Change type | Risk |
-|------|--------|-------------|------|
+| ------ | -------- | ------------- | ------ |
 
 ### Findings
 {Using standard finding format, VULN-xxx}
@@ -921,28 +1189,59 @@ SAFE TO MERGE | SECURITY REVIEW REQUIRED — {reasons}
 
 ---
 
+## Quick mode (`quick`)
+
+A 15-minute triage, NOT a substitute for `full`. Sequence:
+
+1. **Step 0a + 0c** — module inventory and trust boundary map (no 0b endpoint
+   enumeration).
+2. **Step 0d phases 1-2 only** — secret scan of the working tree (skip full
+   git history; note that it was skipped).
+3. **One STRIDE question per boundary** — for each crossing B1-B7, answer the
+   single highest-impact question from the Step 1 matrix (e.g., B1: is
+   default-deny enforced? B5: is the MCP client SSRF-guarded? B6: is tenant
+   context restored in handlers?).
+4. **Report** — findings at CRITICAL/HIGH only, standard format (scratchpad
+   still mandatory), plus a "Not covered — run `/security full`" list naming
+   every domain and check skipped. No compliance matrices, no risk register.
+
+---
+
 ## Rules — STRICT
 
-1. **Read before judging** — always read the full implementation and git history
+1. **Thinking process required (Chain of Thought)** — before writing ANY
+   finding, severity verdict, or compliance matrix row, you MUST reason
+   inside a `<scratchpad>` block using the Step 3a worksheet: map the STRIDE
+   threat to its boundary (B1-B7), justify each CVSS metric one by one, and
+   actively search for compensating controls. No scratchpad → no finding.
+   Scratchpad content NEVER appears in any report, `/tmp` file, or deliverable.
+2. **Read before judging** — always read the full implementation and git history
    before flagging. Security code often has non-obvious reasons.
-2. **Evidence-based** — every finding MUST include a code reference or
+3. **Evidence-based** — every finding MUST include a code reference or
    configuration evidence. No speculative findings.
-3. **CVSS scoring** — use CVSS 3.1 vector strings for Critical/High/Medium
-   findings. Be precise about Attack Vector, Complexity, Privileges Required.
-4. **No false positives** — a false positive in a security audit destroys
-   credibility. When uncertain, classify as INFO with a note to investigate.
-5. **Compensating controls** — always check for existing mitigations before
+4. **CVSS scoring** — use CVSS 3.1 vector strings for Critical/High/Medium
+   findings, computed metric-by-metric in the scratchpad (scoring discipline
+   table in `threat-models.md`). Never state a score without its vector.
+5. **No false positives** — a false positive in a security audit destroys
+   credibility. When uncertain, classify as INFO with
+   `Confidence: Needs investigation` and route it to report section 3.12 —
+   never into the risk register or the posture grade.
+6. **Compensating controls** — always check for existing mitigations before
    raising severity. A vulnerability with a compensating control may be Medium
-   instead of Critical.
-6. **Framework-aware** — `ApplyGranitConventions`, architecture tests, and
+   instead of Critical. State what you searched for, not just what you found.
+7. **Framework-aware** — `ApplyGranitConventions`, architecture tests, and
    Roslyn analyzers already enforce many rules. Acknowledge them as controls.
-7. **DX balance** — if a recommendation would make the framework unusable,
+8. **DX balance** — if a recommendation would make the framework unusable,
    propose a pragmatic alternative with the security trade-off documented.
-8. **MCP first** — use Roslyn MCP tools for code analysis. Fall back to `Read`
+9. **MCP first** — use Roslyn MCP tools for code analysis. Fall back to `Read`
    only for implementation logic and non-C# files.
-9. **Context window discipline** — for full audits, process one domain at a
-   time. Write findings to a temporary file per domain (`/tmp/security-{domain}.md`),
-   then aggregate into the final report. Never attempt to hold all domains in
-   working memory simultaneously.
-10. **No invented standards** — only evaluate against standards listed in this
-    skill. Do not fabricate requirements.
+10. **Context window discipline** — for full audits, process one domain at a
+    time. Write findings to a temporary file per domain (`/tmp/security-{domain}.md`),
+    then aggregate into the final report. Never attempt to hold all domains in
+    working memory simultaneously.
+11. **No invented standards** — only evaluate against standards listed in this
+    skill. Do not fabricate requirements, section numbers, or RFC clauses; if
+    unsure of an exact clause number, cite the standard without the clause.
+12. **Read-only engagement** — an audit never modifies source code, config, or
+    git state. Do not probe external services with discovered credentials.
+    Remediation happens in a separate, explicitly requested task.

--- a/.claude/skills/security/checklist.md
+++ b/.claude/skills/security/checklist.md
@@ -8,8 +8,10 @@ Standards referenced:
 - **ASVS** — OWASP Application Security Verification Standard 4.0
 - **FAPI** — Financial-grade API Security Profile 2.0
 - **ISO** — ISO 27001:2022 Annex A
-- **LLM** — OWASP LLM Top 10 (2025)
-- **RFC** — IETF RFCs (9449, 9126, 7519, 6749, 7636, etc.)
+- **LLM** — OWASP LLM Top 10, **2025 edition numbering** (LLM02 = Sensitive
+  Information Disclosure, LLM05 = Improper Output Handling, LLM06 = Excessive
+  Agency, LLM10 = Unbounded Consumption)
+- **RFC** — IETF RFCs (9449, 9126, 9700, 8725, 7519, 6749, 7636, etc.)
 - **CWE** — Common Weakness Enumeration
 
 ---
@@ -19,7 +21,7 @@ Standards referenced:
 ### 1a. BFF Pattern — Granit.Bff
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 1.1 | CSRF token uses HMAC-SHA256 with cryptographically random key | ASVS 4.2.2 | HIGH |
 | 1.2 | CSRF key is rotated periodically (not hardcoded) | ISO A.8.24 | CRITICAL |
 | 1.3 | CSRF token is bound to user session (not global) | ASVS 4.2.2 | HIGH |
@@ -38,7 +40,7 @@ Standards referenced:
 ### 1b. DPoP — Granit.Authentication.DPoP
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 1.15 | DPoP proof JWT validated: `typ`, `alg`, `jwk`, `htm`, `htu`, `iat` | RFC 9449 §4.3 | CRITICAL |
 | 1.16 | `ath` claim validated (access token hash) | RFC 9449 §4.3 | HIGH |
 | 1.17 | JWK thumbprint (S256) matches token `cnf.jkt` claim | RFC 9449 §6 | CRITICAL |
@@ -51,7 +53,7 @@ Standards referenced:
 ### 1c. OIDC / OpenIddict
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 1.23 | PKCE mandatory with `S256` method (never `plain`) | RFC 7636, FAPI §5.2.2 | CRITICAL |
 | 1.24 | Authorization code is single-use | RFC 6749 §4.1.2 | HIGH |
 | 1.25 | Token endpoint requires client authentication | FAPI §5.2.2 | HIGH |
@@ -70,7 +72,7 @@ Standards referenced:
 ### 1d. API Key Authentication
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 1.37 | API key generated with >= 256 bits of entropy | ASVS 2.4.1 | CRITICAL |
 | 1.38 | API key stored hashed (SHA-256 or better), never plaintext | ASVS 2.4.1 | CRITICAL |
 | 1.39 | Key comparison is timing-safe (`CryptographicOperations.FixedTimeEquals`) | CWE-208 | HIGH |
@@ -82,7 +84,7 @@ Standards referenced:
 ### 1e. Authorization
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 1.44 | Default-deny: endpoints require explicit authorization | ASVS 4.1.1 | CRITICAL |
 | 1.45 | `[AllowAnonymous]` endpoints are inventoried and justified | ASVS 4.1.1 | HIGH |
 | 1.46 | Permission cache TTL is short enough to reflect revocation | ASVS 4.1.3 | MEDIUM |
@@ -94,7 +96,7 @@ Standards referenced:
 ### 1f. Identity & Password Management
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 1.51 | Password hashing uses Argon2id, bcrypt, or PBKDF2 (>= 600K iterations) | ASVS 2.4.1 | CRITICAL |
 | 1.52 | Password complexity enforced (min 8 chars, no max limit < 128) | ASVS 2.1.1 | MEDIUM |
 | 1.53 | Account lockout after N failed attempts (with exponential backoff) | ASVS 2.2.1 | HIGH |
@@ -111,52 +113,52 @@ Standards referenced:
 ### 2a. MCP Tool Discovery & Visibility
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
-| 2.1 | Default discovery mode is explicit (opt-in, not opt-out) | LLM07 | CRITICAL |
-| 2.2 | `McpExposedAttribute` required for tool exposure | LLM07 | HIGH |
-| 2.3 | `TenantAwareVisibilityFilter` enforces tenant isolation | LLM06 | CRITICAL |
-| 2.4 | `ModuleScopeVisibilityFilter` restricts tools to loaded modules | LLM08 | HIGH |
-| 2.5 | Tool descriptions do not leak internal architecture details | LLM06 | MEDIUM |
+| --- | ------- | ---------- | --------------------- |
+| 2.1 | Default discovery mode is explicit (opt-in, not opt-out) | LLM06 | CRITICAL |
+| 2.2 | `McpExposedAttribute` required for tool exposure | LLM06 | HIGH |
+| 2.3 | `TenantAwareVisibilityFilter` enforces tenant isolation | LLM02 | CRITICAL |
+| 2.4 | `ModuleScopeVisibilityFilter` restricts tools to loaded modules | LLM06 | HIGH |
+| 2.5 | Tool descriptions do not leak internal architecture details | LLM02 | MEDIUM |
 | 2.6 | Tool parameter schemas validate input types and ranges | LLM01 | HIGH |
-| 2.7 | MCP transport (stdio/SSE/HTTP) uses authenticated channel | LLM07 | HIGH |
+| 2.7 | MCP transport (stdio/SSE/HTTP) uses authenticated channel | CWE-306 | HIGH |
 
 ### 2b. Output Sanitization
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
-| 2.8 | `IMcpOutputSanitizer` applied to ALL tool responses (not opt-in) | LLM02 | CRITICAL |
-| 2.9 | `[SensitiveData]` coverage: all PII/secret entity properties annotated with correct `Sensitivity` level — `SensitivePropertyRegistry` auto-feeds `PropertyRedactionSanitizer` (threshold: `Confidential`+) | LLM06 | HIGH |
-| 2.10 | `SensitiveDataMode` includes `Omit` for secrets and `Hash` for correlatable IDs — verify no `Restricted` property uses `Mask` (leaks partial value to LLM) | LLM06 | HIGH |
-| 2.11 | Error responses sanitized (no stack traces, connection strings, paths) | LLM06 | HIGH |
-| 2.12 | SQL query results sanitized for cross-tenant data | LLM06 | CRITICAL |
-| 2.13 | File system paths in responses are relative (no absolute paths) | LLM06 | MEDIUM |
+| --- | ------- | ---------- | --------------------- |
+| 2.8 | `IMcpOutputSanitizer` applied to ALL tool responses (not opt-in) | LLM05 | CRITICAL |
+| 2.9 | `[SensitiveData]` coverage: all PII/secret entity properties annotated with correct `Sensitivity` level — `SensitivePropertyRegistry` auto-feeds `PropertyRedactionSanitizer` (threshold: `Confidential`+) | LLM02 | HIGH |
+| 2.10 | `SensitiveDataMode` includes `Omit` for secrets and `Hash` for correlatable IDs — verify no `Restricted` property uses `Mask` (leaks partial value to LLM) | LLM02 | HIGH |
+| 2.11 | Error responses sanitized (no stack traces, connection strings, paths) | LLM02 | HIGH |
+| 2.12 | SQL query results sanitized for cross-tenant data | LLM02 | CRITICAL |
+| 2.13 | File system paths in responses are relative (no absolute paths) | LLM02 | MEDIUM |
 
 ### 2c. Prompt Injection & Confused Deputy
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 2.14 | MCP tool inputs validated against schema before execution | LLM01 | CRITICAL |
 | 2.15 | User-controlled strings not interpolated into tool descriptions | LLM01 | CRITICAL |
-| 2.16 | Tool execution checks CALLING user's permissions (not tool owner) | LLM08 | CRITICAL |
-| 2.17 | `McpTenantScopeAttribute` enforced — tools respect tenant context | LLM08 | CRITICAL |
-| 2.18 | MCP tool calls are audited (who, what, when, result summary) | LLM07 | HIGH |
-| 2.19 | Tool chaining cannot escalate privileges across calls | LLM08 | HIGH |
+| 2.16 | Tool execution checks CALLING user's permissions (not tool owner) | LLM06 | CRITICAL |
+| 2.17 | `McpTenantScopeAttribute` enforced — tools respect tenant context | LLM06 | CRITICAL |
+| 2.18 | MCP tool calls are audited (who, what, when, result summary) | LLM06 | HIGH |
+| 2.19 | Tool chaining cannot escalate privileges across calls | LLM06 | HIGH |
 | 2.20 | Content returned by tools is treated as untrusted by the LLM layer | LLM01 | HIGH |
 
 ### 2d. Resource Exhaustion & Denial of Wallet
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
-| 2.21 | MCP tool calls are rate-limited per user/tenant | LLM08 | HIGH |
-| 2.22 | Expensive operations (DB queries, file I/O) have timeouts | LLM08 | HIGH |
-| 2.23 | Token/cost budget per session or per user | LLM08 | MEDIUM |
-| 2.24 | Recursive tool calls are bounded (max depth) | LLM08 | HIGH |
-| 2.25 | Large result sets are paginated or truncated | LLM06 | MEDIUM |
+| --- | ------- | ---------- | --------------------- |
+| 2.21 | MCP tool calls are rate-limited per user/tenant | LLM10 | HIGH |
+| 2.22 | Expensive operations (DB queries, file I/O) have timeouts | LLM10 | HIGH |
+| 2.23 | Token/cost budget per session or per user | LLM10 | MEDIUM |
+| 2.24 | Recursive tool calls are bounded (max depth) | LLM10 | HIGH |
+| 2.25 | Large result sets are paginated or truncated | LLM10 | MEDIUM |
 
 ### 2e. MCP Client-Side Risks (SSRF)
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 2.26 | `McpConnectionOptions` URL validated against allowlist (no internal IPs) | CWE-918 | CRITICAL |
 | 2.27 | `IMcpClientFactory` rejects connections to `localhost`, `127.0.0.1`, `::1`, `169.254.*` (link-local), RFC 1918 ranges | CWE-918 | CRITICAL |
 | 2.28 | MCP client does not follow redirects to internal endpoints | CWE-918 | HIGH |
@@ -171,7 +173,7 @@ Standards referenced:
 ### 3a. Encryption at Rest
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 3.1 | AES encryption uses GCM mode (authenticated encryption) | ASVS 6.2.1 | CRITICAL |
 | 3.2 | IV/nonce is unique per encryption operation (never reused) | CWE-329 | CRITICAL |
 | 3.3 | Key derivation uses a KDF (HKDF, PBKDF2) — not raw key | ASVS 6.2.2 | HIGH |
@@ -183,7 +185,7 @@ Standards referenced:
 ### 3b. Key Management
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 3.8 | Encryption keys stored in Vault (never in config/env vars) | ISO A.8.24 | CRITICAL |
 | 3.9 | Key rotation supported without data re-encryption downtime | ISO A.8.24 | HIGH |
 | 3.10 | `RetiredKeyVersionException` handled gracefully (re-encrypt, not fail) | ISO A.8.24 | HIGH |
@@ -195,7 +197,7 @@ Standards referenced:
 ### 3c. Crypto-Shredding (GDPR Art. 17)
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 3.15 | `ICryptoShredder` destroys ALL copies of the entity encryption key | GDPR Art. 17 | CRITICAL |
 | 3.16 | Crypto-shredding audit trail (`ICryptoShreddingAuditRecorder`) is immutable | ISO A.8.15 | HIGH |
 | 3.17 | Shredding covers backup keys (or backups are themselves encrypted) | GDPR Art. 17 | HIGH |
@@ -204,7 +206,7 @@ Standards referenced:
 ### 3d. Privacy / GDPR
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 3.19 | `GdprDeletionSaga` has compensation on failure (no partial deletion) | GDPR Art. 17 | CRITICAL |
 | 3.20 | `GdprExportSaga` encrypts exported data before transmission | GDPR Art. 20 | HIGH |
 | 3.21 | `IDataProviderRegistry` covers ALL modules with personal data | GDPR Art. 17 | HIGH |
@@ -220,7 +222,7 @@ Standards referenced:
 ### 4a. Tenant Resolution
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 4.1 | `HeaderTenantResolver` only trusted on internal network (not public) | CWE-290 | CRITICAL |
 | 4.2 | `JwtClaimTenantResolver` validates tenant against known tenant list | CWE-284 | HIGH |
 | 4.3 | Default behavior when no resolver matches: REJECT (not default tenant) | CWE-284 | CRITICAL |
@@ -230,7 +232,7 @@ Standards referenced:
 ### 4b. Data Isolation
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 4.6 | Named query filters (`ApplyGranitConventions`) applied to ALL entities | CWE-639 | CRITICAL |
 | 4.7 | `IgnoreQueryFilters()` usage audited — grep and justify each occurrence | CWE-639 | HIGH |
 | 4.8 | `ExecuteUpdate`/`ExecuteDelete` manually adds tenant WHERE clause | CWE-639 | CRITICAL |
@@ -240,7 +242,7 @@ Standards referenced:
 ### 4c. Cross-Service Isolation
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 4.11 | Cache keys include tenant ID prefix (`{tenantId}:{module}:{key}`) | CWE-639 | CRITICAL |
 | 4.12 | Wolverine messages propagate tenant context (`TenantContextBehavior`) | CWE-639 | CRITICAL |
 | 4.13 | Blob storage paths include tenant partition | CWE-639 | HIGH |
@@ -256,7 +258,7 @@ Standards referenced:
 ### 5a. Wolverine Messaging
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 5.1 | Outbox messages encrypted at rest if containing PII | GDPR Art. 32 | HIGH |
 | 5.2 | Dead-letter queue messages reviewed for PII before manual replay | GDPR Art. 32 | MEDIUM |
 | 5.3 | Poison message detection: max retry count with exponential backoff | CWE-400 | HIGH |
@@ -269,7 +271,7 @@ Standards referenced:
 ### 5b. Rate Limiting
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 5.9 | Rate limiting applied BEFORE authentication (to protect auth endpoint) | CWE-307 | HIGH |
 | 5.10 | `CounterStoreFailureBehavior` is CLOSED (deny on Redis failure) | CWE-636 | HIGH |
 | 5.11 | Redis Lua scripts are atomic (no TOCTOU race conditions) | CWE-362 | HIGH |
@@ -280,7 +282,7 @@ Standards referenced:
 ### 5c. Idempotency
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 5.15 | Idempotency key has sufficient entropy (UUID v4 or better) | CWE-330 | MEDIUM |
 | 5.16 | Idempotency window is bounded (TTL prevents indefinite storage) | CWE-400 | MEDIUM |
 | 5.17 | Stored responses do not leak data to different users with same key | CWE-639 | HIGH |
@@ -289,7 +291,7 @@ Standards referenced:
 ### 5d. Caching Security
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 5.19 | Cache keys are not constructable from user input (injection) | CWE-74 | HIGH |
 | 5.20 | Serialized cache values use safe deserializer (no type resolution) | CWE-502 | CRITICAL |
 | 5.21 | FusionCache stampede protection enabled | CWE-400 | MEDIUM |
@@ -299,7 +301,7 @@ Standards referenced:
 ### 5e. Webhooks
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 5.24 | Outbound webhooks sign payload (HMAC-SHA256 with shared secret) | CWE-345 | HIGH |
 | 5.25 | Inbound webhooks validate signature before processing | CWE-345 | CRITICAL |
 | 5.26 | Webhook URLs validated (no SSRF: reject internal IPs, localhost) | CWE-918 | CRITICAL |
@@ -310,7 +312,7 @@ Standards referenced:
 ## 6. Supply Chain (`supply-chain`)
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 6.1 | All NuGet packages have lock files (`packages.lock.json`) | CWE-1357 | HIGH |
 | 6.2 | No known CVEs in dependency tree (`dotnet list package --vulnerable`) | CWE-1357 | CRITICAL |
 | 6.3 | No deprecated packages (`dotnet list package --deprecated`) | CWE-1357 | MEDIUM |
@@ -333,7 +335,7 @@ Standards referenced:
 ### 7a. Algorithm Inventory
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 7.1 | No MD5 or SHA-1 for security purposes (only checksums) | ASVS 6.2.5 | CRITICAL |
 | 7.2 | AES uses GCM or CCM mode (never ECB, never CBC without HMAC) | ASVS 6.2.1 | CRITICAL |
 | 7.3 | RSA key size >= 2048 bits (4096 preferred) | NIST SP 800-57 | HIGH |
@@ -343,7 +345,7 @@ Standards referenced:
 ### 7b. Random Number Generation
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 7.6 | `RandomNumberGenerator` used (never `System.Random` for security) | CWE-330 | CRITICAL |
 | 7.7 | Token generation uses >= 128 bits of entropy | ASVS 2.4.1 | HIGH |
 | 7.8 | Nonce generation is non-repeating (counter or random) | CWE-330 | HIGH |
@@ -351,7 +353,7 @@ Standards referenced:
 ### 7c. Key Lifecycle
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 7.9 | Keys never logged, never in error messages | CWE-532 | CRITICAL |
 | 7.10 | Key material zeroized after use (Span, ArrayPool return) | CWE-244 | HIGH |
 | 7.11 | Key rotation is automated (background job or Vault) | ISO A.8.24 | HIGH |
@@ -365,7 +367,7 @@ Standards referenced:
 ### 8a. Logging
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 8.1 | No PII in log messages (names, emails, phone numbers) | GDPR Art. 5 | CRITICAL |
 | 8.2 | No secrets in log messages (tokens, keys, passwords) | CWE-532 | CRITICAL |
 | 8.3 | `[SensitiveData]` applied to all sensitive entity properties with correct `Sensitivity` level (`Internal`/`Confidential`/`Restricted`) — enforced by `AuditPiiConventionTests`. `[AuditIgnore]` excludes entire entities/properties from change tracking (verify not misused to hide security-relevant changes). | GDPR Art. 5 | HIGH |
@@ -376,7 +378,7 @@ Standards referenced:
 ### 8b. Metrics
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 8.7 | No user-controlled values as metric tag VALUES (cardinality explosion) | CWE-400 | HIGH |
 | 8.8 | Metric names do not reveal internal architecture | CWE-200 | LOW |
 | 8.9 | Health check endpoints do not expose sensitive system info | CWE-200 | MEDIUM |
@@ -385,7 +387,7 @@ Standards referenced:
 ### 8c. Distributed Tracing
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 8.11 | Trace context does not propagate to untrusted external systems | CWE-200 | MEDIUM |
 | 8.12 | Span attributes do not contain PII or secrets | GDPR Art. 5 | HIGH |
 | 8.13 | Audit entries include trace ID for correlation | ISO A.8.15 | LOW |
@@ -393,7 +395,7 @@ Standards referenced:
 ### 8d. Audit Trail
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 8.14 | Audit log is append-only (no update/delete) | ISO A.8.15 | CRITICAL |
 | 8.15 | Audit log captures: who, what, when, where, result | ISO A.8.15 | HIGH |
 | 8.16 | Security events (login, logout, permission change) are audited | ASVS 7.1.1 | HIGH |
@@ -408,7 +410,7 @@ Standards referenced:
 ### 9a. Response Headers
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 9.1 | `Strict-Transport-Security` with `max-age >= 31536000; includeSubDomains` | ASVS 9.1.1 | HIGH |
 | 9.2 | `Content-Security-Policy` restricts `script-src`, `style-src`, `frame-ancestors` | ASVS 14.4.3 | HIGH |
 | 9.3 | `X-Content-Type-Options: nosniff` on all responses | ASVS 14.4.4 | MEDIUM |
@@ -422,7 +424,7 @@ Standards referenced:
 ### 9b. CORS
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 9.10 | No wildcard `*` origin for authenticated endpoints | CWE-942 | HIGH |
 | 9.11 | `Access-Control-Allow-Credentials` only with explicit origin list | CWE-942 | HIGH |
 | 9.12 | Preflight `Access-Control-Max-Age` bounded (< 7200s) | CWE-942 | LOW |
@@ -434,7 +436,7 @@ Standards referenced:
 ### 10a. JSON Deserialization
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 10.1 | `System.Text.Json` used (not Newtonsoft with `TypeNameHandling`) | CWE-502 | CRITICAL |
 | 10.2 | No `JsonSerializerOptions` with `TypeInfoResolver` allowing arbitrary types | CWE-502 | CRITICAL |
 | 10.3 | Polymorphic deserialization uses `[JsonDerivedType]` with closed type set | CWE-502 | HIGH |
@@ -443,7 +445,7 @@ Standards referenced:
 ### 10b. Wolverine Message Deserialization
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 10.5 | Message envelope uses schema-first deserialization (known types only) | CWE-502 | CRITICAL |
 | 10.6 | Outbox messages cannot contain polymorphic payloads from external input | CWE-502 | HIGH |
 | 10.7 | Dead-letter queue replay validates message schema before re-processing | CWE-502 | HIGH |
@@ -452,7 +454,7 @@ Standards referenced:
 ### 10c. Cache Deserialization
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 10.9 | FusionCache serializer does not resolve arbitrary types | CWE-502 | CRITICAL |
 | 10.10 | `EncryptingFusionCacheSerializer` validates integrity before deserializing | CWE-502 | HIGH |
 | 10.11 | Redis cache values cannot trigger type instantiation on deserialization | CWE-502 | HIGH |
@@ -464,7 +466,7 @@ Standards referenced:
 These checks apply across all domains:
 
 | # | Check | Standard | Severity if missing |
-|---|-------|----------|---------------------|
+| --- | ------- | ---------- | --------------------- |
 | 11.1 | No hardcoded secrets (connection strings, API keys, passwords) in code | CWE-798 | CRITICAL |
 | 11.2 | `appsettings.json` / `appsettings.Development.json` contain no secrets | CWE-798 | CRITICAL |
 | 11.3 | `.gitignore` excludes sensitive files (`.env`, `*.pfx`, `*.key`) | CWE-798 | HIGH |
@@ -475,3 +477,43 @@ These checks apply across all domains:
 | 11.8 | Error responses use RFC 7807 Problem Details (no internal data leak) | CWE-209 | MEDIUM |
 | 11.9 | All `async` methods accept and forward `CancellationToken` | CWE-400 | LOW |
 | 11.10 | Architecture tests in `Granit.ArchitectureTests` cover security conventions | ISO A.8.25 | MEDIUM |
+
+---
+
+## 12. Input Injection (`injection`)
+
+### 12a. SQL Injection
+
+| # | Check | Standard | Severity if missing |
+| --- | ------- | ---------- | --------------------- |
+| 12.1 | No string concatenation/interpolation into `FromSqlRaw`/`ExecuteSqlRaw`/`SqlQueryRaw` — parameters or `*Interpolated` variants only | CWE-89 | CRITICAL |
+| 12.2 | Dynamic SQL identifiers (table/column names) validated against a closed allowlist (parameters cannot protect identifiers) | CWE-89 | CRITICAL |
+| 12.3 | Full-text / `jsonb` query fragments built from user input are escaped or parameterized | CWE-89 | HIGH |
+| 12.4 | EF interceptors/executors that emit raw SQL (TRUNCATE, maintenance) take no user input | CWE-89 | HIGH |
+
+### 12b. Path & File Handling
+
+| # | Check | Standard | Severity if missing |
+| --- | ------- | ---------- | --------------------- |
+| 12.5 | Blob keys/file names reject `..`, absolute paths, and URL-encoded traversal before provider dispatch | CWE-22 | CRITICAL |
+| 12.6 | Archive extraction (DataExchange import) validates entry names (zip-slip) | CWE-22 | HIGH |
+| 12.7 | Content-Type and extension validated on upload (no served executable content) | CWE-434 | HIGH |
+| 12.8 | Download endpoints set `Content-Disposition` with sanitized filename (no CRLF) | CWE-113 | MEDIUM |
+
+### 12c. Template & Output Injection
+
+| # | Check | Standard | Severity if missing |
+| --- | ------- | ---------- | --------------------- |
+| 12.9 | Scriban templates: user data enters as model values, never concatenated into template source | CWE-1336 | CRITICAL |
+| 12.10 | Tenant-supplied templates (if supported) rendered in a sandboxed/limited Scriban context | CWE-1336 | HIGH |
+| 12.11 | HTML email templates encode user values (no raw HTML pass-through) | CWE-79 | HIGH |
+| 12.12 | CSV/Excel exports escape leading `=`, `+`, `-`, `@` in user-supplied cell values | CWE-1236 | MEDIUM |
+
+### 12d. Other Injection Vectors
+
+| # | Check | Standard | Severity if missing |
+| --- | ------- | ---------- | --------------------- |
+| 12.13 | No user input in response header values without CRLF stripping | CWE-113 | HIGH |
+| 12.14 | `[LoggerMessage]` used everywhere — no string interpolation of user input into log calls | CWE-117 | MEDIUM |
+| 12.15 | User-input-facing regexes use `[GeneratedRegex]` with `NonBacktracking` or `matchTimeout` (no nested quantifiers on unbounded input) | CWE-1333 | MEDIUM |
+| 12.16 | OS command execution absent (or arguments passed as array, never shell string) | CWE-78 | CRITICAL |

--- a/.claude/skills/security/threat-models.md
+++ b/.claude/skills/security/threat-models.md
@@ -39,6 +39,18 @@ ZONE 5 — External Identity
 └── ACME / Certificate authorities
 ```
 
+### Boundary crossings (referenced by findings as `Boundary: B#`)
+
+| ID | Crossing | Carried by | Primary TMs |
+| ---- | ---------- | ----------- | ------------- |
+| B1 | Zone 1 → Zone 2 | HTTPS, session cookies, DPoP proofs, API keys, webhook HMAC | TM-01, TM-04, TM-07 |
+| B2 | Zone 2 → Zone 3 | YARP token injection, MCP tool dispatch, tenant resolution | TM-01, TM-02, TM-03 |
+| B3 | Zone 3 → Zone 4 | EF Core (tenant filters), Redis protocol, Vault API, blob SDK | TM-03, TM-05, TM-08 |
+| B4 | Zone 3 ↔ Zone 5 | OIDC code flow, JWKS fetch, back-channel logout | TM-01, TM-04 |
+| B5 | Zone 3 → external egress | Webhooks, SMTP/SMS providers, MCP **client**, AI provider APIs | TM-02 (SSRF) |
+| B6 | Outbox → consumer (time-shifted) | Wolverine envelopes serialized in a PAST security context | TM-06, TM-08 |
+| B7 | Build/CI → packages | NuGet feeds, source generators, CI secrets | supply-chain checklist §6 |
+
 ---
 
 ## TM-01: BFF Authentication Flow
@@ -48,7 +60,7 @@ ZONE 5 — External Identity
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Spoofing** | Attacker replays stolen session cookie | Session cookie: `Secure`, `HttpOnly`, `SameSite=Strict`; session rotation after login | Check `BffLoginEndpoints` cookie settings |
 | **Spoofing** | Attacker forges CSRF token | HMAC-SHA256 with server-side secret, bound to session | Check `HmacBffCsrfTokenGenerator` key source |
 | **Tampering** | Attacker modifies `redirect_uri` in auth request | Allowlist-based validation, exact match | Check `BffLoginEndpoints` redirect validation |
@@ -90,7 +102,7 @@ Goal: Steal user session
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Spoofing** | Attacker impersonates authorized AI agent | MCP transport authentication (API key, mTLS, session) | Check MCP server auth middleware |
 | **Spoofing** | Tool executes with wrong user context | `McpTenantScopeAttribute` + permission check on calling user | Check `TenantAwareVisibilityFilter` |
 | **Tampering** | Prompt injection in tool parameters | Input validation against schema, parameterized queries | Check tool input handling |
@@ -158,7 +170,7 @@ Goal: Access Tenant B data from Tenant A context
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Spoofing** | Attacker sends `X-Tenant-Id` header for another tenant | JWT claim takes precedence, header only for internal calls | Check resolver pipeline priority |
 | **Tampering** | Modify entity's `TenantId` field after creation | `TenantId` has `private set`, set by interceptor | Check entity configuration |
 | **Info Disclosure** | Query returns entities from other tenants | Named query filter on `TenantId` via `ApplyGranitConventions` | Check filter registration for all entities |
@@ -176,7 +188,7 @@ Goal: Access Tenant B data from Tenant A context
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Spoofing** | Stolen access token used without DPoP proof | Token bound to JWK thumbprint, proof required on every request | Check `DPoPValidationMiddleware` enforcement |
 | **Spoofing** | Attacker generates DPoP proof with different key | `cnf.jkt` in token must match proof's JWK thumbprint | Check thumbprint validation |
 | **Tampering** | DPoP proof replayed | Nonce tracking (server-issued) or `jti` uniqueness check | Check replay detection mechanism |
@@ -193,7 +205,7 @@ Goal: Access Tenant B data from Tenant A context
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Spoofing** | Unauthorized deletion request | Request requires authenticated user + self-service or admin permission | Check deletion endpoint authorization |
 | **Tampering** | Deletion saga partially executes (key destroyed but audit missed) | Saga uses compensation, atomic transaction for key + audit | Check saga transaction boundaries |
 | **Repudiation** | Organization denies deletion was performed | Immutable audit record via `ICryptoShreddingAuditRecorder` | Check audit immutability |
@@ -210,7 +222,7 @@ Goal: Access Tenant B data from Tenant A context
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Spoofing** | Fake message injected into outbox table | Outbox table writes via EF Core transaction only (no direct SQL access) | Check outbox table permissions |
 | **Tampering** | Message content modified between outbox and consumer | Message integrity (envelope signing or DB-level integrity) | Check message envelope |
 | **Repudiation** | Message processed but no trace | W3C Trace Context propagation, audit correlation | Check `TraceContextBehavior` |
@@ -228,7 +240,7 @@ Goal: Access Tenant B data from Tenant A context
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Spoofing** | Brute-force API key | High entropy (256-bit), rate limiting, account lockout | Check key generation + rate limiting |
 | **Spoofing** | Timing attack on key comparison | `CryptographicOperations.FixedTimeEquals` | Check comparison implementation |
 | **Spoofing** | X-Forwarded-For spoofing to bypass CIDR | Trust proxy headers only from known load balancer IPs | Check `CidrValidator` IP source |
@@ -250,7 +262,7 @@ Claim Check payloads (blob → handler), MCP tool responses (external → server
 ### STRIDE Analysis
 
 | Threat | Vector | Mitigation (expected) | Verify |
-|--------|--------|----------------------|--------|
+| -------- | -------- | ---------------------- | -------- |
 | **Tampering** | Attacker injects type discriminator in JSON to instantiate arbitrary types | `System.Text.Json` with closed `[JsonDerivedType]` set, no `TypeNameHandling` | Grep for `TypeNameHandling`, `JsonPolymorphicAttribute` with open type sets |
 | **Tampering** | Wolverine outbox message contains crafted payload | Schema-first deserialization with known message types only | Check Wolverine serializer configuration |
 | **Tampering** | Cache poisoning with malicious serialized object | FusionCache serializer does not resolve arbitrary types | Check `EncryptingFusionCacheSerializer` chain |
@@ -293,6 +305,26 @@ Goal: Execute arbitrary code via crafted serialized payload
 
 ---
 
+## TM-09: Input Injection Paths
+
+**Data Flow:** External Input (B1) → Validation → Business Logic → Sink
+(SQL via EF Core raw APIs, blob path, Scriban template, log, export cell)
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+| -------- | -------- | ---------------------- | -------- |
+| **Tampering** | User input concatenated into `FromSqlRaw`/`ExecuteSqlRaw` | Parameterized queries or `*Interpolated` variants; identifiers via closed allowlist | Grep raw SQL APIs across `*.EntityFrameworkCore` |
+| **Tampering** | Blob key contains `../` or absolute path | Key sanitization before provider dispatch (esp. `Granit.BlobStorage.FileSystem`) | Check blob key validation |
+| **Tampering** | Zip-slip during DataExchange import | Archive entry names validated against extraction root | Check import extraction code |
+| **Tampering** | Tenant-supplied Scriban template executes injected directives | Templates from embedded resources only, or sandboxed Scriban context | Check template source loading in `*.Notifications` |
+| **Info Disclosure** | XSS via unencoded user values in HTML email templates | Scriban auto-encoding / explicit encoding of model values | Check template rendering pipeline |
+| **Tampering** | Formula injection in CSV/Excel exports | Leading `=`, `+`, `-`, `@` escaped in user-supplied cells | Check `Granit.DataExchange.Csv` / `.Excel` writers |
+| **Repudiation** | Log forging via CRLF in user input | `[LoggerMessage]` structured params (no interpolation) | Grep interpolated log calls |
+| **DoS** | ReDoS on user-input-facing regex | `[GeneratedRegex]` with `NonBacktracking` or `matchTimeout` | Review regex patterns on input paths |
+
+---
+
 ## Methodology Notes
 
 ### Using these threat models
@@ -309,7 +341,7 @@ Goal: Execute arbitrary code via crafted serialized payload
 Threat models are point-in-time artifacts. Revisit when:
 
 | Change | Affected TMs | Why |
-|--------|-------------|-----|
+| -------- | ------------- | ----- |
 | MCP transport changes (stdio → HTTP/SSE) | TM-02 | New network attack surface, authentication model changes |
 | New identity provider added | TM-01, TM-04 | New trust boundary, token format differences |
 | Redis replaced with another cache | TM-01, TM-03, TM-08 | Encryption-at-rest, authentication model |
@@ -318,6 +350,7 @@ Threat models are point-in-time artifacts. Revisit when:
 | Multi-region deployment | TM-03, TM-05 | Cross-region tenant isolation, data residency |
 | Public API gateway added | TM-01, TM-07 | New trust boundary, rate limiting changes |
 | Serialization library change | TM-08 | Entire deserialization threat model may change |
+| New raw SQL path, template engine, or export format | TM-09 | New injection sink |
 
 **Rule:** Any PR that modifies a trust boundary crossing should reference the
 relevant TM and confirm mitigations still hold.
@@ -325,7 +358,7 @@ relevant TM and confirm mitigations still hold.
 ### CVSS 3.1 Quick Reference
 
 | Metric | Values |
-|--------|--------|
+| -------- | -------- |
 | Attack Vector (AV) | Network (N), Adjacent (A), Local (L), Physical (P) |
 | Attack Complexity (AC) | Low (L), High (H) |
 | Privileges Required (PR) | None (N), Low (L), High (H) |
@@ -336,3 +369,30 @@ relevant TM and confirm mitigations still hold.
 | Availability (A) | None (N), Low (L), High (H) |
 
 Example: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N` = 10.0 (Critical)
+
+### CVSS scoring discipline — Granit conventions
+
+Score metric-by-metric in the `<scratchpad>` (SKILL.md Step 3a), in this
+order, with one line of justification each. Granit-specific calibrations:
+
+| Situation | Calibration |
+| ----------- | ------------- |
+| Cross-tenant data access (isolation broken) | **S:C** — the tenant is a security authority boundary; C at least H |
+| Vulnerability only reachable via internal network (Zone 3+) | AV:A or AV:L, NOT AV:N — be honest about reachability across B1/B2 |
+| Requires a valid authenticated session/API key | PR:L (regular user) or PR:H (admin) — never PR:N "because the attacker could phish" |
+| Exploit needs a non-default option (`Options` class) | AC:H, and name the option in the finding |
+| MCP tool abuse requires a connected AI agent session | PR:L minimum; UI:R if a human must approve the tool call |
+| Secret found in repo (CWE-798) | Score the secret's blast radius, not the act of reading the repo: public repo ⇒ AV:N/PR:N; private ⇒ PR:L |
+| Defense-in-depth gap with an intact primary control | Cap at MEDIUM; primary control is a compensating control |
+
+Common pitfalls that inflate scores (each one is a credibility hit):
+
+- Scoring the worst theoretical chain instead of THIS finding (chained
+  findings are separate findings with their own scores).
+- AV:N for code only reachable behind the BFF with a valid session.
+- S:C without naming the second security authority that is crossed.
+- A:H for a DoS that only degrades one tenant's own throughput.
+
+Severity bands (after final vector): 9.0+ Critical · 7.0-8.9 High ·
+4.0-6.9 Medium · 0.1-3.9 Low. If the computed band contradicts your
+narrative, fix the narrative or the vector BEFORE writing the finding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md - Granit Codex guide
+
+This repository already maintains its agent instructions in `CLAUDE.md`.
+When working here, read and follow:
+
+1. `~/.claude/CLAUDE.md` for global workflow rules.
+2. `./CLAUDE.md` for repository-specific architecture, conventions, commands, and anti-patterns.
+
+Treat those files as the source of truth for project guidance. If a rule in those files conflicts with system, safety, sandbox, or user instructions, follow the higher-priority instruction and call out the conflict when it matters.
+
+Quick reminders for this repo:
+
+- Do not run `dotnet build`, `dotnet test`, or `dotnet format` on the full solution.
+- Target a `.slnf` shard or a single project/test project.
+- Keep code and docs PRs decoupled; docs live in the sibling `granit-docs` repo.
+- Preserve layer purity between base modules, `.Endpoints`, `.EntityFrameworkCore`, provider, Wolverine,
+  notifications, and background job packages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Every `*.Endpoints` module attaches `.WithTags(...)` on its root group. Format: 
 - `endpoints.MapGranitGroup(prefix)` — applies `FluentValidationAutoEndpointFilter` automatically.
 - Validators auto-discovered by `GranitValidationModule`. Opt-out: `WithMetadata(new SkipAutoValidationAttribute())`.
 - `FluentValidationSchemaTransformer` exposes constraints (maxLength, pattern...) in OpenAPI for codegen.
-- **Localized messages MANDATORY**: never hardcode `.WithMessage("...")`. Built-ins (NotEmpty, MaximumLength) auto-converted to error codes by `GranitErrorCodeLanguageManager`. Custom `.Must()` → `.WithErrorCodeAndMessage("Granit:Validation:XxxCode")` + add the key to all 17 JSON files in `src/Granit.Validation/Localization/Validation/`.
+- **Localized messages MANDATORY**: never hardcode `.WithMessage("...")`. Built-ins (NotEmpty, MaximumLength) auto-converted to error codes by `GranitErrorCodeLanguageManager`. Custom `.Must()` → `.WithErrorCodeAndMessage("Granit:Validation:XxxCode")` + add the key to all 18 JSON files in `src/Granit.Validation/Localization/Validation/`.
 
 ### Isolated DbContext (each `*.EntityFrameworkCore` package)
 


### PR DESCRIPTION
## Summary

Agent tooling and guidance updates (no framework code).

- **Skills**: expanded the `audit`, `perf`, and `security` skill definitions and checklists. The `security` SKILL.md and threat-models are substantially reworked (+511 / +80 lines).
- **AGENTS.md** (new): a Codex entry-point that defers to `CLAUDE.md` and the global rules, restating the key repo guardrails (never build/test/format the full solution — target a `.slnf` shard or single project; keep code and docs PRs decoupled).
- **CLAUDE.md**: corrected the validation localization file count (17 → 18) to match the actual culture set.

## Verification
- `markdownlint-cli2` clean on all 9 changed `.md` files (0 errors).
- Tooling/docs only — no build impact.