### PR TITLE
refactor(quality): resolve Sonar code smells across the framework

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7562,12 +7562,6 @@
           "kind": "method",
           "signature": "IsNullOrWhiteSpace(Name)",
           "returnType": "string SchemeName => string."
-        },
-        {
-          "name": "IsNullOrWhiteSpace",
-          "kind": "method",
-          "signature": "IsNullOrWhiteSpace(DisplayName)",
-          "returnType": "string ResolvedDisplayName => string."
         }
       ]
     },
@@ -22983,7 +22977,14 @@
       "project": "Granit.Http.SecurityHeaders.Abstractions",
       "file": "src/Granit.Http.SecurityHeaders.Abstractions/AllowsPopupAuthorizationMetadata.cs",
       "line": 29,
-      "members": []
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "AllowsPopupAuthorizationMetadata Instance { get; } ="
+        }
+      ]
     },
     {
       "name": "CspBuilder",
@@ -39983,7 +39984,7 @@
       "kind": "record",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs",
-      "line": 579,
+      "line": 607,
       "members": []
     },
     {
@@ -40077,7 +40078,14 @@
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/Streaming/BlobBackedExportSource.cs",
       "line": 15,
-      "members": []
+      "members": [
+        {
+          "name": "StreamAsync",
+          "kind": "method",
+          "signature": "StreamAsync(IAsyncEnumerable<BlobBackedExportItem> items, PrivacyExportContext context, string providerName, CancellationToken cancellationToken)",
+          "returnType": "IAsyncEnumerable<ExportFragment>"
+        }
+      ]
     },
     {
       "name": "IBlobBackedExportSource",
@@ -43004,7 +43012,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Vault",
       "file": "src/Granit.Privacy.Vault/VaultExportHmacSigner.cs",
-      "line": 33,
+      "line": 32,
       "members": []
     },
     {

--- a/src/Granit.AI.Extraction/Internal/DefaultDocumentExtractor.cs
+++ b/src/Granit.AI.Extraction/Internal/DefaultDocumentExtractor.cs
@@ -67,7 +67,6 @@ internal sealed partial class DefaultDocumentExtractor<TResult>(
                 LogExtractionFailed(typeof(TResult).Name, result.Status.ToString());
                 return ExtractionResult.Failed<TResult>("Failed to deserialize the LLM response.", result.ModelId);
 
-            case StructuredCompletionStatus.TransportFailure:
             default:
                 LogExtractionFailed(typeof(TResult).Name, result.Status.ToString());
                 return ExtractionResult.Failed<TResult>(

--- a/src/Granit.AI/Tenancy/AIEndpointValidator.cs
+++ b/src/Granit.AI/Tenancy/AIEndpointValidator.cs
@@ -72,6 +72,25 @@ public static partial class AIEndpointValidator
             return AIEndpointValidationResult.Fail("endpoint.invalid_uri");
         }
 
+        AIEndpointValidationResult? shapeViolation = ValidateUriShape(uri, policy);
+        if (shapeViolation is not null)
+        {
+            return shapeViolation;
+        }
+
+        string host = uri.Host;
+        AIEndpointValidationResult? hostViolation = ValidateHost(uri, host, policy);
+        if (hostViolation is not null)
+        {
+            return hostViolation;
+        }
+
+        return AIEndpointValidationResult.Ok(resolvedHost: host);
+    }
+
+    /// <summary>Validates the URI's RFC 3986 shape: userinfo/fragment, scheme, and port allow-lists.</summary>
+    private static AIEndpointValidationResult? ValidateUriShape(Uri uri, AIEndpointPolicy policy)
+    {
         // RFC 3986 normalisation invariants (cheap defences against URL parsing tricks).
         if (!string.IsNullOrEmpty(uri.UserInfo))
         {
@@ -98,9 +117,14 @@ public static partial class AIEndpointValidator
             return AIEndpointValidationResult.Fail("endpoint.port_not_allowed");
         }
 
+        return null;
+    }
+
+    /// <summary>Validates the host: IDN homograph defence, metadata blocklists, and IP-literal ranges.</summary>
+    private static AIEndpointValidationResult? ValidateHost(Uri uri, string host, AIEndpointPolicy policy)
+    {
         // IDN normalisation: a Punycode-only difference between Host and IdnHost means a homograph
         // attempt with non-ASCII characters that became different ASCII after encoding.
-        string host = uri.Host;
         if (!string.Equals(host, uri.IdnHost, StringComparison.Ordinal))
         {
             // Re-check: the IdnHost is the canonical ASCII form. The Host being different means
@@ -129,26 +153,28 @@ public static partial class AIEndpointValidator
         // If the host is an IP literal, evaluate ranges directly (skip DNS).
         if (uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
         {
-            // Reject short-hand IPv4 encodings (decimal, octal, hex, compact dotted) by requiring
-            // a canonical 4-octet dotted-quad. IPAddress.TryParse accepts the other forms.
-            if (uri.HostNameType == UriHostNameType.IPv4 && !DottedQuadIPv4Regex().IsMatch(host))
-            {
-                return AIEndpointValidationResult.Fail("endpoint.non_canonical_ipv4");
-            }
-
-            if (!IPAddress.TryParse(host, out IPAddress? ip))
-            {
-                return AIEndpointValidationResult.Fail("endpoint.invalid_ip");
-            }
-
-            AIEndpointValidationResult? rangeViolation = CheckIpRanges(ip, policy);
-            if (rangeViolation is not null)
-            {
-                return rangeViolation;
-            }
+            return ValidateIpLiteral(uri, host, policy);
         }
 
-        return AIEndpointValidationResult.Ok(resolvedHost: host);
+        return null;
+    }
+
+    /// <summary>Validates an IP-literal host: canonical IPv4 form, parseability, and policy ranges.</summary>
+    private static AIEndpointValidationResult? ValidateIpLiteral(Uri uri, string host, AIEndpointPolicy policy)
+    {
+        // Reject short-hand IPv4 encodings (decimal, octal, hex, compact dotted) by requiring
+        // a canonical 4-octet dotted-quad. IPAddress.TryParse accepts the other forms.
+        if (uri.HostNameType == UriHostNameType.IPv4 && !DottedQuadIPv4Regex().IsMatch(host))
+        {
+            return AIEndpointValidationResult.Fail("endpoint.non_canonical_ipv4");
+        }
+
+        if (!IPAddress.TryParse(host, out IPAddress? ip))
+        {
+            return AIEndpointValidationResult.Fail("endpoint.invalid_ip");
+        }
+
+        return CheckIpRanges(ip, policy);
     }
 
     /// <summary>
@@ -165,12 +191,9 @@ public static partial class AIEndpointValidator
             return AIEndpointValidationResult.Fail("endpoint.loopback_blocked");
         }
 
-        if (!policy.AllowPrivateIp)
+        if (!policy.AllowPrivateIp && IsBlockedAddress(ip))
         {
-            if (IsBlockedAddress(ip))
-            {
-                return AIEndpointValidationResult.Fail("endpoint.private_ip_blocked");
-            }
+            return AIEndpointValidationResult.Fail("endpoint.private_ip_blocked");
         }
 
         // Cloud metadata literal IPs are blocked regardless of policy.
@@ -182,93 +205,48 @@ public static partial class AIEndpointValidator
         return null;
     }
 
-    private static bool IsBlockedAddress(IPAddress ip)
+    private static bool IsBlockedAddress(IPAddress ip) => ip.AddressFamily switch
     {
-        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+        System.Net.Sockets.AddressFamily.InterNetwork => IsBlockedIPv4(ip.GetAddressBytes()),
+        System.Net.Sockets.AddressFamily.InterNetworkV6 => IsBlockedIPv6(ip),
+        _ => false,
+    };
+
+    private static bool IsBlockedIPv4(byte[] bytes)
+    {
+        int b0 = bytes[0];
+        int b1 = bytes[1];
+
+        return b0 switch
         {
-            byte[] bytes = ip.GetAddressBytes();
-            int b0 = bytes[0];
-            int b1 = bytes[1];
+            10 => true,                              // RFC 1918 10.0.0.0/8
+            172 when b1 is >= 16 and <= 31 => true,  // RFC 1918 172.16.0.0/12
+            192 when b1 == 168 => true,              // RFC 1918 192.168.0.0/16
+            169 when b1 == 254 => true,              // Link-local — covers IMDS 169.254.169.254
+            100 when b1 is >= 64 and <= 127 => true, // CGNAT 100.64.0.0/10
+            0 => true,                               // 0.0.0.0/8 (this network)
+            >= 224 and <= 239 => true,               // Multicast 224.0.0.0/4
+            _ => false,
+        };
+    }
 
-            // RFC 1918
-            if (b0 == 10)
-            {
-                return true;
-            }
-            if (b0 == 172 && b1 >= 16 && b1 <= 31)
-            {
-                return true;
-            }
-            if (b0 == 192 && b1 == 168)
-            {
-                return true;
-            }
-
-            // Link-local — covers IMDS 169.254.169.254
-            if (b0 == 169 && b1 == 254)
-            {
-                return true;
-            }
-
-            // CGNAT 100.64.0.0/10
-            if (b0 == 100 && b1 >= 64 && b1 <= 127)
-            {
-                return true;
-            }
-
-            // 0.0.0.0/8 (this network)
-            if (b0 == 0)
-            {
-                return true;
-            }
-
-            // Multicast 224.0.0.0/4
-            if (b0 >= 224 && b0 <= 239)
-            {
-                return true;
-            }
-        }
-        else if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+    private static bool IsBlockedIPv6(IPAddress ip)
+    {
+        // ::1 loopback handled by IPAddress.IsLoopback above.
+        // IPv4-mapped IPv6 (::ffff:0:0/96) — extract the embedded IPv4 and re-check.
+        if (ip.IsIPv4MappedToIPv6)
         {
-            // ::1 loopback handled by IPAddress.IsLoopback above.
-
-            // IPv4-mapped IPv6 (::ffff:0:0/96) — extract the embedded IPv4 and re-check.
-            if (ip.IsIPv4MappedToIPv6)
-            {
-                return IsBlockedAddress(ip.MapToIPv4());
-            }
-
-            byte[] bytes = ip.GetAddressBytes();
-            int firstByte = bytes[0];
-
-            // fc00::/7 — Unique local address
-            if ((firstByte & 0xFE) == 0xFC)
-            {
-                return true;
-            }
-
-            // fe80::/10 — Link-local
-            if (firstByte == 0xFE && (bytes[1] & 0xC0) == 0x80)
-            {
-                return true;
-            }
-
-            // Multicast ff00::/8
-            if (firstByte == 0xFF)
-            {
-                return true;
-            }
-
-            // Documentation 2001:db8::/32 — IsIPv6Documentation is not exposed on .NET 10's
-            // IPAddress, so check manually.
-            if (firstByte == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8)
-            {
-                return true;
-            }
-
-            // ::ffff:x.x.x.x with the IPv4 portion being a metadata IP is covered by IsIPv4MappedToIPv6 above.
+            return IsBlockedIPv4(ip.MapToIPv4().GetAddressBytes());
         }
 
-        return false;
+        byte[] bytes = ip.GetAddressBytes();
+        int firstByte = bytes[0];
+
+        // fc00::/7 ULA; fe80::/10 link-local; ff00::/8 multicast; 2001:db8::/32 documentation
+        // (IsIPv6Documentation is not exposed on .NET 10's IPAddress, so check manually).
+        return (firstByte & 0xFE) == 0xFC
+            || (firstByte == 0xFE && (bytes[1] & 0xC0) == 0x80)
+            || firstByte == 0xFF
+            || (firstByte == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8);
     }
 }

--- a/src/Granit.AI/Tenancy/GranitSafeConnectCallback.cs
+++ b/src/Granit.AI/Tenancy/GranitSafeConnectCallback.cs
@@ -50,15 +50,8 @@ public static class GranitSafeConnectCallback
         IPAddress[] addresses = await Dns.GetHostAddressesAsync(endpoint.Host, cancellationToken).ConfigureAwait(false);
 
         // Pick the first address that passes the policy.
-        IPAddress? acceptable = null;
-        foreach (IPAddress ip in addresses)
-        {
-            if (AIEndpointValidator.CheckIpRanges(ip, policy) is null)
-            {
-                acceptable = ip;
-                break;
-            }
-        }
+        IPAddress? acceptable = addresses.FirstOrDefault(
+            ip => AIEndpointValidator.CheckIpRanges(ip, policy) is null);
 
         if (acceptable is null)
         {

--- a/src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs
+++ b/src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs
@@ -85,25 +85,7 @@ public sealed class PrivacyExportSubjectSubstitutionAnalyzer : SingleRuleAnalyze
             return;
         }
 
-        ArgumentSyntax? subjectArg = null;
-        ArgumentSyntax? callerArg = null;
-
-        for (int i = 0; i < creation.ArgumentList.Arguments.Count; i++)
-        {
-            ArgumentSyntax arg = creation.ArgumentList.Arguments[i];
-            string? parameterName = arg.NameColon?.Name.Identifier.Text
-                ?? (i < ctor.Parameters.Length ? ctor.Parameters[i].Name : null);
-
-            if (parameterName == "SubjectUserId")
-            {
-                subjectArg = arg;
-            }
-            else if (parameterName == "CallerUserId")
-            {
-                callerArg = arg;
-            }
-        }
-
+        (ArgumentSyntax? subjectArg, ArgumentSyntax? callerArg) = FindSubjectAndCallerArgs(creation, ctor);
         if (subjectArg is null || callerArg is null)
         {
             return;
@@ -129,5 +111,33 @@ public sealed class PrivacyExportSubjectSubstitutionAnalyzer : SingleRuleAnalyze
             creation.GetLocation(),
             subjectArg.Expression.ToString(),
             callerArg.Expression.ToString()));
+    }
+
+    // Matches the SubjectUserId / CallerUserId arguments by name (named-colon) or by
+    // positional index against the constructor's parameter list.
+    private static (ArgumentSyntax? Subject, ArgumentSyntax? Caller) FindSubjectAndCallerArgs(
+        BaseObjectCreationExpressionSyntax creation, IMethodSymbol ctor)
+    {
+        ArgumentSyntax? subjectArg = null;
+        ArgumentSyntax? callerArg = null;
+
+        SeparatedSyntaxList<ArgumentSyntax> arguments = creation.ArgumentList!.Arguments;
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            ArgumentSyntax arg = arguments[i];
+            string? parameterName = arg.NameColon?.Name.Identifier.Text
+                ?? (i < ctor.Parameters.Length ? ctor.Parameters[i].Name : null);
+
+            if (parameterName == "SubjectUserId")
+            {
+                subjectArg = arg;
+            }
+            else if (parameterName == "CallerUserId")
+            {
+                callerArg = arg;
+            }
+        }
+
+        return (subjectArg, callerArg);
     }
 }

--- a/src/Granit.Auditing.Privacy/DataExport/AuditingPrivacyDataProvider.cs
+++ b/src/Granit.Auditing.Privacy/DataExport/AuditingPrivacyDataProvider.cs
@@ -45,12 +45,18 @@ public sealed class AuditingPrivacyDataProvider(
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+    public IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return ExportCoreAsync(context, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<ExportFragment> ExportCoreAsync(
         PrivacyExportContext context,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(context);
-
         List<AuditEntry> entries = await reader
             .GetByUserAsync(context.SubjectUserId.ToString(), AuditExportLimit, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Authentication.ApiKeys.Notifications/Internal/ApiKeysNotificationDefinitionProvider.cs
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Internal/ApiKeysNotificationDefinitionProvider.cs
@@ -10,6 +10,7 @@ namespace Granit.Authentication.ApiKeys.Notifications.Internal;
 internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefinitionProvider
 {
     private const string GroupName = "Security";
+    private const string ReadPermission = "AuthenticationApiKeys.Keys.Read";
 
     public void Define(INotificationDefinitionContext context)
     {
@@ -21,7 +22,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Info,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
-            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
+            RequiredPermission = ReadPermission,
         });
 
         context.Add(new NotificationDefinition(ApiKeyRotatedNotificationType.Instance.Name)
@@ -32,7 +33,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Info,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
-            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
+            RequiredPermission = ReadPermission,
         });
 
         context.Add(new NotificationDefinition(ApiKeyRevokedNotificationType.Instance.Name)
@@ -43,7 +44,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Info,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
-            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
+            RequiredPermission = ReadPermission,
         });
 
         context.Add(new NotificationDefinition(ApiKeyExpiringSoonNotificationType.Instance.Name)
@@ -54,7 +55,7 @@ internal sealed class ApiKeysNotificationDefinitionProvider : INotificationDefin
             DefaultSeverity = NotificationSeverity.Warning,
             DefaultChannels = [NotificationChannels.Email, NotificationChannels.InApp],
             AllowUserOptOut = false,
-            RequiredPermission = "AuthenticationApiKeys.Keys.Read",
+            RequiredPermission = ReadPermission,
         });
     }
 }

--- a/src/Granit.Authentication.External/Options/ExternalAuthProvider.cs
+++ b/src/Granit.Authentication.External/Options/ExternalAuthProvider.cs
@@ -63,7 +63,16 @@ public sealed class ExternalAuthProvider
     /// provider <see cref="Type"/> (already display-ready for Google/Microsoft/Apple/GitHub/Facebook),
     /// or the <see cref="SchemeName"/> for the generic <c>Oidc</c> provider.
     /// </summary>
-    public string ResolvedDisplayName => string.IsNullOrWhiteSpace(DisplayName)
-        ? (string.Equals(Type, "Oidc", StringComparison.OrdinalIgnoreCase) ? SchemeName : Type)
-        : DisplayName!;
+    public string ResolvedDisplayName
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(DisplayName))
+            {
+                return DisplayName;
+            }
+
+            return string.Equals(Type, "Oidc", StringComparison.OrdinalIgnoreCase) ? SchemeName : Type;
+        }
+    }
 }

--- a/src/Granit.Bff.Endpoints/Endpoints/BffBackChannelLogoutEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffBackChannelLogoutEndpoints.cs
@@ -166,10 +166,13 @@ internal static partial class BffBackChannelLogoutEndpoints
         string? correlationId = Activity.Current?.Id;
         const string Method = "bff_backchannel_logout";
 
+        string successUserId = string.IsNullOrEmpty(userId)
+            ? AuthenticationAuditEntry.UnknownUserSentinel
+            : userId;
         AuditEntry entry = failureReason is null
             ? AuthenticationAuditEntry.CreateSuccess(
                 timeProvider.GetUtcNow(),
-                userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
+                userId: successUserId,
                 userName: null, method: Method,
                 tenantId, ipAddress, userAgent, correlationId)
             : AuthenticationAuditEntry.CreateFailure(

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -171,6 +171,35 @@ internal static partial class BffLoginEndpoints
         return TypedResults.Redirect(authorizeUrl);
     }
 
