### PR TITLE
feat(user-sessions): greet by name, opt-in IP, friendly device in sign-in alerts

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -50020,7 +50020,7 @@
       "kind": "record",
       "project": "Granit.UserSessions.Notifications",
       "file": "src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs",
-      "line": 23,
+      "line": 26,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -49942,7 +49942,7 @@
       "kind": "class",
       "project": "Granit.UserSessions.Notifications",
       "file": "src/Granit.UserSessions.Notifications/Handlers/SuspiciousUserSessionDetectedHandler.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "HandleAsync",
@@ -50020,7 +50020,7 @@
       "kind": "record",
       "project": "Granit.UserSessions.Notifications",
       "file": "src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs",
-      "line": 19,
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -98,7 +98,7 @@ internal sealed partial class EmailNotificationChannel(
         }
 
         // Build enrichment context for templates
-        EmailEnrichment enrichment = new(definition, allowOptOut, unsubscribeUrl);
+        EmailEnrichment enrichment = new(definition, allowOptOut, unsubscribeUrl, recipient.DisplayName);
 
         // Try type-specific template first, then fall back to the built-in default template
         RenderedEmail? rendered = await TryRenderTemplateAsync(
@@ -361,13 +361,15 @@ internal sealed partial class EmailNotificationChannel(
         dataDict.TryAdd("notification_group", enrichment.Definition?.GroupName ?? "");
         dataDict.TryAdd("allow_opt_out", enrichment.AllowOptOut);
         dataDict.TryAdd("unsubscribe_url", enrichment.AllowOptOut ? enrichment.UnsubscribeUrl : "");
+        dataDict.TryAdd("recipient_name", enrichment.RecipientName ?? "");
     }
 
     /// <summary>Notification metadata resolved once per send, threaded through render methods.</summary>
     private sealed record EmailEnrichment(
         NotificationDefinition? Definition,
         bool AllowOptOut,
-        string UnsubscribeUrl);
+        string UnsubscribeUrl,
+        string? RecipientName);
 
     private static Dictionary<string, object?> JsonElementToDictionary(JsonElement element)
     {

--- a/src/Granit.UserSessions.AnomalyDetection/Internal/DefaultUserSessionRiskEvaluator.cs
+++ b/src/Granit.UserSessions.AnomalyDetection/Internal/DefaultUserSessionRiskEvaluator.cs
@@ -1,5 +1,7 @@
 using Granit.Events;
 using Granit.MultiTenancy;
+using Granit.UserSessions.AnomalyDetection.Options;
+using Microsoft.Extensions.Options;
 
 namespace Granit.UserSessions.AnomalyDetection.Internal;
 
@@ -22,6 +24,7 @@ internal sealed class DefaultUserSessionRiskEvaluator(
     IUserSessionRiskStore riskStore,
     TimeProvider timeProvider,
     ICurrentTenant currentTenant,
+    IOptions<UserSessionsAnomalyDetectionOptions> options,
     IDistributedEventBus? eventBus = null) : IUserSessionRiskEvaluator
 {
     public async Task<UserSessionRiskAssessment> EvaluateAsync(
@@ -55,7 +58,9 @@ internal sealed class DefaultUserSessionRiskEvaluator(
                             candidate.Location?.City,
                             candidate.Location?.CountryCode,
                             candidate.UserAgent,
-                            IpAddress: null, // raw IP withheld by default (GDPR); coarse location carried instead
+                            // Raw IP withheld by default (GDPR); coarse location carried instead. A deployment
+                            // can opt into raw-IP exposure on the alert via IncludeClientIpInAlert.
+                            options.Value.IncludeClientIpInAlert ? candidate.IpAddress : null,
                             now),
                         cancellationToken)
                     .ConfigureAwait(false);

--- a/src/Granit.UserSessions.AnomalyDetection/Options/UserSessionsAnomalyDetectionOptions.cs
+++ b/src/Granit.UserSessions.AnomalyDetection/Options/UserSessionsAnomalyDetectionOptions.cs
@@ -43,4 +43,14 @@ public sealed class UserSessionsAnomalyDetectionOptions
     /// </summary>
     [Range(1d, double.MaxValue)]
     public double MaxTravelKilometersPerHour { get; set; } = 1000d;
+
+    /// <summary>
+    /// When <c>true</c>, the raw client IP is carried on <c>SuspiciousUserSessionDetectedEto</c> so a
+    /// downstream consumer (e.g. the alert email) can display it. <strong>Opt-in</strong>: the default
+    /// (<c>false</c>) keeps alerts location-only. <strong>GDPR note:</strong> enabling this re-introduces the
+    /// raw IP — personal data — into the integration-event payload (and therefore the durable outbox row and the
+    /// resulting email), so only turn it on where that retention and exposure is justified and documented. The
+    /// IP is still never written to logs. Default: <c>false</c>.
+    /// </summary>
+    public bool IncludeClientIpInAlert { get; set; }
 }

--- a/src/Granit.UserSessions.Notifications/Handlers/SuspiciousUserSessionDetectedHandler.cs
+++ b/src/Granit.UserSessions.Notifications/Handlers/SuspiciousUserSessionDetectedHandler.cs
@@ -38,7 +38,8 @@ public class SuspiciousUserSessionDetectedHandler
             evt.City,
             evt.CountryCode,
             evt.IpAddress,
-            UserAgentDescriptor.Describe(evt.UserAgent),
+            UserAgentDescriptor.Browser(evt.UserAgent),
+            UserAgentDescriptor.OperatingSystem(evt.UserAgent),
             evt.DetectedAt);
 
         string[] recipients = [evt.UserId];

--- a/src/Granit.UserSessions.Notifications/Handlers/SuspiciousUserSessionDetectedHandler.cs
+++ b/src/Granit.UserSessions.Notifications/Handlers/SuspiciousUserSessionDetectedHandler.cs
@@ -1,4 +1,5 @@
 using Granit.Notifications.Abstractions;
+using Granit.UserSessions.Notifications.Internal;
 
 namespace Granit.UserSessions.Notifications.Handlers;
 
@@ -36,7 +37,8 @@ public class SuspiciousUserSessionDetectedHandler
             string.Join(", ", evt.Reasons),
             evt.City,
             evt.CountryCode,
-            evt.UserAgent,
+            evt.IpAddress,
+            UserAgentDescriptor.Describe(evt.UserAgent),
             evt.DetectedAt);
 
         string[] recipients = [evt.UserId];

--- a/src/Granit.UserSessions.Notifications/Internal/UserAgentDescriptor.cs
+++ b/src/Granit.UserSessions.Notifications/Internal/UserAgentDescriptor.cs
@@ -1,128 +1,120 @@
 namespace Granit.UserSessions.Notifications.Internal;
 
 /// <summary>
-/// Produces a short, human-readable "Browser on OS" label (e.g. <c>"Chrome on Windows"</c>,
-/// <c>"Safari on iPhone"</c>) from a raw User-Agent string, for display in the sign-in alert email.
+/// Extracts a coarse browser family and operating-system family from a raw User-Agent string, for display in
+/// the sign-in alert email. The two are returned <b>separately</b> (never joined in code) so the email template
+/// can lay them out and label them in the recipient's language — a baked-in English connector like "X on Y"
+/// would leak English into every localized email.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Deliberately coarse and self-contained: a handful of common browser and OS tokens, no version numbers, no
-/// device model, no third-party UA-parsing dependency. This is a courtesy label for a security email, not a
-/// fingerprint — keeping it coarse is also the privacy-conscious choice.
+/// Deliberately coarse and self-contained: a handful of common browser/OS tokens, no version numbers, no device
+/// model, no third-party UA-parsing dependency. A courtesy hint for a security email, not a fingerprint.
 /// </para>
 /// <para>
