### PR TITLE
fix(auditing): own authentication audit at its source + dev cookies over HTTP

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -185,6 +185,7 @@
         "Granit",
         "Granit.Timing",
         "Granit.Guids",
+        "Granit.Auditing.Abstractions",
         "Granit.Http.ExceptionHandling",
         "Granit.DataExchange.Abstractions",
         "Granit.QueryEngine.Abstractions",

--- a/src/Granit.Authentication.ApiKeys/Granit.Authentication.ApiKeys.csproj
+++ b/src/Granit.Authentication.ApiKeys/Granit.Authentication.ApiKeys.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.Auditing.Abstractions\Granit.Auditing.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Http.ExceptionHandling\Granit.Http.ExceptionHandling.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />

--- a/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
+++ b/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
@@ -1,10 +1,14 @@
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.Options;
 using Granit.Diagnostics;
 using Granit.Timing;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -69,6 +73,8 @@ internal sealed partial class ApiKeyAuthenticationHandler(
         if (apiKey is null)
         {
             LogApiKeyNotFound(Logger);
+            await TryWriteFailureAuditAsync("invalid_api_key", apiKeyId: null, apiKeyName: null, tenantId: null)
+                .ConfigureAwait(false);
             return AuthenticateResult.Fail("Invalid API key.");
         }
 
@@ -78,12 +84,16 @@ internal sealed partial class ApiKeyAuthenticationHandler(
         if (apiKey.RevokedAt.HasValue)
         {
             LogApiKeyRevoked(Logger, apiKey.Id);
+            await TryWriteFailureAuditAsync("api_key_revoked", apiKey.Id, apiKey.Name, apiKey.TenantId)
+                .ConfigureAwait(false);
             return AuthenticateResult.Fail("API key has been revoked.");
         }
 
         if (apiKey.ExpiresAt.HasValue && apiKey.ExpiresAt.Value <= now)
         {
             LogApiKeyExpired(Logger, apiKey.Id);
+            await TryWriteFailureAuditAsync("api_key_expired", apiKey.Id, apiKey.Name, apiKey.TenantId)
+                .ConfigureAwait(false);
             return AuthenticateResult.Fail("API key has expired.");
         }
 
@@ -91,6 +101,8 @@ internal sealed partial class ApiKeyAuthenticationHandler(
         if (!CidrValidator.IsAllowed(Context.Connection.RemoteIpAddress, apiKey.AllowedCidrs))
         {
             LogIpNotAllowed(Logger, apiKey.Id, LogRedaction.IpAddress(Context.Connection.RemoteIpAddress?.ToString() ?? "unknown"));
+            await TryWriteFailureAuditAsync("ip_not_allowed", apiKey.Id, apiKey.Name, apiKey.TenantId)
+                .ConfigureAwait(false);
             return AuthenticateResult.Fail("IP address not in allowed CIDR ranges.");
         }
 
@@ -168,8 +180,54 @@ internal sealed partial class ApiKeyAuthenticationHandler(
         return new ClaimsPrincipal(identity);
     }
 
+    /// <summary>
+    /// Records an <see cref="AuditCategory.AccessDenied"/> audit row for a rejected API-key
+    /// authentication. No-op when <see cref="IAuditingWriter"/> is not registered. Successful
+    /// authentications are intentionally not audited per-request: a key authenticates on every
+    /// call, so what it does is attributed via <c>CreatedBy</c> on the entities it touches.
+    /// Audit failures are swallowed so a transient audit-store outage never blocks the request.
+    /// </summary>
+    private async Task TryWriteFailureAuditAsync(string reason, Guid? apiKeyId, string? apiKeyName, Guid? tenantId)
+    {
+        IAuditingWriter? auditingWriter = Context.RequestServices?.GetService<IAuditingWriter>();
+        if (auditingWriter is null)
+        {
+            return;
+        }
+
+        string? ipAddress = Context.Connection.RemoteIpAddress?.ToString();
+        string? userAgent = Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrEmpty(userAgent))
+        {
+            userAgent = null;
+        }
+
+        AuditEntry entry = AuthenticationAuditEntry.CreateFailure(
+            clock.Now,
+            userId: apiKeyId?.ToString(),
+            userName: apiKeyName,
+            method: "api_key",
+            reason: reason,
+            tenantId: tenantId,
+            ipAddress: ipAddress,
+            userAgent: userAgent,
+            correlationId: Activity.Current?.Id);
+
+        try
+        {
+            await auditingWriter.WriteAsync(entry, Context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAuditWriteFailed(Logger, ex);
+        }
+    }
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "API key not found for provided token hash.")]
     private static partial void LogApiKeyNotFound(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "API key authentication: failed to write AccessDenied audit entry — request continues.")]
