### PR TITLE
feat(openiddict): declare DeviceKind on an OIDC application

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1932,7 +1932,8 @@
         "Granit.Http.Cookies",
         "Granit.Identity.Local",
         "Granit.Identity.Local.AspNetIdentity",
-        "Granit.QueryEngine.Abstractions"
+        "Granit.QueryEngine.Abstractions",
+        "Granit.UserSessions.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -37407,12 +37408,28 @@
       ]
     },
     {
+      "name": "OpenIddictApplicationDeviceKindExtensions",
+      "fqn": "Granit.OpenIddict.Extensions.OpenIddictApplicationDeviceKindExtensions",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Extensions/OpenIddictApplicationDeviceKindExtensions.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "SetDeviceKind",
+          "kind": "method",
+          "signature": "SetDeviceKind(this OpenIddictApplicationDescriptor descriptor, DeviceKind? deviceKind)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "GranitOpenIddictModule",
       "fqn": "Granit.OpenIddict.GranitOpenIddictModule",
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
-      "line": 49,
+      "line": 51,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -997,6 +997,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -1022,6 +1023,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -611,6 +611,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
@@ -623,6 +629,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -671,6 +678,13 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.workflow.abstractions": {

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -492,6 +492,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -514,6 +520,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -524,6 +531,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
@@ -569,6 +577,13 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.validation": {

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -508,6 +508,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -539,6 +545,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -549,6 +556,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
@@ -594,6 +602,13 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.workflow.abstractions": {

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -500,6 +500,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }

--- a/src/Granit.OpenIddict/Extensions/OpenIddictApplicationDeviceKindExtensions.cs
+++ b/src/Granit.OpenIddict/Extensions/OpenIddictApplicationDeviceKindExtensions.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using Granit.UserSessions;
+using OpenIddict.Abstractions;
+
+namespace Granit.OpenIddict.Extensions;
+
+/// <summary>
+/// Read/write helpers for the <see cref="DeviceKind"/> an OpenIddict application declares for the devices
+/// that authenticate through it, persisted on the application's <c>Properties</c> dictionary. Read by the
+/// session adapters so <c>/devices</c> shows an accurate, trustworthy classification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DeviceKind"/> cannot be inferred reliably from the User-Agent — it follows from the
+/// authentication context (this declaration, with a redirect-URI/grant heuristic as fallback). Declaring it on
+/// the application record — rather than guessing per request — makes the classification deterministic and lets
+/// the host author own it through normal seeding, exactly like
+/// <see cref="OpenIddictApplicationClientSideExtensions"/> does for the client-side policy.
+/// </para>
+/// <para>
+/// The value is stored as the invariant enum name (<c>"MobileApp"</c>, <c>"Tv"</c>, …) under a
+/// <c>urn:granit:</c>-prefixed key. <see cref="DeviceKind.Unknown"/> and unrecognised values both read back as
+/// <see langword="null"/> ("not declared"), so a kind written by a newer binary never mis-resolves on an older
+/// one — the consumer falls back to its heuristic instead.
+/// </para>
+/// </remarks>
+public static class OpenIddictApplicationDeviceKindExtensions
+{
+    /// <summary>
+    /// Fully-qualified <c>Properties</c> key under which the declared device kind is stored. The
+    /// <c>urn:granit:</c> prefix avoids collisions with OpenIddict's own keys and any other extension.
+    /// </summary>
+    public const string DeviceKindPropertyKey = "urn:granit:openiddict:device_kind";
+
+    /// <summary>
+    /// Writes the declared <paramref name="deviceKind"/> onto the descriptor's
+    /// <see cref="OpenIddictApplicationDescriptor.Properties"/>. Passing <see langword="null"/> or
+    /// <see cref="DeviceKind.Unknown"/> removes the key, returning the application to "not declared".
+    /// </summary>
+    public static void SetDeviceKind(
+        this OpenIddictApplicationDescriptor descriptor,
+        DeviceKind? deviceKind)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (deviceKind is null or DeviceKind.Unknown)
+        {
+            descriptor.Properties.Remove(DeviceKindPropertyKey);
+            return;
+        }
+
+        descriptor.Properties[DeviceKindPropertyKey] = JsonSerializer.SerializeToElement(
+            deviceKind.Value.ToString());
+    }
+
+    /// <summary>
+    /// Reads the declared device kind from the descriptor's
+    /// <see cref="OpenIddictApplicationDescriptor.Properties"/>, or <see langword="null"/> when the key is
+    /// absent or its value is not a recognised, non-<see cref="DeviceKind.Unknown"/> member.
+    /// </summary>
+    public static DeviceKind? GetDeviceKind(this OpenIddictApplicationDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        return descriptor.Properties.TryGetValue(DeviceKindPropertyKey, out JsonElement element)
+            ? ParseDeviceKind(element)
+            : null;
+    }
+
+    /// <summary>
+    /// Reads the declared device kind from an application record via the OpenIddict application manager.
+    /// Returns <see langword="null"/> when the key is absent or its value is not a recognised,
+    /// non-<see cref="DeviceKind.Unknown"/> member.
+    /// </summary>
+    public static async ValueTask<DeviceKind?> GetDeviceKindAsync(
+        this IOpenIddictApplicationManager applicationManager,
+        object application,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(applicationManager);
+        ArgumentNullException.ThrowIfNull(application);
+
+        System.Collections.Immutable.ImmutableDictionary<string, JsonElement> properties =
+            await applicationManager.GetPropertiesAsync(application, cancellationToken)
+                .ConfigureAwait(false);
+
+        return properties.TryGetValue(DeviceKindPropertyKey, out JsonElement element)
+            ? ParseDeviceKind(element)
+            : null;
+    }
+
+    private static DeviceKind? ParseDeviceKind(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        string? raw = element.GetString();
+        return Enum.TryParse(raw, ignoreCase: false, out DeviceKind value)
+            && Enum.IsDefined(value)
+            && value != DeviceKind.Unknown
+            ? value
+            : null;
+    }
+}