-/// Token order matters: several browsers embed each other's names in their UA (Edge and Opera both contain
-/// "Chrome"; Chrome contains "Safari"; "CriOS"/"FxiOS" are Chrome/Firefox on iOS atop the WebKit engine), so the
-/// more specific token is checked first. The OS-token approach mirrors the coarse
-/// <c>DeviceFingerprint.Family</c> in <c>Granit.UserSessions.AnomalyDetection</c> (which is internal to that
-/// module, hence re-implemented here).
+/// "Browser" is the right frame here because the value is parsed from a User-Agent and the only current source
+/// (BFF sessions) is always <c>DeviceKind.Browser</c>. Non-browser clients (mobile/desktop apps, wearables, TVs
+/// — arriving later from the OpenIddict/Keycloak sources, typically without a User-Agent) will need a kind-aware
+/// label derived from <c>DeviceKind</c> instead.
+/// </para>
+/// <para>
+/// Token order matters: several browsers embed each other's names (Edge and Opera both contain "Chrome"; Chrome
+/// contains "Safari"; "CriOS"/"FxiOS" are Chrome/Firefox on iOS), so the more specific token is checked first.
 /// </para>
 /// </remarks>
 internal static class UserAgentDescriptor
 {
-    /// <summary>
-    /// Maps <paramref name="userAgent"/> to a short "Browser on OS" label. Degrades gracefully:
-    /// returns just the OS when the browser is unrecognised, just the browser when the OS is unrecognised,
-    /// and <see langword="null"/> when neither can be derived (or the input is blank).
-    /// </summary>
-    public static string? Describe(string? userAgent)
+    /// <summary>Coarse browser family (e.g. <c>"Chrome"</c>), or <see langword="null"/> when unrecognised/blank.</summary>
+    public static string? Browser(string? userAgent)
     {
         if (string.IsNullOrWhiteSpace(userAgent))
         {
             return null;
         }
 
-        string? browser = Browser(userAgent);
-        string? os = OperatingSystem(userAgent);
-
-        return (browser, os) switch
-        {
-            ({ } b, { } o) => $"{b} on {o}",
-            ({ } b, null) => b,
-            (null, { } o) => o,
-            _ => null,
-        };
-    }
-
-    private static string? Browser(string ua)
-    {
         // Developer / API clients.
-        if (Has(ua, "PostmanRuntime"))
+        if (Has(userAgent, "PostmanRuntime"))
         {
             return "Postman";
         }
 
-        if (Has(ua, "curl/"))
+        if (Has(userAgent, "curl/"))
         {
             return "cURL";
         }
 
         // Edge ("Edg/") and Opera ("OPR/") both carry "Chrome"; check them first.
-        if (Has(ua, "Edg/") || Has(ua, "Edge/") || Has(ua, "EdgiOS/") || Has(ua, "EdgA/"))
+        if (Has(userAgent, "Edg/") || Has(userAgent, "Edge/") || Has(userAgent, "EdgiOS/") || Has(userAgent, "EdgA/"))
         {
             return "Edge";
         }
 
-        if (Has(ua, "OPR/") || Has(ua, "Opera"))
+        if (Has(userAgent, "OPR/") || Has(userAgent, "Opera"))
         {
             return "Opera";
         }
 
-        if (Has(ua, "SamsungBrowser"))
+        if (Has(userAgent, "SamsungBrowser"))
         {
             return "Samsung Internet";
         }
 
         // Firefox on iOS reports "FxiOS"; desktop/Android report "Firefox".
-        if (Has(ua, "Firefox") || Has(ua, "FxiOS"))
+        if (Has(userAgent, "Firefox") || Has(userAgent, "FxiOS"))
         {
             return "Firefox";
         }
 
         // Chrome on iOS reports "CriOS"; everywhere else "Chrome" (which also appears in WebView UAs).
-        if (Has(ua, "Chrome") || Has(ua, "CriOS"))
+        if (Has(userAgent, "Chrome") || Has(userAgent, "CriOS"))
         {
             return "Chrome";
         }
 
         // Safari embeds "Safari" but so does Chrome — only reached once Chrome is ruled out above.
-        return Has(ua, "Safari") ? "Safari" : null;
+        return Has(userAgent, "Safari") ? "Safari" : null;
     }
 
-    private static string? OperatingSystem(string ua)
+    /// <summary>Coarse operating-system family (e.g. <c>"Windows"</c>), or <see langword="null"/> when unrecognised/blank.</summary>
+    public static string? OperatingSystem(string? userAgent)
     {
-        if (Has(ua, "iPhone"))
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return null;
+        }
+
+        if (Has(userAgent, "iPhone"))
         {
             return "iPhone";
         }
 
-        if (Has(ua, "iPad"))
+        if (Has(userAgent, "iPad"))
         {
             return "iPad";
         }
 
-        if (Has(ua, "Android"))
+        if (Has(userAgent, "Android"))
         {
             return "Android";
         }
 
-        if (Has(ua, "Windows"))
+        if (Has(userAgent, "Windows"))
         {
             return "Windows";
         }
 
-        if (Has(ua, "Macintosh") || Has(ua, "Mac OS"))
+        if (Has(userAgent, "Macintosh") || Has(userAgent, "Mac OS"))
         {
             return "macOS";
         }
 
         // CrOS (ChromeOS) also contains "Linux"; surface the more specific name first.
-        if (Has(ua, "CrOS"))
+        if (Has(userAgent, "CrOS"))
         {
             return "ChromeOS";
         }
 
-        return Has(ua, "Linux") ? "Linux" : null;
+        return Has(userAgent, "Linux") ? "Linux" : null;
     }
 
     private static bool Has(string value, string token) =>

