### PR TITLE
test(identity): cover external-login callback redirect mode

### DIFF
--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -1088,6 +1088,49 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task ExternalLoginCallback_RedirectMode_Completed_Redirects302WithStatus()
+    {
+        const string frontendUrl = "http://localhost:5173/auth/external-callback";
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync(frontendUrl);
+        LocalIdentity user = new() { Id = AccountEndpointsTestServer.TestUserId, Email = "external@example.com" };
+        server.UserManager.FindByIdAsync(AccountEndpointsTestServer.TestUserIdString).Returns(user);
+        server.ExternalLoginService
+            .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "Google", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(ProcessCallbackResult.Existing(AccountEndpointsTestServer.TestUserId));
+
+        using HttpClient client = server.CreateNonRedirectingAnonymousClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/account/external-logins/callback");
+        request.Headers.Add(TestExternalAuthHandler.ProviderHeader, "Google");
+        HttpResponseMessage response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldStartWith(frontendUrl);
+        response.Headers.Location.Query.ShouldContain("status=completed");
+        await server.SignInManager.Received(1).SignInAsync(user, false, null);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_RedirectMode_NeedsProfile_Redirects302WithToken()
+    {
+        const string frontendUrl = "http://localhost:5173/auth/external-callback";
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync(frontendUrl);
+        server.ExternalLoginService
+            .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "Google", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(ProcessCallbackResult.NeedsProfile(
+                new ExternalProfilePrefill("Google", "pk-redir", Email: null, "Ada", "Lovelace", "ada")));
+
+        using HttpClient client = server.CreateNonRedirectingAnonymousClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/account/external-logins/callback");
+        request.Headers.Add(TestExternalAuthHandler.ProviderHeader, "Google");
+        HttpResponseMessage response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldStartWith(frontendUrl);
+        response.Headers.Location.Query.ShouldContain("status=needs-profile-completion");
+        response.Headers.Location.Query.ShouldContain("token=");
+    }
+
     private async Task<string> ObtainContinuationTokenAsync(string provider, string providerKey, string? email)
     {
         _server.ExternalLoginService

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -134,7 +134,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         DataFilter = dataFilter;
     }
 
-    public static async Task<AccountEndpointsTestServer> CreateAsync()
+    public static async Task<AccountEndpointsTestServer> CreateAsync(
+        string? externalLoginCallbackRedirectUrl = null)
     {
         // Service mocks
         IIdentityProvider identityProvider = Substitute.For<IIdentityProvider>();
@@ -242,7 +243,10 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
 
         // Options
         builder.Services.AddSingleton(
-            Microsoft.Extensions.Options.Options.Create(new AccountEndpointsOptions()));
+            Microsoft.Extensions.Options.Options.Create(new AccountEndpointsOptions
+            {
+                ExternalLoginCallbackRedirectUrl = externalLoginCallbackRedirectUrl,
+            }));
 
         // Real metrics (needs a real IMeterFactory)
         builder.Services.AddMetrics();
@@ -278,6 +282,13 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
             eventBus, fusionCache, settingProvider, timeProvider,
             signInManager, userManager, currentTenant, dataFilter);
     }
+
+    /// <summary>
+    /// Anonymous client that does NOT auto-follow redirects, so a 302 from the external-login
+    /// callback (redirect mode) can be inspected via its Location header.
+    /// </summary>
+    public HttpClient CreateNonRedirectingAnonymousClient() =>
+        new(_app.GetTestServer().CreateHandler()) { BaseAddress = new Uri("http://localhost") };
 
     public async ValueTask DisposeAsync()
     {


### PR DESCRIPTION
## Context

The external-login callback (PR #2613) has two response modes: JSON (headless / `?mode=json`) and a 302 redirect to a configured frontend URL. The merged tests only exercised JSON mode, leaving the redirect path (`BuildCallbackResult`, query construction) uncovered — part of the `develop` new-code coverage shortfall.

## Change

- Extend the endpoint test host: `CreateAsync` takes an optional `externalLoginCallbackRedirectUrl`, and a new `CreateNonRedirectingAnonymousClient()` lets a test inspect a 302 Location.
- Two tests: completed → 302 to the frontend URL with `status=completed` (and `SignInAsync` invoked); needs-profile → 302 with `status=needs-profile-completion` + `token`.

170/170 `Granit.Identity.Local.Endpoints.Tests` pass. Test-only; no production change.