### PR TITLE
fix(authentication): skip blank-ClientId external providers instead of breaking the pipeline

### DIFF
--- a/src/Granit.Authentication.External/Extensions/ExternalAuthenticationServiceCollectionExtensions.cs
+++ b/src/Granit.Authentication.External/Extensions/ExternalAuthenticationServiceCollectionExtensions.cs
@@ -53,9 +53,15 @@ public static class ExternalAuthenticationServiceCollectionExtensions
             configuration.GetSection(ExternalAuthOptions.SectionName).Get<ExternalAuthOptions>()
             ?? new ExternalAuthOptions();
 
+        // Skip providers with no ClientId: every external provider (OAuth and OIDC) requires one,
+        // and OAuthOptions.Validate() throws on an empty ClientId the moment the remote handler is
+        // initialized — which happens on every request, breaking the whole pipeline. A blank entry
+        // is the documented "configure later via user-secrets" placeholder, so treat it as a no-op
+        // until it is actually filled in rather than registering an unusable scheme.
         List<ExternalAuthProvider> matching =
             [.. options.Providers.Where(p =>
-                string.Equals(p.Type, providerType, StringComparison.OrdinalIgnoreCase))];
+                string.Equals(p.Type, providerType, StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(p.ClientId))];
 
         if (matching.Count == 0)
         {

--- a/src/Granit.Authentication.External/GranitAuthenticationExternalModule.cs
+++ b/src/Granit.Authentication.External/GranitAuthenticationExternalModule.cs
@@ -24,14 +24,21 @@ public sealed class GranitAuthenticationExternalModule : GranitModule
     /// <inheritdoc/>
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
-        // Every provider listed under Authentication:External:Providers is advertised to users as
-        // available, so each MUST have a registered authentication handler. A provider without its
-        // scheme (host forgot to reference/enable the matching Granit.Authentication.External.<X>
+        // Every configured provider under Authentication:External:Providers is advertised to users
+        // as available, so each MUST have a registered authentication handler. A provider without
+        // its scheme (host forgot to reference/enable the matching Granit.Authentication.External.<X>
         // package) would otherwise only fail when a user clicks "Sign in with X".
         ExternalAuthOptions options = context.ServiceProvider
             .GetRequiredService<IOptions<ExternalAuthOptions>>().Value;
 
-        if (options.Providers.Count == 0)
+        // A blank ClientId is the documented "configure later via user-secrets" placeholder:
+        // AddExternalProviderSchemes skips it, so it has no scheme by design and must not trip this
+        // guard. Only actually-configured providers (non-empty ClientId) are validated.
+        ExternalAuthProvider[] configured = options.Providers
+            .Where(p => !string.IsNullOrWhiteSpace(p.ClientId))
+            .ToArray();
+
+        if (configured.Length == 0)
         {
             return;
         }
@@ -44,7 +51,7 @@ public sealed class GranitAuthenticationExternalModule : GranitModule
             .Select(s => s.Name)
             .ToHashSet(StringComparer.Ordinal);
 
-        string[] missing = options.Providers
+        string[] missing = configured
             .Select(p => p.SchemeName)
             .Where(name => !registeredSchemes.Contains(name))
             .ToArray();


### PR DESCRIPTION
Follow-up to #2607.

## Problem

A provider entry under `Authentication:External:Providers` with an **empty `ClientId`** is the documented "configure later via user-secrets" placeholder. It was still:
1. Registered as an auth scheme — but `OAuthOptions.Validate()` throws on an empty `ClientId` the moment the remote handler initializes (every request), **breaking the whole auth pipeline**.
2. Counted by the `OnApplicationInitialization` guard that asserts every advertised provider has a registered scheme — so a placeholder tripped a false "missing scheme" failure.

## Fix

- `AddExternalProviderSchemes` skips providers with a blank `ClientId` (no-op until filled in).
- The startup guard only validates **actually-configured** providers (non-empty `ClientId`).

## Verification

`Granit.Authentication.External` builds, `dotnet format` clean, 11/11 tests pass.