--- a/src/Granit.UserSessions.Notifications/Internal/UserAgentDescriptor.cs
+++ b/src/Granit.UserSessions.Notifications/Internal/UserAgentDescriptor.cs
@@ -1,0 +1,130 @@
+namespace Granit.UserSessions.Notifications.Internal;
+
+/// <summary>
+/// Produces a short, human-readable "Browser on OS" label (e.g. <c>"Chrome on Windows"</c>,
+/// <c>"Safari on iPhone"</c>) from a raw User-Agent string, for display in the sign-in alert email.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately coarse and self-contained: a handful of common browser and OS tokens, no version numbers, no
+/// device model, no third-party UA-parsing dependency. This is a courtesy label for a security email, not a
+/// fingerprint — keeping it coarse is also the privacy-conscious choice.
+/// </para>
+/// <para>
+/// Token order matters: several browsers embed each other's names in their UA (Edge and Opera both contain
+/// "Chrome"; Chrome contains "Safari"; "CriOS"/"FxiOS" are Chrome/Firefox on iOS atop the WebKit engine), so the
+/// more specific token is checked first. The OS-token approach mirrors the coarse
+/// <c>DeviceFingerprint.Family</c> in <c>Granit.UserSessions.AnomalyDetection</c> (which is internal to that
+/// module, hence re-implemented here).
+/// </para>
+/// </remarks>
+internal static class UserAgentDescriptor
+{
+    /// <summary>
+    /// Maps <paramref name="userAgent"/> to a short "Browser on OS" label. Degrades gracefully:
+    /// returns just the OS when the browser is unrecognised, just the browser when the OS is unrecognised,
+    /// and <see langword="null"/> when neither can be derived (or the input is blank).
+    /// </summary>
+    public static string? Describe(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return null;
+        }
+
+        string? browser = Browser(userAgent);
+        string? os = OperatingSystem(userAgent);
+
+        return (browser, os) switch
+        {
+            ({ } b, { } o) => $"{b} on {o}",
+            ({ } b, null) => b,
+            (null, { } o) => o,
+            _ => null,
+        };
+    }
+
+    private static string? Browser(string ua)
+    {
+        // Developer / API clients.
+        if (Has(ua, "PostmanRuntime"))
+        {
+            return "Postman";
+        }
+
+        if (Has(ua, "curl/"))
+        {
+            return "cURL";
+        }
+
+        // Edge ("Edg/") and Opera ("OPR/") both carry "Chrome"; check them first.
+        if (Has(ua, "Edg/") || Has(ua, "Edge/") || Has(ua, "EdgiOS/") || Has(ua, "EdgA/"))
+        {
+            return "Edge";
+        }
+
+        if (Has(ua, "OPR/") || Has(ua, "Opera"))
+        {
+            return "Opera";
+        }
+
+        if (Has(ua, "SamsungBrowser"))
+        {
+            return "Samsung Internet";
+        }
+
+        // Firefox on iOS reports "FxiOS"; desktop/Android report "Firefox".
+        if (Has(ua, "Firefox") || Has(ua, "FxiOS"))
+        {
+            return "Firefox";
+        }
+
+        // Chrome on iOS reports "CriOS"; everywhere else "Chrome" (which also appears in WebView UAs).
+        if (Has(ua, "Chrome") || Has(ua, "CriOS"))
+        {
+            return "Chrome";
+        }
+
+        // Safari embeds "Safari" but so does Chrome — only reached once Chrome is ruled out above.
+        return Has(ua, "Safari") ? "Safari" : null;
+    }
+
+    private static string? OperatingSystem(string ua)
+    {
+        if (Has(ua, "iPhone"))
+        {
+            return "iPhone";
+        }
+
+        if (Has(ua, "iPad"))
+        {
+            return "iPad";
+        }
+
+        if (Has(ua, "Android"))
+        {
+            return "Android";
+        }
+
+        if (Has(ua, "Windows"))
+        {
+            return "Windows";
+        }
+
+        if (Has(ua, "Macintosh") || Has(ua, "Mac OS"))
+        {
+            return "macOS";
+        }
+
+        // CrOS (ChromeOS) also contains "Linux"; surface the more specific name first.
+        if (Has(ua, "CrOS"))
+        {
+            return "ChromeOS";
+        }
+
+        return Has(ua, "Linux") ? "Linux" : null;
+    }
+
+    private static bool Has(string value, string token) =>
+        value.Contains(token, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs
+++ b/src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs
@@ -12,8 +12,12 @@ namespace Granit.UserSessions.Notifications;
 /// notification payload is flattened to a dictionary.</param>
 /// <param name="City">Approximate city of the sign-in, when resolved; otherwise <see langword="null"/>.</param>
 /// <param name="CountryCode">Approximate country (ISO code) of the sign-in, when resolved.</param>
-/// <param name="Device">Raw User-Agent of the sign-in, when available. Rendered as-is for now —
-/// a friendly device label ("Chrome on Windows") is a follow-up; no user-agent parser exists yet.</param>
+/// <param name="IpAddress">Raw client IP of the sign-in, present only when the deployment opted into raw-IP
+/// exposure (<c>UserSessions:AnomalyDetection:IncludeClientIpInAlert</c>); otherwise <see langword="null"/> and
+/// the IP row is omitted. Personal data — never log it.</param>
+/// <param name="Device">Friendly device label ("Chrome on Windows", "Safari on iPhone") derived from the raw
+/// User-Agent via <see cref="Internal.UserAgentDescriptor"/>; <see langword="null"/> when it could not be
+/// derived. Never the raw User-Agent string.</param>
 /// <param name="DetectedAt">When the verdict was produced (rendered in UTC; user-timezone
 /// localization is a follow-up).</param>
 public sealed record SuspiciousUserSessionNotificationData(
@@ -21,5 +25,6 @@ public sealed record SuspiciousUserSessionNotificationData(
     string ReasonsDisplay,
     string? City,
     string? CountryCode,
+    string? IpAddress,
     string? Device,
     DateTimeOffset DetectedAt);

--- a/src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs
+++ b/src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs
@@ -15,9 +15,12 @@ namespace Granit.UserSessions.Notifications;
 /// <param name="IpAddress">Raw client IP of the sign-in, present only when the deployment opted into raw-IP
 /// exposure (<c>UserSessions:AnomalyDetection:IncludeClientIpInAlert</c>); otherwise <see langword="null"/> and
 /// the IP row is omitted. Personal data — never log it.</param>
-/// <param name="Device">Friendly device label ("Chrome on Windows", "Safari on iPhone") derived from the raw
-/// User-Agent via <see cref="Internal.UserAgentDescriptor"/>; <see langword="null"/> when it could not be
-/// derived. Never the raw User-Agent string.</param>
+/// <param name="Browser">Coarse browser family ("Chrome", "Safari") derived from the raw User-Agent via
+/// <see cref="Internal.UserAgentDescriptor"/>; <see langword="null"/> when it could not be derived. Kept
+/// separate from <paramref name="OperatingSystem"/> so the template composes and labels them per culture (no
+/// English connector baked in code). Never the raw User-Agent string.</param>
+/// <param name="OperatingSystem">Coarse OS family ("Windows", "iPhone") derived from the raw User-Agent;
+/// <see langword="null"/> when it could not be derived.</param>
 /// <param name="DetectedAt">When the verdict was produced (rendered in UTC; user-timezone
 /// localization is a follow-up).</param>
 public sealed record SuspiciousUserSessionNotificationData(
@@ -26,5 +29,6 @@ public sealed record SuspiciousUserSessionNotificationData(
     string? City,
     string? CountryCode,
     string? IpAddress,
-    string? Device,
+    string? Browser,
+    string? OperatingSystem,
     DateTimeOffset DetectedAt);

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.cs.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.cs.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Nové přihlášení k vašemu účtu</title>
-<mj-text>Dobrý den,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Dobrý den {{ model.recipient_name }},{{ else }}Dobrý den,{{ end }}</mj-text>
 <mj-text>Zaznamenali jsme nové přihlášení k vašemu účtu. Pokud jste to byli vy, nemusíte nic dělat.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kdy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Zařízení</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresa</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Toto přihlášení proběhlo z místa vzdáleného od místa, odkud se obvykle přihlašujete.{{ else if model.reason == "new_country" }}Jde o první přihlášení, které jsme z této země zaznamenali.{{ else if model.reason == "new_device" }}Toto přihlášení proběhlo ze zařízení, které jsme dosud neviděli.{{ else }}Toto přihlášení se trochu lišilo od vašich obvyklých.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.cs.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.cs.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Zařízení</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Prohlížeč</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Operační systém</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresa</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.de.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.de.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wo</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gerät</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Betriebssystem</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-Adresse</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.de.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.de.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Neue Anmeldung bei Ihrem Konto</title>
-<mj-text>Hallo,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>Wir haben eine neue Anmeldung bei Ihrem Konto festgestellt. Wenn Sie das waren, müssen Sie nichts unternehmen.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wann</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gerät</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-Adresse</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Diese Anmeldung erfolgte von einem Ort, der weit von dem entfernt ist, wo Sie sich üblicherweise anmelden.{{ else if model.reason == "new_country" }}Dies ist die erste Anmeldung, die wir aus diesem Land registriert haben.{{ else if model.reason == "new_device" }}Diese Anmeldung erfolgte von einem Gerät, das wir bisher nicht gesehen haben.{{ else }}Diese Anmeldung unterschied sich ein wenig von Ihren üblichen.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.es.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.es.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dónde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navegador</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operativo</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dirección IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.es.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.es.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Nuevo inicio de sesión en tu cuenta</title>
-<mj-text>Hola:</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hola {{ model.recipient_name }}:{{ else }}Hola:{{ end }}</mj-text>
 <mj-text>Hemos detectado un nuevo inicio de sesión en tu cuenta. Si fuiste tú, no necesitas hacer nada.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cuándo</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dirección IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Este inicio de sesión se realizó desde un lugar muy alejado de donde sueles iniciar sesión.{{ else if model.reason == "new_country" }}Es el primer inicio de sesión que detectamos desde este país.{{ else if model.reason == "new_device" }}Este inicio de sesión se realizó desde un dispositivo que no habíamos visto antes.{{ else }}Este inicio de sesión fue un poco diferente de los habituales.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.fr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.fr.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Où</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Appareil</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navigateur</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Système d'exploitation</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adresse IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.fr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.fr.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Nouvelle connexion à votre compte</title>
-<mj-text>Bonjour,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Bonjour {{ model.recipient_name }},{{ else }}Bonjour,{{ end }}</mj-text>
 <mj-text>Nous avons remarqué une nouvelle connexion à votre compte. Si c'était vous, vous n'avez rien à faire.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quand</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Appareil</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adresse IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Cette connexion provient d'un lieu éloigné de celui où vous vous connectez habituellement.{{ else if model.reason == "new_country" }}Il s'agit de la première connexion que nous observons depuis ce pays.{{ else if model.reason == "new_device" }}Cette connexion provient d'un appareil que nous n'avons jamais vu auparavant.{{ else }}Cette connexion était un peu différente de vos connexions habituelles.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.hi.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.hi.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>आपके खाते में नया साइन-इन</title>
-<mj-text>नमस्ते,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}नमस्ते {{ model.recipient_name }},{{ else }}नमस्ते,{{ end }}</mj-text>
 <mj-text>हमने आपके खाते में एक नया साइन-इन देखा। यदि यह आप ही थे, तो आपको कुछ करने की आवश्यकता नहीं है।</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कब</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">डिवाइस</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP पता</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}यह साइन-इन उस स्थान से बहुत दूर के स्थान से हुआ जहाँ से आप सामान्यतः साइन इन करते हैं।{{ else if model.reason == "new_country" }}यह इस देश से देखा गया पहला साइन-इन है।{{ else if model.reason == "new_device" }}यह साइन-इन एक ऐसे डिवाइस से हुआ जिसे हमने पहले नहीं देखा था।{{ else }}यह साइन-इन आपके सामान्य साइन-इन से थोड़ा अलग लगा।{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.hi.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.hi.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कहाँ</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">डिवाइस</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">ब्राउज़र</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">ऑपरेटिंग सिस्टम</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP पता</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.html
@@ -6,8 +6,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Where</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Device</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Operating system</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP address</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.html
@@ -1,5 +1,5 @@
 <title>New sign-in to your account</title>
-<mj-text>Hi,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hi {{ model.recipient_name }},{{ else }}Hi,{{ end }}</mj-text>
 <mj-text>We noticed a new sign-in to your account. If this was you, there's nothing you need to do.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">When</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -8,6 +8,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Device</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP address</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}This sign-in came from a location far from where you usually sign in.{{ else if model.reason == "new_country" }}This is the first sign-in we've seen from this country.{{ else if model.reason == "new_device" }}This sign-in came from a device we haven't seen before.{{ else }}This sign-in looked a little different from your usual ones.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.it.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.it.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dove</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operativo</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Indirizzo IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.it.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.it.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Nuovo accesso al tuo account</title>
-<mj-text>Ciao,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Ciao {{ model.recipient_name }},{{ else }}Ciao,{{ end }}</mj-text>
 <mj-text>Abbiamo rilevato un nuovo accesso al tuo account. Se sei stato tu, non devi fare nulla.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Indirizzo IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Questo accesso proviene da un luogo molto distante da quello in cui accedi di solito.{{ else if model.reason == "new_country" }}È il primo accesso che rileviamo da questo Paese.{{ else if model.reason == "new_device" }}Questo accesso proviene da un dispositivo che non abbiamo mai visto prima.{{ else }}Questo accesso era un po' diverso da quelli abituali.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ja.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ja.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>アカウントへの新しいサインイン</title>
-<mj-text>こんにちは。</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}{{ model.recipient_name }}様、こんにちは。{{ else }}こんにちは。{{ end }}</mj-text>
 <mj-text>お客様のアカウントへの新しいサインインを検出しました。ご本人によるものであれば、特に対応は必要ありません。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">日時</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">デバイス</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IPアドレス</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}このサインインは、お客様が普段サインインされる場所から遠く離れた場所からのものでした。{{ else if model.reason == "new_country" }}この国からのサインインを確認したのは今回が初めてです。{{ else if model.reason == "new_device" }}このサインインは、これまで確認されていないデバイスからのものでした。{{ else }}このサインインは、いつもとは少し異なるものでした。{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ja.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ja.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">場所</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">デバイス</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">ブラウザ</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">オペレーティングシステム</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IPアドレス</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ko.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ko.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>계정에 대한 새 로그인</title>
-<mj-text>안녕하세요,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}안녕하세요 {{ model.recipient_name }}님,{{ else }}안녕하세요,{{ end }}</mj-text>
 <mj-text>고객님의 계정에서 새 로그인이 감지되었습니다. 본인이 맞으시다면 별도로 하실 일은 없습니다.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">시간</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">기기</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 주소</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}이 로그인은 고객님이 평소 로그인하시는 위치에서 멀리 떨어진 곳에서 이루어졌습니다.{{ else if model.reason == "new_country" }}이 국가에서 확인된 첫 로그인입니다.{{ else if model.reason == "new_device" }}이 로그인은 이전에 확인된 적이 없는 기기에서 이루어졌습니다.{{ else }}이 로그인은 평소와는 조금 다르게 보였습니다.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ko.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ko.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">위치</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">기기</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">브라우저</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">운영 체제</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 주소</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.nl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.nl.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Nieuwe aanmelding bij uw account</title>
