### PR TITLE
test(authentication): cover External provider modules through their real module + dedupe scope/callback

### DIFF
--- a/src/Granit.Authentication.External.Apple/GranitAuthenticationExternalAppleModule.cs
+++ b/src/Granit.Authentication.External.Apple/GranitAuthenticationExternalAppleModule.cs
@@ -37,19 +37,7 @@ public sealed class GranitAuthenticationExternalAppleModule : GranitModule
                     options.KeyId = keyId;
                 }
 
-                if (!string.IsNullOrWhiteSpace(provider.CallbackPath))
-                {
-                    options.CallbackPath = provider.CallbackPath;
-                }
-
-                if (provider.Scopes.Length > 0)
-                {
-                    options.Scope.Clear();
-                    foreach (string scope in provider.Scopes)
-                    {
-                        options.Scope.Add(scope);
-                    }
-                }
+                provider.ApplyCallbackAndScopes(path => options.CallbackPath = path, options.Scope);
 
                 // Apple's client secret is a JWT signed with the P8 private key (PEM in config).
                 options.GenerateClientSecret = true;

--- a/src/Granit.Authentication.External.Oidc/GranitAuthenticationExternalOidcModule.cs
+++ b/src/Granit.Authentication.External.Oidc/GranitAuthenticationExternalOidcModule.cs
@@ -28,18 +28,6 @@ public sealed class GranitAuthenticationExternalOidcModule : GranitModule
                 options.UsePkce = true;
                 options.SaveTokens = true;
 
-                if (!string.IsNullOrWhiteSpace(provider.CallbackPath))
-                {
-                    options.CallbackPath = provider.CallbackPath;
-                }
-
-                if (provider.Scopes.Length > 0)
-                {
-                    options.Scope.Clear();
-                    foreach (string scope in provider.Scopes)
-                    {
-                        options.Scope.Add(scope);
-                    }
-                }
+                provider.ApplyCallbackAndScopes(path => options.CallbackPath = path, options.Scope);
             }));
 }

--- a/src/Granit.Authentication.External/Extensions/OAuthProviderOptionsExtensions.cs
+++ b/src/Granit.Authentication.External/Extensions/OAuthProviderOptionsExtensions.cs
@@ -26,17 +26,36 @@ public static class OAuthProviderOptionsExtensions
         // endpoint reads the resulting ticket from IdentityConstants.ExternalScheme.
         options.SignInScheme = IdentityConstants.ExternalScheme;
 
+        provider.ApplyCallbackAndScopes(path => options.CallbackPath = path, options.Scope);
+    }
+
+    /// <summary>
+    /// Applies the provider's optional callback-path override and scope overrides to a handler.
+    /// Shared by the OAuth handlers and the generic OpenID Connect handler, whose option types
+    /// (<see cref="OAuthOptions"/> and <c>OpenIdConnectOptions</c>) do not share a base exposing
+    /// <c>CallbackPath</c>/<c>Scope</c> — hence the callback-path setter and scope collection are
+    /// passed in rather than the options object.
+    /// </summary>
+    public static void ApplyCallbackAndScopes(
+        this ExternalAuthProvider provider,
+        Action<string> setCallbackPath,
+        ICollection<string> scope)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(setCallbackPath);
+        ArgumentNullException.ThrowIfNull(scope);
+
         if (!string.IsNullOrWhiteSpace(provider.CallbackPath))
         {
-            options.CallbackPath = provider.CallbackPath;
+            setCallbackPath(provider.CallbackPath);
         }
 
         if (provider.Scopes.Length > 0)
         {
-            options.Scope.Clear();
-            foreach (string scope in provider.Scopes)
+            scope.Clear();
+            foreach (string s in provider.Scopes)
             {
-                options.Scope.Add(scope);
+                scope.Add(s);
             }
         }
     }

