### PR TITLE
feat(user-sessions): canonical session-management contracts

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -49557,13 +49557,29 @@
       "kind": "class",
       "project": "Granit.UserSessions.Abstractions",
       "file": "src/Granit.UserSessions.Abstractions/GranitUserSessionsAbstractionsModule.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IUserDeviceProvider",
+      "fqn": "Granit.UserSessions.IUserDeviceProvider",
+      "kind": "interface",
+      "project": "Granit.UserSessions.Abstractions",
+      "file": "src/Granit.UserSessions.Abstractions/IUserDeviceProvider.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<UserDevice>>"
         }
       ]
     },
@@ -49580,6 +49596,68 @@
           "kind": "method",
           "signature": "AssessAsync(UserSessionDescriptor candidate, IReadOnlyList<UserSessionDescriptor> history, CancellationToken cancellationToken = default)",
           "returnType": "Task<UserSessionRiskAssessment>"
+        }
+      ]
+    },
+    {
+      "name": "IUserSessionManager",
+      "fqn": "Granit.UserSessions.IUserSessionManager",
+      "kind": "interface",
+      "project": "Granit.UserSessions.Abstractions",
+      "file": "src/Granit.UserSessions.Abstractions/IUserSessionManager.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(string userId, string? currentSessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<UserSessionView>>"
+        },
+        {
+          "name": "RevokeAsync",
+          "kind": "method",
+          "signature": "RevokeAsync(string userId, string sessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "RevokeOthersAsync",
+          "kind": "method",
+          "signature": "RevokeOthersAsync(string userId, string currentSessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "ListDevicesAsync",
+          "kind": "method",
+          "signature": "ListDevicesAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<UserDevice>>"
+        }
+      ]
+    },
+    {
+      "name": "IUserSessionProvider",
+      "fqn": "Granit.UserSessions.IUserSessionProvider",
+      "kind": "interface",
+      "project": "Granit.UserSessions.Abstractions",
+      "file": "src/Granit.UserSessions.Abstractions/IUserSessionProvider.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(string userId, string? currentSessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<UserSessionDescriptor>>"
+        },
+        {
+          "name": "RevokeAsync",
+          "kind": "method",
+          "signature": "RevokeAsync(string userId, string sessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "RevokeOthersAsync",
+          "kind": "method",
+          "signature": "RevokeOthersAsync(string userId, string currentSessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
         }
       ]
     },
@@ -49618,6 +49696,15 @@
       "project": "Granit.UserSessions.Abstractions",
       "file": "src/Granit.UserSessions.Abstractions/SuspiciousUserSessionDetectedEto.cs",
       "line": 18,
+      "members": []
+    },
+    {
+      "name": "UserDevice",
+      "fqn": "Granit.UserSessions.UserDevice",
+      "kind": "record",
+      "project": "Granit.UserSessions.Abstractions",
+      "file": "src/Granit.UserSessions.Abstractions/UserDevice.cs",
+      "line": 21,
       "members": []
     },
     {
@@ -49661,6 +49748,15 @@
       "project": "Granit.UserSessions.Abstractions",
       "file": "src/Granit.UserSessions.Abstractions/UserSessionRiskVerdict.cs",
       "line": 13,
+      "members": []
+    },
+    {
+      "name": "UserSessionView",
+      "fqn": "Granit.UserSessions.UserSessionView",
+      "kind": "record",
+      "project": "Granit.UserSessions.Abstractions",
+      "file": "src/Granit.UserSessions.Abstractions/UserSessionView.cs",
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.UserSessions.Abstractions/GranitUserSessionsAbstractionsModule.cs
+++ b/src/Granit.UserSessions.Abstractions/GranitUserSessionsAbstractionsModule.cs
@@ -6,11 +6,13 @@ namespace Granit.UserSessions;
 
 /// <summary>
 /// Granit module for shared session contracts (<see cref="UserSessionDescriptor"/>,
-/// <see cref="IUserSessionAnomalyDetector"/>, <see cref="IUserSessionRiskStore"/>).
+/// <see cref="IUserSessionProvider"/>, <see cref="IUserSessionAnomalyDetector"/>,
+/// <see cref="IUserSessionRiskStore"/>).
 /// </summary>
 /// <remarks>
-/// Registers safe no-op / in-memory defaults so the contracts resolve everywhere. Install
-/// <c>Granit.UserSessions.AnomalyDetection</c> to replace the detector and
+/// Registers safe no-op / in-memory defaults so the contracts resolve everywhere. Install a backend
+/// integration package (BFF, OpenIddict, Keycloak) to replace the session/device providers,
+/// <c>Granit.UserSessions.AnomalyDetection</c> to replace the detector, and
 /// <c>Granit.UserSessions.EntityFrameworkCore</c> to replace the risk store with a durable one.
 /// </remarks>
 public sealed class GranitUserSessionsAbstractionsModule : GranitModule
@@ -19,5 +21,7 @@ public sealed class GranitUserSessionsAbstractionsModule : GranitModule
     {
         context.Services.TryAddScoped<IUserSessionAnomalyDetector, NullUserSessionAnomalyDetector>();
         context.Services.TryAddSingleton<IUserSessionRiskStore, MemoryUserSessionRiskStore>();
+        context.Services.TryAddScoped<IUserSessionProvider, NullUserSessionProvider>();
+        context.Services.TryAddScoped<IUserDeviceProvider, NullUserDeviceProvider>();
     }
 }