-<mj-text>Hallo,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>We hebben een nieuwe aanmelding bij uw account opgemerkt. Als u dit was, hoeft u niets te doen.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wanneer</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Apparaat</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adres</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Deze aanmelding kwam van een locatie ver van waar u zich gewoonlijk aanmeldt.{{ else if model.reason == "new_country" }}Dit is de eerste aanmelding die we vanuit dit land hebben gezien.{{ else if model.reason == "new_device" }}Deze aanmelding kwam van een apparaat dat we niet eerder hebben gezien.{{ else }}Deze aanmelding week een beetje af van uw gebruikelijke aanmeldingen.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.nl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.nl.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Waar</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Apparaat</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Besturingssysteem</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adres</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pl.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gdzie</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Urządzenie</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Przeglądarka</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">System operacyjny</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adres IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pl.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Nowe logowanie do Twojego konta</title>
-<mj-text>Witaj,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Witaj {{ model.recipient_name }},{{ else }}Witaj,{{ end }}</mj-text>
 <mj-text>Zauważyliśmy nowe logowanie do Twojego konta. Jeśli to byłeś Ty, nie musisz nic robić.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kiedy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Urządzenie</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adres IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}To logowanie nastąpiło z miejsca odległego od tego, z którego zwykle się logujesz.{{ else if model.reason == "new_country" }}To pierwsze logowanie, jakie odnotowaliśmy z tego kraju.{{ else if model.reason == "new_device" }}To logowanie nastąpiło z urządzenia, którego wcześniej nie widzieliśmy.{{ else }}To logowanie nieco różniło się od Twoich zwykłych logowań.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt-BR.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt-BR.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navegador</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operacional</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt-BR.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt-BR.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Novo login na sua conta</title>
-<mj-text>Olá,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detectamos um novo login na sua conta. Se foi você, não precisa fazer nada.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Este login veio de um local distante de onde você costuma fazer login.{{ else if model.reason == "new_country" }}Este é o primeiro login que registramos a partir deste país.{{ else if model.reason == "new_device" }}Este login veio de um dispositivo que nunca vimos antes.{{ else }}Este login foi um pouco diferente dos habituais.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navegador</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operativo</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Novo início de sessão na sua conta</title>
-<mj-text>Olá,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detetámos um novo início de sessão na sua conta. Se foi o utilizador, não precisa de fazer nada.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Este início de sessão teve origem num local distante daquele onde costuma iniciar sessão.{{ else if model.reason == "new_country" }}Este é o primeiro início de sessão que registámos a partir deste país.{{ else if model.reason == "new_device" }}Este início de sessão teve origem num dispositivo que nunca tínhamos visto antes.{{ else }}Este início de sessão foi um pouco diferente dos habituais.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.sv.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.sv.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Var</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Enhet</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Webbläsare</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Operativsystem</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adress</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.sv.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.sv.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Ny inloggning på ditt konto</title>
-<mj-text>Hej,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hej {{ model.recipient_name }},{{ else }}Hej,{{ end }}</mj-text>
 <mj-text>Vi har upptäckt en ny inloggning på ditt konto. Om det var du behöver du inte göra något.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">När</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Enhet</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adress</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Den här inloggningen kom från en plats långt ifrån där du brukar logga in.{{ else if model.reason == "new_country" }}Det här är den första inloggningen vi har sett från det här landet.{{ else if model.reason == "new_device" }}Den här inloggningen kom från en enhet som vi inte har sett tidigare.{{ else }}Den här inloggningen skiljde sig lite från dina vanliga.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.tr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.tr.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Hesabınızda yeni oturum açma</title>
-<mj-text>Merhaba,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Merhaba {{ model.recipient_name }},{{ else }}Merhaba,{{ end }}</mj-text>
 <mj-text>Hesabınızda yeni bir oturum açma işlemi fark ettik. Bu işlemi siz yaptıysanız yapmanız gereken bir şey yok.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Ne zaman</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cihaz</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresi</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Bu oturum açma işlemi, genellikle oturum açtığınız yerden çok uzak bir konumdan gerçekleşti.{{ else if model.reason == "new_country" }}Bu, bu ülkeden gördüğümüz ilk oturum açma işlemidir.{{ else if model.reason == "new_device" }}Bu oturum açma işlemi, daha önce görmediğimiz bir cihazdan gerçekleşti.{{ else }}Bu oturum açma işlemi, her zamankilerden biraz farklı görünüyordu.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.tr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.tr.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Nerede</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cihaz</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Tarayıcı</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">İşletim sistemi</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresi</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.zh.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.zh.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">地点</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">设备</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">浏览器</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">操作系统</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 地址</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.zh.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.zh.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>您的账户出现新登录</title>
