### PR TITLE
fix(notifications): restore tenant context in in-process dispatch worker

### DIFF
--- a/src/Granit.Notifications/Internal/NotificationDispatchWorker.cs
+++ b/src/Granit.Notifications/Internal/NotificationDispatchWorker.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using Granit.MultiTenancy;
 using Granit.Notifications.Exceptions;
 using Granit.Notifications.Handlers;
 using Granit.Notifications.Messages;
@@ -65,6 +66,17 @@ internal sealed partial class NotificationDispatchWorker(
         try
         {
             await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+
+            // The worker runs in a BackgroundService thread with no ambient tenant, so a fresh
+            // scope defaults to Host context. Restore the tenant captured at publish time
+            // (NotificationTrigger.TenantId) so fan-out recipient resolution, channel delivery,
+            // and per-tenant DB routing all execute in the originating tenant's context — otherwise
+            // tenant-scoped lookups (recipient contact, preferences, tenant schema) resolve nothing
+            // and no notification is delivered. A null TenantId (Host-scoped notification) keeps the
+            // default Host context, so Host mode is unaffected.
+            ICurrentTenant currentTenant = scope.ServiceProvider.GetRequiredService<ICurrentTenant>();
+            using IDisposable tenantScope = currentTenant.Change(trigger.TenantId);
+
             NotificationFanoutHandler fanout =
                 scope.ServiceProvider.GetRequiredService<NotificationFanoutHandler>();
 

--- a/tests/Granit.Notifications.Tests/NotificationDispatchWorkerTests.cs
+++ b/tests/Granit.Notifications.Tests/NotificationDispatchWorkerTests.cs
@@ -1,0 +1,198 @@
+// =============================================================================
+// Tests - NotificationDispatchWorker
+// =============================================================================
+// Verifies the in-process dispatch worker restores the tenant captured on the
+// NotificationTrigger before running fan-out and delivery. Without this, the
+// BackgroundService scope defaults to Host context and tenant-scoped delivery
+// (recipient contact resolution, per-tenant DB routing) silently resolves
+// nothing for tenant users — no email, no delivery attempt.
+// =============================================================================
+
+using System.Text.Json;
+using System.Threading.Channels;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Notifications.Abstractions;
+using Granit.Notifications.Diagnostics;
+using Granit.Notifications.Domain;
+using Granit.Notifications.Handlers;
+using Granit.Notifications.Internal;
+using Granit.Notifications.Messages;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.Tests;
+
+public sealed class NotificationDispatchWorkerTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Dispatch_TenantScopedTrigger_RestoresTenantForDelivery()
+    {
+        var tenantId = Guid.NewGuid();
+        var harness = Harness.Build();
+        using ServiceProvider sp = harness.ServiceProvider;
+
+        await harness.Worker.StartAsync(Ct);
+        await harness.Channel.Writer.WriteAsync(
+            BuildTrigger(tenantId: tenantId, recipientUserIds: ["user-1"]), Ct);
+        await harness.Channel.Sent.WaitAsync(TimeSpan.FromSeconds(5), Ct);
+        await harness.Worker.StopAsync(Ct);
+
+        // The Email channel ran (a delivery attempt was produced)...
+        harness.Channel.SendCount.ShouldBe(1);
+        // ...and it ran inside the originating tenant's ambient context, not Host.
+        harness.Channel.CapturedTenantId.ShouldBe(tenantId);
+
+        // The persisted delivery attempt is tagged with the tenant as well.
+        await harness.DeliveryWriter.Received(1).TryAcquireDeliveryAttemptAsync(
+            Arg.Is<NotificationDeliveryAttempt>(a => a.TenantId == tenantId), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Dispatch_HostScopedTrigger_RunsInHostContext()
+    {
+        var harness = Harness.Build();
+        using ServiceProvider sp = harness.ServiceProvider;
+
+        await harness.Worker.StartAsync(Ct);
+        await harness.Channel.Writer.WriteAsync(
+            BuildTrigger(tenantId: null, recipientUserIds: ["user-1"]), Ct);
+        await harness.Channel.Sent.WaitAsync(TimeSpan.FromSeconds(5), Ct);
+        await harness.Worker.StopAsync(Ct);
+
+        harness.Channel.SendCount.ShouldBe(1);
+        // A Host-scoped notification keeps the default (null) tenant — no regression.
+        harness.Channel.CapturedTenantId.ShouldBeNull();
+    }
+
+    private static NotificationTrigger BuildTrigger(Guid? tenantId, IReadOnlyList<string> recipientUserIds) => new()
+    {
+        NotificationTypeName = "test.notification",
+        Severity = NotificationSeverity.Warning,
+        Data = JsonSerializer.SerializeToElement(new { key = "value" }),
+        RecipientUserIds = recipientUserIds,
+        TenantId = tenantId,
+        OccurredAt = DateTimeOffset.UnixEpoch,
+    };
+
+    /// <summary>Wires a real fan-out + delivery pipeline around the worker with substituted leaf services.</summary>
+    private sealed record Harness(
+        NotificationDispatchWorker Worker,
+        ChannelWithSpy Channel,
+        INotificationDeliveryWriter DeliveryWriter,
+        ServiceProvider ServiceProvider)
+    {
+        public static Harness Build()
+        {
+            ChannelWithSpy channel = new();
+            AsyncLocalCurrentTenant currentTenant = new();
+            CapturingEmailChannel emailChannel = new(currentTenant, channel);
+
+            INotificationSubscriptionReader subscriptionReader = Substitute.For<INotificationSubscriptionReader>();
+            INotificationPreferenceReader preferenceReader = Substitute.For<INotificationPreferenceReader>();
+            preferenceReader.IsChannelEnabledAsync(
+                    Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                .Returns(true);
+
+            INotificationDefinitionStore definitionStore = Substitute.For<INotificationDefinitionStore>();
+            definitionStore.Get("test.notification").Returns(
+                new NotificationDefinition("test.notification")
+                {
+                    DefaultChannels = [NotificationChannels.Email],
+                    AllowUserOptOut = false,
+                });
+
+            INotificationDeliveryWriter deliveryWriter = Substitute.For<INotificationDeliveryWriter>();
+            deliveryWriter.HasBeenDeliveredAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(false);
+            deliveryWriter.TryAcquireDeliveryAttemptAsync(
+                Arg.Any<NotificationDeliveryAttempt>(), Arg.Any<CancellationToken>()).Returns(true);
+
+            IClock clock = Substitute.For<IClock>();
+            clock.Now.Returns(DateTimeOffset.UnixEpoch);
+
+            ServiceCollection services = new();
+            services.AddLogging();
+            services.AddMetrics();
+            services.AddSingleton<NotificationsMetrics>();
+            services.AddSingleton(channel.Channel);
+            services.AddSingleton<ICurrentTenant>(currentTenant);
+            services.AddSingleton<IGuidGenerator, SimpleGuidGenerator>();
+            services.AddSingleton(subscriptionReader);
+            services.AddSingleton(preferenceReader);
+            services.AddSingleton(definitionStore);
+            services.AddSingleton(deliveryWriter);
+            services.AddSingleton(clock);
+            services.AddSingleton<INotificationChannel>(emailChannel);
+            services.AddScoped<NotificationFanoutHandler>();
+            services.AddScoped<NotificationDeliveryHandler>();
+
+            ServiceProvider sp = services.BuildServiceProvider();
+
+            NotificationDispatchWorker worker = new(
+                channel.Channel,
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<ILogger<NotificationDispatchWorker>>());
+
+            return new Harness(worker, channel, deliveryWriter, sp);
+        }
+    }
+
+    /// <summary>Owns the trigger channel and forwards the Email channel's send signal/capture.</summary>
+    private sealed class ChannelWithSpy
+    {
+        public Channel<NotificationTrigger> Channel { get; } = System.Threading.Channels.Channel.CreateUnbounded<NotificationTrigger>();
+        public ChannelWriter<NotificationTrigger> Writer => Channel.Writer;
+        private readonly TaskCompletionSource _sent = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task Sent => _sent.Task;
+        public int SendCount { get; private set; }
+        public Guid? CapturedTenantId { get; private set; }
+
+        public void Record(Guid? tenantId)
+        {
+            CapturedTenantId = tenantId;
+            SendCount++;
+            _sent.TrySetResult();
+        }
+    }
+
+    /// <summary>Email channel that captures the ambient tenant at send time (where recipient resolution runs in prod).</summary>
+    private sealed class CapturingEmailChannel(ICurrentTenant currentTenant, ChannelWithSpy spy) : INotificationChannel
+    {
+        public string Name => NotificationChannels.Email;
+
+        public Task SendAsync(NotificationDeliveryContext context, CancellationToken cancellationToken = default)
+        {
+            spy.Record(currentTenant.Id);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>Minimal <see cref="ICurrentTenant"/> whose <c>Change</c> flows through <see cref="AsyncLocal{T}"/> like production.</summary>
+    private sealed class AsyncLocalCurrentTenant : ICurrentTenant
+    {
+        private readonly AsyncLocal<Guid?> _id = new();
+
+        public bool IsAvailable => _id.Value.HasValue;
+        public Guid? Id => _id.Value;
+        public string? Name => null;
+        public string? Jurisdiction => null;
+
+        public IDisposable Change(Guid? id, string? name = null, string? jurisdiction = null)
+        {
+            Guid? previous = _id.Value;
+            _id.Value = id;
+            return new Scope(this, previous);
+        }
+
+        private sealed class Scope(AsyncLocalCurrentTenant owner, Guid? previous) : IDisposable
+        {
+            public void Dispose() => owner._id.Value = previous;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

As a tenant user, disabling/enabling 2FA produced **no email** and **no row** in `notifications_delivery_attempts`; Host mode worked. Investigated via the `granit-showcase-dotnet` repro (multi-tenant, in-process notification dispatch — `GranitNotificationsWolverineModule` not loaded).

## Root cause

The Wolverine ETO path is fine: `OutgoingContextMiddleware` stamps `X-Tenant-Id` and `TenantContextBehavior` restores `ICurrentTenant`, so `TwoFactorChangedHandler` publishes with the right tenant.

The gap is the **in-process dispatch path**. `NotificationDispatchWorker.DispatchTriggerAsync` opens a fresh DI scope (it runs in a `BackgroundService` thread with no ambient tenant) but never restores the tenant captured on `NotificationTrigger.TenantId`. Fan-out tolerates this for reads (it threads `trigger.TenantId` explicitly), but **delivery** runs in Host context:

- `IdentityRecipientResolver.ResolveAsync` → tenant-scoped `GetUserAsync` returns `null` for a tenant user →
- `EmailNotificationChannel.SendAsync` returns early → no email.

Host worked only because Host is the default context.

## Fix

Resolve `ICurrentTenant` from the per-trigger scope and wrap fan-out + delivery in `using currentTenant.Change(trigger.TenantId)`. A `null` `TenantId` (Host-scoped notification) keeps the default context, so **Host mode is unaffected**.

## Tests

`NotificationDispatchWorkerTests`:
- tenant-scoped trigger → the Email channel runs inside the originating tenant's ambient context, and the persisted delivery attempt is tagged with the tenant;
- Host-scoped trigger → null context, no regression.

Full `Granit.Notifications.Tests` 256/256 green; `dotnet format --verify-no-changes` clean.

## Not in scope

A separate, unrelated symptom seen in the same repro (email body rendered as `<p>Security.TwoFactorChanged</p>`) is **not** a live bug — the showcase was running a stale floating package (`0.1.0-dev.3479`) that predates #2592, which already renamed identity notification types/templates to snake_case on `develop`. Remediation is a showcase package bump, no framework change.