+    private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "API key {ApiKeyId} has been revoked.")]
     private static partial void LogApiKeyRevoked(ILogger logger, Guid apiKeyId);

--- a/src/Granit.Authentication.ApiKeys/packages.lock.json
+++ b/src/Granit.Authentication.ApiKeys/packages.lock.json
@@ -11,6 +11,13 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -284,9 +284,15 @@ internal static partial class BffLoginEndpoints
 
         metrics.RecordLogin(null);
         LogLoginSuccess(logger, BffSessionEndpoints.MaskSessionId(sessionId), frontend.Name);
+
+        // The BFF owns the authentication audit trail for interactive logins it fronts: it carries the
+        // real browser User-Agent and the authenticated user as CreatedBy. The authorization server's
+        // token endpoint deliberately does NOT audit the authorization_code / refresh_token exchange
+        // (see ConnectTokenEndpoints), so this is the single success row for a BFF login.
         await TryWriteAuthAuditAsync(httpContext, logger,
             userId: string.IsNullOrEmpty(userId) ? AuthenticationAuditEntry.UnknownUserSentinel : userId,
-            userName: ExtractClaimFromIdToken(tokens.IdToken, "name"),
+            userName: ExtractClaimFromIdToken(tokens.IdToken, "preferred_username")
+                ?? ExtractClaimFromIdToken(tokens.IdToken, "email"),
             failureReason: null,
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Bff.EntityFrameworkCore/Internal/EfCoreBffTokenStore.cs
+++ b/src/Granit.Bff.EntityFrameworkCore/Internal/EfCoreBffTokenStore.cs
@@ -123,6 +123,7 @@ internal sealed partial class EfCoreBffTokenStore(
         return await db.Sessions
             .AsNoTracking()
             .Where(s => s.FrontendName == frontendName && s.UserId == userId && s.ExpiresAt > clock.Now)
+            .OrderByDescending(s => s.CreatedAt)
             .Select(s => s.SessionId)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Http.Cookies/Internal/GranitCookieManager.cs
+++ b/src/Granit.Http.Cookies/Internal/GranitCookieManager.cs
@@ -1,5 +1,6 @@
 using Granit.Http.Cookies.Exceptions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 
 #pragma warning disable GRSEC004 // This IS the IGranitCookieManager implementation
 
@@ -13,7 +14,8 @@ internal sealed class GranitCookieManager(
     ICookieRegistry registry,
     IConsentResolver consentResolver,
     IGlobalPrivacyControlSignal gpcSignal,
-    ICookieConsentModelProvider consentModelProvider) : IGranitCookieManager
+    ICookieConsentModelProvider consentModelProvider,
+    IHostEnvironment environment) : IGranitCookieManager
 {
     /// <inheritdoc/>
     public async Task SetCookieAsync(HttpContext httpContext, string cookieName, string value)
@@ -47,7 +49,7 @@ internal sealed class GranitCookieManager(
         {
             MaxAge = TimeSpan.FromDays(definition.RetentionDays),
             HttpOnly = definition.IsHttpOnly, // NOSONAR S3330 - intentional: HttpOnly is configurable per cookie (analytics cookies like _ga require JS access)
-            Secure = true,
+            Secure = !environment.IsDevelopment() || httpContext.Request.IsHttps,
             SameSite = definition.SameSite,
             Path = definition.Path,
             Domain = definition.Domain,
@@ -79,7 +81,7 @@ internal sealed class GranitCookieManager(
         httpContext.Response.Cookies.Delete(cookieName, new CookieOptions
         {
             HttpOnly = definition.IsHttpOnly, // NOSONAR S3330 - intentional: must match SetCookieAsync options for browser to delete the cookie
-            Secure = true,
+            Secure = !environment.IsDevelopment() || httpContext.Request.IsHttps,
             SameSite = definition.SameSite,
             Path = definition.Path,
             Domain = definition.Domain, // must mirror Set; omitting leaves the cookie stranded in browser

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -157,12 +157,11 @@ internal static partial class ConnectTokenEndpoints
             metrics.RecordAuthenticationSuccess(tenantId, grantType);
             LogTokenIssued(logger, user.Id.ToString(), grantType);
 
-            await TryWriteAuthAuditAsync(context, logger,
-                method: grantType,
-                userId: user.Id.ToString(),
-                userName: user.UserName,
-                failureReason: null,
-                tenantId).ConfigureAwait(false);
+            // No success audit here: authorization_code / refresh_token do not authenticate the user at
+            // the token endpoint — they exchange an authentication that already happened and was audited
+            // at its source (the BFF session callback, or the interactive login endpoint for direct
+            // clients). Auditing the exchange would duplicate that record. Token-level FAILURES above are
+            // still audited, as a forged/replayed code or refresh token is a security event seen only here.
 
             string? ipAddress = context.Connection.RemoteIpAddress?.ToString();
             string? userAgent = context.Request.Headers.UserAgent.FirstOrDefault();

--- a/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyAuthenticationHandlerTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
 using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.Internal;
 using Granit.Authentication.ApiKeys.Options;
@@ -37,7 +39,8 @@ public sealed class ApiKeyAuthenticationHandlerTests
     private async Task<AuthenticateResult> AuthenticateAsync(
         string? authorizationHeader,
         IPAddress? remoteIp = null,
-        IApiKeyCacheService? cacheService = null)
+        IApiKeyCacheService? cacheService = null,
+        IAuditingWriter? auditingWriter = null)
     {
         IOptionsMonitor<ApiKeyOptions> optionsMonitor = Substitute.For<IOptionsMonitor<ApiKeyOptions>>();
         optionsMonitor.Get(ApiKeyAuthenticationDefaults.AuthenticationScheme).Returns(_options);
@@ -55,6 +58,13 @@ public sealed class ApiKeyAuthenticationHandlerTests
             cacheService);
 
         var context = new DefaultHttpContext();
+
+        if (auditingWriter is not null)
+        {
+            IServiceProvider services = Substitute.For<IServiceProvider>();
+            services.GetService(typeof(IAuditingWriter)).Returns(auditingWriter);
+            context.RequestServices = services;
+        }
 
         if (authorizationHeader is not null)
         {
@@ -143,6 +153,23 @@ public sealed class ApiKeyAuthenticationHandlerTests
 
         result.Succeeded.ShouldBeFalse();
         result.Failure!.Message.ShouldBe("Invalid API key.");
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_Failure_WritesAccessDeniedAudit()
+    {
+        ApiKeyGenerationResult gen = _generator.Generate(ApiKeyType.Secret, "live");
+        _store.FindByHashAsync(gen.HashedKey, Arg.Any<CancellationToken>())
+            .Returns((ApiKeyEntry?)null);
+        IAuditingWriter auditingWriter = Substitute.For<IAuditingWriter>();
+
+        AuthenticateResult result = await AuthenticateAsync(
+            $"Bearer {gen.RawSecret}", auditingWriter: auditingWriter);
+
+        result.Succeeded.ShouldBeFalse();
+        await auditingWriter.Received(1).WriteAsync(
+            Arg.Is<AuditEntry>(e => e.Category == AuditCategory.AccessDenied),
+            Arg.Any<CancellationToken>());
     }
 
     // --- Revoked key ---

--- a/tests/Granit.Authentication.ApiKeys.Tests/packages.lock.json
+++ b/tests/Granit.Authentication.ApiKeys.Tests/packages.lock.json
@@ -235,10 +235,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication.apikeys": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",

--- a/tests/Granit.Http.Cookies.Tests/CookiesServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookiesServiceCollectionExtensionsTests.cs
@@ -1,5 +1,7 @@
 using Granit.Http.Cookies.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -11,6 +13,10 @@ public sealed class CookiesServiceCollectionExtensionsTests
     public void AddGranitCookies_RegistersServices()
     {
         ServiceCollection services = new();
+        // IHostEnvironment is always provided by the host; the cookie manager depends on it.
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(Environments.Production);
+        services.AddSingleton(environment);
         services.AddGranitCookies(cookies =>
         {
             cookies.UseConsentResolver<FakeConsentResolver>();

--- a/tests/Granit.Http.Cookies.Tests/GranitCookieManagerTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/GranitCookieManagerTests.cs
@@ -1,6 +1,7 @@
 using Granit.Http.Cookies.Exceptions;
 using Granit.Http.Cookies.Internal;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -13,11 +14,14 @@ public sealed class GranitCookieManagerTests
     private readonly IConsentResolver _consentResolver = Substitute.For<IConsentResolver>();
     private readonly IGlobalPrivacyControlSignal _gpcSignal = Substitute.For<IGlobalPrivacyControlSignal>();
     private readonly ICookieConsentModelProvider _consentModelProvider = Substitute.For<ICookieConsentModelProvider>();
+    private readonly IHostEnvironment _environment = Substitute.For<IHostEnvironment>();
     private readonly GranitCookieManager _sut;
 
     public GranitCookieManagerTests()
     {
-        _sut = new GranitCookieManager(_registry, _consentResolver, _gpcSignal, _consentModelProvider);
+        // Default to a non-Development environment so Secure stays on (production behaviour).
+        _environment.EnvironmentName.Returns(Environments.Production);
+        _sut = new GranitCookieManager(_registry, _consentResolver, _gpcSignal, _consentModelProvider, _environment);
     }
 
     private static DefaultHttpContext CreateHttpContext() => new();
@@ -104,6 +108,41 @@ public sealed class GranitCookieManagerTests
         string? setCookieHeader = httpContext.Response.Headers.SetCookie.ToString();
         setCookieHeader.ShouldContain("secure");
         setCookieHeader.ShouldContain("samesite=lax");
+    }
+
+    [Fact]
+    public async Task SetCookieAsync_InDevelopmentOverHttp_OmitsSecure()
+    {
+        GranitCookieManager devSut = CreateDevManager();
+        _registry.Register(new("session_id", CookieCategory.StrictlyNecessary, 1, true, "Session"));
+        DefaultHttpContext httpContext = CreateHttpContext(); // plain HTTP
+
+        await devSut.SetCookieAsync(httpContext, "session_id", "val");
+
+        string? setCookieHeader = httpContext.Response.Headers.SetCookie.ToString();
+        setCookieHeader.ShouldContain("session_id=val");
+        setCookieHeader.ShouldNotContain("secure");
+    }
+
+    [Fact]
+    public async Task SetCookieAsync_InDevelopmentOverHttps_KeepsSecure()
+    {
+        GranitCookieManager devSut = CreateDevManager();
+        _registry.Register(new("session_id", CookieCategory.StrictlyNecessary, 1, true, "Session"));
+        DefaultHttpContext httpContext = CreateHttpContext();
+        httpContext.Request.IsHttps = true;
+
+        await devSut.SetCookieAsync(httpContext, "session_id", "val");
+
+        string? setCookieHeader = httpContext.Response.Headers.SetCookie.ToString();
+        setCookieHeader.ShouldContain("secure");
+    }
+
+    private GranitCookieManager CreateDevManager()
+    {
+        IHostEnvironment devEnvironment = Substitute.For<IHostEnvironment>();
+        devEnvironment.EnvironmentName.Returns(Environments.Development);
+        return new GranitCookieManager(_registry, _consentResolver, _gpcSignal, _consentModelProvider, devEnvironment);
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Authentication audit (`AuditEntry` PrivilegedAccess/AccessDenied) was **duplicated** for BFF logins and **absent** for API keys. Co-hosted showcase (BFF + OpenIddict, one audit store) wrote two rows per login — and the surviving token-endpoint row was the poorer one (no browser User-Agent — the BFF calls `/connect/token` server-to-server; `CreatedBy=system`). It also stored the display name (`Admin Showcase`) instead of the login (`admin@showcase.local`).

## What (commit 1 — `fix(auditing)`)

Single owner per authentication source:

| Source | Success | Failure |
|---|---|---|
| **BFF** (interactive logins it fronts) | ✅ `bff_session` (real UA, `CreatedBy=user`, UserName=`preferred_username`) | ✅ |
| **Token endpoint** — `password`/`2fa`/`passkey`/`client_credentials` | ✅ | ✅ |
| **Token endpoint** — `authorization_code`/`refresh_token` | ❌ audited at source | ✅ (forged/replayed token) |
| **Direct login** (no BFF) | ✅ login endpoint | ✅ |
| **API key** | ❌ (attributed via `CreatedBy`) | ✅ `AccessDenied` (invalid/revoked/expired/IP) |

- Fixes the UserName: BFF reads `preferred_username` (fallback `email`), not the `name` claim.
- API key handler now writes `AccessDenied` audit on its 4 failure paths (soft-dep on `IAuditingWriter`).

## What (commit 2 — `fix(http-cookies)`)

`GranitCookieManager` forced `Secure=true` unconditionally → browsers dropped session cookies over `http://localhost` in dev. Now gated on `!IsDevelopment() || request.IsHttps` (production unchanged). Plus BFF session lookup ordered by `CreatedAt` desc.

## Tests

ApiKeys 132 (incl. new AccessDenied-on-failure test), Bff 166, Bff.Endpoints 116, Http.Cookies 72 (incl. 2 new dev-cookie tests). `dotnet format` clean.

## Out of scope

The ~2s relogin cadence observed is a **granit-showcase-react** renew/redirect storm, tracked separately.