-<mj-text>您好，</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}您好 {{ model.recipient_name }}，{{ else }}您好，{{ end }}</mj-text>
 <mj-text>我们注意到您的账户有一次新登录。如果是您本人操作，您无需进行任何操作。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">时间</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">设备</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 地址</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}此次登录来自一个远离您平常登录地点的位置。{{ else if model.reason == "new_country" }}这是我们首次发现来自该国家/地区的登录。{{ else if model.reason == "new_device" }}此次登录来自一台我们此前从未见过的设备。{{ else }}此次登录与您平常的登录略有不同。{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.cs.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.cs.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Podezřelé přihlášení k vašemu účtu</title>
-<mj-text>Dobrý den,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Dobrý den {{ model.recipient_name }},{{ else }}Dobrý den,{{ end }}</mj-text>
 <mj-text>Zaznamenali jsme přihlášení k vašemu účtu, které vypadalo neobvykle, a chceme se ujistit, že jste to byli vy.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kdy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Zařízení</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresa</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Toto přihlášení proběhlo z místa vzdáleného od místa, odkud se obvykle přihlašujete, a příliš daleko na to, abyste tam od své poslední relace stihli docestovat.{{ else if model.reason == "new_country" }}Jde o první přihlášení, které jsme z této země zaznamenali.{{ else if model.reason == "new_device" }}Toto přihlášení proběhlo ze zařízení, které jsme dosud neviděli.{{ else }}Toto přihlášení se u vašeho účtu jevilo jako neobvyklé.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.cs.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.cs.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Zařízení</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Prohlížeč</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Operační systém</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresa</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.de.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.de.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Verdächtige Anmeldung bei Ihrem Konto</title>
-<mj-text>Hallo,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>Wir haben bei Ihrem Konto eine Anmeldung festgestellt, die ungewöhnlich erschien, und möchten sicherstellen, dass Sie es waren.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wann</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gerät</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-Adresse</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Diese Anmeldung erfolgte von einem Ort, der weit von dem entfernt ist, wo Sie sich üblicherweise anmelden, und zu weit, um seit Ihrer letzten Sitzung dorthin gereist zu sein.{{ else if model.reason == "new_country" }}Dies ist die erste Anmeldung, die wir aus diesem Land registriert haben.{{ else if model.reason == "new_device" }}Diese Anmeldung erfolgte von einem Gerät, das wir bisher nicht gesehen haben.{{ else }}Diese Anmeldung erschien für Ihr Konto ungewöhnlich.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.de.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.de.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wo</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gerät</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Betriebssystem</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-Adresse</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.es.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.es.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dónde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navegador</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operativo</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dirección IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.es.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.es.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Inicio de sesión sospechoso en tu cuenta</title>
-<mj-text>Hola:</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hola {{ model.recipient_name }}:{{ else }}Hola:{{ end }}</mj-text>
 <mj-text>Hemos detectado un inicio de sesión en tu cuenta que parecía inusual y queremos asegurarnos de que fuiste tú.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cuándo</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dirección IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Este inicio de sesión se realizó desde un lugar muy alejado de donde sueles iniciar sesión, y demasiado lejos como para haberte desplazado allí desde tu última sesión.{{ else if model.reason == "new_country" }}Es el primer inicio de sesión que detectamos desde este país.{{ else if model.reason == "new_device" }}Este inicio de sesión se realizó desde un dispositivo que no habíamos visto antes.{{ else }}Este inicio de sesión pareció inusual para tu cuenta.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.fr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.fr.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Connexion suspecte à votre compte</title>
-<mj-text>Bonjour,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Bonjour {{ model.recipient_name }},{{ else }}Bonjour,{{ end }}</mj-text>
 <mj-text>Nous avons remarqué une connexion à votre compte qui semblait inhabituelle, et nous voulons nous assurer qu'il s'agissait bien de vous.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quand</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Appareil</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adresse IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Cette connexion provient d'un lieu éloigné de celui où vous vous connectez habituellement, et trop éloigné pour que vous ayez pu vous y rendre depuis votre dernière session.{{ else if model.reason == "new_country" }}Il s'agit de la première connexion que nous observons depuis ce pays.{{ else if model.reason == "new_device" }}Cette connexion provient d'un appareil que nous n'avons jamais vu auparavant.{{ else }}Cette connexion a semblé inhabituelle pour votre compte.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.fr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.fr.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Où</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Appareil</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navigateur</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Système d'exploitation</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adresse IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.hi.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.hi.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>आपके खाते में संदिग्ध साइन-इन</title>
-<mj-text>नमस्ते,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}नमस्ते {{ model.recipient_name }},{{ else }}नमस्ते,{{ end }}</mj-text>
 <mj-text>हमने आपके खाते में एक साइन-इन देखा जो असामान्य लगा, और हम यह सुनिश्चित करना चाहते हैं कि यह आप ही थे।</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कब</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">डिवाइस</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP पता</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}यह साइन-इन उस स्थान से बहुत दूर के स्थान से हुआ जहाँ से आप सामान्यतः साइन इन करते हैं, और इतनी दूर कि आप अपने पिछले सत्र के बाद से वहाँ यात्रा नहीं कर सकते थे।{{ else if model.reason == "new_country" }}यह इस देश से देखा गया पहला साइन-इन है।{{ else if model.reason == "new_device" }}यह साइन-इन एक ऐसे डिवाइस से हुआ जिसे हमने पहले नहीं देखा था।{{ else }}यह साइन-इन आपके खाते के लिए असामान्य लगा।{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.hi.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.hi.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कहाँ</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">डिवाइस</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">ब्राउज़र</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">ऑपरेटिंग सिस्टम</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP पता</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.html
@@ -6,8 +6,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Where</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Device</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Operating system</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP address</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.html
@@ -1,5 +1,5 @@
 <title>Suspicious sign-in to your account</title>
-<mj-text>Hi,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hi {{ model.recipient_name }},{{ else }}Hi,{{ end }}</mj-text>
 <mj-text>We noticed a sign-in to your account that looked unusual, and we want to make sure it was you.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">When</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -8,6 +8,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Device</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP address</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}This sign-in came from a location far from where you usually sign in, and too far to have travelled there since your last session.{{ else if model.reason == "new_country" }}This is the first sign-in we've seen from this country.{{ else if model.reason == "new_device" }}This sign-in came from a device we haven't seen before.{{ else }}This sign-in looked unusual for your account.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.it.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.it.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dove</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operativo</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Indirizzo IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.it.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.it.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Accesso sospetto al tuo account</title>
-<mj-text>Ciao,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Ciao {{ model.recipient_name }},{{ else }}Ciao,{{ end }}</mj-text>
 <mj-text>Abbiamo rilevato un accesso al tuo account che è sembrato insolito e vogliamo assicurarci che sia stato effettuato da te.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Indirizzo IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Questo accesso proviene da un luogo molto distante da quello in cui accedi di solito, e troppo lontano perché tu possa esserci arrivato dalla tua ultima sessione.{{ else if model.reason == "new_country" }}È il primo accesso che rileviamo da questo Paese.{{ else if model.reason == "new_device" }}Questo accesso proviene da un dispositivo che non abbiamo mai visto prima.{{ else }}Questo accesso è sembrato insolito per il tuo account.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ja.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ja.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>アカウントへの不審なサインイン</title>
-<mj-text>こんにちは。</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}{{ model.recipient_name }}様、こんにちは。{{ else }}こんにちは。{{ end }}</mj-text>
 <mj-text>お客様のアカウントで通常とは異なるサインインを検出したため、ご本人によるものかどうかを確認させていただきたく存じます。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">日時</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">デバイス</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IPアドレス</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}このサインインは、お客様が普段サインインされる場所から遠く離れた場所からのものであり、前回のセッション以降に移動するには遠すぎる距離でした。{{ else if model.reason == "new_country" }}この国からのサインインを確認したのは今回が初めてです。{{ else if model.reason == "new_device" }}このサインインは、これまで確認されていないデバイスからのものでした。{{ else }}このサインインは、お客様のアカウントにとって通常とは異なるものでした。{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ja.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ja.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">場所</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">デバイス</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">ブラウザ</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">オペレーティングシステム</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IPアドレス</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ko.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ko.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">위치</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">기기</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">브라우저</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">운영 체제</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 주소</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ko.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ko.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>계정에 대한 의심스러운 로그인</title>
-<mj-text>안녕하세요,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}안녕하세요 {{ model.recipient_name }}님,{{ else }}안녕하세요,{{ end }}</mj-text>
 <mj-text>고객님의 계정에서 평소와 다른 로그인이 감지되어, 본인이 맞으신지 확인하고자 합니다.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">시간</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">기기</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 주소</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}이 로그인은 고객님이 평소 로그인하시는 위치에서 멀리 떨어진 곳에서 이루어졌으며, 마지막 세션 이후 이동하기에는 너무 먼 거리였습니다.{{ else if model.reason == "new_country" }}이 국가에서 확인된 첫 로그인입니다.{{ else if model.reason == "new_device" }}이 로그인은 이전에 확인된 적이 없는 기기에서 이루어졌습니다.{{ else }}이 로그인은 고객님의 계정에서 평소와 다르게 보였습니다.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.nl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.nl.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Waar</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Apparaat</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Browser</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Besturingssysteem</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adres</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.nl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.nl.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Verdachte aanmelding bij uw account</title>
-<mj-text>Hallo,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>We hebben een aanmelding bij uw account opgemerkt die ongebruikelijk leek, en we willen zeker weten dat u dit was.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wanneer</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Apparaat</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adres</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Deze aanmelding kwam van een locatie ver van waar u zich gewoonlijk aanmeldt, en te ver om er sinds uw laatste sessie naartoe te zijn gereisd.{{ else if model.reason == "new_country" }}Dit is de eerste aanmelding die we vanuit dit land hebben gezien.{{ else if model.reason == "new_device" }}Deze aanmelding kwam van een apparaat dat we niet eerder hebben gezien.{{ else }}Deze aanmelding leek ongebruikelijk voor uw account.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pl.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Podejrzane logowanie do Twojego konta</title>
-<mj-text>Witaj,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Witaj {{ model.recipient_name }},{{ else }}Witaj,{{ end }}</mj-text>
 <mj-text>Zauważyliśmy logowanie do Twojego konta, które wyglądało nietypowo, i chcemy upewnić się, że to byłeś Ty.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kiedy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Urządzenie</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adres IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}To logowanie nastąpiło z miejsca odległego od tego, z którego zwykle się logujesz, i zbyt odległego, abyś mógł tam dotrzeć od czasu poprzedniej sesji.{{ else if model.reason == "new_country" }}To pierwsze logowanie, jakie odnotowaliśmy z tego kraju.{{ else if model.reason == "new_device" }}To logowanie nastąpiło z urządzenia, którego wcześniej nie widzieliśmy.{{ else }}To logowanie wyglądało nietypowo dla Twojego konta.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pl.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gdzie</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Urządzenie</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Przeglądarka</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">System operacyjny</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Adres IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt-BR.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt-BR.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navegador</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operacional</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt-BR.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt-BR.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Login suspeito na sua conta</title>
