### PR TITLE
fix(test): repair develop CI — stale UserDevice ctor in DefaultUserSessionManagerTests (#2679 fallout)

### DIFF
--- a/tests/Granit.UserSessions.Tests/DefaultUserSessionManagerTests.cs
+++ b/tests/Granit.UserSessions.Tests/DefaultUserSessionManagerTests.cs
@@ -64,7 +64,7 @@ public sealed class DefaultUserSessionManagerTests
     [Fact]
     public async Task ListDevicesAsync_DelegatesToProvider()
     {
-        UserDevice device = new("d1", DeviceKind.Browser, "Chrome on Windows", "Windows", "Chrome", null, 2, null);
+        UserDevice device = new("d1", DeviceKind.Browser, "Windows", "Chrome", null, 2, null);
         _devices.ListAsync("user-1", Ct).Returns([device]);
 
         (await _sut.ListDevicesAsync("user-1", Ct)).ShouldBe([device]);


### PR DESCRIPTION
**Repairs red develop CI.** #2679 (drop `UserDevice.DisplayName`) didn't update `DefaultUserSessionManagerTests`, which still called the old 8-argument `UserDevice` constructor → `Granit.UserSessions.Tests` fails to compile (CS1729). Develop CI has been failing on the **Core+AI** and **Infrastructure** shards since #2679 merged.

Confirmed against the failing run: the only build error is `DefaultUserSessionManagerTests.cs(67,29): CS1729 'UserDevice' does not contain a constructor that takes 8 arguments`.

Fix: drop the removed `DisplayName` argument (`"Chrome on Windows"`); the 7-arg ctor `(DeviceId, Kind, OperatingSystem, Browser, LastSeen, SessionCount, LastLocation)` now matches. `Granit.UserSessions.Tests` green (6/6).

Note: the same fix also rides in the P1 migration PR #2682 (which rebases cleanly once this lands).