### PR TITLE
fix(test): drop removed logger arg from VaultExportHmacSigner ctor call (CS1729)

### DIFF
--- a/tests/Granit.Privacy.Vault.Tests/VaultExportHmacSignerTests.cs
+++ b/tests/Granit.Privacy.Vault.Tests/VaultExportHmacSignerTests.cs
@@ -2,7 +2,6 @@ using System.Text;
 using Granit.Privacy.DataExport.Security;
 using Granit.Privacy.Vault.Options;
 using Granit.Vault;
-using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -23,8 +22,7 @@ public sealed class VaultExportHmacSignerTests
         };
         _sut = new VaultExportHmacSigner(
             _macService,
-            Microsoft.Extensions.Options.Options.Create(options),
-            NullLogger<VaultExportHmacSigner>.Instance);
+            Microsoft.Extensions.Options.Options.Create(options));
     }
 
     private static ExportHmacParameters MakeParameters(DateTimeOffset? expiry = null) => new(


### PR DESCRIPTION
## Problem

The `privacy`/vault test shard fails to compile:

```
VaultExportHmacSignerTests.cs(24,20): error CS1729: 'VaultExportHmacSigner'
does not contain a constructor that takes 3 arguments
```

## Root cause

#2616 (Sonar code-smell cleanup) removed the unused `ILogger<VaultExportHmacSigner>` field and its constructor parameter from `VaultExportHmacSigner` — a genuinely unread field, so the removal is correct. But the cleanup did not update `VaultExportHmacSignerTests`, which still passed `NullLogger<VaultExportHmacSigner>.Instance` as a third constructor argument. (The commit's "verified against existing test suites" missed this shard.)

## Fix

Drop the stale third argument and the now-unused `Microsoft.Extensions.Logging.Abstractions` using. Verified locally — the project compiles and all 6 tests pass.