### PR TITLE
feat(identity): Keycloak session-created emission via the IdP webhook login event (closes #2662)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -24100,7 +24100,7 @@
       "kind": "record",
       "project": "Granit.Identity.Endpoints",
       "file": "src/Granit.Identity.Endpoints/Dtos/IdentityWebhookPayload.cs",
-      "line": 10,
+      "line": 13,
       "members": []
     },
     {

--- a/src/Granit.Identity.Endpoints/Dtos/IdentityWebhookPayload.cs
+++ b/src/Granit.Identity.Endpoints/Dtos/IdentityWebhookPayload.cs
@@ -4,10 +4,16 @@ namespace Granit.Identity.Endpoints.Dtos;
 /// Generic webhook payload from an identity provider.
 /// The application host translates provider-specific formats into this structure.
 /// </summary>
-/// <param name="EventType">Event type: <c>user_updated</c> or <c>user_deleted</c>.</param>
+/// <param name="EventType">Event type: <c>user_created</c>, <c>user_updated</c>, <c>user_deleted</c>, or <c>login</c>.</param>
 /// <param name="UserId">External user ID in the identity provider.</param>
 /// <param name="Timestamp">Event timestamp from the provider.</param>
+/// <param name="SessionId">For a <c>login</c> event: the IdP session id (Keycloak <c>sid</c>) the new session is keyed by — must match what the session provider surfaces so anomaly detection can locate it. Ignored for user_* events.</param>
+/// <param name="IpAddress">For a <c>login</c> event: the client IP, used off the critical path for geolocation. Server-side only; never logged or echoed.</param>
+/// <param name="UserAgent">For a <c>login</c> event: the client User-Agent, when the provider includes it.</param>
 public sealed record IdentityWebhookPayload(
     string EventType,
     string UserId,
-    DateTimeOffset? Timestamp = null);
+    DateTimeOffset? Timestamp = null,
+    string? SessionId = null,
+    string? IpAddress = null,
+    string? UserAgent = null);

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
@@ -1,12 +1,16 @@
 using System.Text.Json;
+using Granit.Events;
 using Granit.Identity.Endpoints.Dtos;
 using Granit.Identity.Endpoints.Internal;
 using Granit.Identity.Endpoints.Options;
+using Granit.MultiTenancy;
+using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.Endpoints.Endpoints;
@@ -35,8 +39,8 @@ internal static class IdentityWebhookEndpoints
 
         endpoints.MapPost(webhookRoute, HandleWebhookAsync)
             .WithName("IdentityWebhook")
-            .WithSummary("Receives identity provider webhook events (user created/updated/deleted).")
-            .WithDescription("Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries. No bearer authentication — security relies on HMAC signature validation in the handler.")
+            .WithSummary("Receives identity provider webhook events (user created/updated/deleted, login).")
+            .WithDescription("Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries, and login events by announcing a UserSessionCreatedEto so anomaly detection runs off the login path (the IdP's push channel for session-created — used by Keycloak via its event SPI). No bearer authentication — security relies on HMAC signature validation in the handler.")
             .WithTags(tagName)
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -113,6 +117,14 @@ internal static class IdentityWebhookEndpoints
                 await lookupService.DeleteByIdAsync(payload.UserId, cancellationToken).ConfigureAwait(false);
                 break;
 
+            case "login":
+                // A new IdP session was established (Keycloak is push-only via its event SPI — it never
+                // calls us on login otherwise). Announce it so anomaly detection runs off the login path,
+                // exactly like the BFF and OpenIddict sources. The session's full shape is read on demand
+                // from the IdP's Admin API by the consumer; this only carries the trigger + the keying ids.
+                await EmitSessionCreatedAsync(request.HttpContext, payload, cancellationToken).ConfigureAwait(false);
+                break;
+
             default:
                 return TypedResults.Problem(
                     detail: "Unsupported event type.",
@@ -120,5 +132,39 @@ internal static class IdentityWebhookEndpoints
         }
 
         return TypedResults.Ok();
