### PR TITLE
fix(build): restore using directives removed by #2605 (green develop)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -8179,7 +8179,7 @@
       "kind": "class",
       "project": "Granit.Authorization.AI",
       "file": "src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitAuthorizationAI",
@@ -10472,7 +10472,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.AI",
       "file": "src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitBlobStorageAI",
@@ -28223,7 +28223,7 @@
       "kind": "class",
       "project": "Granit.Imaging.AI",
       "file": "src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitImagingAI",
@@ -28605,7 +28605,7 @@
       "kind": "class",
       "project": "Granit.Indexing.AI",
       "file": "src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitIndexingAISummarizer",
@@ -29848,7 +29848,7 @@
       "kind": "class",
       "project": "Granit.LanguageDetection.AI",
       "file": "src/Granit.LanguageDetection.AI/Extensions/ServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitLanguageDetectionAI",
@@ -30097,7 +30097,7 @@
       "kind": "class",
       "project": "Granit.Localization.AI",
       "file": "src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs",
-      "line": 11,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitLocalizationAI",
@@ -32495,7 +32495,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AI",
       "file": "src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitNotificationsAI",
@@ -35470,7 +35470,7 @@
       "kind": "class",
       "project": "Granit.Observability",
       "file": "src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitObservability",
@@ -39559,7 +39559,7 @@
       "kind": "class",
       "project": "Granit.Privacy.AI",
       "file": "src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs",
-      "line": 11,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitPrivacyAI",
@@ -39575,7 +39575,7 @@
       "kind": "class",
       "project": "Granit.Privacy.AI",
       "file": "src/Granit.Privacy.AI/GranitPrivacyAIModule.cs",
-      "line": 19,
+      "line": 20,
       "members": []
     },
     {
@@ -47729,7 +47729,7 @@
       "kind": "class",
       "project": "Granit.Timeline.AI",
       "file": "src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitTimelineAI",
@@ -52513,7 +52513,7 @@
       "kind": "class",
       "project": "Granit.Workflow.AI",
       "file": "src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs",
-      "line": 11,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitWorkflowAI",

--- a/src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs
@@ -1,6 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Authorization.AI.Internal;
 using Granit.Authorization.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Authorization.AI.Extensions;
 

--- a/src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs
@@ -1,6 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.BlobStorage.AI.Internal;
 using Granit.BlobStorage.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.BlobStorage.AI.Extensions;
 

--- a/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
@@ -1,7 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
+using Granit.Diagnostics;
 using Granit.Imaging.AI.Diagnostics;
 using Granit.Imaging.AI.Internal;
 using Granit.Imaging.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Imaging.AI.Extensions;
 

--- a/src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,9 @@ using Granit.Indexing.AI.Diagnostics;
 using Granit.Indexing.AI.Internal;
 using Granit.Indexing.AI.Options;
 using Granit.Indexing.AI.Prompts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Indexing.AI.Extensions;
 

--- a/src/Granit.LanguageDetection.AI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.LanguageDetection.AI/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,9 @@ using Granit.LanguageDetection.AI.Diagnostics;
 using Granit.LanguageDetection.AI.Internal;
 using Granit.LanguageDetection.AI.Options;
 using Granit.LanguageDetection.AI.Prompts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.LanguageDetection.AI.Extensions;
 

--- a/src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs
@@ -1,6 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Localization.AI.Internal;
 using Granit.Localization.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Localization.AI.Extensions;
 

--- a/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Notifications.AI.Internal;
 using Granit.Notifications.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Notifications.AI.Extensions;
 

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -3,6 +3,10 @@ using Granit.Observability.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Serilog;
 
 namespace Granit.Observability.Extensions;
 

--- a/src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs
@@ -1,6 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Privacy.AI.Internal;
 using Granit.Privacy.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Privacy.AI.Extensions;
 

--- a/src/Granit.Privacy.AI/GranitPrivacyAIModule.cs
+++ b/src/Granit.Privacy.AI/GranitPrivacyAIModule.cs
@@ -1,4 +1,5 @@
 using Granit.AI;
+using Granit.Modularity;
 
 namespace Granit.Privacy.AI;
 

--- a/src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs
@@ -1,7 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
+using Granit.Diagnostics;
 using Granit.Timeline.AI.Diagnostics;
 using Granit.Timeline.AI.Internal;
 using Granit.Timeline.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Timeline.AI.Extensions;
 

--- a/src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs
@@ -1,6 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.Workflow.AI.Internal;
 using Granit.Workflow.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Workflow.AI.Extensions;
 

--- a/tests/Granit.DataExchange.AI.Tests/DataExchangeAIOptionsTests.cs
+++ b/tests/Granit.DataExchange.AI.Tests/DataExchangeAIOptionsTests.cs
@@ -1,4 +1,5 @@
 using Granit.DataExchange.AI.Options;
+using Shouldly;
 
 namespace Granit.DataExchange.AI.Tests;
 

--- a/tests/Granit.QueryEngine.AI.Tests/Options/QueryEngineAIOptionsTests.cs
+++ b/tests/Granit.QueryEngine.AI.Tests/Options/QueryEngineAIOptionsTests.cs
@@ -1,4 +1,5 @@
 using Granit.QueryEngine.AI.Options;
+using Shouldly;
 
 namespace Granit.QueryEngine.AI.Tests.Options;
 

--- a/tests/Granit.Templating.AI.Tests/TemplatingAIOptionsTests.cs
+++ b/tests/Granit.Templating.AI.Tests/TemplatingAIOptionsTests.cs
@@ -1,4 +1,5 @@
 using Granit.Templating.AI.Options;
+using Shouldly;
 
 namespace Granit.Templating.AI.Tests;
 


### PR DESCRIPTION
## Incident

`develop` does **not compile** — ~14 packages (`Granit.Observability` + the `Granit.*.AI` family + their `*OptionsTests`) are missing in-use `using` directives.

## Cause

#2605 (`SectionName homogenization [WIP]`) ran a faulty "remove unused usings" that deleted **in-use** usings while keeping the SectionName changes. Its own diff shows the `-using ...;` removals (e.g. `-using Shouldly;`, `-using OpenTelemetry.Trace;`, `-using Microsoft.Extensions.Hosting;`).

## Fix

Deterministic inverse: re-add exactly the usings #2605 removed (extracted from its diff) across the 21 affected files, and re-sort the blocks per `.editorconfig` (`dotnet_sort_system_directives_first`).

## Verification

All affected projects build again (`Granit.Indexing.AI`, `Granit.LanguageDetection.AI`, `Granit.Privacy.AI`, `Granit.Observability`, `Granit.DataExchange.AI.Tests`, … all green). **Merge this first** — it unblocks every other open PR whose CI is red purely due to this breakage (#2608, #2609).