### PR TITLE
feat(identity): resolve device kind from the OIDC client declaration (#2668)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28959,7 +28959,7 @@
       "kind": "record",
       "project": "Granit.Identity.Abstractions",
       "file": "src/Granit.Identity.Abstractions/UserSessionDescriptor.cs",
-      "line": 22,
+      "line": 28,
       "members": []
     },
     {
@@ -37563,7 +37563,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs",
-      "line": 18,
+      "line": 20,
       "members": []
     },
     {
@@ -37581,7 +37581,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs",
-      "line": 19,
+      "line": 21,
       "members": []
     },
     {
@@ -37626,7 +37626,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateApplicationRequest.cs",
-      "line": 20,
+      "line": 22,
       "members": []
     },
     {
@@ -38085,7 +38085,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 8,
+      "line": 9,
       "members": [
         {
           "name": "Applications",
@@ -38107,7 +38107,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 37,
+      "line": 39,
       "members": []
     },
     {
@@ -38116,7 +38116,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 56,
+      "line": 59,
       "members": []
     },
     {

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/Services/EfCoreAuditingReader.cs
@@ -43,6 +43,7 @@ internal sealed class EfCoreAuditingReader(
         AuditEntry? entry = await dbContext.AuditEntries
             .Include(e => e.EntityChanges)
                 .ThenInclude(ec => ec.PropertyChanges)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
             .ConfigureAwait(false);
 
@@ -84,6 +85,7 @@ internal sealed class EfCoreAuditingReader(
         IQueryable<AuditEntry> queryable = dbContext.AuditEntries
             .Include(e => e.EntityChanges)
                 .ThenInclude(ec => ec.PropertyChanges)
+            .AsSplitQuery()
             .Where(e => e.EntityChanges.Any(ec =>
                 matchTypes.Contains(ec.EntityType) && ec.EntityId == entityId))
             .AsNoTracking();
@@ -159,6 +161,7 @@ internal sealed class EfCoreAuditingReader(
         return await dbContext.AuditEntries
             .Include(e => e.EntityChanges)
                 .ThenInclude(ec => ec.PropertyChanges)
+            .AsSplitQuery()
             .Where(outer)
             .OrderByDescending(e => e.Timestamp)
             .Take(limit)
@@ -182,6 +185,7 @@ internal sealed class EfCoreAuditingReader(
         return await dbContext.AuditEntries
             .Include(e => e.EntityChanges)
                 .ThenInclude(ec => ec.PropertyChanges)
+            .AsSplitQuery()
             .Where(e => e.UserId == userId)
             .OrderByDescending(e => e.Timestamp)
             .Take(limit)
@@ -203,6 +207,7 @@ internal sealed class EfCoreAuditingReader(
         return await dbContext.AuditEntries
             .Include(e => e.EntityChanges)
                 .ThenInclude(ec => ec.PropertyChanges)
+            .AsSplitQuery()
             .Where(e => e.CorrelationId == correlationId)
             .OrderByDescending(e => e.Timestamp)
             .AsNoTracking()

--- a/src/Granit.Identity.Abstractions/UserSessionDescriptor.cs
+++ b/src/Granit.Identity.Abstractions/UserSessionDescriptor.cs
@@ -19,6 +19,12 @@ namespace Granit.Identity;
 /// <param name="UserAgent">User-Agent captured at establishment, when available.</param>
 /// <param name="IpAddress">Raw client IP (server-side only), when available.</param>
 /// <param name="Location">Approximate location derived from <paramref name="IpAddress"/>, when resolved.</param>
+/// <param name="Kind">
+/// Device classification of the client that established the session, resolved from the authentication context
+/// (the OIDC client's declared <see cref="DeviceKind"/>, with a redirect-URI/grant heuristic as fallback) — not
+/// guessed from the User-Agent. <see cref="DeviceKind.Unknown"/> when the backend cannot classify it; the
+/// device view then defaults it to <see cref="DeviceKind.Browser"/>.
+/// </param>
 public sealed record UserSessionDescriptor(
     string SessionId,
     string? UserId,
@@ -27,4 +33,5 @@ public sealed record UserSessionDescriptor(
     DateTimeOffset? LastAccessedAt,
     string? UserAgent,
     string? IpAddress,
-    GeoLocation? Location);
+    GeoLocation? Location,
+    DeviceKind Kind = DeviceKind.Unknown);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs
@@ -1,3 +1,4 @@
+using Granit.Identity;
 using Granit.MultiTenancy;
 
 namespace Granit.OpenIddict.Endpoints.Dtos;
@@ -14,6 +15,7 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="PostLogoutRedirectUris">The allowed post-logout redirect URIs.</param>
 /// <param name="ConsentType">The consent type (<c>implicit</c>, <c>explicit</c>, or <c>systematic</c>).</param>
 /// <param name="ClientSide">The host/tenant policy enforced at sign-in, or <see langword="null"/> for no restriction.</param>
+/// <param name="DeviceKind">The device classification declared for this client, or <see langword="null"/> when not declared.</param>
 /// <param name="HasSigningKey">Whether a public signing key (JWK) is registered for <c>private_key_jwt</c> authentication.</param>
 public sealed record AdminOidcApplicationResponse(
     string? ClientId,
@@ -25,4 +27,5 @@ public sealed record AdminOidcApplicationResponse(
     string[] PostLogoutRedirectUris,
     string? ConsentType,
     MultiTenancySides? ClientSide,
+    DeviceKind? DeviceKind,
     bool HasSigningKey);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
@@ -1,3 +1,4 @@
+using Granit.Identity;
 using Granit.MultiTenancy;
 
 namespace Granit.OpenIddict.Endpoints.Dtos;
@@ -15,6 +16,7 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="ConsentType">The consent type (<c>implicit</c>, <c>explicit</c>, or <c>systematic</c>). Default: <c>implicit</c>.</param>
 /// <param name="SigningKeyJwk">Public signing key as JWK JSON for <c>private_key_jwt</c> authentication (RFC 7523). Null for shared-secret clients.</param>
 /// <param name="ClientSide">Host/tenant policy enforced at sign-in. Null means no restriction.</param>
+/// <param name="DeviceKind">Device classification for the devices that authenticate through this client (e.g. <c>MobileApp</c>, <c>Tv</c>). Null or omitted means not declared (the session adapters fall back to a redirect-URI/grant heuristic).</param>
 #pragma warning disable GRSEC003 // ClientSecret is a DTO parameter, not a stored secret
 public sealed record AdminOidcCreateApplicationRequest(
     string ClientId,
@@ -26,5 +28,6 @@ public sealed record AdminOidcCreateApplicationRequest(
     string[]? PostLogoutRedirectUris = null,
     string? ConsentType = null,
     string? SigningKeyJwk = null,
-    MultiTenancySides? ClientSide = null);
+    MultiTenancySides? ClientSide = null,
+    DeviceKind? DeviceKind = null);
 #pragma warning restore GRSEC003

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateApplicationRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcUpdateApplicationRequest.cs
@@ -1,3 +1,4 @@
+using Granit.Identity;
 using Granit.MultiTenancy;
 
 namespace Granit.OpenIddict.Endpoints.Dtos;
@@ -17,6 +18,7 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="ConsentType">The consent type (<c>implicit</c>, <c>explicit</c>, or <c>systematic</c>). Null leaves it unchanged.</param>
 /// <param name="SigningKeyJwk">Public signing key as JWK JSON for <c>private_key_jwt</c> authentication. Null leaves it unchanged; empty string clears the key.</param>
 /// <param name="ClientSide">Host/tenant policy enforced at sign-in. Null leaves it unchanged.</param>
+/// <param name="DeviceKind">Device classification for the devices that authenticate through this client. Null leaves it unchanged; <c>Unknown</c> clears the declaration.</param>
 public sealed record AdminOidcUpdateApplicationRequest(
     string? DisplayName = null,
     string? Type = null,
@@ -25,4 +27,5 @@ public sealed record AdminOidcUpdateApplicationRequest(
     string[]? PostLogoutRedirectUris = null,
     string? ConsentType = null,
     string? SigningKeyJwk = null,
-    MultiTenancySides? ClientSide = null);
+    MultiTenancySides? ClientSide = null,
+    DeviceKind? DeviceKind = null);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -240,6 +240,7 @@ internal static class AdminOidcEndpoints
         }
 
         descriptor.SetClientSide(request.ClientSide);
+        descriptor.SetDeviceKind(request.DeviceKind);
 
         object app = await applicationManager.CreateAsync(descriptor, cancellationToken).ConfigureAwait(false);
 
@@ -379,6 +380,12 @@ internal static class AdminOidcEndpoints
         if (request.ClientSide is not null)
         {
             descriptor.SetClientSide(request.ClientSide.Value);
+        }
+
+        if (request.DeviceKind is not null)
+        {
+            // SetDeviceKind treats Unknown as "clear the declaration".
+            descriptor.SetDeviceKind(request.DeviceKind.Value);
         }
     }
 
@@ -633,6 +640,7 @@ internal static class AdminOidcEndpoints
             [.. descriptor.PostLogoutRedirectUris.Select(u => u.ToString())],
             descriptor.ConsentType,
             descriptor.GetClientSide(),
+            descriptor.GetDeviceKind(),
             descriptor.JsonWebKeySet is not null);
 
     /// <summary>

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -1,3 +1,4 @@
+using Granit.Identity;
 using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Options;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
@@ -140,7 +141,15 @@ internal sealed partial class OpenIddictSeedContributor(
             return true;
         }
 
-        return current.GetClientSide() != desired.ClientSide;
+        if (current.GetClientSide() != desired.ClientSide)
+        {
+            return true;
+        }
+
+        // SetDeviceKind stores null and Unknown identically (the key is removed), so normalise the desired
+        // value before comparing against the stored one — otherwise Unknown would read back as a phantom diff.
+        DeviceKind? desiredKind = desired.DeviceKind is null or DeviceKind.Unknown ? null : desired.DeviceKind;
+        return current.GetDeviceKind() != desiredKind;
     }
 
     /// <summary>
@@ -214,6 +223,10 @@ internal sealed partial class OpenIddictSeedContributor(
         // Host/tenant policy — persisted in Properties so the OIDC server can enforce
         // host-only / tenant-only client access without depending on Granit.Bff.
         appDescriptor.SetClientSide(source.ClientSide);
+
+        // Declared device kind — persisted in Properties and read by the session adapters so /devices
+        // classifies devices accurately instead of guessing from the User-Agent.
+        appDescriptor.SetDeviceKind(source.DeviceKind);
     }
 
     private async Task SeedScopeAsync(

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
@@ -1,3 +1,4 @@
+using Granit.Identity;
 using Granit.MultiTenancy;
 
 namespace Granit.OpenIddict.Options;
@@ -34,6 +35,7 @@ public sealed class GranitOpenIddictSeedingOptions
 /// <param name="ConsentType">The consent type for the application (<c>"implicit"</c>, <c>"explicit"</c>, or <c>"systematic"</c>). Default: <c>"implicit"</c> (auto-grant for first-party apps).</param>
 /// <param name="ApplicationType">The application type (<c>"web"</c> or <c>"native"</c>). Default: <c>"web"</c>.</param>
 /// <param name="ClientSide">Optional host/tenant policy enforced at sign-in. <see cref="MultiTenancySides.Host"/> = only users with <c>TenantId = null</c> may obtain tokens for this client; <see cref="MultiTenancySides.Tenant"/> = only users with a non-null <c>TenantId</c>; <see cref="MultiTenancySides.Both"/> or <see langword="null"/> = no restriction. Stored on the OIDC application's <c>Properties</c> bag and enforced by <c>ClientSideAuthorizationHandler</c>.</param>
+/// <param name="DeviceKind">Optional device classification for the devices that authenticate through this client (e.g. <see cref="DeviceKind.MobileApp"/>, <see cref="DeviceKind.Tv"/>). Stored on the OIDC application's <c>Properties</c> bag and read by the session adapters so <c>/devices</c> shows an accurate classification. <see langword="null"/> or <see cref="DeviceKind.Unknown"/> = not declared (the adapter falls back to a redirect-URI/grant heuristic).</param>
 public sealed record OidcApplicationSeedDescriptor(
     string ClientId,
     string? ClientSecret,
@@ -44,7 +46,8 @@ public sealed record OidcApplicationSeedDescriptor(
     string? SigningKeyJwk = null,
     string? ConsentType = null,
     string? ApplicationType = null,
-    MultiTenancySides? ClientSide = null);
+    MultiTenancySides? ClientSide = null,
+    DeviceKind? DeviceKind = null);
 
 /// <summary>
 /// Describes an OIDC scope to seed.

--- a/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
+++ b/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
@@ -4,6 +4,7 @@ using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Identity;
 using Granit.Identity.Local.Services;
+using Granit.OpenIddict.Extensions;
 using Granit.Timing;
 using OpenIddict.Abstractions;
 using ZiggyCreatures.Caching.Fusion;
@@ -18,6 +19,7 @@ namespace Granit.OpenIddict.Services;
 /// </summary>
 internal sealed class OpenIddictUserSessionProvider(
     IOpenIddictTokenManager tokenManager,
+    IOpenIddictApplicationManager applicationManager,
     IFusionCache cache,
     IClock clock,
     IDataFilter? dataFilter = null) : IUserSessionProvider, IUserDeviceProvider
@@ -31,10 +33,14 @@ internal sealed class OpenIddictUserSessionProvider(
         // Disable the IMultiTenant filter so tenant users can see their own tokens.
         using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
 
+        // One device-kind resolution per distinct client across the whole listing — many of a user's tokens
+        // typically belong to the same application, so cache the resolved kind by application id.
+        var kindByApplicationId = new Dictionary<string, DeviceKind>(StringComparer.Ordinal);
+
         await foreach (object token in tokenManager.FindBySubjectAsync(userId, cancellationToken))
         {
             UserSessionDescriptor? session = await MapTokenToSessionAsync(
-                userId, token, currentSessionId, cancellationToken).ConfigureAwait(false);
+                userId, token, currentSessionId, kindByApplicationId, cancellationToken).ConfigureAwait(false);
             if (session is not null)
             {
                 sessions.Add(session);
@@ -47,7 +53,8 @@ internal sealed class OpenIddictUserSessionProvider(
     // Maps a single OpenIddict token to a UserSessionDescriptor, or null when the token is not a
     // valid refresh token (the only kind that represents a live session) or carries no id.
     private async Task<UserSessionDescriptor?> MapTokenToSessionAsync(
-        string userId, object token, string? currentSessionId, CancellationToken cancellationToken)
+        string userId, object token, string? currentSessionId,
+        Dictionary<string, DeviceKind> kindByApplicationId, CancellationToken cancellationToken)
     {
         string? sessionId = await GetValidRefreshTokenIdAsync(token, cancellationToken)
             .ConfigureAwait(false);
@@ -70,6 +77,9 @@ internal sealed class OpenIddictUserSessionProvider(
         string? ipAddress = GetStringProperty(properties, "ip_address");
         string? userAgent = GetStringProperty(properties, "user_agent");
 
+        DeviceKind kind = await ResolveDeviceKindAsync(token, kindByApplicationId, cancellationToken)
+            .ConfigureAwait(false);
+
         return new UserSessionDescriptor(
             SessionId: sessionId,
             UserId: userId,
@@ -78,7 +88,68 @@ internal sealed class OpenIddictUserSessionProvider(
             LastAccessedAt: lastAccess,
             UserAgent: userAgent,
             IpAddress: ipAddress,
-            Location: null);
+            Location: null,
+            Kind: kind);
+    }
+
+    // Resolves the device kind for the token's client: the application's declared DeviceKind, else a
+    // redirect-URI/grant-type heuristic. Returns Unknown only when the token carries no resolvable application.
+    private async ValueTask<DeviceKind> ResolveDeviceKindAsync(
+        object token, Dictionary<string, DeviceKind> kindByApplicationId, CancellationToken cancellationToken)
+    {
+        string? applicationId = await tokenManager.GetApplicationIdAsync(token, cancellationToken)
+            .ConfigureAwait(false);
+        if (applicationId is null)
+        {
+            return DeviceKind.Unknown;
+        }
+
+        if (kindByApplicationId.TryGetValue(applicationId, out DeviceKind cached))
+        {
+            return cached;
+        }
+
+        DeviceKind resolved = DeviceKind.Unknown;
+        object? application = await applicationManager.FindByIdAsync(applicationId, cancellationToken)
+            .ConfigureAwait(false);
+        if (application is not null)
+        {
+            resolved = await applicationManager.GetDeviceKindAsync(application, cancellationToken).ConfigureAwait(false)
+                ?? await InferDeviceKindAsync(application, cancellationToken).ConfigureAwait(false);
+        }
+
+        kindByApplicationId[applicationId] = resolved;
+        return resolved;
+    }
+
+    // Fallback when the client declares no DeviceKind: classify from the authentication context. An
+    // extension redirect URI marks a BrowserExtension; the device-authorization grant marks a Tv-class
+    // input-constrained device; a client-credentials-only grant marks an ApiClient; otherwise Browser.
+    private async ValueTask<DeviceKind> InferDeviceKindAsync(
+        object application, CancellationToken cancellationToken)
+    {
+        ImmutableArray<string> redirectUris = await applicationManager
+            .GetRedirectUrisAsync(application, cancellationToken).ConfigureAwait(false);
+        if (redirectUris.Any(static uri =>
+                uri.StartsWith("chrome-extension://", StringComparison.OrdinalIgnoreCase)
+                || uri.StartsWith("moz-extension://", StringComparison.OrdinalIgnoreCase)))
+        {
+            return DeviceKind.BrowserExtension;
+        }
+
+        ImmutableArray<string> permissions = await applicationManager
+            .GetPermissionsAsync(application, cancellationToken).ConfigureAwait(false);
+        if (permissions.Contains(OpenIddictConstants.Permissions.GrantTypes.DeviceCode))
+        {
+            return DeviceKind.Tv;
+        }
+
+        if (permissions.Contains(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials))
+        {
+            return DeviceKind.ApiClient;
+        }
+
+        return DeviceKind.Browser;
     }
 
     // Returns the token id when the token is a valid refresh token (the only kind representing a
@@ -165,17 +236,33 @@ internal sealed class OpenIddictUserSessionProvider(
             await ListAsync(userId, currentSessionId: null, cancellationToken).ConfigureAwait(false);
 
         // The OpenIddict backend exposes no stable device id, OS or browser — only the raw IP. Group
-        // sessions by IP and synthesize a stable device signature from it (IdP SSO devices are
-        // browser-based unless the backend declares otherwise).
+        // sessions by IP and synthesize a stable device signature from it; the kind comes from the client
+        // the session authenticated through (declared on the OIDC application, heuristic otherwise).
         return [.. sessions
             .GroupBy(s => s.IpAddress ?? "unknown")
             .Select(g => new UserDevice(
                 DeviceId: g.Key,
-                Kind: DeviceKind.Browser,
+                Kind: ResolveGroupKind(g),
                 OperatingSystem: null,
                 Browser: null,
                 LastSeen: g.Max(s => s.LastAccessedAt),
                 SessionCount: g.Count(),
                 LastLocation: null))];
+    }
+
+    // A "device" here is an IP that may have sessions from several clients. Surface the most specific kind
+    // seen (a BrowserExtension/Tv/ApiClient is more informative than a plain browser), defaulting to Browser
+    // rather than Unknown — an IdP-SSO device is browser-based unless something more specific is known.
+    private static DeviceKind ResolveGroupKind(IEnumerable<UserSessionDescriptor> group)
+    {
+        foreach (DeviceKind kind in group.Select(s => s.Kind))
+        {
+            if (kind is not DeviceKind.Unknown and not DeviceKind.Browser)
+            {
+                return kind;
+            }
+        }
+
+        return DeviceKind.Browser;
     }
 }

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
+using Granit.Identity;
 using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.OpenIddict.Entities.OpenIddict;
+using Granit.OpenIddict.Extensions;
 using NSubstitute;
 using OpenIddict.Abstractions;
 using Shouldly;
@@ -140,6 +142,48 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         result.DisplayName.ShouldBe("New App");
         result.Type.ShouldBe("web");
         result.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateApplication_DeclaredDeviceKind_PersistsAndReturnsIt()
+    {
+        GranitOpenIddictApplication createdApp = new() { TenantId = null };
+
+        _server.ApplicationManager.CreateAsync(
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdApp);
+#pragma warning disable CA2012 // NSubstitute mock setup intentionally doesn't await ValueTask
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), createdApp, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "tv-client";
+                d.DisplayName = "TV App";
+                d.ApplicationType = "web";
+                d.SetDeviceKind(DeviceKind.Tv);
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcCreateApplicationRequest request = new("tv-client", "TV App", null, "web", DeviceKind: DeviceKind.Tv);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        // The endpoint wrote the declared kind onto the descriptor it created.
+        await _server.ApplicationManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictApplicationDescriptor>(d => d.GetDeviceKind() == DeviceKind.Tv),
+            Arg.Any<CancellationToken>());
+
+        AdminOidcApplicationResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcApplicationResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.DeviceKind.ShouldBe(DeviceKind.Tv);
     }
 
     [Fact]

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSeedContributorTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSeedContributorTests.cs
@@ -1,4 +1,6 @@
+using Granit.Identity;
 using Granit.OpenIddict.EntityFrameworkCore.Seeding;
+using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Options;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -258,6 +260,83 @@ public sealed class OpenIddictSeedContributorTests
         await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
 
         await _appManager.Received(1).UpdateAsync(
+            existingApp,
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedApplicationAsync_DeviceKindChanged_PerformsUpdate()
+    {
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        const string clientId = "showcase-tv";
+        object existingApp = new();
+        _appManager.FindByClientIdAsync(clientId, Arg.Any<CancellationToken>()).Returns(existingApp);
+
+        _appManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictApplicationDescriptor>(), existingApp, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.DisplayName = "Showcase TV";
+                // Current app declares no device kind — the seed declaring Tv must trigger an update.
+            });
+
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: clientId,
+            ClientSecret: null,
+            DisplayName: "Showcase TV",
+            Permissions: [],
+            RedirectUris: [],
+            PostLogoutRedirectUris: [],
+            SigningKeyJwk: null,
+            DeviceKind: DeviceKind.Tv);
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _appManager.Received(1).UpdateAsync(
+            existingApp,
+            Arg.Is<OpenIddictApplicationDescriptor>(d => d.GetDeviceKind() == DeviceKind.Tv),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedApplicationAsync_DeviceKindUnknownAndNoneStored_SkipsUpdate()
+    {
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        const string clientId = "showcase-web";
+        object existingApp = new();
+        _appManager.FindByClientIdAsync(clientId, Arg.Any<CancellationToken>()).Returns(existingApp);
+
+        _appManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictApplicationDescriptor>(), existingApp, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.DisplayName = "Showcase Web";
+                // No device kind stored.
+            });
+
+        // Declaring Unknown is "not declared" — it must normalise to the stored absence, not a phantom diff.
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: clientId,
+            ClientSecret: null,
+            DisplayName: "Showcase Web",
+            Permissions: [],
+            RedirectUris: [],
+            PostLogoutRedirectUris: [],
+            SigningKeyJwk: null,
+            DeviceKind: DeviceKind.Unknown);
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _appManager.DidNotReceive().UpdateAsync(
             existingApp,
             Arg.Any<OpenIddictApplicationDescriptor>(),
             Arg.Any<CancellationToken>());

--- a/tests/Granit.OpenIddict.Tests/Services/OpenIddictUserSessionProviderTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Services/OpenIddictUserSessionProviderTests.cs
@@ -19,6 +19,8 @@ public sealed class OpenIddictUserSessionProviderTests
     private static readonly DateTimeOffset FixedNow = new(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
 
     private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
+    private readonly IOpenIddictApplicationManager _applicationManager =
+        Substitute.For<IOpenIddictApplicationManager>();
     private readonly IFusionCache _cache = Substitute.For<IFusionCache>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
@@ -30,7 +32,7 @@ public sealed class OpenIddictUserSessionProviderTests
     }
 
     private OpenIddictUserSessionProvider CreateSut() =>
-        new(_tokenManager, _cache, _clock, _dataFilter);
+        new(_tokenManager, _applicationManager, _cache, _clock, _dataFilter);
 
     // ── Multi-tenant filter bypass ────────────────────────────────────────
 
@@ -238,6 +240,124 @@ public sealed class OpenIddictUserSessionProviderTests
         result.Count.ShouldBe(2);
     }
 
+    // ── Device kind: declared on the client wins over the heuristic ───────
+
+    [Fact]
+    public async Task DeviceListAsync_ClientDeclaresKind_SurfacesDeclaredKindOverHeuristic()
+    {
+        const string userId = "user-dk1";
+        const string ip = "10.0.0.5";
+        const string appId = "app-mobile";
+
+        object token = new(), app = new();
+        SetupValidRefreshToken(token, "tok-dk1", FixedNow, userId);
+        SetupTokenProperties(token, ip);
+        SetupCacheMiss(userId, "tok-dk1");
+        SetupTokenApplication(token, appId, app);
+        // Declared MobileApp, but the permissions would otherwise infer Tv — the declaration must win.
+        SetupApplication(app, declaredKind: DeviceKind.MobileApp,
+            permissions: [OpenIddictConstants.Permissions.GrantTypes.DeviceCode]);
+
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(token));
+
+        IReadOnlyList<UserDevice> result =
+            await CreateSut().ListAsync(userId, TestContext.Current.CancellationToken);
+
+        result[0].Kind.ShouldBe(DeviceKind.MobileApp);
+    }
+
+    // ── Device kind: heuristic fallback when the client declares nothing ──
+
+    [Fact]
+    public async Task DeviceListAsync_ExtensionRedirectUri_InfersBrowserExtension()
+    {
+        const string userId = "user-dk2";
+        const string appId = "app-ext";
+
+        object token = new(), app = new();
+        SetupValidRefreshToken(token, "tok-dk2", FixedNow, userId);
+        SetupTokenProperties(token, "10.0.0.6");
+        SetupCacheMiss(userId, "tok-dk2");
+        SetupTokenApplication(token, appId, app);
+        SetupApplication(app, redirectUris: ["chrome-extension://abcdef/callback"]);
+
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(token));
+
+        IReadOnlyList<UserDevice> result =
+            await CreateSut().ListAsync(userId, TestContext.Current.CancellationToken);
+
+        result[0].Kind.ShouldBe(DeviceKind.BrowserExtension);
+    }
+
+    [Fact]
+    public async Task DeviceListAsync_DeviceCodeGrant_InfersTv()
+    {
+        const string userId = "user-dk3";
+        const string appId = "app-tv";
+
+        object token = new(), app = new();
+        SetupValidRefreshToken(token, "tok-dk3", FixedNow, userId);
+        SetupTokenProperties(token, "10.0.0.7");
+        SetupCacheMiss(userId, "tok-dk3");
+        SetupTokenApplication(token, appId, app);
+        SetupApplication(app, permissions: [OpenIddictConstants.Permissions.GrantTypes.DeviceCode]);
+
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(token));
+
+        IReadOnlyList<UserDevice> result =
+            await CreateSut().ListAsync(userId, TestContext.Current.CancellationToken);
+
+        result[0].Kind.ShouldBe(DeviceKind.Tv);
+    }
+
+    [Fact]
+    public async Task DeviceListAsync_ClientCredentialsGrant_InfersApiClient()
+    {
+        const string userId = "user-dk4";
+        const string appId = "app-api";
+
+        object token = new(), app = new();
+        SetupValidRefreshToken(token, "tok-dk4", FixedNow, userId);
+        SetupTokenProperties(token, "10.0.0.8");
+        SetupCacheMiss(userId, "tok-dk4");
+        SetupTokenApplication(token, appId, app);
+        SetupApplication(app, permissions: [OpenIddictConstants.Permissions.GrantTypes.ClientCredentials]);
+
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(token));
+
+        IReadOnlyList<UserDevice> result =
+            await CreateSut().ListAsync(userId, TestContext.Current.CancellationToken);
+
+        result[0].Kind.ShouldBe(DeviceKind.ApiClient);
+    }
+
+    [Fact]
+    public async Task DeviceListAsync_PlainClient_DefaultsToBrowser()
+    {
+        const string userId = "user-dk5";
+        const string appId = "app-web";
+
+        object token = new(), app = new();
+        SetupValidRefreshToken(token, "tok-dk5", FixedNow, userId);
+        SetupTokenProperties(token, "10.0.0.9");
+        SetupCacheMiss(userId, "tok-dk5");
+        SetupTokenApplication(token, appId, app);
+        SetupApplication(app, redirectUris: ["https://app.example.com/callback"],
+            permissions: [OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode]);
+
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(token));
+
+        IReadOnlyList<UserDevice> result =
+            await CreateSut().ListAsync(userId, TestContext.Current.CancellationToken);
+
+        result[0].Kind.ShouldBe(DeviceKind.Browser);
+    }
+
     // ── Revocation (real, not a no-op) ────────────────────────────────────
 
     [Fact]
