### PR TITLE
feat(user-sessions): sign-in alert times in the recipient's local timezone

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28413,6 +28413,12 @@
           "kind": "property",
           "signature": "IList<string> PreferredCultureMetadataKeys",
           "returnType": "IList<string>"
+        },
+        {
+          "name": "DefaultCulture",
+          "kind": "property",
+          "signature": "string? DefaultCulture",
+          "returnType": "string?"
         }
       ]
     },
@@ -50020,7 +50026,7 @@
       "kind": "record",
       "project": "Granit.UserSessions.Notifications",
       "file": "src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs",
-      "line": 26,
+      "line": 27,
       "members": []
     },
     {

--- a/src/Granit.Identity.Notifications/Internal/IdentityRecipientResolver.cs
+++ b/src/Granit.Identity.Notifications/Internal/IdentityRecipientResolver.cs
@@ -47,6 +47,7 @@ internal sealed partial class IdentityRecipientResolver(
             Email = user.Email,
             PhoneNumber = ResolvePhoneNumber(user),
             PreferredCulture = ResolvePreferredCulture(user),
+            PreferredTimeZone = ResolvePreferredTimeZone(user),
             DisplayName = ResolveDisplayName(user),
         };
     }
@@ -69,6 +70,16 @@ internal sealed partial class IdentityRecipientResolver(
         }
 
         return ProbeMetadata(user, _options.PreferredCultureMetadataKeys) ?? _options.DefaultCulture;
+    }
+
+    private string? ResolvePreferredTimeZone(IIdentityUser user)
+    {
+        if (user is User { Timezone: { Length: > 0 } tz })
+        {
+            return tz;
+        }
+
+        return ProbeMetadata(user, _options.TimeZoneMetadataKeys);
     }
 
     private static string? ResolveDisplayName(IIdentityUser user)

--- a/src/Granit.Identity.Notifications/Options/IdentityRecipientResolverOptions.cs
+++ b/src/Granit.Identity.Notifications/Options/IdentityRecipientResolverOptions.cs
@@ -48,4 +48,12 @@ public sealed class IdentityRecipientResolverOptions
     /// applies its own default.
     /// </summary>
     public string? DefaultCulture { get; set; }
+
+    /// <summary>
+    /// Metadata keys probed, in order, to resolve the recipient preferred time
+    /// zone (IANA id) when the backend does not expose it as a first-class field.
+    /// The first key with a non-empty value wins. Defaults cover the common
+    /// provider conventions (<c>zoneinfo</c> is the OIDC standard claim).
+    /// </summary>
+    public IList<string> TimeZoneMetadataKeys { get; set; } = ["timezone", "zoneinfo"];
 }

--- a/src/Granit.Notifications.Abstractions/RecipientInfo.cs
+++ b/src/Granit.Notifications.Abstractions/RecipientInfo.cs
@@ -17,6 +17,9 @@ public sealed record RecipientInfo
     /// <summary>Preferred culture/language (BCP 47, e.g. "fr").</summary>
     public string? PreferredCulture { get; init; }
 
+    /// <summary>Preferred time zone (IANA id, e.g. "Europe/Brussels"). <c>null</c> leaves dates in UTC.</summary>
+    public string? PreferredTimeZone { get; init; }
+
     /// <summary>Display name for personalization.</summary>
     public string? DisplayName { get; init; }
 }

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -6,6 +6,7 @@ using Granit.Notifications.Email.Options;
 using Granit.Templating.Keys;
 using Granit.Templating.Layouts;
 using Granit.Templating.Pipeline;
