### PR TITLE
fix(identity): wire session providers deterministically so /sessions stops silently returning 200 []

### DIFF
--- a/.github/shard-filters/security.slnf
+++ b/.github/shard-filters/security.slnf
@@ -38,6 +38,7 @@
       "src/Granit.BackgroundJobs/Granit.BackgroundJobs.csproj",
       "src/Granit.Bff.BackgroundJobs/Granit.Bff.BackgroundJobs.csproj",
       "src/Granit.Bff.EntityFrameworkCore/Granit.Bff.EntityFrameworkCore.csproj",
+      "src/Granit.Bff.UserSessions/Granit.Bff.UserSessions.csproj",
       "src/Granit.Bff/Granit.Bff.csproj",
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10493,7 +10493,7 @@
       "kind": "class",
       "project": "Granit.Bff.UserSessions",
       "file": "src/Granit.Bff.UserSessions/GranitBffUserSessionsModule.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureServices",
@@ -24233,7 +24233,7 @@
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
       "file": "src/Granit.Identity.Endpoints/Extensions/UserSessionEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitUserSessions",
@@ -24688,6 +24688,15 @@
           "returnType": "IServiceCollection"
         }
       ]
+    },
+    {
+      "name": "UserSessionProviderServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Extensions.UserSessionProviderServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/Extensions/UserSessionProviderServiceCollectionExtensions.cs",
+      "line": 21,
+      "members": []
     },
     {
       "name": "GranitIdentityFederatedCognitoBackgroundJobsModule",
@@ -25959,6 +25968,15 @@
           "returnType": "Task"
         }
       ]
+    },
+    {
+      "name": "IFallbackUserSessionProvider",
+      "fqn": "Granit.Identity.IFallbackUserSessionProvider",
+      "kind": "interface",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/IFallbackUserSessionProvider.cs",
+      "line": 8,
+      "members": []
     },
     {
       "name": "IIdentityClientRoleManager",
@@ -28960,6 +28978,15 @@
       "project": "Granit.Identity.Abstractions",
       "file": "src/Granit.Identity.Abstractions/UserSessionDescriptor.cs",
       "line": 28,
+      "members": []
+    },
+    {
+      "name": "UserSessionProviderPrecedence",
+      "fqn": "Granit.Identity.UserSessionProviderPrecedence",
+      "kind": "enum",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/UserSessionProviderPrecedence.cs",
+      "line": 14,
       "members": []
     },
     {
@@ -37842,7 +37869,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "AddGranitOpenIddict",
@@ -37977,6 +38004,22 @@
           "kind": "method",
           "signature": "SetDeviceKind(this OpenIddictApplicationDescriptor descriptor, DeviceKind? deviceKind)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "OpenIddictUserSessionServiceCollectionExtensions",
+      "fqn": "Granit.OpenIddict.Extensions.OpenIddictUserSessionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Extensions/OpenIddictUserSessionServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddOpenIddictUserSessionProvider",
+          "kind": "method",
+          "signature": "AddOpenIddictUserSessionProvider(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
         }
       ]
     },

--- a/src/Granit.Bff.UserSessions/GranitBffUserSessionsModule.cs
+++ b/src/Granit.Bff.UserSessions/GranitBffUserSessionsModule.cs
@@ -1,8 +1,7 @@
 using Granit.Bff.UserSessions.Internal;
 using Granit.Identity;
+using Granit.Identity.Extensions;
 using Granit.Modularity;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Bff.UserSessions;
 
@@ -18,5 +17,5 @@ public sealed class GranitBffUserSessionsModule : GranitModule
 {
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context) =>
-        context.Services.Replace(ServiceDescriptor.Scoped<IUserSessionProvider, BffUserSessionProvider>());
+        context.Services.SetUserSessionProvider<BffUserSessionProvider>(UserSessionProviderPrecedence.Bff);
 }