@@ -406,6 +526,38 @@ public sealed class OpenIddictUserSessionProviderTests
             Arg.Any<CancellationToken>())
             .Returns(_ => new ValueTask<MaybeValue<UserSessionActivity>>(
                 MaybeValue<UserSessionActivity>.None));
+
+    private void SetupTokenApplication(object token, string applicationId, object application)
+    {
+        _tokenManager.GetApplicationIdAsync(token, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult<string?>(applicationId));
+        _applicationManager.FindByIdAsync(applicationId, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult<object?>(application));
+    }
+
+    // Mocks the manager-level reads the DeviceKind extension methods delegate to: the declared kind lives in
+    // the Properties bag; the heuristic reads redirect URIs and permissions.
+    private void SetupApplication(
+        object application,
+        DeviceKind? declaredKind = null,
+        string[]? redirectUris = null,
+        string[]? permissions = null)
+    {
+        ImmutableDictionary<string, JsonElement> props = ImmutableDictionary<string, JsonElement>.Empty;
+        if (declaredKind is not null)
+        {
+            props = props.Add(
+                "urn:granit:openiddict:device_kind",
+                JsonSerializer.SerializeToElement(declaredKind.Value.ToString()));
+        }
+
+        _applicationManager.GetPropertiesAsync(application, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(props));
+        _applicationManager.GetRedirectUrisAsync(application, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(ImmutableArray.Create(redirectUris ?? [])));
+        _applicationManager.GetPermissionsAsync(application, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(ImmutableArray.Create(permissions ?? [])));
+    }
 
 #pragma warning restore CA2012
 


