### PR TITLE
docs(identity): fix stale package names after UserSessions→Identity merge (migration P6)

### DIFF
--- a/src/Granit.Bff.UserSessions/README.md
+++ b/src/Granit.Bff.UserSessions/README.md
@@ -1,7 +1,7 @@
 # Granit.Bff.UserSessions
 
 Makes the BFF the backend for `granit`'s **canonical user-session API**. Install it
-alongside `Granit.Bff` and `Granit.UserSessions.Endpoints` and a user's browser↔BFF
+alongside `Granit.Bff` and `Granit.Identity.Endpoints` and a user's browser↔BFF
 sessions surface — and revoke — through `/sessions`, with no BFF-specific client code.
 
 Part of the [granit](https://granit-fx.dev) framework.

--- a/src/Granit.Identity.Abstractions/README.md
+++ b/src/Granit.Identity.Abstractions/README.md
@@ -33,8 +33,8 @@ both project to `UserSessionDescriptor`, so a single enrichment pipeline
 
 Registering `GranitIdentityAbstractionsModule` wires safe defaults: no-op session and
 device providers, a no-op anomaly detector (`UserSessionRiskLevel.None`), and an
-in-memory risk store. Install `Granit.UserSessions.AnomalyDetection` to enable
-detection and `Granit.UserSessions.EntityFrameworkCore` for a durable,
+in-memory risk store. Install `Granit.Identity.AnomalyDetection` to enable
+detection and `Granit.Identity.EntityFrameworkCore` for a durable,
 cluster-shared risk store.
 
 ## Installation


### PR DESCRIPTION
**P6 — final in-repo cleanup.** The code migration (P1–P5, all merged) is complete; the only remaining `Granit.UserSessions.*` package is `Granit.Bff.UserSessions` (kept by design). This PR fixes the last two stale doc references.

- `Granit.Identity.Abstractions/README.md`: `Granit.UserSessions.AnomalyDetection` / `.EntityFrameworkCore` → `Granit.Identity.AnomalyDetection` / `.EntityFrameworkCore`.
- `Granit.Bff.UserSessions/README.md`: `Granit.UserSessions.Endpoints` → `Granit.Identity.Endpoints`.

**Verified repo-wide:** no other `Granit.UserSessions.*` reference remains in code, csproj, or docs — besides `Granit.Bff.UserSessions` and one intentional *historical* comment in `GranitIdentityModule` ("formerly Granit.UserSessions …"). `Granit.Bff.UserSessions` + its test build clean. markdownlint clean.

## Migration status (6/7 in-repo done)

P1 contracts · P2 core+endpoints+bridge · P3 risk store → User DbContext · P4 AnomalyDetection · P5 Notifications · **P6 doc cleanup ← this**. All in-repo work is done. **P7 = cross-repo handoffs** (granit-showcase, granit-front, granit-docs) — delivered as self-contained prompts, not driven from this repo.