### PR TITLE
build(deps): regenerate lockfiles after Identity.Endpoints reference (#2700)

### DIFF
--- a/src/Granit.BlobStorage.S3/packages.lock.json
+++ b/src/Granit.BlobStorage.S3/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.24.3",
-        "contentHash": "vexHQGHi1CYHceVl9cKlbmvLrV0vhDlLm5CSLHZBHGmQUrtoimUT/Jxcr4i1d1+Sx58eZt/X7B5CBL3GkSXvyQ==",
+        "resolved": "4.0.24.4",
+        "contentHash": "r7naF7ZPfMjsj1jLjC9JP7Npg868+PT9/nUKgMNFNBvvTKzmAD5CMNw/DCT9AVd4qoCpI3YTYcCEIPlWcgW1bQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -79,8 +79,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",

--- a/src/Granit.Html.AngleSharp/packages.lock.json
+++ b/src/Granit.Html.AngleSharp/packages.lock.json
@@ -5,8 +5,8 @@
       "AngleSharp": {
         "type": "Direct",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",

--- a/src/Granit.Html/packages.lock.json
+++ b/src/Granit.Html/packages.lock.json
@@ -5,8 +5,8 @@
       "AngleSharp": {
         "type": "Direct",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -10,8 +10,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -292,10 +292,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.4",
-        "contentHash": "fHnqBzCqVBPiZc8XKyKRiHxiYA0gYGv5Wi4TYM74Gox118q34tzeTHtRDDeH8xQbgxazNbVVD2gbeAcfb+zdEw==",
+        "resolved": "4.0.9.5",
+        "contentHash": "jRom+s0uHW4zA6tPV5rp1qjGjV8GJtsiLwFRT/PCCf7RHoHlZdjQaXQnEoCTmkXbtjd4e+aypmnHhlBAr7apJA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Cronos": {

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.4",
-        "contentHash": "fHnqBzCqVBPiZc8XKyKRiHxiYA0gYGv5Wi4TYM74Gox118q34tzeTHtRDDeH8xQbgxazNbVVD2gbeAcfb+zdEw==",
+        "resolved": "4.0.9.5",
+        "contentHash": "jRom+s0uHW4zA6tPV5rp1qjGjV8GJtsiLwFRT/PCCf7RHoHlZdjQaXQnEoCTmkXbtjd4e+aypmnHhlBAr7apJA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -32,8 +32,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Brevo/packages.lock.json
+++ b/src/Granit.Notifications.Brevo/packages.lock.json
@@ -387,8 +387,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.14.4",
-        "contentHash": "rQjuoktALOTfnLamerF18uQs+Yheu1rpJoy5/eHoLC4qXGS5QqnHaeOJ/DblmgUW+shJJFihva6WzvpYB6qiPA==",
+        "resolved": "4.0.14.5",
+        "contentHash": "Ja48L7ZRxvGg3wj0MpqVrWMyVKurA4JSzVYB9qkv+mraSXAAC30EM60Dvt/CJ7Oq/AOmnhtYiViKQgveu0NJIg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -69,8 +69,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -208,8 +208,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/packages.lock.json
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/packages.lock.json
@@ -274,8 +274,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.Email.Scaleway/packages.lock.json
+++ b/src/Granit.Notifications.Email.Scaleway/packages.lock.json
@@ -369,8 +369,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.Email.SendGrid/packages.lock.json
+++ b/src/Granit.Notifications.Email.SendGrid/packages.lock.json
@@ -369,8 +369,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.Email.Smtp/packages.lock.json
+++ b/src/Granit.Notifications.Email.Smtp/packages.lock.json
@@ -223,8 +223,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.Email/packages.lock.json
+++ b/src/Granit.Notifications.Email/packages.lock.json
@@ -140,8 +140,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.3.3",
-        "contentHash": "pB1ehrah/EeKq+biE+uKnTqY0T7YfIns3ni8kFCGIu8k+EwxIltO9K1hExoSNbORjRx/Wwd8MJrR0vNs93ZyGQ==",
+        "resolved": "4.0.3.4",
+        "contentHash": "BWJ4sqzL5L8+5yetkpr86U9nqc9BXTEZy9h5WGlCEGydf6Pixf0UKrMa3xwZ2X7rubRDIA856m5HDvOTC5VLEQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.3.3",
-        "contentHash": "pB1ehrah/EeKq+biE+uKnTqY0T7YfIns3ni8kFCGIu8k+EwxIltO9K1hExoSNbORjRx/Wwd8MJrR0vNs93ZyGQ==",
+        "resolved": "4.0.3.4",
+        "contentHash": "BWJ4sqzL5L8+5yetkpr86U9nqc9BXTEZy9h5WGlCEGydf6Pixf0UKrMa3xwZ2X7rubRDIA856m5HDvOTC5VLEQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -834,6 +834,7 @@
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Identity.Abstractions": "[0.1.0-dev, )",
           "Granit.IpGeolocation": "[0.1.0-dev, )",
@@ -880,6 +881,7 @@
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
+          "Granit.Identity.Endpoints": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",

--- a/src/Granit.TextExtraction.Email/packages.lock.json
+++ b/src/Granit.TextExtraction.Email/packages.lock.json
@@ -98,8 +98,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.TextExtraction.Text/packages.lock.json
+++ b/src/Granit.TextExtraction.Text/packages.lock.json
@@ -84,8 +84,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -5,19 +5,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.4",
-        "contentHash": "T20E+szAWTGBH+/64223haNw3zExzGoF7bvmO+A/oqaY1iesypHn5N6jzzcwPANQ+md9kvDFB3ifb2lzAbzEMw==",
+        "resolved": "4.0.12.5",
+        "contentHash": "RnICgGseExGrWk9W9bakozkfzHYeWqJZ4oCVYnCxBY9/Lm9slmtezvMfjhALBmzY8aLqO7p+RddS8Hm2H4nh4g==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.5.3",
-        "contentHash": "WQsetMo2H2EFcrI9fShTOZ2x6W+d1f+FueXd3t+bwO4AGabiCsCXW6+GVYKO4WTX4LW+c29SEdDs5t3wfbl/OQ==",
+        "resolved": "4.0.5.4",
+        "contentHash": "vKjc1Hlx1grNNXgLQuxI3n0mWxwvmv0T43/bsGh9Hk97PbCzlatpzb1Ky+36LBHJMOPVWsHTURIF/JBAgKF3Cw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -91,8 +91,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/bundles/Granit.Bundle.Notifications/packages.lock.json
+++ b/src/bundles/Granit.Bundle.Notifications/packages.lock.json
@@ -430,8 +430,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -706,6 +706,21 @@
           "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.identity.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Identity.Abstractions": "[0.1.0-dev, )",
+          "Granit.IpGeolocation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity.local": {
         "type": "Project",
         "dependencies": {
@@ -743,10 +758,21 @@
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
+          "Granit.Identity.Endpoints": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ipgeolocation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
       "granit.ipgeolocation.abstractions": {
@@ -866,11 +892,28 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.settings": {

--- a/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
@@ -72,8 +72,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "AWSSDK.SQS": {
         "type": "Transitive",
@@ -541,10 +541,10 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.24.3",
-        "contentHash": "vexHQGHi1CYHceVl9cKlbmvLrV0vhDlLm5CSLHZBHGmQUrtoimUT/Jxcr4i1d1+Sx58eZt/X7B5CBL3GkSXvyQ==",
+        "resolved": "4.0.24.4",
+        "contentHash": "r7naF7ZPfMjsj1jLjC9JP7Npg868+PT9/nUKgMNFNBvvTKzmAD5CMNw/DCT9AVd4qoCpI3YTYcCEIPlWcgW1bQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {

--- a/tests/Granit.Bundle.Tests/packages.lock.json
+++ b/tests/Granit.Bundle.Tests/packages.lock.json
@@ -756,8 +756,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",

--- a/tests/Granit.Html.AngleSharp.Tests/packages.lock.json
+++ b/tests/Granit.Html.AngleSharp.Tests/packages.lock.json
@@ -262,8 +262,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.Html.Tests/packages.lock.json
+++ b/tests/Granit.Html.Tests/packages.lock.json
@@ -254,8 +254,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -531,10 +531,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.4",
-        "contentHash": "fHnqBzCqVBPiZc8XKyKRiHxiYA0gYGv5Wi4TYM74Gox118q34tzeTHtRDDeH8xQbgxazNbVVD2gbeAcfb+zdEw==",
+        "resolved": "4.0.9.5",
+        "contentHash": "jRom+s0uHW4zA6tPV5rp1qjGjV8GJtsiLwFRT/PCCf7RHoHlZdjQaXQnEoCTmkXbtjd4e+aypmnHhlBAr7apJA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Cronos": {

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.4",
-        "contentHash": "fHnqBzCqVBPiZc8XKyKRiHxiYA0gYGv5Wi4TYM74Gox118q34tzeTHtRDDeH8xQbgxazNbVVD2gbeAcfb+zdEw==",
+        "resolved": "4.0.9.5",
+        "contentHash": "jRom+s0uHW4zA6tPV5rp1qjGjV8GJtsiLwFRT/PCCf7RHoHlZdjQaXQnEoCTmkXbtjd4e+aypmnHhlBAr7apJA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "coverlet.collector": {
@@ -70,15 +70,15 @@
       "WireMock.Net": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.10.0",
-        "contentHash": "DMDXOvjTqm3sAMUeKfQQqP/LEKboTCm0l24IbpGsLTor5dZ3tgh1Qp2AGxlDmohRirZkww3/72Gn0C0dPhTPsA==",
+        "resolved": "2.11.0",
+        "contentHash": "gQgO9LPslgAPr0cHwHIx2OP3UYZX0Ex11UdAhFyiY2cHBjpxtw9A6GOcF79B56vMFOhYFBHWUgl6fcSFLin0yg==",
         "dependencies": {
-          "WireMock.Net.GraphQL": "2.10.0",
-          "WireMock.Net.Matchers.SystemTextJsonPath": "2.10.0",
-          "WireMock.Net.MimePart": "2.10.0",
-          "WireMock.Net.Minimal": "2.10.0",
-          "WireMock.Net.OpenTelemetry": "2.10.0",
-          "WireMock.Net.ProtoBuf": "2.10.0"
+          "WireMock.Net.GraphQL": "2.11.0",
+          "WireMock.Net.Matchers.SystemTextJsonPath": "2.11.0",
+          "WireMock.Net.MimePart": "2.11.0",
+          "WireMock.Net.Minimal": "2.11.0",
+          "WireMock.Net.OpenTelemetry": "2.11.0",
+          "WireMock.Net.ProtoBuf": "2.11.0"
         }
       },
       "xunit.runner.visualstudio": {
@@ -103,8 +103,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -1110,8 +1110,8 @@
       },
       "Stef.Validation": {
         "type": "Transitive",
-        "resolved": "0.2.0",
-        "contentHash": "X43dtF+Vbqjg1apJ3yzzceznLyW6ziBB2ZvjsB0jtJfpZZOejwXPCS5NNWmwu+NXaD09pJJ3+rCk4Bdd7zWA8w=="
+        "resolved": "0.3.0",
+        "contentHash": "OfzmxQMK4eBzmobph43p1NsLTgVAC3XGTcvQS0odhsdL6uS7UsFzBMK6S9mAfIijZdLW4q98aZ3dtTOeTaQo6Q=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -1147,40 +1147,40 @@
       },
       "WireMock.Net.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "OBV6UV2og1HGCn900lxbAMqv1VtBS0Z2Od8DZFxcxjtMmgMC0gjoR/zXO8zvKrGrwuI8/sjXWIKR6wh+B9BJcA=="
+        "resolved": "2.11.0",
+        "contentHash": "/iy5Jn1QHW1CDmyVj6e+/rhUQpuNHk5Y6Qy6MQSFv48R86YovqZ2Au0VwtL2nVvwbRY0TeMH3XkhARHcynRUPA=="
       },
       "WireMock.Net.GraphQL": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "8i1SC+kth9fUQBVMv4FWk8KqqRzSjbXyMu41nZETCuOcmrSafhITFKaoCuqHYdTuhJmJHnJEr08buT+pKqMfPA==",
+        "resolved": "2.11.0",
+        "contentHash": "QVfnWZrjI9P9v3pOzfDByZ0IN4JmV91jo+H6jz5heJ2dWPFFmmqLpxIc2Y2ExuJGYQAJmvNYAMC3/2YSXK7+wQ==",
         "dependencies": {
           "GraphQL.NewtonsoftJson": "8.5.0",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.Matchers.SystemTextJsonPath": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "zWix/Fpo4BcY0L0MsUAdBOhrpdXR6FshVWvkNemQ0sJ85vqLOh7LPxTPy5LBSQaXUARcK/Lu6iPioYT/Qsl6IQ==",
+        "resolved": "2.11.0",
+        "contentHash": "B8qofF1bdEgtwHRgswtOJkZxHmLmmf8RIH4Jk6KJSHn4QKwwMrtPdEOD632/03P8n93O2K2mfd8PDsovLQ7gcQ==",
         "dependencies": {
           "JsonPath.Net": "3.0.2",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.MimePart": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "7s5NJm9ZpUSpErAvKTj+FKT3bOZcagXbbAkHDvz3H7CCWEe7naR/EhIPAGFLFKwQ5Y9ujf7Ba013Q9QOaru9IA==",
+        "resolved": "2.11.0",
+        "contentHash": "+aCR6r3cx+ZvS0hhu5CUjNAstub5Sy1JmqFC7q3QQK82yazlH7OB4Dzh1rTJH+BXcxoWKC91nqXgt6xfD8Uv8g==",
         "dependencies": {
-          "Stef.Validation": "0.2.0",
-          "WireMock.Net.Shared": "2.10.0"
+          "Stef.Validation": "0.3.0",
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.Minimal": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "gynnIWKQDU4jj+EE3Fb+tBC3Bt055PcStoGFl9/+eZkyetKXLEYUspXGLlMKBOwByi9qWK7ngAseV1LgLATGjQ==",
+        "resolved": "2.11.0",
+        "contentHash": "NmQrlaNiZRx535OFUJYCG3+HZRXEi0rom4mN+09qas6RVaZgnh+ChxnWFIdOS8rXoTRlpDmFHG1fdUVHHX4mhA==",
         "dependencies": {
           "JmesPath.Net": "1.1.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.34.0",
@@ -1189,49 +1189,49 @@
           "Scriban.Signed": "7.2.0",
           "SimMetrics.Net": "1.0.5",
           "TinyMapper.Signed": "4.0.0",
-          "WireMock.Net.OpenApiParser": "2.10.0",
-          "WireMock.Net.Shared": "2.10.0",
-          "WireMock.Org.Abstractions": "2.10.0"
+          "WireMock.Net.OpenApiParser": "2.11.0",
+          "WireMock.Net.Shared": "2.11.0",
+          "WireMock.Org.Abstractions": "2.11.0"
         }
       },
       "WireMock.Net.OpenApiParser": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "cq+CgJpf/dxOxFd8sJA9nNLeU0BWR2sWDXeAaG4E/wO5OMJ0fqOH1HI37d061DEkfo4AXshg530jPVone4mrtw==",
+        "resolved": "2.11.0",
+        "contentHash": "b3awrEjgWG6iPCT2wO5Jdye6JaGlCeGoCrgtaeucP0GVYn/BmeNGqKU6BGpIsx7J0+W6YBj0QgpNQp7/nRgeaw==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4",
           "RamlToOpenApiConverter.SourceOnly": "0.11.0",
           "RandomDataGenerator.Net": "1.0.19.1",
           "SharpYaml": "2.1.3",
-          "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.10.0",
+          "Stef.Validation": "0.3.0",
+          "WireMock.Net.Abstractions": "2.11.0",
           "YamlDotNet": "16.3.0"
         }
       },
       "WireMock.Net.OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "qhK2jH3kcINl3DoLGsfK5ScptakfP4VeRR+qQT46PuY2xBxJqiFqlD2tP466tHkPhYqsczDRaL4JG6PoMIfzUQ==",
+        "resolved": "2.11.0",
+        "contentHash": "T+ShaY7mI82RhQmCUrs5n5ZX67xlTyIfC1/gNiftca/wiaXCctj+b8gt7tr7z+LuKroTnMRQDuOFdHhBKVjUQQ==",
         "dependencies": {
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.Instrumentation.AspNetCore": "1.15.2",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.ProtoBuf": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "FUN60sArEDzVthMxSZqUnSQwI9s03GnPaHdR/AFxx27AxKHQgzr8p2tAZSE6B9l+0JPc/q1xZ4/yIs3skAttIQ==",
+        "resolved": "2.11.0",
+        "contentHash": "cWJTxP4oG9PZoOQDTzRNbuJX8mY/MtmjMCiwnSx2h6Vm33HxHFngdmHdgK4ZjbZfnqq6gKIXPel+DvEExXa6lQ==",
         "dependencies": {
           "ProtoBufJsonConverter": "0.11.0",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.Shared": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "Hd94TjT/s6yIx6R1VlFZxgena8idt4nSCV599dDeVh9zpDv0Ro9Uo0IY0KHmMgnCgPSaxLyeYlU4tuFJVr8cug==",
+        "resolved": "2.11.0",
+        "contentHash": "WvVfCUHP6noNmNdpCWuWeBok44QFjgwQITGoTiMd0v40fCB85SKJU/1uocP8ZgRABELBMbbLALsIuz31KdeNcA==",
         "dependencies": {
           "AnyOf": "0.5.0.1",
           "Handlebars.Net.Helpers": "2.5.5",
@@ -1245,14 +1245,14 @@
           "JsonConverter.System.Text.Json": "0.13.0",
           "Microsoft.AspNetCore.Http": "2.3.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.10.0"
+          "Stef.Validation": "0.3.0",
+          "WireMock.Net.Abstractions": "2.11.0"
         }
       },
       "WireMock.Org.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "vnaZ5UP93U5lz5Y0zHOCUOx8IqtujBMYLosvVys6aMkSyBMAOEQVkfS09BxYE5qikZlS6QKSK0wOBn0QcAzUlg=="
+        "resolved": "2.11.0",
+        "contentHash": "ERlcOKHCgOblIaph2QZYpj9wrIwHRirwHFRqzfo4qDUVxH3QB8PoxuVEaL6LGFUM9gKBilrdvs4ulsxKiwjqwQ=="
       },
       "XPath2": {
         "type": "Transitive",

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -510,10 +510,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.4",
-        "contentHash": "fHnqBzCqVBPiZc8XKyKRiHxiYA0gYGv5Wi4TYM74Gox118q34tzeTHtRDDeH8xQbgxazNbVVD2gbeAcfb+zdEw==",
+        "resolved": "4.0.9.5",
+        "contentHash": "jRom+s0uHW4zA6tPV5rp1qjGjV8GJtsiLwFRT/PCCf7RHoHlZdjQaXQnEoCTmkXbtjd4e+aypmnHhlBAr7apJA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
@@ -61,15 +61,15 @@
       "WireMock.Net": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.10.0",
-        "contentHash": "DMDXOvjTqm3sAMUeKfQQqP/LEKboTCm0l24IbpGsLTor5dZ3tgh1Qp2AGxlDmohRirZkww3/72Gn0C0dPhTPsA==",
+        "resolved": "2.11.0",
+        "contentHash": "gQgO9LPslgAPr0cHwHIx2OP3UYZX0Ex11UdAhFyiY2cHBjpxtw9A6GOcF79B56vMFOhYFBHWUgl6fcSFLin0yg==",
         "dependencies": {
-          "WireMock.Net.GraphQL": "2.10.0",
-          "WireMock.Net.Matchers.SystemTextJsonPath": "2.10.0",
-          "WireMock.Net.MimePart": "2.10.0",
-          "WireMock.Net.Minimal": "2.10.0",
-          "WireMock.Net.OpenTelemetry": "2.10.0",
-          "WireMock.Net.ProtoBuf": "2.10.0"
+          "WireMock.Net.GraphQL": "2.11.0",
+          "WireMock.Net.Matchers.SystemTextJsonPath": "2.11.0",
+          "WireMock.Net.MimePart": "2.11.0",
+          "WireMock.Net.Minimal": "2.11.0",
+          "WireMock.Net.OpenTelemetry": "2.11.0",
+          "WireMock.Net.ProtoBuf": "2.11.0"
         }
       },
       "xunit.runner.visualstudio": {
@@ -1210,8 +1210,8 @@
       },
       "Stef.Validation": {
         "type": "Transitive",
-        "resolved": "0.2.0",
-        "contentHash": "X43dtF+Vbqjg1apJ3yzzceznLyW6ziBB2ZvjsB0jtJfpZZOejwXPCS5NNWmwu+NXaD09pJJ3+rCk4Bdd7zWA8w=="
+        "resolved": "0.3.0",
+        "contentHash": "OfzmxQMK4eBzmobph43p1NsLTgVAC3XGTcvQS0odhsdL6uS7UsFzBMK6S9mAfIijZdLW4q98aZ3dtTOeTaQo6Q=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -1252,40 +1252,40 @@
       },
       "WireMock.Net.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "OBV6UV2og1HGCn900lxbAMqv1VtBS0Z2Od8DZFxcxjtMmgMC0gjoR/zXO8zvKrGrwuI8/sjXWIKR6wh+B9BJcA=="
+        "resolved": "2.11.0",
+        "contentHash": "/iy5Jn1QHW1CDmyVj6e+/rhUQpuNHk5Y6Qy6MQSFv48R86YovqZ2Au0VwtL2nVvwbRY0TeMH3XkhARHcynRUPA=="
       },
       "WireMock.Net.GraphQL": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "8i1SC+kth9fUQBVMv4FWk8KqqRzSjbXyMu41nZETCuOcmrSafhITFKaoCuqHYdTuhJmJHnJEr08buT+pKqMfPA==",
+        "resolved": "2.11.0",
+        "contentHash": "QVfnWZrjI9P9v3pOzfDByZ0IN4JmV91jo+H6jz5heJ2dWPFFmmqLpxIc2Y2ExuJGYQAJmvNYAMC3/2YSXK7+wQ==",
         "dependencies": {
           "GraphQL.NewtonsoftJson": "8.5.0",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.Matchers.SystemTextJsonPath": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "zWix/Fpo4BcY0L0MsUAdBOhrpdXR6FshVWvkNemQ0sJ85vqLOh7LPxTPy5LBSQaXUARcK/Lu6iPioYT/Qsl6IQ==",
+        "resolved": "2.11.0",
+        "contentHash": "B8qofF1bdEgtwHRgswtOJkZxHmLmmf8RIH4Jk6KJSHn4QKwwMrtPdEOD632/03P8n93O2K2mfd8PDsovLQ7gcQ==",
         "dependencies": {
           "JsonPath.Net": "3.0.2",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.MimePart": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "7s5NJm9ZpUSpErAvKTj+FKT3bOZcagXbbAkHDvz3H7CCWEe7naR/EhIPAGFLFKwQ5Y9ujf7Ba013Q9QOaru9IA==",
+        "resolved": "2.11.0",
+        "contentHash": "+aCR6r3cx+ZvS0hhu5CUjNAstub5Sy1JmqFC7q3QQK82yazlH7OB4Dzh1rTJH+BXcxoWKC91nqXgt6xfD8Uv8g==",
         "dependencies": {
-          "Stef.Validation": "0.2.0",
-          "WireMock.Net.Shared": "2.10.0"
+          "Stef.Validation": "0.3.0",
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.Minimal": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "gynnIWKQDU4jj+EE3Fb+tBC3Bt055PcStoGFl9/+eZkyetKXLEYUspXGLlMKBOwByi9qWK7ngAseV1LgLATGjQ==",
+        "resolved": "2.11.0",
+        "contentHash": "NmQrlaNiZRx535OFUJYCG3+HZRXEi0rom4mN+09qas6RVaZgnh+ChxnWFIdOS8rXoTRlpDmFHG1fdUVHHX4mhA==",
         "dependencies": {
           "JmesPath.Net": "1.1.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.34.0",
@@ -1294,49 +1294,49 @@
           "Scriban.Signed": "7.2.0",
           "SimMetrics.Net": "1.0.5",
           "TinyMapper.Signed": "4.0.0",
-          "WireMock.Net.OpenApiParser": "2.10.0",
-          "WireMock.Net.Shared": "2.10.0",
-          "WireMock.Org.Abstractions": "2.10.0"
+          "WireMock.Net.OpenApiParser": "2.11.0",
+          "WireMock.Net.Shared": "2.11.0",
+          "WireMock.Org.Abstractions": "2.11.0"
         }
       },
       "WireMock.Net.OpenApiParser": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "cq+CgJpf/dxOxFd8sJA9nNLeU0BWR2sWDXeAaG4E/wO5OMJ0fqOH1HI37d061DEkfo4AXshg530jPVone4mrtw==",
+        "resolved": "2.11.0",
+        "contentHash": "b3awrEjgWG6iPCT2wO5Jdye6JaGlCeGoCrgtaeucP0GVYn/BmeNGqKU6BGpIsx7J0+W6YBj0QgpNQp7/nRgeaw==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4",
           "RamlToOpenApiConverter.SourceOnly": "0.11.0",
           "RandomDataGenerator.Net": "1.0.19.1",
           "SharpYaml": "2.1.3",
-          "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.10.0",
+          "Stef.Validation": "0.3.0",
+          "WireMock.Net.Abstractions": "2.11.0",
           "YamlDotNet": "16.3.0"
         }
       },
       "WireMock.Net.OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "qhK2jH3kcINl3DoLGsfK5ScptakfP4VeRR+qQT46PuY2xBxJqiFqlD2tP466tHkPhYqsczDRaL4JG6PoMIfzUQ==",
+        "resolved": "2.11.0",
+        "contentHash": "T+ShaY7mI82RhQmCUrs5n5ZX67xlTyIfC1/gNiftca/wiaXCctj+b8gt7tr7z+LuKroTnMRQDuOFdHhBKVjUQQ==",
         "dependencies": {
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.Instrumentation.AspNetCore": "1.15.2",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.ProtoBuf": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "FUN60sArEDzVthMxSZqUnSQwI9s03GnPaHdR/AFxx27AxKHQgzr8p2tAZSE6B9l+0JPc/q1xZ4/yIs3skAttIQ==",
+        "resolved": "2.11.0",
+        "contentHash": "cWJTxP4oG9PZoOQDTzRNbuJX8mY/MtmjMCiwnSx2h6Vm33HxHFngdmHdgK4ZjbZfnqq6gKIXPel+DvEExXa6lQ==",
         "dependencies": {
           "ProtoBufJsonConverter": "0.11.0",
-          "WireMock.Net.Shared": "2.10.0"
+          "WireMock.Net.Shared": "2.11.0"
         }
       },
       "WireMock.Net.Shared": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "Hd94TjT/s6yIx6R1VlFZxgena8idt4nSCV599dDeVh9zpDv0Ro9Uo0IY0KHmMgnCgPSaxLyeYlU4tuFJVr8cug==",
+        "resolved": "2.11.0",
+        "contentHash": "WvVfCUHP6noNmNdpCWuWeBok44QFjgwQITGoTiMd0v40fCB85SKJU/1uocP8ZgRABELBMbbLALsIuz31KdeNcA==",
         "dependencies": {
           "AnyOf": "0.5.0.1",
           "Handlebars.Net.Helpers": "2.5.5",
@@ -1350,14 +1350,14 @@
           "JsonConverter.System.Text.Json": "0.13.0",
           "Microsoft.AspNetCore.Http": "2.3.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Stef.Validation": "0.2.0",
-          "WireMock.Net.Abstractions": "2.10.0"
+          "Stef.Validation": "0.3.0",
+          "WireMock.Net.Abstractions": "2.11.0"
         }
       },
       "WireMock.Org.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "vnaZ5UP93U5lz5Y0zHOCUOx8IqtujBMYLosvVys6aMkSyBMAOEQVkfS09BxYE5qikZlS6QKSK0wOBn0QcAzUlg=="
+        "resolved": "2.11.0",
+        "contentHash": "ERlcOKHCgOblIaph2QZYpj9wrIwHRirwHFRqzfo4qDUVxH3QB8PoxuVEaL6LGFUM9gKBilrdvs4ulsxKiwjqwQ=="
       },
       "XPath2": {
         "type": "Transitive",

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -595,6 +595,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -627,6 +633,21 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Identity.Abstractions": "[0.1.0-dev, )",
+          "Granit.IpGeolocation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.identity.local": {
@@ -666,10 +687,19 @@
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
+          "Granit.Identity.Endpoints": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ipgeolocation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ipgeolocation.abstractions": {
@@ -707,11 +737,28 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.settings": {

--- a/tests/Granit.Notifications.Brevo.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Brevo.Tests/packages.lock.json
@@ -579,8 +579,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -393,16 +393,16 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.14.4",
-        "contentHash": "rQjuoktALOTfnLamerF18uQs+Yheu1rpJoy5/eHoLC4qXGS5QqnHaeOJ/DblmgUW+shJJFihva6WzvpYB6qiPA==",
+        "resolved": "4.0.14.5",
+        "contentHash": "Ja48L7ZRxvGg3wj0MpqVrWMyVKurA4JSzVYB9qkv+mraSXAAC30EM60Dvt/CJ7Oq/AOmnhtYiViKQgveu0NJIg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/packages.lock.json
@@ -446,8 +446,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Azure.Communication.Email": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.Email.Scaleway.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Scaleway.Tests/packages.lock.json
@@ -559,8 +559,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.Email.SendGrid.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.SendGrid.Tests/packages.lock.json
@@ -559,8 +559,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.Email.Smtp.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Smtp.Tests/packages.lock.json
@@ -399,8 +399,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "MailKit": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.Email.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Tests/packages.lock.json
@@ -439,8 +439,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -310,10 +310,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.3.3",
-        "contentHash": "pB1ehrah/EeKq+biE+uKnTqY0T7YfIns3ni8kFCGIu8k+EwxIltO9K1hExoSNbORjRx/Wwd8MJrR0vNs93ZyGQ==",
+        "resolved": "4.0.3.4",
+        "contentHash": "BWJ4sqzL5L8+5yetkpr86U9nqc9BXTEZy9h5WGlCEGydf6Pixf0UKrMa3xwZ2X7rubRDIA856m5HDvOTC5VLEQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -309,10 +309,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.3.3",
-        "contentHash": "pB1ehrah/EeKq+biE+uKnTqY0T7YfIns3ni8kFCGIu8k+EwxIltO9K1hExoSNbORjRx/Wwd8MJrR0vNs93ZyGQ==",
+        "resolved": "4.0.3.4",
+        "contentHash": "BWJ4sqzL5L8+5yetkpr86U9nqc9BXTEZy9h5WGlCEGydf6Pixf0UKrMa3xwZ2X7rubRDIA856m5HDvOTC5VLEQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -835,6 +835,21 @@
           "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.identity.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Identity.Abstractions": "[0.1.0-dev, )",
+          "Granit.IpGeolocation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity.local": {
         "type": "Project",
         "dependencies": {
@@ -872,10 +887,19 @@
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
+          "Granit.Identity.Endpoints": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ipgeolocation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.IpGeolocation.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ipgeolocation.abstractions": {
@@ -981,11 +1005,28 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.settings": {

--- a/tests/Granit.TextExtraction.Email.Tests/packages.lock.json
+++ b/tests/Granit.TextExtraction.Email.Tests/packages.lock.json
@@ -338,8 +338,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.TextExtraction.Text.Tests/packages.lock.json
+++ b/tests/Granit.TextExtraction.Text.Tests/packages.lock.json
@@ -318,8 +318,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.0",
-        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+        "resolved": "1.5.1",
+        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
       },
       "Markdig": {
         "type": "CentralTransitive",

--- a/tests/Granit.Vault.Aws.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Aws.Tests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9",
-        "contentHash": "++VT2Q80ieKgJaSkD4WsIB+lSwDbkOn45AJ89M4zMZyuogW3AeUG915ePy7hAcfpujTWnf39cUgNDA30c45IpA=="
+        "resolved": "4.0.9.2",
+        "contentHash": "BW8nJkdjRFWMqk1ufvqUMqF+Axx+lJX/HTst6eKQw//PQf2wUx8i9xf5MSItazHZeatOVLLhZhwyALIlsiQD7g=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -407,19 +407,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.4",
-        "contentHash": "T20E+szAWTGBH+/64223haNw3zExzGoF7bvmO+A/oqaY1iesypHn5N6jzzcwPANQ+md9kvDFB3ifb2lzAbzEMw==",
+        "resolved": "4.0.12.5",
+        "contentHash": "RnICgGseExGrWk9W9bakozkfzHYeWqJZ4oCVYnCxBY9/Lm9slmtezvMfjhALBmzY8aLqO7p+RddS8Hm2H4nh4g==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.5.3",
-        "contentHash": "WQsetMo2H2EFcrI9fShTOZ2x6W+d1f+FueXd3t+bwO4AGabiCsCXW6+GVYKO4WTX4LW+c29SEdDs5t3wfbl/OQ==",
+        "resolved": "4.0.5.4",
+        "contentHash": "vKjc1Hlx1grNNXgLQuxI3n0mWxwvmv0T43/bsGh9Hk97PbCzlatpzb1Ky+36LBHJMOPVWsHTURIF/JBAgKF3Cw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.2, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {


### PR DESCRIPTION
## Problem

CI restore in **locked mode** fails with `NU1004` on the `integration` and `src-only` shards:

> A new project reference to `Granit.Identity.Endpoints` was found for net10.0 … the packages lock file is inconsistent with the project dependencies.

#2700 (Trusted devices) added a `ProjectReference` from `Granit.Identity.Local.Endpoints` → `Granit.Identity.Endpoints`, but the **downstream consumers'** `packages.lock.json` were never force-evaluated: `Granit.OpenIddict.Tests.Integration`, `Granit.Identity.Local.AspNetIdentity.Tests.Integration`, `Granit.Bundle.OpenIddict`, `Granit.OpenApi.Generator`.

## Fix

`dotnet restore Granit.slnx --force-evaluate` regenerates **42** stale lock files:
- the new transitive `Granit.Identity.Endpoints` project reference on the consumers, and
- accumulated `CentralTransitive` patch floats (e.g. `1.5.0 → 1.5.1`) that locked mode would fail on next.

**No direct dependency changed** (all bumps are `CentralTransitive`) → `THIRD-PARTY-NOTICES.md` is unaffected. Only `packages.lock.json` files are touched — no source/build changes.

## Verification

Locked-mode restore now passes on the previously-failing shards:

```
dotnet restore .github/shard-filters/integration.slnf --locked-mode   # ✅
dotnet restore .github/shard-filters/src-only.slnf    --locked-mode   # ✅
```