### PR TITLE
fix(arch-tests): resolve convention violations exposed by module coverage

### DIFF
--- a/src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj
+++ b/src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.AI.Anthropic.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.TextExtraction.Office/Internal/OpenXmlGate.cs
+++ b/src/Granit.TextExtraction.Office/Internal/OpenXmlGate.cs
@@ -40,7 +40,7 @@ internal static class OpenXmlGate
     /// </summary>
     internal const long RatioCheckMinCompressedBytes = 1024;
 
-    public enum GateResult
+    internal enum GateResult
     {
         Ok,
         TooManyEntries,

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/BackgroundJobConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/BackgroundJobConventionRules.cs
@@ -23,7 +23,7 @@ public static class BackgroundJobConventionRules
             .Where(c => c.FullName.StartsWith(typePrefix, StringComparison.Ordinal)
                 && !c.IsAbstract.GetValueOrDefault()
                 && ImplementsInterface(c, "Granit.BackgroundJobs.IBackgroundJob"))
-            .Where(c => !c.Name.EndsWith("Job", StringComparison.Ordinal))
+            .Where(c => !StripGenericArity(c.Name).EndsWith("Job", StringComparison.Ordinal))
             .Select(c => $"{c.FullName} (IBackgroundJob must end with 'Job')")
             .ToList();
 
@@ -50,6 +50,14 @@ public static class BackgroundJobConventionRules
         violations.ShouldBeEmpty(
             "Types with [RecurringJob] must implement IBackgroundJob. " +
             $"Violators: {string.Join(", ", violations)}");
+    }
+
+    // ArchUnitNET reports generic type names with a CLR arity suffix (e.g. "RebuildIndexJob`1");
+    // strip it so generic jobs are matched on their declared name.
+    private static string StripGenericArity(string name)
+    {
+        int backtick = name.IndexOf('`', StringComparison.Ordinal);
+        return backtick < 0 ? name : name[..backtick];
     }
 
     private static bool ImplementsInterface(Class c, string interfaceFullName) =>

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -246,7 +246,6 @@
     <ProjectReference Include="..\..\src\Granit.Oidc\Granit.Oidc.csproj" />
     <ProjectReference Include="..\..\src\Granit.Oidc.TokenManagement\Granit.Oidc.TokenManagement.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenApi.Generation\Granit.OpenApi.Generation.csproj" />
-    <ProjectReference Include="..\..\src\Granit.OpenApi.Generator\Granit.OpenApi.Generator.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict\Granit.OpenIddict.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict.BackgroundJobs\Granit.OpenIddict.BackgroundJobs.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict.Endpoints\Granit.OpenIddict.Endpoints.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3292,43 +3292,6 @@
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )"
         }
       },
-      "granit.openapi.generator": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.AI.Endpoints": "[0.1.0-dev, )",
-          "Granit.Auditing.Endpoints": "[0.1.0-dev, )",
-          "Granit.Authentication.ApiKeys.Endpoints": "[0.1.0-dev, )",
-          "Granit.Authorization.Endpoints": "[0.1.0-dev, )",
-          "Granit.BackgroundJobs.Endpoints": "[0.1.0-dev, )",
-          "Granit.Bff.Endpoints": "[0.1.0-dev, )",
-          "Granit.BlobStorage.Endpoints": "[0.1.0-dev, )",
-          "Granit.DataExchange.Endpoints": "[0.1.0-dev, )",
-          "Granit.DataLookup.Endpoints": "[0.1.0-dev, )",
-          "Granit.Diagnostics.Endpoints": "[0.1.0-dev, )",
-          "Granit.Features.Endpoints": "[0.1.0-dev, )",
-          "Granit.Hostnames.Endpoints": "[0.1.0-dev, )",
-          "Granit.Http.Cookies.Endpoints": "[0.1.0-dev, )",
-          "Granit.Http.SecurityHeaders.Endpoints": "[0.1.0-dev, )",
-          "Granit.Identity.Endpoints": "[0.1.0-dev, )",
-          "Granit.Identity.Local.Endpoints": "[0.1.0-dev, )",
-          "Granit.Localization.Endpoints": "[0.1.0-dev, )",
-          "Granit.MultiTenancy.Endpoints": "[0.1.0-dev, )",
-          "Granit.Notifications.Endpoints": "[0.1.0-dev, )",
-          "Granit.OpenApi.Generation": "[0.1.0-dev, )",
-          "Granit.OpenIddict.Endpoints": "[0.1.0-dev, )",
-          "Granit.Presence.Endpoints": "[0.1.0-dev, )",
-          "Granit.Privacy.Endpoints": "[0.1.0-dev, )",
-          "Granit.Scheduling.Endpoints": "[0.1.0-dev, )",
-          "Granit.Settings.Endpoints": "[0.1.0-dev, )",
-          "Granit.Templating.Endpoints": "[0.1.0-dev, )",
-          "Granit.Timeline.Endpoints": "[0.1.0-dev, )",
-          "Granit.Validation.Endpoints": "[0.1.0-dev, )",
-          "Granit.Webhooks.Endpoints": "[0.1.0-dev, )",
-          "Granit.Workflow.Endpoints": "[0.1.0-dev, )",
-          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
-          "Microsoft.Extensions.ApiDescription.Server": "[10.*, )"
-        }
-      },
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
@@ -4719,12 +4682,6 @@
           "Microsoft.Extensions.AI.Abstractions": "10.7.0",
           "OpenAI": "2.11.0"
         }
-      },
-      "Microsoft.Extensions.ApiDescription.Server": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.9",
-        "contentHash": "n1m7EAbCbHMGiTy++F+mLSan4MrZe0t00XEpJrkai6BFpB6lwEcirflI9FiMm4G4u55h/2RnWToYBDwS+MnN6g=="
       },
       "Microsoft.Extensions.Caching.Hybrid": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Context

[#2651](https://github.com/granit-fx/granit-dotnet/pull/2651) extended the architecture-test reference set to **~50 framework modules** that had silently escaped coverage (their assemblies were never loaded into the ArchUnitNET graph, so no convention test ran against them). That coverage is the right move — but it surfaced **6 latent convention violations** that were never fixed, leaving the `architecture` shard **red on `develop`**.

This PR makes the architecture shard green again.

## Fixes

| Module | Fix | Why it matters |
| --- | --- | --- |
| `Granit.AI.Anthropic` | add `<InternalsVisibleTo Include="WolverineHandlers" />` | **Real runtime bug** — the internal `AnthropicCredentialCacheInvalidationHandler` was silently skipped by Wolverine (handlers need their assembly to expose internals to `WolverineHandlers`). |
| `Granit.TextExtraction.Office` | `GateResult` enum `public` → `internal` | Public type in an `*.Internal.*` namespace; the enclosing `OpenXmlGate` is already `internal`, so `public` was misleading. |
| `Granit.ArchitectureTests.Abstractions` | strip CLR generic-arity suffix before the `IBackgroundJob` "must end with `Job`" check | False positive on `RebuildIndexJob<TKey>` (ArchUnitNET reports the name as `` RebuildIndexJob`1 ``). |
| `Granit.ArchitectureTests` | drop the `Granit.OpenApi.Generator` reference | It is a non-packable `Exe` build-time tool, not a framework module — it should not be bound by module-naming/`*Module` conventions. |

## Verification

- `architecture` shard builds with **0 errors**
- architecture tests **223/223 passing** (red → green)
- `dotnet format --verify-no-changes` clean on all touched projects