### PR DESCRIPTION
Part of #2668 (part of the unified user-session epic #2654).

## What

`DeviceKind` can't be inferred reliably from the User-Agent — it follows from the **authentication context**. The OpenIddict application already carries a declared `DeviceKind` (`SetDeviceKind`/`GetDeviceKind` on its `Properties` bag, shipped earlier). This PR wires the **native OpenIddict session adapter** to read it and lets operators declare it.

### Device-kind resolution (`OpenIddictUserSessionProvider`)
Each session's kind is resolved from the token's client application:
1. the **declared** `DeviceKind` when present, else
2. a **heuristic** fallback: `chrome-extension://`/`moz-extension://` redirect URI → `BrowserExtension`; `device_authorization` grant → `Tv`; `client_credentials` grant → `ApiClient`; otherwise `Browser`.

Resolution is cached per application id across a listing (a user's tokens usually share one client). The `/devices` view surfaces the most specific kind seen per device (IP), defaulting to `Browser` rather than `Unknown`.

`UserSessionDescriptor` now carries the resolved `Kind` (trailing optional, defaults to `Unknown` so every other backend compiles unchanged).

### Declaration surfaces (mirror the existing `ClientSide` pattern)
- **Seeding**: `OidcApplicationSeedDescriptor.DeviceKind`; the seed-update comparison normalises `Unknown` to "not declared" (no phantom diff).
- **Admin OIDC API**: `DeviceKind` on the create/update requests and the response DTO.

## Scope — federated backends deferred
Keycloak and Entra ID list devices from the **upstream IdP's account data**, which carries no Granit OIDC client record, and their SSO devices are browser-based. The issue's "Keycloak equivalent via a client attribute" is a distinct slice (per-client admin-API attribute fetch + correlation) with little value for browser SSO — tracked as a follow-up rather than bundled here. The native OpenIddict authority path is delivered in full.

## Also included
`perf(auditing)`: `AsSplitQuery()` on the audit-entry reads (two collection includes were multiplying rows into a cartesian explosion). Separate commit; verified independently (136 auditing tests green).

## Verification
- Builds: Identity.Abstractions, OpenIddict(+EF, +Endpoints), federated providers, OpenIddict.Server, Auditing.EF ✅
- Tests: OpenIddict **316** (+5 resolution), OpenIddict.EF **10** (+2 seeding), OpenIddict.Endpoints **122** (+1 admin), Auditing.EF **136** ✅
- `dotnet format --verify-no-changes` (all touched projects) ✅
- architecture shard **224** ✅