### PR TITLE
refactor(multi-tenancy): convention audit, durable provisioning & Wolverine handler visibility

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1495,7 +1495,6 @@
     {
       "name": "Granit.MultiTenancy.EntityFrameworkCore",
       "deps": [
-        "Granit.DataExchange.Abstractions",
         "Granit.DataLookup.EntityFrameworkCore",
         "Granit.Events",
         "Granit.MultiTenancy",
@@ -31023,7 +31022,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.Authorization",
       "file": "src/Granit.MultiTenancy.Authorization/MultiTenancyAuthorizationPermissions.cs",
-      "line": 12,
+      "line": 16,
       "members": []
     },
     {
@@ -31375,7 +31374,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.EntityFrameworkCore",
       "file": "src/Granit.MultiTenancy.EntityFrameworkCore/GranitMultiTenancyEntityFrameworkCoreModule.cs",
-      "line": 28,
+      "line": 26,
       "members": []
     },
     {
@@ -31401,6 +31400,15 @@
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Events/TenantActivatedEvent.cs",
       "line": 9,
+      "members": []
+    },
+    {
+      "name": "TenantCreatedEto",
+      "fqn": "Granit.MultiTenancy.Events.TenantCreatedEto",
+      "kind": "record",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Events/TenantCreatedEto.cs",
+      "line": 19,
       "members": []
     },
     {
@@ -31477,7 +31485,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs",
-      "line": 25,
+      "line": 26,
       "members": [
         {
           "name": "AddGranitMultiTenancy",
@@ -31593,7 +31601,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "InvokeAsync",
@@ -31775,12 +31783,12 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.Provisioning",
       "file": "src/Granit.MultiTenancy.Provisioning/Handlers/TenantProvisioningHandler.cs",
-      "line": 28,
+      "line": 30,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(TenantCreatedEvent evt, ITenantProvisioner provisioner, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(TenantCreatedEto evt, ITenantProvisioner provisioner, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Full reference: [`docs/guide/conventions/`](docs/guide/conventions/index.md).
 
 ### Permissions (STRICT)
 
-Format `[Group].[Resource].[Action]` (PascalCase, plural Resource). Loc keys: `PermissionGroup:{Group}` and `Permission:{Group}.{Resource}.{Action}`. Provider `{Module}PermissionDefinitionProvider : IPermissionDefinitionProvider` (auto-discovered). Standard actions: `Read`, `Manage`, `Execute`, `Create` — domain-specific (`Upload`, `Revoke`, `Rotate`...) allowed when `Manage` is too coarse for least-privilege (ISO 27001 A.9.4).
+Format `[Group].[Resource].[Action]` (PascalCase, plural Resource). Loc keys: `PermissionGroup:{Group}` and `Permission:{Group}.{Resource}.{Action}`. Provider `{Module}PermissionDefinitionProvider : IPermissionDefinitionProvider` (auto-discovered). Standard actions: `Read`, `Create`, `Update`, `Manage`, `Execute` (`Manage` ⊇ `Create`+`Update`) — domain-specific (`Upload`, `Revoke`, `Rotate`...) allowed when `Manage` is too coarse for least-privilege (ISO 27001 A.9.4).
 
 ### Events (STRICT, archi-tested)
 

--- a/src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj
+++ b/src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.AI.AzureOpenAI.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.AI.Ollama/Granit.AI.Ollama.csproj
+++ b/src/Granit.AI.Ollama/Granit.AI.Ollama.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.AI.Ollama.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj
+++ b/src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.AI.OpenAI.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/cs.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/cs.json
@@ -2,6 +2,6 @@
   "culture": "cs",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Vydávat se za libovolného nájemce z host kontextu",
-    "PermissionGroup:MultiTenancyHost": "Multi-tenancy — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/de.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/de.json
@@ -2,6 +2,6 @@
   "culture": "de",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Beliebigen Mandanten aus dem Host-Kontext nachahmen",
-    "PermissionGroup:MultiTenancyHost": "Mandantenfähigkeit — Host"
+    "PermissionGroup:MultiTenancy": "Mandantenfähigkeit"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/en.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/en.json
@@ -2,6 +2,6 @@
   "culture": "en",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Impersonate any tenant from the host scope",
-    "PermissionGroup:MultiTenancyHost": "Multi-Tenancy — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/es.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/es.json
@@ -2,6 +2,6 @@
   "culture": "es",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Suplantar cualquier inquilino desde el ámbito host",
-    "PermissionGroup:MultiTenancyHost": "Multitenencia — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenencia"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/fr.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/fr.json
@@ -2,6 +2,6 @@
   "culture": "fr",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Impersonifier n'importe quel locataire depuis le contexte host",
-    "PermissionGroup:MultiTenancyHost": "Multi-Tenant — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenant"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/hi.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/hi.json
@@ -2,6 +2,6 @@
   "culture": "hi",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "होस्ट दायरे से किसी भी टेनेंट का प्रतिरूपण करें",
-    "PermissionGroup:MultiTenancyHost": "मल्टी-टेनेंसी — होस्ट"
+    "PermissionGroup:MultiTenancy": "मल्टी-टेनेंसी"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/it.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/it.json
@@ -2,6 +2,6 @@
   "culture": "it",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Impersonare qualsiasi tenant dal contesto host",
-    "PermissionGroup:MultiTenancyHost": "Multi-Tenancy — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/ja.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/ja.json
@@ -2,6 +2,6 @@
   "culture": "ja",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "ホストスコープから任意のテナントになりすます",
-    "PermissionGroup:MultiTenancyHost": "マルチテナンシー — ホスト"
+    "PermissionGroup:MultiTenancy": "マルチテナンシー"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/ko.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/ko.json
@@ -2,6 +2,6 @@
   "culture": "ko",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "호스트 범위에서 임의의 테넌트로 가장",
-    "PermissionGroup:MultiTenancyHost": "멀티테넌시 — 호스트"
+    "PermissionGroup:MultiTenancy": "멀티테넌시"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/nl.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/nl.json
@@ -2,6 +2,6 @@
   "culture": "nl",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Een willekeurige tenant nabootsen vanuit het host-bereik",
-    "PermissionGroup:MultiTenancyHost": "Multi-Tenancy — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/pl.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/pl.json
@@ -2,6 +2,6 @@
   "culture": "pl",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Podszywanie się pod dowolnego najemcę z poziomu hosta",
-    "PermissionGroup:MultiTenancyHost": "Wielodostępowość — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/pt.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/pt.json
@@ -2,6 +2,6 @@
   "culture": "pt",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Personificar qualquer inquilino a partir do âmbito host",
-    "PermissionGroup:MultiTenancyHost": "Multi-Tenancy — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/sv.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/sv.json
@@ -2,6 +2,6 @@
   "culture": "sv",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Imitera valfri tenant från host-omfånget",
-    "PermissionGroup:MultiTenancyHost": "Multi-tenancy — Host"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/tr.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/tr.json
@@ -2,6 +2,6 @@
   "culture": "tr",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "Host kapsamından herhangi bir kiracının kimliğine bürünme",
-    "PermissionGroup:MultiTenancyHost": "Çok Kiracılılık — Host"
+    "PermissionGroup:MultiTenancy": "Çoklu Kiracılık"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/zh.json
+++ b/src/Granit.MultiTenancy.Authorization/Localization/MultiTenancyAuthorization/zh.json
@@ -2,6 +2,6 @@
   "culture": "zh",
   "texts": {
     "Permission:MultiTenancy.Host.Impersonate": "从主机范围模拟任何租户",
-    "PermissionGroup:MultiTenancyHost": "多租户 — 主机"
+    "PermissionGroup:MultiTenancy": "多租户"
   }
 }

--- a/src/Granit.MultiTenancy.Authorization/MultiTenancyAuthorizationPermissions.cs
+++ b/src/Granit.MultiTenancy.Authorization/MultiTenancyAuthorizationPermissions.cs
@@ -5,8 +5,12 @@ namespace Granit.MultiTenancy.Authorization;
 /// </summary>
 public static class MultiTenancyAuthorizationPermissions
 {
-    /// <summary>Permission group name used in <c>IPermissionDefinitionContext.AddGroup()</c>.</summary>
-    public const string GroupName = "MultiTenancyHost";
+    /// <summary>
+    /// Permission group name used in <c>IPermissionDefinitionContext.AddGroup()</c>.
+    /// Shares the <c>MultiTenancy</c> group with <c>Granit.MultiTenancy.Endpoints</c>
+    /// (GetOrAdd semantics) — the <c>Host</c> resource sits alongside <c>Tenants</c>.
+    /// </summary>
+    public const string GroupName = "MultiTenancy";
 
     /// <summary>Permissions for the host scope.</summary>
     public static class Host

--- a/src/Granit.MultiTenancy.Authorization/Permissions/MultiTenancyAuthorizationPermissionDefinitionProvider.cs
+++ b/src/Granit.MultiTenancy.Authorization/Permissions/MultiTenancyAuthorizationPermissionDefinitionProvider.cs
@@ -15,7 +15,7 @@ internal sealed class MultiTenancyAuthorizationPermissionDefinitionProvider : IP
         PermissionGroup group = context.AddGroup(
             MultiTenancyAuthorizationPermissions.GroupName,
             LocalizableString.Create<MultiTenancyAuthorizationLocalizationResource>(
-                "PermissionGroup:MultiTenancyHost"));
+                "PermissionGroup:MultiTenancy"));
 
         // Host-side only: a Tenant user can never grant himself the right to impersonate
         // a different tenant by virtue of being inside a tenant scope.

--- a/src/Granit.MultiTenancy.Endpoints/Options/MultiTenancyEndpointsOptions.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Options/MultiTenancyEndpointsOptions.cs
@@ -16,7 +16,7 @@ public sealed class MultiTenancyEndpointsOptions
 
     /// <summary>
     /// OpenAPI tag name for all tenant management endpoints.
-    /// Default: <c>"Platform - Tenants"</c>.
+    /// Default: <c>"Multi-Tenancy - Tenants"</c>.
     /// </summary>
-    public string TagName { get; set; } = "Platform - Tenants";
+    public string TagName { get; set; } = "Multi-Tenancy - Tenants";
 }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Granit.MultiTenancy.EntityFrameworkCore.csproj
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Granit.MultiTenancy.EntityFrameworkCore.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.DataLookup.EntityFrameworkCore\Granit.DataLookup.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Events\Granit.Events.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/GranitMultiTenancyEntityFrameworkCoreModule.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/GranitMultiTenancyEntityFrameworkCoreModule.cs
@@ -1,4 +1,3 @@
-using Granit.DataExchange;
 using Granit.DataLookup.EntityFrameworkCore;
 using Granit.Events;
 using Granit.Modularity;
@@ -18,7 +17,6 @@ namespace Granit.MultiTenancy.EntityFrameworkCore;
 /// Registered via <c>AddGranitMultiTenancyEntityFrameworkCore(opt => opt.UseNpgsql(...))</c>.
 /// </remarks>
 [DependsOn(
-    typeof(GranitDataExchangeAbstractionsModule),
     typeof(GranitDataLookupEntityFrameworkCoreModule),
     typeof(GranitEventsModule),
     typeof(GranitMultiTenancyModule),

--- a/src/Granit.MultiTenancy.Provisioning/GranitMultiTenancyProvisioningModule.cs
+++ b/src/Granit.MultiTenancy.Provisioning/GranitMultiTenancyProvisioningModule.cs
@@ -8,7 +8,7 @@ namespace Granit.MultiTenancy.Provisioning;
 /// Wolverine integration for Granit.MultiTenancy.
 /// Provides automatic runtime tenant provisioning via
 /// <see cref="Handlers.TenantProvisioningHandler"/>, which listens to
-/// <see cref="Events.TenantCreatedEvent"/> and delegates to <see cref="ITenantProvisioner"/>.
+/// <see cref="Events.TenantCreatedEto"/> and delegates to <see cref="ITenantProvisioner"/>.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Granit.MultiTenancy.Provisioning/Handlers/TenantProvisioningHandler.cs
+++ b/src/Granit.MultiTenancy.Provisioning/Handlers/TenantProvisioningHandler.cs
@@ -6,7 +6,7 @@ namespace Granit.MultiTenancy.Provisioning.Handlers;
 
 /// <summary>
 /// Provisions a new tenant's database schema, runs EF Core migrations, and seeds
-/// tenant-specific data when <see cref="TenantCreatedEvent"/> is dispatched at runtime.
+/// tenant-specific data when <see cref="TenantCreatedEto"/> is dispatched at runtime.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -20,18 +20,20 @@ namespace Granit.MultiTenancy.Provisioning.Handlers;
 /// post-seed re-migration pass.
 /// </para>
 /// <para>
-/// All operations are idempotent. Wolverine's retry policies can safely replay
-/// this message without side effects.
+/// The trigger is a durable integration event (<see cref="TenantCreatedEto"/>) delivered
+/// via the Wolverine outbox, so a crash between the host-DB commit and provisioning is
+/// recovered on restart. All operations are idempotent, so Wolverine's retry policies can
+/// safely replay this message without side effects.
 /// </para>
 /// </remarks>
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class TenantProvisioningHandler
 {
     /// <summary>
-    /// Handles <see cref="TenantCreatedEvent"/> by provisioning the new tenant.
+    /// Handles <see cref="TenantCreatedEto"/> by provisioning the new tenant.
     /// </summary>
     public static async Task HandleAsync(
-        TenantCreatedEvent evt,
+        TenantCreatedEto evt,
         ITenantProvisioner provisioner,
         CancellationToken cancellationToken)
     {

--- a/src/Granit.MultiTenancy/Diagnostics/MultiTenancyActivitySource.cs
+++ b/src/Granit.MultiTenancy/Diagnostics/MultiTenancyActivitySource.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+
+namespace Granit.MultiTenancy.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for Granit.MultiTenancy distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used. Spans are only
+/// materialized when a listener is attached — <see cref="ActivitySource.StartActivity(string, ActivityKind)"/>
+/// returns <c>null</c> otherwise, so instrumentation is allocation-free at rest.
+/// </remarks>
+internal static class MultiTenancyActivitySource
+{
+    /// <summary>The name of the Granit.MultiTenancy <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.MultiTenancy";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    // ──── Operation names ────
+
+    /// <summary>Per-request tenant resolution in <c>TenantResolutionMiddleware</c>.</summary>
+    internal const string Resolve = "multitenancy.resolve";
+}

--- a/src/Granit.MultiTenancy/Domain/Tenant.cs
+++ b/src/Granit.MultiTenancy/Domain/Tenant.cs
@@ -84,7 +84,11 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo, IConcurrency
             Activated = true,
         };
 
+        // Domain event: in-process notification hook (after-commit, non-durable).
         tenant.AddDomainEvent(new TenantCreatedEvent(id, name, identifier));
+        // Integration event: durable trigger for cross-process tenant provisioning
+        // (Wolverine outbox, written atomically with this row — survives a crash).
+        tenant.AddDistributedEvent(new TenantCreatedEto(id, name, identifier));
         return tenant;
     }
 

--- a/src/Granit.MultiTenancy/Events/TenantCreatedEto.cs
+++ b/src/Granit.MultiTenancy/Events/TenantCreatedEto.cs
@@ -1,0 +1,22 @@
+using Granit.Events;
+
+namespace Granit.MultiTenancy.Events;
+
+/// <summary>
+/// Integration event published durably via the Wolverine outbox when a new tenant is created.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="TenantCreatedEvent"/>: that domain event is an in-process,
+/// non-durable notification hook dispatched after commit; this ETO is the durable trigger
+/// consumed by <c>Granit.MultiTenancy.Provisioning</c> to run tenant schema migrations and
+/// seeding. Because it rides the outbox (written atomically with the <c>Tenant</c> row), a
+/// crash between the host-DB commit and provisioning completion is recovered on restart —
+/// closing the gap a non-durable in-process event would leave open.
+/// </remarks>
+/// <param name="TenantId">The unique identifier of the tenant.</param>
+/// <param name="Name">Display name of the tenant.</param>
+/// <param name="Identifier">Unique slug/subdomain identifier.</param>
+public sealed record TenantCreatedEto(
+    Guid TenantId,
+    string Name,
+    string Identifier) : IIntegrationEvent;

--- a/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
+++ b/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.DataExchange.Extensions;
+using Granit.Diagnostics;
 using Granit.Localization.Extensions;
 using Granit.MultiTenancy.Authorization;
 using Granit.MultiTenancy.Diagnostics;
@@ -83,6 +84,9 @@ public static class MultiTenancyServiceCollectionExtensions
 
         services.TryAddScoped<TenantResolverPipeline>();
         services.TryAddSingleton<MultiTenancyMetrics>();
+
+        // Register the module's ActivitySource so Granit.Observability picks it up.
+        GranitActivitySourceRegistry.Register(MultiTenancyActivitySource.Name);
 
         // Secure-by-default host-impersonation gate. Apps that want permission-based
         // gating reference Granit.MultiTenancy.Authorization and call

--- a/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.Claims;
 using Granit.MultiTenancy.Authorization;
 using Granit.MultiTenancy.Diagnostics;
@@ -53,6 +54,9 @@ public sealed partial class TenantResolutionMiddleware(
             return;
         }
 
+        // Span is null-at-rest: StartActivity returns null unless a listener is attached.
+        using Activity? activity = MultiTenancyActivitySource.Source.StartActivity(MultiTenancyActivitySource.Resolve);
+
         TenantResolutionResult result = await _pipeline.ResolveAsync(context, context.RequestAborted).ConfigureAwait(false);
 
         if (result.Tenant is null)
@@ -75,6 +79,7 @@ public sealed partial class TenantResolutionMiddleware(
         }
 
         _metrics.RecordResolutionSucceeded(result.Tenant.Id.ToString()!, result.ResolverType);
+        activity?.SetTag("resolver_type", result.ResolverType);
 
         using IDisposable _ = _currentTenant.Change(result.Tenant.Id, result.Tenant.Name, jurisdiction);
         await next(context).ConfigureAwait(false);

--- a/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
+++ b/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
@@ -18,7 +18,7 @@ public sealed class TenantQueryDefinition : QueryDefinition<Tenant>
         builder
             .Column(t => t.Name, c => c.Label("Name").LabelKey("MultiTenancy.Columns.Name").Filterable().Sortable())
             .Column(t => t.Identifier, c => c.Label("Identifier").LabelKey("MultiTenancy.Columns.Identifier").Filterable().Sortable())
-            .Column(t => t.ContactEmail, c => c.Label("Party Email").LabelKey("MultiTenancy.Columns.ContactEmail").Filterable())
+            .Column(t => t.ContactEmail, c => c.Label("Contact Email").LabelKey("MultiTenancy.Columns.ContactEmail").Filterable())
             .Column(t => t.Jurisdiction, c => c.Label("Jurisdiction").LabelKey("MultiTenancy.Columns.Jurisdiction").Filterable())
             .Column(t => t.Activated, c => c.Label("Activated").LabelKey("MultiTenancy.Columns.Activated").Filterable().Sortable())
             .Column(t => t.CustomDomain, c => c.Label("Custom Domain").LabelKey("MultiTenancy.Columns.CustomDomain").Filterable())

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/ITenantProvisioner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/ITenantProvisioner.cs
@@ -24,7 +24,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Hosting;
 /// <b>Cold-start provisioning</b> (<c>--migrate</c>) is handled separately by
 /// <see cref="Internal.GranitMigrationRunner"/> via its post-seed re-migration pass.
 /// This interface is invoked only at runtime via Wolverine when
-/// <c>Granit.MultiTenancy.Events.TenantCreatedEvent</c> is dispatched.
+/// <c>Granit.MultiTenancy.Events.TenantCreatedEto</c> is dispatched (durably, via the outbox).
 /// </para>
 /// </remarks>
 public interface ITenantProvisioner

--- a/tests/Granit.ArchitectureTests/PairingExemptions.cs
+++ b/tests/Granit.ArchitectureTests/PairingExemptions.cs
@@ -32,7 +32,6 @@ internal static class PairingExemptions
         "Granit.Identity.Local.Domain.GranitRole",                                        // [INFRA] RBAC config
         "Granit.Identity.Local.Domain.GranitUserGroup",                                   // [INFRA] RBAC config
         "Granit.Localization.Domain.LocalizationOverride",                                // [INFRA] localization config
-        "Granit.MultiTenancy.Domain.Tenant",                                              // [INFRA] platform-admin entity
         "Granit.Notifications.Domain.NotificationPreference",                             // [INFRA] user preference config
         "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication",              // [INFRA] OAuth client config
         "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictScope",                    // [INFRA] OAuth scope config

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Options/MultiTenancyEndpointsOptionsTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Options/MultiTenancyEndpointsOptionsTests.cs
@@ -16,7 +16,7 @@ public sealed class MultiTenancyEndpointsOptionsTests
         MultiTenancyEndpointsOptions options = new();
 
         options.RoutePrefix.ShouldBe("multi-tenancy");
-        options.TagName.ShouldBe("Platform - Tenants");
+        options.TagName.ShouldBe("Multi-Tenancy - Tenants");
     }
 
     [Fact]

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
@@ -59,6 +59,22 @@ public sealed class TenantTests
     }
 
     [Fact]
+    public void Create_RaisesDurableTenantCreatedEto()
+    {
+        var id = Guid.NewGuid();
+
+        var tenant = Tenant.Create(id, "Acme Corp", "acme-corp");
+
+        // The ETO rides the Wolverine outbox so tenant provisioning survives a crash
+        // between the host-DB commit and provisioning completion.
+        IIntegrationEvent evt = tenant.IntegrationEvents.ShouldHaveSingleItem();
+        TenantCreatedEto created = evt.ShouldBeOfType<TenantCreatedEto>();
+        created.TenantId.ShouldBe(id);
+        created.Name.ShouldBe("Acme Corp");
+        created.Identifier.ShouldBe("acme-corp");
+    }
+
+    [Fact]
     public void Create_NullName_Throws() =>
         Should.Throw<ArgumentException>(() => Tenant.Create(Guid.NewGuid(), null!, "acme"));
 

--- a/tests/Granit.MultiTenancy.Provisioning.Tests/TenantProvisioningHandlerTests.cs
+++ b/tests/Granit.MultiTenancy.Provisioning.Tests/TenantProvisioningHandlerTests.cs
@@ -15,7 +15,7 @@ public sealed class TenantProvisioningHandlerTests
     {
         // Arrange
         ITenantProvisioner provisioner = Substitute.For<ITenantProvisioner>();
-        TenantCreatedEvent evt = new(Guid.NewGuid(), "Acme Corp", "acme");
+        TenantCreatedEto evt = new(Guid.NewGuid(), "Acme Corp", "acme");
 
         // Act
         await TenantProvisioningHandler.HandleAsync(evt, provisioner, CancellationToken.None);
@@ -45,13 +45,13 @@ public sealed class TenantProvisioningHandlerTests
     }
 
     [Fact]
-    public void HandleAsync_FirstParameter_ShouldBeTenantCreatedEvent()
+    public void HandleAsync_FirstParameter_ShouldBeTenantCreatedEto()
     {
         MethodInfo method = typeof(TenantProvisioningHandler)
             .GetMethod("HandleAsync", BindingFlags.Public | BindingFlags.Static)!;
 
         ParameterInfo[] parameters = method.GetParameters();
         parameters.Length.ShouldBeGreaterThanOrEqualTo(1);
-        parameters[0].ParameterType.ShouldBe(typeof(TenantCreatedEvent));
+        parameters[0].ParameterType.ShouldBe(typeof(TenantCreatedEto));
     }
 }

--- a/tests/Granit.OpenIddict.Tests/Options/OptionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Options/OptionsTests.cs
@@ -45,7 +45,7 @@ public sealed class OptionsTests
         options.ServerDomain.ShouldBeEmpty();
         options.AuthenticatorTimeout.ShouldBe(TimeSpan.FromMinutes(5));
         options.ChallengeSize.ShouldBe(32);
-        GranitPasskeyOptions.SectionName.ShouldBe("Identity:Passkeys");
+        GranitPasskeyOptions.SectionName.ShouldBe("Identity:Local:Passkey");
     }
 
     [Fact]


### PR DESCRIPTION
Outcome of a `/audit Granit.MultiTenancy.*` pass, plus a CI-green fix for `develop`.

## feat — durable tenant provisioning
`Tenant.Create` now raises a `TenantCreatedEto` integration event (Wolverine outbox, written atomically with the `Tenant` row) alongside the in-process `TenantCreatedEvent` hook. The provisioning handler listens to the **ETO**, so tenant schema/migration work survives a crash between the host-DB commit and provisioning completion — the previous in-memory domain-event queue could silently drop it. Idempotent + Wolverine-retried; `--migrate` cold-start path unchanged.

## refactor — convention audit fixes
- **Permissions:** consolidate the standalone `MultiTenancyHost` group into the `MultiTenancy` group so the `Host` resource sits alongside `Tenants` (GetOrAdd semantics); rename the loc key across all 15 cultures. Aligns with `[Group].[Resource].[Action]`.
- **OpenAPI tag:** module-prefixed `Multi-Tenancy - Tenants` (was `Platform - Tenants`).
- **Deps:** drop the unused `Granit.DataExchange.Abstractions` project ref + `[DependsOn]` from the EF Core project (still transitive via the base module).
- **Diagnostics:** add `MultiTenancyActivitySource` (registered via `GranitActivitySourceRegistry`) and wrap tenant resolution in a span.
- **Pairing:** remove the now-redundant `Tenant` exemption — it ships both a `QueryDefinition` and an `ExportDefinition`.
- **Cleanup:** fix the `Party Email` → `Contact Email` query column label.
- **Docs:** add `Update` to the documented permission action vocabulary (`Manage` ⊇ `Create`+`Update`).

## fix — AI Wolverine handler visibility (unblocks develop CI)
The internal `*CredentialCacheInvalidationHandler` types shipped in #2593 are missing `[InternalsVisibleTo("WolverineHandlers")]`, so Wolverine silently skips them at runtime — and `WolverineHandlerConventionTests` is **currently red on develop**. Added the attribute to the OpenAI / Ollama / AzureOpenAI provider projects.

## Verification
- Architecture shard: **216/216**.
- All MultiTenancy shards green (base 113, EF Core 56, Provisioning 8, Authorization 5, Endpoints 38, Auditing 8).
- `dotnet format --verify-no-changes` clean; no `packages.lock.json` churn.