### PR TITLE
fix(indexing): use tolerance for RRF tie detection (S1244)

### DIFF
--- a/src/Granit.Indexing.Embeddings/Internal/ReciprocalRankFusion.cs
+++ b/src/Granit.Indexing.Embeddings/Internal/ReciprocalRankFusion.cs
@@ -22,6 +22,13 @@ namespace Granit.Indexing.Embeddings.Internal;
 /// </remarks>
 internal static class ReciprocalRankFusion
 {
+    /// <summary>
+    /// Tolerance for treating two adjacent raw scores as a tie. Raw scores are IEEE-754 doubles
+    /// from BM25 / <c>ts_rank</c> / cosine, so an exact <c>!=</c> would split scores that differ
+    /// only by floating-point noise into separate dense ranks. A span smaller than this is a tie.
+    /// </summary>
+    private const double ScoreTieEpsilon = 1e-9;
+
     /// <summary>Fuses two ranked hit lists into a single descending-score list.</summary>
     /// <typeparam name="TKey">Resource primary key.</typeparam>
     /// <typeparam name="TResult">Projected payload.</typeparam>
@@ -69,7 +76,7 @@ internal static class ReciprocalRankFusion
 
         foreach (SearchHit<TKey, TResult> hit in hits)
         {
-            if (lastRawScore is null || hit.Score != lastRawScore.Value)
+            if (lastRawScore is null || Math.Abs(hit.Score - lastRawScore.Value) > ScoreTieEpsilon)
             {
                 denseRank++;
                 lastRawScore = hit.Score;


### PR DESCRIPTION
## Context

SonarCloud flagged a new reliability bug (S1244) at `ReciprocalRankFusion.AccumulateDenseRanks`: dense-rank tie detection compared raw IEEE-754 scores with exact `!=`. This is the condition dragging the `develop` new-code reliability rating to D.

## Change

Treat two adjacent raw scores as a tie when they differ by less than `1e-9` instead of requiring bit-exact equality. This keeps the documented dense-ranking semantics (equal scores share a rank) while no longer splitting scores that differ only by floating-point noise.

Behavior is unchanged for realistic score distributions; all 15 `Granit.Indexing.Embeddings.Tests` pass.