-<mj-text>Olá,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detectamos um login na sua conta que pareceu incomum e queremos ter certeza de que foi você.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Este login veio de um local distante de onde você costuma fazer login e longe demais para você ter viajado até lá desde a sua última sessão.{{ else if model.reason == "new_country" }}Este é o primeiro login que registramos a partir deste país.{{ else if model.reason == "new_device" }}Este login veio de um dispositivo que nunca vimos antes.{{ else }}Este login pareceu incomum para a sua conta.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Início de sessão suspeito na sua conta</title>
-<mj-text>Olá,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detetámos um início de sessão na sua conta que pareceu invulgar e queremos certificar-nos de que foi o utilizador.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Este início de sessão teve origem num local distante daquele onde costuma iniciar sessão e demasiado longe para lá ter viajado desde a sua última sessão.{{ else if model.reason == "new_country" }}Este é o primeiro início de sessão que registámos a partir deste país.{{ else if model.reason == "new_device" }}Este início de sessão teve origem num dispositivo que nunca tínhamos visto antes.{{ else }}Este início de sessão pareceu invulgar para a sua conta.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dispositivo</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Navegador</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Sistema operativo</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Endereço IP</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.sv.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.sv.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Var</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Enhet</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Webbläsare</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Operativsystem</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adress</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.sv.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.sv.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Misstänkt inloggning på ditt konto</title>
-<mj-text>Hej,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Hej {{ model.recipient_name }},{{ else }}Hej,{{ end }}</mj-text>
 <mj-text>Vi har upptäckt en inloggning på ditt konto som såg ovanlig ut, och vi vill försäkra oss om att det var du.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">När</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Enhet</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP-adress</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Den här inloggningen kom från en plats långt ifrån där du brukar logga in, och för långt bort för att du skulle ha hunnit resa dit sedan din senaste session.{{ else if model.reason == "new_country" }}Det här är den första inloggningen vi har sett från det här landet.{{ else if model.reason == "new_device" }}Den här inloggningen kom från en enhet som vi inte har sett tidigare.{{ else }}Den här inloggningen såg ovanlig ut för ditt konto.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.tr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.tr.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>Hesabınızda şüpheli oturum açma</title>
-<mj-text>Merhaba,</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}Merhaba {{ model.recipient_name }},{{ else }}Merhaba,{{ end }}</mj-text>
 <mj-text>Hesabınızda olağan dışı görünen bir oturum açma işlemi fark ettik ve bunun siz olduğunuzdan emin olmak istiyoruz.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Ne zaman</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cihaz</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresi</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}Bu oturum açma işlemi, genellikle oturum açtığınız yerden çok uzak ve son oturumunuzdan bu yana oraya seyahat etmiş olamayacağınız kadar uzak bir konumdan gerçekleşti.{{ else if model.reason == "new_country" }}Bu, bu ülkeden gördüğümüz ilk oturum açma işlemidir.{{ else if model.reason == "new_device" }}Bu oturum açma işlemi, daha önce görmediğimiz bir cihazdan gerçekleşti.{{ else }}Bu oturum açma işlemi, hesabınız için olağan dışı görünüyordu.{{ end }}</mj-text>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.tr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.tr.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Nerede</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cihaz</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Tarayıcı</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">İşletim sistemi</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP adresi</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.zh.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.zh.html
@@ -7,8 +7,11 @@
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">地点</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}
-  {{ if model.device }}
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">设备</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ if model.browser }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">浏览器</td><td style="padding: 6px 0;"><strong>{{ model.browser }}</strong></td></tr>
+  {{ end }}
+  {{ if model.operating_system }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">操作系统</td><td style="padding: 6px 0;"><strong>{{ model.operating_system }}</strong></td></tr>
   {{ end }}
   {{ if model.ip_address }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 地址</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.zh.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.zh.html
@@ -1,6 +1,6 @@
 <!-- AUTO-TRANSLATED (claude-opus, manual) — REVIEW BEFORE PRODUCTION -->
 <title>您的账户出现可疑登录</title>
-<mj-text>您好，</mj-text>
+<mj-text>{{ if model.recipient_name != "" }}您好 {{ model.recipient_name }}，{{ else }}您好，{{ end }}</mj-text>
 <mj-text>我们注意到您的账户有一次看起来不寻常的登录，希望确认是否为您本人操作。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">时间</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
@@ -9,6 +9,9 @@
   {{ end }}
   {{ if model.device }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">设备</td><td style="padding: 6px 0;"><strong>{{ model.device }}</strong></td></tr>
+  {{ end }}
+  {{ if model.ip_address }}
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">IP 地址</td><td style="padding: 6px 0;"><strong>{{ model.ip_address }}</strong></td></tr>
   {{ end }}
 </mj-table>
 <mj-text>{{ if model.reason == "impossible_travel" }}此次登录来自一个远离您平常登录地点的位置，且距离过远，您不可能在上次会话之后前往该地。{{ else if model.reason == "new_country" }}这是我们首次发现来自该国家/地区的登录。{{ else if model.reason == "new_device" }}此次登录来自一台我们此前从未见过的设备。{{ else }}此次登录对于您的账户而言显得不寻常。{{ end }}</mj-text>

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
@@ -586,6 +586,102 @@ public sealed class EmailNotificationChannelTests
         capturedData["notification_type"].ShouldBe("test.notification");
     }
 
+    [Fact]
+    public async Task SendAsync_ThreadsRecipientNameIntoModel()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com", displayName: "Ada Lovelace");
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<p>{{ model.recipient_name }}</p>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        Dictionary<string, object?>? capturedData = null;
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedData = callInfo.Arg<Dictionary<string, object?>>();
+                return new Granit.Templating.Pipeline.TextRenderedContent(
+                    "<p>Ada Lovelace</p>",
+                    Granit.Templating.Keys.DocumentFormat.Html);
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        capturedData.ShouldNotBeNull();
+        capturedData.ShouldContainKey("recipient_name");
+        capturedData["recipient_name"].ShouldBe("Ada Lovelace");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithoutDisplayName_ThreadsEmptyRecipientName()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com", displayName: null);
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<p>{{ model.recipient_name }}</p>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        Dictionary<string, object?>? capturedData = null;
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedData = callInfo.Arg<Dictionary<string, object?>>();
+                return new Granit.Templating.Pipeline.TextRenderedContent(
+                    "<p></p>",
+                    Granit.Templating.Keys.DocumentFormat.Html);
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        capturedData.ShouldNotBeNull();
+        capturedData.ShouldContainKey("recipient_name");
+        capturedData["recipient_name"].ShouldBe("");
+    }
+
     // ──── ToName and FromNameOverride propagation tests ────
 
     [Fact]

--- a/tests/Granit.UserSessions.AnomalyDetection.Tests/DefaultUserSessionRiskEvaluatorTests.cs
+++ b/tests/Granit.UserSessions.AnomalyDetection.Tests/DefaultUserSessionRiskEvaluatorTests.cs
@@ -1,0 +1,75 @@
+using Granit.Events;
+using Granit.IpGeolocation;
+using Granit.MultiTenancy;
+using Granit.UserSessions.AnomalyDetection.Internal;
+using Granit.UserSessions.AnomalyDetection.Options;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.UserSessions.AnomalyDetection.Tests;
+
+/// <summary>
+/// Verifies the raw-IP opt-in gate on the published <see cref="SuspiciousUserSessionDetectedEto"/>:
+/// location-only by default, raw IP carried only when <see cref="UserSessionsAnomalyDetectionOptions.IncludeClientIpInAlert"/>
+/// is enabled.
+/// </summary>
+public sealed class DefaultUserSessionRiskEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 12, 10, 0, 0, TimeSpan.Zero);
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static UserSessionDescriptor Candidate() =>
+        new("s-new", "user-1", IsCurrent: true, Now, null, "ua", "203.0.113.7",
+            new GeoLocation { City = "Brussels", CountryCode = "BE" });
+
+    private static async Task<SuspiciousUserSessionDetectedEto?> EvaluateAndCaptureAsync(bool includeIp)
+    {
+        IUserSessionAnomalyDetector detector = Substitute.For<IUserSessionAnomalyDetector>();
+        detector.AssessAsync(Arg.Any<UserSessionDescriptor>(), Arg.Any<IReadOnlyList<UserSessionDescriptor>>(), Arg.Any<CancellationToken>())
+            .Returns(new UserSessionRiskAssessment(UserSessionRiskLevel.High, 0.9, ["impossible_travel"]));
+
+        IUserSessionRiskStore store = Substitute.For<IUserSessionRiskStore>();
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+
+        IDistributedEventBus bus = Substitute.For<IDistributedEventBus>();
+        SuspiciousUserSessionDetectedEto? captured = null;
+        await bus.PublishAsync(
+            Arg.Do<SuspiciousUserSessionDetectedEto>(e => captured = e),
+            Arg.Any<CancellationToken>());
+
+        IOptions<UserSessionsAnomalyDetectionOptions> options =
+            Microsoft.Extensions.Options.Options.Create(
+                new UserSessionsAnomalyDetectionOptions { IncludeClientIpInAlert = includeIp });
+
+        var evaluator = new DefaultUserSessionRiskEvaluator(
+            detector, store, TimeProvider.System, tenant, options, bus);
+
+        await evaluator.EvaluateAsync(Candidate(), [], Ct);
+
+        return captured;
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenIpOptInDisabled_PublishesEtoWithoutRawIp()
+    {
+        SuspiciousUserSessionDetectedEto? eto = await EvaluateAndCaptureAsync(includeIp: false);
+
+        eto.ShouldNotBeNull();
+        eto.IpAddress.ShouldBeNull();
+        eto.City.ShouldBe("Brussels");
+        eto.CountryCode.ShouldBe("BE");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenIpOptInEnabled_PublishesEtoWithRawIp()
+    {
+        SuspiciousUserSessionDetectedEto? eto = await EvaluateAndCaptureAsync(includeIp: true);
+
+        eto.ShouldNotBeNull();
+        eto.IpAddress.ShouldBe("203.0.113.7");
+    }
+}

--- a/tests/Granit.UserSessions.Notifications.Tests/Handlers/SuspiciousUserSessionDetectedHandlerTests.cs
+++ b/tests/Granit.UserSessions.Notifications.Tests/Handlers/SuspiciousUserSessionDetectedHandlerTests.cs
@@ -98,11 +98,12 @@ public sealed class SuspiciousUserSessionDetectedHandlerTests
         captured.ReasonsDisplay.ShouldBe("impossible_travel, new_country");
         captured.City.ShouldBe("Brussels");
         captured.CountryCode.ShouldBe("BE");
-        captured.Device.ShouldBe("Chrome on Windows");
+        captured.Browser.ShouldBe("Chrome");
+        captured.OperatingSystem.ShouldBe("Windows");
     }
 
     [Fact]
