### PR TITLE
fix(oidc): stabilize DPoP proof key and harden token-management conventions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35554,7 +35554,7 @@
       "kind": "class",
       "project": "Granit.Oidc.TokenManagement",
       "file": "src/Granit.Oidc.TokenManagement/Extensions/TokenManagementServiceCollectionExtensions.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitTokenManagement",
@@ -35570,7 +35570,7 @@
       "kind": "class",
       "project": "Granit.Oidc.TokenManagement",
       "file": "src/Granit.Oidc.TokenManagement/GranitOidcTokenManagementModule.cs",
-      "line": 17,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Authentication.DPoP/Validation/Internal/DPoPProofValidator.cs
+++ b/src/Granit.Authentication.DPoP/Validation/Internal/DPoPProofValidator.cs
@@ -376,8 +376,7 @@ internal sealed class DPoPProofValidator(
     private async Task<string> GenerateAndStoreNonceAsync(DPoPValidationOptions opts, CancellationToken cancellationToken)
     {
         byte[] nonceBytes = RandomNumberGenerator.GetBytes(32);
-        string nonce = Convert.ToBase64String(nonceBytes)
-            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        string nonce = System.Buffers.Text.Base64Url.EncodeToString(nonceBytes);
 
         string cacheKey = $"{NonceCachePrefix}{nonce}";
         await cache.SetAsync(cacheKey, true,
@@ -416,15 +415,6 @@ internal sealed class DPoPProofValidator(
         return uri.TrimEnd('/');
     }
 
-    private static byte[] Base64UrlDecode(string base64Url)
-    {
-        string padded = base64Url.Replace('-', '+').Replace('_', '/');
-        switch (padded.Length % 4)
-        {
-            case 2: padded += "=="; break;
-            case 3: padded += "="; break;
-        }
-
-        return Convert.FromBase64String(padded);
-    }
+    private static byte[] Base64UrlDecode(string base64Url) =>
+        System.Buffers.Text.Base64Url.DecodeFromChars(base64Url);
 }

--- a/src/Granit.Authentication.DPoP/Validation/Internal/JwkThumbprintCalculator.cs
+++ b/src/Granit.Authentication.DPoP/Validation/Internal/JwkThumbprintCalculator.cs
@@ -30,7 +30,7 @@ internal static class JwkThumbprintCalculator
         };
 
         byte[] hash = SHA256.HashData(canonicalJson);
-        return Base64UrlEncode(hash);
+        return System.Buffers.Text.Base64Url.EncodeToString(hash);
     }
 
     /// <summary>
@@ -78,10 +78,4 @@ internal static class JwkThumbprintCalculator
 
         return buffer.WrittenSpan.ToArray();
     }
-
-    private static string Base64UrlEncode(byte[] data) =>
-        Convert.ToBase64String(data)
-            .Replace('+', '-')
-            .Replace('/', '_')
-            .TrimEnd('=');
 }