+using Granit.Timing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -45,6 +46,7 @@ internal sealed partial class EmailNotificationChannel(
     IOptions<EmailChannelOptions> options,
     IRecipientResolver recipientResolver,
     IConfiguration configuration,
+    ICurrentTimezoneProvider timezoneProvider,
     [FromKeyedServices(HtmlConverterKeys.Trusted)] IHtmlToPlainTextConverter htmlToPlainText,
     ILogger<EmailNotificationChannel> logger) : INotificationChannel
 {
@@ -98,20 +100,34 @@ internal sealed partial class EmailNotificationChannel(
         }
 
         // Build enrichment context for templates
-        EmailEnrichment enrichment = new(definition, allowOptOut, unsubscribeUrl, recipient.DisplayName);
+        EmailEnrichment enrichment = new(
+            definition, allowOptOut, unsubscribeUrl, recipient.DisplayName, recipient.PreferredTimeZone);
 
-        // Try type-specific template first, then fall back to the built-in default template
-        RenderedEmail? rendered = await TryRenderTemplateAsync(
-                context.NotificationTypeName, context, enrichment, cancellationToken).ConfigureAwait(false)
-            ?? await TryRenderTemplateAsync(
-                FallbackTemplateName, context, enrichment, cancellationToken).ConfigureAwait(false);
+        // Render in the recipient's time zone so {{ to_user_time }} localizes timestamps.
+        // ICurrentTimezoneProvider is AsyncLocal — set it, render, restore in finally.
+        string? previousTz = timezoneProvider.Timezone;
+        timezoneProvider.Timezone = recipient.PreferredTimeZone;
 
-        // Apply layout wrapping (two-pass: content was rendered above, now wrap in layout)
-        if (rendered is not null)
+        RenderedEmail? rendered;
+        try
         {
-            rendered = await TryApplyLayoutAsync(
-                context.NotificationTypeName, rendered, context, enrichment, cancellationToken).ConfigureAwait(false)
-                ?? rendered;
+            // Try type-specific template first, then fall back to the built-in default template
+            rendered = await TryRenderTemplateAsync(
+                    context.NotificationTypeName, context, enrichment, cancellationToken).ConfigureAwait(false)
+                ?? await TryRenderTemplateAsync(
+                    FallbackTemplateName, context, enrichment, cancellationToken).ConfigureAwait(false);
+
+            // Apply layout wrapping (two-pass: content was rendered above, now wrap in layout)
+            if (rendered is not null)
+            {
+                rendered = await TryApplyLayoutAsync(
+                    context.NotificationTypeName, rendered, context, enrichment, cancellationToken).ConfigureAwait(false)
+                    ?? rendered;
+            }
+        }
+        finally
+        {
+            timezoneProvider.Timezone = previousTz;
         }
 
         string subject = rendered?.Subject ?? context.NotificationTypeName.Replace('.', ' ');
@@ -362,6 +378,7 @@ internal sealed partial class EmailNotificationChannel(
         dataDict.TryAdd("allow_opt_out", enrichment.AllowOptOut);
         dataDict.TryAdd("unsubscribe_url", enrichment.AllowOptOut ? enrichment.UnsubscribeUrl : "");
         dataDict.TryAdd("recipient_name", enrichment.RecipientName ?? "");
+        dataDict.TryAdd("recipient_timezone", enrichment.RecipientTimeZone ?? "");
     }
 
     /// <summary>Notification metadata resolved once per send, threaded through render methods.</summary>
@@ -369,7 +386,8 @@ internal sealed partial class EmailNotificationChannel(
         NotificationDefinition? Definition,
         bool AllowOptOut,
         string UnsubscribeUrl,
-        string? RecipientName);
+        string? RecipientName,
+        string? RecipientTimeZone);
 
     private static Dictionary<string, object?> JsonElementToDictionary(JsonElement element)
     {

--- a/src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs
+++ b/src/Granit.UserSessions.Notifications/SuspiciousUserSessionNotificationData.cs
@@ -21,8 +21,9 @@ namespace Granit.UserSessions.Notifications;
 /// English connector baked in code). Never the raw User-Agent string.</param>
 /// <param name="OperatingSystem">Coarse OS family ("Windows", "iPhone") derived from the raw User-Agent;
 /// <see langword="null"/> when it could not be derived.</param>
-/// <param name="DetectedAt">When the verdict was produced (rendered in UTC; user-timezone
-/// localization is a follow-up).</param>
+/// <param name="DetectedAt">When the verdict was produced. The template renders it in the recipient's
+/// time zone (via the <c>to_user_time</c> Scriban function) with the IANA zone shown in parentheses,
+/// falling back to UTC when the recipient has no time zone configured.</param>
 public sealed record SuspiciousUserSessionNotificationData(
     string Reason,
     string ReasonsDisplay,

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.cs.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.cs.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Dobrý den {{ model.recipient_name }},{{ else }}Dobrý den,{{ end }}</mj-text>
 <mj-text>Zaznamenali jsme nové přihlášení k vašemu účtu. Pokud jste to byli vy, nemusíte nic dělat.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kdy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kdy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.de.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.de.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>Wir haben eine neue Anmeldung bei Ihrem Konto festgestellt. Wenn Sie das waren, müssen Sie nichts unternehmen.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wann</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wann</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wo</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.es.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.es.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hola {{ model.recipient_name }}:{{ else }}Hola:{{ end }}</mj-text>
 <mj-text>Hemos detectado un nuevo inicio de sesión en tu cuenta. Si fuiste tú, no necesitas hacer nada.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cuándo</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cuándo</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dónde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.fr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.fr.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Bonjour {{ model.recipient_name }},{{ else }}Bonjour,{{ end }}</mj-text>
 <mj-text>Nous avons remarqué une nouvelle connexion à votre compte. Si c'était vous, vous n'avez rien à faire.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quand</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quand</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Où</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.hi.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.hi.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}नमस्ते {{ model.recipient_name }},{{ else }}नमस्ते,{{ end }}</mj-text>
 <mj-text>हमने आपके खाते में एक नया साइन-इन देखा। यदि यह आप ही थे, तो आपको कुछ करने की आवश्यकता नहीं है।</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कब</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कब</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कहाँ</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.html
@@ -2,7 +2,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hi {{ model.recipient_name }},{{ else }}Hi,{{ end }}</mj-text>
 <mj-text>We noticed a new sign-in to your account. If this was you, there's nothing you need to do.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">When</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">When</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Where</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.it.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.it.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Ciao {{ model.recipient_name }},{{ else }}Ciao,{{ end }}</mj-text>
 <mj-text>Abbiamo rilevato un nuovo accesso al tuo account. Se sei stato tu, non devi fare nulla.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dove</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ja.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ja.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}{{ model.recipient_name }}様、こんにちは。{{ else }}こんにちは。{{ end }}</mj-text>
 <mj-text>お客様のアカウントへの新しいサインインを検出しました。ご本人によるものであれば、特に対応は必要ありません。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">日時</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">日時</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">場所</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ko.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.ko.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}안녕하세요 {{ model.recipient_name }}님,{{ else }}안녕하세요,{{ end }}</mj-text>
 <mj-text>고객님의 계정에서 새 로그인이 감지되었습니다. 본인이 맞으시다면 별도로 하실 일은 없습니다.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">시간</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">시간</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">위치</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.nl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.nl.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>We hebben een nieuwe aanmelding bij uw account opgemerkt. Als u dit was, hoeft u niets te doen.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wanneer</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wanneer</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Waar</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pl.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Witaj {{ model.recipient_name }},{{ else }}Witaj,{{ end }}</mj-text>
 <mj-text>Zauważyliśmy nowe logowanie do Twojego konta. Jeśli to byłeś Ty, nie musisz nic robić.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kiedy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kiedy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gdzie</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt-BR.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt-BR.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detectamos um novo login na sua conta. Se foi você, não precisa fazer nada.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.pt.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detetámos um novo início de sessão na sua conta. Se foi o utilizador, não precisa de fazer nada.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.sv.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.sv.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hej {{ model.recipient_name }},{{ else }}Hej,{{ end }}</mj-text>
 <mj-text>Vi har upptäckt en ny inloggning på ditt konto. Om det var du behöver du inte göra något.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">När</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">När</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Var</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.tr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.tr.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Merhaba {{ model.recipient_name }},{{ else }}Merhaba,{{ end }}</mj-text>
 <mj-text>Hesabınızda yeni bir oturum açma işlemi fark ettik. Bu işlemi siz yaptıysanız yapmanız gereken bir şey yok.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Ne zaman</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Ne zaman</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Nerede</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.zh.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.new_session_review.zh.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}您好 {{ model.recipient_name }}，{{ else }}您好，{{ end }}</mj-text>
 <mj-text>我们注意到您的账户有一次新登录。如果是您本人操作，您无需进行任何操作。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">时间</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">时间</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">地点</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.cs.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.cs.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Dobrý den {{ model.recipient_name }},{{ else }}Dobrý den,{{ end }}</mj-text>
 <mj-text>Zaznamenali jsme přihlášení k vašemu účtu, které vypadalo neobvykle, a chceme se ujistit, že jste to byli vy.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kdy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kdy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.de.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.de.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>Wir haben bei Ihrem Konto eine Anmeldung festgestellt, die ungewöhnlich erschien, und möchten sicherstellen, dass Sie es waren.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wann</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wann</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wo</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.es.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.es.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hola {{ model.recipient_name }}:{{ else }}Hola:{{ end }}</mj-text>
 <mj-text>Hemos detectado un inicio de sesión en tu cuenta que parecía inusual y queremos asegurarnos de que fuiste tú.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cuándo</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Cuándo</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dónde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.fr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.fr.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Bonjour {{ model.recipient_name }},{{ else }}Bonjour,{{ end }}</mj-text>
 <mj-text>Nous avons remarqué une connexion à votre compte qui semblait inhabituelle, et nous voulons nous assurer qu'il s'agissait bien de vous.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quand</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quand</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Où</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.hi.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.hi.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}नमस्ते {{ model.recipient_name }},{{ else }}नमस्ते,{{ end }}</mj-text>
 <mj-text>हमने आपके खाते में एक साइन-इन देखा जो असामान्य लगा, और हम यह सुनिश्चित करना चाहते हैं कि यह आप ही थे।</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कब</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कब</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">कहाँ</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.html
