### PR TITLE
test(architecture): enforce nullable *Request DTO params declare a default (#2546)

### DIFF
--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/RequestDtoNullableDefaultRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/RequestDtoNullableDefaultRules.cs
@@ -1,0 +1,125 @@
+using System.Reflection;
+using Shouldly;
+
+namespace Granit.ArchitectureTests.Abstractions.Rules;
+
+/// <summary>
+/// Reusable rule: a nullable constructor parameter on a <c>*Request</c> DTO in an
+/// <c>.Endpoints</c> assembly must declare a default value (<c>= null</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="System.Text.Json"/>'s <c>RespectRequiredConstructorParameters</c> (default
+/// <see langword="true"/> since .NET 9) treats a JSON property as <c>required</c> iff its
+/// constructor parameter has <b>no default value</b> — independent of nullability. So a
+/// positional record parameter typed <c>string?</c> with no <c>= null</c> is emitted as
+/// <c>required</c> in the OpenAPI contract while typed <c>["null","string"]</c>, which
+/// <c>openapi-typescript</c> codegen renders as a required <c>string | null</c> instead of an
+/// optional <c>foo?</c>. Adding <c>= null</c> drops the parameter from <c>required</c>.
+/// </para>
+/// <para>
+/// The rule is <b>direction-aware</b>: it targets <c>*Request</c> (input) DTOs only. It must
+/// never touch <c>*Response</c> (output) DTOs, where <c>required</c> + nullable correctly means
+/// "the server always returns the key, and its value may be null".
+/// </para>
+/// <para>
+/// The rare legitimately-required-but-nullable input parameter (e.g. an explicit tenancy choice
+/// that must be present in the payload) is exempted via the caller-supplied set, keyed
+/// <c>{RequestTypeName}.{ParameterName}</c>.
+/// </para>
+/// </remarks>
+public static class RequestDtoNullableDefaultRules
+{
+    /// <summary>
+    /// Every nullable constructor parameter on a <c>*Request</c> DTO must declare a default value,
+    /// unless the <paramref name="exemptions"/> set lists it as a deliberate required-but-nullable input.
+    /// </summary>
+    /// <param name="endpointAssemblies">The <c>*.Endpoints</c> assemblies to scan.</param>
+    /// <param name="exemptions">
+    /// Keys (<c>{RequestTypeName}.{ParameterName}</c>) of parameters that are intentionally
+    /// required despite being nullable. Each entry must carry an inline justification at its source.
+    /// </param>
+    public static void NullableRequestParametersMustHaveDefault(
+        IEnumerable<Assembly> endpointAssemblies,
+        ISet<string> exemptions)
+    {
+        ArgumentNullException.ThrowIfNull(endpointAssemblies);
+        ArgumentNullException.ThrowIfNull(exemptions);
+
+        NullabilityInfoContext nullability = new();
+        List<string> violations = [];
+
+        foreach (Assembly assembly in endpointAssemblies)
+        {
+            foreach (Type type in GetLoadableTypes(assembly))
+            {
+                if (!IsRequestDto(type))
+                {
+                    continue;
+                }
+
+                ConstructorInfo? ctor = type.GetConstructors()
+                    .OrderByDescending(c => c.GetParameters().Length)
+                    .FirstOrDefault(c => c.GetParameters().Length > 0);
+
+                if (ctor is null)
+                {
+                    continue;
+                }
+
+                foreach (ParameterInfo parameter in ctor.GetParameters())
+                {
+                    if (parameter.HasDefaultValue || !IsNullable(nullability, parameter))
+                    {
+                        continue;
+                    }
+
+                    string key = $"{type.Name}.{parameter.Name}";
+                    if (exemptions.Contains(key))
+                    {
+                        continue;
+                    }
+
+                    violations.Add(
+                        $"  {type.FullName}.{parameter.Name} ({DisplayType(parameter.ParameterType)}) " +
+                        "— nullable input without `= null`; emitted as required in OpenAPI.");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Nullable `*Request` DTO parameters without a `= null` default are emitted as `required` "
+            + "in the OpenAPI contract (System.Text.Json RespectRequiredConstructorParameters). "
+            + "Add `= null` to make the input optional, or add the parameter to the exemption set "
+            + "(with an inline justification) if it is deliberately required-but-nullable."
+            + Environment.NewLine + string.Join(Environment.NewLine, violations.OrderBy(v => v, StringComparer.Ordinal)));
+    }
+
+    private static bool IsRequestDto(Type type) =>
+        type is { IsClass: true, IsAbstract: false }
+        && type.Name.EndsWith("Request", StringComparison.Ordinal)
+        && type.Namespace is { } ns
+        && ns.Contains(".Endpoints", StringComparison.Ordinal);
+
+    private static bool IsNullable(NullabilityInfoContext context, ParameterInfo parameter) =>
+        Nullable.GetUnderlyingType(parameter.ParameterType) is not null
+        || context.Create(parameter).WriteState == NullabilityState.Nullable;
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t is not null)!;
+        }
+    }
+
+    private static string DisplayType(Type type)
+    {
+        Type? underlying = Nullable.GetUnderlyingType(type);
+        return underlying is not null ? $"{underlying.Name}?" : type.Name;
+    }
+}

