### PR TITLE
fix(identity): fold session-risk config into shared ConfigureGranitIdentityModule

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -24411,7 +24411,7 @@
       "kind": "class",
       "project": "Granit.Identity.EntityFrameworkCore",
       "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "ConfigureGranitIdentityModule",

--- a/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Identity.EntityFrameworkCore.EntityConfigurations;
+using Granit.Identity.EntityFrameworkCore.Internal.Configurations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Identity.EntityFrameworkCore.Extensions;
@@ -10,9 +11,11 @@ namespace Granit.Identity.EntityFrameworkCore.Extensions;
 public static class IdentityModelBuilderExtensions
 {
     /// <summary>
-    /// Applies all entity configurations for the Granit Identity module
-    /// (currently the <see cref="Granit.Identity.Domain.User"/> aggregate
-    /// configured in <see cref="UserConfiguration"/>).
+    /// Applies all entity configurations for the Granit Identity module: the
+    /// <see cref="Granit.Identity.Domain.User"/> aggregate (<see cref="UserConfiguration"/>)
+    /// and the durable session-risk verdict store (<see cref="UserSessionRiskEntityConfiguration"/>).
+    /// Apps that fold the identity model into a host-owned <see cref="DbContext"/>
+    /// get the full table set — including <c>user_sessions_risks</c> — from this one call.
     /// </summary>
     /// <param name="modelBuilder">The model builder.</param>
     /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
@@ -20,6 +23,7 @@ public static class IdentityModelBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfiguration(new UserConfiguration());
+        modelBuilder.ApplyConfiguration(new UserSessionRiskEntityConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
@@ -42,7 +42,6 @@ internal sealed class IdentityDbContext(
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ConfigureGranitIdentityModule();
-        modelBuilder.ApplyConfiguration(new Configurations.UserSessionRiskEntityConfiguration());
         modelBuilder.ApplyEncryptionConventions(_encryption);
     }
 }


### PR DESCRIPTION
## Problem

`ConfigureGranitIdentityModule()` applied only `UserConfiguration`. The
`user_sessions_risks` store was wired solely by an explicit
`ApplyConfiguration(new UserSessionRiskEntityConfiguration())` call inside the
framework's internal `IdentityDbContext`.

Any host that folds the Identity model into its **own** `DbContext` via the
public extension — e.g. `ShowcaseHostDbContext.ConfigureGranitIdentityModule()` —
therefore silently dropped the risk table. The session-risk verdict store would
have no backing table at runtime in those topologies.

This is the framework-side root cause behind the showcase migration gap surfaced
during the `Granit.UserSessions.*` → `Granit.Identity.*` consolidation (#2682–#2689).

## Fix

- Move `UserSessionRiskEntityConfiguration` into the shared
  `ConfigureGranitIdentityModule()` extension, so a single call ships the full
  table set (`identity_users` **and** `user_sessions_risks`) to any host-folded
  context.
- Drop the now-redundant explicit `ApplyConfiguration` from `IdentityDbContext`
  (no double-apply — it relies on the extension like every other consumer).

## Verification

- `dotnet build src/Granit.Identity.EntityFrameworkCore` — clean (0 warnings).
- `dotnet test tests/Granit.Identity.EntityFrameworkCore.Tests` — **16/16 pass**.
  The `EfCoreUserSessionRiskStore` tests now exercise the risk table purely
  through the extension path (the explicit call is gone), so they act as the
  regression guard.
- `dotnet format src/Granit.Identity.EntityFrameworkCore --verify-no-changes` — clean.

## Downstream

Consuming apps that fold the Identity model (e.g. granit-showcase-dotnet) must
regenerate their host migration after bumping to the dev package built from this
PR, to create the `user_sessions_risks` table.