--- a/tests/Granit.Authentication.External.Apple.Tests/AppleProviderTests.cs
+++ b/tests/Granit.Authentication.External.Apple.Tests/AppleProviderTests.cs
@@ -1,8 +1,10 @@
-using Granit.Authentication.External.Extensions;
+using AspNet.Security.OAuth.Apple;
+using Granit.Modularity;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -10,30 +12,56 @@ namespace Granit.Authentication.External.Apple.Tests;
 
 public sealed class AppleProviderTests
 {
-    [Fact]
-    public async Task RegistersScheme_WhenProviderConfigured()
+    private static ServiceProvider BuildProvider()
     {
-        var services = new ServiceCollection();
-        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Authentication:External:Providers:0:Type"] = "Apple",
             ["Authentication:External:Providers:0:ClientId"] = "com.example.service",
+            ["Authentication:External:Providers:0:Scopes:0"] = "name",
+            ["Authentication:External:Providers:0:Scopes:1"] = "email",
             ["Authentication:External:Providers:0:Properties:TeamId"] = "TEAMID",
             ["Authentication:External:Providers:0:Properties:KeyId"] = "KEYID",
-        }).Build();
+            ["Authentication:External:Providers:0:Properties:PrivateKey"] =
+                "-----BEGIN PRIVATE KEY-----\nDUMMY\n-----END PRIVATE KEY-----",
+        });
+        builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
-        services.AddExternalProviderSchemes(
-            config, "Apple",
-            (builder, provider) => builder.AddApple(provider.SchemeName, options =>
-            {
-                options.ClientId = provider.ClientId;
-                options.SignInScheme = IdentityConstants.ExternalScheme;
-            }));
+        GranitAuthenticationExternalAppleModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        module.ConfigureServices(context);
 
-        await using ServiceProvider sp = services.BuildServiceProvider();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Module_InheritsFromGranitModule() =>
+        typeof(GranitAuthenticationExternalAppleModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public async Task ConfigureServices_RegistersAppleScheme()
+    {
+        await using ServiceProvider sp = BuildProvider();
+
         AuthenticationScheme? scheme = await sp
             .GetRequiredService<IAuthenticationSchemeProvider>().GetSchemeAsync("Apple");
 
         scheme.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureServices_MapsServicesIdTeamKeyAndScopes()
+    {
+        using ServiceProvider sp = BuildProvider();
+
+        AppleAuthenticationOptions options = sp
+            .GetRequiredService<IOptionsMonitor<AppleAuthenticationOptions>>().Get("Apple");
+
+        options.ClientId.ShouldBe("com.example.service");
+        options.TeamId.ShouldBe("TEAMID");
+        options.KeyId.ShouldBe("KEYID");
+        options.GenerateClientSecret.ShouldBeTrue();
+        options.Scope.ShouldBe(["name", "email"]);
     }
 }

--- a/tests/Granit.Authentication.External.Facebook.Tests/FacebookProviderTests.cs
+++ b/tests/Granit.Authentication.External.Facebook.Tests/FacebookProviderTests.cs
@@ -1,7 +1,11 @@
-using Granit.Authentication.External.Extensions;
+using Granit.Modularity;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Facebook;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -9,26 +13,52 @@ namespace Granit.Authentication.External.Facebook.Tests;
 
 public sealed class FacebookProviderTests
 {
-    [Fact]
-    public async Task RegistersScheme_WhenProviderConfigured()
+    private static ServiceProvider BuildProvider()
     {
-        var services = new ServiceCollection();
-        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Authentication:External:Providers:0:Type"] = "Facebook",
             ["Authentication:External:Providers:0:ClientId"] = "cid",
             ["Authentication:External:Providers:0:ClientSecret"] = "sec",
-        }).Build();
+            ["Authentication:External:Providers:0:Scopes:0"] = "public_profile",
+            ["Authentication:External:Providers:0:Scopes:1"] = "email",
+        });
+        builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
-        services.AddExternalProviderSchemes(
-            config, "Facebook",
-            (builder, provider) => builder.AddFacebook(
-                provider.SchemeName, options => options.ApplyExternalProvider(provider)));
+        GranitAuthenticationExternalFacebookModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        module.ConfigureServices(context);
 