+    // Validates the authorization-response issuer (RFC 9207). Returns an error redirect to send
+    // back, or null when the issuer is present and matches the configured authority.
+    private static async Task<RedirectHttpResult?> ValidateCallbackIssuerAsync(
+        HttpContext httpContext, GranitBffOptions bffOptions, BffFrontendOptions frontend,
+        string? iss, CancellationToken cancellationToken)
+    {
+        ILogger logger = httpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.Bff.Endpoints.BffLoginEndpoints");
+        string expectedIssuer = bffOptions.Authority.ToString().TrimEnd('/');
+
+        if (string.IsNullOrEmpty(iss))
+        {
+            LogIssuerMissing(logger, frontend.Name);
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: "issuer_missing", cancellationToken).ConfigureAwait(false);
+            return RedirectToError(frontend, "issuer_missing");
+        }
+
+        if (!string.Equals(iss.TrimEnd('/'), expectedIssuer, StringComparison.OrdinalIgnoreCase))
+        {
+            LogIssuerMismatch(logger, iss, expectedIssuer, frontend.Name);
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: "issuer_mismatch", cancellationToken).ConfigureAwait(false);
+            return RedirectToError(frontend, "issuer_mismatch");
+        }
+
+        return null;
+    }
+
     private static async Task<RedirectHttpResult> HandleCallbackAsync(
         HttpContext httpContext,
         BffFrontendOptions frontend,
@@ -210,22 +239,11 @@ internal static partial class BffLoginEndpoints
         // Verify authorization response issuer (RFC 9207, FAPI 2.0 §5.3.3.2)
         if (bffOptions.RequireIssuerValidation)
         {
-            string expectedIssuer = bffOptions.Authority.ToString().TrimEnd('/');
-
-            if (string.IsNullOrEmpty(iss))
+            RedirectHttpResult? issuerError = await ValidateCallbackIssuerAsync(
+                httpContext, bffOptions, frontend, iss, cancellationToken).ConfigureAwait(false);
+            if (issuerError is not null)
             {
-                LogIssuerMissing(logger, frontend.Name);
-                await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
-                    failureReason: "issuer_missing", cancellationToken).ConfigureAwait(false);
-                return RedirectToError(frontend, "issuer_missing");
-            }
-
-            if (!string.Equals(iss.TrimEnd('/'), expectedIssuer, StringComparison.OrdinalIgnoreCase))
-            {
-                LogIssuerMismatch(logger, iss, expectedIssuer, frontend.Name);
-                await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
-                    failureReason: "issuer_mismatch", cancellationToken).ConfigureAwait(false);
-                return RedirectToError(frontend, "issuer_mismatch");
+                return issuerError;
             }
         }
 

--- a/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
+++ b/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
@@ -59,36 +59,8 @@ public static partial class ApiDocumentationApplicationBuilderExtensions
         }
 
         IEndpointConventionBuilder scalarEndpoint =
-            app.MapScalarApiReference(scalarOptions =>
-            {
-                scalarOptions.WithTitle(options.Title);
-
-                if (!string.IsNullOrEmpty(options.FaviconUrl))
-                {
-                    scalarOptions.WithFavicon(options.FaviconUrl);
-                }
-
-                if (options.OAuth2.IsConfigured)
-                {
-                    scalarOptions.AddAuthorizationCodeFlow("OAuth2", flow =>
-                    {
-                        flow
-                            .WithClientId(options.OAuth2.ClientId!)
-                            .WithSelectedScopes(options.OAuth2.Scopes);
-
-                        if (options.OAuth2.EnablePkce)
-                        {
-                            flow.WithPkce(Pkce.Sha256);
-                        }
-
-                        if (!string.IsNullOrEmpty(options.OAuth2.RedirectUri))
-                        {
-                            flow.WithRedirectUri(options.OAuth2.RedirectUri);
-                        }
-                    });
-                }
-            });
-        scalarEndpoint.WithMetadata(new ScalarApiReferenceMetadata());
+            app.MapScalarApiReference(scalarOptions => ConfigureScalar(scalarOptions, options));
+        scalarEndpoint.WithMetadata(ScalarApiReferenceMetadata.Instance);
 
         // Scalar's Authorize button opens the IdP in a popup and polls the
         // popup's location for the auth code. The framework default COOP
@@ -99,7 +71,7 @@ public static partial class ApiDocumentationApplicationBuilderExtensions
         // Only needed when OAuth2 is wired — otherwise no popup is opened.
         if (options.OAuth2.IsConfigured)
         {
-            scalarEndpoint.WithMetadata(new AllowsPopupAuthorizationMetadata());
+            scalarEndpoint.WithMetadata(AllowsPopupAuthorizationMetadata.Instance);
         }
 
         ApplyAuthorizationPolicy(scalarEndpoint, options.AuthorizationPolicy);
@@ -126,6 +98,38 @@ public static partial class ApiDocumentationApplicationBuilderExtensions
     /// unresolved — the contributor registration is a no-op (logged at
     /// Debug) and the consumer is left to manage CSP externally.
     /// </remarks>
+    private static void ConfigureScalar(ScalarOptions scalarOptions, ApiDocumentationOptions options)
+    {
+        scalarOptions.WithTitle(options.Title);
+
+        if (!string.IsNullOrEmpty(options.FaviconUrl))
+        {
+            scalarOptions.WithFavicon(options.FaviconUrl);
+        }
+
+        if (options.OAuth2.IsConfigured)
+        {
+            scalarOptions.AddAuthorizationCodeFlow("OAuth2", flow => ConfigureOAuth2Flow(flow, options.OAuth2));
+        }
+    }
+
+    private static void ConfigureOAuth2Flow(AuthorizationCodeFlow flow, Options.OAuth2Options oauth2)
+    {
+        flow
+            .WithClientId(oauth2.ClientId!)
+            .WithSelectedScopes(oauth2.Scopes);
+
+        if (oauth2.EnablePkce)
+        {
+            flow.WithPkce(Pkce.Sha256);
+        }
+
+        if (!string.IsNullOrEmpty(oauth2.RedirectUri))
+        {
+            flow.WithRedirectUri(oauth2.RedirectUri);
+        }
+    }
+
     private static void RegisterScalarCspContributor(WebApplication app)
     {
         ICspContributorRegistry? registry =

--- a/src/Granit.Http.ApiDocumentation/Internal/ScalarApiReferenceMetadata.cs
+++ b/src/Granit.Http.ApiDocumentation/Internal/ScalarApiReferenceMetadata.cs
@@ -7,4 +7,8 @@ namespace Granit.Http.ApiDocumentation.Internal;
 /// <c>context.GetEndpoint()?.Metadata.GetMetadata&lt;ScalarApiReferenceMetadata&gt;()</c>
 /// to scope the CSP relaxation to the Scalar route only.
 /// </summary>
-internal sealed class ScalarApiReferenceMetadata;
+internal sealed class ScalarApiReferenceMetadata
+{
+    /// <summary>Shared stateless marker instance.</summary>
+    public static ScalarApiReferenceMetadata Instance { get; } = new();
+}

--- a/src/Granit.Http.ApiDocumentation/Internal/ScalarCspContributor.cs
+++ b/src/Granit.Http.ApiDocumentation/Internal/ScalarCspContributor.cs
@@ -31,6 +31,8 @@ namespace Granit.Http.ApiDocumentation.Internal;
 /// </remarks>
 internal sealed class ScalarCspContributor(IOptions<ApiDocumentationOptions> options) : ICspContributor
 {
+    private const string SelfSource = "'self'";
+
     private readonly ApiDocumentationOptions _options = options.Value;
 
     public void Contribute(HttpContext context, CspBuilder builder)
@@ -40,15 +42,15 @@ internal sealed class ScalarCspContributor(IOptions<ApiDocumentationOptions> opt
             return;
         }
 
-        List<string> connectSources = ["'self'", "https://api.scalar.com"];
+        List<string> connectSources = [SelfSource, "https://api.scalar.com"];
         AddOrigin(connectSources, _options.OAuth2.AuthorizationUrl);
         AddOrigin(connectSources, _options.OAuth2.TokenUrl);
 
         builder
-            .AddScriptSrc("'self'", "'unsafe-inline'", "'unsafe-eval'")
-            .AddStyleSrc("'self'", "'unsafe-inline'")
-            .AddFontSrc("'self'", "data:", "https://fonts.scalar.com")
-            .AddImgSrc("'self'", "data:", "https:")
+            .AddScriptSrc(SelfSource, "'unsafe-inline'", "'unsafe-eval'")
+            .AddStyleSrc(SelfSource, "'unsafe-inline'")
+            .AddFontSrc(SelfSource, "data:", "https://fonts.scalar.com")
+            .AddImgSrc(SelfSource, "data:", "https:")
             .AddConnectSrc([.. connectSources.Distinct()]);
     }
 

--- a/src/Granit.Http.SecurityHeaders.Abstractions/AllowsPopupAuthorizationMetadata.cs
+++ b/src/Granit.Http.SecurityHeaders.Abstractions/AllowsPopupAuthorizationMetadata.cs
@@ -26,4 +26,8 @@ namespace Granit.Http.SecurityHeaders;
 /// JSON/data endpoints.
 /// </para>
 /// </remarks>
-public sealed class AllowsPopupAuthorizationMetadata;
+public sealed class AllowsPopupAuthorizationMetadata
+{
+    /// <summary>Shared stateless marker instance.</summary>
+    public static AllowsPopupAuthorizationMetadata Instance { get; } = new();
+}

--- a/src/Granit.Http.SecurityHeaders.Abstractions/CspBuilder.cs
+++ b/src/Granit.Http.SecurityHeaders.Abstractions/CspBuilder.cs
@@ -208,16 +208,13 @@ public sealed class CspBuilder
         // Reject directive separators, CR/LF, NUL, and all C0 controls + DEL.
         // These would either break the CSP header (newline → header injection)
         // or silently produce a malformed policy that browsers ignore.
-        foreach (char c in source)
+        if (source.Any(c => c == ';' || c == '\r' || c == '\n' || c < 0x20 || c == 0x7F))
         {
-            if (c == ';' || c == '\r' || c == '\n' || c < 0x20 || c == 0x7F)
-            {
-                throw new ArgumentException(
-                    "Invalid CSP source: directive separators (';') and control " +
-                    "characters (CR, LF, NUL, C0, DEL) are not allowed. " +
-                    $"Got source '{Sanitise(source)}'.",
-                    nameof(source));
-            }
+            throw new ArgumentException(
+                "Invalid CSP source: directive separators (';') and control " +
+                "characters (CR, LF, NUL, C0, DEL) are not allowed. " +
+                $"Got source '{Sanitise(source)}'.",
+                nameof(source));
         }
     }
 

--- a/src/Granit.Http.SecurityHeaders/Internal/CspComposer.cs
+++ b/src/Granit.Http.SecurityHeaders/Internal/CspComposer.cs
@@ -172,6 +172,14 @@ internal sealed partial class CspComposer : IDisposable
         StringBuilder sb = new();
         bool first = true;
 
+        AppendDirectives(sb, builder, ref first);
+        AppendReportingHints(sb, builder, csp, includeBuilderReporting, ref first);
+
+        return sb.ToString();
+    }
+
+    private static void AppendDirectives(StringBuilder sb, CspBuilder builder, ref bool first)
+    {
         foreach (string directive in CspDirectiveNames.All)
         {
             if (!builder.Directives.TryGetValue(directive, out IReadOnlyCollection<string>? sources)
@@ -195,7 +203,11 @@ internal sealed partial class CspComposer : IDisposable
                 sb.Append(' ').Append(source);
             }
         }
+    }
 
+    private static void AppendReportingHints(
+        StringBuilder sb, CspBuilder builder, CspOptions csp, bool includeBuilderReporting, ref bool first)
+    {
         // Reporting hints — builder state takes precedence over options
         // (a contributor that sets ReportUri overrides the global default).
         string? reportUri = includeBuilderReporting ? builder.ReportUri ?? csp.ReportUri : csp.ReportUri;
@@ -222,8 +234,6 @@ internal sealed partial class CspComposer : IDisposable
             if (!first) { sb.Append("; "); }
             sb.Append("upgrade-insecure-requests");
         }
-
-        return sb.ToString();
     }
 
     private static string HeaderName(bool reportOnly) =>
@@ -265,15 +275,8 @@ internal sealed partial class CspComposer : IDisposable
             return;
         }
 
-        bool anyUnsafeInline = false;
-        foreach (KeyValuePair<string, IReadOnlyCollection<string>> directive in builder.Directives)
-        {
-            if (directive.Value.Contains("'unsafe-inline'"))
-            {
-                anyUnsafeInline = true;
-                break;
-            }
-        }
+        bool anyUnsafeInline = builder.Directives.Any(
+            directive => directive.Value.Contains("'unsafe-inline'"));
 
         if (!anyUnsafeInline)
         {
@@ -283,12 +286,10 @@ internal sealed partial class CspComposer : IDisposable
         // One warning per distinct contributor name observed in a composition
         // that emits 'unsafe-inline'. Best-effort attribution: we can't know
         // which contributor wrote the source, so we name all of them.
-        foreach (string name in activeNames)
+        // TryAdd doubles as the de-dup filter — the lazy Where keeps it one log per name.
+        foreach (string name in activeNames.Where(name => _loggedProdUnsafeInline.TryAdd(name, 0)))
         {
-            if (_loggedProdUnsafeInline.TryAdd(name, 0))
-            {
-                LogProductionUnsafeInline(name);
-            }
+            LogProductionUnsafeInline(name);
         }
     }
 

