### PR TITLE
fix(templating): register template engines additively so Scriban survives alongside other engines

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -16295,7 +16295,7 @@
       "kind": "class",
       "project": "Granit.DocumentGeneration.Excel",
       "file": "src/Granit.DocumentGeneration.Excel/Extensions/ServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitDocumentGenerationExcel",

--- a/src/Granit.DocumentGeneration.Excel/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.DocumentGeneration.Excel/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.DocumentGeneration.Excel.Internal;
 using Granit.Templating.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.DocumentGeneration.Excel.Extensions;
 
@@ -30,6 +31,12 @@ public static class ServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddGranitDocumentGenerationExcel(
-        this IServiceCollection services) =>
-        services.AddSingleton<ITemplateEngine, ClosedXmlTemplateEngine>();
+        this IServiceCollection services)
+    {
+        // TryAddEnumerable: ITemplateEngine is a set (selected per-template via CanRender).
+        // Coexists with Scriban and any other engine, and dedupes on repeat registration.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ITemplateEngine, ClosedXmlTemplateEngine>());
+        return services;
+    }
 }

--- a/src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs
@@ -37,8 +37,16 @@ public static class ServiceCollectionExtensions
         services.AddGranitTemplating();
 
         services.TryAddSingleton<GranitTemplateLoader>();
-        services.TryAddSingleton<ITemplateEngine>(sp =>
-            new ScribanTemplateEngine(sp, sp.GetService<GranitTemplateLoader>()));
+
+        // TryAddEnumerable (NOT TryAddSingleton): engines are a set resolved as
+        // IEnumerable<ITemplateEngine> and selected per-template via CanRender. A plain
+        // TryAddSingleton<ITemplateEngine> would no-op whenever ANY other engine is already
+        // registered (e.g. Granit.DocumentGeneration.Excel's ClosedXmlTemplateEngine), silently
+        // dropping Scriban — so HTML/text templates would find no engine and every email would
+        // fall back to its raw notification-type name. TryAddEnumerable keeps all engines and
+        // dedupes Scriban on repeat AddGranitTemplatingWithScriban() calls.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITemplateEngine, ScribanTemplateEngine>(
+            sp => new ScribanTemplateEngine(sp, sp.GetService<GranitTemplateLoader>())));
 
         services.AddTemplateGlobalContext<NowGlobalContext>();
         services.AddTemplateGlobalContext<ExecutionContextGlobalContext>();

--- a/tests/Granit.DocumentGeneration.Excel.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.DocumentGeneration.Excel.Tests/ServiceCollectionExtensionsTests.cs
@@ -24,14 +24,15 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddGranitDocumentGenerationExcel_CalledTwice_RegistersBothEngines()
+    public void AddGranitDocumentGenerationExcel_CalledTwice_RegistersEngineOnce()
     {
-        // Additive registration — allows combining with other engines (Scriban, etc.)
+        // TryAddEnumerable registration: additive across DIFFERENT engines (coexists with
+        // Scriban, etc.) but deduped on repeat self-registration.
         ServiceCollection services = new();
         services.AddGranitDocumentGenerationExcel();
         services.AddGranitDocumentGenerationExcel();
 
         services.Count(d => d.ServiceType == typeof(ITemplateEngine))
-                .ShouldBe(2, "each call must add an independent registration");
+            .ShouldBe(1, "TryAddEnumerable must dedupe the Excel engine on repeat registration");
     }
 }

--- a/tests/Granit.Templating.Scriban.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,8 @@
 using Granit.Templating.GlobalContext;
+using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;
 using Granit.Templating.Scriban.Extensions;