--- a/src/Granit.OpenIddict/Granit.OpenIddict.csproj
+++ b/src/Granit.OpenIddict/Granit.OpenIddict.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local.AspNetIdentity\Granit.Identity.Local.AspNetIdentity.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.UserSessions.Abstractions\Granit.UserSessions.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -23,6 +23,7 @@ using Granit.OpenIddict.Queries;
 using Granit.OpenIddict.Services;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Extensions;
+using Granit.UserSessions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -45,7 +46,8 @@ namespace Granit.OpenIddict;
     typeof(GranitHttpCookiesModule),
     typeof(GranitIdentityLocalAspNetIdentityModule),
     typeof(GranitIdentityLocalModule),
-    typeof(GranitQueryEngineAbstractionsModule))]
+    typeof(GranitQueryEngineAbstractionsModule),
+    typeof(GranitUserSessionsAbstractionsModule))]
 public sealed class GranitOpenIddictModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -442,6 +442,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.persistence": {
         "type": "Project",
         "dependencies": {
@@ -482,6 +488,13 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.workflow.abstractions": {

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -741,6 +741,12 @@
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -774,6 +780,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -824,6 +831,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
@@ -873,6 +881,13 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.validation": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3304,6 +3304,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -3354,6 +3355,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -825,6 +825,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
@@ -837,6 +843,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -895,6 +902,13 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.workflow.abstractions": {

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -763,6 +763,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -794,6 +800,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -834,6 +841,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
@@ -879,6 +887,13 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.validation": {

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -675,6 +675,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -706,6 +712,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -731,6 +738,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
@@ -776,6 +784,13 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.workflow.abstractions": {

--- a/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
@@ -688,6 +688,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -870,6 +870,12 @@
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -901,6 +907,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -941,6 +948,7 @@
           "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
@@ -986,6 +994,13 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.validation": {

--- a/tests/Granit.OpenIddict.Tests/Extensions/OpenIddictApplicationDeviceKindExtensionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Extensions/OpenIddictApplicationDeviceKindExtensionsTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using Granit.OpenIddict.Extensions;
+using Granit.UserSessions;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="OpenIddictApplicationDeviceKindExtensions"/> — the read/write helpers that persist a
+/// declared <see cref="DeviceKind"/> on an OIDC application's <see cref="OpenIddictApplicationDescriptor.Properties"/> bag.
+/// </summary>
+public sealed class OpenIddictApplicationDeviceKindExtensionsTests
+{
+    [Theory]
+    [InlineData(DeviceKind.Browser)]
+    [InlineData(DeviceKind.MobileApp)]
+    [InlineData(DeviceKind.Tv)]
+    [InlineData(DeviceKind.ApiClient)]
+    [InlineData(DeviceKind.Wearable)]
+    public void SetDeviceKind_Then_GetDeviceKind_Roundtrip(DeviceKind kind)
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+
+        descriptor.SetDeviceKind(kind);
+
+        descriptor.GetDeviceKind().ShouldBe(kind);
+    }
+
+    [Fact]
+    public void SetDeviceKind_Writes_InvariantName_To_WellKnown_Key()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+
+        descriptor.SetDeviceKind(DeviceKind.MobileApp);
+
+        descriptor.Properties.ShouldContainKey(
+            OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey);
+        JsonElement element = descriptor.Properties[
+            OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey];
+        element.ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetString().ShouldBe("MobileApp");
+    }
+
+    [Fact]
+    public void SetDeviceKind_Null_Removes_Property()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.SetDeviceKind(DeviceKind.Tv);
+
+        descriptor.SetDeviceKind(null);
+
+        descriptor.Properties.ShouldNotContainKey(
+            OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey);
+        descriptor.GetDeviceKind().ShouldBeNull();
+    }
+
+    [Fact]
+    public void SetDeviceKind_Unknown_Removes_Property()
+    {
+        // Unknown is "not declared" — writing it must not persist a value the heuristic fallback would
+        // then be skipped for. Symmetric with null.
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.SetDeviceKind(DeviceKind.DesktopApp);
+
+        descriptor.SetDeviceKind(DeviceKind.Unknown);
+
+        descriptor.Properties.ShouldNotContainKey(
+            OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey);
+        descriptor.GetDeviceKind().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetDeviceKind_ReturnsNull_WhenPropertyAbsent()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+
+        descriptor.GetDeviceKind().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetDeviceKind_ReturnsNull_WhenValueIsNotAString()
+    {
+        // Forward-compatibility: a future schema could write a number under the same key. Treat unknown
+        // shapes as "not declared" rather than throwing.
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.Properties[OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey] =
+            JsonSerializer.SerializeToElement(42);
+
+        descriptor.GetDeviceKind().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetDeviceKind_ReturnsNull_WhenStringIsNotAnEnumMember()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.Properties[OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey] =
+            JsonSerializer.SerializeToElement("Hologram");
+
+        descriptor.GetDeviceKind().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetDeviceKind_ReturnsNull_WhenValueIsUnknownName()
+    {
+        // "Unknown" persisted by an external writer means "not declared" — never SetDeviceKind writes it.
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.Properties[OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey] =
+            JsonSerializer.SerializeToElement("Unknown");
+
+        descriptor.GetDeviceKind().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetDeviceKind_IsCaseSensitive_OnEnumName()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.Properties[OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey] =
+            JsonSerializer.SerializeToElement("mobileapp");
+
+        descriptor.GetDeviceKind().ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(DeviceKind.Browser)]
+    [InlineData(DeviceKind.Tv)]
+    [InlineData(DeviceKind.Embedded)]
+    public async Task GetDeviceKindAsync_Reads_FromApplicationManager(DeviceKind kind)
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IOpenIddictApplicationManager manager = Substitute.For<IOpenIddictApplicationManager>();
+        object application = new();
+
+        ImmutableDictionary<string, JsonElement> properties =
+            ImmutableDictionary<string, JsonElement>.Empty.Add(
+                OpenIddictApplicationDeviceKindExtensions.DeviceKindPropertyKey,
+                JsonSerializer.SerializeToElement(kind.ToString()));
+
+        manager.GetPropertiesAsync(application, Arg.Any<CancellationToken>())
+            .Returns(properties);
+
+        DeviceKind? resolved = await manager.GetDeviceKindAsync(application, cancellationToken);
+
+        resolved.ShouldBe(kind);
+    }
+
+    [Fact]
+    public async Task GetDeviceKindAsync_ReturnsNull_WhenKeyAbsent()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IOpenIddictApplicationManager manager = Substitute.For<IOpenIddictApplicationManager>();
+        object application = new();
+
+        manager.GetPropertiesAsync(application, Arg.Any<CancellationToken>())
+            .Returns(ImmutableDictionary<string, JsonElement>.Empty);
+
+        DeviceKind? resolved = await manager.GetDeviceKindAsync(application, cancellationToken);
+
+        resolved.ShouldBeNull();
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -657,6 +657,12 @@
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.ipgeolocation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
@@ -669,6 +675,7 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.UserSessions.Abstractions": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
@@ -713,6 +720,13 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.usersessions.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.workflow.abstractions": {


### PR DESCRIPTION
Part of #2654. **Increment 1 of #2668** — the declaration primitive.

`DeviceKind` (Browser, MobileApp, Tv, ApiClient, …) cannot be inferred reliably from the User-Agent — it follows from the **authentication context**. This lets an OIDC application **declare** its device kind, exactly mirroring the established `ClientSide` pattern (`OpenIddictApplicationClientSideExtensions`).

## What

`OpenIddictApplicationDeviceKindExtensions` (in `Granit.OpenIddict`):
- `SetDeviceKind(this OpenIddictApplicationDescriptor, DeviceKind?)` / `GetDeviceKind(...)` — seeding side.
- `GetDeviceKindAsync(this IOpenIddictApplicationManager, application, ct)` — read side, for the session adapters.
- Stored as the invariant enum name under `urn:granit:openiddict:device_kind`. `Unknown` and unrecognised/case-mismatched values read back as `null` ("not declared"), so a newer-binary write never mis-resolves on an older one and the consumer falls back to its heuristic.

`Granit.OpenIddict` now references `Granit.UserSessions.Abstractions` for the `DeviceKind` contract (`[DependsOn]` added; lock files updated additively across the OpenIddict closure — no version drift).

## Scope / next increment

This ships the **declaration mechanism** only — the issue's first deliverable. The follow-up wires the **readers**: the session adapters resolve `UserDevice.Kind` from this declaration with the redirect-URI/grant heuristic fallback, plus the Keycloak client-attribute equivalent. Split out because that wiring touches `IdentityDeviceActivity`/the session managers, and the module-boundary review (UserSessions ↔ Identity) is pending — keeping this PR to the clean, dependency-light primitive.

## Tests

- `OpenIddictApplicationDeviceKindExtensionsTests` (17 cases): round-trip for each kind, invariant-name storage, `null`/`Unknown` remove the key, forward-compat (non-string / unknown / case-mismatch → null), manager read path. Full `Granit.OpenIddict.Tests` green (305); `dotnet format` clean.