### PR TITLE
refactor(http-cookies): derive CookieDefinition.IsEssential from Category

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -21582,6 +21582,12 @@
           "kind": "property",
           "signature": "string Path",
           "returnType": "string"
+        },
+        {
+          "name": "IsEssential",
+          "kind": "property",
+          "signature": "bool IsEssential",
+          "returnType": "bool"
         }
       ]
     },

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -68,7 +68,6 @@ public static class BffEndpointRouteBuilderExtensions
         {
             SameSite = SameSiteMode.Strict,
             Path = "/",
-            IsEssential = true,
         });
     }
 

--- a/src/Granit.Http.Cookies/CookieDefinition.cs
+++ b/src/Granit.Http.Cookies/CookieDefinition.cs
@@ -31,10 +31,13 @@ public sealed record CookieDefinition(
     public string Path { get; init; } = "/";
 
     /// <summary>
-    /// Gets whether the cookie is marked as essential (bypasses GDPR consent banner suppression).
-    /// Only <see cref="CookieCategory.StrictlyNecessary"/> cookies should set this to <see langword="true"/>.
+    /// Gets whether the cookie is essential and therefore bypasses GDPR consent suppression.
+    /// Derived from <see cref="Category"/>: a cookie is essential <b>if and only if</b> it is
+    /// <see cref="CookieCategory.StrictlyNecessary"/>. Coupling the two by construction prevents a
+    /// strictly-necessary cookie from being consent-gated, or a consent-gated cookie from being
+    /// flagged essential.
     /// </summary>
-    public bool IsEssential { get; init; }
+    public bool IsEssential => Category == CookieCategory.StrictlyNecessary;
 
     /// <summary>
     /// Optional <c>Domain</c> attribute for the cookie. When set, the cookie is

--- a/src/Granit.Http.Cookies/Internal/AntiforgeryCookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies/Internal/AntiforgeryCookieDefinitionContributor.cs
@@ -30,7 +30,6 @@ internal sealed class AntiforgeryCookieDefinitionContributor(
             "CSRF protection token.")
         {
             SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict,
-            IsEssential = true,
         };
     }
 }

--- a/src/Granit.Http.Cookies/Internal/SessionCookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies/Internal/SessionCookieDefinitionContributor.cs
@@ -31,7 +31,6 @@ internal sealed class SessionCookieDefinitionContributor(
             "Server-side session identifier.")
         {
             SameSite = SameSiteMode.Strict,
-            IsEssential = true,
         };
     }
 }

--- a/src/Granit.OpenIddict/Internal/IdentityCookieDefinitionContributor.cs
+++ b/src/Granit.OpenIddict/Internal/IdentityCookieDefinitionContributor.cs
@@ -62,7 +62,6 @@ internal sealed class IdentityCookieDefinitionContributor(
         return new CookieDefinition(name, CookieCategory.StrictlyNecessary, 1, true, purpose)
         {
             SameSite = SameSiteMode.Strict,
-            IsEssential = true,
         };
     }
 }

--- a/tests/Granit.Http.Cookies.Tests/CookieDefinitionTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookieDefinitionTests.cs
@@ -35,12 +35,23 @@ public sealed class CookieDefinitionTests
         {
             SameSite = SameSiteMode.Strict,
             Path = "/",
-            IsEssential = true,
         };
 
         definition.SameSite.ShouldBe(SameSiteMode.Strict);
         definition.Path.ShouldBe("/");
-        definition.IsEssential.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(CookieCategory.StrictlyNecessary, true)]
+    [InlineData(CookieCategory.Preferences, false)]
+    [InlineData(CookieCategory.Analytics, false)]
+    [InlineData(CookieCategory.Marketing, false)]
+    [InlineData(CookieCategory.SaleOrSharing, false)]
+    public void IsEssential_IsDerivedFromStrictlyNecessaryCategory(CookieCategory category, bool expected)
+    {
+        CookieDefinition definition = new("cookie", category, 1, true, "Test");
+
+        definition.IsEssential.ShouldBe(expected);
     }
 
     [Fact]

--- a/tests/Granit.Http.Cookies.Tests/GranitCookieManagerTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/GranitCookieManagerTests.cs
@@ -152,7 +152,6 @@ public sealed class GranitCookieManagerTests
         {
             SameSite = SameSiteMode.Strict,
             Path = "/",
-            IsEssential = true,
         };
         _registry.Register(definition);
         DefaultHttpContext httpContext = CreateHttpContext();


### PR DESCRIPTION
## What

Make `CookieDefinition.IsEssential` a **computed** property — `Category == CookieCategory.StrictlyNecessary` — instead of an independently-settable `{ get; init; }` flag.

## Why

Coupling the two by construction removes a whole class of inconsistency:

- a `StrictlyNecessary` cookie can no longer accidentally be consent-gated, and
- a consent-gated cookie can no longer be flagged essential (bypassing the GDPR consent banner suppression).

The redundant `IsEssential` assignments in the antiforgery, session and identity cookie contributors (and the BFF route builder) are removed — they were just restating the category.

## Notes

- Pure refactor, no behavioural change for correctly-declared cookies.
- `Granit.Http.Cookies.Tests`: 77 passed; `dotnet format --verify-no-changes` clean on touched projects.