-    public async Task Data_DerivesFriendlyDeviceLabel_FromUserAgent()
+    public async Task Data_DerivesBrowserAndOperatingSystem_FromUserAgent()
     {
         INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
         SuspiciousUserSessionNotificationData? captured = null;
@@ -118,11 +119,12 @@ public sealed class SuspiciousUserSessionDetectedHandlerTests
             publisher, TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
-        captured.Device.ShouldBe("Safari on iPhone");
+        captured.Browser.ShouldBe("Safari");
+        captured.OperatingSystem.ShouldBe("iPhone");
     }
 
     [Fact]
-    public async Task Data_NullUserAgent_YieldsNullDevice()
+    public async Task Data_NullUserAgent_YieldsNullBrowserAndOperatingSystem()
     {
         INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
         SuspiciousUserSessionNotificationData? captured = null;
@@ -136,7 +138,8 @@ public sealed class SuspiciousUserSessionDetectedHandlerTests
             Eto(UserSessionRiskLevel.High, userAgent: null), publisher, TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
-        captured.Device.ShouldBeNull();
+        captured.Browser.ShouldBeNull();
+        captured.OperatingSystem.ShouldBeNull();
     }
 
     [Theory]

--- a/tests/Granit.UserSessions.Notifications.Tests/Handlers/SuspiciousUserSessionDetectedHandlerTests.cs
+++ b/tests/Granit.UserSessions.Notifications.Tests/Handlers/SuspiciousUserSessionDetectedHandlerTests.cs
@@ -13,10 +13,15 @@ namespace Granit.UserSessions.Notifications.Tests.Handlers;
 /// </summary>
 public sealed class SuspiciousUserSessionDetectedHandlerTests
 {
+    private const string ChromeWindowsUa =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
     private static SuspiciousUserSessionDetectedEto Eto(
         UserSessionRiskLevel level,
         string userId = "user-123",
-        IReadOnlyList<string>? reasons = null) =>
+        IReadOnlyList<string>? reasons = null,
+        string? userAgent = ChromeWindowsUa,
+        string? ipAddress = null) =>
         new(
             userId,
             "session-1",
@@ -26,8 +31,8 @@ public sealed class SuspiciousUserSessionDetectedHandlerTests
             RiskScore: 0.9,
             City: "Brussels",
             CountryCode: "BE",
-            UserAgent: "Mozilla/5.0",
-            IpAddress: null,
+            UserAgent: userAgent,
+            IpAddress: ipAddress,
             DetectedAt: DateTimeOffset.UtcNow);
 
     [Fact]
@@ -93,7 +98,65 @@ public sealed class SuspiciousUserSessionDetectedHandlerTests
         captured.ReasonsDisplay.ShouldBe("impossible_travel, new_country");
         captured.City.ShouldBe("Brussels");
         captured.CountryCode.ShouldBe("BE");