--- a/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPrivacyDataProvider.cs
@@ -46,12 +46,18 @@ public sealed class IdentityFederatedPrivacyDataProvider(
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+    public IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return ExportCoreAsync(context, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<ExportFragment> ExportCoreAsync(
         PrivacyExportContext context,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(context);
-
         string externalUserId = context.SubjectUserId.ToString();
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -31,6 +31,10 @@ namespace Granit.Identity.Local.Endpoints.Endpoints;
 /// </summary>
 internal static partial class AccountLoginEndpoints
 {
+    private const string LocalLoginMethod = "password";
+    private const string InvalidLoginReason = "invalid_credentials";
+    private const string AccountLockedReason = "account_locked";
+
     internal static RouteGroupBuilder MapAccountLoginEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/login", HandleLoginAsync)
@@ -100,7 +104,7 @@ internal static partial class AccountLoginEndpoints
 
         using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
             IdentityLocalActivitySource.UserAuthentication);
-        activity?.SetTag(IdentityLocalActivitySource.TagProvider, "password");
+        activity?.SetTag(IdentityLocalActivitySource.TagProvider, LocalLoginMethod);
 
         return await HandleLoginCoreAsync(
             request, signInManager, userManager, httpContext, cancellationToken)
@@ -148,10 +152,10 @@ internal static partial class AccountLoginEndpoints
             PerformDummyPasswordHash(httpContext);
 
             LogLoginFailed(logger, request.Login, "user_not_found");
-            metrics?.RecordAuthenticationFailure(null, "invalid_credentials");
+            metrics?.RecordAuthenticationFailure(null, InvalidLoginReason);
             await TryWriteAuthAuditAsync(httpContext, logger,
-                method: "password", userId: null, userName: null,
-                failureReason: "invalid_credentials", cancellationToken).ConfigureAwait(false);
+                method: LocalLoginMethod, userId: null, userName: null,
+                failureReason: InvalidLoginReason, cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Problem(
                 detail: AccountEndpointMessages.Localize(
@@ -173,9 +177,9 @@ internal static partial class AccountLoginEndpoints
         if (result.Succeeded)
         {
             LogLoginSuccess(logger, user.Id.ToString());
-            metrics?.RecordAuthenticationSuccess(null, "password");
+            metrics?.RecordAuthenticationSuccess(null, LocalLoginMethod);
             await TryWriteAuthAuditAsync(httpContext, logger,
-                method: "password", userId: user.Id.ToString(), userName: user.UserName,
+                method: LocalLoginMethod, userId: user.Id.ToString(), userName: user.UserName,
                 failureReason: null, cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
@@ -201,13 +205,13 @@ internal static partial class AccountLoginEndpoints
         if (result.IsLockedOut)
         {
             LogLoginLockedOut(logger, user.Id.ToString());
-            metrics?.RecordAuthenticationFailure(null, "account_locked");
+            metrics?.RecordAuthenticationFailure(null, AccountLockedReason);
 
             await PublishAccountLockedAsync(httpContext, userManager, user, cancellationToken)
                 .ConfigureAwait(false);
             await TryWriteAuthAuditAsync(httpContext, logger,
-                method: "password", userId: user.Id.ToString(), userName: user.UserName,
-                failureReason: "account_locked", cancellationToken).ConfigureAwait(false);
+                method: LocalLoginMethod, userId: user.Id.ToString(), userName: user.UserName,
+                failureReason: AccountLockedReason, cancellationToken).ConfigureAwait(false);
 
             // Return 401 (same as invalid credentials) to prevent account enumeration.
             // The user is notified of the lockout exclusively via email.
@@ -222,7 +226,7 @@ internal static partial class AccountLoginEndpoints
             LogLoginNotAllowed(logger, user.Id.ToString());
             metrics?.RecordAuthenticationFailure(null, "email_not_confirmed");
             await TryWriteAuthAuditAsync(httpContext, logger,
-                method: "password", userId: user.Id.ToString(), userName: user.UserName,
+                method: LocalLoginMethod, userId: user.Id.ToString(), userName: user.UserName,
                 failureReason: "email_not_confirmed", cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Problem(
@@ -233,10 +237,10 @@ internal static partial class AccountLoginEndpoints
 
         // Generic failure (wrong password)
         LogLoginFailed(logger, request.Login, "invalid_password");
-        metrics?.RecordAuthenticationFailure(null, "invalid_credentials");
+        metrics?.RecordAuthenticationFailure(null, InvalidLoginReason);
         await TryWriteAuthAuditAsync(httpContext, logger,
-            method: "password", userId: user.Id.ToString(), userName: user.UserName,
-            failureReason: "invalid_credentials", cancellationToken).ConfigureAwait(false);
+            method: LocalLoginMethod, userId: user.Id.ToString(), userName: user.UserName,
+            failureReason: InvalidLoginReason, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Problem(
             detail: AccountEndpointMessages.Localize(
@@ -359,7 +363,7 @@ internal static partial class AccountLoginEndpoints
                 .ConfigureAwait(false);
 
             LogLoginLockedOut(logger, lockedUser?.Id.ToString() ?? "two-factor-user");
-            metrics?.RecordAuthenticationFailure(null, "account_locked");
+            metrics?.RecordAuthenticationFailure(null, AccountLockedReason);
 
             if (lockedUser is not null)
             {
@@ -372,7 +376,7 @@ internal static partial class AccountLoginEndpoints
                 method: method,
                 userId: lockedUser?.Id.ToString(),
                 userName: lockedUser?.UserName,
-                failureReason: "account_locked",
+                failureReason: AccountLockedReason,
                 cancellationToken).ConfigureAwait(false);
 
             // Return 401 (same as invalid code) to prevent account enumeration.

--- a/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
@@ -39,12 +39,18 @@ public sealed class IdentityLocalPrivacyDataProvider(
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+    public IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return ExportCoreAsync(context, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<ExportFragment> ExportCoreAsync(
         PrivacyExportContext context,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(context);
-
         LocalIdentity? user = await userManager.FindByIdAsync(context.SubjectUserId.ToString()).ConfigureAwait(false);
         if (user is null)
         {

--- a/src/Granit.Indexing.AI/Diagnostics/IndexingAIMetrics.cs
+++ b/src/Granit.Indexing.AI/Diagnostics/IndexingAIMetrics.cs
@@ -16,6 +16,9 @@ public sealed class IndexingAIMetrics
 {
     public const string MeterName = "Granit.Indexing.AI";
 
+    internal const string TenantIdTag = "tenant_id";
+    internal const string GlobalTenant = "global";
+
     private readonly Counter<long> _summarizerAttempted;
     private readonly Counter<long> _summarizerThrottled;
     private readonly Counter<long> _summarizerFailed;
@@ -77,13 +80,13 @@ public sealed class IndexingAIMetrics
 
     public void RecordSummarizerAttempted(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _summarizerAttempted.Add(1, tags);
     }
 
     public void RecordSummarizerThrottled(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _summarizerThrottled.Add(1, tags);
     }
 
@@ -91,7 +94,7 @@ public sealed class IndexingAIMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("reason", reason),
         ];
         _summarizerFailed.Add(1, tags);
@@ -99,25 +102,25 @@ public sealed class IndexingAIMetrics
 
     public void RecordSummarizerTruncated(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _summarizerTruncated.Add(1, tags);
     }
 
     public void RecordSummarizerInjection(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _summarizerInjection.Add(1, tags);
     }
 
     public void RecordAutoTaggerAttempted(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _autoTaggerAttempted.Add(1, tags);
     }
 
     public void RecordAutoTaggerThrottled(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _autoTaggerThrottled.Add(1, tags);
     }
 
@@ -125,7 +128,7 @@ public sealed class IndexingAIMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("reason", reason),
         ];
         _autoTaggerFailed.Add(1, tags);
@@ -133,7 +136,7 @@ public sealed class IndexingAIMetrics
 
     public void RecordAutoTaggerInjection(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _autoTaggerInjection.Add(1, tags);
     }
 
@@ -143,7 +146,7 @@ public sealed class IndexingAIMetrics
         {
             return;
         }
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _autoTaggerOutOfCandidate.Add(droppedCount, tags);
     }
 }

--- a/src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Indexing.AI/Extensions/ServiceCollectionExtensions.cs
@@ -89,12 +89,15 @@ public static class ServiceCollectionExtensions
         // (summarizer / auto-tagger) — gate on a marker so the probe is added exactly once.
         if (!services.Any(d => d.ServiceType == typeof(RedactionWarningMarker)))
         {
-            services.AddSingleton<RedactionWarningMarker>();
+            services.AddSingleton(RedactionWarningMarker.Instance);
             services.AddAIRedactionStartupWarning(
                 "Granit.Indexing.AI",
                 sp => sp.GetRequiredService<IOptions<IndexingAIOptions>>().Value.RedactPIIBeforeLLMCall);
         }
     }
 
-    private sealed class RedactionWarningMarker;
+    private sealed class RedactionWarningMarker
+    {
+        public static readonly RedactionWarningMarker Instance = new();
+    }
 }

--- a/src/Granit.Indexing.AI/Internal/AIAutoTagger.cs
+++ b/src/Granit.Indexing.AI/Internal/AIAutoTagger.cs
@@ -100,7 +100,7 @@ internal sealed partial class AIAutoTagger : IAutoTagger
             return [];
         }
 
-        string bucketKey = $"indexing_autotag:{tenantId ?? "global"}";
+        string bucketKey = $"indexing_autotag:{tenantId ?? IndexingAIMetrics.GlobalTenant}";
         bool admitted = await _rateLimiter
             .TryAcquireAsync(bucketKey, _options.MaxAutoTagCallsPerHourPerTenant, cancellationToken)
             .ConfigureAwait(false);
@@ -108,7 +108,7 @@ internal sealed partial class AIAutoTagger : IAutoTagger
         if (!admitted)
         {
             _metrics.RecordAutoTaggerThrottled(tenantId);
-            LogThrottled(tenantId ?? "global");
+            LogThrottled(tenantId ?? IndexingAIMetrics.GlobalTenant);
             return [];
         }
 
@@ -150,17 +150,16 @@ internal sealed partial class AIAutoTagger : IAutoTagger
                     _metrics.RecordAutoTaggerInjection(tenantId);
                     return [];
 
-                case StructuredCompletionStatus.TransportFailure:
                 default:
                     _metrics.RecordAutoTaggerFailed(tenantId, "transport");
-                    LogTransportFailure(tenantId ?? "global", result.Status.ToString());
+                    LogTransportFailure(tenantId ?? IndexingAIMetrics.GlobalTenant, result.Status.ToString());
                     return [];
             }
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             _metrics.RecordAutoTaggerFailed(tenantId, "timeout");
-            LogTimeout(tenantId ?? "global", _options.TimeoutSeconds);
+            LogTimeout(tenantId ?? IndexingAIMetrics.GlobalTenant, _options.TimeoutSeconds);
             return [];
         }
     }
@@ -202,7 +201,7 @@ internal sealed partial class AIAutoTagger : IAutoTagger
         if (dropped > 0)
         {
             _metrics.RecordAutoTaggerOutOfCandidate(tenantId, dropped);
-            LogOutOfCandidate(tenantId ?? "global", dropped);
+            LogOutOfCandidate(tenantId ?? IndexingAIMetrics.GlobalTenant, dropped);
         }
 
         return kept;

--- a/src/Granit.Indexing.AI/Internal/AISummarizer.cs
+++ b/src/Granit.Indexing.AI/Internal/AISummarizer.cs
@@ -83,7 +83,7 @@ internal sealed partial class AISummarizer : ISummarizer
         _ = language;
 
         string? tenantId = _currentTenant.Id?.ToString();
-        string bucketKey = $"indexing_summarizer:{tenantId ?? "global"}";
+        string bucketKey = $"indexing_summarizer:{tenantId ?? IndexingAIMetrics.GlobalTenant}";
 
         bool admitted = await _rateLimiter
             .TryAcquireAsync(bucketKey, _options.MaxAICallsPerHourPerTenant, cancellationToken)
@@ -92,7 +92,7 @@ internal sealed partial class AISummarizer : ISummarizer
         if (!admitted)
         {
             _metrics.RecordSummarizerThrottled(tenantId);
-            LogThrottled(tenantId ?? "global");
+            LogThrottled(tenantId ?? IndexingAIMetrics.GlobalTenant);
             return null;
         }
 
@@ -132,17 +132,16 @@ internal sealed partial class AISummarizer : ISummarizer
                     _metrics.RecordSummarizerInjection(tenantId);
                     return null;
 
-                case StructuredCompletionStatus.TransportFailure:
                 default:
                     _metrics.RecordSummarizerFailed(tenantId, "transport");
-                    LogTransportFailure(tenantId ?? "global", result.Status.ToString());
+                    LogTransportFailure(tenantId ?? IndexingAIMetrics.GlobalTenant, result.Status.ToString());
                     return null;
             }
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             _metrics.RecordSummarizerFailed(tenantId, "timeout");
-            LogTimeout(tenantId ?? "global", _options.TimeoutSeconds);
+            LogTimeout(tenantId ?? IndexingAIMetrics.GlobalTenant, _options.TimeoutSeconds);
             return null;
         }
     }

--- a/src/Granit.Indexing.BackgroundJobs/Services/RebuildIndexService.cs
+++ b/src/Granit.Indexing.BackgroundJobs/Services/RebuildIndexService.cs
@@ -122,21 +122,17 @@ public sealed partial class RebuildIndexService<TKey>
             new IndexRebuildStartedEvent(tenantId, sourceName, KeyTypeName, resumed, dispatchedBy),
             cancellationToken).ConfigureAwait(false);
 
-        long indexed = 0;
-        long skipped = 0;
-        long failed = 0;
-        // `processedInBatch > 0` is the sole guard for checkpoint writes (a positive count
-        // implies the loop body assigned `lastSuccessfulKey` before incrementing). We do NOT
-        // gate on `lastSuccessfulKey is not null` because `TKey?` collapses to non-nullable
+        // `ProcessedInBatch > 0` is the sole guard for checkpoint writes (a positive count
+        // implies a loop body assigned `LastSuccessfulKey` before incrementing). We do NOT
+        // gate on `LastSuccessfulKey is not null` because `TKey?` collapses to non-nullable
         // `TKey` under the `notnull` constraint for value-type instantiations.
-        int processedInBatch = 0;
-        int consecutiveFailures = 0;
-        TKey? lastSuccessfulKey = checkpoint;
+        RebuildProgress progress = new() { LastSuccessfulKey = checkpoint };
 
         long startTimestamp = _timeProvider.GetTimestamp();
         TimeSpan? maxDuration = _options.MaxRunDurationSeconds is int s
             ? TimeSpan.FromSeconds(s)
             : null;
+        RebuildRunContext context = new(tenantId, tenantTag, sourceName, dispatchedBy, startTimestamp, maxDuration);
 
         try
         {
@@ -145,99 +141,8 @@ public sealed partial class RebuildIndexService<TKey>
                 .ConfigureAwait(false))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    IndexedEntry<TKey>? entry = await _source
-                        .BuildEntryAsync(key, cancellationToken)
-                        .ConfigureAwait(false);
-
-                    if (entry is null)
-                    {
-                        _metrics.RecordEntrySkipped(tenantTag, sourceName);
-                        skipped++;
-                    }
-                    else
-                    {
-                        await _indexer.IndexAsync(entry, cancellationToken).ConfigureAwait(false);
-                        _metrics.RecordEntryIndexed(tenantTag, sourceName);
-                        indexed++;
-                    }
-
-                    lastSuccessfulKey = key;
-                    consecutiveFailures = 0;
-                    processedInBatch++;
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    consecutiveFailures++;
-                    failed++;
-                    _metrics.RecordEntryFailed(tenantTag, sourceName, "build_or_index_error");
-                    LogEntryFailed(tenantTag, sourceName, ex.Message);
-
-                    if (consecutiveFailures >= _options.MaxConsecutiveFailures)
-                    {
-                        await AbortAsync(
-                            "max_consecutive_failures",
-                            tenantId,
-                            tenantTag,
-                            sourceName,
-                            lastSuccessfulKey,
-                            processedInBatch,
-                            indexed + skipped + failed,
-                            dispatchedBy,
-                            cancellationToken).ConfigureAwait(false);
-                        LogAborted(tenantTag, sourceName, consecutiveFailures);
-                        throw;
-                    }
-                }
-
-                if (processedInBatch >= _options.CheckpointBatchSize)
-                {
-                    await _checkpoints
-                        .SetCheckpointAsync(tenantId, sourceName, lastSuccessfulKey!, cancellationToken)
-                        .ConfigureAwait(false);
-                    _metrics.RecordCheckpointWritten(tenantTag, sourceName);
-                    processedInBatch = 0;
-                }
-
-                long processedTotal = indexed + skipped + failed;
-
-                if (_options.MaxEntriesPerRun is int maxEntries && processedTotal >= maxEntries)
-                {
-                    await AbortAsync(
-                        "max_entries_per_run",
-                        tenantId,
-                        tenantTag,
-                        sourceName,
-                        lastSuccessfulKey,
-                        processedInBatch,
-                        processedTotal,
-                        dispatchedBy,
-                        cancellationToken).ConfigureAwait(false);
-                    LogBudgetExceeded(tenantTag, sourceName, "max_entries_per_run", processedTotal);
-                    throw new RebuildBudgetExceededException("max_entries_per_run", tenantId, sourceName, processedTotal);
-                }
-
-                if (maxDuration is TimeSpan budget && _timeProvider.GetElapsedTime(startTimestamp) >= budget)
-                {
-                    await AbortAsync(
-                        "max_run_duration",
-                        tenantId,
-                        tenantTag,
-                        sourceName,
-                        lastSuccessfulKey,
-                        processedInBatch,
-                        processedTotal,
-                        dispatchedBy,
-                        cancellationToken).ConfigureAwait(false);
-                    LogBudgetExceeded(tenantTag, sourceName, "max_run_duration", processedTotal);
-                    throw new RebuildBudgetExceededException("max_run_duration", tenantId, sourceName, processedTotal);
-                }
+                await IndexSingleKeyAsync(key, progress, context, cancellationToken).ConfigureAwait(false);
+                await EnforceLimitsAsync(progress, context, cancellationToken).ConfigureAwait(false);
             }
 
             await _checkpoints.ClearAsync(tenantId, sourceName, cancellationToken).ConfigureAwait(false);
@@ -245,25 +150,149 @@ public sealed partial class RebuildIndexService<TKey>
             LogCompleted(tenantTag, sourceName);
 
             await _eventBus.PublishAsync(
-                new IndexRebuildCompletedEvent(tenantId, sourceName, KeyTypeName, indexed, skipped, failed, dispatchedBy),
+                new IndexRebuildCompletedEvent(
+                    tenantId, sourceName, KeyTypeName, progress.Indexed, progress.Skipped, progress.Failed, dispatchedBy),
                 cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
             // Persist progress on graceful cancellation so a re-dispatch resumes.
-            if (processedInBatch > 0)
+            if (progress.ProcessedInBatch > 0)
             {
                 await _checkpoints
-                    .SetCheckpointAsync(tenantId, sourceName, lastSuccessfulKey!, CancellationToken.None)
+                    .SetCheckpointAsync(tenantId, sourceName, progress.LastSuccessfulKey!, CancellationToken.None)
                     .ConfigureAwait(false);
                 _metrics.RecordCheckpointWritten(tenantTag, sourceName);
             }
 
             // Best-effort: cancellation may be racing event-bus shutdown, so use a fresh token.
             await _eventBus.PublishAsync(
-                new IndexRebuildAbortedEvent(tenantId, sourceName, KeyTypeName, "cancelled", indexed + skipped + failed, dispatchedBy),
+                new IndexRebuildAbortedEvent(
+                    tenantId, sourceName, KeyTypeName, "cancelled", progress.ProcessedTotal, dispatchedBy),
                 CancellationToken.None).ConfigureAwait(false);
             throw;
+        }
+    }
+
+    // Per-run mutable counters and the resume cursor.
+    private sealed class RebuildProgress
+    {
+        public long Indexed;
+        public long Skipped;
+        public long Failed;
+        public int ProcessedInBatch;
+        public int ConsecutiveFailures;
+        public TKey? LastSuccessfulKey;
+        public long ProcessedTotal => Indexed + Skipped + Failed;
+    }
+
+    // Run-invariant context threaded through the per-key helpers.
+    private readonly record struct RebuildRunContext(
+        Guid? TenantId, string TenantTag, string SourceName, string? DispatchedBy,
+        long StartTimestamp, TimeSpan? MaxDuration);
+
+    // Builds and indexes one key, updating counters. Aborts (and rethrows) once the
+    // consecutive-failure threshold is crossed; cancellation propagates untouched.
+    private async Task IndexSingleKeyAsync(
+        TKey key, RebuildProgress progress, RebuildRunContext ctx, CancellationToken cancellationToken)
+    {
+        try
+        {
+            IndexedEntry<TKey>? entry = await _source
+                .BuildEntryAsync(key, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (entry is null)
+            {
+                _metrics.RecordEntrySkipped(ctx.TenantTag, ctx.SourceName);
+                progress.Skipped++;
+            }
+            else
+            {
+                await _indexer.IndexAsync(entry, cancellationToken).ConfigureAwait(false);
+                _metrics.RecordEntryIndexed(ctx.TenantTag, ctx.SourceName);
+                progress.Indexed++;
+            }
+
+            progress.LastSuccessfulKey = key;
+            progress.ConsecutiveFailures = 0;
+            progress.ProcessedInBatch++;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            progress.ConsecutiveFailures++;
+            progress.Failed++;
+            _metrics.RecordEntryFailed(ctx.TenantTag, ctx.SourceName, "build_or_index_error");
+            LogEntryFailed(ctx.TenantTag, ctx.SourceName, ex.Message);
+
+            if (progress.ConsecutiveFailures >= _options.MaxConsecutiveFailures)
+            {
+                await AbortAsync(
+                    "max_consecutive_failures",
+                    ctx.TenantId,
+                    ctx.TenantTag,
+                    ctx.SourceName,
+                    progress.LastSuccessfulKey,
+                    progress.ProcessedInBatch,
+                    progress.ProcessedTotal,
+                    ctx.DispatchedBy,
+                    cancellationToken).ConfigureAwait(false);
+                LogAborted(ctx.TenantTag, ctx.SourceName, progress.ConsecutiveFailures);
+                throw;
+            }
+        }
+    }
+
+    // Writes a checkpoint once a batch fills, then enforces the per-run entry-count and
+    // duration budgets — aborting (and throwing RebuildBudgetExceededException) when exceeded.
+    private async Task EnforceLimitsAsync(
+        RebuildProgress progress, RebuildRunContext ctx, CancellationToken cancellationToken)
+    {
+        if (progress.ProcessedInBatch >= _options.CheckpointBatchSize)
+        {
+            await _checkpoints
+                .SetCheckpointAsync(ctx.TenantId, ctx.SourceName, progress.LastSuccessfulKey!, cancellationToken)
+                .ConfigureAwait(false);
+            _metrics.RecordCheckpointWritten(ctx.TenantTag, ctx.SourceName);
+            progress.ProcessedInBatch = 0;
+        }
+
+        long processedTotal = progress.ProcessedTotal;
+
+        if (_options.MaxEntriesPerRun is int maxEntries && processedTotal >= maxEntries)
+        {
+            await AbortAsync(
+                "max_entries_per_run",
+                ctx.TenantId,
+                ctx.TenantTag,
+                ctx.SourceName,
+                progress.LastSuccessfulKey,
+                progress.ProcessedInBatch,
+                processedTotal,
+                ctx.DispatchedBy,
+                cancellationToken).ConfigureAwait(false);
+            LogBudgetExceeded(ctx.TenantTag, ctx.SourceName, "max_entries_per_run", processedTotal);
+            throw new RebuildBudgetExceededException("max_entries_per_run", ctx.TenantId, ctx.SourceName, processedTotal);
+        }
+
+        if (ctx.MaxDuration is TimeSpan budget && _timeProvider.GetElapsedTime(ctx.StartTimestamp) >= budget)
+        {
+            await AbortAsync(
+                "max_run_duration",
+                ctx.TenantId,
+                ctx.TenantTag,
+                ctx.SourceName,
+                progress.LastSuccessfulKey,
+                progress.ProcessedInBatch,
+                processedTotal,
+                ctx.DispatchedBy,
+                cancellationToken).ConfigureAwait(false);
+            LogBudgetExceeded(ctx.TenantTag, ctx.SourceName, "max_run_duration", processedTotal);
+            throw new RebuildBudgetExceededException("max_run_duration", ctx.TenantId, ctx.SourceName, processedTotal);
         }
     }
 

--- a/src/Granit.Indexing.Embeddings/Diagnostics/EmbeddingsMetrics.cs
+++ b/src/Granit.Indexing.Embeddings/Diagnostics/EmbeddingsMetrics.cs
@@ -15,6 +15,9 @@ public sealed class EmbeddingsMetrics
 {
     public const string MeterName = "Granit.Indexing.Embeddings";
 
+    internal const string TenantIdTag = "tenant_id";
+    internal const string GlobalTenant = "global";
+
     private readonly Counter<long> _embeddingsGenerated;
     private readonly Counter<long> _embeddingsFailed;
     private readonly Counter<long> _hybridSearchQueries;
@@ -53,7 +56,7 @@ public sealed class EmbeddingsMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("model_id", string.IsNullOrEmpty(modelId) ? "unknown" : modelId),
         ];
         _embeddingsGenerated.Add(1, tags);
@@ -63,7 +66,7 @@ public sealed class EmbeddingsMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("reason", reason),
         ];
         _embeddingsFailed.Add(1, tags);
@@ -71,19 +74,19 @@ public sealed class EmbeddingsMetrics
 
     public void RecordHybridQuery(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _hybridSearchQueries.Add(1, tags);
     }
 
     public void RecordHybridLatency(string? tenantId, double durationSeconds)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _hybridSearchLatency.Record(durationSeconds, tags);
     }
 
     public void RecordVectorBackendMiss(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _vectorBackendMisses.Add(1, tags);
     }
 }