+    }
+
+    private static async Task EmitSessionCreatedAsync(
+        HttpContext context, IdentityWebhookPayload payload, CancellationToken cancellationToken)
+    {
+        // No session id → nothing the session provider could match against, so nothing to evaluate.
+        if (string.IsNullOrEmpty(payload.SessionId))
+        {
+            return;
+        }
+
+        // Best-effort: a no-op when no distributed bus is wired.
+        if (context.RequestServices.GetService<IDistributedEventBus>() is not { } eventBus)
+        {
+            return;
+        }
+
+        Guid? tenantId = context.RequestServices.GetService<ICurrentTenant>() is { IsAvailable: true } tenant
+            ? tenant.Id
+            : null;
+        DateTimeOffset createdAt = payload.Timestamp
+            ?? context.RequestServices.GetService<IClock>()?.Now
+            ?? TimeProvider.System.GetUtcNow();
+
+        await eventBus.PublishAsync(
+            new UserSessionCreatedEto(
+                payload.UserId,
+                payload.SessionId,
+                tenantId,
+                UserSessionSource.Keycloak,
+                payload.UserAgent,
+                payload.IpAddress,
+                createdAt),
+            cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Granit.Events;
 using Granit.Identity.Endpoints.Extensions;
 using Granit.Identity.Endpoints.Options;
 using Granit.Identity.Endpoints.Permissions;
@@ -30,6 +31,7 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
 
     private readonly IUserLookupService _lookupService = Substitute.For<IUserLookupService>();
     private readonly IUserCacheStats _cacheStats = Substitute.For<IUserCacheStats>();
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
     private readonly FakeTimeProvider _clock = new(Now);
     private readonly WebApplication _app;
     private readonly HttpClient _client;
@@ -54,6 +56,7 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
         builder.Services.AddGranitIdentityEndpoints();
         builder.Services.AddSingleton(_lookupService);
         builder.Services.AddSingleton(_cacheStats);
+        builder.Services.AddSingleton(_eventBus);
 
         // Replace the default TimeProvider so signature-replay-window tests can
         // pin "now" deterministically.
@@ -111,6 +114,48 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         await _lookupService.Received(1).DeleteByIdAsync("user-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Webhook_login_publishes_UserSessionCreatedEto()
+    {
+        var payload = new
+        {
+            eventType = "login",
+            userId = "user-9",
+            sessionId = "kc-sid-1",
+            ipAddress = "1.2.3.4",
+            userAgent = "Mozilla/5.0",
+        };
+        using HttpRequestMessage request = CreateSignedRequest(payload);
+
+        using HttpResponseMessage response = await _client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<UserSessionCreatedEto>(e =>
+                e.UserId == "user-9"
+                && e.SessionId == "kc-sid-1"
+                && e.Source == UserSessionSource.Keycloak
+                && e.IpAddress == "1.2.3.4"
+                && e.UserAgent == "Mozilla/5.0"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Webhook_login_without_sessionId_does_not_publish()
+    {
+        // No session id → nothing the session provider could match against; the event is a no-op.
+        var payload = new { eventType = "login", userId = "user-9" };
+        using HttpRequestMessage request = CreateSignedRequest(payload);
+
+        using HttpResponseMessage response = await _client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await _eventBus.DidNotReceiveWithAnyArgs()
+            .PublishAsync<UserSessionCreatedEto>(default!, Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
Closes the **last bullet of #2662** — the Keycloak source for `UserSessionCreatedEto`.

## Why a webhook, not a login hook

Unlike BFF (#2672) and OpenIddict (#2674), **Keycloak is push-only** — `Granit.Identity.Federated.Keycloak` is an Admin-API read adapter and there is **no in-process login point** to hook (in federation, Keycloak *is* the IdP; login happens at the app/BFF OIDC layer). The canonical channel for "a Keycloak session was created" is Keycloak's **event-listener SPI → webhook**.

## What

Rather than a new package, this **extends the existing HMAC-validated identity webhook receiver** (`Granit.Identity.Endpoints`, the *Identity - Webhook* endpoint that already handles `user_created`/`updated`/`deleted`):

- `IdentityWebhookPayload` gains optional `SessionId` / `IpAddress` / `UserAgent` (login only).
- A new **`login`** event case publishes `UserSessionCreatedEto(Source=Keycloak)` via `IDistributedEventBus` (best-effort), keyed by the Keycloak `sid` so the anomaly-detection consumer's **ownership guard** matches it against the Admin-API session list. No-op without a session id or a wired bus.

## Data flow (answers "where is it stored / do we call Keycloak?")

- **Webhook**: makes **no** Keycloak call — receives the push, emits, returns 200. Carries only the trigger + keying ids.
- **Consumer** (existing `UserSessionCreatedHandler`, off the login path): calls the Keycloak **Admin API** (`KeycloakSessionManager`) for session history, resolves geo, evaluates risk, persists the verdict to the **User DbContext** (`user_sessions_risks`, P3). Sessions themselves are never duplicated — Keycloak stays the source of truth.

## Host side (out of framework)

Deploy a Keycloak event-listener SPI POSTing `LOGIN` events to `/identity/webhook` with the HMAC signature (header + `t=…,v1=…` HMAC-SHA256, the receiver's existing scheme). → granit-docs handoff.

## Verification

`IdentityWebhookEndpointsTests` green (**12**, +2: login publishes the Eto with `Source=Keycloak` and the `sid`; no-publish without a session id). Whole graph compiles; architecture conventions green (90); `dotnet format` clean; **zero lock changes** (no new deps).

With this, #2662 is fully delivered (BFF + OpenIddict + Keycloak sources).