-        captured.Device.ShouldBe("Mozilla/5.0");
+        captured.Device.ShouldBe("Chrome on Windows");
+    }
+
+    [Fact]
+    public async Task Data_DerivesFriendlyDeviceLabel_FromUserAgent()
+    {
+        INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
+        SuspiciousUserSessionNotificationData? captured = null;
+        await publisher.PublishAsync(
+            Arg.Any<NotificationType<SuspiciousUserSessionNotificationData>>(),
+            Arg.Do<SuspiciousUserSessionNotificationData>(d => captured = d),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>());
+
+        await SuspiciousUserSessionDetectedHandler.HandleAsync(
+            Eto(UserSessionRiskLevel.High,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"),
+            publisher, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Device.ShouldBe("Safari on iPhone");
+    }
+
+    [Fact]
+    public async Task Data_NullUserAgent_YieldsNullDevice()
+    {
+        INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
+        SuspiciousUserSessionNotificationData? captured = null;
+        await publisher.PublishAsync(
+            Arg.Any<NotificationType<SuspiciousUserSessionNotificationData>>(),
+            Arg.Do<SuspiciousUserSessionNotificationData>(d => captured = d),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>());
+
+        await SuspiciousUserSessionDetectedHandler.HandleAsync(
+            Eto(UserSessionRiskLevel.High, userAgent: null), publisher, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Device.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("203.0.113.42")]
+    public async Task Data_CarriesEtoIpAddress_AsIs(string? ip)
+    {
+        INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
+        SuspiciousUserSessionNotificationData? captured = null;
+        await publisher.PublishAsync(
+            Arg.Any<NotificationType<SuspiciousUserSessionNotificationData>>(),
+            Arg.Do<SuspiciousUserSessionNotificationData>(d => captured = d),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>());
+
+        await SuspiciousUserSessionDetectedHandler.HandleAsync(
+            Eto(UserSessionRiskLevel.High, ipAddress: ip), publisher, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.IpAddress.ShouldBe(ip);
     }
 
     [Fact]

--- a/tests/Granit.UserSessions.Notifications.Tests/Internal/UserAgentDescriptorTests.cs
+++ b/tests/Granit.UserSessions.Notifications.Tests/Internal/UserAgentDescriptorTests.cs
@@ -1,0 +1,69 @@
+using Granit.UserSessions.Notifications.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.UserSessions.Notifications.Tests.Internal;
+
+/// <summary>
+/// Coarse "Browser on OS" labelling. Pins the common desktop/mobile combinations and the graceful
+/// degradation paths (browser-only, OS-only, null). Order-sensitive cases (Edge/Opera carrying
+/// "Chrome", Chrome carrying "Safari", ChromeOS carrying "Linux") are covered explicitly.
+/// </summary>
+public sealed class UserAgentDescriptorTests
+{
+    [Theory]
+    // Chrome on Windows
+    [InlineData(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+        "Chrome on Windows")]
+    // Edge on Windows (UA also contains Chrome + Safari → Edge must win)
+    [InlineData(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36 Edg/120.0",
+        "Edge on Windows")]
+    // Firefox on macOS
+    [InlineData(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0",
+        "Firefox on macOS")]
+    // Safari on iPhone (Chrome ruled out)
+    [InlineData(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+        "Safari on iPhone")]
+    // Chrome on Android
+    [InlineData(
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36",
+        "Chrome on Android")]
+    // Opera on Windows (carries Chrome)
+    [InlineData(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36 OPR/106.0",
+        "Opera on Windows")]
+    // Chrome on iOS reports CriOS
+    [InlineData(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0 Mobile/15E148 Safari/604.1",
+        "Chrome on iPhone")]
+    // ChromeOS carries "Linux" → ChromeOS must win
+    [InlineData(
+        "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+        "Chrome on ChromeOS")]
+    // Firefox on Linux
+    [InlineData(
+        "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+        "Firefox on Linux")]
+    public void Describe_ReturnsBrowserOnOs(string userAgent, string expected) =>
+        UserAgentDescriptor.Describe(userAgent).ShouldBe(expected);
+
+    [Fact]
+    public void Describe_UnknownBrowser_DegradesToOsOnly() =>
+        UserAgentDescriptor.Describe("SomeCrawler/1.0 (Windows NT 10.0)").ShouldBe("Windows");
+
+    [Fact]
+    public void Describe_UnknownOs_DegradesToBrowserOnly() =>
+        UserAgentDescriptor.Describe("Chrome/120.0 (some-exotic-device)").ShouldBe("Chrome");
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("totally-unrecognisable-token")]
+    public void Describe_BlankOrUnrecognised_ReturnsNull(string? userAgent) =>
+        UserAgentDescriptor.Describe(userAgent).ShouldBeNull();
+}

--- a/tests/Granit.UserSessions.Notifications.Tests/Internal/UserAgentDescriptorTests.cs
+++ b/tests/Granit.UserSessions.Notifications.Tests/Internal/UserAgentDescriptorTests.cs
@@ -5,9 +5,10 @@ using Xunit;
 namespace Granit.UserSessions.Notifications.Tests.Internal;
 
 /// <summary>
-/// Coarse "Browser on OS" labelling. Pins the common desktop/mobile combinations and the graceful
-/// degradation paths (browser-only, OS-only, null). Order-sensitive cases (Edge/Opera carrying
-/// "Chrome", Chrome carrying "Safari", ChromeOS carrying "Linux") are covered explicitly.
+/// Coarse browser-family and OS-family extraction, returned <b>separately</b> (never joined in code)
+/// so the email template composes and labels them per culture. Pins the common desktop/mobile
+/// combinations and the order-sensitive cases (Edge/Opera carrying "Chrome", Chrome carrying
+/// "Safari", ChromeOS carrying "Linux"); browser-only / OS-only / null degrade gracefully.
 /// </summary>
 public sealed class UserAgentDescriptorTests
 {
@@ -15,55 +16,76 @@ public sealed class UserAgentDescriptorTests
     // Chrome on Windows
     [InlineData(
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
-        "Chrome on Windows")]
+        "Chrome", "Windows")]
     // Edge on Windows (UA also contains Chrome + Safari → Edge must win)
     [InlineData(
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36 Edg/120.0",
-        "Edge on Windows")]
+        "Edge", "Windows")]
     // Firefox on macOS
     [InlineData(
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0",
-        "Firefox on macOS")]
+        "Firefox", "macOS")]
     // Safari on iPhone (Chrome ruled out)
     [InlineData(
         "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
-        "Safari on iPhone")]
+        "Safari", "iPhone")]
+    // Safari on iPad
+    [InlineData(
+        "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+        "Safari", "iPad")]
     // Chrome on Android
     [InlineData(
         "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36",
-        "Chrome on Android")]
+        "Chrome", "Android")]
     // Opera on Windows (carries Chrome)
     [InlineData(
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36 OPR/106.0",
-        "Opera on Windows")]
+        "Opera", "Windows")]
+    // Samsung Internet on Android (carries Chrome)
+    [InlineData(
+        "Mozilla/5.0 (Linux; Android 14; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0 Mobile Safari/537.36",
+        "Samsung Internet", "Android")]
     // Chrome on iOS reports CriOS
     [InlineData(
         "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0 Mobile/15E148 Safari/604.1",
-        "Chrome on iPhone")]
+        "Chrome", "iPhone")]
     // ChromeOS carries "Linux" → ChromeOS must win
     [InlineData(
         "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
-        "Chrome on ChromeOS")]
+        "Chrome", "ChromeOS")]
     // Firefox on Linux
     [InlineData(
         "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
-        "Firefox on Linux")]
-    public void Describe_ReturnsBrowserOnOs(string userAgent, string expected) =>
-        UserAgentDescriptor.Describe(userAgent).ShouldBe(expected);
+        "Firefox", "Linux")]
+    public void ReturnsBrowserAndOperatingSystemSeparately(string userAgent, string expectedBrowser, string expectedOs)
+    {
+        UserAgentDescriptor.Browser(userAgent).ShouldBe(expectedBrowser);
+        UserAgentDescriptor.OperatingSystem(userAgent).ShouldBe(expectedOs);
+    }
+
+    [Theory]
+    // Developer / API clients have no OS token.
+    [InlineData("PostmanRuntime/7.36.0", "Postman")]
+    [InlineData("curl/8.4.0", "cURL")]
+    public void Browser_DeveloperClients(string userAgent, string expectedBrowser) =>
+        UserAgentDescriptor.Browser(userAgent).ShouldBe(expectedBrowser);
 
     [Fact]
-    public void Describe_UnknownBrowser_DegradesToOsOnly() =>
-        UserAgentDescriptor.Describe("SomeCrawler/1.0 (Windows NT 10.0)").ShouldBe("Windows");
+    public void Browser_UnknownBrowser_ReturnsNull() =>
+        UserAgentDescriptor.Browser("SomeCrawler/1.0 (Windows NT 10.0)").ShouldBeNull();
 
     [Fact]
-    public void Describe_UnknownOs_DegradesToBrowserOnly() =>
-        UserAgentDescriptor.Describe("Chrome/120.0 (some-exotic-device)").ShouldBe("Chrome");
+    public void OperatingSystem_UnknownOs_ReturnsNull() =>
+        UserAgentDescriptor.OperatingSystem("Chrome/120.0 (some-exotic-device)").ShouldBeNull();
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("totally-unrecognisable-token")]
-    public void Describe_BlankOrUnrecognised_ReturnsNull(string? userAgent) =>
-        UserAgentDescriptor.Describe(userAgent).ShouldBeNull();
+    public void BlankOrUnrecognised_ReturnsNull(string? userAgent)
+    {
+        UserAgentDescriptor.Browser(userAgent).ShouldBeNull();
+        UserAgentDescriptor.OperatingSystem(userAgent).ShouldBeNull();
+    }
 }


### PR DESCRIPTION
Closes **3 of the 4** remaining acceptance criteria of #2663 (the 4th — localized time in the recipient's timezone — is a separate follow-up; it needs a generic Scriban timezone mechanism).

## What changed

- **Greeting by name.** Framework: the email channel resolved `RecipientInfo.DisplayName` (for the `To` header) but never exposed it to templates, so every email opened with a generic "Hi,". It's now threaded through `EmailEnrichment` into the model as `{{ model.recipient_name }}` (empty when unknown) — **any** notification template can greet by name. The two sign-in templates now do.
- **Opt-in raw IP.** Location stays the default (no raw IP). New `UserSessionsAnomalyDetectionOptions.IncludeClientIpInAlert` (default `false`) opts a deployment into carrying the IP on `SuspiciousUserSessionDetectedEto` so the email shows it (GDPR: re-introduces the IP into the outbox/email — off by default). The email renders a conditional IP row.
- **Friendly device label.** A small, self-contained `UserAgentDescriptor` turns the raw User-Agent into a coarse "Browser on OS" label ("Chrome on Windows", "Safari on iPhone") — no versions, no device model, no third-party UA library. Replaces the raw UA in the email.
- **16 cultures regenerated** for the greeting and the conditional IP row (Scriban/MJML byte-identical, only the greeting word + "IP address" label per language; AUTO-TRANSLATED markers preserved).

## Verification

Builds clean. Tests: **Notifications.Email 54**, **AnomalyDetection 14**, **UserSessions.Notifications 92** — all green. `dotnet format` clean (6 projects). No lock changes.

## Notes

- After this merges, #2663 has **one** criterion left (localized time / `RecipientInfo.PreferredTimeZone`); then it's closeable.
- The `ja`/`ko`/`zh` greeting forms are reasonable but flagged for a native-speaker review (the `REVIEW BEFORE PRODUCTION` markers already cover the auto-translated variants).