--- a/src/Granit.Oidc.TokenManagement/Cache/Internal/ClientCredentialsTokenCache.cs
+++ b/src/Granit.Oidc.TokenManagement/Cache/Internal/ClientCredentialsTokenCache.cs
@@ -20,7 +20,18 @@ internal sealed partial class ClientCredentialsTokenCache(
     {
         ArgumentException.ThrowIfNullOrEmpty(clientName);
 
-        MaybeValue<string?> maybe = await cache.TryGetAsync<string?>(BuildKey(clientName), token: cancellationToken).ConfigureAwait(false);
+        MaybeValue<string?> maybe;
+        try
+        {
+            maybe = await cache.TryGetAsync<string?>(BuildKey(clientName), token: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Fail-open: a cache outage re-triggers a token endpoint round-trip
+            // rather than failing the outbound request.
+            LogCacheFailure(clientName, nameof(GetTokenAsync), ex.Message);
+            return null;
+        }
 
         if (!maybe.HasValue)
         {
@@ -42,11 +53,19 @@ internal sealed partial class ClientCredentialsTokenCache(
         ArgumentException.ThrowIfNullOrEmpty(clientName);
         ArgumentException.ThrowIfNullOrEmpty(accessToken);
 
-        await cache.SetAsync(
-            BuildKey(clientName),
-            accessToken,
-            new FusionCacheEntryOptions { Duration = expiry },
-            token: cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await cache.SetAsync(
+                BuildKey(clientName),
+                accessToken,
+                new FusionCacheEntryOptions { Duration = expiry },
+                token: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogCacheFailure(clientName, nameof(SetTokenAsync), ex.Message);
+            return;
+        }
 
         LogCacheSet(clientName, expiry);
     }
@@ -56,7 +75,15 @@ internal sealed partial class ClientCredentialsTokenCache(
     {
         ArgumentException.ThrowIfNullOrEmpty(clientName);
 
-        await cache.RemoveAsync(BuildKey(clientName), token: cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await cache.RemoveAsync(BuildKey(clientName), token: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogCacheFailure(clientName, nameof(RemoveTokenAsync), ex.Message);
+            return;
+        }
 
         LogCacheRemoved(clientName);
     }
@@ -74,6 +101,9 @@ internal sealed partial class ClientCredentialsTokenCache(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Removed cached client credentials token for client {ClientName}")]
     private partial void LogCacheRemoved(string clientName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Client credentials token cache operation {Operation} failed for client {ClientName} — falling back to token endpoint. {ErrorMessage}")]
+    private partial void LogCacheFailure(string clientName, string operation, string errorMessage);
 }
 
 #pragma warning restore GRSEC003

--- a/src/Granit.Oidc.TokenManagement/Cache/Internal/ClientCredentialsTokenCache.cs
+++ b/src/Granit.Oidc.TokenManagement/Cache/Internal/ClientCredentialsTokenCache.cs
@@ -25,7 +25,7 @@ internal sealed partial class ClientCredentialsTokenCache(
         {
             maybe = await cache.TryGetAsync<string?>(BuildKey(clientName), token: cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Fail-open: a cache outage re-triggers a token endpoint round-trip
             // rather than failing the outbound request.
@@ -61,7 +61,7 @@ internal sealed partial class ClientCredentialsTokenCache(
                 new FusionCacheEntryOptions { Duration = expiry },
                 token: cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogCacheFailure(clientName, nameof(SetTokenAsync), ex.Message);
             return;
@@ -79,7 +79,7 @@ internal sealed partial class ClientCredentialsTokenCache(
         {
             await cache.RemoveAsync(BuildKey(clientName), token: cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogCacheFailure(clientName, nameof(RemoveTokenAsync), ex.Message);
             return;

--- a/src/Granit.Oidc.TokenManagement/DPoP/IDPoPKeyStore.cs
+++ b/src/Granit.Oidc.TokenManagement/DPoP/IDPoPKeyStore.cs
@@ -1,0 +1,23 @@
+namespace Granit.Oidc.TokenManagement.DPoP;
+
+/// <summary>
+/// Provides a stable DPoP (RFC 9449) proof key per named HTTP client.
+/// </summary>
+/// <remarks>
+/// DPoP-bound access tokens carry a <c>cnf.jkt</c> claim pinned to the thumbprint of
+/// the key that requested them. Delegating handlers are recreated every
+/// <c>HttpClientFactory</c> handler-lifetime rotation (~2&#160;min by default), whereas a
+/// token is cached for its full lifetime — often much longer. If the proof key lived on
+/// the handler instance it would change on every rotation, leaving cached tokens bound to
+/// a thumbprint the new key no longer matches (<c>invalid_dpop_proof</c>). Holding the key
+/// in a singleton keyed by client name keeps it stable for the process lifetime so cached
+/// tokens stay valid for their whole TTL.
+/// </remarks>
+internal interface IDPoPKeyStore
+{
+    /// <summary>
+    /// Returns the stable DPoP private-key JWK for <paramref name="clientName"/>,
+    /// generating one on first use.
+    /// </summary>
+    string GetOrCreateKey(string clientName);
+}

--- a/src/Granit.Oidc.TokenManagement/DPoP/Internal/DPoPKeyStore.cs
+++ b/src/Granit.Oidc.TokenManagement/DPoP/Internal/DPoPKeyStore.cs
@@ -1,0 +1,20 @@
+using System.Collections.Concurrent;
+using Granit.Oidc.DPoP;
+
+namespace Granit.Oidc.TokenManagement.DPoP.Internal;
+
+/// <summary>
+/// Singleton <see cref="IDPoPKeyStore"/> holding one stable EC P-256 proof key per
+/// named client for the lifetime of the process.
+/// </summary>
+internal sealed class DPoPKeyStore(IDPoPProofService proofService) : IDPoPKeyStore
+{
+    private readonly ConcurrentDictionary<string, string> _keys = new(StringComparer.Ordinal);
+
+    /// <inheritdoc/>
+    public string GetOrCreateKey(string clientName)
+    {
+        ArgumentNullException.ThrowIfNull(clientName);
+        return _keys.GetOrAdd(clientName, _ => proofService.GenerateKeyPair());
+    }
+}

--- a/src/Granit.Oidc.TokenManagement/Extensions/TokenManagementServiceCollectionExtensions.cs
+++ b/src/Granit.Oidc.TokenManagement/Extensions/TokenManagementServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@ using Granit.Http.Resilience.Extensions;
 using Granit.Oidc.TokenManagement.Cache;
 using Granit.Oidc.TokenManagement.Cache.Internal;
 using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.DPoP;
+using Granit.Oidc.TokenManagement.DPoP.Internal;
 using Granit.Oidc.TokenManagement.Handlers;
 using Granit.Oidc.TokenManagement.Options;
 using Granit.Oidc.TokenManagement.Services;
@@ -34,6 +36,7 @@ public static class TokenManagementServiceCollectionExtensions
         services.TryAddSingleton<ITokenEndpointService, TokenEndpointService>();
         services.TryAddSingleton<ITokenRevocationService, TokenRevocationService>();
         services.TryAddSingleton<IClientCredentialsTokenCache, ClientCredentialsTokenCache>();
+        services.TryAddSingleton<IDPoPKeyStore, DPoPKeyStore>();
 
         services.AddGranitHttpClient("Granit.TokenManagement");
 
@@ -60,6 +63,7 @@ public static class TokenManagementServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(configure);
 
         services.AddGranitTokenManagement();
+        services.TryAddSingleton<IValidateOptions<ClientCredentialsOptions>, ClientCredentialsOptionsValidator>();
         services.Configure(name, configure);
 
         return services.AddGranitHttpClient(name)

--- a/src/Granit.Oidc.TokenManagement/GranitOidcTokenManagementModule.cs
+++ b/src/Granit.Oidc.TokenManagement/GranitOidcTokenManagementModule.cs
@@ -1,4 +1,5 @@
 using Granit.Caching;
+using Granit.Http.Resilience;
 using Granit.Modularity;
 using Granit.Oidc.TokenManagement.Extensions;
 using Granit.Timing;
@@ -12,6 +13,7 @@ namespace Granit.Oidc.TokenManagement;
 /// </summary>
 [DependsOn(
     typeof(GranitCachingModule),
+    typeof(GranitHttpResilienceModule),
     typeof(GranitOidcModule),
     typeof(GranitTimingModule))]
 public sealed class GranitOidcTokenManagementModule : GranitModule

--- a/src/Granit.Oidc.TokenManagement/Handlers/ClientCredentialsTokenHandler.cs
+++ b/src/Granit.Oidc.TokenManagement/Handlers/ClientCredentialsTokenHandler.cs
@@ -8,6 +8,7 @@ using Granit.Oidc.Requests;
 using Granit.Oidc.Responses;
 using Granit.Oidc.TokenManagement.Cache;
 using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.DPoP;
 using Granit.Oidc.TokenManagement.Options;
 using Granit.Oidc.TokenManagement.Services;
 using Granit.Timing;
@@ -27,13 +28,16 @@ internal sealed partial class ClientCredentialsTokenHandler(
     ITokenEndpointService tokenEndpointService,
     IClientCredentialsTokenCache tokenCache,
     IDPoPProofService dpopProofService,
+    IDPoPKeyStore dpopKeyStore,
     IOptionsMonitor<ClientCredentialsOptions> clientCredentialsOptionsMonitor,
     IOptions<TokenManagementOptions> tokenManagementOptions,
     IClock clock,
     TokenManagementMetrics metrics,
     ILogger<ClientCredentialsTokenHandler> logger) : DelegatingHandler
 {
-    private string? _dpopPrivateKeyJwk;
+    // The proof key is stable per client (see IDPoPKeyStore) so cached
+    // sender-constrained tokens keep matching across handler rotations. Only the
+    // short-lived, server-supplied nonce is tracked per handler instance.
     private string? _dpopNonce;
     private readonly Lock _dpopLock = new();
 
@@ -152,16 +156,15 @@ internal sealed partial class ClientCredentialsTokenHandler(
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("DPoP", accessToken);
 
-            string? privateKey;
             string? nonce;
             lock (_dpopLock)
             {
-                privateKey = _dpopPrivateKeyJwk;
                 nonce = _dpopNonce;
             }
 
-            if (privateKey is not null && request.RequestUri is not null)
+            if (request.RequestUri is not null)
             {
+                string privateKey = dpopKeyStore.GetOrCreateKey(ClientName);
                 string proof = dpopProofService.CreateProof(
                     privateKey, request.Method.Method, request.RequestUri.ToString(), nonce);
                 request.Headers.TryAddWithoutValidation("DPoP", proof);
@@ -180,10 +183,10 @@ internal sealed partial class ClientCredentialsTokenHandler(
             return null;
         }
 
+        string privateKey = dpopKeyStore.GetOrCreateKey(ClientName);
         lock (_dpopLock)
         {
-            _dpopPrivateKeyJwk ??= dpopProofService.GenerateKeyPair();
-            return new DPoPOptions(_dpopPrivateKeyJwk, _dpopNonce);
+            return new DPoPOptions(privateKey, _dpopNonce);
         }
     }
 

--- a/src/Granit.Oidc.TokenManagement/Handlers/OnBehalfOfTokenHandler.cs
+++ b/src/Granit.Oidc.TokenManagement/Handlers/OnBehalfOfTokenHandler.cs
@@ -12,6 +12,7 @@ using Granit.Oidc.DPoP;
 using Granit.Oidc.Requests;
 using Granit.Oidc.Responses;
 using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.DPoP;
 using Granit.Oidc.TokenManagement.Options;
 using Granit.Oidc.TokenManagement.Services;
 using Granit.Timing;
@@ -53,6 +54,7 @@ internal sealed partial class OnBehalfOfTokenHandler(
     ITokenEndpointService tokenEndpointService,
     IConditionalCache tokenCache,
     IDPoPProofService dpopProofService,
+    IDPoPKeyStore dpopKeyStore,
     IHttpContextAccessor httpContextAccessor,
     ICurrentTenant currentTenant,
     ICurrentUserService currentUser,
@@ -63,11 +65,10 @@ internal sealed partial class OnBehalfOfTokenHandler(
 {
     private const string CacheKeyPrefix = "granit.oidc.obo";
 
-    // Per-handler-instance DPoP key + server-supplied nonce. The handler is a
-    // transient delegating handler but HttpClientFactory keeps the outer
-    // HttpMessageHandler pinned for the lifetime of its HandlerLifetime, so the
-    // key survives across requests for the same named client.
-    private string? _dpopPrivateKeyJwk;
+    // The DPoP proof key is stable per client (see IDPoPKeyStore) so exchanged
+    // sender-constrained tokens — cached for their full lifetime — keep matching
+    // the proof key across HttpClientFactory handler rotations. Only the
+    // short-lived, server-supplied nonce is tracked per handler instance.
     private string? _dpopNonce;
     private readonly Lock _dpopLock = new();
 
@@ -342,16 +343,15 @@ internal sealed partial class OnBehalfOfTokenHandler(
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("DPoP", accessToken);
 
-            string? privateKey;
             string? nonce;
             lock (_dpopLock)
             {
-                privateKey = _dpopPrivateKeyJwk;
                 nonce = _dpopNonce;
             }
 
-            if (privateKey is not null && request.RequestUri is not null)
+            if (request.RequestUri is not null)
             {
+                string privateKey = dpopKeyStore.GetOrCreateKey(ClientName);
                 string proof = dpopProofService.CreateProof(
                     privateKey, request.Method.Method, request.RequestUri.ToString(), nonce);
                 request.Headers.TryAddWithoutValidation("DPoP", proof);
@@ -370,10 +370,10 @@ internal sealed partial class OnBehalfOfTokenHandler(
             return null;
         }
 
+        string privateKey = dpopKeyStore.GetOrCreateKey(ClientName);
         lock (_dpopLock)
         {
-            _dpopPrivateKeyJwk ??= dpopProofService.GenerateKeyPair();
-            return new DPoPOptions(_dpopPrivateKeyJwk, _dpopNonce);
+            return new DPoPOptions(privateKey, _dpopNonce);
         }
     }
 

--- a/src/Granit.Oidc.TokenManagement/Options/ClientCredentialsOptionsValidator.cs
+++ b/src/Granit.Oidc.TokenManagement/Options/ClientCredentialsOptionsValidator.cs
@@ -5,18 +5,19 @@ using Microsoft.Extensions.Options;
 namespace Granit.Oidc.TokenManagement.Options;
 
 /// <summary>
-/// Validates <see cref="OnBehalfOfOptions"/> when the named options are first
-/// resolved (the first request through the handler).
-/// Refuses any configuration that would reintroduce the confused-deputy
-/// vector (no audience, no host allow-list, non-https authority in prod).
+/// Validates <see cref="ClientCredentialsOptions"/> when first resolved.
+/// Catches misconfigurations that would otherwise fail silently at the first
+/// outbound request: missing authority/client id, non-https authority in
+/// non-Development environments, and a client-authentication method without its
+/// matching credential.
 /// </summary>
-internal sealed class OnBehalfOfOptionsValidator(IHostEnvironment environment)
-    : IValidateOptions<OnBehalfOfOptions>
+internal sealed class ClientCredentialsOptionsValidator(IHostEnvironment environment)
+    : IValidateOptions<ClientCredentialsOptions>
 {
-    public ValidateOptionsResult Validate(string? name, OnBehalfOfOptions options)
+    public ValidateOptionsResult Validate(string? name, ClientCredentialsOptions options)
     {
         List<string> failures = [];
-        string prefix = string.IsNullOrEmpty(name) ? "OnBehalfOfOptions" : $"OnBehalfOfOptions[{name}]";
+        string prefix = string.IsNullOrEmpty(name) ? "ClientCredentialsOptions" : $"ClientCredentialsOptions[{name}]";
 
         if (string.IsNullOrWhiteSpace(options.Authority))
         {
@@ -35,22 +36,6 @@ internal sealed class OnBehalfOfOptionsValidator(IHostEnvironment environment)
             failures.Add($"{prefix}.{nameof(options.ClientId)} is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(options.Audience))
-        {
-            failures.Add(
-                $"{prefix}.{nameof(options.Audience)} is required. Without an audience the " +
-                "exchanged token is not narrowed to the downstream API, defeating the purpose " +
-                "of token exchange (RFC 8693).");
-        }
-
-        if (options.AllowedHosts is null || options.AllowedHosts.Length == 0)
-        {
-            failures.Add(
-                $"{prefix}.{nameof(options.AllowedHosts)} must contain at least one host. " +
-                "Without it the handler has no way to detect attacker-influenced target URLs.");
-        }
-
-        // At least one form of client authentication must be configured
         bool hasClientSecret = !string.IsNullOrEmpty(options.ClientSecret);
         bool hasSigningKey = !string.IsNullOrEmpty(options.ClientSigningKeyJwk);
 
@@ -69,10 +54,9 @@ internal sealed class OnBehalfOfOptionsValidator(IHostEnvironment environment)
                 break;
         }
 
-        if (options.TokenLifetimeSafetyMargin < TimeSpan.Zero)
+        if (options.CacheMargin is { } margin && margin < TimeSpan.Zero)
         {
-            failures.Add(
-                $"{prefix}.{nameof(options.TokenLifetimeSafetyMargin)} must be non-negative.");
+            failures.Add($"{prefix}.{nameof(options.CacheMargin)} must be non-negative.");
         }
 
         return failures.Count == 0

--- a/src/Granit.Oidc/ClientAuthentication/Internal/PrivateKeyJwtStrategy.cs
+++ b/src/Granit.Oidc/ClientAuthentication/Internal/PrivateKeyJwtStrategy.cs
@@ -69,8 +69,17 @@ internal sealed class PrivateKeyJwtStrategy(string privateKeyJwk, IClock clock) 
 
     private string CreateRsaAssertion(JsonElement jwk, string clientId, string tokenEndpoint)
     {
-        using var rsa = RSA.Create();
-        rsa.ImportFromPem(ExportRsaJwkToPkcs8Pem(jwk));
+        using var rsa = RSA.Create(new RSAParameters
+        {
+            Modulus = Base64Url.Decode(jwk.GetProperty("n").GetString()!),
+            Exponent = Base64Url.Decode(jwk.GetProperty("e").GetString()!),
+            D = Base64Url.Decode(jwk.GetProperty("d").GetString()!),
+            P = Base64Url.Decode(jwk.GetProperty("p").GetString()!),
+            Q = Base64Url.Decode(jwk.GetProperty("q").GetString()!),
+            DP = Base64Url.Decode(jwk.GetProperty("dp").GetString()!),
+            DQ = Base64Url.Decode(jwk.GetProperty("dq").GetString()!),
+            InverseQ = Base64Url.Decode(jwk.GetProperty("qi").GetString()!),
+        });
 
         string header = JsonSerializer.Serialize(new Dictionary<string, string>
         {
@@ -98,23 +107,6 @@ internal sealed class PrivateKeyJwtStrategy(string privateKeyJwk, IClock clock) 
             ["exp"] = now + AssertionLifetimeSeconds,
         });
 #pragma warning restore GRSEC002
-    }
-
-    private static ReadOnlySpan<char> ExportRsaJwkToPkcs8Pem(JsonElement jwk)
-    {
-        using var rsa = RSA.Create(new RSAParameters
-        {
-            Modulus = Base64Url.Decode(jwk.GetProperty("n").GetString()!),
-            Exponent = Base64Url.Decode(jwk.GetProperty("e").GetString()!),
-            D = Base64Url.Decode(jwk.GetProperty("d").GetString()!),
-            P = Base64Url.Decode(jwk.GetProperty("p").GetString()!),
-            Q = Base64Url.Decode(jwk.GetProperty("q").GetString()!),
-            DP = Base64Url.Decode(jwk.GetProperty("dp").GetString()!),
-            DQ = Base64Url.Decode(jwk.GetProperty("dq").GetString()!),
-            InverseQ = Base64Url.Decode(jwk.GetProperty("qi").GetString()!),
-        });
-
-        return rsa.ExportRSAPrivateKeyPem();
     }
 }
 

--- a/src/Granit.Oidc/Discovery/Internal/DiscoveryDocumentService.cs
+++ b/src/Granit.Oidc/Discovery/Internal/DiscoveryDocumentService.cs
@@ -16,6 +16,12 @@ internal sealed partial class DiscoveryDocumentService(
 {
     private static readonly TimeSpan DefaultCacheDuration = TimeSpan.FromHours(24);
 
+    // Base Granit.Oidc cannot reference Granit.Http.Resilience (layering), so the
+    // discovery client has no resilience pipeline. Cap its timeout well below the
+    // 100s HttpClient default so a slow or unreachable authority fails fast instead
+    // of stalling every token acquisition queued behind it.
+    private static readonly TimeSpan DiscoveryTimeout = TimeSpan.FromSeconds(15);
+
     /// <inheritdoc/>
     public async Task<OidcDiscoveryDocument> GetAsync(string authority, CancellationToken cancellationToken = default)
     {
@@ -31,6 +37,7 @@ internal sealed partial class DiscoveryDocumentService(
                 LogFetchingDiscoveryDocument(discoveryUrl);
 
                 using HttpClient httpClient = httpClientFactory.CreateClient(nameof(DiscoveryDocumentService));
+                httpClient.Timeout = DiscoveryTimeout;
                 using HttpResponseMessage response = await httpClient.GetAsync(discoveryUrl, ct).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
 
@@ -64,13 +71,31 @@ internal sealed partial class DiscoveryDocumentService(
         string normalizedAuthority = authority.TrimEnd('/');
         string normalizedIssuer = issuer.TrimEnd('/');
 
-        if (!string.Equals(normalizedAuthority, normalizedIssuer, StringComparison.OrdinalIgnoreCase))
+        if (!IssuerMatches(normalizedAuthority, normalizedIssuer))
         {
             throw new OidcDiscoveryException(
                 authority,
                 $"Issuer mismatch: expected '{normalizedAuthority}' but discovery document contains '{normalizedIssuer}'. " +
                 "This may indicate a misconfigured authority URL or a security issue.");
         }
+    }
+
+    // OIDC Discovery §4.3 requires the issuer to be identical to the authority used.
+    // Comparison is case-sensitive on the path (per URI semantics) but tolerates
+    // case differences in scheme and host, which are case-insensitive by RFC 3986.
+    private static bool IssuerMatches(string authority, string issuer)
+    {
+        if (string.Equals(authority, issuer, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return Uri.TryCreate(authority, UriKind.Absolute, out Uri? a)
+            && Uri.TryCreate(issuer, UriKind.Absolute, out Uri? i)
+            && string.Equals(a.Scheme, i.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(a.Host, i.Host, StringComparison.OrdinalIgnoreCase)
+            && a.Port == i.Port
+            && string.Equals(a.AbsolutePath.TrimEnd('/'), i.AbsolutePath.TrimEnd('/'), StringComparison.Ordinal);
     }
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Fetching OIDC discovery document from {DiscoveryUrl}")]

--- a/src/Granit.Oidc/Exceptions/OidcDiscoveryException.cs
+++ b/src/Granit.Oidc/Exceptions/OidcDiscoveryException.cs
@@ -3,7 +3,20 @@ namespace Granit.Oidc.Exceptions;
 /// <summary>
 /// Thrown when the OIDC discovery document cannot be retrieved or parsed from the specified authority.
 /// </summary>
-public sealed class OidcDiscoveryException(string authority, string message, Exception? innerException = null)
-    : InvalidOperationException(
-        $"Failed to retrieve OIDC discovery document from '{authority}/.well-known/openid-configuration': {message}",
-        innerException);
+public sealed class OidcDiscoveryException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OidcDiscoveryException"/> class.
+    /// </summary>
+    /// <param name="authority">The authority whose discovery document could not be resolved.</param>
+    /// <param name="message">A description of the failure.</param>
+    /// <param name="innerException">The underlying exception, if any.</param>
+    public OidcDiscoveryException(string authority, string message, Exception? innerException = null)
+        : base(
+            $"Failed to retrieve OIDC discovery document from '{authority}/.well-known/openid-configuration': {message}",
+            innerException) =>
+        Authority = authority;
+
+    /// <summary>The authority whose discovery document could not be resolved.</summary>
+    public string Authority { get; }
+}

--- a/src/Granit.Oidc/Internal/Base64Url.cs
+++ b/src/Granit.Oidc/Internal/Base64Url.cs
@@ -1,7 +1,8 @@
 namespace Granit.Oidc.Internal;
 
 /// <summary>
-/// Base64url encoding and decoding utilities (RFC 4648 §5).
+/// Base64url encoding and decoding utilities (RFC 4648 §5), delegating to the
+/// allocation-free BCL <see cref="System.Buffers.Text.Base64Url"/> (.NET 9+).
 /// </summary>
 internal static class Base64Url
 {
@@ -9,28 +10,14 @@ internal static class Base64Url
     /// Encodes the specified byte array to a base64url string without padding.
     /// </summary>
     internal static string Encode(byte[] data) =>
-        Convert.ToBase64String(data)
-            .Replace('+', '-')
-            .Replace('/', '_')
-            .TrimEnd('=');
+        System.Buffers.Text.Base64Url.EncodeToString(data);
 
     /// <summary>
-    /// Decodes a base64url string to a byte array, adding padding as needed.
+    /// Decodes a base64url string (with or without padding) to a byte array.
     /// </summary>
     internal static byte[] Decode(string base64Url)
     {
         ArgumentException.ThrowIfNullOrEmpty(base64Url);
-
-        string padded = base64Url
-            .Replace('-', '+')
-            .Replace('_', '/');
-
-        switch (padded.Length % 4)
-        {
-            case 2: padded += "=="; break;
-            case 3: padded += "="; break;
-        }
-
-        return Convert.FromBase64String(padded);
+        return System.Buffers.Text.Base64Url.DecodeFromChars(base64Url);
     }
 }

--- a/tests/Granit.Oidc.TokenManagement.Tests/DPoP/DPoPKeyStoreTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/DPoP/DPoPKeyStoreTests.cs
@@ -1,0 +1,48 @@
+using Granit.Oidc.DPoP;
+using Granit.Oidc.TokenManagement.DPoP.Internal;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests.DPoP;
+
+public sealed class DPoPKeyStoreTests
+{
+    private readonly IDPoPProofService _proofService = Substitute.For<IDPoPProofService>();
+
+    [Fact]
+    public void GetOrCreateKey_SameClient_ReturnsStableKey()
+    {
+        _proofService.GenerateKeyPair().Returns("key-a-1", "key-a-2");
+        DPoPKeyStore store = new(_proofService);
+
+        string first = store.GetOrCreateKey("client-a");
+        string second = store.GetOrCreateKey("client-a");
+
+        // Stability across calls is what keeps DPoP-bound tokens valid past a
+        // handler rotation: the key must NOT change for a given client.
+        second.ShouldBe(first);
+        _proofService.Received(1).GenerateKeyPair();
+    }
+
+    [Fact]
+    public void GetOrCreateKey_DifferentClients_ReturnsDistinctKeys()
+    {
+        _proofService.GenerateKeyPair().Returns("key-a", "key-b");
+        DPoPKeyStore store = new(_proofService);
+
+        string a = store.GetOrCreateKey("client-a");
+        string b = store.GetOrCreateKey("client-b");
+
+        a.ShouldNotBe(b);
+        _proofService.Received(2).GenerateKeyPair();
+    }
+
+    [Fact]
+    public void GetOrCreateKey_NullClientName_Throws()
+    {
+        DPoPKeyStore store = new(_proofService);
+
+        Should.Throw<ArgumentNullException>(() => store.GetOrCreateKey(null!));
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/Handlers/ClientCredentialsTokenHandlerTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Handlers/ClientCredentialsTokenHandlerTests.cs
@@ -4,6 +4,7 @@ using Granit.Oidc.DPoP;
 using Granit.Oidc.Responses;
 using Granit.Oidc.TokenManagement.Cache;
 using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.DPoP;
 using Granit.Oidc.TokenManagement.Handlers;
 using Granit.Oidc.TokenManagement.Options;
 using Granit.Oidc.TokenManagement.Services;
@@ -23,6 +24,7 @@ public sealed class ClientCredentialsTokenHandlerTests : IDisposable
     private readonly ITokenEndpointService _tokenEndpointService = Substitute.For<ITokenEndpointService>();
     private readonly IClientCredentialsTokenCache _tokenCache = Substitute.For<IClientCredentialsTokenCache>();
     private readonly IDPoPProofService _dpopProofService = Substitute.For<IDPoPProofService>();
+    private readonly IDPoPKeyStore _dpopKeyStore = Substitute.For<IDPoPKeyStore>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly ServiceProvider _sp;
     private readonly TokenManagementMetrics _metrics;
@@ -62,6 +64,7 @@ public sealed class ClientCredentialsTokenHandlerTests : IDisposable
             _tokenEndpointService,
             _tokenCache,
             _dpopProofService,
+            _dpopKeyStore,
             _optionsMonitor,
             MsOptions.Options.Create(new TokenManagementOptions()),
             _clock,
@@ -111,6 +114,7 @@ public sealed class ClientCredentialsTokenHandlerTests : IDisposable
             _tokenEndpointService,
             _tokenCache,
             _dpopProofService,
+            _dpopKeyStore,
             _optionsMonitor,
             MsOptions.Options.Create(new TokenManagementOptions()),
             _clock,
@@ -159,6 +163,7 @@ public sealed class ClientCredentialsTokenHandlerTests : IDisposable
             _tokenEndpointService,
             _tokenCache,
             _dpopProofService,
+            _dpopKeyStore,
             _optionsMonitor,
             MsOptions.Options.Create(new TokenManagementOptions()),
             _clock,
@@ -195,6 +200,7 @@ public sealed class ClientCredentialsTokenHandlerTests : IDisposable
             _tokenEndpointService,
             _tokenCache,
             _dpopProofService,
+            _dpopKeyStore,
             _optionsMonitor,
             MsOptions.Options.Create(new TokenManagementOptions()),
             _clock,

--- a/tests/Granit.Oidc.TokenManagement.Tests/Handlers/OnBehalfOfTokenHandlerTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Handlers/OnBehalfOfTokenHandlerTests.cs
@@ -22,6 +22,7 @@ using Granit.MultiTenancy;
 using Granit.Oidc.DPoP;
 using Granit.Oidc.Responses;
 using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.DPoP;
 using Granit.Oidc.TokenManagement.Handlers;
 using Granit.Oidc.TokenManagement.Options;
 using Granit.Oidc.TokenManagement.Services;
@@ -47,6 +48,7 @@ public sealed class OnBehalfOfTokenHandlerTests : IDisposable
     private readonly ITokenEndpointService _tokenEndpoint = Substitute.For<ITokenEndpointService>();
     private readonly IConditionalCache _cache = Substitute.For<IConditionalCache>();
     private readonly IDPoPProofService _dpop = Substitute.For<IDPoPProofService>();
+    private readonly IDPoPKeyStore _dpopKeyStore = Substitute.For<IDPoPKeyStore>();
     private readonly IHttpContextAccessor _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
     private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
@@ -114,6 +116,7 @@ public sealed class OnBehalfOfTokenHandlerTests : IDisposable
             _tokenEndpoint,
             _cache,
             _dpop,
+            _dpopKeyStore,
             _httpContextAccessor,
             _currentTenant,
             _currentUser,

--- a/tests/Granit.Oidc.TokenManagement.Tests/Options/ClientCredentialsOptionsValidatorTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Options/ClientCredentialsOptionsValidatorTests.cs
@@ -1,0 +1,109 @@
+using Granit.Oidc.ClientAuthentication;
+using Granit.Oidc.TokenManagement.Options;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests.Options;
+
+public sealed class ClientCredentialsOptionsValidatorTests
+{
+    private static ClientCredentialsOptionsValidator CreateValidator(string environmentName)
+    {
+        IHostEnvironment env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns(environmentName);
+        return new ClientCredentialsOptionsValidator(env);
+    }
+
+    private static ClientCredentialsOptions ValidOptions() => new()
+    {
+        Authority = "https://idp.example.com",
+        ClientId = "svc-client",
+        ClientSecret = "s3cr3t",
+        ClientAuthenticationMethod = ClientAuthenticationMethod.ClientSecretPost,
+    };
+
+    [Fact]
+    public void Validate_ValidConfiguration_Succeeds()
+    {
+        ValidateOptionsResult result = CreateValidator(Environments.Production)
+            .Validate("api", ValidOptions());
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_MissingAuthority_Fails()
+    {
+        ClientCredentialsOptions options = ValidOptions();
+        options.Authority = "";
+
+        ValidateOptionsResult result = CreateValidator(Environments.Production).Validate("api", options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(options.Authority));
+    }
+
+    [Fact]
+    public void Validate_NonHttpsAuthorityInProduction_Fails()
+    {
+        ClientCredentialsOptions options = ValidOptions();
+        options.Authority = "http://idp.example.com";
+
+        ValidateOptionsResult result = CreateValidator(Environments.Production).Validate("api", options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("https");
+    }
+
+    [Fact]
+    public void Validate_NonHttpsAuthorityInDevelopment_Succeeds()
+    {
+        ClientCredentialsOptions options = ValidOptions();
+        options.Authority = "http://localhost:8080";
+
+        ValidateOptionsResult result = CreateValidator(Environments.Development).Validate("api", options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ClientSecretPostWithoutSecret_Fails()
+    {
+        ClientCredentialsOptions options = ValidOptions();
+        options.ClientSecret = null;
+
+        ValidateOptionsResult result = CreateValidator(Environments.Production).Validate("api", options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(options.ClientSecret));
+    }
+
+    [Fact]
+    public void Validate_PrivateKeyJwtWithoutSigningKey_Fails()
+    {
+        ClientCredentialsOptions options = ValidOptions();
+        options.ClientAuthenticationMethod = ClientAuthenticationMethod.PrivateKeyJwt;
+        options.ClientSecret = null;
+        options.ClientSigningKeyJwk = null;
+
+        ValidateOptionsResult result = CreateValidator(Environments.Production).Validate("api", options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(options.ClientSigningKeyJwk));
+    }
+
+    [Fact]
+    public void Validate_NegativeCacheMargin_Fails()
+    {
+        ClientCredentialsOptions options = ValidOptions();
+        options.CacheMargin = TimeSpan.FromSeconds(-1);
+
+        ValidateOptionsResult result = CreateValidator(Environments.Production).Validate("api", options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(options.CacheMargin));
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/TokenManagementServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/TokenManagementServiceCollectionExtensionsTests.cs
@@ -4,6 +4,7 @@ using Granit.Oidc.TokenManagement.Extensions;
 using Granit.Oidc.TokenManagement.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -94,6 +95,11 @@ public sealed class TokenManagementServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<Granit.Oidc.DPoP.IDPoPProofService>());
         services.AddSingleton(Substitute.For<Granit.Timing.IClock>());
         services.AddSingleton<IMeterFactory>(new TestMeterFactory());
+
+        // A real host always provides IHostEnvironment; the options validators depend on it.
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(Environments.Development);
+        services.AddSingleton(environment);
     }
 
     private sealed class TestMeterFactory : IMeterFactory


### PR DESCRIPTION
## Summary

Audit-driven fixes and improvements across `Granit.Oidc`, `Granit.Oidc.TokenManagement`, and `Granit.Authentication.DPoP`. The modules were already in good shape; this addresses one real correctness bug plus a cluster of convention/robustness/modernization items.

### Correctness (headline)
- **Stable DPoP proof key** (`IDPoPKeyStore` singleton, keyed by client name). The key previously lived on the `DelegatingHandler` instance and regenerated on every `HttpClientFactory` handler rotation (~2 min), while DPoP-bound tokens are cached for their full lifetime. After a rotation the cached token's `cnf.jkt` no longer matched the new proof key:
  - **On-behalf-of** calls failed (401) until cache expiry — the 401 path only handled nonce challenges, never a `jkt` mismatch.
  - **Client credentials** self-healed only via a spurious 401 + token request on every rotation.

### Conventions / robustness
- Add the missing `[DependsOn(GranitHttpResilienceModule)]` (every other consumer of `Granit.Http.Resilience` declares it).
- New `ClientCredentialsOptionsValidator`, symmetric with the OBO validator (https-in-prod, required authority/client-id, auth-method ↔ credential consistency).
- `ClientCredentialsTokenCache` is now fail-open on a cache outage (matches the OBO posture).
- `DiscoveryDocumentService`: 15s HTTP timeout (was the 100s default, no resilience pipeline at this layer) + spec-correct issuer match (OIDC Discovery §4.3 — exact, tolerating only scheme/host case).
- `OidcDiscoveryException` exposes `Authority`.
- Corrected the OBO validator doc (validation is lazy, not at startup — deliberately no `ValidateOnStart` to keep config-free OpenAPI generation working).

### Modernization / dedup
- Replaced **4** hand-rolled base64url implementations with the BCL `System.Buffers.Text.Base64Url` (.NET 9+): `Granit.Oidc.Internal.Base64Url`, `JwkThumbprintCalculator`, and `DPoPProofValidator` (decode + nonce).
- `PrivateKeyJwtStrategy` builds RSA directly from `RSAParameters`, dropping the JWK → PEM → RSA round-trip.

### Deliberately *not* done (with reasons)
- **Explicit `FrameworkReference Microsoft.AspNetCore.App`** on the token-management csproj — reverted: it triggers NU1510, and removing the "redundant" `Microsoft.Extensions.Http` package drops `Microsoft.Extensions.Telemetry.Abstractions`, which the `[LoggerMessage]` generator output needs at runtime. The module-level `[DependsOn]` already makes the dependency explicit.
- **Tenant-scoping the client-credentials cache/metrics** — client-credentials tokens are app identity, not tenant-scoped; `tenant_id="global"` is the correct tag and partitioning would cause redundant per-tenant token requests.

## Testing
- `Granit.Oidc.Tests` 54 ✅ · `Granit.Authentication.DPoP.Tests` 72 ✅ · `Granit.Oidc.TokenManagement.Tests` 66 ✅ (+10 new: DPoP key-store stability, CC options validator)
- Architecture shard 216 + 5 ✅
- `dotnet format --verify-no-changes` clean on all touched projects
- No new third-party dependencies (BCL-only) → no `THIRD-PARTY-NOTICES.md` change