--- a/src/Granit.Identity.Abstractions/Extensions/UserSessionProviderServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Abstractions/Extensions/UserSessionProviderServiceCollectionExtensions.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.Identity.Extensions;
+
+/// <summary>
+/// Registers a backend's <see cref="IUserSessionProvider"/> (and, when it implements it,
+/// <see cref="IUserDeviceProvider"/>) as the active provider for the canonical session API, with
+/// <strong>explicit, order-independent precedence</strong>.
+/// </summary>
+/// <remarks>
+/// Backends call these helpers instead of <c>IServiceCollection.Replace</c> directly so that, when several
+/// are present on one host (e.g. OpenIddict + BFF), the winner of each facet is decided by
+/// <see cref="UserSessionProviderPrecedence"/> — not by the accident of module topological order or the
+/// order of imperative <c>AddGranit*</c> calls. A registration wins a facet only when its precedence is
+/// greater than or equal to the precedence already recorded for that facet, so the highest-precedence
+/// backend always wins regardless of the call order. The no-op defaults from
+/// <c>GranitIdentityAbstractionsModule</c> sit at the implicit <see cref="UserSessionProviderPrecedence.None"/>
+/// floor and are replaced by any real backend.
+/// </remarks>
+public static class UserSessionProviderServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <typeparamref name="TProvider"/> (resolved as itself) as the session provider, and as the
+    /// device provider too when it implements <see cref="IUserDeviceProvider"/>, at <paramref name="precedence"/>.
+    /// </summary>
+    public static IServiceCollection SetUserSessionProvider<TProvider>(
+        this IServiceCollection services,
+        UserSessionProviderPrecedence precedence)
+        where TProvider : class, IUserSessionProvider
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.TryAddScoped<TProvider>();
+
+        Func<IServiceProvider, IUserDeviceProvider>? deviceFactory =
+            typeof(IUserDeviceProvider).IsAssignableFrom(typeof(TProvider))
+                ? sp => (IUserDeviceProvider)sp.GetRequiredService<TProvider>()
+                : null;
+
+        return services.SetUserSessionProvider(
+            precedence,
+            sessionFactory: sp => sp.GetRequiredService<TProvider>(),
+            deviceFactory: deviceFactory);
+    }
+
+    /// <summary>
+    /// Registers the session provider (and optionally the device provider) via factories, at
+    /// <paramref name="precedence"/>. Use this overload when both facets forward to a shared instance
+    /// (e.g. the federated <c>IIdentityProvider</c>) rather than a dedicated provider type.
+    /// </summary>
+    public static IServiceCollection SetUserSessionProvider(
+        this IServiceCollection services,
+        UserSessionProviderPrecedence precedence,
+        Func<IServiceProvider, IUserSessionProvider> sessionFactory,
+        Func<IServiceProvider, IUserDeviceProvider>? deviceFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(sessionFactory);
+
+        PrecedenceState state = GetOrAddState(services);
+
+        if (precedence >= state.Session)
+        {
+            state.Session = precedence;
+            services.Replace(ServiceDescriptor.Scoped(sessionFactory));
+        }
+
+        if (deviceFactory is not null && precedence >= state.Device)
+        {
+            state.Device = precedence;
+            services.Replace(ServiceDescriptor.Scoped(deviceFactory));
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Returns the precedence of the backend currently winning each facet (<see cref="UserSessionProviderPrecedence.None"/>
+    /// when only the no-op defaults are registered). Useful for startup diagnostics and tests.
+    /// </summary>
+    public static (UserSessionProviderPrecedence Session, UserSessionProviderPrecedence Device)
+        GetUserSessionProviderPrecedence(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        return services.FirstOrDefault(d => d.ServiceType == typeof(PrecedenceState))?.ImplementationInstance
+            is PrecedenceState state
+            ? (state.Session, state.Device)
+            : (UserSessionProviderPrecedence.None, UserSessionProviderPrecedence.None);
+    }
+
+    private static PrecedenceState GetOrAddState(IServiceCollection services)
+    {
+        if (services.FirstOrDefault(d => d.ServiceType == typeof(PrecedenceState))?.ImplementationInstance
+            is PrecedenceState existing)
+        {
+            return existing;
+        }
+
+        PrecedenceState state = new();
+        services.AddSingleton(state);
+        return state;
+    }
+
+    // Tracks the winning precedence per facet across registration calls. Stored in the collection so the
+    // guard is the single source of truth and order-independent; harmless in the built container (a private
+    // type nothing resolves).
+    private sealed class PrecedenceState
+    {
+        public UserSessionProviderPrecedence Session { get; set; } = UserSessionProviderPrecedence.None;
+
+        public UserSessionProviderPrecedence Device { get; set; } = UserSessionProviderPrecedence.None;
+    }
+}

--- a/src/Granit.Identity.Abstractions/IFallbackUserSessionProvider.cs
+++ b/src/Granit.Identity.Abstractions/IFallbackUserSessionProvider.cs
@@ -1,0 +1,8 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// Marker on the no-op <see cref="IUserSessionProvider"/> default. Lets the canonical session endpoints
+/// detect at startup that no real backend replaced it and emit a clear warning, rather than silently
+/// serving <c>200 []</c> from <c>/sessions</c> and <c>/devices</c>.
+/// </summary>
+public interface IFallbackUserSessionProvider;

--- a/src/Granit.Identity.Abstractions/Internal/NullUserSessionProvider.cs
+++ b/src/Granit.Identity.Abstractions/Internal/NullUserSessionProvider.cs
@@ -5,7 +5,7 @@ namespace Granit.Identity.Internal;
 /// nothing. Replaced when a backend integration package (BFF, OpenIddict, Keycloak) is installed, so
 /// the canonical session API always resolves but only surfaces real data once a backend is wired.
 /// </summary>
-internal sealed class NullUserSessionProvider : IUserSessionProvider
+internal sealed class NullUserSessionProvider : IUserSessionProvider, IFallbackUserSessionProvider
 {
     public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(
         string userId, string? currentSessionId, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Identity.Abstractions/UserSessionProviderPrecedence.cs
+++ b/src/Granit.Identity.Abstractions/UserSessionProviderPrecedence.cs
@@ -1,0 +1,33 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// Explicit precedence for backend <see cref="IUserSessionProvider"/> / <see cref="IUserDeviceProvider"/>
+/// registrations. When several backends are present on one host (e.g. OpenIddict + BFF), the highest
+/// precedence wins each facet — <strong>deterministically, independent of registration order</strong>
+/// (module topological order or the order of imperative <c>AddGranit*</c> calls).
+/// </summary>
+/// <remarks>
+/// Backends register through <c>SetUserSessionProvider</c> rather than calling
+/// <c>IServiceCollection.Replace</c> directly, so the winner is a single explicit value here instead of an
+/// accident of ordering. To change the winner, change the precedence a backend registers with.
+/// </remarks>
+public enum UserSessionProviderPrecedence
+{
+    /// <summary>The no-op defaults. Replaced by any real backend.</summary>
+    None = 0,
+
+    /// <summary>
+    /// Federated identity providers (Entra ID, Cognito, Keycloak): sessions/devices read from the
+    /// external IdP.
+    /// </summary>
+    Federated = 10,
+
+    /// <summary>OpenIddict authority: one session per live refresh-token grant.</summary>
+    OpenIddict = 20,
+
+    /// <summary>
+    /// BFF gateway: the user-facing browser↔BFF session — the one the user revokes from the canonical
+    /// API. Wins the session facet by default when it coexists with another backend.
+    /// </summary>
+    Bff = 30,
+}

--- a/src/Granit.Identity.Endpoints/Extensions/UserSessionEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Endpoints/Extensions/UserSessionEndpointRouteBuilderExtensions.cs
@@ -4,13 +4,15 @@ using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Granit.Identity.Endpoints.Extensions;
 
 /// <summary>
 /// Extension methods for mapping the canonical user-session API (<c>/sessions</c> and <c>/devices</c>).
 /// </summary>
-public static class UserSessionEndpointRouteBuilderExtensions
+public static partial class UserSessionEndpointRouteBuilderExtensions
 {
     /// <summary>
     /// Maps the canonical, self-service session and device endpoints. The whole surface requires an
@@ -27,6 +29,8 @@ public static class UserSessionEndpointRouteBuilderExtensions
         UserSessionsEndpointsOptions options = new();
         configure?.Invoke(options);
 
+        WarnIfNoSessionBackend(endpoints);
+
         string prefix = string.IsNullOrEmpty(options.RoutePrefix) ? "" : $"{options.RoutePrefix.Trim('/')}/";
 
         endpoints.MapGranitGroup($"{prefix}sessions")
@@ -41,4 +45,31 @@ public static class UserSessionEndpointRouteBuilderExtensions
 
         return endpoints;
     }
+
+    // The canonical API resolves everywhere thanks to the no-op defaults, so a host that maps it without
+    // wiring a backend gets a clean 200 [] with no error — easy to mistake for "no sessions". Surface it
+    // loudly at startup instead. Resolving the provider here (the container is built by map time) costs one
+    // scoped instance; in the failure case it's the cheap no-op.
+    private static void WarnIfNoSessionBackend(IEndpointRouteBuilder endpoints)
+    {
+        using IServiceScope scope = endpoints.ServiceProvider.CreateScope();
+        IUserSessionProvider? provider = scope.ServiceProvider.GetService<IUserSessionProvider>();
+        // Null (nothing registered) or the no-op default both mean the endpoints will serve empty data.
+        if (provider is not (null or IFallbackUserSessionProvider))
+        {
+            return;
+        }
+
+        LogNoSessionBackend(endpoints.ServiceProvider
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.Identity.UserSessions"));
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The canonical user-session API (/sessions, /devices) is mapped but no backend session " +
+                  "provider is registered — both endpoints will return empty. Wire a backend: call its " +
+                  "AddGranit* extension (e.g. AddGranitOpenIddict, AddGranitIdentityKeycloak) or add its " +
+                  "module (e.g. GranitBffUserSessionsModule) to your AddGranit graph.")]
+    private static partial void LogNoSessionBackend(ILogger logger);
 }

--- a/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
@@ -68,10 +68,11 @@ public static class IdentityCognitoServiceCollectionExtensions
         // Session/device facets. Replace the Null defaults so the canonical /sessions and /devices
         // endpoints surface Cognito data. Both forward to the SAME scoped IIdentityProvider instance
         // (mirroring IIdentityClientRoleManager above) so every facet shares one CognitoIdentityProvider.
-        services.Replace(ServiceDescriptor.Scoped<IUserSessionProvider>(sp =>
-            (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>()));
-        services.Replace(ServiceDescriptor.Scoped<IUserDeviceProvider>(sp =>
-            (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>()));
+        // Registered at Federated precedence: a co-resident BFF wins the session facet deterministically.
+        services.SetUserSessionProvider(
+            UserSessionProviderPrecedence.Federated,
+            sessionFactory: sp => (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>(),
+            deviceFactory: sp => (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>());
 
         // Client-role sync pipeline — enumerates prefix-matching Cognito groups for each
         // tracked app-client id at host boot and upserts RoleMetadata rows.

--- a/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
@@ -74,10 +74,11 @@ public static class IdentityEntraIdServiceCollectionExtensions
         // Session/device facets — forward to the scoped IIdentityProvider so the EntraId provider
         // surfaces sessions and devices to IUserSessionManager, replacing the Null defaults from
         // Granit.Identity.Abstractions. Same forwarding rationale as IIdentityClientRoleManager above.
-        services.Replace(ServiceDescriptor.Scoped<IUserSessionProvider>(sp =>
-            (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>()));
-        services.Replace(ServiceDescriptor.Scoped<IUserDeviceProvider>(sp =>
-            (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>()));
+        // Registered at Federated precedence: a co-resident BFF wins the session facet deterministically.
+        services.SetUserSessionProvider(
+            UserSessionProviderPrecedence.Federated,
+            sessionFactory: sp => (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>(),
+            deviceFactory: sp => (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>());
 
         // Client-role sync pipeline — enumerates Entra ID App Roles for each tracked appId
         // at host boot and upserts RoleMetadata rows. See ADR-026 for details.

--- a/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
@@ -87,10 +87,11 @@ public static class IdentityKeycloakServiceCollectionExtensions
         // and revoke them via the Admin API. Both forward to the same scoped IIdentityProvider so
         // every facet resolves to the SAME KeycloakIdentityProvider instance, sharing its admin-token
         // acquisition (same instance-sharing rationale as IIdentityClientRoleManager above).
-        services.Replace(ServiceDescriptor.Scoped<IUserSessionProvider>(sp =>
-            (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>()));
-        services.Replace(ServiceDescriptor.Scoped<IUserDeviceProvider>(sp =>
-            (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>()));
+        // Registered at Federated precedence: a co-resident BFF wins the session facet deterministically.
+        services.SetUserSessionProvider(
+            UserSessionProviderPrecedence.Federated,
+            sessionFactory: sp => (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>(),
+            deviceFactory: sp => (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>());
 
         // Client-role sync pipeline — enumerates Keycloak client roles for each tracked
         // clientId at host boot and upserts RoleMetadata rows. See ADR-025 for details.

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Granit.Identity.Local.Options;
 using Granit.Identity.Local.Services;
 using Granit.OpenIddict.Entities.OpenIddict;
 using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Server.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -95,6 +96,11 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
         //    with the host authorization DbContext when both target the same database.
         builder.Services.TryAddScoped<IIdentityDbContextAccessor,
             OpenIddictIdentityDbContextAccessor>();
+
+        // 7. Session/device provider for the canonical /sessions + /devices API. Registered here, with
+        //    the authority wiring, so a host cannot enable OpenIddict auth and still silently serve the
+        //    no-op session defaults (the failure mode when GranitOpenIddictModule is absent from the graph).
+        builder.Services.AddOpenIddictUserSessionProvider();
 
         return builder;
     }

--- a/src/Granit.OpenIddict/Extensions/OpenIddictUserSessionServiceCollectionExtensions.cs
+++ b/src/Granit.OpenIddict/Extensions/OpenIddictUserSessionServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Granit.Identity;
+using Granit.Identity.Extensions;
+using Granit.OpenIddict.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.OpenIddict.Extensions;
+
+/// <summary>
+/// Registers the OpenIddict-backed session/device provider for the canonical session API.
+/// </summary>
+public static class OpenIddictUserSessionServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <c>OpenIddictUserSessionProvider</c> as the active <see cref="IUserSessionProvider"/> and
+    /// <see cref="IUserDeviceProvider"/> at <see cref="UserSessionProviderPrecedence.OpenIddict"/>, replacing
+    /// the no-op defaults. Called by <c>AddGranitOpenIddict</c> so wiring the authority also wires its
+    /// providers — they are no longer registered by <c>GranitOpenIddictModule</c>, which a host can omit
+    /// from its module graph while still calling <c>AddGranitOpenIddict</c>.
+    /// </summary>
+    public static IServiceCollection AddOpenIddictUserSessionProvider(this IServiceCollection services) =>
+        services.SetUserSessionProvider<OpenIddictUserSessionProvider>(UserSessionProviderPrecedence.OpenIddict);
+}

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -141,13 +141,11 @@ public sealed class GranitOpenIddictModule : GranitModule
         context.Services.AddEntityDefinition<GranitOpenIddictApplication, GranitOpenIddictApplicationEntityDefinition>();
         context.Services.AddEntityDefinition<GranitOpenIddictScope, GranitOpenIddictScopeEntityDefinition>();
 
-        // Replace the Null session/device providers with an implementation that reads active
-        // refresh tokens from the OpenIddict token store and revokes them on demand.
-        context.Services.TryAddScoped<OpenIddictUserSessionProvider>();
-        context.Services.Replace(ServiceDescriptor.Scoped<IUserSessionProvider>(
-            sp => sp.GetRequiredService<OpenIddictUserSessionProvider>()));
-        context.Services.Replace(ServiceDescriptor.Scoped<IUserDeviceProvider>(
-            sp => sp.GetRequiredService<OpenIddictUserSessionProvider>()));
+        // NOTE: the session/device provider (OpenIddictUserSessionProvider) is registered by
+        // AddGranitOpenIddict, not here — co-located with the imperative authority wiring so a host
+        // cannot wire OpenIddict auth without also wiring its providers (which previously left the
+        // canonical /sessions + /devices endpoints silently serving the no-op defaults). See
+        // OpenIddictUserSessionServiceCollectionExtensions.AddOpenIddictUserSessionProvider.
     }
 
     private static void PostConfigureIdentityCookie(

--- a/tests/Granit.Identity.Abstractions.Tests/UserSessionProviderPrecedenceTests.cs
+++ b/tests/Granit.Identity.Abstractions.Tests/UserSessionProviderPrecedenceTests.cs
@@ -1,0 +1,108 @@
+using Granit.Identity.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="UserSessionProviderServiceCollectionExtensions.SetUserSessionProvider{TProvider}"/>:
+/// the explicit, order-independent precedence guard that decides which backend wins the
+/// <see cref="IUserSessionProvider"/> / <see cref="IUserDeviceProvider"/> facets.
+/// </summary>
+public sealed class UserSessionProviderPrecedenceTests
+{
+    // Fake backends — resolvable with no external dependencies, so we can assert the resolved instance type.
+    private sealed class LowProvider : IUserSessionProvider, IUserDeviceProvider
+    {
+        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string u, string? c, CancellationToken t = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
+        public Task<bool> RevokeAsync(string u, string s, CancellationToken t = default) => Task.FromResult(false);
+        public Task<int> RevokeOthersAsync(string u, string c, CancellationToken t = default) => Task.FromResult(0);
+        Task<IReadOnlyList<UserDevice>> IUserDeviceProvider.ListAsync(string u, CancellationToken t) => Task.FromResult<IReadOnlyList<UserDevice>>([]);
+    }
+
+    private sealed class HighProvider : IUserSessionProvider, IUserDeviceProvider
+    {
+        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string u, string? c, CancellationToken t = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
+        public Task<bool> RevokeAsync(string u, string s, CancellationToken t = default) => Task.FromResult(false);
+        public Task<int> RevokeOthersAsync(string u, string c, CancellationToken t = default) => Task.FromResult(0);
+        Task<IReadOnlyList<UserDevice>> IUserDeviceProvider.ListAsync(string u, CancellationToken t) => Task.FromResult<IReadOnlyList<UserDevice>>([]);
+    }
+
+    // Session-only backend (like BFF): does not implement IUserDeviceProvider.
+    private sealed class SessionOnlyProvider : IUserSessionProvider
+    {
+        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string u, string? c, CancellationToken t = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
+        public Task<bool> RevokeAsync(string u, string s, CancellationToken t = default) => Task.FromResult(false);
+        public Task<int> RevokeOthersAsync(string u, string c, CancellationToken t = default) => Task.FromResult(0);
+    }
+
+    private const UserSessionProviderPrecedence Low = UserSessionProviderPrecedence.Federated;
+    private const UserSessionProviderPrecedence High = UserSessionProviderPrecedence.OpenIddict;
+
+    [Theory]
+    [InlineData(true)]  // low registered first
+    [InlineData(false)] // high registered first
+    public void Highest_precedence_wins_regardless_of_registration_order(bool lowFirst)
+    {
+        ServiceCollection services = [];
+
+        if (lowFirst)
+        {
+            services.SetUserSessionProvider<LowProvider>(Low);
+            services.SetUserSessionProvider<HighProvider>(High);
+        }
+        else
+        {
+            services.SetUserSessionProvider<HighProvider>(High);
+            services.SetUserSessionProvider<LowProvider>(Low);
+        }
+
+        services.GetUserSessionProviderPrecedence().ShouldBe((High, High));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IUserSessionProvider>().ShouldBeOfType<HighProvider>();
+        scope.ServiceProvider.GetRequiredService<IUserDeviceProvider>().ShouldBeOfType<HighProvider>();
+    }
+
+    [Fact]
+    public void Session_only_backend_does_not_register_the_device_facet()
+    {
+        ServiceCollection services = [];
+        // Device-capable backend first, then a higher session-only backend (the OpenIddict + BFF shape).
+        services.SetUserSessionProvider<HighProvider>(High);
+        services.SetUserSessionProvider<SessionOnlyProvider>(UserSessionProviderPrecedence.Bff);
+
+        // Session goes to the higher session-only backend; device stays with the device-capable one.
+        services.GetUserSessionProviderPrecedence()
+            .ShouldBe((UserSessionProviderPrecedence.Bff, High));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IUserSessionProvider>().ShouldBeOfType<SessionOnlyProvider>();
+        scope.ServiceProvider.GetRequiredService<IUserDeviceProvider>().ShouldBeOfType<HighProvider>();
+    }
+
+    [Fact]
+    public void Both_facets_resolve_the_same_scoped_instance()
+    {
+        ServiceCollection services = [];
+        services.SetUserSessionProvider<HighProvider>(High);
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        object session = scope.ServiceProvider.GetRequiredService<IUserSessionProvider>();
+        object device = scope.ServiceProvider.GetRequiredService<IUserDeviceProvider>();
+
+        session.ShouldBeSameAs(device);
+    }
+
+    [Fact]
+    public void No_registration_reports_the_None_floor()
+    {
+        ServiceCollection services = [];
+        services.GetUserSessionProviderPrecedence()
+            .ShouldBe((UserSessionProviderPrecedence.None, UserSessionProviderPrecedence.None));
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
+++ b/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Bff.UserSessions\Granit.Bff.UserSessions.csproj" />
     <ProjectReference Include="..\..\src\Granit.Encryption\Granit.Encryption.csproj" />
     <ProjectReference Include="..\..\src\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict\Granit.OpenIddict.csproj" />

--- a/tests/Granit.OpenIddict.Tests/UserSessionProviderRegistrationTests.cs
+++ b/tests/Granit.OpenIddict.Tests/UserSessionProviderRegistrationTests.cs
@@ -1,0 +1,102 @@
+using Granit.Bff.UserSessions;
+using Granit.Identity;
+using Granit.Identity.Extensions;
+using Granit.Modularity;
+using Granit.OpenIddict.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests;
+
+/// <summary>
+/// End-to-end registration tests for the canonical session/device providers across the real backends
+/// (no-op abstractions defaults, OpenIddict, BFF). Locks in the fix for the "<c>/sessions</c> returns
+/// <c>200 []</c>" bug: the OpenIddict provider is now co-located with <c>AddGranitOpenIddict</c> (not the
+/// module), and precedence between coexisting backends is explicit and order-independent.
+/// </summary>
+public sealed class UserSessionProviderRegistrationTests
+{
+    private static IServiceCollection NewServices()
+    {
+        HostApplicationBuilder builder = new();
+        return builder.Services;
+    }
+
+    private static void RunModule(IServiceCollection services, GranitModule module)
+    {
+        HostApplicationBuilder builder = new();
+        // Reuse the same collection so several modules accumulate into one graph.
+        ServiceConfigurationContext context = new(services, builder.Configuration, builder);
+        module.ConfigureServices(context);
+    }
+
+    [Fact]
+    public void Abstractions_alone_resolves_the_fallback_provider()
+    {
+        // The reported bug: only the always-present abstractions module ran (no backend in the graph),
+        // so the canonical endpoints resolve the no-op provider and serve 200 [].
+        IServiceCollection services = NewServices();
+        RunModule(services, new GranitIdentityAbstractionsModule());
+
+        services.GetUserSessionProviderPrecedence()
+            .ShouldBe((UserSessionProviderPrecedence.None, UserSessionProviderPrecedence.None));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        // The fallback marker is what the startup warning keys on.
+        scope.ServiceProvider.GetRequiredService<IUserSessionProvider>()
+            .ShouldBeAssignableTo<IFallbackUserSessionProvider>();
+    }
+
+    [Fact]
+    public void OpenIddict_module_no_longer_registers_a_session_provider()
+    {
+        // Regression guard for the co-location: the Replace moved OUT of GranitOpenIddictModule into
+        // AddGranitOpenIddict. Running the module alone must NOT wire a provider.
+        IServiceCollection services = NewServices();
+        RunModule(services, new GranitOpenIddictModule());
+
+        services.GetUserSessionProviderPrecedence()
+            .ShouldBe((UserSessionProviderPrecedence.None, UserSessionProviderPrecedence.None));
+        services.Any(d => d.ServiceType == typeof(IUserSessionProvider)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddOpenIddictUserSessionProvider_wins_over_the_fallback()
+    {
+        // What AddGranitOpenIddict now calls. This is the seam that fixes the bug for the common path.
+        IServiceCollection services = NewServices();
+        RunModule(services, new GranitIdentityAbstractionsModule());
+        services.AddOpenIddictUserSessionProvider();
+
+        services.GetUserSessionProviderPrecedence()
+            .ShouldBe((UserSessionProviderPrecedence.OpenIddict, UserSessionProviderPrecedence.OpenIddict));
+    }
+
+    [Theory]
+    [InlineData(true)]  // OpenIddict registered first
+    [InlineData(false)] // BFF registered first
+    public void OpenIddict_and_Bff_together_Bff_wins_session_OpenIddict_wins_device_either_order(bool openIddictFirst)
+    {
+        // The contested case (OpenIddict authority + BFF gateway on one host). The winner must be
+        // deterministic, NOT an accident of which one registered last.
+        IServiceCollection services = NewServices();
+        RunModule(services, new GranitIdentityAbstractionsModule());
+
+        if (openIddictFirst)
+        {
+            services.AddOpenIddictUserSessionProvider();
+            RunModule(services, new GranitBffUserSessionsModule());
+        }
+        else
+        {
+            RunModule(services, new GranitBffUserSessionsModule());
+            services.AddOpenIddictUserSessionProvider();
+        }
+
+        services.GetUserSessionProviderPrecedence()
+            .ShouldBe((UserSessionProviderPrecedence.Bff, UserSessionProviderPrecedence.OpenIddict));
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -153,18 +153,18 @@
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "Oh/FQJrTZqiqZuFktqDCwLFgxIUnNATZx46AwUTf5A/+FmK/TzPf/iwSqMK85QlioLD9ehOxWe0NBfsCSkp5pw=="
+        "resolved": "10.7.0",
+        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "b3gmxtyX0n8bQFuZ679f8QiOWqjeZKFc6XXPUsYNFzMcWi0Q44Ej3pB41N/QQ0maX380kmOMF36bLSBHNThXAg=="
+        "resolved": "10.7.0",
+        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "g6/S5rhP1XNBqeDa9zKXri/uDKe6gjzSqGsocuySb1OdVm8fz/M9YcWTJsCw5RHF8xIb/B3NgsfBPQF9Emjk3Q=="
+        "resolved": "10.7.0",
+        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -173,15 +173,15 @@
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "TZAZsAFThNQDqCnWaGxV/X7OPSA7b+kY7wNTPNvPvSWa0jcTbmGVyzIY/feF4OgyAUUdzSnnLW6ri2Q+4keM4A=="
+        "resolved": "10.7.0",
+        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "/xuNWNxI4WLVatiTvaqfLd5ijFhQ/qvE14bOyWxeEWmXJkjh/g2G/5TdzMfoe0afq16OdWLGbrD9gWHo178hbg==",
+        "resolved": "10.7.0",
+        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.3.0"
+          "Microsoft.Extensions.Telemetry": "10.7.0"
         }
       },
       "Microsoft.Extensions.Http.Polly": {
@@ -195,31 +195,31 @@
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "xc0dZuPkBaVIdMlODDppmNY/dxE27wIQ46gTzStoFXO4/yVcOMKlPmtr9vTP4edyXBRizGxPtcAFmqxZ5gPTkQ==",
+        "resolved": "10.7.0",
+        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.3.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "M1esrIGmwU2JBY0JpwdlUTXTNBXSBFEs+41bYBd59+9/vCaXw+vGhtYcCL+JXeGmxTLUHmuXcKbX/uVCSFcuzA==",
+        "resolved": "10.7.0",
+        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.3.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.3.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.3.0",
-        "contentHash": "aKxH6ZsGAewGF8uSXyx1WkjqItwZA+hd1hhQ/4i7o5injCWSdr9vIZ3R3djJfy8OG3xaWK+LZY/+slVvlnwEHw==",
+        "resolved": "10.7.0",
+        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.3.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
@@ -557,6 +557,23 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.bff": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Http.Resilience": "[0.1.0-dev, )",
+          "Granit.Oidc": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.bff.usersessions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Bff": "[0.1.0-dev, )",
+          "Granit.Identity.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -620,6 +637,13 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.resilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -669,6 +693,14 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.oidc": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.openiddict": {
@@ -777,11 +809,11 @@
       "Microsoft.Extensions.Http.Resilience": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.3.0",
-        "contentHash": "P4+s/eUH3dZdn1HnivSL2dh6/Jb0ndLt2l88oQPZ9BYdyb4tSRAsnz4QkJHGfPA9lS/XblI5QYsxEdfkurPvIg==",
+        "resolved": "10.7.0",
+        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.3.0",
-          "Microsoft.Extensions.Resilience": "10.3.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
+          "Microsoft.Extensions.Resilience": "10.7.0"
         }
       },
       "OpenIddict": {


### PR DESCRIPTION
## Problem

The canonical session API (`GET /api/v1/sessions`, `GET /api/v1/devices` via `MapGranitUserSessions`) silently returned `200 []` for an authenticated user on a consumer host, despite a valid BFF session **and** a valid OpenIddict refresh token existing for the same subject.

**Root cause (proven empirically by an isolated module-boot test):** the framework `Replace`/`TryAdd` logic is correct. The no-op providers only win because the backend modules carrying the `Replace` are absent from the consumer's `AddGranit` graph. `AddGranitOpenIddict(...)` (imperative) wires the authority but did **not** register `IUserSessionProvider`/`IUserDeviceProvider` — that `Replace` lived **only** in `GranitOpenIddictModule.ConfigureServices`. A host that wired auth imperatively without adding the module to its graph never ran the `Replace`, so the always-present no-op defaults from `GranitIdentityAbstractionsModule` (pulled transitively by `GranitIdentityModule`) won → `200 []`, cleanly, on both facets.

A second, latent flaw: when several backends coexist (OpenIddict + BFF), the winner was an accident of registration/topological order — not an explicit decision.

## Fix

**1. Co-locate (mechanism).** The OpenIddict provider registration moves from `GranitOpenIddictModule` into `AddGranitOpenIddict` (via the public seam `AddOpenIddictUserSessionProvider`). Wiring the authority now inseparably wires its providers — the reported failure mode cannot recur.

**2. Explicit, order-independent precedence.** New public `UserSessionProviderPrecedence` enum (`Bff=30 > OpenIddict=20 > Federated=10 > None=0`) + `SetUserSessionProvider` guard (`>=`, shared-instance factories). All backends — OpenIddict, BFF, EntraId/Cognito/Keycloak — register through it, removing the "must be the last provider-registration call" fragility. **BFF wins the session facet, the authority wins the device facet, regardless of registration order.** Flip the winner by changing the precedence a backend registers with.

**3. Fail-loud observability.** `MapGranitUserSessions` emits a startup `Warning` when the resolved session provider is the no-op fallback (new `IFallbackUserSessionProvider` marker on `NullUserSessionProvider`), turning the silent `200 []` into an actionable signal.

## Tests

- **Precedence guard** (`Granit.Identity.Abstractions.Tests`): order-independence, shared scoped instance, device-facet skipped for a session-only backend, `None` floor.
- **End-to-end registration** (`Granit.OpenIddict.Tests`, + `Granit.Bff.UserSessions` projref): abstractions-only → fallback; module no longer self-registers (co-location guard); OpenIddict seam wins; OpenIddict + BFF deterministic in **both** orders (session=Bff, device=OpenIddict).
- Full suites green: Abstractions 21, OpenIddict 321, BFF 4, Endpoints 184, Federated 135/70/179, Identity 153, **Architecture 225**. `dotnet format` clean.

## Notes

- No new NuGet dependencies (THIRD-PARTY-NOTICES unchanged).
- A `granit-docs` page on session-provider precedence will follow in a separate PR (docs decoupled from code per convention).