@@ -2,7 +2,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hi {{ model.recipient_name }},{{ else }}Hi,{{ end }}</mj-text>
 <mj-text>We noticed a sign-in to your account that looked unusual, and we want to make sure it was you.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">When</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">When</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Where</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.it.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.it.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Ciao {{ model.recipient_name }},{{ else }}Ciao,{{ end }}</mj-text>
 <mj-text>Abbiamo rilevato un accesso al tuo account che è sembrato insolito e vogliamo assicurarci che sia stato effettuato da te.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Dove</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ja.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ja.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}{{ model.recipient_name }}様、こんにちは。{{ else }}こんにちは。{{ end }}</mj-text>
 <mj-text>お客様のアカウントで通常とは異なるサインインを検出したため、ご本人によるものかどうかを確認させていただきたく存じます。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">日時</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">日時</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">場所</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ko.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.ko.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}안녕하세요 {{ model.recipient_name }}님,{{ else }}안녕하세요,{{ end }}</mj-text>
 <mj-text>고객님의 계정에서 평소와 다른 로그인이 감지되어, 본인이 맞으신지 확인하고자 합니다.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">시간</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">시간</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">위치</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.nl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.nl.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hallo {{ model.recipient_name }},{{ else }}Hallo,{{ end }}</mj-text>
 <mj-text>We hebben een aanmelding bij uw account opgemerkt die ongebruikelijk leek, en we willen zeker weten dat u dit was.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wanneer</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Wanneer</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Waar</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pl.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pl.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Witaj {{ model.recipient_name }},{{ else }}Witaj,{{ end }}</mj-text>
 <mj-text>Zauważyliśmy logowanie do Twojego konta, które wyglądało nietypowo, i chcemy upewnić się, że to byłeś Ty.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kiedy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Kiedy</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Gdzie</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt-BR.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt-BR.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detectamos um login na sua conta que pareceu incomum e queremos ter certeza de que foi você.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.pt.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Olá {{ model.recipient_name }},{{ else }}Olá,{{ end }}</mj-text>
 <mj-text>Detetámos um início de sessão na sua conta que pareceu invulgar e queremos certificar-nos de que foi o utilizador.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Quando</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Onde</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.sv.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.sv.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Hej {{ model.recipient_name }},{{ else }}Hej,{{ end }}</mj-text>
 <mj-text>Vi har upptäckt en inloggning på ditt konto som såg ovanlig ut, och vi vill försäkra oss om att det var du.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">När</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">När</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Var</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.tr.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.tr.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}Merhaba {{ model.recipient_name }},{{ else }}Merhaba,{{ end }}</mj-text>
 <mj-text>Hesabınızda olağan dışı görünen bir oturum açma işlemi fark ettik ve bunun siz olduğunuzdan emin olmak istiyoruz.</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Ne zaman</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Ne zaman</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">Nerede</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.zh.html
