### PR TITLE
refactor(config): SectionName homogenization for Granit.{X}.AI packages [WIP]

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -8129,7 +8129,7 @@
       "kind": "class",
       "project": "Granit.Authorization.AI",
       "file": "src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitAuthorizationAI",
@@ -10422,7 +10422,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.AI",
       "file": "src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitBlobStorageAI",
@@ -28192,7 +28192,7 @@
       "kind": "class",
       "project": "Granit.Imaging.AI",
       "file": "src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitImagingAI",
@@ -28574,7 +28574,7 @@
       "kind": "class",
       "project": "Granit.Indexing.AI",
       "file": "src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitIndexingAISummarizer",
@@ -29817,7 +29817,7 @@
       "kind": "class",
       "project": "Granit.LanguageDetection.AI",
       "file": "src/Granit.LanguageDetection.AI/Extensions/ServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitLanguageDetectionAI",
@@ -30066,7 +30066,7 @@
       "kind": "class",
       "project": "Granit.Localization.AI",
       "file": "src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitLocalizationAI",
@@ -32464,7 +32464,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AI",
       "file": "src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitNotificationsAI",
@@ -35439,7 +35439,7 @@
       "kind": "class",
       "project": "Granit.Observability",
       "file": "src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitObservability",
@@ -39528,7 +39528,7 @@
       "kind": "class",
       "project": "Granit.Privacy.AI",
       "file": "src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitPrivacyAI",
@@ -39544,7 +39544,7 @@
       "kind": "class",
       "project": "Granit.Privacy.AI",
       "file": "src/Granit.Privacy.AI/GranitPrivacyAIModule.cs",