-        await using ServiceProvider sp = services.BuildServiceProvider();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Module_InheritsFromGranitModule() =>
+        typeof(GranitAuthenticationExternalFacebookModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public async Task ConfigureServices_RegistersFacebookScheme()
+    {
+        await using ServiceProvider sp = BuildProvider();
+
         AuthenticationScheme? scheme = await sp
             .GetRequiredService<IAuthenticationSchemeProvider>().GetSchemeAsync("Facebook");
 
         scheme.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureServices_MapsCredentialsScopesAndSignInScheme()
+    {
+        using ServiceProvider sp = BuildProvider();
+
+        FacebookOptions options = sp
+            .GetRequiredService<IOptionsMonitor<FacebookOptions>>().Get("Facebook");
+
+        options.ClientId.ShouldBe("cid");
+        options.ClientSecret.ShouldBe("sec");
+        options.SignInScheme.ShouldBe(IdentityConstants.ExternalScheme);
+        options.Scope.ShouldBe(["public_profile", "email"]);
     }
 }

--- a/tests/Granit.Authentication.External.GitHub.Tests/GitHubProviderTests.cs
+++ b/tests/Granit.Authentication.External.GitHub.Tests/GitHubProviderTests.cs
@@ -1,7 +1,11 @@
-using Granit.Authentication.External.Extensions;
+using AspNet.Security.OAuth.GitHub;
+using Granit.Modularity;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -9,26 +13,52 @@ namespace Granit.Authentication.External.GitHub.Tests;
 
 public sealed class GitHubProviderTests
 {
-    [Fact]
-    public async Task RegistersScheme_WhenProviderConfigured()
+    private static ServiceProvider BuildProvider()
     {
-        var services = new ServiceCollection();
-        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Authentication:External:Providers:0:Type"] = "GitHub",
             ["Authentication:External:Providers:0:ClientId"] = "cid",
             ["Authentication:External:Providers:0:ClientSecret"] = "sec",
-        }).Build();
+            ["Authentication:External:Providers:0:Scopes:0"] = "read:user",
+            ["Authentication:External:Providers:0:Scopes:1"] = "user:email",
+        });
+        builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
-        services.AddExternalProviderSchemes(
-            config, "GitHub",
-            (builder, provider) => builder.AddGitHub(
-                provider.SchemeName, options => options.ApplyExternalProvider(provider)));
+        GranitAuthenticationExternalGitHubModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        module.ConfigureServices(context);
 
-        await using ServiceProvider sp = services.BuildServiceProvider();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Module_InheritsFromGranitModule() =>
+        typeof(GranitAuthenticationExternalGitHubModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public async Task ConfigureServices_RegistersGitHubScheme()
+    {
+        await using ServiceProvider sp = BuildProvider();
+
         AuthenticationScheme? scheme = await sp
             .GetRequiredService<IAuthenticationSchemeProvider>().GetSchemeAsync("GitHub");
 
         scheme.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureServices_MapsCredentialsScopesAndSignInScheme()
+    {
+        using ServiceProvider sp = BuildProvider();
+
+        GitHubAuthenticationOptions options = sp
+            .GetRequiredService<IOptionsMonitor<GitHubAuthenticationOptions>>().Get("GitHub");
+
+        options.ClientId.ShouldBe("cid");
+        options.ClientSecret.ShouldBe("sec");
+        options.SignInScheme.ShouldBe(IdentityConstants.ExternalScheme);
+        options.Scope.ShouldBe(["read:user", "user:email"]);
     }
 }

--- a/tests/Granit.Authentication.External.Google.Tests/GoogleProviderTests.cs
+++ b/tests/Granit.Authentication.External.Google.Tests/GoogleProviderTests.cs
@@ -1,7 +1,11 @@
-using Granit.Authentication.External.Extensions;
+using Granit.Modularity;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -9,26 +13,52 @@ namespace Granit.Authentication.External.Google.Tests;
 
 public sealed class GoogleProviderTests
 {
-    [Fact]
-    public async Task RegistersScheme_WhenProviderConfigured()
+    private static ServiceProvider BuildProvider()
     {
-        var services = new ServiceCollection();
-        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Authentication:External:Providers:0:Type"] = "Google",
             ["Authentication:External:Providers:0:ClientId"] = "cid",
             ["Authentication:External:Providers:0:ClientSecret"] = "sec",
-        }).Build();
+            ["Authentication:External:Providers:0:Scopes:0"] = "openid",
+            ["Authentication:External:Providers:0:Scopes:1"] = "email",
+        });
+        builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
-        services.AddExternalProviderSchemes(
-            config, "Google",
-            (builder, provider) => builder.AddGoogle(
-                provider.SchemeName, options => options.ApplyExternalProvider(provider)));
+        GranitAuthenticationExternalGoogleModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        module.ConfigureServices(context);
 