--- a/src/Granit.Indexing/Diagnostics/IndexingMetrics.cs
+++ b/src/Granit.Indexing/Diagnostics/IndexingMetrics.cs
@@ -18,6 +18,9 @@ public sealed class IndexingMetrics
 {
     public const string MeterName = "Granit.Indexing";
 
+    internal const string TenantIdTag = "tenant_id";
+    internal const string GlobalTenant = "global";
+
     private readonly Counter<long> _entryIndexed;
     private readonly Counter<long> _entryFailed;
     private readonly Counter<long> _searchQueries;
@@ -71,7 +74,7 @@ public sealed class IndexingMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("backend", backend),
         ];
         _entryIndexed.Add(1, tags);
@@ -81,7 +84,7 @@ public sealed class IndexingMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("backend", backend),
             new("reason", reason),
         ];
@@ -92,7 +95,7 @@ public sealed class IndexingMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("backend", backend),
         ];
         _searchQueries.Add(1, tags);
@@ -102,7 +105,7 @@ public sealed class IndexingMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("backend", backend),
         ];
         _searchLatency.Record(durationSeconds, tags);
@@ -117,7 +120,7 @@ public sealed class IndexingMetrics
 
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("backend", backend),
         ];
         _authorizationFiltered.Add(filteredCount, tags);
@@ -125,7 +128,7 @@ public sealed class IndexingMetrics
 
     public void RecordEmptyResultThrottled(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? "global")];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _emptyResultThrottled.Add(1, tags);
     }
 
@@ -138,7 +141,7 @@ public sealed class IndexingMetrics
 
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("backend", backend),
         ];
         _backendHitCount.Add(count, tags);
@@ -148,7 +151,7 @@ public sealed class IndexingMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("detector", detector),
         ];
         _aiInjectionAttempts.Add(1, tags);

--- a/src/Granit.Indexing/Internal/DefaultSearchService.cs
+++ b/src/Granit.Indexing/Internal/DefaultSearchService.cs
@@ -72,65 +72,9 @@ internal sealed class DefaultSearchService<TKey, TResult> : ISearchService<TKey,
 
         // Exponential over-fetch loop. Cumulative authorised hits accumulate in
         // backend-score order; we slice the requested page at the end.
-        int multiplier = Math.Max(_authorizer.RecommendedInitialMultiplier, 1);
-        int window = pageSize * multiplier;
-        int offset = 0;
-        int backendHitCount = 0;
-        bool hitLimit = false;
-        List<SearchHit<TKey, TResult>> authorisedHits = [];
-        HashSet<TKey> authorisedKeys = new();
-
-        while (true)
-        {
-            BackendSearchPage<TKey, TResult> page = await _backend
-                .SearchAsync(request, offset, window, cancellationToken)
+        (List<SearchHit<TKey, TResult>> authorisedHits, int backendHitCount, bool hitLimit) =
+            await CollectAuthorisedHitsAsync(request, pageSize, wantThrough, tenantTag, backendName, cancellationToken)
                 .ConfigureAwait(false);
-
-            backendHitCount += page.Hits.Count;
-
-            if (page.Hits.Count > 0)
-            {
-                IReadOnlyList<TKey> candidateKeys = page.Hits.Select(h => h.Key).ToArray();
-                AuthorizedResult<TKey> authorised = await _authorizer
-                    .FilterAsync(candidateKeys, cancellationToken)
-                    .ConfigureAwait(false);
-
-                HashSet<TKey> authorisedSet = [.. authorised.Authorized];
-                long filteredOut = page.Hits.Count - authorisedSet.Count;
-                _metrics.RecordAuthorizationFiltered(tenantTag, backendName, filteredOut);
-
-                foreach (SearchHit<TKey, TResult> hit in page.Hits)
-                {
-                    if (authorisedSet.Contains(hit.Key) && authorisedKeys.Add(hit.Key))
-                    {
-                        authorisedHits.Add(hit);
-                    }
-                }
-            }
-
-            if (authorisedHits.Count >= wantThrough)
-            {
-                break;
-            }
-
-            if (!page.HasMore || page.Hits.Count == 0)
-            {
-                break;
-            }
-
-            if (backendHitCount >= _options.MaxAuthorizationDepth)
-            {
-                hitLimit = true;
-                break;
-            }
-
-            offset += page.Hits.Count;
-            // Double the window for the next iteration; cap at the remaining authorization
-            // depth so the very last iteration cannot blow past MaxAuthorizationDepth.
-            int nextWindow = window * 2;
-            int remaining = _options.MaxAuthorizationDepth - backendHitCount;
-            window = Math.Max(1, Math.Min(nextWindow, remaining));
-        }
 
         int skip = (request.Page - 1) * pageSize;
         TResult[] items = authorisedHits.Count <= skip
@@ -164,5 +108,73 @@ internal sealed class DefaultSearchService<TKey, TResult> : ISearchService<TKey,
             HitAuthorizationLimit = hitLimit,
             BackendHitCount = backendHitCount,
         };
+    }
+
+    // Exponential over-fetch loop: repeatedly pulls a growing window from the backend,
+    // authorises each page, and accumulates distinct authorised hits in backend-score
+    // order until the requested page is covered, the backend is exhausted, or the
+    // MaxAuthorizationDepth budget is hit.
+    private async Task<(List<SearchHit<TKey, TResult>> Hits, int BackendHitCount, bool HitLimit)> CollectAuthorisedHitsAsync(
+        SearchRequest request, int pageSize, int wantThrough, string? tenantTag, string backendName,
+        CancellationToken cancellationToken)
+    {
+        int multiplier = Math.Max(_authorizer.RecommendedInitialMultiplier, 1);
+        int window = pageSize * multiplier;
+        int offset = 0;
+        int backendHitCount = 0;
+        bool hitLimit = false;
+        List<SearchHit<TKey, TResult>> authorisedHits = [];
+        HashSet<TKey> authorisedKeys = [];
+
+        while (true)
+        {
+            BackendSearchPage<TKey, TResult> page = await _backend
+                .SearchAsync(request, offset, window, cancellationToken)
+                .ConfigureAwait(false);
+
+            backendHitCount += page.Hits.Count;
+
+            if (page.Hits.Count > 0)
+            {
+                IReadOnlyList<TKey> candidateKeys = page.Hits.Select(h => h.Key).ToArray();
+                AuthorizedResult<TKey> authorised = await _authorizer
+                    .FilterAsync(candidateKeys, cancellationToken)
+                    .ConfigureAwait(false);
+
+                HashSet<TKey> authorisedSet = [.. authorised.Authorized];
+                long filteredOut = page.Hits.Count - authorisedSet.Count;
+                _metrics.RecordAuthorizationFiltered(tenantTag, backendName, filteredOut);
+
+                // authorisedKeys.Add doubles as the cross-page de-dup; the lazy Where keeps each
+                // distinct authorised hit exactly once.
+                authorisedHits.AddRange(page.Hits
+                    .Where(hit => authorisedSet.Contains(hit.Key) && authorisedKeys.Add(hit.Key)));
+            }
+
+            if (authorisedHits.Count >= wantThrough)
+            {
+                break;
+            }
+
+            if (!page.HasMore || page.Hits.Count == 0)
+            {
+                break;
+            }
+
+            if (backendHitCount >= _options.MaxAuthorizationDepth)
+            {
+                hitLimit = true;
+                break;
+            }
+
+            offset += page.Hits.Count;
+            // Double the window for the next iteration; cap at the remaining authorization
+            // depth so the very last iteration cannot blow past MaxAuthorizationDepth.
+            int nextWindow = window * 2;
+            int remaining = _options.MaxAuthorizationDepth - backendHitCount;
+            window = Math.Max(1, Math.Min(nextWindow, remaining));
+        }
+
+        return (authorisedHits, backendHitCount, hitLimit);
     }
 }

--- a/src/Granit.LanguageDetection.AI/Diagnostics/LanguageDetectionAIMetrics.cs
+++ b/src/Granit.LanguageDetection.AI/Diagnostics/LanguageDetectionAIMetrics.cs
@@ -17,6 +17,8 @@ public sealed class LanguageDetectionAIMetrics
 {
     public const string MeterName = "Granit.LanguageDetection.AI";
 
+    internal const string TenantIdTag = "tenant_id";
+
     /// <summary>Fallback tenant tag value when no tenant context is active.</summary>
     internal const string GlobalTenant = "global";
 
@@ -50,13 +52,13 @@ public sealed class LanguageDetectionAIMetrics
 
     public void RecordCallAttempted(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? GlobalTenant)];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _callsAttempted.Add(1, tags);
     }
 
     public void RecordCallThrottled(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? GlobalTenant)];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _callsThrottled.Add(1, tags);
     }
 
@@ -64,7 +66,7 @@ public sealed class LanguageDetectionAIMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? GlobalTenant),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("reason", reason),
         ];
         _callsFailed.Add(1, tags);
@@ -72,7 +74,7 @@ public sealed class LanguageDetectionAIMetrics
 
     public void RecordInjectionDetected(string? tenantId)
     {
-        TagList tags = [new("tenant_id", tenantId ?? GlobalTenant)];
+        TagList tags = [new(TenantIdTag, tenantId ?? GlobalTenant)];
         _injectionsDetected.Add(1, tags);
     }
 }

--- a/src/Granit.LanguageDetection.AI/Internal/AILanguageDetector.cs
+++ b/src/Granit.LanguageDetection.AI/Internal/AILanguageDetector.cs
@@ -138,7 +138,6 @@ internal sealed partial class AILanguageDetector : ILanguageDetectorProvider
                     _metrics.RecordInjectionDetected(tenantId);
                     return null;
 
-                case StructuredCompletionStatus.TransportFailure:
                 default:
                     _metrics.RecordCallFailed(tenantId, "transport");
                     LogTransportFailure(tenantId ?? LanguageDetectionAIMetrics.GlobalTenant, result.Status.ToString());

--- a/src/Granit.LanguageDetection.Trigram/Internal/ScriptDetector.cs
+++ b/src/Granit.LanguageDetection.Trigram/Internal/ScriptDetector.cs
@@ -70,7 +70,14 @@ internal static class ScriptDetector
         Other = -1,
     }
 