+++ b/src/Granit.UserSessions.Notifications/Templates/user_sessions.suspicious_session.zh.html
@@ -3,7 +3,7 @@
 <mj-text>{{ if model.recipient_name != "" }}您好 {{ model.recipient_name }}，{{ else }}您好，{{ end }}</mj-text>
 <mj-text>我们注意到您的账户有一次看起来不寻常的登录，希望确认是否为您本人操作。</mj-text>
 <mj-table cellpadding="0" font-size="15px">
-  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">时间</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">时间</td><td style="padding: 6px 0;"><strong>{{ model.detected_at | to_user_time | date.to_string '%B %d, %Y at %H:%M' }}{{ if model.recipient_timezone != "" }} ({{ model.recipient_timezone }}){{ else }} UTC{{ end }}</strong></td></tr>
   {{ if model.city || model.country_code }}
   <tr><td style="padding: 6px 16px 6px 0; color: #6b7280;">地点</td><td style="padding: 6px 0;"><strong>{{ if model.city }}{{ model.city }}, {{ end }}{{ model.country_code }}</strong></td></tr>
   {{ end }}

--- a/tests/Granit.Identity.Notifications.Tests/IdentityRecipientResolverTests.cs
+++ b/tests/Granit.Identity.Notifications.Tests/IdentityRecipientResolverTests.cs
@@ -174,6 +174,35 @@ public sealed class IdentityRecipientResolverTests
         recipient.DisplayName.ShouldBe("Canon Ical");
         recipient.PhoneNumber.ShouldBe("+3225559999");
         recipient.PreferredCulture.ShouldBe("nl");
