### PR TITLE
fix(persistence): audit LocalIdentity via ICreationAuditedObject pivot

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -16658,6 +16658,15 @@
       "members": []
     },
     {
+      "name": "ICreationAuditedObject",
+      "fqn": "Granit.Domain.ICreationAuditedObject",
+      "kind": "interface",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ICreationAuditedObject.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "IEmitEntityLifecycleEvents",
       "fqn": "Granit.Domain.IEmitEntityLifecycleEvents",
       "kind": "interface",
@@ -26092,7 +26101,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Domain/LocalIdentity.cs",
-      "line": 28,
+      "line": 34,
       "members": [
         {
           "name": "UserId",

--- a/src/Granit.Identity.Local/Domain/LocalIdentity.cs
+++ b/src/Granit.Identity.Local/Domain/LocalIdentity.cs
@@ -20,12 +20,19 @@ namespace Granit.Identity.Local.Domain;
 /// <see cref="IdentityUser{TKey}.ConcurrencyStamp"/> property.
 /// </para>
 /// <para>
+/// Implements <see cref="ICreationAuditedObject"/> and <see cref="IModificationAuditedObject"/>
+/// so <c>AuditedEntityInterceptor</c> populates the audit fields. It cannot inherit
+/// <c>CreationAuditedEntity</c> (single inheritance is taken by <see cref="IdentityUser{TKey}"/>),
+/// so the interceptor pivots on these interfaces rather than the base class.
+/// </para>
+/// <para>
 /// Implements <see cref="IHasMetadata"/> via explicit interface mapping to
 /// <see cref="CustomAttributesJson"/>. The generic <c>MetadataSyncInterceptor</c>
 /// in <c>Granit.Persistence.EntityFrameworkCore</c> handles Shadow Property synchronization.
 /// </para>
 /// </remarks>
-public class LocalIdentity : IdentityUser<Guid>, IMultiTenant, IIdentityUser, IHasMetadata
+public class LocalIdentity
+    : IdentityUser<Guid>, IMultiTenant, IIdentityUser, IHasMetadata, ICreationAuditedObject, IModificationAuditedObject
 {
     private IReadOnlyDictionary<string, string>? _parsedMetadata;
 

--- a/src/Granit.Persistence.EntityFrameworkCore/Interceptors/AuditedEntityInterceptor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Interceptors/AuditedEntityInterceptor.cs
@@ -11,7 +11,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Interceptors;
 
 /// <summary>
 /// EF Core interceptor that automatically populates audit fields
-/// on entities inheriting from <see cref="CreationAuditedEntity"/>,
+/// on entities implementing <see cref="ICreationAuditedObject"/>,
 /// and the <see cref="IMultiTenant.TenantId"/> on multi-tenant entities.
 /// </summary>
 /// <remarks>
@@ -57,7 +57,12 @@ public sealed class AuditedEntityInterceptor(
         DateTimeOffset now = clock.Now;
         string userId = currentUserService.UserId ?? "system";
 
-        foreach (EntityEntry<CreationAuditedEntity> entry in context.ChangeTracker.Entries<CreationAuditedEntity>())
+        // Pivot on ICreationAuditedObject rather than the CreationAuditedEntity base
+        // class so entities that cannot inherit it — e.g. LocalIdentity, forced to
+        // extend ASP.NET Identity's IdentityUser<Guid> — still get their audit fields.
+        // Without this, CreatedAt stayed at default(DateTimeOffset), which Npgsql
+        // persists as -infinity.
+        foreach (EntityEntry<ICreationAuditedObject> entry in context.ChangeTracker.Entries<ICreationAuditedObject>())
         {
             switch (entry.State)
             {
@@ -72,14 +77,16 @@ public sealed class AuditedEntityInterceptor(
         }
     }
 
-    private void ApplyCreationFields(EntityEntry<CreationAuditedEntity> entry, DateTimeOffset now, string userId)
+    private void ApplyCreationFields(EntityEntry<ICreationAuditedObject> entry, DateTimeOffset now, string userId)
     {
         entry.Entity.CreatedAt = now;
         entry.Entity.CreatedBy = userId;
 
-        if (entry.Entity.Id == Guid.Empty)
+        // GUID generation is an Entity concern. Entities outside that hierarchy
+        // (e.g. IdentityUser-derived) own their key and set it before save.
+        if (entry.Entity is Entity entity && entity.Id == Guid.Empty)
         {
-            entry.Entity.Id = guidGenerator.Create();
+            entity.Id = guidGenerator.Create();
         }
 
         // Multi-tenant isolation: inject current TenantId if the entity supports it.
@@ -90,7 +97,7 @@ public sealed class AuditedEntityInterceptor(
         }
     }
 
-    private static void ApplyModificationFields(EntityEntry<CreationAuditedEntity> entry, DateTimeOffset now, string userId)
+    private static void ApplyModificationFields(EntityEntry<ICreationAuditedObject> entry, DateTimeOffset now, string userId)
     {
         // Protect creation fields from modification
         entry.Property(e => e.CreatedAt).IsModified = false;

--- a/src/Granit/Domain/CreationAuditedEntity.cs
+++ b/src/Granit/Domain/CreationAuditedEntity.cs
@@ -4,7 +4,7 @@ namespace Granit.Domain;
 /// Entity with creation-only audit trail.
 /// Inherits from <see cref="Entity"/> and adds CreatedAt/CreatedBy.
 /// </summary>
-public abstract class CreationAuditedEntity : Entity
+public abstract class CreationAuditedEntity : Entity, ICreationAuditedObject
 {
     /// <summary>Creation timestamp (UTC).</summary>
     public DateTimeOffset CreatedAt { get; set; }

--- a/src/Granit/Domain/ICreationAuditedObject.cs
+++ b/src/Granit/Domain/ICreationAuditedObject.cs
@@ -1,0 +1,18 @@
+namespace Granit.Domain;
+
+/// <summary>
+/// Marker for entities that carry a creation audit trail (ISO 27001).
+/// Implemented by the <see cref="CreationAuditedEntity"/> hierarchy so the audit
+/// interceptor can populate the fields by interface rather than by base class.
+/// This lets entities that cannot inherit <see cref="CreationAuditedEntity"/> —
+/// e.g. an ASP.NET Identity user extending <c>IdentityUser&lt;TKey&gt;</c> — still
+/// participate in the audit pipeline. Mirrors <see cref="IModificationAuditedObject"/>.
+/// </summary>
+public interface ICreationAuditedObject
+{
+    /// <summary>Creation timestamp (UTC).</summary>
+    DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>Identifier of the user who created the entity.</summary>
+    string CreatedBy { get; set; }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/AuditedEntityInterceptorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/AuditedEntityInterceptorTests.cs
@@ -435,6 +435,55 @@ public sealed class AuditedEntityInterceptorTests
     }
 
     // -------------------------------------------------------------------------
+    // ICreationAuditedObject sur une entité hors hiérarchie Entity
+    // -------------------------------------------------------------------------
+    // Régression : LocalIdentity étend IdentityUser<Guid> et ne PEUT donc pas
+    // dériver de CreationAuditedEntity. Avant le pivot sur ICreationAuditedObject
+    // l'intercepteur l'ignorait, CreatedAt restait à default(DateTimeOffset) et
+    // Npgsql le persistait en -infinity. Le pivot interface couvre désormais ce cas.
+
+    [Fact]
+    public async Task SaveChangesAsync_IdentityLikeEntity_OnAdd_SetsCreatedFields()
+    {
+        // Arrange
+        await using TestDbContext context = CreateContext();
+        TestIdentityLikeAuditable entity = new() { Id = Guid.NewGuid(), Name = "Alice" };
+        context.IdentityLikeAuditables.Add(entity);
+
+        // Act
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Assert — plus de default(DateTimeOffset) → plus de -infinity en base
+        entity.CreatedAt.ShouldBe(FixedNow);
+        entity.CreatedBy.ShouldBe("user-test-123");
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_IdentityLikeEntity_OnModify_SetsModifiedFields_AndProtectsCreated()
+    {
+        // Arrange
+        await using TestDbContext context = CreateContext();
+        TestIdentityLikeAuditable entity = new() { Id = Guid.NewGuid(), Name = "Alice" };
+        context.IdentityLikeAuditables.Add(entity);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        DateTimeOffset originalCreatedAt = entity.CreatedAt;
+        string originalCreatedBy = entity.CreatedBy;
+        _clock.Now.Returns(FixedNow.AddHours(1));
+
+        // Act
+        entity.Name = "Alice Updated";
+        context.Entry(entity).State = EntityState.Modified;
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        entity.ModifiedAt.ShouldBe(FixedNow.AddHours(1));
+        entity.ModifiedBy.ShouldBe("user-test-123");
+        entity.CreatedAt.ShouldBe(originalCreatedAt);
+        entity.CreatedBy.ShouldBe(originalCreatedBy);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -479,6 +528,18 @@ public sealed class AuditedEntityInterceptorTests
         public Guid? TenantId { get; set; }
     }
 
+    // Mimics LocalIdentity: owns a Guid PK but does NOT derive from Entity /
+    // CreationAuditedEntity — it only implements the audit interfaces.
+    private sealed class TestIdentityLikeAuditable : ICreationAuditedObject, IModificationAuditedObject
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public DateTimeOffset CreatedAt { get; set; }
+        public string CreatedBy { get; set; } = string.Empty;
+        public DateTimeOffset? ModifiedAt { get; set; }
+        public string? ModifiedBy { get; set; }
+    }
+
     private sealed class TestDbContext(DbContextOptions<AuditedEntityInterceptorTests.TestDbContext> options) : DbContext(options)
     {
         public DbSet<TestCreationAuditedEntity> CreationAuditedEntities => Set<TestCreationAuditedEntity>();
@@ -487,6 +548,7 @@ public sealed class AuditedEntityInterceptorTests
         public DbSet<TestAuditedAggregateRoot> AuditedAggregateRoots => Set<TestAuditedAggregateRoot>();
         public DbSet<TestFullAuditedAggregateRoot> FullAuditedAggregateRoots => Set<TestFullAuditedAggregateRoot>();
         public DbSet<TestMultiTenantEntity> MultiTenantEntities => Set<TestMultiTenantEntity>();
+        public DbSet<TestIdentityLikeAuditable> IdentityLikeAuditables => Set<TestIdentityLikeAuditable>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -495,6 +557,13 @@ public sealed class AuditedEntityInterceptorTests
             modelBuilder.Entity<TestAuditedEntity>().Property(e => e.Id).ValueGeneratedNever();
             modelBuilder.Entity<TestFullAuditedEntity>().Property(e => e.Id).ValueGeneratedNever();
             modelBuilder.Entity<TestMultiTenantEntity>().Property(e => e.Id).ValueGeneratedNever();
+
+            // Hors hiérarchie Entity : PK déclarée explicitement, posée par l'appelant.
+            modelBuilder.Entity<TestIdentityLikeAuditable>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+            });
 
             // Aggregate roots expose event collections that are not persisted columns.
             modelBuilder.Entity<TestAuditedAggregateRoot>(b =>


### PR DESCRIPTION
## Problem

`host.openiddict_users` rows (the `LocalIdentity` entity) persist `CreatedAt` as **`-infinity`**, and `ModifiedAt`/`ModifiedBy` stay `NULL`.

Root cause: `AuditedEntityInterceptor` only visits `context.ChangeTracker.Entries<CreationAuditedEntity>()`. `LocalIdentity` extends ASP.NET Identity's `IdentityUser<Guid>` and therefore **cannot** inherit `CreationAuditedEntity` (single inheritance). It re-declares the audit fields by hand with a comment claiming the interceptor populates them — but the interceptor skips it. `CreatedAt` stays at `default(DateTimeOffset)`, which Npgsql writes to `timestamptz` as `-infinity`.

Same structural gap already handled manually for soft-delete on `LocalIdentity`; audit was overlooked.

## Fix (interface pivot)

Mirrors the existing `IModificationAuditedObject` pivot already used for the modification branch:

- New `ICreationAuditedObject { CreatedAt; CreatedBy }` in `Granit.Domain`.
- `CreationAuditedEntity` implements it (fields already match — no behavioural change for existing entities).
- `AuditedEntityInterceptor` iterates `Entries<ICreationAuditedObject>()` instead of the base class. GUID auto-generation stays gated on `is Entity` (IdentityUser-derived types own their key).
- `LocalIdentity` implements `ICreationAuditedObject` + `IModificationAuditedObject`.

Now `CreatedAt`/`CreatedBy` **and** `ModifiedAt`/`ModifiedBy` are populated centrally on every `SaveChanges`, across all `UserManager` update paths.

## Tests

- New regression tests in `AuditedEntityInterceptorTests` using an `IdentityUser`-like entity (own `Guid` PK, no `Entity` base) — asserts created/modified fields are set and creation fields protected on update.
- Full suites green: `AuditedEntityInterceptorTests` (18), `Granit.Tests` (528), `Granit.Identity.Local.Tests` (41), `Granit.ArchitectureTests` (218). Format clean on touched projects.

## Notes

- `Granit.Domain.AuditableEntity` is an orphaned parallel scaffolding (unused) with the same fields — left untouched, out of scope.
- Doc note for a separate `granit-docs` PR: `persistence.md` describes the interceptor as keying on `CreationAuditedEntity`; update to mention the interface pivot.