--- a/tests/Granit.ArchitectureTests/DtoConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/DtoConventionTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Granit.ArchitectureTests.Abstractions.Rules;
 using Xunit;
 
@@ -22,5 +23,38 @@ public sealed class DtoConventionTests
             .Distinct()];
 
         NamingConventionRules.EndpointTypesShouldNotUseDtoSuffix(Architecture, endpointNamespaces);
+    }
+
+    [Fact]
+    public void Nullable_request_parameters_must_have_a_default() =>
+        RequestDtoNullableDefaultRules.NullableRequestParametersMustHaveDefault(
+            LoadEndpointAssemblies(),
+            RequestDtoNullableDefaultExemptions.RequiredButNullable);
+
+    /// <summary>
+    /// Loads the <c>Granit.*.Endpoints</c> assemblies from the test output directory so the rule can
+    /// reflect over their request DTOs' constructor parameter defaults and nullability.
+    /// </summary>
+    private static IReadOnlyList<Assembly> LoadEndpointAssemblies()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(DtoConventionTests).Assembly.Location)!;
+
+        return [.. Directory.GetFiles(outputDir, "Granit.*.Endpoints.dll")
+            .Where(path => !Path.GetFileNameWithoutExtension(path).Contains("Tests", StringComparison.Ordinal))
+            .Select(LoadOrNull)
+            .Where(a => a is not null)
+            .Cast<Assembly>()];
+    }
+
+    private static Assembly? LoadOrNull(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileLoadException)
+        {
+            return null;
+        }
     }
 }

--- a/tests/Granit.ArchitectureTests/RequestDtoNullableDefaultExemptions.cs
+++ b/tests/Granit.ArchitectureTests/RequestDtoNullableDefaultExemptions.cs
@@ -1,0 +1,20 @@
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Canonical list of <c>*Request</c> DTO parameters that are deliberately required despite
+/// being nullable, exempted from <see cref="DtoConventionTests.Nullable_request_parameters_must_have_a_default"/>.
+/// </summary>
+/// <remarks>
+/// Keyed <c>{RequestTypeName}.{ParameterName}</c>. Each entry needs a one-line justification
+/// (inline comment) explaining why the value must be present in the payload yet may be null.
+/// The default action for a nullable optional input is to add <c>= null</c>, not an exemption.
+/// </remarks>
+internal static class RequestDtoNullableDefaultExemptions
+{
+    public static readonly HashSet<string> RequiredButNullable = new(StringComparer.Ordinal)
+    {
+        // Explicit tenancy choice: the caller must consciously send a value (a tenant id, or `null`
+        // for a global/host-level role) — omitting the key is not a valid create request. (#2546)
+        "RoleCreateRequest.TenantId",
+    };
+}


### PR DESCRIPTION
Closes the last open deliverable of #2546: the **direction-aware arch-test** that enforces the convention introduced by the DTO sweep.

## What

A nullable constructor parameter on a `*Request` DTO in an `.Endpoints` assembly must declare a default value (`= null`). Without it, `System.Text.Json`'s `RespectRequiredConstructorParameters` (default `true` since .NET 9) emits the property as `required` in the OpenAPI contract — **independent of nullability** — which `openapi-typescript` renders as a required `string | null` instead of an optional `foo?`.

## How

- `RequestDtoNullableDefaultRules` (reusable, in `Granit.ArchitectureTests.Abstractions`) reflects over constructor parameters, mirroring STJ semantics exactly: `ParameterInfo.HasDefaultValue` + `NullabilityInfoContext`. No new package dependency.
- **Direction-aware**: targets `*Request` (input) only — never `*Response`, where `required` + nullable correctly means "always returned, value may be null".
- The rare required-but-nullable input is exempted via `RequestDtoNullableDefaultExemptions` (keyed `{Type}.{Param}`, inline justification required). Single entry: `RoleCreateRequest.TenantId` — the deliberate explicit-tenancy choice.

## Sequencing

The issue gated this test on clearing the ~49 actionable `*Request` params (sweep #2549 + the 11 ordering-blocked cases, now all carrying `= null`). That backlog being resolved, **the test passes green**. Verified it has teeth: removing the exemption makes it fail flagging exactly `RoleCreateRequest.TenantId (Guid?)` and nothing else — confirming no uncovered `*Request` remains.

`*Response` DTOs (~158 nullable-no-default) are intentionally untouched.

## Checks

- `dotnet build` ✅ (Abstractions + ArchitectureTests)
- `dotnet test --filter DtoConventionTests` ✅ (2/2)
- `dotnet format --verify-no-changes` ✅

---
Closes #2546.