+        recipient.PreferredTimeZone.ShouldBe("Europe/Brussels");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_resolves_timezone_from_default_metadata_keys()
+    {
+        SetUser(new FakeIdentityUser
+        {
+            UserId = UserId,
+            Email = "kc@example.com",
+            Metadata = new Dictionary<string, string>
+            {
+                ["zoneinfo"] = "America/New_York",
+            },
+        });
+
+        RecipientInfo? recipient = await CreateResolver().ResolveAsync(UserId, TestContext.Current.CancellationToken);
+
+        recipient!.PreferredTimeZone.ShouldBe("America/New_York");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_leaves_timezone_null_when_none_resolved()
+    {
+        SetUser(new FakeIdentityUser { UserId = UserId, Email = "notz@example.com" });
+
+        RecipientInfo? recipient = await CreateResolver().ResolveAsync(UserId, TestContext.Current.CancellationToken);
+
+        recipient!.PreferredTimeZone.ShouldBeNull();
     }
 
     private void SetUser(IIdentityUser user) =>

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
@@ -11,6 +11,7 @@ using Granit.Notifications.Abstractions;
 using Granit.Notifications.Email.Internal;
 using Granit.Notifications.Email.Options;
 using Granit.Templating.Pipeline;
+using Granit.Timing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,7 @@ public sealed class EmailNotificationChannelTests
     private readonly IEmailSender _emailSender = Substitute.For<IEmailSender>();
     private readonly IRecipientResolver _recipientResolver = Substitute.For<IRecipientResolver>();
     private readonly IKeyedServiceProvider _serviceProvider = Substitute.For<IKeyedServiceProvider>();
+    private readonly CurrentTimezoneProvider _timezoneProvider = new();
     private readonly IOptions<EmailChannelOptions> _options;
     private readonly EmailNotificationChannel _channel;
 
@@ -46,6 +48,7 @@ public sealed class EmailNotificationChannelTests
             _options,
             _recipientResolver,
             new ConfigurationBuilder().Build(),
+            _timezoneProvider,
             new AngleSharpHtmlToPlainTextConverter(),
             Substitute.For<ILogger<EmailNotificationChannel>>());
     }
@@ -682,6 +685,114 @@ public sealed class EmailNotificationChannelTests
         capturedData["recipient_name"].ShouldBe("");
     }
 