-        await using ServiceProvider sp = services.BuildServiceProvider();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Module_InheritsFromGranitModule() =>
+        typeof(GranitAuthenticationExternalGoogleModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public async Task ConfigureServices_RegistersGoogleScheme()
+    {
+        await using ServiceProvider sp = BuildProvider();
+
         AuthenticationScheme? scheme = await sp
             .GetRequiredService<IAuthenticationSchemeProvider>().GetSchemeAsync("Google");
 
         scheme.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureServices_MapsCredentialsScopesAndSignInScheme()
+    {
+        using ServiceProvider sp = BuildProvider();
+
+        GoogleOptions options = sp
+            .GetRequiredService<IOptionsMonitor<GoogleOptions>>().Get("Google");
+
+        options.ClientId.ShouldBe("cid");
+        options.ClientSecret.ShouldBe("sec");
+        options.SignInScheme.ShouldBe(IdentityConstants.ExternalScheme);
+        options.Scope.ShouldBe(["openid", "email"]);
     }
 }

--- a/tests/Granit.Authentication.External.Microsoft.Tests/MicrosoftProviderTests.cs
+++ b/tests/Granit.Authentication.External.Microsoft.Tests/MicrosoftProviderTests.cs
@@ -1,7 +1,11 @@
-using Granit.Authentication.External.Extensions;
+using Granit.Modularity;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -9,26 +13,52 @@ namespace Granit.Authentication.External.Microsoft.Tests;
 
 public sealed class MicrosoftProviderTests
 {
-    [Fact]
-    public async Task RegistersScheme_WhenProviderConfigured()
+    private static ServiceProvider BuildProvider()
     {
-        var services = new ServiceCollection();
-        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Authentication:External:Providers:0:Type"] = "Microsoft",
             ["Authentication:External:Providers:0:ClientId"] = "cid",
             ["Authentication:External:Providers:0:ClientSecret"] = "sec",
-        }).Build();
+            ["Authentication:External:Providers:0:Scopes:0"] = "openid",
+            ["Authentication:External:Providers:0:Scopes:1"] = "email",
+        });
+        builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
-        services.AddExternalProviderSchemes(
-            config, "Microsoft",
-            (builder, provider) => builder.AddMicrosoftAccount(
-                provider.SchemeName, options => options.ApplyExternalProvider(provider)));
+        GranitAuthenticationExternalMicrosoftModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        module.ConfigureServices(context);
 