-      "line": 20,
+      "line": 19,
       "members": []
     },
     {
@@ -47698,7 +47698,7 @@
       "kind": "class",
       "project": "Granit.Timeline.AI",
       "file": "src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs",
-      "line": 17,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitTimelineAI",
@@ -49196,6 +49196,15 @@
       "members": []
     },
     {
+      "name": "ValidationMetrics",
+      "fqn": "Granit.Validation.Endpoints.Diagnostics.ValidationMetrics",
+      "kind": "class",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Diagnostics/ValidationMetrics.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "ValidationFieldStatus",
       "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldStatus",
       "kind": "enum",
@@ -49262,8 +49271,15 @@
       "kind": "class",
       "project": "Granit.Validation.Endpoints",
       "file": "src/Granit.Validation.Endpoints/GranitValidationEndpointsModule.cs",
-      "line": 18,
-      "members": []
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "ValidationEndpointsOptions",
@@ -52466,7 +52482,7 @@
       "kind": "class",
       "project": "Granit.Workflow.AI",
       "file": "src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitWorkflowAI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,157 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Changed (framework — BREAKING: appsettings)
+
+- **`SectionName` homogenization across the framework.** Every `public const string SectionName` on a Granit options class now follows the same convention: a colon-separated, ASP.NET-style hierarchical path aligned on the project namespace after stripping the internal `Granit` prefix (`Granit.Foo.Bar.Baz` → `"Foo:Bar:Baz"`). Three classes of legacy values were eliminated: (1) the `Granit:` root prefix (which was leaking the code namespace into config — `"Granit:ApiKeys"`, `"Granit:IO:TempFiles"`, `"Granit:Templating:App"`, `"Granit:DataExchange:BlobStorage"`); (2) PascalCase-glued compound names that hid a real hierarchy (`"WolverinePostgresql"`, `"WolverineSqlServer"`, `"GranitMigrations"`, `"TenantSchema"`, every `"*Endpoints"` umbrella, every `Http.*` flat name); (3) vendor-rooted or wrong-segmented names under `Notifications.*` and `Identity.Federated.*` (`"AzureCommunicationServices:Email"`, `"Notifications:Smtp"`, `"KeycloakAdmin"`, `"EntraIdAdmin"`, `"CognitoAdmin"`, `"Identity:UserCacheHasher"`, …). One real binding collision was also fixed: `ImportOptions` and the root data-exchange config both bound to `"DataExchange"`, silently shadowing one another — `ImportOptions` now lives at `"DataExchange:Import"` and `ExportOptions` at `"DataExchange:Export"`. `TenantIsolationOptions` (which had no `SectionName` const and was bound to the literal `"TenantIsolation"`) now exposes the const and binds to `"MultiTenancy:TenantIsolation"`, aligned with `MultiTenancy:TenantSchema`. The convention is enforced going forward by `Granit.ArchitectureTests.SectionNameConventionTests` (forbids `Granit:` root, forbids flat compound names, requires SectionName uniqueness). Every renamed section also has its `*OptionsTests.SectionName.ShouldBe(...)` assertion updated, every test that builds an in-memory `IConfiguration` for a service-collection extension was migrated to the new prefix (otherwise the binder fails silently and tests assert default values), and the `templates/granit-api-full/appsettings.json` was repointed (`"Cors"` → `"Http:Cors"`). The Keycloak JwtBearer rename (`"Keycloak"` → `"Authentication:Keycloak"`) shipped earlier in this release is part of the same sweep. The 13 cross-module AI integration packages (`Granit.{X}.AI`) had their section direction inverted to match the namespace — `"AI:Authorization"` → `"Authorization:AI"`, `"AI:BlobStorage"` → `"BlobStorage:AI"`, … `"AI:Validation"` → `"Validation:AI"` — so they now align with the `Indexing:AI` / `LanguageDetection:AI` / `TextExtraction:Ocr:AI` packages that already followed the rule; the core `Granit.AI.*` provider family (`AI:OpenAI`, `AI:Anthropic`, `AI:Extraction`, …) is unchanged, since there `AI` is itself the owning module.
+
+  **Migration** — rewrite the host `appsettings.json` (only the sections you actually use):
+
+  ```diff
+  - "Keycloak":              { ... }      // JwtBearer
+  + "Authentication": { "Keycloak": { ... } }
+
+  - "Cognito":               { ... }
+  - "EntraId":               { ... }
+  - "GoogleCloudAuth":       { ... }
+  + "Authentication": { "Cognito": { ... }, "EntraId": { ... }, "GoogleCloud": { ... } }
+
+  - "Granit:ApiKeys":        { ... }
+  + "Authentication": { "ApiKeys": { ... } }
+
+  - "WolverinePostgresql":   { ... }
+  - "WolverineSqlServer":    { ... }
+  + "Wolverine": { "Postgresql": { ... }, "SqlServer": { ... } }
+
+  - "GranitMigrations":      { ... }
+  + "Persistence": { "Migrations": { ... } }
+
+  - "TenantSchema":          { ... }
+  + "MultiTenancy": { "TenantSchema": { ... } }
+
+  - "TokenManagement":       { ... }
+  + "Oidc": { "TokenManagement": { ... } }
+
+  - "ReEncryption":          { ... }
+  + "Vault": { "ReEncryption": { ... } }
+
+  - "Granit:IO:TempFiles":   { ... }
+  + "IO": { "TempFiles": { ... } }
+
+  - "Granit:Templating:App": { ... }
+  + "Templating": { "App": { ... } }
+
+  - "Granit:DataExchange:BlobStorage": { ... }
+  + "DataExchange": { "BlobStorage": { ... } }
+
+  - "TenantIsolation":      { ... }
+  + "MultiTenancy": { "TenantIsolation": { ... } }
+
+  # *.Endpoints umbrella sections (one example, applies to every Endpoints module):
+  - "BlobStorageEndpoints":  { ... }
+  + "BlobStorage": { "Endpoints": { ... } }
+  - "AIEndpoints":           { ... }
+  + "AI": { "Endpoints": { ... } }
+  - "ApiKeysEndpoints":      { ... }
+  + "Authentication": { "ApiKeys": { "Endpoints": { ... } } }
+  - "AuthorizationEndpoints":{ ... }
+  + "Authorization": { "Endpoints": { ... } }
+  - "BackgroundJobsEndpoints":{ ... }
+  + "BackgroundJobs": { "Endpoints": { ... } }
+  - "DataExchangeEndpoints": { ... }
+  + "DataExchange": { "Endpoints": { ... } }
+  - "IdentityEndpoints":     { ... }
+  - "IdentityProviderEndpoints": { ... }
+  - "IdentityWebhook":       { ... }
+  + "Identity": { "Endpoints": { ... , "Provider": { ... } }, "Webhook": { ... } }
+  - "SchedulingEndpoints":   { ... }
+  + "Scheduling": { "Endpoints": { ... } }
+  - "TimelineEndpoints":     { ... }
+  + "Timeline": { "Endpoints": { ... } }
+  - "WebhooksEndpoints":     { ... }
+  + "Webhooks": { "Endpoints": { ... } }
+  - "WorkflowEndpoints":     { ... }
+  + "Workflow": { "Endpoints": { ... } }
+
+  # Http.* — all flat names now under "Http:":
+  - "ApiDocumentation":      { ... }
+  - "ApiVersioning":         { ... }
+  - "Bulkhead":              { ... }
+  - "Cors":                  { ... }
+  - "Cookies":               { ... }
+  - "Klaro":                 { ... }
+  - "HttpResilience":        { ... }
+  - "Idempotency":           { ... }
+  - "OutputCaching":         { ... }
+  - "OutputCaching:Redis":   { ... }
+  - "ResponseCompression":   { ... }
+  - "SecurityHeaders":       { ... }
+  + "Http": {
+  +   "ApiDocumentation": { ... }, "ApiVersioning": { ... }, "Bulkhead": { ... },
+  +   "Cors": { ... }, "Cookies": { ..., "Klaro": { ... } }, "Resilience": { ... },
+  +   "Idempotency": { ... }, "OutputCaching": { ..., "Redis": { ... } },
+  +   "ResponseCompression": { ... }, "SecurityHeaders": { ... }
+  + }
+
+  # Notifications.* — missing channel segment / wrong root:
+  - "Notifications:Smtp":             { ... }
+  - "Notifications:AwsSes":           { ... }
+  - "AzureCommunicationServices:Email":  { ... }
+  - "AzureCommunicationServices:Sms":    { ... }
+  - "Notifications:AzureNotificationHubs":{ ... }
+  - "Notifications:Push":             { ... }  // WebPush
+  + "Notifications": {
+  +   "Email": { "Smtp": { ... }, "AwsSes": { ... }, "AzureCommunicationServices": { ... } },
+  +   "Sms":   { "AzureCommunicationServices": { ... } },
+  +   "MobilePush": { "AzureNotificationHubs": { ... } },
+  +   "WebPush": { ... }
+  + }
+
+  # Identity.Federated.* — admin providers and sub-options:
+  - "KeycloakAdmin":              { ... }
+  - "KeycloakAdmin:ClientRoleSync":{ ... }
+  - "CognitoAdmin":               { ... }
+  - "CognitoAdmin:ClientRoleSync": { ... }
+  - "EntraIdAdmin":               { ... }
+  - "EntraIdAdmin:ClientRoleSync": { ... }
+  - "Identity:GoogleCloud":       { ... }
+  - "Identity:UserCacheHasher":   { ... }
+  - "IdentityUserCache":          { ... }
+  - "IdentityFederatedNotifications": { ... }
+  + "Identity": { "Federated": {
+  +   "Keycloak":    { ..., "ClientRoleSync": { ... } },
+  +   "Cognito":     { ..., "ClientRoleSync": { ... } },
+  +   "EntraId":     { ..., "ClientRoleSync": { ... } },
+  +   "GoogleCloud": { ... },
+  +   "UserCacheHasher": { ... }, "UserCache": { ... },
+  +   "Notifications":   { ... }
+  + } }
+
+  # Granit.{X}.AI integration packages — direction aligned to the namespace
+  # ("Foo:AI", matching Granit.Foo.AI — not the inverted "AI:Foo"). The core
+  # Granit.AI.* provider family (AI:OpenAI, AI:Anthropic, AI:Extraction, …) is
+  # unchanged — there "AI" IS the owning module.
+  - "AI": { "Authorization": { ... }, "BlobStorage": { ... }, "DataExchange": { ... },
+  -         "Imaging": { ... }, "Localization": { ... }, "Notifications": { ... },
+  -         "Observability": { ... }, "Privacy": { ... }, "QueryEngine": { ... },
+  -         "Templating": { ... }, "Timeline": { ... }, "Validation": { ... }, "Workflow": { ... } }
+  + "Authorization": { "AI": { ... } }
+  + "BlobStorage":   { "AI": { ... } }
+  + "DataExchange":  { "AI": { ... } }
+  + "Imaging":       { "AI": { ... } }
+  + "Localization":  { "AI": { ... } }
+  + "Notifications": { "AI": { ... } }
+  + "Observability": { "AI": { ... } }
+  + "Privacy":       { "AI": { ... } }   # note: Privacy:AI:FailMode follows
+  + "QueryEngine":   { "AI": { ... } }
+  + "Templating":    { "AI": { ... } }
+  + "Timeline":      { "AI": { ... } }
+  + "Validation":    { "AI": { ... } }
+  + "Workflow":      { "AI": { ... } }
+  ```
+
+  **Operational impact**: every Granit-using host must rewrite its `appsettings.json`, K8s/Vault projections (the `__` env-var syntax mirrors the new key), CI secrets, and ExternalSecret manifests in the same deploy. Containers should be rolled together: a mixed fleet will see whichever pods still read the old key fall back to defaults silently. The accompanying Keycloak JwtBearer fix (described next) addresses an `IDX10500` regression introduced by the previous Keycloak section split.
+
 ### Changed (framework — behavior)
 
 - **Local-identity account endpoints now return localized error details.** The `Account*` self-service endpoints (`change-password`, `delete-account`, two-factor, passkeys, external login) previously returned hardcoded English `detail` strings on their RFC 7807 problem responses — and in a few cases passed the raw service `ex.Message` straight to the client, leaking internal user/passkey GUIDs (info disclosure, ISO 27001 A.8). They now resolve translatable keys (`Granit:Identity:Account:*`, `Granit:Identity:Passkey:*`, `Granit:Identity:TwoFactor:*`, `Granit:Identity:ExternalLogin:*`) from the `IdentityLocalEndpoints` resource in the request culture (all 15 base cultures translated), degrading to English only when localization is not wired. The internal jargon "Unable to determine username from token claims." is replaced by a user-facing "Your session is invalid. Please sign in again."

--- a/src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs
@@ -1,10 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Authorization.AI.Internal;
 using Granit.Authorization.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 
 namespace Granit.Authorization.AI.Extensions;
 
@@ -12,7 +8,7 @@ namespace Granit.Authorization.AI.Extensions;
 /// Extension methods for registering AI access anomaly detection services.
 /// </summary>
 /// <remarks>
-/// Binds <see cref="AuthorizationAIOptions"/> from the <c>AI:Authorization</c> configuration section
+/// Binds <see cref="AuthorizationAIOptions"/> from the <c>Authorization:AI</c> configuration section
 /// and registers <see cref="IAIAccessAnomalyDetector"/> as a scoped service backed by an LLM.
 /// Requires an AI provider to be registered (e.g. <c>AddGranitAIOpenAI()</c>).
 /// </remarks>

--- a/src/Granit.Authorization.AI/Options/AuthorizationAIOptions.cs
+++ b/src/Granit.Authorization.AI/Options/AuthorizationAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.Authorization.AI.Options;
 /// Configuration options for AI-powered access anomaly detection.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Authorization</c> configuration section.
+/// Bound to the <c>Authorization:AI</c> configuration section.
 /// </remarks>
 public sealed class AuthorizationAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Authorization";
+    public const string SectionName = "Authorization:AI";
 
     /// <summary>
     /// Name of the AI workspace used for access anomaly detection.

--- a/src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.BlobStorage.AI.Internal;
 using Granit.BlobStorage.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.AI.Extensions;
 
@@ -20,7 +17,7 @@ public static class BlobStorageAIHostApplicationBuilderExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Reads <see cref="BlobStorageAIOptions"/> from the <c>"AI:BlobStorage"</c> configuration section.
+    /// Reads <see cref="BlobStorageAIOptions"/> from the <c>"BlobStorage:AI"</c> configuration section.
     /// Requires <c>Granit.AI</c> core services (<c>AddGranitAI()</c>) and at least one AI provider
     /// to be registered beforehand.
     /// </para>

--- a/src/Granit.BlobStorage.AI/Options/BlobStorageAIOptions.cs
+++ b/src/Granit.BlobStorage.AI/Options/BlobStorageAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.BlobStorage.AI.Options;
 /// Configuration options for the AI blob classifier.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:BlobStorage</c> configuration section.
+/// Bound to the <c>BlobStorage:AI</c> configuration section.
 /// </remarks>
 public sealed class BlobStorageAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:BlobStorage";
+    public const string SectionName = "BlobStorage:AI";
 
     /// <summary>
     /// Name of the AI workspace to use for blob classification.

--- a/src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs
+++ b/src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.DataExchange.AI.Options;
 /// Configuration options for the AI-powered semantic mapping service.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:DataExchange</c> configuration section.
+/// Bound to the <c>DataExchange:AI</c> configuration section.
 /// </remarks>
 public sealed class DataExchangeAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:DataExchange";
+    public const string SectionName = "DataExchange:AI";
 
     /// <summary>
     /// Name of the AI workspace to use for mapping suggestions.

--- a/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using Granit.Diagnostics;
 using Granit.Imaging.AI.Diagnostics;
 using Granit.Imaging.AI.Internal;
 using Granit.Imaging.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 
 namespace Granit.Imaging.AI.Extensions;
 
@@ -19,7 +15,7 @@ public static class ImagingAIHostApplicationBuilderExtensions
     /// Adds AI-powered image analysis services to the application.
     /// </summary>
     /// <remarks>
-    /// Binds <see cref="ImagingAIOptions"/> from the <c>AI:Imaging</c> configuration section
+    /// Binds <see cref="ImagingAIOptions"/> from the <c>Imaging:AI</c> configuration section
     /// and registers <see cref="IAIImageAnalyzer"/> backed by a multimodal LLM.
     /// Requires <c>Granit.AI</c> to be registered with a vision-capable provider.
     /// </remarks>

--- a/src/Granit.Imaging.AI/Options/ImagingAIOptions.cs
+++ b/src/Granit.Imaging.AI/Options/ImagingAIOptions.cs
@@ -4,12 +4,12 @@ namespace Granit.Imaging.AI.Options;
 /// Configuration options for AI-powered image analysis.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Imaging</c> configuration section.
+/// Bound to the <c>Imaging:AI</c> configuration section.
 /// </remarks>
 public sealed class ImagingAIOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "AI:Imaging";
+    public const string SectionName = "Imaging:AI";
 
     /// <summary>
     /// Name of the AI workspace to use for image analysis.

--- a/src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs
@@ -1,12 +1,8 @@
 using Granit.AI.Redaction;
-using Granit.Diagnostics;
 using Granit.Indexing.AI.Diagnostics;
 using Granit.Indexing.AI.Internal;
 using Granit.Indexing.AI.Options;
 using Granit.Indexing.AI.Prompts;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 
 namespace Granit.Indexing.AI.Extensions;
 
@@ -76,8 +72,6 @@ public static class ServiceCollectionExtensions
 
     private static void RegisterCommon(IServiceCollection services)
     {
-        GranitActivitySourceRegistry.Register(IndexingAIMetrics.MeterName);
-
         // ValidateOnStart aborts host boot on an out-of-range option rather than
         // silently degrading every call (which would inflate the injection counters).
         services.AddOptions<IndexingAIOptions>()

--- a/src/Granit.LanguageDetection.AI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.LanguageDetection.AI/Extensions/ServiceCollectionExtensions.cs
@@ -1,12 +1,8 @@
 using Granit.AI.Redaction;
-using Granit.Diagnostics;
 using Granit.LanguageDetection.AI.Diagnostics;
 using Granit.LanguageDetection.AI.Internal;
 using Granit.LanguageDetection.AI.Options;
 using Granit.LanguageDetection.AI.Prompts;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 
 namespace Granit.LanguageDetection.AI.Extensions;
 
@@ -31,8 +27,6 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddGranitLanguageDetectionAI(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
-
-        GranitActivitySourceRegistry.Register(LanguageDetectionAIMetrics.MeterName);
 
         // ValidateOnStart aborts host boot when MaxContentLength / TimeoutSeconds /
         // MaxAICallsPerHourPerTenant / WorkspaceName are out of range. Silent

--- a/src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Localization.AI.Internal;
 using Granit.Localization.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 
 namespace Granit.Localization.AI.Extensions;
 
@@ -15,7 +12,7 @@ public static class LocalizationAIHostApplicationBuilderExtensions
 {
     /// <summary>
     /// Adds Granit AI translation suggestion services and binds <see cref="LocalizationAIOptions"/>
-    /// from the <c>AI:Localization</c> configuration section.
+    /// from the <c>Localization:AI</c> configuration section.
     /// </summary>
     /// <param name="builder">The host application builder.</param>
     /// <returns>The builder for chaining.</returns>

--- a/src/Granit.Localization.AI/Options/LocalizationAIOptions.cs
+++ b/src/Granit.Localization.AI/Options/LocalizationAIOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Localization.AI.Options;
 /// Configuration options for AI-powered translation suggestions.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Localization</c> configuration section and validated at startup via
+/// Bound to the <c>Localization:AI</c> configuration section and validated at startup via
 /// <c>ValidateDataAnnotations().ValidateOnStart()</c> so an out-of-range value aborts
 /// host boot instead of silently degrading every suggestion call.
 /// </remarks>
@@ -15,7 +15,7 @@ public sealed class LocalizationAIOptions
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Localization";
+    public const string SectionName = "Localization:AI";
 
     /// <summary>
     /// AI workspace name to use for translation. Defaults to <c>"default"</c>.

--- a/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Notifications.AI.Internal;
 using Granit.Notifications.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Granit.Notifications.AI.Extensions;
 
@@ -20,7 +18,7 @@ public static class NotificationsAIHostApplicationBuilderExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Reads <see cref="NotificationsAIOptions"/> from the <c>"AI:Notifications"</c> configuration section.
+    /// Reads <see cref="NotificationsAIOptions"/> from the <c>"Notifications:AI"</c> configuration section.
     /// Requires <c>Granit.AI</c> core services (<c>AddGranitAI()</c>) and at least one AI provider
     /// to be registered beforehand.
     /// </para>

--- a/src/Granit.Notifications.AI/Options/NotificationsAIOptions.cs
+++ b/src/Granit.Notifications.AI/Options/NotificationsAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.Notifications.AI.Options;
 /// Configuration options for the AI notification content generator and channel selector.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Notifications</c> configuration section.
+/// Bound to the <c>Notifications:AI</c> configuration section.
 /// </remarks>
 public sealed class NotificationsAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Notifications";
+    public const string SectionName = "Notifications:AI";
 
     /// <summary>
     /// Name of the AI workspace to use for notification content generation and channel selection.

--- a/src/Granit.Observability.AI/Options/ObservabilityAIOptions.cs
+++ b/src/Granit.Observability.AI/Options/ObservabilityAIOptions.cs
@@ -6,14 +6,14 @@ namespace Granit.Observability.AI.Options;
 /// Configuration options for AI-powered observability features.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Observability</c> configuration section.
+/// Bound to the <c>Observability:AI</c> configuration section.
 /// </remarks>
 public sealed class ObservabilityAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Observability";
+    public const string SectionName = "Observability:AI";
 
     /// <summary>
     /// Name of the AI workspace to use for log analysis.

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -3,10 +3,6 @@ using Granit.Observability.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
-using Serilog;
 
 namespace Granit.Observability.Extensions;
 
@@ -184,7 +180,13 @@ public static class ObservabilityServiceCollectionExtensions
 
         metrics
             .AddAspNetCoreInstrumentation()
-            .AddHttpClientInstrumentation();
+            .AddHttpClientInstrumentation()
+            // Every Granit module meter is created via IMeterFactory with the name
+            // "Granit.<Package>" (see the *Metrics classes). Subscribe to them all by
+            // wildcard so module metrics export with no per-module registration — the
+            // metrics counterpart to GranitActivitySourceRegistry on the tracing side,
+            // but self-maintaining: a new *Metrics class needs no Observability change.
+            .AddMeter("Granit.*");
 
         // Apply metrics contributors declared by SDK-embedding modules.
         foreach (Action<MeterProviderBuilder> contributor in

--- a/src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs
@@ -1,10 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Privacy.AI.Internal;
 using Granit.Privacy.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 
 namespace Granit.Privacy.AI.Extensions;
 
@@ -16,7 +12,7 @@ public static class PrivacyAIHostApplicationBuilderExtensions
 {
     /// <summary>
     /// Adds AI-powered PII detection services and binds <see cref="PrivacyAIOptions"/>
-    /// from the <c>AI:Privacy</c> configuration section.
+    /// from the <c>Privacy:AI</c> configuration section.
     /// </summary>
     /// <remarks>
     /// Registers <see cref="IAIPiiDetector"/> backed by an LLM via <see cref="Granit.AI.IAIChatClientFactory"/>.
@@ -41,7 +37,7 @@ public static class PrivacyAIHostApplicationBuilderExtensions
         {
             optionsBuilder.Validate(
                 opts => opts.FailMode != PiiDetectionFailMode.Open,
-                "AI:Privacy:FailMode 'Open' is only permitted in the Development "
+                "Privacy:AI:FailMode 'Open' is only permitted in the Development "
                 + "environment — outside it, PII would silently go undetected on LLM "
                 + "unavailability, violating GDPR Art. 25 (Privacy by Design). "
                 + "Use 'Closed' instead.");

--- a/src/Granit.Privacy.AI/GranitPrivacyAIModule.cs
+++ b/src/Granit.Privacy.AI/GranitPrivacyAIModule.cs
@@ -1,5 +1,4 @@
 using Granit.AI;
-using Granit.Modularity;
 
 namespace Granit.Privacy.AI;
 
@@ -13,7 +12,7 @@ namespace Granit.Privacy.AI;
 /// <para>
 /// PII detection data should not leave the security perimeter. Configure a local model
 /// (Ollama) or a provider covered by a Data Processing Agreement (Azure OpenAI with DPA)
-/// in the <c>AI:Privacy</c> workspace.
+/// in the <c>Privacy:AI</c> workspace.
 /// </para>
 /// </remarks>
 [DependsOn(typeof(GranitAIModule), typeof(GranitPrivacyModule))]

--- a/src/Granit.Privacy.AI/Options/PrivacyAIOptions.cs
+++ b/src/Granit.Privacy.AI/Options/PrivacyAIOptions.cs
@@ -6,7 +6,7 @@ namespace Granit.Privacy.AI.Options;
 /// Configuration options for AI-powered PII detection.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Privacy</c> configuration section.
+/// Bound to the <c>Privacy:AI</c> configuration section.
 /// <para>
 /// <b>Data sovereignty warning:</b> PII detection sends text to an AI model.
 /// Configure <see cref="WorkspaceName"/> to point to a workspace using a local model
@@ -19,7 +19,7 @@ public sealed class PrivacyAIOptions
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Privacy";
+    public const string SectionName = "Privacy:AI";
 
     /// <summary>
     /// AI workspace name to use for PII detection. Defaults to <c>"default"</c>.

--- a/src/Granit.QueryEngine.AI/Options/QueryEngineAIOptions.cs
+++ b/src/Granit.QueryEngine.AI/Options/QueryEngineAIOptions.cs
@@ -6,9 +6,9 @@ namespace Granit.QueryEngine.AI.Options;
 public sealed class QueryEngineAIOptions
 {
     /// <summary>
-    /// Configuration section name (<c>"AI:QueryEngine"</c>).
+    /// Configuration section name (<c>"QueryEngine:AI"</c>).
     /// </summary>
-    public const string SectionName = "AI:QueryEngine";
+    public const string SectionName = "QueryEngine:AI";
 
     /// <summary>
     /// AI workspace name used to create the <c>IChatClient</c>. Defaults to <c>"default"</c>.

--- a/src/Granit.Templating.AI/Options/TemplatingAIOptions.cs
+++ b/src/Granit.Templating.AI/Options/TemplatingAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.Templating.AI.Options;
 /// Configuration options for AI-powered template assistance.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Templating</c> configuration section.
+/// Bound to the <c>Templating:AI</c> configuration section.
 /// </remarks>
 public sealed class TemplatingAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Templating";
+    public const string SectionName = "Templating:AI";
 
     /// <summary>
     /// Name of the AI workspace to use for template generation.

--- a/src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using Granit.Diagnostics;
 using Granit.Timeline.AI.Diagnostics;
 using Granit.Timeline.AI.Internal;
 using Granit.Timeline.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 
 namespace Granit.Timeline.AI.Extensions;
 
@@ -22,7 +18,7 @@ public static class TimelineAIHostApplicationBuilderExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Reads <see cref="TimelineAIOptions"/> from the <c>"AI:Timeline"</c> configuration section.
+    /// Reads <see cref="TimelineAIOptions"/> from the <c>"Timeline:AI"</c> configuration section.
     /// Requires <c>Granit.AI</c> core services (<c>AddGranitAI()</c>) and at least one AI provider
     /// to be registered beforehand.
     /// </para>

--- a/src/Granit.Timeline.AI/Options/TimelineAIOptions.cs
+++ b/src/Granit.Timeline.AI/Options/TimelineAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.Timeline.AI.Options;
 /// Configuration options for AI-powered timeline analysis.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Timeline</c> configuration section.
+/// Bound to the <c>Timeline:AI</c> configuration section.
 /// </remarks>
 public sealed class TimelineAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Timeline";
+    public const string SectionName = "Timeline:AI";
 
     /// <summary>
     /// Name of the AI workspace to use for timeline analysis.

--- a/src/Granit.Validation.AI/Extensions/ValidationAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Validation.AI/Extensions/ValidationAIHostApplicationBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class ValidationAIHostApplicationBuilderExtensions
     /// Adds AI-powered content moderation to the application.
     /// </summary>
     /// <remarks>
-    /// Binds <see cref="ValidationAIOptions"/> from the <c>AI:Validation</c> configuration section
+    /// Binds <see cref="ValidationAIOptions"/> from the <c>Validation:AI</c> configuration section
     /// and registers <see cref="IAIContentModerator"/> as a scoped service backed by an LLM.
     /// Requires an AI provider to be registered (e.g. <c>AddGranitAIOpenAI()</c>).
     /// </remarks>

--- a/src/Granit.Validation.AI/Options/ValidationAIOptions.cs
+++ b/src/Granit.Validation.AI/Options/ValidationAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.Validation.AI.Options;
 /// Configuration options for AI-powered content moderation.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Validation</c> configuration section.
+/// Bound to the <c>Validation:AI</c> configuration section.
 /// </remarks>
 public sealed class ValidationAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Validation";
+    public const string SectionName = "Validation:AI";
 
     /// <summary>
     /// Name of the AI workspace used for content moderation.

--- a/src/Granit.Validation.Endpoints/Diagnostics/ValidationMetrics.cs
+++ b/src/Granit.Validation.Endpoints/Diagnostics/ValidationMetrics.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Granit.Validation.Endpoints.Dtos;
+
+namespace Granit.Validation.Endpoints.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the public server-side field-validation endpoints.
+/// Meter: <c>Granit.Validation.Endpoints</c>.
+/// </summary>
+/// <remarks>
+/// The endpoints are unauthenticated by default and abuse-prone (rate-limiting is
+/// recommended), so a spike in <c>ValidatorNotFound</c> outcomes is a useful
+/// enumeration/scan signal and a high <c>Invalid</c> ratio flags a broken client.
+/// </remarks>
+public sealed class ValidationMetrics
+{
+    /// <summary>Name of the <see cref="Meter"/> owned by this package.</summary>
+    public const string MeterName = "Granit.Validation.Endpoints";
+
+    private readonly Counter<long> _fieldValidations;
+
+    /// <summary>Initializes a new <see cref="ValidationMetrics"/> bound to <paramref name="meterFactory"/>.</summary>
+    public ValidationMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+
+        Meter meter = meterFactory.Create(MeterName);
+
+        _fieldValidations = meter.CreateCounter<long>(
+            "granit.validation.field.validated",
+            description: "Server-side field validations performed via the validation endpoints, tagged with the error code and outcome.");
+    }
+
+    /// <summary>
+    /// Records a single field validation.
+    /// </summary>
+    /// <param name="tenantId">
+    /// Resolved tenant, or <see langword="null"/> for the anonymous/public case — coalesced to <c>"global"</c>.
+    /// </param>
+    /// <param name="errorCode">
+    /// The registered validator code, or <see langword="null"/> when the requested code is unknown.
+    /// The raw client-supplied code is deliberately NOT tagged in the unknown case (it is unbounded and
+    /// would explode tag cardinality under a scan); it is recorded as <c>"(unknown)"</c> instead.
+    /// </param>
+    /// <param name="status">The validation outcome.</param>
+    public void RecordFieldValidated(string? tenantId, string? errorCode, ValidationFieldStatus status)
+    {
+        TagList tags =
+        [
+            new("tenant_id", tenantId ?? "global"),
+            new("error_code", errorCode ?? "(unknown)"),
+            new("status", status.ToString()),
+        ];
+
+        _fieldValidations.Add(1, tags);
+    }
+}

--- a/src/Granit.Validation.Endpoints/Endpoints/ValidationEndpoints.cs
+++ b/src/Granit.Validation.Endpoints/Endpoints/ValidationEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Validation.Endpoints.Diagnostics;
 using Granit.Validation.Endpoints.Dtos;
 using Granit.Validation.ServerValidation;
 using Microsoft.AspNetCore.Builder;
@@ -47,12 +48,15 @@ internal static class ValidationEndpoints
     internal static Results<Ok<ValidationFieldValidateResponse>, ProblemHttpResult> HandleValidate(
         ValidationFieldValidateRequest request,
         [FromServices] ServerValidatorRegistry registry,
+        [FromServices] ValidationMetrics metrics,
         HttpContext httpContext)
     {
         IServerValidator? validator = ResolveValidator(registry, request.ErrorCode, httpContext);
 
         if (validator is null)
         {
+            // Unknown (or sensitive-and-hidden) code: record without the client-supplied code to cap cardinality.
+            metrics.RecordFieldValidated(tenantId: null, errorCode: null, ValidationFieldStatus.ValidatorNotFound);
             return ValidatorNotFound();
         }
 
@@ -60,12 +64,15 @@ internal static class ValidationEndpoints
             ? ValidationFieldStatus.Valid
             : ValidationFieldStatus.Invalid;
 
+        metrics.RecordFieldValidated(tenantId: null, request.ErrorCode, status);
+
         return TypedResults.Ok(new ValidationFieldValidateResponse(request.ErrorCode, status));
     }
 
     internal static Ok<ValidationFieldValidateBatchResponse> HandleValidateBatch(
         ValidationFieldValidateBatchRequest request,
         [FromServices] ServerValidatorRegistry registry,
+        [FromServices] ValidationMetrics metrics,
         HttpContext httpContext)
     {
         List<ValidationFieldValidateResponse> results = new(request.Fields.Count);
@@ -78,12 +85,14 @@ internal static class ValidationEndpoints
             if (validator is null)
             {
                 status = ValidationFieldStatus.ValidatorNotFound;
+                metrics.RecordFieldValidated(tenantId: null, errorCode: null, status);
             }
             else
             {
                 status = validator.Validate(field.Value)
                     ? ValidationFieldStatus.Valid
                     : ValidationFieldStatus.Invalid;
+                metrics.RecordFieldValidated(tenantId: null, field.ErrorCode, status);
             }
 
             results.Add(new ValidationFieldValidateResponse(field.ErrorCode, status));

--- a/src/Granit.Validation.Endpoints/GranitValidationEndpointsModule.cs
+++ b/src/Granit.Validation.Endpoints/GranitValidationEndpointsModule.cs
@@ -1,5 +1,7 @@
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
+using Granit.Validation.Endpoints.Diagnostics;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Validation.Endpoints;
 
@@ -15,4 +17,9 @@ namespace Granit.Validation.Endpoints;
 [DependsOn(
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitValidationModule))]
-public sealed class GranitValidationEndpointsModule : GranitModule;
+public sealed class GranitValidationEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.TryAddSingleton<ValidationMetrics>();
+}

--- a/src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Workflow.AI.Internal;
 using Granit.Workflow.AI.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 
 namespace Granit.Workflow.AI.Extensions;
 
@@ -15,7 +12,7 @@ public static class WorkflowAIHostApplicationBuilderExtensions
 {
     /// <summary>
     /// Adds Granit Workflow AI services and binds <see cref="WorkflowAIOptions"/>
-    /// from the <c>AI:Workflow</c> configuration section.
+    /// from the <c>Workflow:AI</c> configuration section.
     /// </summary>
     /// <param name="builder">The host application builder.</param>
     /// <returns>The builder for chaining.</returns>

--- a/src/Granit.Workflow.AI/Options/WorkflowAIOptions.cs
+++ b/src/Granit.Workflow.AI/Options/WorkflowAIOptions.cs
@@ -4,14 +4,14 @@ namespace Granit.Workflow.AI.Options;
 /// Configuration options for AI-powered workflow recommendations and risk evaluation.
 /// </summary>
 /// <remarks>
-/// Bound to the <c>AI:Workflow</c> configuration section.
+/// Bound to the <c>Workflow:AI</c> configuration section.
 /// </remarks>
 public sealed class WorkflowAIOptions
 {
     /// <summary>
     /// Configuration section name in appsettings.json.
     /// </summary>
-    public const string SectionName = "AI:Workflow";
+    public const string SectionName = "Workflow:AI";
 
     /// <summary>
     /// AI workspace name to use for workflow AI operations. Defaults to <c>"default"</c>.

--- a/tests/Granit.Authorization.AI.Tests/AuthorizationAIOptionsTests.cs
+++ b/tests/Granit.Authorization.AI.Tests/AuthorizationAIOptionsTests.cs
@@ -1,12 +1,11 @@
 using Granit.Authorization.AI.Options;
-using Shouldly;
 
 namespace Granit.Authorization.AI.Tests;
 
 public sealed class AuthorizationAIOptionsTests
 {
     [Fact]
-    public void SectionName_IsAIAuthorization() => AuthorizationAIOptions.SectionName.ShouldBe("AI:Authorization");
+    public void SectionName_IsAuthorizationAI() => AuthorizationAIOptions.SectionName.ShouldBe("Authorization:AI");
 
     [Fact]
     public void WorkspaceName_Default_IsDefault()

--- a/tests/Granit.BlobStorage.AI.Tests/BlobStorageAIOptionsTests.cs
+++ b/tests/Granit.BlobStorage.AI.Tests/BlobStorageAIOptionsTests.cs
@@ -1,13 +1,11 @@
 using Granit.BlobStorage.AI.Options;
-using Shouldly;
-using Xunit;
 
 namespace Granit.BlobStorage.AI.Tests;
 
 public sealed class BlobStorageAIOptionsTests
 {
     [Fact]
-    public void SectionName_IsExpected() => BlobStorageAIOptions.SectionName.ShouldBe("AI:BlobStorage");
+    public void SectionName_IsExpected() => BlobStorageAIOptions.SectionName.ShouldBe("BlobStorage:AI");
 
     [Fact]
     public void DefaultWorkspaceName_IsNull()

--- a/tests/Granit.DataExchange.AI.Tests/DataExchangeAIOptionsTests.cs
+++ b/tests/Granit.DataExchange.AI.Tests/DataExchangeAIOptionsTests.cs
@@ -1,5 +1,4 @@
 using Granit.DataExchange.AI.Options;
-using Shouldly;
 
 namespace Granit.DataExchange.AI.Tests;
 
@@ -7,7 +6,7 @@ public sealed class DataExchangeAIOptionsTests
 {
     [Fact]
     public void SectionName_IsCorrect() =>
-        DataExchangeAIOptions.SectionName.ShouldBe("AI:DataExchange");
+        DataExchangeAIOptions.SectionName.ShouldBe("DataExchange:AI");
 
     [Fact]
     public void Default_WorkspaceName_IsDefault()

--- a/tests/Granit.Imaging.AI.Tests/ImagingAIOptionsTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/ImagingAIOptionsTests.cs
@@ -1,5 +1,4 @@
 using Granit.Imaging.AI.Options;
-using Shouldly;
 
 namespace Granit.Imaging.AI.Tests;
 
@@ -16,5 +15,5 @@ public sealed class ImagingAIOptionsTests
 
     [Fact]
     public void SectionName_IsCorrect() =>
-        ImagingAIOptions.SectionName.ShouldBe("AI:Imaging");
+        ImagingAIOptions.SectionName.ShouldBe("Imaging:AI");
 }

--- a/tests/Granit.Localization.AI.Tests/LocalizationAIOptionsTests.cs
+++ b/tests/Granit.Localization.AI.Tests/LocalizationAIOptionsTests.cs
@@ -1,12 +1,11 @@
 using Granit.Localization.AI.Options;
-using Shouldly;
 
 namespace Granit.Localization.AI.Tests;
 
 public sealed class LocalizationAIOptionsTests
 {
     [Fact]
-    public void SectionName_IsExpected() => LocalizationAIOptions.SectionName.ShouldBe("AI:Localization");
+    public void SectionName_IsExpected() => LocalizationAIOptions.SectionName.ShouldBe("Localization:AI");
 
     [Fact]
     public void WorkspaceName_DefaultsToDefault()

--- a/tests/Granit.QueryEngine.AI.Tests/Options/QueryEngineAIOptionsTests.cs
+++ b/tests/Granit.QueryEngine.AI.Tests/Options/QueryEngineAIOptionsTests.cs
@@ -1,12 +1,11 @@
 using Granit.QueryEngine.AI.Options;
-using Shouldly;
 
 namespace Granit.QueryEngine.AI.Tests.Options;
 
 public sealed class QueryEngineAIOptionsTests
 {
     [Fact]
-    public void SectionName_is_AI_QueryEngine() => QueryEngineAIOptions.SectionName.ShouldBe("AI:QueryEngine");
+    public void SectionName_is_QueryEngine_AI() => QueryEngineAIOptions.SectionName.ShouldBe("QueryEngine:AI");
 
     [Fact]
     public void WorkspaceName_defaults_to_default()

--- a/tests/Granit.Templating.AI.Tests/TemplatingAIOptionsTests.cs
+++ b/tests/Granit.Templating.AI.Tests/TemplatingAIOptionsTests.cs
@@ -1,12 +1,11 @@
 using Granit.Templating.AI.Options;
-using Shouldly;
 
 namespace Granit.Templating.AI.Tests;
 
 public sealed class TemplatingAIOptionsTests
 {
     [Fact]
-    public void SectionName_IsCorrect() => TemplatingAIOptions.SectionName.ShouldBe("AI:Templating");
+    public void SectionName_IsCorrect() => TemplatingAIOptions.SectionName.ShouldBe("Templating:AI");
 
     [Fact]
     public void Defaults_AreCorrect()

--- a/tests/Granit.Timeline.AI.Tests/TimelineAIOptionsTests.cs
+++ b/tests/Granit.Timeline.AI.Tests/TimelineAIOptionsTests.cs
@@ -1,13 +1,11 @@
 using Granit.Timeline.AI.Options;
-using Shouldly;
-using Xunit;
 
 namespace Granit.Timeline.AI.Tests;
 
 public sealed class TimelineAIOptionsTests
 {
     [Fact]
-    public void SectionName_is_AI_Timeline() => TimelineAIOptions.SectionName.ShouldBe("AI:Timeline");
+    public void SectionName_is_Timeline_AI() => TimelineAIOptions.SectionName.ShouldBe("Timeline:AI");
 
     [Fact]
     public void Default_WorkspaceName_IsNull()

--- a/tests/Granit.Validation.AI.Tests/ValidationAIOptionsTests.cs
+++ b/tests/Granit.Validation.AI.Tests/ValidationAIOptionsTests.cs
@@ -6,7 +6,7 @@ namespace Granit.Validation.AI.Tests;
 public sealed class ValidationAIOptionsTests
 {
     [Fact]
-    public void SectionName_IsCorrect() => ValidationAIOptions.SectionName.ShouldBe("AI:Validation");
+    public void SectionName_IsCorrect() => ValidationAIOptions.SectionName.ShouldBe("Validation:AI");
 
     [Fact]
     public void WorkspaceName_DefaultValue_IsDefault()

--- a/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointTests.cs
+++ b/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointTests.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics.Metrics;
 using System.Security.Claims;
+using Granit.Validation.Endpoints.Diagnostics;
 using Granit.Validation.Endpoints.Dtos;
 using Granit.Validation.Endpoints.Endpoints;
 using Granit.Validation.ServerValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shouldly;
@@ -25,7 +28,7 @@ public sealed class ValidationEndpointTests
 
         var request = new ValidationFieldValidateRequest("Validation:InvalidIban", "BE68539007547034");
         Results<Ok<ValidationFieldValidateResponse>, ProblemHttpResult> result =
-            ValidationEndpoints.HandleValidate(request, registry, CreateAuthenticatedContext());
+            ValidationEndpoints.HandleValidate(request, registry, CreateMetrics(), CreateAuthenticatedContext());
 
         Ok<ValidationFieldValidateResponse> ok = result.Result.ShouldBeOfType<Ok<ValidationFieldValidateResponse>>();
         ok.Value.ShouldNotBeNull();
@@ -41,7 +44,7 @@ public sealed class ValidationEndpointTests
 
         var request = new ValidationFieldValidateRequest("Validation:InvalidIban", "INVALID");
         Results<Ok<ValidationFieldValidateResponse>, ProblemHttpResult> result =
-            ValidationEndpoints.HandleValidate(request, registry, CreateAnonymousContext());
+            ValidationEndpoints.HandleValidate(request, registry, CreateMetrics(), CreateAnonymousContext());
 
         Ok<ValidationFieldValidateResponse> ok = result.Result.ShouldBeOfType<Ok<ValidationFieldValidateResponse>>();
         ok.Value.ShouldNotBeNull();
@@ -55,7 +58,7 @@ public sealed class ValidationEndpointTests
 
         var request = new ValidationFieldValidateRequest("Validation:Unknown", "value");
         Results<Ok<ValidationFieldValidateResponse>, ProblemHttpResult> result =
-            ValidationEndpoints.HandleValidate(request, registry, CreateAnonymousContext());
+            ValidationEndpoints.HandleValidate(request, registry, CreateMetrics(), CreateAnonymousContext());
 
         ProblemHttpResult problem = result.Result.ShouldBeOfType<ProblemHttpResult>();
         problem.StatusCode.ShouldBe(404);
@@ -69,7 +72,7 @@ public sealed class ValidationEndpointTests
 
         var request = new ValidationFieldValidateRequest("Validation:InvalidUsSsn", "123-45-6789");
         Results<Ok<ValidationFieldValidateResponse>, ProblemHttpResult> result =
-            ValidationEndpoints.HandleValidate(request, registry, CreateAnonymousContext());
+            ValidationEndpoints.HandleValidate(request, registry, CreateMetrics(), CreateAnonymousContext());
 
         ProblemHttpResult problem = result.Result.ShouldBeOfType<ProblemHttpResult>();
         problem.StatusCode.ShouldBe(404);
@@ -83,7 +86,7 @@ public sealed class ValidationEndpointTests
 
         var request = new ValidationFieldValidateRequest("Validation:InvalidUsSsn", "123-45-6789");
         Results<Ok<ValidationFieldValidateResponse>, ProblemHttpResult> result =
-            ValidationEndpoints.HandleValidate(request, registry, CreateAuthenticatedContext());
+            ValidationEndpoints.HandleValidate(request, registry, CreateMetrics(), CreateAuthenticatedContext());
 
         Ok<ValidationFieldValidateResponse> ok = result.Result.ShouldBeOfType<Ok<ValidationFieldValidateResponse>>();
         ok.Value.ShouldNotBeNull();
@@ -109,7 +112,7 @@ public sealed class ValidationEndpointTests
         ]);
 
         Ok<ValidationFieldValidateBatchResponse> result =
-            ValidationEndpoints.HandleValidateBatch(request, registry, CreateAuthenticatedContext());
+            ValidationEndpoints.HandleValidateBatch(request, registry, CreateMetrics(), CreateAuthenticatedContext());
 
         ValidationFieldValidateBatchResponse ok = result.Value.ShouldNotBeNull();
         ok.Results.Count.ShouldBe(3);
@@ -132,7 +135,7 @@ public sealed class ValidationEndpointTests
         ]);
 
         Ok<ValidationFieldValidateBatchResponse> result =
-            ValidationEndpoints.HandleValidateBatch(request, registry, CreateAnonymousContext());
+            ValidationEndpoints.HandleValidateBatch(request, registry, CreateMetrics(), CreateAnonymousContext());
 
         ValidationFieldValidateBatchResponse ok = result.Value.ShouldNotBeNull();
         ok.Results.Count.ShouldBe(2);
@@ -206,6 +209,11 @@ public sealed class ValidationEndpointTests
         context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "testuser")], "TestAuth"));
         return context;
     }
+
+    private static readonly IMeterFactory MeterFactory =
+        new ServiceCollection().AddMetrics().BuildServiceProvider().GetRequiredService<IMeterFactory>();
+
+    private static ValidationMetrics CreateMetrics() => new(MeterFactory);
 
     private static ServerValidatorRegistry CreateRegistry(params IServerValidator[] validators)
     {

--- a/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointsHttpTests.cs
+++ b/tests/Granit.Validation.Endpoints.Tests/ValidationEndpointsHttpTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentValidation;
 using Granit.Testing.Endpoints;
+using Granit.Validation.Endpoints.Diagnostics;
 using Granit.Validation.Endpoints.Dtos;
 using Granit.Validation.Endpoints.Extensions;
 using Granit.Validation.Endpoints.Validators;
@@ -26,6 +27,7 @@ public sealed class ValidationEndpointsHttpTests
         GranitEndpointTestHost.StartAsync(
             configureServices: services =>
             {
+                services.AddSingleton<ValidationMetrics>();
                 services.AddSingleton<IServerValidatorContributor>(
                     new TestContributor(validators));
                 services.AddSingleton(sp =>

--- a/tests/Granit.Validation.Endpoints.Tests/ValidationMetricsTests.cs
+++ b/tests/Granit.Validation.Endpoints.Tests/ValidationMetricsTests.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics.Metrics;
+using Granit.Validation.Endpoints.Diagnostics;
+using Granit.Validation.Endpoints.Dtos;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Validation.Endpoints.Tests;
+
+public sealed class ValidationMetricsTests
+{
+    [Fact]
+    public void RecordFieldValidated_KnownCode_TagsCodeStatusAndGlobalTenant()
+    {
+        using var recorder = Recorder.Start();
+
+        recorder.Metrics.RecordFieldValidated(tenantId: null, "Validation:InvalidIban", ValidationFieldStatus.Valid);
+
+        Measurement m = recorder.Single();
+        m.Value.ShouldBe(1);
+        m.Tag("error_code").ShouldBe("Validation:InvalidIban");
+        m.Tag("status").ShouldBe("Valid");
+        m.Tag("tenant_id").ShouldBe("global");
+    }
+
+    [Fact]
+    public void RecordFieldValidated_UnknownCode_IsCappedToSentinel()
+    {
+        // The raw client-supplied code must never reach the tag (cardinality bomb under a scan).
+        using var recorder = Recorder.Start();
+
+        recorder.Metrics.RecordFieldValidated(tenantId: null, errorCode: null, ValidationFieldStatus.ValidatorNotFound);
+
+        Measurement m = recorder.Single();
+        m.Tag("error_code").ShouldBe("(unknown)");
+        m.Tag("status").ShouldBe("ValidatorNotFound");
+    }
+
+    [Fact]
+    public void RecordFieldValidated_ResolvedTenant_IsTagged()
+    {
+        using var recorder = Recorder.Start();
+
+        recorder.Metrics.RecordFieldValidated("tenant-7", "Validation:InvalidEmail", ValidationFieldStatus.Invalid);
+
+        Measurement m = recorder.Single();
+        m.Tag("tenant_id").ShouldBe("tenant-7");
+        m.Tag("status").ShouldBe("Invalid");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers — a minimal in-process MeterListener collector (no extra package).
+    // -------------------------------------------------------------------------
+
+    private sealed record Measurement(long Value, KeyValuePair<string, object?>[] Tags)
+    {
+        public object? Tag(string key) => Tags.Single(t => t.Key == key).Value;
+    }
+
+    private sealed class Recorder : IDisposable
+    {
+        private readonly MeterListener _listener;
+        private readonly List<Measurement> _measurements = [];
+
+        public ValidationMetrics Metrics { get; }
+
+        private Recorder()
+        {
+            IMeterFactory factory = new ServiceCollection().AddMetrics()
+                .BuildServiceProvider().GetRequiredService<IMeterFactory>();
+            Metrics = new ValidationMetrics(factory);
+
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == ValidationMetrics.MeterName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            _listener.SetMeasurementEventCallback<long>(
+                (_, measurement, tags, _) => _measurements.Add(new Measurement(measurement, tags.ToArray())));
+            _listener.Start();
+        }
+
+        public static Recorder Start() => new();
+
+        // Measurements are delivered synchronously on Add, so the list is already populated.
+        public Measurement Single() => _measurements.ShouldHaveSingleItem();
+
+        public void Dispose() => _listener.Dispose();
+    }
+}

--- a/tests/Granit.Workflow.AI.Tests/WorkflowAIOptionsTests.cs
+++ b/tests/Granit.Workflow.AI.Tests/WorkflowAIOptionsTests.cs
@@ -1,5 +1,4 @@
 using Granit.Workflow.AI.Options;
-using Shouldly;
 
 namespace Granit.Workflow.AI.Tests;
 
@@ -10,7 +9,7 @@ public sealed class WorkflowAIOptionsTests
 {
     [Fact]
     public void SectionName_ShouldBeAIWorkflow() =>
-        WorkflowAIOptions.SectionName.ShouldBe("AI:Workflow");
+        WorkflowAIOptions.SectionName.ShouldBe("Workflow:AI");
 
     [Fact]
     public void Default_WorkspaceName_ShouldBeDefault()


### PR DESCRIPTION
**Draft — WIP pushed to preserve work.** Isolated from a shared working tree onto a fresh `develop` base (does not include the in-flight validation-localization work, already merged via #2604).

## What's here

- **SectionName homogenization** for the 14 cross-module `Granit.{X}.AI` integration packages: section direction inverted to match the namespace (`AI:Authorization` → `Authorization:AI`, `AI:BlobStorage` → `BlobStorage:AI`, … `AI:Validation` → `Validation:AI`), aligning with `Indexing:AI` / `LanguageDetection:AI`. Options classes, host-builder extensions, and `*OptionsTests` updated. CHANGELOG entry included.
- **Bundled (should be split):** an in-progress `Granit.Validation.Endpoints` metrics addition (`Diagnostics/` + `ValidationMetricsTests`).

## Status

- Sanity-checked: `Granit.Validation.AI.Tests` (24) and `Granit.Validation.Endpoints.Tests` (60) build + pass on this base. The full sweep is **not** verified across all 14 packages — left as WIP.
- **Before review:** split the SectionName refactor from the Validation-metrics feature into separate PRs.