### PR TITLE
ci: retry the GitLab package push instead of relying on the push timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,13 +526,24 @@ jobs:
           dotnet nuget add source \
             "https://gitlab.digitaldynamics.be/api/v4/projects/11/packages/nuget/index.json" \
             --name gitlab_granit_business
-          # GitLab's NuGet endpoint is sometimes slow on large packages — bump from
-          # the 300s default to 900s so transient PUT stalls don't fail the publish.
-          dotnet nuget push "nupkgs/*.nupkg" \
+          # GitLab's NuGet endpoint is sometimes slow on large packages — bump the
+          # PUT timeout from the 300s default to 900s. The service-index GET, though,
+          # uses HttpClient's fixed 100s timeout (not governed by --timeout), so retry
+          # the whole push a few times before failing the publish on a transient stall.
+          n=0
+          until dotnet nuget push "nupkgs/*.nupkg" \
             --source gitlab_granit_business \
             --api-key "$GITLAB_NUGET_TOKEN" \
             --skip-duplicate \
-            --timeout 900
+            --timeout 900; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::GitLab push failed after $n attempts"
+              exit 1
+            fi
+            echo "::warning::GitLab push attempt $n failed (slow service index?); retrying in 30s…"
+            sleep 30
+          done
 
   # nuget.org — release packages on version tags
   publish-nuget:


### PR DESCRIPTION
## Problem
The `publish-gitlab` step intermittently fails with:
```
error: Unable to load the service index for source https://gitlab.digitaldynamics.be/api/v4/projects/11/packages/nuget/index.json.
error:   The HTTP request to 'GET …/index.json' has timed out after 100000ms.
```
That **100 s** ceiling is `HttpClient`'s default timeout for the **service-index discovery GET**. It is *not* governed by `dotnet nuget push --timeout` (already `900`), which only bounds the upload PUT — so raising the timeout cannot fix this failure (the failing run already ran with `--timeout 900`).

## Fix
Wrap the push in a 3-attempt retry loop (30 s apart). `--skip-duplicate` keeps retries idempotent; the job fails only if all attempts fail.

```bash
n=0
until dotnet nuget push … --skip-duplicate --timeout 900; do
  n=$((n + 1))
  [ "$n" -ge 3 ] && { echo "::error::GitLab push failed after $n attempts"; exit 1; }
  echo "::warning::GitLab push attempt $n failed (slow service index?); retrying in 30s…"
  sleep 30
done
```

No secret/permission changes. YAML validated.