### PR TITLE
feat(identity): raise device trust to Strong on passkey assertion (#2667 follow-up)

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
@@ -3,6 +3,8 @@ using Granit.Auditing;
 using Granit.Auditing.Domain;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Http.SecurityHeaders.Extensions;
+using Granit.Identity.Endpoints;
+using Granit.Identity.Endpoints.Options;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
@@ -17,6 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.Local.Endpoints.Endpoints;
 
@@ -208,6 +211,8 @@ internal static partial class AccountPasskeyEndpoints
         }
 
         await signInManager.SignInAsync(user, isPersistent: false).ConfigureAwait(false);
+        await TryRaiseDeviceTrustToStrongAsync(httpContext, logger, user.Id.ToString(), cancellationToken)
+            .ConfigureAwait(false);
         metrics?.RecordAuthenticationSuccess(null, "passkey");
         await TryWritePasskeyAuditAsync(httpContext, logger,
             userId: user.Id.ToString(), userName: user.UserName,
@@ -271,6 +276,56 @@ internal static partial class AccountPasskeyEndpoints
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Passkey login: failed to write authentication audit entry — login flow continues.")]
     private static partial void LogAuditWriteFailed(ILogger logger, Exception exception);
+
+    /// <summary>
+    /// Raises this browser's device-trust verdict to <see cref="DeviceTrustLevel.Strong"/> after a successful
+    /// passkey assertion — but only on a device the user has already bound (a valid signed device cookie is
+    /// present). A passkey can be a roaming authenticator (security key, phone via hybrid) used on a public
+    /// browser, so an assertion alone must never silently trust an unknown device; on an already-trusted device
+    /// it proves a device-bound credential and upgrades <see cref="DeviceTrustLevel.Remembered"/> to
+    /// <see cref="DeviceTrustLevel.Strong"/>, refreshing the trust window. No-op when the device-trust endpoint
+    /// services are not registered. Best-effort: a store failure never blocks the already-successful login.
+    /// </summary>
+    private static async Task TryRaiseDeviceTrustToStrongAsync(
+        HttpContext httpContext,
+        ILogger logger,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        IDeviceTrustCookieService? cookieService = httpContext.RequestServices.GetService<IDeviceTrustCookieService>();
+        IDeviceTrustStore? trustStore = httpContext.RequestServices.GetService<IDeviceTrustStore>();
+        if (cookieService is null || trustStore is null)
+        {
+            return;
+        }
+
+        string? deviceId = cookieService.ResolveDeviceId(httpContext, userId);
+        if (deviceId is null)
+        {
+            return;
+        }
+
+        TimeProvider timeProvider = httpContext.RequestServices.GetService<TimeProvider>() ?? TimeProvider.System;
+        DeviceTrustOptions options = httpContext.RequestServices
+            .GetService<IOptions<DeviceTrustOptions>>()?.Value ?? new DeviceTrustOptions();
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        try
+        {
+            await trustStore.SetAsync(
+                userId,
+                deviceId,
+                new DeviceTrustVerdict(DeviceTrustLevel.Strong, now, now + options.TrustDuration, "passkey"),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogDeviceTrustRaiseFailed(logger, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Passkey login: failed to raise device trust to Strong — login flow continues.")]
+    private static partial void LogDeviceTrustRaiseFailed(ILogger logger, Exception exception);
 
     private static async Task<Results<NoContent, ProblemHttpResult>> RenamePasskeyAsync(
         Guid id,

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
+using Microsoft.AspNetCore.Http;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Shouldly;
@@ -604,6 +605,68 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
 
         result.ShouldNotBeNull();
         result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CompletePasskeyAssertion_BoundDevice_RaisesTrustToStrong()
+    {
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.PasskeyService
+            .CompleteAssertionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GranitPasskeyAssertionResult(true, AccountEndpointsTestServer.TestUserIdString));
+        _server.UserManager
+            .FindByIdAsync(AccountEndpointsTestServer.TestUserIdString)
+            .Returns(fakeUser);
+
+        // The browser is already bound to a device the user trusted ("remember this device").
+        _server.DeviceTrustCookieService
+            .ResolveDeviceId(Arg.Any<HttpContext>(), AccountEndpointsTestServer.TestUserIdString)
+            .Returns("device-123");
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/account/passkeys/assertion/complete",
+            new AccountPasskeyLoginRequest("""{"id":"cred123","response":{}}"""),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // The passkey proves a device-bound credential — trust is raised to Strong with the "passkey" reason.
+        await _server.DeviceTrustStore.Received(1).SetAsync(
+            AccountEndpointsTestServer.TestUserIdString,
+            "device-123",
+            Arg.Is<DeviceTrustVerdict>(v => v.Level == DeviceTrustLevel.Strong && v.Reason == "passkey"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompletePasskeyAssertion_UnboundDevice_DoesNotRaiseTrust()
+    {
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.PasskeyService
+            .CompleteAssertionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GranitPasskeyAssertionResult(true, AccountEndpointsTestServer.TestUserIdString));
+        _server.UserManager
+            .FindByIdAsync(AccountEndpointsTestServer.TestUserIdString)
+            .Returns(fakeUser);
+
+        // No device cookie present (default) — a passkey can be a roaming authenticator on a public browser,
+        // so the assertion alone must not silently trust an unknown device.
+        _server.DeviceTrustCookieService
+            .ResolveDeviceId(Arg.Any<HttpContext>(), Arg.Any<string>())
+            .Returns((string?)null);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/account/passkeys/assertion/complete",
+            new AccountPasskeyLoginRequest("""{"id":"cred123","response":{}}"""),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await _server.DeviceTrustStore.DidNotReceive().SetAsync(
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<DeviceTrustVerdict>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 using Granit.Authentication.External;
 using Granit.DataFiltering;
 using Granit.Events;
+using Granit.Identity.Endpoints;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Endpoints;
@@ -72,6 +73,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
     public UserManager<LocalIdentity> UserManager { get; }
     public ICurrentTenant CurrentTenant { get; }
     public IDataFilter DataFilter { get; }
+    public IDeviceTrustCookieService DeviceTrustCookieService { get; }
+    public IDeviceTrustStore DeviceTrustStore { get; }
 
     private AccountEndpointsTestServer(
         WebApplication app,
@@ -100,7 +103,9 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         SignInManager<LocalIdentity> signInManager,
         UserManager<LocalIdentity> userManager,
         ICurrentTenant currentTenant,
-        IDataFilter dataFilter)
+        IDataFilter dataFilter,
+        IDeviceTrustCookieService deviceTrustCookieService,
+        IDeviceTrustStore deviceTrustStore)
     {
         _app = app;
         AuthenticatedClient = authenticatedClient;
@@ -129,6 +134,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         UserManager = userManager;
         CurrentTenant = currentTenant;
         DataFilter = dataFilter;
+        DeviceTrustCookieService = deviceTrustCookieService;
+        DeviceTrustStore = deviceTrustStore;
     }
 
     public static async Task<AccountEndpointsTestServer> CreateAsync(
@@ -148,6 +155,11 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         IExternalLoginService externalLoginService = Substitute.For<IExternalLoginService>();
         IExternalProviderRegistry externalProviderRegistry = Substitute.For<IExternalProviderRegistry>();
         IPasskeyService passkeyService = Substitute.For<IPasskeyService>();
+        // Device trust — a successful passkey assertion raises trust to Strong, but only on a device the user
+        // already bound (the cookie service resolves a device id). Default: no bound device (ResolveDeviceId
+        // returns null), so the raise is a no-op and pre-existing tests are unaffected.
+        IDeviceTrustCookieService deviceTrustCookieService = Substitute.For<IDeviceTrustCookieService>();
+        IDeviceTrustStore deviceTrustStore = Substitute.For<IDeviceTrustStore>();
         IImpersonationService impersonationService = Substitute.For<IImpersonationService>();
         IAccountDeletionService deletionService = Substitute.For<IAccountDeletionService>();
         IDistributedEventBus eventBus = Substitute.For<IDistributedEventBus>();
@@ -224,6 +236,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         builder.Services.AddSingleton(externalLoginService);
         builder.Services.AddSingleton(externalProviderRegistry);
         builder.Services.AddSingleton(passkeyService);
+        builder.Services.AddSingleton(deviceTrustCookieService);
+        builder.Services.AddSingleton(deviceTrustStore);
         builder.Services.AddSingleton(impersonationService);
         builder.Services.AddSingleton(deletionService);
         builder.Services.AddSingleton(eventBus);
@@ -284,7 +298,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
             externalLoginService, externalProviderRegistry,
             passkeyService, impersonationService, deletionService,
             eventBus, fusionCache, settingProvider, timeProvider,
-            signInManager, userManager, currentTenant, dataFilter);
+            signInManager, userManager, currentTenant, dataFilter,
+            deviceTrustCookieService, deviceTrustStore);
     }
 
     /// <summary>

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -629,6 +629,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -668,6 +674,7 @@
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Identity.Abstractions": "[0.1.0-dev, )",
           "Granit.IpGeolocation": "[0.1.0-dev, )",


### PR DESCRIPTION
## What

Wires the **passkey → `DeviceTrustLevel.Strong`** follow-up left open by #2700 (Trusted Devices, #2667).

A successful passkey assertion proves a **device-bound credential** lives in this browser. After sign-in, `AccountPasskeyEndpoints.CompleteAssertionAsync` now raises the device-trust verdict to `Strong` (reason `"passkey"`), refreshing the trust window — so a later **password** login on the same device can skip the 2FA step-up where the deployment opts in (`DeviceTrustOptions.AllowMfaBypass`, default `false`).

## Why guarded to *raise an existing* binding only

The verdict is only raised when the browser is **already bound** to a device the user trusted (a valid signed device-trust cookie resolves a device id). A passkey can be a **roaming authenticator** (security key, phone via hybrid/caBLE) plugged into a *public* browser — an assertion alone must never silently trust an unknown device. On an already-trusted device, the passkey upgrades `Remembered → Strong`. This matches the original design intent ("passkey *may later raise* the verdict to Strong").

## Safety

- **No-op** when the device-trust endpoint services aren't registered (resolved optionally from `RequestServices`, mirroring the existing metrics/auditing pattern in this handler).
- **Best-effort**: a store failure is logged (Warning) and never blocks the already-successful login.
- No public API / OpenAPI contract change — purely an internal side effect after the existing sign-in.

## IsTrusted list reconciliation

The second follow-up (device-list `IsTrusted` reconciliation) was **already documented inline** in `DefaultUserSessionManager.ListDevicesAsync` — best-effort surfacing, authoritative path stays cookie → store → step-up. No code change needed; confirmed accurate.

## Tests

- `CompletePasskeyAssertion_BoundDevice_RaisesTrustToStrong` — bound cookie → `SetAsync` called with `Strong` + `"passkey"`.
- `CompletePasskeyAssertion_UnboundDevice_DoesNotRaiseTrust` — no cookie → `SetAsync` never called.
- Existing passkey/account tests unaffected (raise no-ops with default mocks).

## Verification

- `dotnet build src/Granit.Identity.Local.Endpoints` ✅
- `Granit.Identity.Local.Endpoints.Tests`: **172** passed (+2) ✅
- `dotnet format --verify-no-changes` (src + tests) ✅
- architecture shard: **224** passed ✅