-        await using ServiceProvider sp = services.BuildServiceProvider();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Module_InheritsFromGranitModule() =>
+        typeof(GranitAuthenticationExternalMicrosoftModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public async Task ConfigureServices_RegistersMicrosoftScheme()
+    {
+        await using ServiceProvider sp = BuildProvider();
+
         AuthenticationScheme? scheme = await sp
             .GetRequiredService<IAuthenticationSchemeProvider>().GetSchemeAsync("Microsoft");
 
         scheme.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureServices_MapsCredentialsScopesAndSignInScheme()
+    {
+        using ServiceProvider sp = BuildProvider();
+
+        MicrosoftAccountOptions options = sp
+            .GetRequiredService<IOptionsMonitor<MicrosoftAccountOptions>>().Get("Microsoft");
+
+        options.ClientId.ShouldBe("cid");
+        options.ClientSecret.ShouldBe("sec");
+        options.SignInScheme.ShouldBe(IdentityConstants.ExternalScheme);
+        options.Scope.ShouldBe(["openid", "email"]);
     }
 }

--- a/tests/Granit.Authentication.External.Oidc.Tests/OidcProviderTests.cs
+++ b/tests/Granit.Authentication.External.Oidc.Tests/OidcProviderTests.cs
@@ -1,8 +1,11 @@
-using Granit.Authentication.External.Extensions;
+using Granit.Modularity;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -10,32 +13,57 @@ namespace Granit.Authentication.External.Oidc.Tests;
 
 public sealed class OidcProviderTests
 {
-    [Fact]
-    public async Task RegistersScheme_WhenProviderConfigured()
+    private static ServiceProvider BuildProvider()
     {
-        var services = new ServiceCollection();
-        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Authentication:External:Providers:0:Type"] = "Oidc",
             ["Authentication:External:Providers:0:Authority"] = "https://login.example.com/",
             ["Authentication:External:Providers:0:ClientId"] = "cid",
             ["Authentication:External:Providers:0:ClientSecret"] = "sec",
-        }).Build();
+            ["Authentication:External:Providers:0:Scopes:0"] = "openid",
+            ["Authentication:External:Providers:0:Scopes:1"] = "profile",
+        });
+        builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
-        services.AddExternalProviderSchemes(
-            config, "Oidc",
-            (builder, provider) => builder.AddOpenIdConnect(provider.SchemeName, options =>
-            {
-                options.Authority = provider.Authority;
-                options.ClientId = provider.ClientId;
-                options.ClientSecret = provider.ClientSecret;
-                options.SignInScheme = IdentityConstants.ExternalScheme;
-            }));
+        GranitAuthenticationExternalOidcModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+        module.ConfigureServices(context);
 
-        await using ServiceProvider sp = services.BuildServiceProvider();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Module_InheritsFromGranitModule() =>
+        typeof(GranitAuthenticationExternalOidcModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public async Task ConfigureServices_RegistersOidcScheme()
+    {
+        await using ServiceProvider sp = BuildProvider();
+
         AuthenticationScheme? scheme = await sp
             .GetRequiredService<IAuthenticationSchemeProvider>().GetSchemeAsync("Oidc");
 
         scheme.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureServices_EnablesAuthorizationCodeWithPkce()
+    {
+        using ServiceProvider sp = BuildProvider();
+
+        OpenIdConnectOptions options = sp
+            .GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>().Get("Oidc");
+
+        options.Authority.ShouldBe("https://login.example.com/");
+        options.ClientId.ShouldBe("cid");
+        options.ClientSecret.ShouldBe("sec");
+        options.SignInScheme.ShouldBe(IdentityConstants.ExternalScheme);
+        options.ResponseType.ShouldBe("code");
+        options.UsePkce.ShouldBeTrue();
+        options.SaveTokens.ShouldBeTrue();
+        options.Scope.ShouldBe(["openid", "profile"]);
     }
 }


### PR DESCRIPTION
Follow-up to #2601 — addresses the two non-blocking findings from the `Granit.Authentication.External.*` audit that were deferred to keep #2601 tight.

## #3 — Provider unit tests now drive the real module
The per-provider tests re-implemented `AddGoogle`/`AddApple`/… inline instead of invoking the module, so the provider-specific wiring had **zero coverage**:
- **Apple** — `TeamId` / `KeyId` / `GenerateClientSecret` from `Properties`
- **Oidc** — `ResponseType=code` / `UsePkce` / `SaveTokens`
- all providers — scope + callback-path overrides and `SignInScheme`

Each test now builds the module through `ServiceConfigurationContext` (canonical pattern, same as `GranitAuthenticationJwtBearerCognitoModuleTests`) and asserts the resolved handler options via `IOptionsMonitor<T>.Get(scheme)`.

## #4 — Dedupe the scope/callback block
`OAuthOptions` and `OpenIdConnectOptions` share no base exposing `CallbackPath`/`Scope`, so the callback-path + scope-override loop was copy-pasted in `ApplyExternalProvider`, the Apple module, and the Oidc module. Extracted into a shared `ExternalAuthProvider.ApplyCallbackAndScopes(setCallbackPath, scope)` helper.

## Verification
- 7 External test projects green (23 tests)
- `architecture` shard green (216 + 5) — the provider modules (covered since #2601) still pass every convention
- `dotnet format --verify-no-changes` clean on all touched projects