+    // ──── Recipient time zone tests ────
+
+    [Fact]
+    public async Task SendAsync_SetsAmbientTimezoneToRecipientDuringRender_ThenRestores()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com", preferredTimeZone: "Europe/Brussels");
+
+        _timezoneProvider.Timezone = "UTC"; // pre-existing ambient value to verify restoration
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<p>{{ model.recipient_timezone }}</p>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        string? timezoneDuringRender = null;
+        Dictionary<string, object?>? capturedData = null;
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                timezoneDuringRender = _timezoneProvider.Timezone;
+                capturedData = callInfo.Arg<Dictionary<string, object?>>();
+                return new Granit.Templating.Pipeline.TextRenderedContent(
+                    "<p>Europe/Brussels</p>",
+                    Granit.Templating.Keys.DocumentFormat.Html);
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        timezoneDuringRender.ShouldBe("Europe/Brussels");
+        // Ambient value restored after render
+        _timezoneProvider.Timezone.ShouldBe("UTC");
+        // Zone also exposed to the template model
+        capturedData.ShouldNotBeNull();
+        capturedData["recipient_timezone"].ShouldBe("Europe/Brussels");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithoutRecipientTimeZone_ThreadsEmptyTimezone()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com", preferredTimeZone: null);
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<p>{{ model.recipient_timezone }}</p>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        string? timezoneDuringRender = "sentinel";
+        Dictionary<string, object?>? capturedData = null;
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                timezoneDuringRender = _timezoneProvider.Timezone;
+                capturedData = callInfo.Arg<Dictionary<string, object?>>();
+                return new Granit.Templating.Pipeline.TextRenderedContent(
+                    "<p></p>",
+                    Granit.Templating.Keys.DocumentFormat.Html);
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        // No recipient time zone => ambient stays UTC (null) during render, model gets empty string
+        timezoneDuringRender.ShouldBeNull();
+        capturedData.ShouldNotBeNull();
+        capturedData["recipient_timezone"].ShouldBe("");
+    }
+
     // ──── ToName and FromNameOverride propagation tests ────
 
     [Fact]
@@ -899,13 +1010,15 @@ public sealed class EmailNotificationChannelTests
     // Helpers
     // -------------------------------------------------------------------------
 
-    private void SetupRecipient(string userId, string? email, string? displayName = null) =>
+    private void SetupRecipient(
+        string userId, string? email, string? displayName = null, string? preferredTimeZone = null) =>
         _recipientResolver.ResolveAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new RecipientInfo
             {
                 UserId = userId,
                 Email = email,
                 DisplayName = displayName,
+                PreferredTimeZone = preferredTimeZone,
             });
 
     private static NotificationDeliveryContext BuildContext() => new()
@@ -942,6 +1055,7 @@ public sealed class EmailNotificationChannelTests
             Microsoft.Extensions.Options.Options.Create(opts),
             _recipientResolver,
             config,
+            _timezoneProvider,
             new AngleSharpHtmlToPlainTextConverter(),
             Substitute.For<ILogger<EmailNotificationChannel>>());
     }


### PR DESCRIPTION
**Closes #2663** — the last remaining acceptance criterion (localized time).

The sign-in alert showed the time in UTC. It now renders in the **recipient's local timezone**, reusing the framework's existing pieces (no new Scriban function):

- **`RecipientInfo.PreferredTimeZone`** (IANA id, `string?` — same form as `ICurrentTimezoneProvider.Timezone`, `User.Timezone`, `IClock`), populated by `IdentityRecipientResolver` from `User.Timezone` (+ `timezone`/`zoneinfo` metadata fallback). Local + federated, like the rest of recipient resolution.
- **`EmailNotificationChannel`** sets the ambient `ICurrentTimezoneProvider` to the recipient's zone around rendering (AsyncLocal, restored in `finally`), so the existing `{{ to_user_time }}` function converts timestamps; also exposes `{{ model.recipient_timezone }}` for display. **General capability — every notification template benefits.**
- The 16-culture templates render `{{ model.detected_at | to_user_time | date.to_string '…' }}` + the IANA zone in parens, falling back to `UTC` when no timezone is known (uniform change, no new translations).

## Verification

Builds clean. Tests: **Identity.Notifications 11/11, Notifications.Email 56/56, UserSessions.Notifications 96/96**. `dotnet format` clean.

With this merged, **#2663 is fully delivered** (greeting by name, opt-in IP, friendly browser/OS, and now local time).