-    private static ScriptId ClassifyChar(char c) => c switch
+    private static ScriptId ClassifyChar(char c)
+    {
+        ScriptId id = ClassifyWesternChar(c);
+        return id != ScriptId.Other ? id : ClassifyAsianChar(c);
+    }
+
+    // Latin / Greek / Cyrillic / Hebrew / Arabic block ranges.
+    private static ScriptId ClassifyWesternChar(char c) => c switch
     {
         // Latin (Basic + Latin-1 + Latin Extended A/B + IPA + Latin Extended Additional)
         >= 'A' and <= 'Z' => ScriptId.Latin,
@@ -88,6 +95,12 @@ internal static class ScriptDetector
         >= '؀' and <= 'ۿ' => ScriptId.Arabic,
         >= 'ﭐ' and <= '﷿' => ScriptId.Arabic,
         >= 'ﹰ' and <= '﻿' => ScriptId.Arabic,
+        _ => ScriptId.Other,
+    };
+
+    // South-Asian / South-East-Asian / Ethiopic / CJK block ranges.
+    private static ScriptId ClassifyAsianChar(char c) => c switch
+    {
         // Devanagari
         >= 'ऀ' and <= 'ॿ' => ScriptId.Devanagari,
         // Bengali

--- a/src/Granit.Localization.AI/Internal/LlmTranslationSuggestionService.cs
+++ b/src/Granit.Localization.AI/Internal/LlmTranslationSuggestionService.cs
@@ -77,9 +77,6 @@ internal sealed partial class LlmTranslationSuggestionService(
                     LogTranslationSucceeded(key, suggestions.Count, targetCultures.Count);
                     return suggestions;
 
-                case StructuredCompletionStatus.ModelRefused:
-                case StructuredCompletionStatus.SchemaViolation:
-                case StructuredCompletionStatus.TransportFailure:
                 default:
                     LogTranslationRejected(key, result.Status.ToString());
                     return [];

--- a/src/Granit.Notifications.Privacy/DataExport/NotificationsPrivacyDataProvider.cs
+++ b/src/Granit.Notifications.Privacy/DataExport/NotificationsPrivacyDataProvider.cs
@@ -68,12 +68,18 @@ public sealed class NotificationsPrivacyDataProvider(
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<ExportFragment> ExportAsync(
+    public IAsyncEnumerable<ExportFragment> ExportAsync(
+        PrivacyExportContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return ExportCoreAsync(context, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<ExportFragment> ExportCoreAsync(
         PrivacyExportContext context,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(context);
-
         string recipientUserId = context.SubjectUserId.ToString();
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 

--- a/src/Granit.Notifications/Handlers/NotificationFanoutHandler.cs
+++ b/src/Granit.Notifications/Handlers/NotificationFanoutHandler.cs
@@ -38,15 +38,7 @@ public sealed class NotificationFanoutHandler(
         activity?.SetTag("notifications.type", trigger.NotificationTypeName);
 
         // Decrypt payload when encryption was applied by WolverineNotificationPublisher
-        JsonElement data = trigger.Data;
-        if (trigger.EncryptedData is not null && encryptionService is not null)
-        {
-            string? decrypted = encryptionService.Decrypt(trigger.EncryptedData);
-            if (decrypted is not null)
-            {
-                data = JsonDocument.Parse(decrypted).RootElement;
-            }
-        }
+        JsonElement data = ResolvePayloadData(trigger);
 
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : trigger.TenantId;
         NotificationDefinition? definition = definitionStore.Get(trigger.NotificationTypeName);
@@ -70,12 +62,9 @@ public sealed class NotificationFanoutHandler(
         {
             foreach (string channelName in defaultChannels)
             {
-                if (allowOptOut && !await IsChannelEnabledAsync(userId, trigger, channelName, tenantId, cancellationToken).ConfigureAwait(false))
-                {
-                    continue;
-                }
-
-                if (!bypassGates && !await AllGatesAllowAsync(userId, trigger, channelName, tenantId, cancellationToken).ConfigureAwait(false))
+                if (!await ShouldDeliverChannelAsync(
+                        userId, trigger, channelName, tenantId, allowOptOut, bypassGates, cancellationToken)
+                    .ConfigureAwait(false))
                 {
                     continue;
                 }
@@ -106,6 +95,40 @@ public sealed class NotificationFanoutHandler(
             trigger.NotificationTypeName);
 
         return commands;
+    }
+
+    // Decrypts the payload when WolverineNotificationPublisher encrypted it; otherwise
+    // returns the trigger's plaintext data unchanged.
+    private JsonElement ResolvePayloadData(NotificationTrigger trigger)
+    {
+        if (trigger.EncryptedData is not null && encryptionService is not null)
+        {
+            string? decrypted = encryptionService.Decrypt(trigger.EncryptedData);
+            if (decrypted is not null)
+            {
+                return JsonDocument.Parse(decrypted).RootElement;
+            }
+        }
+
+        return trigger.Data;
+    }
+
+    // Applies the opt-out preference and delivery-gate checks for a single user x channel.
+    private async Task<bool> ShouldDeliverChannelAsync(
+        string userId, NotificationTrigger trigger, string channelName, Guid? tenantId,
+        bool allowOptOut, bool bypassGates, CancellationToken cancellationToken)
+    {
+        if (allowOptOut && !await IsChannelEnabledAsync(userId, trigger, channelName, tenantId, cancellationToken).ConfigureAwait(false))
+        {
+            return false;
+        }
+
+        if (!bypassGates && !await AllGatesAllowAsync(userId, trigger, channelName, tenantId, cancellationToken).ConfigureAwait(false))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Granit.Observability.AI/Internal/LlmLogAnalyzer.cs
+++ b/src/Granit.Observability.AI/Internal/LlmLogAnalyzer.cs
@@ -87,7 +87,6 @@ internal sealed partial class LlmLogAnalyzer(
                     metrics.RecordAnalysisDuration(tenantId, sw.Elapsed.TotalSeconds);
                     return new LogAnalysisReport("AI analysis returned a non-JSON response.", [], truncatedEntries.Count);
 
-                case StructuredCompletionStatus.TransportFailure:
                 default:
                     // Transport problems are surfaced to the caller, as before.
                     sw.Stop();

--- a/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
+++ b/src/Granit.OpenApi.Generation/OpenApiContractGenerator.cs
@@ -67,9 +67,8 @@ public static class OpenApiContractGenerator
         // One OpenAPI document per module, sliced by the GroupName stamped on its routes below, each
         // carrying the full Granit transformer chain so the artifacts match the framework's served
         // output (int32 normalized, int64 string-union kept, problem-details enriched, tags sorted).
-        foreach (OpenApiContractModule module in modules)
+        foreach (string slug in modules.Select(module => module.Slug))
         {
-            string slug = module.Slug;
             builder.AddGranitOpenApiDocument(slug, slug, description => description.GroupName == slug);
         }
 
@@ -87,44 +86,7 @@ public static class OpenApiContractGenerator
 
         for (int i = builder.Services.Count - 1; i >= 0; i--)
         {
-            ServiceDescriptor d = builder.Services[i];
-
-            // (1) Keyed services from the OpenAPI assembly (OpenApiDocumentService, IOpenApiDocumentProvider,
-            //     OpenApiSchemaService, …). These are resolved at generation time — one set per document.
-            if (d.IsKeyedService
-                && d.ServiceKey is string docKey
-                && !slugSet.Contains(docKey)
-                && d.ServiceType.Assembly == openApiAssembly)
-            {
-                builder.Services.RemoveAt(i);
-                continue;
-            }
-
-            // (2) Non-keyed NamedService<OpenApiDocumentService> instances (internal, OpenAPI assembly).
-            //     OpenApiDocumentProvider.GetDocumentNames() iterates these to build its list; leaving
-            //     a "v1" entry here causes GetDocumentNames() to return "v1" even after (1) is stripped,
-            //     which then fails in GenerateAsync when the keyed service can't be resolved.
-            if (!d.IsKeyedService
-                && d.ImplementationInstance is not null
-                && d.ServiceType.Assembly == openApiAssembly)
-            {
-                PropertyInfo? nameProp = d.ImplementationInstance.GetType()
-                    .GetProperty("Name", BindingFlags.Public | BindingFlags.Instance);
-                if (nameProp?.GetValue(d.ImplementationInstance) is string svcName
-                    && !slugSet.Contains(svcName))
-                {
-                    builder.Services.RemoveAt(i);
-                    continue;
-                }
-            }
-
-            // (3) IConfigureNamedOptions<OpenApiOptions> for non-slug document names. A stale entry
-            //     here is harmless for GetDocumentNames() but keep removal for completeness.
-            if (!d.IsKeyedService
-                && d.ServiceType == typeof(IConfigureOptions<OpenApiOptions>)
-                && d.ImplementationInstance is ConfigureNamedOptions<OpenApiOptions> namedOpts
-                && namedOpts.Name is not null   // null == ConfigureAll → keep
-                && !slugSet.Contains(namedOpts.Name))
+            if (ShouldStripOpenApiDescriptor(builder.Services[i], slugSet, openApiAssembly))
             {
                 builder.Services.RemoveAt(i);
             }
@@ -154,5 +116,47 @@ public static class OpenApiContractGenerator
         }
 
         await app.RunAsync().ConfigureAwait(false);
+    }
+
+    // True when a service descriptor belongs to the OpenAPI assembly for a document name
+    // that is NOT in the requested slug set — those stale registrations must be stripped so
+    // the generator emits exactly the declared documents. Three registration shapes exist.
+    private static bool ShouldStripOpenApiDescriptor(
+        ServiceDescriptor d, HashSet<string> slugSet, Assembly openApiAssembly)
+    {
+        // (1) Keyed services from the OpenAPI assembly (OpenApiDocumentService, IOpenApiDocumentProvider,
+        //     OpenApiSchemaService, …). These are resolved at generation time — one set per document.
+        if (d.IsKeyedService
+            && d.ServiceKey is string docKey
+            && !slugSet.Contains(docKey)
+            && d.ServiceType.Assembly == openApiAssembly)
+        {
+            return true;
+        }
+
+        // (2) Non-keyed NamedService<OpenApiDocumentService> instances (internal, OpenAPI assembly).
+        //     OpenApiDocumentProvider.GetDocumentNames() iterates these to build its list; leaving
+        //     a "v1" entry here causes GetDocumentNames() to return "v1" even after (1) is stripped,
+        //     which then fails in GenerateAsync when the keyed service can't be resolved.
+        if (!d.IsKeyedService
+            && d.ImplementationInstance is not null
+            && d.ServiceType.Assembly == openApiAssembly)
+        {
+            PropertyInfo? nameProp = d.ImplementationInstance.GetType()
+                .GetProperty("Name", BindingFlags.Public | BindingFlags.Instance);
+            if (nameProp?.GetValue(d.ImplementationInstance) is string svcName
+                && !slugSet.Contains(svcName))
+            {
+                return true;
+            }
+        }
+
+        // (3) IConfigureNamedOptions<OpenApiOptions> for non-slug document names. A stale entry
+        //     here is harmless for GetDocumentNames() but keep removal for completeness.
+        return !d.IsKeyedService
+            && d.ServiceType == typeof(IConfigureOptions<OpenApiOptions>)
+            && d.ImplementationInstance is ConfigureNamedOptions<OpenApiOptions> namedOpts
+            && namedOpts.Name is not null   // null == ConfigureAll → keep
+            && !slugSet.Contains(namedOpts.Name);
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -29,6 +29,11 @@ namespace Granit.OpenIddict.Endpoints.Endpoints;
 #pragma warning disable GRAPI003 // Private handler methods — not exposed as endpoint parameters
 internal static partial class ConnectTokenEndpoints
 {
+    private const string LoggerCategory = "Granit.OpenIddict.Endpoints.ConnectTokenEndpoints";
+    private const string TwoFactorGrantType = "urn:granit:grant_type:two_factor";
+    private const string PasskeyGrantType = "urn:granit:grant_type:passkey";
+    private const string InvalidLoginReason = "invalid_credentials";
+
     internal static IEndpointRouteBuilder MapConnectTokenEndpoints(this IEndpointRouteBuilder endpoints)
     {
         endpoints.MapPost("/connect/token", (Delegate)HandleTokenAsync)
@@ -48,7 +53,7 @@ internal static partial class ConnectTokenEndpoints
             .GetRequiredService<OpenIddictMetrics>();
         ILogger logger = context.RequestServices
             .GetRequiredService<ILoggerFactory>()
-            .CreateLogger("Granit.OpenIddict.Endpoints.ConnectTokenEndpoints");
+            .CreateLogger(LoggerCategory);
         ICurrentTenant? currentTenant = context.RequestServices
             .GetService<ICurrentTenant>();
         string? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id?.ToString() : null;
@@ -65,14 +70,14 @@ internal static partial class ConnectTokenEndpoints
             return HandleClientCredentials(context, request, metrics, tenantId);
         }
 
-        if (request.GrantType == "urn:granit:grant_type:two_factor")
+        if (request.GrantType == TwoFactorGrantType)
         {
             return await HandleTwoFactorAsync(
                 context, request, principalFactory, metrics, tenantId)
                 .ConfigureAwait(false);
         }
 
-        if (request.GrantType == "urn:granit:grant_type:passkey")
+        if (request.GrantType == PasskeyGrantType)
         {
             return await HandlePasskeyAsync(
                 context, request, principalFactory, metrics, tenantId)
@@ -93,7 +98,7 @@ internal static partial class ConnectTokenEndpoints
     {
         ILogger logger = context.RequestServices
             .GetRequiredService<ILoggerFactory>()
-            .CreateLogger("Granit.OpenIddict.Endpoints.ConnectTokenEndpoints");
+            .CreateLogger(LoggerCategory);
 
         // OpenIddict has already validated the code/refresh_token — authenticate to get the principal.
         AuthenticateResult authenticateResult = await context.AuthenticateAsync(
@@ -136,10 +141,10 @@ internal static partial class ConnectTokenEndpoints
             if (user is null)
             {
                 LogUserNotFound(logger, subject ?? "(null)");
-                metrics.RecordAuthenticationFailure(tenantId, "invalid_credentials");
+                metrics.RecordAuthenticationFailure(tenantId, InvalidLoginReason);
                 await TryWriteAuthAuditAsync(context, logger,
                     method: request.GrantType!, userId: subject, userName: null,
-                    failureReason: "invalid_credentials", tenantId).ConfigureAwait(false);
+                    failureReason: InvalidLoginReason, tenantId).ConfigureAwait(false);
                 return Results.Forbid(
                     authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
             }
@@ -199,7 +204,7 @@ internal static partial class ConnectTokenEndpoints
     {
         ILogger logger = context.RequestServices
             .GetRequiredService<ILoggerFactory>()
-            .CreateLogger("Granit.OpenIddict.Endpoints.ConnectTokenEndpoints");
+            .CreateLogger(LoggerCategory);
 
         ClaimsPrincipal principal = OidcPrincipalFactory.CreateClientPrincipal(
             request.ClientId!,
@@ -222,7 +227,7 @@ internal static partial class ConnectTokenEndpoints
     {
         ILogger logger = context.RequestServices
             .GetRequiredService<ILoggerFactory>()
-            .CreateLogger("Granit.OpenIddict.Endpoints.ConnectTokenEndpoints");
+            .CreateLogger(LoggerCategory);
 
         UserManager<LocalIdentity> userManager = context.RequestServices
             .GetRequiredService<UserManager<LocalIdentity>>();
@@ -245,10 +250,10 @@ internal static partial class ConnectTokenEndpoints
         if (user is null)
         {
             LogUserNotFound(logger, username);
-            metrics.RecordAuthenticationFailure(tenantId, "invalid_credentials");
+            metrics.RecordAuthenticationFailure(tenantId, InvalidLoginReason);
             await TryWriteAuthAuditAsync(context, logger,
-                method: "urn:granit:grant_type:two_factor", userId: null, userName: username,
-                failureReason: "invalid_credentials", tenantId).ConfigureAwait(false);
+                method: TwoFactorGrantType, userId: null, userName: username,
+                failureReason: InvalidLoginReason, tenantId).ConfigureAwait(false);
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
@@ -272,7 +277,7 @@ internal static partial class ConnectTokenEndpoints
             LogTwoFactorFailed(logger, user.Id.ToString());
             metrics.RecordAuthenticationFailure(tenantId, "invalid_two_factor_code");
             await TryWriteAuthAuditAsync(context, logger,
-                method: "urn:granit:grant_type:two_factor", userId: user.Id.ToString(), userName: user.UserName,
+                method: TwoFactorGrantType, userId: user.Id.ToString(), userName: user.UserName,
                 failureReason: "invalid_two_factor_code", tenantId).ConfigureAwait(false);
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
@@ -283,12 +288,12 @@ internal static partial class ConnectTokenEndpoints
             user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
             .ConfigureAwait(false);
 
-        metrics.RecordTokenIssued(tenantId, "urn:granit:grant_type:two_factor");
-        metrics.RecordAuthenticationSuccess(tenantId, "urn:granit:grant_type:two_factor");
-        LogTokenIssued(logger, user.Id.ToString(), "urn:granit:grant_type:two_factor");
+        metrics.RecordTokenIssued(tenantId, TwoFactorGrantType);
+        metrics.RecordAuthenticationSuccess(tenantId, TwoFactorGrantType);
+        LogTokenIssued(logger, user.Id.ToString(), TwoFactorGrantType);
 
         await TryWriteAuthAuditAsync(context, logger,
-            method: "urn:granit:grant_type:two_factor",
+            method: TwoFactorGrantType,
             userId: user.Id.ToString(),
             userName: user.UserName,
             failureReason: null,
@@ -325,7 +330,7 @@ internal static partial class ConnectTokenEndpoints
     {
         ILogger logger = context.RequestServices
             .GetRequiredService<ILoggerFactory>()
-            .CreateLogger("Granit.OpenIddict.Endpoints.ConnectTokenEndpoints");
+            .CreateLogger(LoggerCategory);
 
         string? credentialJson = (string?)request["credential_json"];
         if (string.IsNullOrEmpty(credentialJson))
@@ -348,7 +353,7 @@ internal static partial class ConnectTokenEndpoints
             LogPasskeyAssertionFailed(logger);
             metrics.RecordAuthenticationFailure(tenantId, "invalid_passkey");
             await TryWriteAuthAuditAsync(context, logger,
-                method: "urn:granit:grant_type:passkey", userId: null, userName: null,
+                method: PasskeyGrantType, userId: null, userName: null,
                 failureReason: "invalid_passkey", tenantId).ConfigureAwait(false);
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
@@ -361,10 +366,10 @@ internal static partial class ConnectTokenEndpoints
         if (user is null)
         {
             LogUserNotFound(logger, assertion.UserId);
-            metrics.RecordAuthenticationFailure(tenantId, "invalid_credentials");
+            metrics.RecordAuthenticationFailure(tenantId, InvalidLoginReason);
             await TryWriteAuthAuditAsync(context, logger,
-                method: "urn:granit:grant_type:passkey", userId: assertion.UserId, userName: null,
-                failureReason: "invalid_credentials", tenantId).ConfigureAwait(false);
+                method: PasskeyGrantType, userId: assertion.UserId, userName: null,
+                failureReason: InvalidLoginReason, tenantId).ConfigureAwait(false);
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
@@ -374,12 +379,12 @@ internal static partial class ConnectTokenEndpoints
             user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
             .ConfigureAwait(false);
 
-        metrics.RecordTokenIssued(tenantId, "urn:granit:grant_type:passkey");
-        metrics.RecordAuthenticationSuccess(tenantId, "urn:granit:grant_type:passkey");
-        LogTokenIssued(logger, user.Id.ToString(), "urn:granit:grant_type:passkey");
+        metrics.RecordTokenIssued(tenantId, PasskeyGrantType);
+        metrics.RecordAuthenticationSuccess(tenantId, PasskeyGrantType);
+        LogTokenIssued(logger, user.Id.ToString(), PasskeyGrantType);
 
         await TryWriteAuthAuditAsync(context, logger,
-            method: "urn:granit:grant_type:passkey",
+            method: PasskeyGrantType,
             userId: user.Id.ToString(),
             userName: user.UserName,
             failureReason: null,

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -277,57 +277,62 @@ public static class ModelBuilderExtensions
         {
             foreach (IMutableProperty property in entityType.GetProperties())
             {
-                Type? enumType = GetEnumType(property.ClrType);
-                if (enumType is null)
-                {
-                    continue;
-                }
-
-                // Respect explicit overrides: a HasConversion<...>() call in the entity
-                // configuration always wins over the convention. EF Core exposes the
-                // override in two different ways depending on the overload:
-                //   - HasConversion(ValueConverter) / HasConversion<TConverter>()
-                //       → SetValueConverter, surfaced by GetValueConverter()
-                //   - HasConversion<TProvider>()  (e.g. HasConversion<short>())
-                //       → SetProviderClrType only; the ValueConverter is materialised
-                //         later from the type mapping, so GetValueConverter() is null
-                //         at convention-application time. Without the second check the
-                //         convention stacks EnumToStringConverter on top of the
-                //         provider type and EF crashes on default-value sanitisation
-                //         (FormatException trying to parse "Available" as short).
-                if (property.GetValueConverter() is not null
-                    || property.GetProviderClrType() is not null)
-                {
-                    continue;
-                }
-
-                // Skip opt-out: property marked [PersistAsInt] with a documented reason.
-                if (property.PropertyInfo?.GetCustomAttribute<PersistAsIntAttribute>() is not null)
-                {
-                    continue;
-                }
-
-                // [Flags] enums encode multiple values bitwise — storing them as a single
-                // string name would lose information. Keep the int column unless an
-                // explicit converter was configured above.
-                if (enumType.GetCustomAttribute<FlagsAttribute>() is not null)
-                {
-                    continue;
-                }
-
-                Type converterType = typeof(EnumToStringConverter<>).MakeGenericType(enumType);
-                property.SetValueConverter(
-                    (ValueConverter)Activator.CreateInstance(converterType)!);
-
-                // Preserve any explicit HasMaxLength(N) the entity configuration already set
-                // (e.g. AuditEntry.Category keeps its 50-char column even though the convention
-                // floor would compute a smaller value). Only apply the default when missing.
-                if (property.GetMaxLength() is null)
-                {
-                    int longestName = Enum.GetNames(enumType).Max(name => name.Length);
-                    property.SetMaxLength(Math.Max(20, longestName + 4));
-                }
+                ApplyEnumStringConverter(property);
             }
+        }
+    }
+
+    private static void ApplyEnumStringConverter(IMutableProperty property)
+    {
+        Type? enumType = GetEnumType(property.ClrType);
+        if (enumType is null)
+        {
+            return;
+        }
+
+        // Respect explicit overrides: a HasConversion<...>() call in the entity
+        // configuration always wins over the convention. EF Core exposes the
+        // override in two different ways depending on the overload:
+        //   - HasConversion(ValueConverter) / HasConversion<TConverter>()
+        //       → SetValueConverter, surfaced by GetValueConverter()
+        //   - HasConversion<TProvider>()  (e.g. HasConversion<short>())
+        //       → SetProviderClrType only; the ValueConverter is materialised
+        //         later from the type mapping, so GetValueConverter() is null
+        //         at convention-application time. Without the second check the
+        //         convention stacks EnumToStringConverter on top of the
+        //         provider type and EF crashes on default-value sanitisation
+        //         (FormatException trying to parse "Available" as short).
+        if (property.GetValueConverter() is not null
+            || property.GetProviderClrType() is not null)
+        {
+            return;
+        }
+
+        // Skip opt-out: property marked [PersistAsInt] with a documented reason.
+        if (property.PropertyInfo?.GetCustomAttribute<PersistAsIntAttribute>() is not null)
+        {
+            return;
+        }
+
+        // [Flags] enums encode multiple values bitwise — storing them as a single
+        // string name would lose information. Keep the int column unless an
+        // explicit converter was configured above.
+        if (enumType.GetCustomAttribute<FlagsAttribute>() is not null)
+        {
+            return;
+        }
+
+        Type converterType = typeof(EnumToStringConverter<>).MakeGenericType(enumType);
+        property.SetValueConverter(
+            (ValueConverter)Activator.CreateInstance(converterType)!);
+
+        // Preserve any explicit HasMaxLength(N) the entity configuration already set
+        // (e.g. AuditEntry.Category keeps its 50-char column even though the convention
+        // floor would compute a smaller value). Only apply the default when missing.
+        if (property.GetMaxLength() is null)
+        {
+            int longestName = Enum.GetNames(enumType).Max(name => name.Length);
+            property.SetMaxLength(Math.Max(20, longestName + 4));
         }
     }
 
@@ -412,68 +417,83 @@ public static class ModelBuilderExtensions
 
             foreach (System.Reflection.PropertyInfo clrProperty in valueObjectClrProperties)
             {
-                // Fail fast on explicit OwnsOne(...) over a ValueObject subtype on a real entity
-                // owner: this would create a third VO persistence path beyond the two supported
-                // by ADR-017 / ADR-058 (convention auto-JSON / scalar, or ComplexProperty for
-                // typed flat columns). Silent-override the previous behavior — produced schema
-                // drift and late STJ failures with no diagnostic. A nested-VO owner stays on
-                // the existing detach-only path: nobody opts in to OwnsOne on a VO-inside-VO.
-                IMutableNavigation? nav = ownerEntityType.FindNavigation(clrProperty.Name);
-                if (!ownerIsValueObject && nav?.ForeignKey.IsOwnership == true)
-                {
-                    throw new InvalidOperationException(
-                        $"'{ownerEntityType.ClrType.Name}.{clrProperty.Name}' is a ValueObject " +
-                        $"subtype configured via OwnsOne(...). Granit reserves ValueObject " +
-                        $"persistence to two paths: (1) let ApplyGranitConventions auto-serialize " +
-                        $"to JSON (multi-field) or a scalar column (SingleValueObject<T>), or " +
-                        $"(2) map explicitly via ComplexProperty(...) for typed flat columns. " +
-                        $"Drop the OwnsOne call or switch to ComplexProperty. " +
-                        $"See ADR-017 (DDD VO strategy) and ADR-058 (JSON persistence policy).");
-                }
-
-                ownerBuilder.Ignore(clrProperty.Name);
-
-                // A value object owner is removed wholesale below — only the navigation needs
-                // detaching. A real entity keeps the data, re-attached as a column.
-                if (ownerIsValueObject)
-                {
-                    continue;
-                }
-
-                Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder propertyBuilder =
-                    ownerBuilder.Property(clrProperty.PropertyType, clrProperty.Name);
-
-                // SingleValueObject<T> maps to its underlying primitive (ApplySingleValueObjectConverters,
-                // next step). A multi-field value object has no single primitive — serialize it to JSON.
-                if (GetSingleValueObjectBase(clrProperty.PropertyType) is null)
-                {
-                    ApplyJsonValueObjectConverterMethod // NOSONAR S3011 - intentional: generic value converter over the property CLR type requires reflection
-                        .MakeGenericMethod(clrProperty.PropertyType)
-                        .Invoke(null, [propertyBuilder.Metadata]);
-                }
+                ReattachOrDetachValueObjectProperty(ownerBuilder, ownerEntityType, clrProperty, ownerIsValueObject);
             }
         }
 
-        // RemoveEntityType alone is not enough: an earlier convention that calls
-        // modelBuilder.Entity<T>() on the OWNER (the IConcurrencyAware / soft-delete passes
-        // above) re-fires EF navigation discovery, and model FINALIZATION then re-materialises
-        // these phantom value object entity types — with their shadow-FK graph
-        // (OpenGraph → OgImage → ImageDimensions) — straight off the still-present CLR
-        // navigation properties. Finalization then fails binding e.g.
-        // ImageDimensions(int width, int height).
-        //
-        // The model-level Ignore(type) adds the CLR type to the model's ignored set so NO
-        // later convention can re-add it. Restrict it to MULTI-FIELD value objects: a
-        // SingleValueObject<T> must stay visible as a scalar property so the next pass
-        // (ApplySingleValueObjectConverters) can wrap it with its primitive converter —
-        // Ignore(type) would hide that property and drop the column.
-        //
-        // Exception: when a module author explicitly mapped the VO as a property column in a
-        // custom IEntityTypeConfiguration (e.g. WebManifest via HasConversion in
-        // SiteSeoDefaultsConfiguration), the navigation loop above found no raw navigation to
-        // process. No navigation → no risk of re-discovery during finalization → RemoveEntityType
-        // is sufficient and avoids the EF Core warning "entity type was first mapped explicitly
-        // and then ignored" that Ignore() emits in this scenario.
+        RemoveOrIgnoreValueObjectEntityTypes(modelBuilder, valueObjectClrTypes);
+    }
+
+    // Detaches one auto-discovered value-object navigation on an owner. On a real entity the CLR
+    // member is re-registered as a column (scalar for SingleValueObject<T>, JSON otherwise); on a
+    // value-object owner (removed wholesale later) only the navigation is detached. Throws when the
+    // member was explicitly mapped via OwnsOne(...) on a real entity — an unsupported third VO
+    // persistence path (ADR-017 / ADR-058).
+    private static void ReattachOrDetachValueObjectProperty(
+        Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder ownerBuilder,
+        IMutableEntityType ownerEntityType,
+        System.Reflection.PropertyInfo clrProperty,
+        bool ownerIsValueObject)
+    {
+        IMutableNavigation? nav = ownerEntityType.FindNavigation(clrProperty.Name);
+        if (!ownerIsValueObject && nav?.ForeignKey.IsOwnership == true)
+        {
+            throw new InvalidOperationException(
+                $"'{ownerEntityType.ClrType.Name}.{clrProperty.Name}' is a ValueObject " +
+                $"subtype configured via OwnsOne(...). Granit reserves ValueObject " +
+                $"persistence to two paths: (1) let ApplyGranitConventions auto-serialize " +
+                $"to JSON (multi-field) or a scalar column (SingleValueObject<T>), or " +
+                $"(2) map explicitly via ComplexProperty(...) for typed flat columns. " +
+                $"Drop the OwnsOne call or switch to ComplexProperty. " +
+                $"See ADR-017 (DDD VO strategy) and ADR-058 (JSON persistence policy).");
+        }
+
+        ownerBuilder.Ignore(clrProperty.Name);
+
+        // A value object owner is removed wholesale below — only the navigation needs
+        // detaching. A real entity keeps the data, re-attached as a column.
+        if (ownerIsValueObject)
+        {
+            return;
+        }
+
+        Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder propertyBuilder =
+            ownerBuilder.Property(clrProperty.PropertyType, clrProperty.Name);
+
+        // SingleValueObject<T> maps to its underlying primitive (ApplySingleValueObjectConverters,
+        // next step). A multi-field value object has no single primitive — serialize it to JSON.
+        if (GetSingleValueObjectBase(clrProperty.PropertyType) is null)
+        {
+            ApplyJsonValueObjectConverterMethod // NOSONAR S3011 - intentional: generic value converter over the property CLR type requires reflection
+                .MakeGenericMethod(clrProperty.PropertyType)
+                .Invoke(null, [propertyBuilder.Metadata]);
+        }
+    }
+
+    // Un-maps the phantom value-object entity types after their navigations were detached.
+    //
+    // RemoveEntityType alone is not enough: an earlier convention that calls
+    // modelBuilder.Entity<T>() on the OWNER (the IConcurrencyAware / soft-delete passes
+    // above) re-fires EF navigation discovery, and model FINALIZATION then re-materialises
+    // these phantom value object entity types — with their shadow-FK graph
+    // (OpenGraph → OgImage → ImageDimensions) — straight off the still-present CLR
+    // navigation properties. Finalization then fails binding e.g.
+    // ImageDimensions(int width, int height).
+    //
+    // The model-level Ignore(type) adds the CLR type to the model's ignored set so NO
+    // later convention can re-add it. Restrict it to MULTI-FIELD value objects: a
+    // SingleValueObject<T> must stay visible as a scalar property so the next pass
+    // (ApplySingleValueObjectConverters) can wrap it with its primitive converter —
+    // Ignore(type) would hide that property and drop the column.
+    //
+    // Exception: when a module author explicitly mapped the VO as a property column in a
+    // custom IEntityTypeConfiguration (e.g. WebManifest via HasConversion in
+    // SiteSeoDefaultsConfiguration), the navigation loop above found no raw navigation to
+    // process. No navigation → no risk of re-discovery during finalization → RemoveEntityType
+    // is sufficient and avoids the EF Core warning "entity type was first mapped explicitly
+    // and then ignored" that Ignore() emits in this scenario.
+    private static void RemoveOrIgnoreValueObjectEntityTypes(ModelBuilder modelBuilder, HashSet<Type> valueObjectClrTypes)
+    {
         foreach (Type valueObjectClrType in valueObjectClrTypes)
         {
             if (GetSingleValueObjectBase(valueObjectClrType) is null)

--- a/src/Granit.Presence/Internal/FusionCacheResourcePresenceTracker.cs
+++ b/src/Granit.Presence/Internal/FusionCacheResourcePresenceTracker.cs
@@ -36,6 +36,7 @@ internal sealed class FusionCacheResourcePresenceTracker(
 {
     private const string CacheKeyPrefix = "granit.presence.room";
     private const string GlobalTenant = "global";
+    private const string RoomSizeTag = "room.size";
 
     /// <summary>Maximum metadata size in bytes (UTF-8) accepted by <see cref="JoinAsync"/>.</summary>
     public const int MaxMetadataBytes = 512;
@@ -84,7 +85,7 @@ internal sealed class FusionCacheResourcePresenceTracker(
         {
             metrics.RecordRoomMetadataBytes(resource.Kind, metadataBytes);
         }
-        activity?.SetTag("room.size", merged.Count);
+        activity?.SetTag(RoomSizeTag, merged.Count);
 
         return new ResourceRoom(resource, merged);
     }
@@ -108,7 +109,7 @@ internal sealed class FusionCacheResourcePresenceTracker(
 
         if (existing is null || existing.Count == 0)
         {
-            activity?.SetTag("room.size", 0);
+            activity?.SetTag(RoomSizeTag, 0);
             return;
         }
 
@@ -155,7 +156,7 @@ internal sealed class FusionCacheResourcePresenceTracker(
         }
 
         metrics.RecordRoomSize(tenantId, resource.Kind, remaining.Count);
-        activity?.SetTag("room.size", remaining.Count);
+        activity?.SetTag(RoomSizeTag, remaining.Count);
     }
 
     public async Task<ResourceRoom> GetAsync(
@@ -176,7 +177,7 @@ internal sealed class FusionCacheResourcePresenceTracker(
 
         if (existing is null || existing.Count == 0)
         {
-            activity?.SetTag("room.size", 0);
+            activity?.SetTag(RoomSizeTag, 0);
             metrics.RecordRoomSize(tenantId, resource.Kind, 0);
             return new ResourceRoom(resource, []);
         }
@@ -194,7 +195,7 @@ internal sealed class FusionCacheResourcePresenceTracker(
         }
 
         metrics.RecordRoomSize(tenantId, resource.Kind, live.Count);
-        activity?.SetTag("room.size", live.Count);
+        activity?.SetTag(RoomSizeTag, live.Count);
 
         return new ResourceRoom(resource, live);
     }

--- a/src/Granit.Privacy.Auditing/AuditingPrivacyExportAuditWriter.cs
+++ b/src/Granit.Privacy.Auditing/AuditingPrivacyExportAuditWriter.cs
@@ -25,6 +25,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
     : IPrivacyExportAuditWriter
 {
     private const string SyntheticEntityType = "PrivacyExport";
+    private const string PhaseProperty = "Phase";
 
     public Task WriteExportRequestedAsync(PrivacyExportRequestedAudit data, CancellationToken cancellationToken) =>
         auditingWriter.WriteAsync(new AuditEntry
@@ -40,7 +41,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 data.RequestId,
                 AuditChangeType.Created,
                 [
-                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "requested" },
+                    new AuditPropertyChange { PropertyName = PhaseProperty, NewValue = "requested" },
                     new AuditPropertyChange { PropertyName = "SubjectUserId", NewValue = data.SubjectUserId.ToString("D", CultureInfo.InvariantCulture) },
                     new AuditPropertyChange { PropertyName = "Regulation", NewValue = data.Regulation },
                     new AuditPropertyChange { PropertyName = "ResolvedScopes", NewValue = string.Join(",", data.ResolvedScopes) },
@@ -58,7 +59,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 data.RequestId,
                 AuditChangeType.Modified,
                 [
-                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "fragment-prepared" },
+                    new AuditPropertyChange { PropertyName = PhaseProperty, NewValue = "fragment-prepared" },
                     new AuditPropertyChange { PropertyName = "ProviderName", NewValue = data.ProviderName },
                     new AuditPropertyChange { PropertyName = "FragmentKind", NewValue = data.FragmentKind },
                     new AuditPropertyChange { PropertyName = "EntryPathHash", NewValue = data.EntryPathHash },
@@ -77,7 +78,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 data.RequestId,
                 AuditChangeType.Modified,
                 [
-                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "assembly-started" },
+                    new AuditPropertyChange { PropertyName = PhaseProperty, NewValue = "assembly-started" },
                     new AuditPropertyChange { PropertyName = "Regulation", NewValue = data.Regulation },
                     new AuditPropertyChange { PropertyName = "ExpectedFragmentCount", NewValue = data.ExpectedFragmentCount.ToString(CultureInfo.InvariantCulture) },
                     new AuditPropertyChange { PropertyName = "IsResumed", NewValue = data.IsResumed ? "true" : "false" },
@@ -95,7 +96,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 data.RequestId,
                 AuditChangeType.Modified,
                 [
-                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "shard-completed" },
+                    new AuditPropertyChange { PropertyName = PhaseProperty, NewValue = "shard-completed" },
                     new AuditPropertyChange { PropertyName = "ShardIndex", NewValue = data.ShardIndex.ToString(CultureInfo.InvariantCulture) },
                     new AuditPropertyChange { PropertyName = "SizeBytes", NewValue = data.SizeBytes.ToString(CultureInfo.InvariantCulture) },
                     new AuditPropertyChange { PropertyName = "Sha256", NewValue = data.Sha256Hex },
@@ -114,7 +115,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 data.RequestId,
                 AuditChangeType.Modified,
                 [
-                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "completed" },
+                    new AuditPropertyChange { PropertyName = PhaseProperty, NewValue = "completed" },
                     new AuditPropertyChange { PropertyName = "Regulation", NewValue = data.Regulation },
                     new AuditPropertyChange { PropertyName = "ShardCount", NewValue = data.ShardCount.ToString(CultureInfo.InvariantCulture) },
                     new AuditPropertyChange { PropertyName = "IsPartial", NewValue = data.IsPartial ? "true" : "false" },
@@ -139,7 +140,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 data.RequestId,
                 AuditChangeType.Modified,
                 [
-                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "shard-downloaded" },
+                    new AuditPropertyChange { PropertyName = PhaseProperty, NewValue = "shard-downloaded" },
                     new AuditPropertyChange { PropertyName = "SubjectUserId", NewValue = data.SubjectUserId.ToString("D", CultureInfo.InvariantCulture) },
                     new AuditPropertyChange { PropertyName = "ShardIndex", NewValue = data.ShardIndex.ToString(CultureInfo.InvariantCulture) },
                     new AuditPropertyChange { PropertyName = "AuthMethod", NewValue = data.AuthMethod ?? "" },
@@ -157,7 +158,7 @@ public sealed class AuditingPrivacyExportAuditWriter(IAuditingWriter auditingWri
                 data.RequestId,
                 AuditChangeType.Modified,
                 [
-                    new AuditPropertyChange { PropertyName = "Phase", NewValue = "failed" },
+                    new AuditPropertyChange { PropertyName = PhaseProperty, NewValue = "failed" },
                     new AuditPropertyChange { PropertyName = "ExceptionType", NewValue = data.ExceptionType },
                     new AuditPropertyChange { PropertyName = "RetryCount", NewValue = data.RetryCount.ToString(CultureInfo.InvariantCulture) },
                 ])],

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
@@ -142,7 +142,7 @@ internal sealed partial class PrivacyExportAssemblyService(
 
         string objectKeyPrefix = BuildObjectKeyPrefix(completion.RequestId);
         await using ShardingArchiveWriter writer = new(
-            blobStoreProvider, PrivacyExportContainerBucket(opts), objectKeyPrefix, shardMaxBytes,
+            blobStoreProvider, PrivacyExportContainerBucket(), objectKeyPrefix, shardMaxBytes,
             startShardIndex: startShardIndex,
             priorShards: priorShards);
 
@@ -156,69 +156,14 @@ internal sealed partial class PrivacyExportAssemblyService(
             // to keep the manifest's emptyProviders / manifestFragments lists complete
             // (covering pre-resume work too), but only stream non-empty fragments at or
             // past startFragmentIndex into the writer.
+            FragmentAssemblyContext fragmentContext = new(
+                completion, writer, startFragmentIndex, downloadTtl, httpClient, hmacExpiryWindow,
+                emptyProviders, manifestFragments);
+
             for (int i = 0; i < completion.Fragments.Count; i++)
             {
-                ReceivedFragment fragment = completion.Fragments[i];
-
-                if (string.Equals(fragment.FragmentKind, PrivacyFragmentUploader.EmptyFragmentKind, StringComparison.Ordinal))
-                {
-                    emptyProviders.Add(fragment.ProviderName);
-                    continue;
-                }
-
-                if (!Guid.TryParse(fragment.BlobReferenceId.Value, out Guid blobId))
-                {
-                    LogUnexpectedBlobReference(logger, fragment.ProviderName, fragment.BlobReferenceId.Value, completion.RequestId);
-                    continue;
-                }
-
-                if (i < startFragmentIndex)
-                {
-                    // Re-build manifest metadata for the fragment without re-streaming
-                    // its bytes — the shard it lived in is already committed.
-                    string priorEntryName = await ResolveEntryNameAsync(fragment, blobId, cancellationToken).ConfigureAwait(false);
-                    manifestFragments.Add(new ExportManifestFragment(
-                        fragment.ProviderName, priorEntryName, fragment.ContentType, fragment.BlobReferenceId));
-                    continue;
-                }
-
-                if (!VerifyFragmentTag(completion, fragment, blobId, hmacExpiryWindow))
-                {
-                    LogIntegrityTagRejected(logger, fragment.ProviderName, completion.RequestId);
-                    throw new InvalidOperationException(
-                        $"HMAC integrity tag verification failed for provider '{fragment.ProviderName}' on request {completion.RequestId}.");
-                }
-
-                int shardsBefore = writer.Shards.Count;
-
-                string entryName = await ResolveEntryNameAsync(fragment, blobId, cancellationToken).ConfigureAwait(false);
-                await CopyFragmentToWriterAsync(writer, entryName, fragment, blobId, downloadTtl, httpClient, cancellationToken)
+                shardStartTimestamp = await ProcessFragmentAsync(fragmentContext, i, shardStartTimestamp, cancellationToken)
                     .ConfigureAwait(false);
-
-                manifestFragments.Add(new ExportManifestFragment(
-                    fragment.ProviderName, entryName, fragment.ContentType, fragment.BlobReferenceId));
-
-                // AppendAsync rolls over BEFORE writing when the prior shard hit the cap,
-                // so a growth in Shards.Count means the rolled-over shard is fully
-                // committed to storage. Persist a checkpoint pointing at the fragment
-                // currently in flight (this one): a re-dispatch will re-do this fragment
-                // into a fresh shard, which is fine because the committed shards stay
-                // addressable individually.
-                if (writer.Shards.Count > shardsBefore)
-                {
-                    await checkpointStore.SetAsync(
-                        completion.RequestId,
-                        completion.TenantId,
-                        new ExportAssemblyCheckpoint(
-                            LastCompletedShardIndex: writer.Shards[^1].Index,
-                            NextFragmentIndex: i,
-                            CompletedShardObjectKeys: [.. writer.Shards.Select(s => s.ObjectKey)]),
-                        cancellationToken).ConfigureAwait(false);
-
-                    await EmitShardCompletedAuditAsync(completion, writer.Shards[^1], shardStartTimestamp, cancellationToken)
-                        .ConfigureAwait(false);
-                    shardStartTimestamp = Stopwatch.GetTimestamp();
-                }
             }
 
             // Capture the shard count before CompleteAsync to detect whether a final
@@ -526,6 +471,89 @@ internal sealed partial class PrivacyExportAssemblyService(
         return ms.ToArray();
     }
 
+    // Run-invariant context for the per-fragment assembly loop. The two lists are mutated in place.
+    private sealed record FragmentAssemblyContext(
+        ExportCompletedEto Completion,
+        ShardingArchiveWriter Writer,
+        int StartFragmentIndex,
+        TimeSpan DownloadTtl,
+        HttpClient HttpClient,
+        DateTimeOffset HmacExpiryWindow,
+        List<string> EmptyProviders,
+        List<ExportManifestFragment> ManifestFragments);
+
+    // Processes fragment <paramref name="i"/>: skips empty / malformed / already-committed
+    // fragments, verifies the HMAC tag, streams the bytes into the writer, and checkpoints on a
+    // shard rollover. Returns the (possibly reset) per-shard start timestamp.
+    private async Task<long> ProcessFragmentAsync(
+        FragmentAssemblyContext ctx, int i, long shardStartTimestamp, CancellationToken cancellationToken)
+    {
+        ExportCompletedEto completion = ctx.Completion;
+        ReceivedFragment fragment = completion.Fragments[i];
+
+        if (string.Equals(fragment.FragmentKind, PrivacyFragmentUploader.EmptyFragmentKind, StringComparison.Ordinal))
+        {
+            ctx.EmptyProviders.Add(fragment.ProviderName);
+            return shardStartTimestamp;
+        }
+
+        if (!Guid.TryParse(fragment.BlobReferenceId.Value, out Guid blobId))
+        {
+            LogUnexpectedBlobReference(logger, fragment.ProviderName, fragment.BlobReferenceId.Value, completion.RequestId);
+            return shardStartTimestamp;
+        }
+
+        if (i < ctx.StartFragmentIndex)
+        {
+            // Re-build manifest metadata for the fragment without re-streaming
+            // its bytes — the shard it lived in is already committed.
+            string priorEntryName = await ResolveEntryNameAsync(fragment, blobId, cancellationToken).ConfigureAwait(false);
+            ctx.ManifestFragments.Add(new ExportManifestFragment(
+                fragment.ProviderName, priorEntryName, fragment.ContentType, fragment.BlobReferenceId));
+            return shardStartTimestamp;
+        }
+
+        if (!VerifyFragmentTag(completion, fragment, blobId, ctx.HmacExpiryWindow))
+        {
+            LogIntegrityTagRejected(logger, fragment.ProviderName, completion.RequestId);
+            throw new InvalidOperationException(
+                $"HMAC integrity tag verification failed for provider '{fragment.ProviderName}' on request {completion.RequestId}.");
+        }
+
+        int shardsBefore = ctx.Writer.Shards.Count;
+
+        string entryName = await ResolveEntryNameAsync(fragment, blobId, cancellationToken).ConfigureAwait(false);
+        await CopyFragmentToWriterAsync(ctx.Writer, entryName, fragment, blobId, ctx.DownloadTtl, ctx.HttpClient, cancellationToken)
+            .ConfigureAwait(false);
+
+        ctx.ManifestFragments.Add(new ExportManifestFragment(
+            fragment.ProviderName, entryName, fragment.ContentType, fragment.BlobReferenceId));
+
+        // AppendAsync rolls over BEFORE writing when the prior shard hit the cap,
+        // so a growth in Shards.Count means the rolled-over shard is fully
+        // committed to storage. Persist a checkpoint pointing at the fragment
+        // currently in flight (this one): a re-dispatch will re-do this fragment
+        // into a fresh shard, which is fine because the committed shards stay
+        // addressable individually.
+        if (ctx.Writer.Shards.Count > shardsBefore)
+        {
+            await checkpointStore.SetAsync(
+                completion.RequestId,
+                completion.TenantId,
+                new ExportAssemblyCheckpoint(
+                    LastCompletedShardIndex: ctx.Writer.Shards[^1].Index,
+                    NextFragmentIndex: i,
+                    CompletedShardObjectKeys: [.. ctx.Writer.Shards.Select(s => s.ObjectKey)]),
+                cancellationToken).ConfigureAwait(false);
+
+            await EmitShardCompletedAuditAsync(completion, ctx.Writer.Shards[^1], shardStartTimestamp, cancellationToken)
+                .ConfigureAwait(false);
+            return Stopwatch.GetTimestamp();
+        }
+
+        return shardStartTimestamp;
+    }
+
     private static string BuildObjectKeyPrefix(Guid requestId) =>
         $"personal-data-export/{requestId}";
 
@@ -533,7 +561,7 @@ internal sealed partial class PrivacyExportAssemblyService(
     // bucket name (not container). The privacy export uses a single bucket name —
     // re-use the fragment-container constant so providers that wire one bucket per
     // container resolve consistently.
-    private static string PrivacyExportContainerBucket(GranitPrivacyOptions _) =>
+    private static string PrivacyExportContainerBucket() =>
         PrivacyExportContainerNames.FragmentContainer;
 
     private static string ExtensionFor(string contentType) => contentType switch

--- a/src/Granit.Privacy.BlobStorage/DataExport/ShardingArchiveWriter.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/ShardingArchiveWriter.cs
@@ -166,7 +166,7 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
         // completed shards stay committed in storage.
         if (_zip is not null)
         {
-            try { _zip.Dispose(); }
+            try { await _zip.DisposeAsync().ConfigureAwait(false); }
             catch { /* ignore — abort path */ }
             _zip = null;
         }
@@ -222,7 +222,7 @@ internal sealed class ShardingArchiveWriter : IAsyncDisposable
         // counter into the multipart stream. Must precede CompleteAsync on the multipart
         // so the upload captures the directory — and ComputeHashAndReset must happen
         // after the dispose so the central directory is included in the digest.
-        _zip.Dispose();
+        await _zip.DisposeAsync().ConfigureAwait(false);
         _zip = null;
 
         byte[] sha256 = _hasher!.ComputeHashAndReset();

--- a/src/Granit.Privacy.BlobStorage/Streaming/BlobBackedExportSource.cs
+++ b/src/Granit.Privacy.BlobStorage/Streaming/BlobBackedExportSource.cs
@@ -18,16 +18,24 @@ public sealed class BlobBackedExportSource(
     TimeProvider timeProvider) : IBlobBackedExportSource
 {
     /// <inheritdoc />
-    public async IAsyncEnumerable<ExportFragment> StreamAsync(
+    public IAsyncEnumerable<ExportFragment> StreamAsync(
+        IAsyncEnumerable<BlobBackedExportItem> items,
+        PrivacyExportContext context,
+        string providerName,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrEmpty(providerName);
+        return StreamCoreAsync(items, context, providerName, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<ExportFragment> StreamCoreAsync(
         IAsyncEnumerable<BlobBackedExportItem> items,
         PrivacyExportContext context,
         string providerName,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(items);
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentException.ThrowIfNullOrEmpty(providerName);
-
         // Capability TTL: saga timeout + worker headroom. Same envelope StagedFragmentBuilder
         // uses, so a single rotation horizon covers both fragment kinds.
         DateTimeOffset expiresAt = timeProvider.GetUtcNow()

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyTenantScopedProviderValidator.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/PrivacyTenantScopedProviderValidator.cs
@@ -113,17 +113,10 @@ internal sealed partial class PrivacyTenantScopedProviderValidator(
         // Inspect every public constructor's parameter list. Most providers expose a single
         // primary ctor, but we don't assume — any ctor reachable by DI is a potential bind
         // site, and a false negative here would defeat the validator's purpose.
-        HashSet<Type> matches = [];
-        foreach (System.Reflection.ConstructorInfo ctor in providerType.GetConstructors())
-        {
-            foreach (System.Reflection.ParameterInfo param in ctor.GetParameters())
-            {
-                if (isolatedDbContextTypes.Contains(param.ParameterType))
-                {
-                    matches.Add(param.ParameterType);
-                }
-            }
-        }
+        HashSet<Type> matches = [.. providerType.GetConstructors()
+            .SelectMany(ctor => ctor.GetParameters())
+            .Select(param => param.ParameterType)
+            .Where(isolatedDbContextTypes.Contains)];
         return [.. matches];
     }
 

--- a/src/Granit.Privacy.Vault/VaultExportHmacSigner.cs
+++ b/src/Granit.Privacy.Vault/VaultExportHmacSigner.cs
@@ -1,7 +1,6 @@
 using Granit.Privacy.DataExport.Security;
 using Granit.Privacy.Vault.Options;
 using Granit.Vault;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Privacy.Vault;
@@ -36,21 +35,17 @@ public sealed partial class VaultExportHmacSigner : IExportHmacSigner, IExportCo
 
     private readonly ITransitMacService _macService;
     private readonly VaultExportSignerOptions _options;
-    private readonly ILogger<VaultExportHmacSigner> _logger;
 
     /// <summary>Initializes a new instance.</summary>
     public VaultExportHmacSigner(
         ITransitMacService macService,
-        IOptions<VaultExportSignerOptions> options,
-        ILogger<VaultExportHmacSigner> logger)
+        IOptions<VaultExportSignerOptions> options)
     {
         ArgumentNullException.ThrowIfNull(macService);
         ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(logger);
 
         _macService = macService;
         _options = options.Value;
-        _logger = logger;
     }
 
     /// <inheritdoc />

--- a/src/Granit.Privacy/DataExport/Sanitization/EntryPathSanitizer.cs
+++ b/src/Granit.Privacy/DataExport/Sanitization/EntryPathSanitizer.cs
@@ -75,17 +75,28 @@ public static partial class EntryPathSanitizer
         }
 
         // Control characters anywhere in the string.
-        foreach (char c in normalized)
+        if (normalized.Cast<char?>().FirstOrDefault(c => c < 0x20 || c == 0x7F) is { } control)
         {
-            if (c < 0x20 || c == 0x7F)
-            {
-                throw new InvalidExportEntryPathException(entryPath, $"control character 0x{(int)c:X2} not allowed");
-            }
+            throw new InvalidExportEntryPathException(
+                entryPath, $"control character 0x{(int)control:X2} not allowed");
         }
 
-        // Per-segment checks.
-        string[] segments = normalized.Split('/');
-        foreach (string segment in segments)
+        ValidateSegments(entryPath, normalized);
+
+        int fullByteLength = Encoding.UTF8.GetByteCount(normalized);
+        if (fullByteLength > MaxFullPathBytes)
+        {
+            throw new InvalidExportEntryPathException(
+                entryPath,
+                $"path exceeds {MaxFullPathBytes} bytes ({fullByteLength})");
+        }
+
+        return normalized;
+    }
+
+    private static void ValidateSegments(string entryPath, string normalized)
+    {
+        foreach (string segment in normalized.Split('/'))
         {
             if (segment.Length == 0)
             {
@@ -117,16 +128,6 @@ public static partial class EntryPathSanitizer
                     $"segment '{segment}' uses a Windows reserved name");
             }
         }
-
-        int fullByteLength = Encoding.UTF8.GetByteCount(normalized);
-        if (fullByteLength > MaxFullPathBytes)
-        {
-            throw new InvalidExportEntryPathException(
-                entryPath,
-                $"path exceeds {MaxFullPathBytes} bytes ({fullByteLength})");
-        }
-
-        return normalized;
     }
 
     private static string Normalize(string entryPath)

--- a/src/Granit.TextExtraction.Office/ExcelTextExtractor.cs
+++ b/src/Granit.TextExtraction.Office/ExcelTextExtractor.cs
@@ -80,7 +80,7 @@ public sealed partial class ExcelTextExtractor : ITextExtractor
             StringBuilder sb = new(Math.Min(maxCharLength, 8192));
             bool truncated = false;
 
-            foreach (WorksheetPart worksheetPart in workbookPart.WorksheetParts)
+            foreach (Worksheet? worksheet in workbookPart.WorksheetParts.Select(part => part.Worksheet))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -90,35 +90,13 @@ public sealed partial class ExcelTextExtractor : ITextExtractor
                     if (truncated) { break; }
                 }
 
-                Worksheet? worksheet = worksheetPart.Worksheet;
                 if (worksheet is null) { continue; }
 
-                foreach (Row row in worksheet.Descendants<Row>())
+                if (AppendWorksheet(sb, worksheet, sharedStrings, maxCharLength, cancellationToken))
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    bool firstCellInRow = true;
-                    foreach (Cell cell in row.Descendants<Cell>())
-                    {
-                        if (!firstCellInRow)
-                        {
-                            AppendIfRoom(sb, '\t', maxCharLength, ref truncated);
-                            if (truncated) { break; }
-                        }
-
-                        string cellText = ResolveCellText(cell, sharedStrings);
-                        AppendIfRoom(sb, cellText, maxCharLength, ref truncated);
-                        if (truncated) { break; }
-
-                        firstCellInRow = false;
-                    }
-
-                    if (truncated) { break; }
-                    AppendIfRoom(sb, '\n', maxCharLength, ref truncated);
-                    if (truncated) { break; }
+                    truncated = true;
+                    break;
                 }
-
-                if (truncated) { break; }
             }
 
             return new TextExtractionResult(
@@ -134,6 +112,51 @@ public sealed partial class ExcelTextExtractor : ITextExtractor
             LogPackageParseFailed(ex);
             return OpenXmlExtraction.Skipped(ExtractorName);
         }
+    }
+
+    // Appends one worksheet's rows. Returns true once the output cap is hit.
+    private static bool AppendWorksheet(
+        StringBuilder sb, Worksheet worksheet, SharedStringTable? sharedStrings,
+        int maxCharLength, CancellationToken cancellationToken)
+    {
+        bool truncated = false;
+        foreach (Row row in worksheet.Descendants<Row>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (AppendRow(sb, row, sharedStrings, maxCharLength))
+            {
+                return true;
+            }
+
+            AppendIfRoom(sb, '\n', maxCharLength, ref truncated);
+            if (truncated) { return true; }
+        }
+
+        return false;
+    }
+
+    // Appends one row's tab-separated cells. Returns true once the output cap is hit.
+    private static bool AppendRow(StringBuilder sb, Row row, SharedStringTable? sharedStrings, int maxCharLength)
+    {
+        bool truncated = false;
+        bool firstCellInRow = true;
+        foreach (Cell cell in row.Descendants<Cell>())
+        {
+            if (!firstCellInRow)
+            {
+                AppendIfRoom(sb, '\t', maxCharLength, ref truncated);
+                if (truncated) { return true; }
+            }
+
+            string cellText = ResolveCellText(cell, sharedStrings);
+            AppendIfRoom(sb, cellText, maxCharLength, ref truncated);
+            if (truncated) { return true; }
+
+            firstCellInRow = false;
+        }
+
+        return false;
     }
 
     private static string ResolveCellText(Cell cell, SharedStringTable? sharedStrings)

--- a/src/Granit.TextExtraction.Pdf.Ocr/PdfOcrTextExtractor.cs
+++ b/src/Granit.TextExtraction.Pdf.Ocr/PdfOcrTextExtractor.cs
@@ -135,38 +135,17 @@ public sealed partial class PdfOcrTextExtractor : ITextExtractor
                 cancellationToken.ThrowIfCancellationRequested();
 
                 Page page = document.GetPage(i);
-                (string nativeText, bool pageFallback) = ExtractPageText(page);
-                usedFallback |= pageFallback;
+                PageAppendResult result = await AppendPageTextAsync(
+                    sb, page, pageNumber: i, ocrExtractor, pdfMemory, maxCharLength, cancellationToken)
+                    .ConfigureAwait(false);
 
-                string pageText = nativeText;
-                bool scanned = nativeText.Length < _ocrOptions.MinNativeCharsPerPage;
-                if (scanned && ocrExtractor is not null)
+                usedFallback |= result.UsedFallback;
+                usedOcr |= result.UsedOcr;
+                if (result.Truncated)
                 {
-                    string? ocrText = await TryOcrPageAsync(
-                        ocrExtractor, pdfMemory, pageIndex: i - 1, page, maxCharLength, cancellationToken)
-                        .ConfigureAwait(false);
-                    if (!string.IsNullOrEmpty(ocrText))
-                    {
-                        pageText = ocrText;
-                        usedOcr = true;
-                    }
-                }
-
-                if (sb.Length > 0)
-                {
-                    sb.Append('\n');
-                    sb.Append('\n');
-                }
-
-                int remaining = maxCharLength - sb.Length;
-                if (pageText.Length >= remaining)
-                {
-                    sb.Append(pageText, 0, Math.Max(remaining, 0));
                     truncated = true;
                     break;
                 }
-
-                sb.Append(pageText);
             }
 
             string content = sb.ToString();
@@ -183,6 +162,48 @@ public sealed partial class PdfOcrTextExtractor : ITextExtractor
                     ? ExtractionConfidence.Heuristic
                     : ExtractionConfidence.Deterministic);
         }
+    }
+
+    private readonly record struct PageAppendResult(bool Truncated, bool UsedOcr, bool UsedFallback);
+
+    // Extracts one page (native text, falling back to OCR for scanned pages), appends it to
+    // <paramref name="sb"/> with a blank-line separator, and reports whether the output cap was hit.
+    private async Task<PageAppendResult> AppendPageTextAsync(
+        StringBuilder sb, Page page, int pageNumber, ITextExtractor? ocrExtractor,
+        ReadOnlyMemory<byte> pdfMemory, int maxCharLength, CancellationToken cancellationToken)
+    {
+        (string nativeText, bool pageFallback) = ExtractPageText(page);
+
+        string pageText = nativeText;
+        bool usedOcr = false;
+        bool scanned = nativeText.Length < _ocrOptions.MinNativeCharsPerPage;
+        if (scanned && ocrExtractor is not null)
+        {
+            string? ocrText = await TryOcrPageAsync(
+                ocrExtractor, pdfMemory, pageIndex: pageNumber - 1, page, maxCharLength, cancellationToken)
+                .ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(ocrText))
+            {
+                pageText = ocrText;
+                usedOcr = true;
+            }
+        }
+
+        if (sb.Length > 0)
+        {
+            sb.Append('\n');
+            sb.Append('\n');
+        }
+
+        int remaining = maxCharLength - sb.Length;
+        if (pageText.Length >= remaining)
+        {
+            sb.Append(pageText, 0, Math.Max(remaining, 0));
+            return new PageAppendResult(Truncated: true, usedOcr, pageFallback);
+        }
+
+        sb.Append(pageText);
+        return new PageAppendResult(Truncated: false, usedOcr, pageFallback);
     }
 
     private async Task<string?> TryOcrPageAsync(

--- a/src/Granit.TextExtraction/Diagnostics/TextExtractionMetrics.cs
+++ b/src/Granit.TextExtraction/Diagnostics/TextExtractionMetrics.cs
@@ -19,6 +19,10 @@ public sealed class TextExtractionMetrics
 {
     public const string MeterName = "Granit.TextExtraction";
 
+    internal const string TenantIdTag = "tenant_id";
+    internal const string ContentTypeTag = "content_type";
+    internal const string GlobalTenant = "global";
+
     /// <summary>
     /// Sentinel surfaced on the <c>content_type</c> tag when the caller-supplied MIME string
     /// fails RFC 2045 parsing (malformed, empty, all-whitespace). Stable across releases so
@@ -58,9 +62,9 @@ public sealed class TextExtractionMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("extractor", extractorName),
-            new("content_type", NormalizeContentType(contentType)),
+            new(ContentTypeTag, NormalizeContentType(contentType)),
         ];
         _success.Add(1, tags);
     }
@@ -69,9 +73,9 @@ public sealed class TextExtractionMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("extractor", extractorName),
-            new("content_type", NormalizeContentType(contentType)),
+            new(ContentTypeTag, NormalizeContentType(contentType)),
             new("reason", reason),
         ];
         _failed.Add(1, tags);
@@ -81,8 +85,8 @@ public sealed class TextExtractionMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
-            new("content_type", NormalizeContentType(contentType)),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
+            new(ContentTypeTag, NormalizeContentType(contentType)),
         ];
         _skipped.Add(1, tags);
     }
@@ -91,9 +95,9 @@ public sealed class TextExtractionMetrics
     {
         TagList tags =
         [
-            new("tenant_id", tenantId ?? "global"),
+            new(TenantIdTag, tenantId ?? GlobalTenant),
             new("extractor", extractorName),
-            new("content_type", NormalizeContentType(contentType)),
+            new(ContentTypeTag, NormalizeContentType(contentType)),
         ];
         _truncated.Add(1, tags);
     }

--- a/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
+++ b/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
@@ -142,12 +142,9 @@ internal sealed class TextExtractionPipeline : ITextExtractionPipeline, IDisposa
 
     private ITextExtractor SelectExtractor(string contentType)
     {
-        foreach (ITextExtractor extractor in _extractors)
+        if (_extractors.FirstOrDefault(extractor => extractor.CanHandle(contentType)) is { } match)
         {
-            if (extractor.CanHandle(contentType))
-            {
-                return extractor;
-            }
+            return match;
         }
 
         // Universal fallback. RecordSkipped is fired so dashboards surface unmapped MIMEs even

--- a/src/Granit.Timeline/Domain/EmojiValidator.cs
+++ b/src/Granit.Timeline/Domain/EmojiValidator.cs
@@ -65,49 +65,20 @@ public static class EmojiValidator
         foreach (Rune r in emoji.EnumerateRunes())
         {
             RuneKind kind = Classify(r.Value);
-            switch (kind)
+            if (kind == RuneKind.Invalid)
             {
-                case RuneKind.Invalid:
-                    return false;
-                case RuneKind.Base:
-                case RuneKind.KeycapBase:
-                    hasBase = true;
-                    break;
-                case RuneKind.Modifier:
-                case RuneKind.Vs16:
-                case RuneKind.KeycapCombiner:
-                    // Combiners need a preceding atom (base or keycap base).
-                    if (previous is RuneKind.Start or RuneKind.Zwj)
-                    {
-                        return false;
-                    }
-                    break;
-                case RuneKind.Zwj:
-                    // ZWJ at start or doubled is not allowed.
-                    if (previous is RuneKind.Start or RuneKind.Zwj)
-                    {
-                        return false;
-                    }
-                    break;
-                case RuneKind.TagChar:
-                    // Tag chars (U+E0020..U+E007E) form the payload of an
-                    // Emoji_Tag_Sequence after a base — e.g. the
-                    // subdivision flags 🏴󠁧󠁢󠁥󠁮󠁧󠁿 (England). They are never
-                    // valid at start, after a combiner, or after a ZWJ.
-                    if (previous is not (RuneKind.Base or RuneKind.TagChar))
-                    {
-                        return false;
-                    }
-                    break;
-                case RuneKind.TagEnd:
-                    // Cancel-tag (U+E007F) terminates an open tag sequence
-                    // and is only valid right after at least one tag char.
-                    if (previous != RuneKind.TagChar)
-                    {
-                        return false;
-                    }
-                    break;
+                return false;
             }
+
+            if (kind is RuneKind.Base or RuneKind.KeycapBase)
+            {
+                hasBase = true;
+            }
+            else if (!IsValidTransition(kind, previous))
+            {
+                return false;
+            }
+
             previous = kind;
         }
 
@@ -170,6 +141,23 @@ public static class EmojiValidator
         return buffer.ToString();
     }
 
+    // Validates that a combiner/joiner/tag rune may follow <paramref name="previous"/>.
+    // Base / KeycapBase / Invalid are handled by the caller and never reach here.
+    private static bool IsValidTransition(RuneKind kind, RuneKind previous) => kind switch
+    {
+        // Combiners and ZWJ need a preceding atom; ZWJ may not start or double.
+        RuneKind.Modifier or RuneKind.Vs16 or RuneKind.KeycapCombiner or RuneKind.Zwj
+            => previous is not (RuneKind.Start or RuneKind.Zwj),
+        // Tag chars (U+E0020..U+E007E) form an Emoji_Tag_Sequence after a base —
+        // e.g. the subdivision flags 🏴󠁧󠁢󠁥󠁮󠁧󠁿 (England). Never valid at start, after a
+        // combiner, or after a ZWJ.
+        RuneKind.TagChar => previous is RuneKind.Base or RuneKind.TagChar,
+        // Cancel-tag (U+E007F) terminates an open tag sequence, valid only right
+        // after at least one tag char.
+        RuneKind.TagEnd => previous == RuneKind.TagChar,
+        _ => true,
+    };
+
     private enum RuneKind
     {
         Start,
@@ -225,33 +213,35 @@ public static class EmojiValidator
     private static bool IsKeycapBase(int cp) =>
         cp == 0x23 || cp == 0x2A || (cp >= 0x30 && cp <= 0x39);
 
-    // Recognised emoji codepoints, ordered by block. The set mirrors the
-    // Unicode Extended_Pictographic property for blocks where emojis live;
-    // the safety-net goal does not require the strict RGI subset.
-    private static bool IsEmojiBase(int cp) => cp switch
-    {
-        0x00A9 or 0x00AE => true,
-        0x203C or 0x2049 => true,
-        0x2122 or 0x2139 => true,
-        >= 0x2194 and <= 0x2199 => true,
-        >= 0x21A9 and <= 0x21AA => true,
-        >= 0x231A and <= 0x231B => true,
-        0x2328 => true,
-        0x23CF => true,
-        >= 0x23E9 and <= 0x23F3 => true,
-        >= 0x23F8 and <= 0x23FA => true,
-        0x24C2 => true,
-        >= 0x25AA and <= 0x25AB => true,
-        0x25B6 or 0x25C0 => true,
-        >= 0x25FB and <= 0x25FE => true,
-        >= 0x2600 and <= 0x27BF => true,
-        >= 0x2934 and <= 0x2935 => true,
-        >= 0x2B00 and <= 0x2BFF => true,
-        0x3030 or 0x303D or 0x3297 or 0x3299 => true,
-        // Supplementary Multilingual Plane emoji blocks. The Fitzpatrick
-        // range (0x1F3FB..0x1F3FF) is intercepted earlier by Classify so
-        // it never reaches this switch as a base.
-        >= 0x1F000 and <= 0x1FAFF => true,
-        _ => false,
-    };
+    // Recognised emoji codepoint ranges, ordered by block. The set mirrors the
+    // Unicode Extended_Pictographic property for blocks where emojis live; the
+    // safety-net goal does not require the strict RGI subset. Single codepoints
+    // are encoded as a one-element range (Min == Max). The Fitzpatrick range
+    // (0x1F3FB..0x1F3FF) is intercepted earlier by Classify, so it never reaches
+    // this table as a base even though it falls inside 0x1F000..0x1FAFF.
+    private static readonly (int Min, int Max)[] EmojiBaseRanges =
+    [
+        (0x00A9, 0x00A9), (0x00AE, 0x00AE),
+        (0x203C, 0x203C), (0x2049, 0x2049),
+        (0x2122, 0x2122), (0x2139, 0x2139),
+        (0x2194, 0x2199),
+        (0x21A9, 0x21AA),
+        (0x231A, 0x231B),
+        (0x2328, 0x2328),
+        (0x23CF, 0x23CF),
+        (0x23E9, 0x23F3),
+        (0x23F8, 0x23FA),
+        (0x24C2, 0x24C2),
+        (0x25AA, 0x25AB),
+        (0x25B6, 0x25B6), (0x25C0, 0x25C0),
+        (0x25FB, 0x25FE),
+        (0x2600, 0x27BF),
+        (0x2934, 0x2935),
+        (0x2B00, 0x2BFF),
+        (0x3030, 0x3030), (0x303D, 0x303D), (0x3297, 0x3297), (0x3299, 0x3299),
+        (0x1F000, 0x1FAFF),
+    ];
+
+    private static bool IsEmojiBase(int cp) =>
+        Array.Exists(EmojiBaseRanges, range => cp >= range.Min && cp <= range.Max);
 }

--- a/src/Granit.Validation.AI/Internal/LlmContentModerator.cs
+++ b/src/Granit.Validation.AI/Internal/LlmContentModerator.cs
@@ -63,8 +63,6 @@ internal sealed partial class LlmContentModerator(
                     LogModerationFailed();
                     return AcceptWithWarning();
 
-                case StructuredCompletionStatus.ModelRefused:
-                case StructuredCompletionStatus.SchemaViolation:
                 default:
                     // Refused or unparseable output suggests adversarial manipulation — fail closed.
                     LogModerationParseFailure();

--- a/src/Granit.Validation/Internal/PropertyNameHumanizer.cs
+++ b/src/Granit.Validation/Internal/PropertyNameHumanizer.cs
@@ -55,16 +55,5 @@ internal static partial class PropertyNameHumanizer
         return string.Join(' ', words);
     }
 
-    private static bool IsAcronym(string word)
-    {
-        foreach (char c in word)
-        {
-            if (char.IsLower(c))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
+    private static bool IsAcronym(string word) => !word.Any(char.IsLower);
 }

--- a/src/Granit.Vault.Azure/Services/AzureManagedHsmMacService.cs
+++ b/src/Granit.Vault.Azure/Services/AzureManagedHsmMacService.cs
@@ -23,6 +23,7 @@ internal sealed partial class AzureManagedHsmMacService : ITransitMacService, ID
 {
     private const string ProviderName = "azure-hsm";
     private const string TagPrefix = "ahsm:";
+    private const string VerifyOperation = "verify";
 
     private readonly AzureManagedHsmMacOptions _options;
     private readonly VaultMetrics _metrics;
@@ -160,7 +161,7 @@ internal sealed partial class AzureManagedHsmMacService : ITransitMacService, ID
             bool ok = result.IsValid;
             _metrics.RecordOperationCompleted(
                 tenantId,
-                "verify",
+                VerifyOperation,
                 ProviderName,
                 ok ? "success" : "rejected");
             return ok;
@@ -168,18 +169,18 @@ internal sealed partial class AzureManagedHsmMacService : ITransitMacService, ID
         catch (RequestFailedException ex) when (ex.Status is 404 or 403)
         {
             // Version unknown / disabled / forbidden — treat as miss rather than error.
-            _metrics.RecordOperationCompleted(tenantId, "verify", ProviderName, "rejected");
+            _metrics.RecordOperationCompleted(tenantId, VerifyOperation, ProviderName, "rejected");
             return false;
         }
         catch
         {
-            _metrics.RecordOperationError(tenantId, "verify", ProviderName);
+            _metrics.RecordOperationError(tenantId, VerifyOperation, ProviderName);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            _metrics.RecordOperationDuration(tenantId, "verify", ProviderName, stopwatch.Elapsed);
+            _metrics.RecordOperationDuration(tenantId, VerifyOperation, ProviderName, stopwatch.Elapsed);
         }
     }
 

--- a/src/Granit.Vault.GoogleCloud/Services/GoogleCloudKmsMacService.cs
+++ b/src/Granit.Vault.GoogleCloud/Services/GoogleCloudKmsMacService.cs
@@ -30,6 +30,7 @@ internal sealed partial class GoogleCloudKmsMacService(
 {
     private const string ProviderName = "googlecloud";
     private const string TagPrefix = "gcpkms:";
+    private const string VerifyOperation = "verify";
 
     private readonly CryptoKeyName _cryptoKeyName = new(
         vaultOptions.Value.ProjectId,
@@ -148,14 +149,14 @@ internal sealed partial class GoogleCloudKmsMacService(
             }
             catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
             {
-                metrics.RecordOperationCompleted(tenantId, "verify", ProviderName, "rejected");
+                metrics.RecordOperationCompleted(tenantId, VerifyOperation, ProviderName, "rejected");
                 return false;
             }
 
             if (versionState.State != CryptoKeyVersion.Types.CryptoKeyVersionState.Enabled)
             {
                 LogVersionDisabled(logger, _cryptoKeyName.CryptoKeyId, version, versionState.State.ToString());
-                metrics.RecordOperationCompleted(tenantId, "verify", ProviderName, "rejected");
+                metrics.RecordOperationCompleted(tenantId, VerifyOperation, ProviderName, "rejected");
                 return false;
             }
 
@@ -169,20 +170,20 @@ internal sealed partial class GoogleCloudKmsMacService(
             bool ok = response.Success;
             metrics.RecordOperationCompleted(
                 tenantId,
-                "verify",
+                VerifyOperation,
                 ProviderName,
                 ok ? "success" : "rejected");
             return ok;
         }
         catch
         {
-            metrics.RecordOperationError(tenantId, "verify", ProviderName);
+            metrics.RecordOperationError(tenantId, VerifyOperation, ProviderName);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            metrics.RecordOperationDuration(tenantId, "verify", ProviderName, stopwatch.Elapsed);
+            metrics.RecordOperationDuration(tenantId, VerifyOperation, ProviderName, stopwatch.Elapsed);
         }
     }
 

--- a/src/Granit.Vault.HashiCorp/Services/HashiCorpTransitMacService.cs
+++ b/src/Granit.Vault.HashiCorp/Services/HashiCorpTransitMacService.cs
@@ -27,6 +27,7 @@ internal sealed partial class HashiCorpTransitMacService(
     ILogger<HashiCorpTransitMacService> logger) : ITransitMacService
 {
     private const string ProviderName = "hashicorp";
+    private const string VerifyOperation = "verify";
     private readonly HashiCorpVaultOptions _options = options.Value;
 
     // Vault Transit HMAC tag format: vault:v{N}:base64
@@ -128,25 +129,25 @@ internal sealed partial class HashiCorpTransitMacService(
             bool valid = ExtractValid(response.Data);
             metrics.RecordOperationCompleted(
                 tenantId,
-                "verify",
+                VerifyOperation,
                 ProviderName,
                 valid ? "success" : "rejected");
             return valid;
         }
         catch (Exception ex) when (IsKeyNotFound(ex))
         {
-            metrics.RecordOperationError(tenantId, "verify", ProviderName);
+            metrics.RecordOperationError(tenantId, VerifyOperation, ProviderName);
             throw new MacKeyNotFoundException(keyName, ex);
         }
         catch
         {
-            metrics.RecordOperationError(tenantId, "verify", ProviderName);
+            metrics.RecordOperationError(tenantId, VerifyOperation, ProviderName);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            metrics.RecordOperationDuration(tenantId, "verify", ProviderName, stopwatch.Elapsed);
+            metrics.RecordOperationDuration(tenantId, VerifyOperation, ProviderName, stopwatch.Elapsed);
         }
     }
 

--- a/src/Granit.Vault/Services/SecretBackedMacService.cs
+++ b/src/Granit.Vault/Services/SecretBackedMacService.cs
@@ -31,6 +31,7 @@ public sealed partial class SecretBackedMacService : ITransitMacService, IDispos
 {
     private const string ProviderName = "secret-backed";
     private const string TagPrefix = "sbm:";
+    private const string VerifyOperation = "verify";
     private const int RequiredKeySizeBytes = 32;
 
     private readonly ISecretStore _secretStore;
@@ -125,7 +126,7 @@ public sealed partial class SecretBackedMacService : ITransitMacService, IDispos
             int colon = body.IndexOf(':');
             if (colon <= 0)
             {
-                _metrics.RecordOperationCompleted(tenantId, "verify", ProviderName, "rejected");
+                _metrics.RecordOperationCompleted(tenantId, VerifyOperation, ProviderName, "rejected");
                 return false;
             }
 
@@ -136,7 +137,7 @@ public sealed partial class SecretBackedMacService : ITransitMacService, IDispos
             }
             catch (FormatException)
             {
-                _metrics.RecordOperationCompleted(tenantId, "verify", ProviderName, "rejected");
+                _metrics.RecordOperationCompleted(tenantId, VerifyOperation, ProviderName, "rejected");
                 return false;
             }
 
@@ -159,20 +160,20 @@ public sealed partial class SecretBackedMacService : ITransitMacService, IDispos
             bool ok = currentMatch || previousMatch;
             _metrics.RecordOperationCompleted(
                 tenantId,
-                "verify",
+                VerifyOperation,
                 ProviderName,
                 ok ? "success" : "rejected");
             return ok;
         }
         catch
         {
-            _metrics.RecordOperationError(tenantId, "verify", ProviderName);
+            _metrics.RecordOperationError(tenantId, VerifyOperation, ProviderName);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            _metrics.RecordOperationDuration(tenantId, "verify", ProviderName, stopwatch.Elapsed);
+            _metrics.RecordOperationDuration(tenantId, VerifyOperation, ProviderName, stopwatch.Elapsed);
         }
     }
 

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDualScopeIntegrationValidator.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDualScopeIntegrationValidator.cs
@@ -2,7 +2,6 @@ using System.Text;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.Webhooks.Domain;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -43,16 +42,10 @@ internal sealed partial class WebhooksDualScopeIntegrationValidator(
     /// <inheritdoc/>
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        List<(Type DbContextType, List<string> Entities)> offenders = [];
-
-        foreach (IsolatedDbContextMarker marker in markers)
-        {
-            List<string>? folded = TryFindFoldedWebhooksEntities(marker.DbContextType);
-            if (folded is { Count: > 0 })
-            {
-                offenders.Add((marker.DbContextType, folded));
-            }
-        }
+        List<(Type DbContextType, List<string> Entities)> offenders = [.. markers
+            .Select(marker => (marker.DbContextType, Folded: TryFindFoldedWebhooksEntities(marker.DbContextType)))
+            .Where(x => x.Folded is { Count: > 0 })
+            .Select(x => (x.DbContextType, x.Folded!))];
 
         if (offenders.Count == 0)
         {
@@ -109,15 +102,10 @@ internal sealed partial class WebhooksDualScopeIntegrationValidator(
 
             try
             {
-                List<string> matches = [];
-                foreach (IEntityType entityType in context.Model.GetEntityTypes())
-                {
-                    if (WebhooksAggregates.Contains(entityType.ClrType))
-                    {
-                        matches.Add(entityType.ClrType.Name);
-                    }
-                }
-                return matches;
+                return [.. context.Model.GetEntityTypes()
+                    .Select(entityType => entityType.ClrType)
+                    .Where(WebhooksAggregates.Contains)
+                    .Select(clrType => clrType.Name)];
             }
             finally
             {

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/InMemoryExportAssemblyCheckpointStoreTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/InMemoryExportAssemblyCheckpointStoreTests.cs
@@ -58,7 +58,7 @@ public sealed class InMemoryExportAssemblyCheckpointStoreTests
     public async Task ClearAsync_OnMissing_IsNoOp()
     {
         InMemoryExportAssemblyCheckpointStore sut = new();
-        await sut.ClearAsync(Guid.NewGuid(), tenantId: null, TestContext.Current.CancellationToken);
-        // Should not throw.
+        await Should.NotThrowAsync(
+            async () => await sut.ClearAsync(Guid.NewGuid(), tenantId: null, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDualScopeIntegrationValidatorTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDualScopeIntegrationValidatorTests.cs
@@ -28,7 +28,7 @@ public sealed class WebhooksDualScopeIntegrationValidatorTests
             serviceProvider: sp,
             logger: NullLogger<WebhooksDualScopeIntegrationValidator>.Instance);
 
-        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await Should.NotThrowAsync(() => sut.StartAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public sealed class WebhooksDualScopeIntegrationValidatorTests
             serviceProvider: sp,
             logger: NullLogger<WebhooksDualScopeIntegrationValidator>.Instance);
 
-        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await Should.NotThrowAsync(() => sut.StartAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public sealed class WebhooksDualScopeIntegrationValidatorTests
             serviceProvider: sp,
             logger: NullLogger<WebhooksDualScopeIntegrationValidator>.Instance);
 
-        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await Should.NotThrowAsync(() => sut.StartAsync(TestContext.Current.CancellationToken));
     }
 
     private static ServiceProvider BuildProvider<TContext>(bool validateScopes = false)


### PR DESCRIPTION
## Summary

Resolves the open Sonar **Blocker / Critical / Major / Minor** findings across the framework. All changes are behaviour-preserving and verified against the existing test suites (1300+ tests across the touched modules).

59 files (57 src, 2 test), no public-contract changes beyond pre-1.0-acceptable cleanups.

## What changed

- **Cognitive complexity (18 methods)** — behaviour-preserving helper extraction: `AIEndpointValidator` (SSRF validation), `RebuildIndexService` (checkpoint/resume state machine), `ExcelTextExtractor` (cc 37), Persistence `ModelBuilderExtensions` (enum-string + value-object conventions), `PrivacyExportAssemblyService`, `CspComposer`, `DefaultSearchService`, `EmojiValidator`, `ScriptDetector`, `NotificationFanoutHandler`, `OpenApiContractGenerator`, `EntryPathSanitizer`, `PdfOcrTextExtractor`, `ApiDocumentationApplicationBuilderExtensions`, `PrivacyExportSubjectSubstitutionAnalyzer`, `BffLoginEndpoints`.
- **Empty `case` clauses** removed (11).
- **Repeated literals → named constants** — metric tags (`tenant_id`/`global`/`content_type`), Vault `verify`, OIDC grant-type URNs, CSP `'self'`, audit `Phase`, `room.size`, API-key permission.
- **Dead code** — unread `_logger` field + param, unused method param, empty marker types → `Instance` singletons, DI presence-token.
- **LINQ** — loops simplified to `Where`/`Select`/`Any`/`FirstOrDefault` (8 sites).
- **Iterator param-checks** split from bodies (S4456, 5 providers).
- **`ZipArchive.DisposeAsync`** awaited instead of sync `Dispose` (.NET 10).
- **Tests** — explicit `Should.NotThrowAsync` assertions on 4 no-throw Blocker tests.

## Deliberately not changed (won't-fix)

- 5× "remove commented code" — Sonar S125 false-positives on explanatory prose.
- 2× unused `TKey` — load-bearing phantom types for open-generic DI / Wolverine dispatch.
- Param-count findings — Minimal-API model-bound handlers + real DI deps (per `CLAUDE.md`).
- ~60 Info-severity nits — the repo's own `.editorconfig` keeps these at `suggestion` severity; `dotnet format` intentionally leaves them.

## Verification

- Per-project builds clean (IDE0005-as-error catches unused usings).
- `dotnet format whitespace --verify-no-changes` clean.
- Test suites pass on every refactored module (AI, Timeline, Persistence, Indexing, Bff, SecurityHeaders, TextExtraction, Notifications, Analyzers, Webhooks, Privacy.BlobStorage, ...).