+using Granit.Templating.Scriban.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
@@ -47,13 +49,48 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddGranitTemplatingWithScriban_ITemplateEngine_IsReplaceable_WithTryAdd()
+    public void AddGranitTemplatingWithScriban_KeepsScriban_WhenAnotherEngineAlreadyRegistered()
+    {
+        // Reproduces the regression: when another ITemplateEngine is registered first
+        // (e.g. Granit.DocumentGeneration.Excel's ClosedXmlTemplateEngine), a plain
+        // TryAddSingleton<ITemplateEngine> would no-op and silently drop Scriban — leaving
+        // HTML/text templates with no engine. TryAddEnumerable must keep both.
+        ServiceCollection services = new();
+        services.AddSingleton<ITemplateEngine, FakeTemplateEngine>();
+        services.AddGranitTemplatingWithScriban();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        List<ITemplateEngine> engines = [.. provider.GetServices<ITemplateEngine>()];
+
+        engines.ShouldContain(e => e is ScribanTemplateEngine,
+            "Scriban must register additively so it survives alongside other engines.");
+        engines.ShouldContain(e => e is FakeTemplateEngine);
+    }
+
+    [Fact]
+    public void AddGranitTemplatingWithScriban_CalledTwice_RegistersScribanOnce()
     {
         ServiceCollection services = new();
-        services.AddSingleton<ITemplateEngine>(_ => null!); // pre-register custom engine
-        services.AddGranitTemplatingWithScriban();           // TryAdd must not replace
+        services.AddGranitTemplatingWithScriban();
+        services.AddGranitTemplatingWithScriban();
 
-        services.Count(d => d.ServiceType == typeof(ITemplateEngine))
-                .ShouldBe(1, "TryAddSingleton must not add a duplicate");
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetServices<ITemplateEngine>().Count(e => e is ScribanTemplateEngine)
+                .ShouldBe(1, "TryAddEnumerable must dedupe Scriban on repeat registration.");
+    }
+
+    private sealed class FakeTemplateEngine : ITemplateEngine
+    {
+        public bool CanRender(TemplateDescriptor descriptor) => false;
+
+        public Task<RenderedContent> RenderAsync<TData>(
+            TemplateDescriptor descriptor,
+            TData data,
+            DocumentFormat targetFormat,
+            IReadOnlyList<ITemplateGlobalContext> globalContexts,
+            CancellationToken cancellationToken = default)
+            where TData : notnull =>
+            throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Problem (root cause of the broken notification emails)

A forgot-password email arrived with a **raw fallback**: subject `identity password_reset`, body `<p>identity.password_reset</p>`. The app log showed:

```
No template engine can render template for notification 'identity.password_reset'.
No template engine can render template for notification 'Notifications.Default'.
```

`ITemplateEngine` is a **set** — `EmailNotificationChannel` (and every templating consumer) resolves `IEnumerable<ITemplateEngine>` and picks the one whose `CanRender` matches the descriptor's MIME type. But:

- `Granit.Templating.Scriban` registered its engine with **`TryAddSingleton<ITemplateEngine>`** — a no-op whenever *any* `ITemplateEngine` is already registered.
- `Granit.DocumentGeneration.Excel` registers `ClosedXmlTemplateEngine` (which only renders the XLSX MIME type).

In any app referencing **both** (e.g. the showcase), the Excel engine registered first → Scriban's `TryAddSingleton` silently no-op'd → the **only** engine left rejected `text/html` → no engine matched → every templated email fell back to the raw notification-type name. (The earlier localized-`<title>` fix #2696 only addressed the *subject*; this is why the *body* was still raw.)

## Fix

Register template engines with **`TryAddEnumerable`** so they coexist and dedupe on repeat registration:

- `Granit.Templating.Scriban`: `TryAddSingleton` → `TryAddEnumerable`
- `Granit.DocumentGeneration.Excel`: `AddSingleton` → `TryAddEnumerable`

## Tests

- New `ServiceCollectionExtensionsTests.AddGranitTemplatingWithScriban_KeepsScriban_WhenAnotherEngineAlreadyRegistered` — reproduces the Excel+Scriban coexistence regression.
- New dedup test (`…_CalledTwice_RegistersScribanOnce`).
- Updated the two DI tests that pinned the previous (buggy) behavior.
- `Granit.Templating.Scriban.Tests`: 51 passing · `Granit.DocumentGeneration.Excel.Tests`: 22 passing · `dotnet format` clean.

## Together with #2696

#2696 (merged) fixes the localized **subject**; this PR fixes the **rendering** so the body is the real template. Both are needed for the full repro.