--- a/src/Granit.UserSessions.Abstractions/IUserDeviceProvider.cs
+++ b/src/Granit.UserSessions.Abstractions/IUserDeviceProvider.cs
@@ -1,0 +1,20 @@
+namespace Granit.UserSessions;
+
+/// <summary>
+/// Thin, backend-specific adapter that lists the devices a user has signed in from. One
+/// implementation per session backend, registered by the matching integration package.
+/// </summary>
+/// <remarks>
+/// Like <see cref="IUserSessionProvider"/>, a provider carries no policy — authorization, audit and
+/// geolocation enrichment are centralized in <see cref="IUserSessionManager"/>. The default
+/// registration returns no devices so the canonical <c>/devices</c> API resolves everywhere.
+/// </remarks>
+public interface IUserDeviceProvider
+{
+    /// <summary>
+    /// Lists the devices associated with <paramref name="userId"/>'s sessions.
+    /// </summary>
+    Task<IReadOnlyList<UserDevice>> ListAsync(
+        string userId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.UserSessions.Abstractions/IUserSessionManager.cs
+++ b/src/Granit.UserSessions.Abstractions/IUserSessionManager.cs
@@ -1,0 +1,58 @@
+namespace Granit.UserSessions;
+
+/// <summary>
+/// The single, topology-agnostic orchestrator for user-session management. It is the one entry
+/// point the canonical <c>/sessions</c> and <c>/devices</c> API depends on, regardless of whether a
+/// BFF is present or whether the identity provider is OpenIddict or Keycloak.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The manager centralizes all policy: it enriches each session with geolocation and the persisted
+/// risk verdict (<see cref="IUserSessionRiskStore"/>) exactly once, and dispatches revoke commands to
+/// the registered backend <see cref="IUserSessionProvider"/> / <see cref="IUserDeviceProvider"/>.
+/// Backends contribute only the irreducible mechanism (querying and revoking in their store);
+/// they never duplicate this enrichment or authorization logic.
+/// </para>
+/// <para>
+/// Authorization (the caller may only manage their own sessions, unless an administrator) and audit
+/// are applied by the manager and its hosting endpoints, not by the providers.
+/// </para>
+/// </remarks>
+public interface IUserSessionManager
+{
+    /// <summary>
+    /// Lists <paramref name="userId"/>'s sessions, enriched with geolocation and risk.
+    /// </summary>
+    /// <param name="userId">Subject whose sessions to list.</param>
+    /// <param name="currentSessionId">The caller's current session id, to flag the current entry.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<UserSessionView>> ListAsync(
+        string userId,
+        string? currentSessionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes a single session of <paramref name="userId"/>.
+    /// </summary>
+    /// <returns><see langword="true"/> when a matching session was found and revoked.</returns>
+    Task<bool> RevokeAsync(
+        string userId,
+        string sessionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes every session of <paramref name="userId"/> except <paramref name="currentSessionId"/>.
+    /// </summary>
+    /// <returns>The number of sessions revoked.</returns>
+    Task<int> RevokeOthersAsync(
+        string userId,
+        string currentSessionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists <paramref name="userId"/>'s devices, enriched with geolocation.
+    /// </summary>
+    Task<IReadOnlyList<UserDevice>> ListDevicesAsync(
+        string userId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.UserSessions.Abstractions/IUserSessionProvider.cs
+++ b/src/Granit.UserSessions.Abstractions/IUserSessionProvider.cs
@@ -1,0 +1,60 @@
+namespace Granit.UserSessions;
+
+/// <summary>
+/// Thin, backend-specific adapter that exposes a user's sessions and the irreducible
+/// operations to revoke them. One implementation per session backend — BFF gateway store,
+/// OpenIddict authority, Keycloak — registered by the matching integration package.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A provider carries <strong>no policy</strong>: it does not authorize the caller, write audit
+/// rows, resolve geolocation, or compute risk. Those are centralized in
+/// <see cref="IUserSessionManager"/>, which is the single orchestrator that calls into the
+/// registered provider. The provider only knows how to talk to its backend.
+/// </para>
+/// <para>
+/// Returned <see cref="UserSessionDescriptor"/> values carry the raw backend data
+/// (<see cref="UserSessionDescriptor.IpAddress"/>, timestamps, user-agent) with
+/// <see cref="UserSessionDescriptor.Location"/> left <see langword="null"/> — the manager fills
+/// geolocation. The provider does set <see cref="UserSessionDescriptor.IsCurrent"/> by comparing
+/// against <c>currentSessionId</c>, since only it knows how its backend identifies a session.
+/// </para>
+/// <para>
+/// The default registration is a no-op returning no sessions, so the canonical session API
+/// resolves everywhere; install a backend integration package to surface real sessions.
+/// </para>
+/// </remarks>
+public interface IUserSessionProvider
+{
+    /// <summary>
+    /// Lists the backend sessions belonging to <paramref name="userId"/>.
+    /// </summary>
+    /// <param name="userId">Subject whose sessions to list.</param>
+    /// <param name="currentSessionId">
+    /// The caller's current session id (resolved at the transport layer), used to flag
+    /// <see cref="UserSessionDescriptor.IsCurrent"/>; <see langword="null"/> when unknown.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(
+        string userId,
+        string? currentSessionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes a single session of <paramref name="userId"/>.
+    /// </summary>
+    /// <returns><see langword="true"/> when a matching session was found and revoked.</returns>
+    Task<bool> RevokeAsync(
+        string userId,
+        string sessionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes every session of <paramref name="userId"/> except <paramref name="currentSessionId"/>.
+    /// </summary>
+    /// <returns>The number of sessions revoked.</returns>
+    Task<int> RevokeOthersAsync(
+        string userId,
+        string currentSessionId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.UserSessions.Abstractions/Internal/NullUserDeviceProvider.cs
+++ b/src/Granit.UserSessions.Abstractions/Internal/NullUserDeviceProvider.cs
@@ -1,0 +1,12 @@
+namespace Granit.UserSessions.Internal;
+
+/// <summary>
+/// No-op <see cref="IUserDeviceProvider"/> registered by default: reports no devices. Replaced when a
+/// backend integration package is installed.
+/// </summary>
+internal sealed class NullUserDeviceProvider : IUserDeviceProvider
+{
+    public Task<IReadOnlyList<UserDevice>> ListAsync(
+        string userId, CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<UserDevice>>([]);
+}

--- a/src/Granit.UserSessions.Abstractions/Internal/NullUserSessionProvider.cs
+++ b/src/Granit.UserSessions.Abstractions/Internal/NullUserSessionProvider.cs
@@ -1,0 +1,21 @@
+namespace Granit.UserSessions.Internal;
+
+/// <summary>
+/// No-op <see cref="IUserSessionProvider"/> registered by default: reports no sessions and revokes
+/// nothing. Replaced when a backend integration package (BFF, OpenIddict, Keycloak) is installed, so
+/// the canonical session API always resolves but only surfaces real data once a backend is wired.
+/// </summary>
+internal sealed class NullUserSessionProvider : IUserSessionProvider
+{
+    public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(
+        string userId, string? currentSessionId, CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
+
+    public Task<bool> RevokeAsync(
+        string userId, string sessionId, CancellationToken cancellationToken = default) =>
+        Task.FromResult(false);
+
+    public Task<int> RevokeOthersAsync(
+        string userId, string currentSessionId, CancellationToken cancellationToken = default) =>
+        Task.FromResult(0);
+}

--- a/src/Granit.UserSessions.Abstractions/UserDevice.cs
+++ b/src/Granit.UserSessions.Abstractions/UserDevice.cs
@@ -1,0 +1,28 @@
+using Granit.IpGeolocation;
+
+namespace Granit.UserSessions;
+
+/// <summary>
+/// Canonical, store-agnostic view of a device a user has signed in from — an aggregation of one
+/// or more sessions sharing the same device fingerprint.
+/// </summary>
+/// <remarks>
+/// Surfaced by the canonical <c>/devices</c> API. Like <see cref="UserSessionDescriptor"/>, every
+/// derived field is optional: a backend populates only what its data exposes. The raw client IP is
+/// never carried here — only the privacy-friendlier <see cref="LastLocation"/>.
+/// </remarks>
+/// <param name="DeviceId">Stable device identifier (fingerprint or backend device id).</param>
+/// <param name="DeviceType">Coarse form factor (e.g. <c>"desktop"</c>, <c>"mobile"</c>, <c>"tablet"</c>), when known.</param>
+/// <param name="OperatingSystem">Operating-system family (e.g. <c>"Windows"</c>), when known.</param>
+/// <param name="Browser">Browser family (e.g. <c>"Chrome"</c>), when known.</param>
+/// <param name="LastSeen">Last observed activity from this device, when tracked.</param>
+/// <param name="SessionCount">Number of active sessions associated with this device.</param>
+/// <param name="LastLocation">Approximate location of the most recent activity, when resolved.</param>
+public sealed record UserDevice(
+    string DeviceId,
+    string? DeviceType,
+    string? OperatingSystem,
+    string? Browser,
+    DateTimeOffset? LastSeen,
+    int SessionCount,
+    GeoLocation? LastLocation);

--- a/src/Granit.UserSessions.Abstractions/UserSessionView.cs
+++ b/src/Granit.UserSessions.Abstractions/UserSessionView.cs
@@ -1,0 +1,18 @@
+namespace Granit.UserSessions;
+
+/// <summary>
+/// A user session enriched for presentation: the canonical <see cref="UserSessionDescriptor"/>
+/// (with geolocation resolved) paired with its persisted risk verdict, when one exists.
+/// </summary>
+/// <remarks>
+/// This is what <see cref="IUserSessionManager"/> returns — the descriptor comes from the backend
+/// <see cref="IUserSessionProvider"/>, the manager fills <see cref="UserSessionDescriptor.Location"/>
+/// and attaches <see cref="Risk"/> read from <see cref="IUserSessionRiskStore"/>. Keeping risk as a
+/// separate member (rather than folding it into the descriptor) preserves the descriptor's role as the
+/// detector's input and avoids a circular shape.
+/// </remarks>
+/// <param name="Session">The enriched session descriptor (geolocation resolved).</param>
+/// <param name="Risk">The persisted risk verdict, or <see langword="null"/> when none was recorded.</param>
+public sealed record UserSessionView(
+    UserSessionDescriptor Session,
+    UserSessionRiskVerdict? Risk);

--- a/tests/Granit.UserSessions.Abstractions.Tests/NullUserSessionProviderTests.cs
+++ b/tests/Granit.UserSessions.Abstractions.Tests/NullUserSessionProviderTests.cs
@@ -1,0 +1,32 @@
+using Granit.UserSessions.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.UserSessions.Abstractions.Tests;
+
+public sealed class NullUserSessionProviderTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task ListAsync_ReturnsEmpty()
+    {
+        NullUserSessionProvider sut = new();
+
+        IReadOnlyList<UserSessionDescriptor> result = await sut.ListAsync("user-1", "session-1", Ct);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task RevokeAsync_ReturnsFalse() =>
+        (await new NullUserSessionProvider().RevokeAsync("user-1", "session-1", Ct)).ShouldBeFalse();
+
+    [Fact]
+    public async Task RevokeOthersAsync_ReturnsZero() =>
+        (await new NullUserSessionProvider().RevokeOthersAsync("user-1", "session-1", Ct)).ShouldBe(0);
+
+    [Fact]
+    public async Task DeviceProvider_ListAsync_ReturnsEmpty() =>
+        (await new NullUserDeviceProvider().ListAsync("user-1", Ct)).ShouldBeEmpty();
+}


### PR DESCRIPTION
First step of the unified, BFF-/IdP-agnostic session API. **Closes #2655** (epic #2654).

## What

Adds the contracts to `Granit.UserSessions.Abstractions` (no transport, no policy yet):

- **`IUserSessionProvider`** / **`IUserDeviceProvider`** — thin backend adapters, one per backend (BFF, OpenIddict, Keycloak). They carry only the irreducible mechanism (list/revoke in their store, flag the current session); no authorization, audit, geo or risk. Null defaults registered so the canonical API resolves everywhere and surfaces real data once a backend integration package is installed.
- **`IUserSessionManager`** — the single orchestrator the canonical `/sessions` + `/devices` API will depend on (impl in the next feature): centralizes geolocation + risk enrichment once and dispatches revoke commands to the registered provider.
- **`UserSessionView`** (canonical `UserSessionDescriptor` + persisted `UserSessionRiskVerdict`) and **`UserDevice`** read-models.

Reuses the existing `UserSessionDescriptor` as the canonical session shape (added in the session-enrichment foundation).

## Why this layering

The session data lives in different backends depending on topology; the manager owns all policy/enrichment so the front always calls the same API regardless of BFF presence or IdP (OpenIddict/Keycloak). See epic #2654.

## Verification

`Granit.UserSessions.Abstractions` builds; tests 9/9 (incl. new Null-provider tests); `AbstractionsPurity` arch-tests 12/12 (contracts stay dependency-pure); `dotnet format` clean.

## Next

#2656 (Granit.UserSessions.Endpoints + manager impl) builds on this.