### PR TITLE
feat(identity): durable habitual profile to cut anomaly false positives (#2669 PR1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -23839,12 +23839,12 @@
       "kind": "class",
       "project": "Granit.Identity.AnomalyDetection",
       "file": "src/Granit.Identity.AnomalyDetection/Handlers/UserSessionCreatedHandler.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(UserSessionCreatedEto evt, ICurrentTenant currentTenant, IUserSessionRiskEvaluator evaluator, IUserSessionProvider sessionProvider, IIpGeolocationResolver geoResolver, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(UserSessionCreatedEto evt, ICurrentTenant currentTenant, IUserSessionRiskEvaluator evaluator, IUserSessionProvider sessionProvider, IIpGeolocationResolver geoResolver, IUserBehavioralProfileStore profileStore, TimeProvider timeProvider, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -23896,8 +23896,44 @@
           "kind": "property",
           "signature": "double MaxTravelKilometersPerHour",
           "returnType": "double"
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(180)",
+          "returnType": "TimeSpan ProfileRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MinObservationsForHabitual",
+          "kind": "property",
+          "signature": "int MinObservationsForHabitual",
+          "returnType": "int"
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(30)",
+          "returnType": "TimeSpan HabitualRecencyWindow { get; set; } = TimeSpan."
         }
       ]
+    },
+    {
+      "name": "BehavioralObservation",
+      "fqn": "Granit.Identity.BehavioralObservation",
+      "kind": "record",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/BehavioralObservation.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "BehavioralObservationKind",
+      "fqn": "Granit.Identity.BehavioralObservationKind",
+      "kind": "enum",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/BehavioralObservationKind.cs",
+      "line": 7,
+      "members": []
     },
     {
       "name": "DeviceKind",
@@ -26229,6 +26265,28 @@
           "kind": "method",
           "signature": "CreateUserAsync(IdentityUserCreate user, CancellationToken cancellationToken = default)",
           "returnType": "Task<IIdentityUser>"
+        }
+      ]
+    },
+    {
+      "name": "IUserBehavioralProfileStore",
+      "fqn": "Granit.Identity.IUserBehavioralProfileStore",
+      "kind": "interface",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/IUserBehavioralProfileStore.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<UserBehavioralProfile>"
+        },
+        {
+          "name": "RecordObservationAsync",
+          "kind": "method",
+          "signature": "RecordObservationAsync(string userId, string? country, string? deviceFamily, string? coarseLocation, DateTimeOffset observedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
         }
       ]
     },
@@ -28952,6 +29010,28 @@
       "file": "src/Granit.Identity.Abstractions/SuspiciousUserSessionDetectedEto.cs",
       "line": 32,
       "members": []
+    },
+    {
+      "name": "UserBehavioralProfile",
+      "fqn": "Granit.Identity.UserBehavioralProfile",
+      "kind": "record",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/UserBehavioralProfile.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new([])",
+          "returnType": "UserBehavioralProfile Empty { get; } ="
+        },
+        {
+          "name": "IsHabitual",
+          "kind": "method",
+          "signature": "IsHabitual(BehavioralObservationKind kind, string value, DateTimeOffset now, int minObservations, TimeSpan recencyWindow, TimeSpan retention)",
+          "returnType": "bool"
+        }
+      ]
     },
     {
       "name": "UserDevice",

--- a/src/Granit.Identity.Abstractions/BehavioralObservation.cs
+++ b/src/Granit.Identity.Abstractions/BehavioralObservation.cs
@@ -1,0 +1,17 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// One entry in a user's durable habitual profile: a value seen for a given dimension, with how often and how
+/// recently it has been observed.
+/// </summary>
+/// <param name="Kind">The dimension this value belongs to.</param>
+/// <param name="Value">The observed value (e.g. a country code, device family, or coarse-location bucket).</param>
+/// <param name="Count">How many times the value has been observed.</param>
+/// <param name="FirstSeenAt">When the value was first observed.</param>
+/// <param name="LastSeenAt">When the value was most recently observed.</param>
+public sealed record BehavioralObservation(
+    BehavioralObservationKind Kind,
+    string Value,
+    int Count,
+    DateTimeOffset FirstSeenAt,
+    DateTimeOffset LastSeenAt);

--- a/src/Granit.Identity.Abstractions/BehavioralObservationKind.cs
+++ b/src/Granit.Identity.Abstractions/BehavioralObservationKind.cs
@@ -1,0 +1,17 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// The dimension of a recorded behavioural observation in a user's durable habitual profile. The anomaly
+/// detector consults the profile so a value seen repeatedly (or recently) is not re-flagged as new on every visit.
+/// </summary>
+public enum BehavioralObservationKind
+{
+    /// <summary>An ISO 3166-1 alpha-2 country code the user has authenticated from.</summary>
+    Country,
+
+    /// <summary>A coarse device family (browser/OS class) derived from the User-Agent.</summary>
+    DeviceFamily,
+
+    /// <summary>A coarse geographic bucket (rounded latitude/longitude) the user has authenticated from.</summary>
+    CoarseLocation,
+}

--- a/src/Granit.Identity.Abstractions/GranitIdentityAbstractionsModule.cs
+++ b/src/Granit.Identity.Abstractions/GranitIdentityAbstractionsModule.cs
@@ -21,6 +21,7 @@ public sealed class GranitIdentityAbstractionsModule : GranitModule
     {
         context.Services.TryAddScoped<IUserSessionAnomalyDetector, NullUserSessionAnomalyDetector>();
         context.Services.TryAddSingleton<IUserSessionRiskStore, MemoryUserSessionRiskStore>();
+        context.Services.TryAddSingleton<IUserBehavioralProfileStore, MemoryUserBehavioralProfileStore>();
         context.Services.TryAddSingleton<IDeviceTrustStore, MemoryDeviceTrustStore>();
         context.Services.TryAddScoped<IUserSessionProvider, NullUserSessionProvider>();
         context.Services.TryAddScoped<IUserDeviceProvider, NullUserDeviceProvider>();

--- a/src/Granit.Identity.Abstractions/IUserBehavioralProfileStore.cs
+++ b/src/Granit.Identity.Abstractions/IUserBehavioralProfileStore.cs
@@ -1,0 +1,38 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// Durable store for a user's habitual behavioural profile (observed countries / device families / coarse
+/// locations). The anomaly detector reads it to suppress <c>new_country</c> / <c>new_device</c> for familiar
+/// values, and the session-created handler records each new observation into it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default registration (<c>Granit.Identity.Abstractions</c>) is in-memory, single-node, and non-durable —
+/// suitable for development. Install <c>Granit.Identity.EntityFrameworkCore</c> for a durable store that survives
+/// restarts and is shared across instances (otherwise the profile resets on every restart and the false-positive
+/// reduction is lost).
+/// </para>
+/// <para>
+/// Lifetime contract mirrors <see cref="IUserSessionRiskStore"/>: depend on this interface from a scoped (or
+/// transient) service — never capture it in a singleton. The in-memory default is <c>Singleton</c>; the EF Core
+/// store is <c>Scoped</c>.
+/// </para>
+/// </remarks>
+public interface IUserBehavioralProfileStore
+{
+    /// <summary>Reads the user's full habitual profile, or <see cref="UserBehavioralProfile.Empty"/> when none.</summary>
+    Task<UserBehavioralProfile> GetAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records an observation: for each non-null/non-empty value, increments its count and updates its
+    /// last-seen timestamp (inserting it on first sighting). Pass a <see cref="TimeProvider"/>-derived
+    /// <paramref name="observedAt"/>.
+    /// </summary>
+    Task RecordObservationAsync(
+        string userId,
+        string? country,
+        string? deviceFamily,
+        string? coarseLocation,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Identity.Abstractions/Internal/MemoryUserBehavioralProfileStore.cs
+++ b/src/Granit.Identity.Abstractions/Internal/MemoryUserBehavioralProfileStore.cs
@@ -1,0 +1,75 @@
+using System.Collections.Concurrent;
+
+namespace Granit.Identity.Internal;
+
+/// <summary>
+/// In-memory, single-node, non-durable <see cref="IUserBehavioralProfileStore"/> registered by default. Suitable
+/// for development and tests; replaced by <c>Granit.Identity.EntityFrameworkCore</c> for durable production use
+/// (the in-memory profile resets on restart, so the false-positive reduction would not survive one).
+/// </summary>
+internal sealed class MemoryUserBehavioralProfileStore : IUserBehavioralProfileStore
+{
+    private sealed class Entry
+    {
+        public int Count { get; set; }
+        public DateTimeOffset FirstSeenAt { get; set; }
+        public DateTimeOffset LastSeenAt { get; set; }
+    }
+
+    private readonly ConcurrentDictionary<(string UserId, BehavioralObservationKind Kind, string Value), Entry> _entries =
+        new();
+    private readonly Lock _gate = new();
+
+    public Task<UserBehavioralProfile> GetAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        List<BehavioralObservation> observations;
+        lock (_gate)
+        {
+            observations =
+            [
+                .. _entries
+                    .Where(kvp => kvp.Key.UserId == userId)
+                    .Select(kvp => new BehavioralObservation(
+                        kvp.Key.Kind, kvp.Key.Value, kvp.Value.Count, kvp.Value.FirstSeenAt, kvp.Value.LastSeenAt)),
+            ];
+        }
+
+        return Task.FromResult(observations.Count == 0 ? UserBehavioralProfile.Empty : new UserBehavioralProfile(observations));
+    }
+
+    public Task RecordObservationAsync(
+        string userId,
+        string? country,
+        string? deviceFamily,
+        string? coarseLocation,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            Record(userId, BehavioralObservationKind.Country, country, observedAt);
+            Record(userId, BehavioralObservationKind.DeviceFamily, deviceFamily, observedAt);
+            Record(userId, BehavioralObservationKind.CoarseLocation, coarseLocation, observedAt);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void Record(string userId, BehavioralObservationKind kind, string? value, DateTimeOffset observedAt)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        if (_entries.TryGetValue((userId, kind, value), out Entry? entry))
+        {
+            entry.Count++;
+            entry.LastSeenAt = observedAt;
+        }
+        else
+        {
+            _entries[(userId, kind, value)] = new Entry { Count = 1, FirstSeenAt = observedAt, LastSeenAt = observedAt };
+        }
+    }
+}

--- a/src/Granit.Identity.Abstractions/UserBehavioralProfile.cs
+++ b/src/Granit.Identity.Abstractions/UserBehavioralProfile.cs
@@ -1,0 +1,49 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// A user's durable habitual profile — the distinct countries, device families, and coarse locations they have
+/// authenticated from over time, with recency/frequency. Unlike the set of currently-active sessions (which a
+/// monthly second residence drops out of between visits), this persists, so the anomaly detector can tell a
+/// habitual location/device from a genuinely new one and stop re-flagging the familiar one as <c>new_country</c>
+/// / <c>new_device</c> on every visit.
+/// </summary>
+/// <param name="Observations">Every recorded observation, across all dimensions.</param>
+public sealed record UserBehavioralProfile(IReadOnlyList<BehavioralObservation> Observations)
+{
+    /// <summary>An empty profile — the value returned for a user with no recorded history.</summary>
+    public static UserBehavioralProfile Empty { get; } = new([]);
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is a habitual value for <paramref name="kind"/> as of
+    /// <paramref name="now"/>: observed at least <paramref name="minObservations"/> times, or seen within
+    /// <paramref name="recencyWindow"/>. Observations last seen longer ago than <paramref name="retention"/> are
+    /// treated as expired and never count. Callers pass a <see cref="TimeProvider"/>-derived
+    /// <paramref name="now"/> — never <c>DateTimeOffset.UtcNow</c> directly.
+    /// </summary>
+    public bool IsHabitual(
+        BehavioralObservationKind kind,
+        string value,
+        DateTimeOffset now,
+        int minObservations,
+        TimeSpan recencyWindow,
+        TimeSpan retention)
+    {
+        foreach (BehavioralObservation observation in Observations)
+        {
+            if (observation.Kind != kind
+                || !string.Equals(observation.Value, value, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (now - observation.LastSeenAt > retention)
+            {
+                return false;
+            }
+
+            return observation.Count >= minObservations || now - observation.LastSeenAt <= recencyWindow;
+        }
+
+        return false;
+    }
+}

--- a/src/Granit.Identity.AnomalyDetection/Handlers/UserSessionCreatedHandler.cs
+++ b/src/Granit.Identity.AnomalyDetection/Handlers/UserSessionCreatedHandler.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using Granit.Identity.AnomalyDetection.Internal;
 using Granit.IpGeolocation;
 using Granit.MultiTenancy;
 
@@ -19,6 +21,8 @@ public class UserSessionCreatedHandler
         IUserSessionRiskEvaluator evaluator,
         IUserSessionProvider sessionProvider,
         IIpGeolocationResolver geoResolver,
+        IUserBehavioralProfileStore profileStore,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         // Distributed dispatch carries no ambient tenant — establish it from the event so the risk store, the
@@ -57,7 +61,26 @@ public class UserSessionCreatedHandler
             sessions, evt.SessionId, geoResolver, cancellationToken).ConfigureAwait(false);
 
         await evaluator.EvaluateAsync(candidate, history, evt.DeviceId, cancellationToken).ConfigureAwait(false);
+
+        // Record the candidate's observation into the durable profile AFTER assessment, so a genuinely-new first
+        // sighting still scores; repeated visits to the same country/device then become habitual and stop
+        // re-flagging. "unknown" device families are not recorded (they would not help suppression).
+        string deviceFamily = DeviceFingerprint.Family(evt.UserAgent);
+        await profileStore.RecordObservationAsync(
+            evt.UserId,
+            candidateLocation?.CountryCode,
+            deviceFamily == DeviceFingerprint.Unknown ? null : deviceFamily,
+            CoarseLocation(candidateLocation),
+            timeProvider.GetUtcNow(),
+            cancellationToken).ConfigureAwait(false);
     }
+
+    // A coarse geographic bucket (whole-degree latitude/longitude, ~111 km) — enough to recognise a habitual
+    // area without storing a precise position.
+    private static string? CoarseLocation(GeoLocation? location) =>
+        location is { Latitude: { } lat, Longitude: { } lon }
+            ? string.Create(CultureInfo.InvariantCulture, $"{(int)Math.Round(lat)},{(int)Math.Round(lon)}")
+            : null;
 
     // The provider returns the user's other sessions with raw IPs but no resolved location; resolve each here so
     // the heuristics (impossible travel, new country) can compare against history. Lookups are cache-backed and

--- a/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
+++ b/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
@@ -20,6 +20,8 @@ internal sealed class UserSessionAnomalyDetector(
     IAICallRateLimiter rateLimiter,
     IOptions<IdentityAnomalyDetectionOptions> options,
     ICurrentTenant currentTenant,
+    IUserBehavioralProfileStore profileStore,
+    TimeProvider timeProvider,
     IdentityAnomalyDetectionMetrics metrics) : IUserSessionAnomalyDetector
 {
     private const string AiInstruction =
@@ -39,7 +41,15 @@ internal sealed class UserSessionAnomalyDetector(
         using Activity? activity = IdentityAnomalyDetectionActivitySource.Source.StartActivity("UserSession.AssessAnomaly");
 
         IdentityAnomalyDetectionOptions opts = options.Value;
-        UserSessionRiskAssessment heuristic = EvaluateHeuristics(candidate, history, opts);
+
+        // Source the "known" facts from the durable habitual profile (not just active sessions), so a familiar
+        // country/device is not re-flagged once active sessions for it have expired.
+        UserBehavioralProfile profile = candidate.UserId is { } profileUserId
+            ? await profileStore.GetAsync(profileUserId, cancellationToken).ConfigureAwait(false)
+            : UserBehavioralProfile.Empty;
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        UserSessionRiskAssessment heuristic = EvaluateHeuristics(candidate, history, opts, profile, now);
         string? tenantId = currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null;
 
         if (!opts.UseAi)
@@ -65,7 +75,9 @@ internal sealed class UserSessionAnomalyDetector(
     private static UserSessionRiskAssessment EvaluateHeuristics(
         UserSessionDescriptor candidate,
         IReadOnlyList<UserSessionDescriptor> history,
-        IdentityAnomalyDetectionOptions opts)
+        IdentityAnomalyDetectionOptions opts,
+        UserBehavioralProfile profile,
+        DateTimeOffset now)
     {
         List<string> reasons = [];
         bool impossibleTravel = HasImpossibleTravel(candidate, history, opts.MaxTravelKilometersPerHour);
@@ -78,14 +90,20 @@ internal sealed class UserSessionAnomalyDetector(
         {
             string? country = candidate.Location?.CountryCode;
             if (!string.IsNullOrEmpty(country)
-                && !history.Any(h => string.Equals(h.Location?.CountryCode, country, StringComparison.OrdinalIgnoreCase)))
+                && !history.Any(h => string.Equals(h.Location?.CountryCode, country, StringComparison.OrdinalIgnoreCase))
+                && !profile.IsHabitual(
+                    BehavioralObservationKind.Country, country, now,
+                    opts.MinObservationsForHabitual, opts.HabitualRecencyWindow, opts.ProfileRetention))
             {
                 reasons.Add("new_country");
             }
 
             string device = DeviceFingerprint.Family(candidate.UserAgent);
             if (device != DeviceFingerprint.Unknown
-                && !history.Any(h => DeviceFingerprint.Family(h.UserAgent) == device))
+                && !history.Any(h => DeviceFingerprint.Family(h.UserAgent) == device)
+                && !profile.IsHabitual(
+                    BehavioralObservationKind.DeviceFamily, device, now,
+                    opts.MinObservationsForHabitual, opts.HabitualRecencyWindow, opts.ProfileRetention))
             {
                 reasons.Add("new_device");
             }

--- a/src/Granit.Identity.AnomalyDetection/Options/IdentityAnomalyDetectionOptions.cs
+++ b/src/Granit.Identity.AnomalyDetection/Options/IdentityAnomalyDetectionOptions.cs
@@ -45,6 +45,26 @@ public sealed class IdentityAnomalyDetectionOptions
     public double MaxTravelKilometersPerHour { get; set; } = 1000d;
 
     /// <summary>
+    /// How long an observation in a user's durable habitual profile stays relevant. A country/device last seen
+    /// longer ago than this no longer suppresses a <c>new_country</c> / <c>new_device</c> signal. Default: 180 days.
+    /// </summary>
+    public TimeSpan ProfileRetention { get; set; } = TimeSpan.FromDays(180);
+
+    /// <summary>
+    /// How many times a value must be observed before it counts as habitual (and thus suppresses the
+    /// corresponding new-country/new-device signal) regardless of recency. Default: 3.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int MinObservationsForHabitual { get; set; } = 3;
+
+    /// <summary>
+    /// A value seen within this window counts as habitual even below <see cref="MinObservationsForHabitual"/> —
+    /// "you were just here". This is what stops a legitimate occasional location (e.g. a second residence) from
+    /// being re-flagged on each visit. Default: 30 days.
+    /// </summary>
+    public TimeSpan HabitualRecencyWindow { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
     /// When <c>true</c>, the raw client IP is carried on <c>SuspiciousUserSessionDetectedEto</c> so a
     /// downstream consumer (e.g. the alert email) can display it. <strong>Opt-in</strong>: the default
     /// (<c>false</c>) keeps alerts location-only. <strong>GDPR note:</strong> enabling this re-introduces the

--- a/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs
@@ -25,6 +25,7 @@ public static class IdentityModelBuilderExtensions
         modelBuilder.ApplyConfiguration(new UserConfiguration());
         modelBuilder.ApplyConfiguration(new UserSessionRiskEntityConfiguration());
         modelBuilder.ApplyConfiguration(new DeviceTrustEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new UserBehavioralProfileEntityConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
@@ -35,5 +35,9 @@ public sealed class GranitIdentityEntityFrameworkCoreModule : GranitModule
         // Durable device-trust store, in the same context — a device marked trusted survives restarts and is
         // honoured across instances. Overrides the in-memory default from Granit.Identity.Abstractions.
         context.Services.AddScoped<IDeviceTrustStore, EfCoreDeviceTrustStore>();
+
+        // Durable habitual-profile store, in the same context — a habitual location/device stays recognised
+        // between visits instead of resetting on restart. Overrides the in-memory default.
+        context.Services.AddScoped<IUserBehavioralProfileStore, EfCoreUserBehavioralProfileStore>();
     }
 }

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/Configurations/UserBehavioralProfileEntityConfiguration.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/Configurations/UserBehavioralProfileEntityConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Identity.EntityFrameworkCore.Internal.Configurations;
+
+/// <summary>
+/// EF Core configuration for <see cref="UserBehavioralProfileEntity"/>.
+/// </summary>
+internal sealed class UserBehavioralProfileEntityConfiguration : IEntityTypeConfiguration<UserBehavioralProfileEntity>
+{
+    public void Configure(EntityTypeBuilder<UserBehavioralProfileEntity> builder)
+    {
+        builder.ToTable(GranitIdentityDbProperties.DbTablePrefix + "user_behavioral_profiles", GranitIdentityDbProperties.DbSchema);
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).ValueGeneratedNever();
+        builder.Property(e => e.UserId).HasMaxLength(128).IsRequired();
+        builder.Property(e => e.Kind).HasMaxLength(32).IsRequired();
+        builder.Property(e => e.Value).HasMaxLength(128).IsRequired();
+        builder.Property(e => e.Count).IsRequired();
+        builder.Property(e => e.FirstSeenAt).IsRequired();
+        builder.Property(e => e.LastSeenAt).IsRequired();
+
+        builder.HasIndex(e => new { e.UserId, e.Kind, e.Value }).IsUnique();
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserBehavioralProfileStore.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserBehavioralProfileStore.cs
@@ -1,0 +1,103 @@
+using Granit.Guids;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Identity.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Durable <see cref="IUserBehavioralProfileStore"/> backed by EF Core. The profile survives restarts and is
+/// shared across instances, so a habitual location/device stays recognised between visits instead of resetting.
+/// </summary>
+internal sealed class EfCoreUserBehavioralProfileStore(
+    IDbContextFactory<IdentityDbContext> dbContextFactory,
+    IGuidGenerator guidGenerator) : IUserBehavioralProfileStore
+{
+    public async Task<UserBehavioralProfile> GetAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<UserBehavioralProfileEntity> rows = await db.UserBehavioralProfiles
+            .AsNoTracking()
+            .Where(e => e.UserId == userId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows.Count == 0
+            ? UserBehavioralProfile.Empty
+            : new UserBehavioralProfile(
+                [.. rows.Select(r => new BehavioralObservation(r.Kind, r.Value, r.Count, r.FirstSeenAt, r.LastSeenAt))]);
+    }
+
+    public async Task RecordObservationAsync(
+        string userId,
+        string? country,
+        string? deviceFamily,
+        string? coarseLocation,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken = default)
+    {
+        List<(BehavioralObservationKind Kind, string Value)> signals = [];
+        Add(signals, BehavioralObservationKind.Country, country);
+        Add(signals, BehavioralObservationKind.DeviceFamily, deviceFamily);
+        Add(signals, BehavioralObservationKind.CoarseLocation, coarseLocation);
+        if (signals.Count == 0)
+        {
+            return;
+        }
+
+        // Upsert+increment each signal with one retry: two concurrent observations of the same
+        // (userId, kind, value) can both miss the existing row and both insert, tripping the unique index. On
+        // that conflict, re-read and increment the winner's row instead of surfacing the DbUpdateException.
+        for (int attempt = 0; ; attempt++)
+        {
+            await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach ((BehavioralObservationKind kind, string value) in signals)
+            {
+                UserBehavioralProfileEntity? existing = await db.UserBehavioralProfiles
+                    .FirstOrDefaultAsync(
+                        e => e.UserId == userId && e.Kind == kind && e.Value == value, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (existing is not null)
+                {
+                    existing.Count++;
+                    existing.LastSeenAt = observedAt;
+                }
+                else
+                {
+                    db.UserBehavioralProfiles.Add(new UserBehavioralProfileEntity
+                    {
+                        Id = guidGenerator.Create(),
+                        UserId = userId,
+                        Kind = kind,
+                        Value = value,
+                        Count = 1,
+                        FirstSeenAt = observedAt,
+                        LastSeenAt = observedAt,
+                    });
+                }
+            }
+
+            try
+            {
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (DbUpdateException) when (attempt == 0)
+            {
+                // Lost an insert race; loop once to re-read and increment the winner's row.
+            }
+        }
+    }
+
+    private static void Add(
+        List<(BehavioralObservationKind Kind, string Value)> signals, BehavioralObservationKind kind, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+        {
+            signals.Add((kind, value));
+        }
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
@@ -43,6 +43,13 @@ internal sealed class IdentityDbContext(
     /// </summary>
     public DbSet<DeviceTrustEntity> DeviceTrusts => Set<DeviceTrustEntity>();
 
+    /// <summary>
+    /// Durable habitual-profile observations, keyed by <c>(UserId, Kind, Value)</c>. Persisted in the same
+    /// context as <see cref="User"/> — behavioural history is part of the identity domain (no separate context
+    /// per table).
+    /// </summary>
+    public DbSet<UserBehavioralProfileEntity> UserBehavioralProfiles => Set<UserBehavioralProfileEntity>();
+
     /// <inheritdoc />
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/UserBehavioralProfileEntity.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/UserBehavioralProfileEntity.cs
@@ -1,0 +1,32 @@
+namespace Granit.Identity.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core entity persisting one entry of a user's durable habitual profile — a value observed for a given
+/// dimension, with frequency and recency — keyed by <c>(UserId, Kind, Value)</c>.
+/// </summary>
+internal sealed class UserBehavioralProfileEntity
+{
+    /// <summary>Primary key.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Subject the observation belongs to.</summary>
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Dimension of the observed value. Persisted as its PascalCase name (for SQL-audit readability) by the
+    /// Granit enum-as-string convention applied via <c>ApplyGranitConventions</c>.
+    /// </summary>
+    public BehavioralObservationKind Kind { get; set; }
+
+    /// <summary>The observed value (country code, device family, or coarse-location bucket).</summary>
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>How many times the value has been observed.</summary>
+    public int Count { get; set; }
+
+    /// <summary>When the value was first observed.</summary>
+    public DateTimeOffset FirstSeenAt { get; set; }
+
+    /// <summary>When the value was most recently observed.</summary>
+    public DateTimeOffset LastSeenAt { get; set; }
+}

--- a/tests/Granit.Identity.Abstractions.Tests/MemoryUserBehavioralProfileStoreTests.cs
+++ b/tests/Granit.Identity.Abstractions.Tests/MemoryUserBehavioralProfileStoreTests.cs
@@ -1,0 +1,61 @@
+using Granit.Identity.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Abstractions.Tests;
+
+public sealed class MemoryUserBehavioralProfileStoreTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 6, 12, 10, 0, 0, TimeSpan.Zero);
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private readonly MemoryUserBehavioralProfileStore _sut = new();
+
+    [Fact]
+    public async Task RecordThenGet_ReturnsOneObservationPerNonNullDimension()
+    {
+        await _sut.RecordObservationAsync("u1", "BE", "windows", "50,4", T0, Ct);
+
+        UserBehavioralProfile profile = await _sut.GetAsync("u1", Ct);
+
+        profile.Observations.Count.ShouldBe(3);
+        profile.Observations.ShouldContain(o =>
+            o.Kind == BehavioralObservationKind.Country && o.Value == "BE" && o.Count == 1
+            && o.FirstSeenAt == T0 && o.LastSeenAt == T0);
+    }
+
+    [Fact]
+    public async Task Record_Twice_IncrementsCountAndAdvancesLastSeenKeepingFirstSeen()
+    {
+        await _sut.RecordObservationAsync("u1", "BE", null, null, T0, Ct);
+        await _sut.RecordObservationAsync("u1", "BE", null, null, T0.AddDays(1), Ct);
+
+        BehavioralObservation be = (await _sut.GetAsync("u1", Ct)).Observations
+            .Single(o => o.Kind == BehavioralObservationKind.Country && o.Value == "BE");
+
+        be.Count.ShouldBe(2);
+        be.FirstSeenAt.ShouldBe(T0);
+        be.LastSeenAt.ShouldBe(T0.AddDays(1));
+    }
+
+    [Fact]
+    public async Task Record_SkipsNullAndEmptyValues()
+    {
+        await _sut.RecordObservationAsync("u1", "BE", null, "", T0, Ct);
+
+        (await _sut.GetAsync("u1", Ct)).Observations.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Get_UnknownUser_ReturnsEmpty() =>
+        (await _sut.GetAsync("nobody", Ct)).ShouldBe(UserBehavioralProfile.Empty);
+
+    [Fact]
+    public async Task Profiles_AreIsolatedPerUser()
+    {
+        await _sut.RecordObservationAsync("u1", "BE", null, null, T0, Ct);
+
+        (await _sut.GetAsync("u2", Ct)).Observations.ShouldBeEmpty();
+    }
+}

--- a/tests/Granit.Identity.Abstractions.Tests/UserBehavioralProfileTests.cs
+++ b/tests/Granit.Identity.Abstractions.Tests/UserBehavioralProfileTests.cs
@@ -1,0 +1,52 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Abstractions.Tests;
+
+public sealed class UserBehavioralProfileTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 12, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Recency = TimeSpan.FromDays(30);
+    private static readonly TimeSpan Retention = TimeSpan.FromDays(180);
+    private const int MinObservations = 3;
+
+    private static UserBehavioralProfile Profile(int count, TimeSpan lastSeenAgo) =>
+        new([new BehavioralObservation(
+            BehavioralObservationKind.Country, "BE", count, Now - lastSeenAgo - TimeSpan.FromDays(1), Now - lastSeenAgo)]);
+
+    [Fact]
+    public void IsHabitual_FrequentWithinRetention_True() =>
+        Profile(count: 5, lastSeenAgo: TimeSpan.FromDays(90))
+            .IsHabitual(BehavioralObservationKind.Country, "BE", Now, MinObservations, Recency, Retention)
+            .ShouldBeTrue();
+
+    [Fact]
+    public void IsHabitual_RecentButInfrequent_True() =>
+        Profile(count: 1, lastSeenAgo: TimeSpan.FromDays(3))
+            .IsHabitual(BehavioralObservationKind.Country, "BE", Now, MinObservations, Recency, Retention)
+            .ShouldBeTrue();
+
+    [Fact]
+    public void IsHabitual_InfrequentAndOutsideRecency_False() =>
+        Profile(count: 1, lastSeenAgo: TimeSpan.FromDays(60))
+            .IsHabitual(BehavioralObservationKind.Country, "BE", Now, MinObservations, Recency, Retention)
+            .ShouldBeFalse();
+
+    [Fact]
+    public void IsHabitual_FrequentButBeyondRetention_False() =>
+        Profile(count: 10, lastSeenAgo: TimeSpan.FromDays(200))
+            .IsHabitual(BehavioralObservationKind.Country, "BE", Now, MinObservations, Recency, Retention)
+            .ShouldBeFalse();
+
+    [Fact]
+    public void IsHabitual_UnknownValue_False() =>
+        Profile(count: 5, lastSeenAgo: TimeSpan.FromDays(1))
+            .IsHabitual(BehavioralObservationKind.Country, "FR", Now, MinObservations, Recency, Retention)
+            .ShouldBeFalse();
+
+    [Fact]
+    public void IsHabitual_WrongKind_False() =>
+        Profile(count: 5, lastSeenAgo: TimeSpan.FromDays(1))
+            .IsHabitual(BehavioralObservationKind.DeviceFamily, "BE", Now, MinObservations, Recency, Retention)
+            .ShouldBeFalse();
+}

--- a/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionAnomalyDetectorTests.cs
+++ b/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionAnomalyDetectorTests.cs
@@ -29,6 +29,15 @@ public sealed class UserSessionAnomalyDetectorTests
     private readonly IStructuredCompletion _structuredCompletion = Substitute.For<IStructuredCompletion>();
     private readonly IAICallRateLimiter _rateLimiter = Substitute.For<IAICallRateLimiter>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly IUserBehavioralProfileStore _profileStore = Substitute.For<IUserBehavioralProfileStore>();
+    private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
+
+    public UserSessionAnomalyDetectorTests()
+    {
+        _timeProvider.GetUtcNow().Returns(Now);
+        // Default: empty durable profile, so existing scenarios behave exactly as before (no suppression).
+        _profileStore.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(UserBehavioralProfile.Empty);
+    }
 
     [Fact]
     public async Task AssessAsync_NoHistory_ReturnsNone()
@@ -153,12 +162,88 @@ public sealed class UserSessionAnomalyDetectorTests
             Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>());
     }
 
+    // ── Durable habitual profile suppresses familiar country/device (the second-residence fix) ──
+
+    [Fact]
+    public async Task AssessAsync_HabitualCountry_SuppressesNewCountry()
+    {
+        // BE is habitual in the durable profile (seen 5×), even though the only active session is in FR.
+        _profileStore.GetAsync("user-1", Arg.Any<CancellationToken>()).Returns(new UserBehavioralProfile(
+            [new BehavioralObservation(BehavioralObservationKind.Country, "BE", 5, Now.AddDays(-90), Now.AddDays(-5))]));
+
+        UserSessionAnomalyDetector sut = CreateDetector();
+        UserSessionDescriptor candidate = Session("s2", Brussels, Desktop, Now);
+        UserSessionDescriptor prior = Session("s1", Paris, Desktop, Now.AddHours(-10));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldNotContain("new_country");
+        result.Level.ShouldBe(UserSessionRiskLevel.None);
+    }
+
+    [Fact]
+    public async Task AssessAsync_HabitualCountryAndDevice_SuppressesBoth()
+    {
+        string mobileFamily = DeviceFingerprint.Family(Mobile);
+        _profileStore.GetAsync("user-1", Arg.Any<CancellationToken>()).Returns(new UserBehavioralProfile(
+        [
+            new BehavioralObservation(BehavioralObservationKind.Country, "BE", 5, Now.AddDays(-90), Now.AddDays(-5)),
+            new BehavioralObservation(BehavioralObservationKind.DeviceFamily, mobileFamily, 5, Now.AddDays(-90), Now.AddDays(-5)),
+        ]));
+
+        UserSessionAnomalyDetector sut = CreateDetector();
+        UserSessionDescriptor candidate = Session("s2", Brussels, Mobile, Now);
+        UserSessionDescriptor prior = Session("s1", Paris, Desktop, Now.AddHours(-10));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldNotContain("new_country");
+        result.Reasons.ShouldNotContain("new_device");
+        result.Level.ShouldBe(UserSessionRiskLevel.None);
+    }
+
+    [Fact]
+    public async Task AssessAsync_RecentlySeenCountryBelowFrequency_StillSuppressed()
+    {
+        // Seen once (< MinObservationsForHabitual = 3) but only 3 days ago (< 30-day recency window) — "you were
+        // just here", so it must not re-flag.
+        _profileStore.GetAsync("user-1", Arg.Any<CancellationToken>()).Returns(new UserBehavioralProfile(
+            [new BehavioralObservation(BehavioralObservationKind.Country, "BE", 1, Now.AddDays(-3), Now.AddDays(-3))]));
+
+        UserSessionAnomalyDetector sut = CreateDetector();
+        UserSessionDescriptor candidate = Session("s2", Brussels, Desktop, Now);
+        UserSessionDescriptor prior = Session("s1", Paris, Desktop, Now.AddHours(-10));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldNotContain("new_country");
+    }
+
+    [Fact]
+    public async Task AssessAsync_StaleCountryBeyondRetention_StillFlagged()
+    {
+        // Frequent long ago but last seen beyond the 180-day retention window — no longer counts, so it flags.
+        _profileStore.GetAsync("user-1", Arg.Any<CancellationToken>()).Returns(new UserBehavioralProfile(
+            [new BehavioralObservation(BehavioralObservationKind.Country, "BE", 5, Now.AddDays(-400), Now.AddDays(-200))]));
+
+        UserSessionAnomalyDetector sut = CreateDetector();
+        UserSessionDescriptor candidate = Session("s2", Brussels, Desktop, Now);
+        UserSessionDescriptor prior = Session("s1", Paris, Desktop, Now.AddHours(-10));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldContain("new_country");
+        result.Level.ShouldBe(UserSessionRiskLevel.Low);
+    }
+
     private UserSessionAnomalyDetector CreateDetector(bool useAi = false) =>
         new(
             _structuredCompletion,
             _rateLimiter,
             Microsoft.Extensions.Options.Options.Create(new IdentityAnomalyDetectionOptions { UseAi = useAi }),
             _currentTenant,
+            _profileStore,
+            _timeProvider,
             CreateMetrics());
 
     private static UserSessionDescriptor Session(string id, GeoLocation location, string userAgent, DateTimeOffset createdAt) =>

--- a/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionCreatedHandlerTests.cs
+++ b/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionCreatedHandlerTests.cs
@@ -35,9 +35,13 @@ public sealed class UserSessionCreatedHandlerTests
                 new("s-old", "user-1", IsCurrent: false, Now.AddDays(-1), Now.AddDays(-1), "ua2", "2.2.2.2", Location: null),
             });
 
+        IUserBehavioralProfileStore profileStore = Substitute.For<IUserBehavioralProfileStore>();
+        TimeProvider timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(Now);
+
         UserSessionCreatedEto evt = new("user-1", "s-new", TenantId: null, UserSessionSource.Bff, "ua", "1.1.1.1", Now);
 
-        await UserSessionCreatedHandler.HandleAsync(evt, tenant, evaluator, provider, geo, Ct);
+        await UserSessionCreatedHandler.HandleAsync(evt, tenant, evaluator, provider, geo, profileStore, timeProvider, Ct);
 
         await evaluator.Received(1).EvaluateAsync(
             Arg.Is<UserSessionDescriptor>(c =>
@@ -46,6 +50,10 @@ public sealed class UserSessionCreatedHandlerTests
                 h.Count == 1 && h[0].SessionId == "s-old" && h[0].Location!.City == "Paris"),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
+
+        // The candidate's observation is recorded into the durable profile after assessment.
+        await profileStore.Received(1).RecordObservationAsync(
+            "user-1", "BE", Arg.Any<string?>(), Arg.Any<string?>(), Now, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -64,9 +72,13 @@ public sealed class UserSessionCreatedHandlerTests
                 new("s1", "user-1", IsCurrent: true, Now, null, "ua", null, Location: null),
             });
 
+        IUserBehavioralProfileStore profileStore = Substitute.For<IUserBehavioralProfileStore>();
+        TimeProvider timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(Now);
+
         UserSessionCreatedEto evt = new("user-1", "s1", eventTenant, UserSessionSource.Bff, "ua", null, Now);
 
-        await UserSessionCreatedHandler.HandleAsync(evt, tenant, evaluator, provider, geo, Ct);
+        await UserSessionCreatedHandler.HandleAsync(evt, tenant, evaluator, provider, geo, profileStore, timeProvider, Ct);
 
         tenant.Received(1).Change(eventTenant);
     }
@@ -89,12 +101,20 @@ public sealed class UserSessionCreatedHandlerTests
                 new("bff-sid", "user-1", IsCurrent: true, Now, null, "ua", "1.1.1.1", Location: null),
             });
 
+        IUserBehavioralProfileStore profileStore = Substitute.For<IUserBehavioralProfileStore>();
+        TimeProvider timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(Now);
+
         UserSessionCreatedEto evt = new(
             "user-1", "oidc-token-id", TenantId: null, UserSessionSource.OpenIddict, "ua", "1.1.1.1", Now);
 
-        await UserSessionCreatedHandler.HandleAsync(evt, tenant, evaluator, provider, geo, Ct);
+        await UserSessionCreatedHandler.HandleAsync(evt, tenant, evaluator, provider, geo, profileStore, timeProvider, Ct);
 
         await evaluator.DidNotReceiveWithAnyArgs().EvaluateAsync(default!, default!, default, Ct);
         await geo.DidNotReceiveWithAnyArgs().ResolveAsync(default, Ct);
+
+        // A session this topology does not own is neither assessed nor recorded into the profile.
+        await profileStore.DidNotReceiveWithAnyArgs().RecordObservationAsync(
+            default!, default, default, default, default, Ct);
     }
 }

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/EfCoreUserBehavioralProfileStoreTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/EfCoreUserBehavioralProfileStoreTests.cs
@@ -1,0 +1,108 @@
+using Granit.Guids;
+using Granit.Identity.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.EntityFrameworkCore.Tests;
+
+public sealed class EfCoreUserBehavioralProfileStoreTests : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 6, 12, 10, 0, 0, TimeSpan.Zero);
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    // SQLite (not InMemory): enforces the unique (UserId, Kind, Value) index the upsert-race retry relies on.
+    private readonly TestDbContextFactory _factory = TestDbContextFactory.Create();
+
+    public void Dispose() => _factory.Dispose();
+
+    [Fact]
+    public async Task RecordThenGet_RoundtripsObservations()
+    {
+        EfCoreUserBehavioralProfileStore store = CreateStore();
+
+        await store.RecordObservationAsync("user-1", "BE", "windows", "50,4", T0, Ct);
+        UserBehavioralProfile profile = await store.GetAsync("user-1", Ct);
+
+        profile.Observations.Count.ShouldBe(3);
+        BehavioralObservation country = profile.Observations
+            .Single(o => o.Kind == BehavioralObservationKind.Country);
+        country.Value.ShouldBe("BE");
+        country.Count.ShouldBe(1);
+        country.FirstSeenAt.ShouldBe(T0);
+    }
+
+    [Fact]
+    public async Task Record_Twice_IncrementsCount_OneRowPerValue()
+    {
+        EfCoreUserBehavioralProfileStore store = CreateStore();
+
+        await store.RecordObservationAsync("user-1", "BE", null, null, T0, Ct);
+        await store.RecordObservationAsync("user-1", "BE", null, null, T0.AddDays(1), Ct);
+
+        await using IdentityDbContext db = _factory.CreateDbContext();
+        (await db.UserBehavioralProfiles.CountAsync(Ct)).ShouldBe(1);
+
+        BehavioralObservation be = (await store.GetAsync("user-1", Ct)).Observations.Single();
+        be.Count.ShouldBe(2);
+        be.FirstSeenAt.ShouldBe(T0);
+        be.LastSeenAt.ShouldBe(T0.AddDays(1));
+    }
+
+    [Fact]
+    public async Task RecordConcurrentFirstWrites_ConvergeToOneRowCountedTwice()
+    {
+        // Two observations of the same (user, country) racing from a cold start both miss the existing row and
+        // both insert; SQLite trips the unique index on one, and the store's retry re-reads and increments the
+        // winner's row. Invariant: exactly one row, count 2, no exception escapes.
+        EfCoreUserBehavioralProfileStore store = CreateStore();
+
+        await Task.WhenAll(
+            store.RecordObservationAsync("user-1", "BE", null, null, T0, Ct),
+            store.RecordObservationAsync("user-1", "BE", null, null, T0, Ct));
+
+        await using IdentityDbContext db = _factory.CreateDbContext();
+        (await db.UserBehavioralProfiles.CountAsync(Ct)).ShouldBe(1);
+        (await store.GetAsync("user-1", Ct)).Observations.Single().Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task UniqueIndex_RejectsDuplicateUserKindValueTriple()
+    {
+        await using (IdentityDbContext db = _factory.CreateDbContext())
+        {
+            db.UserBehavioralProfiles.Add(NewEntity("user-1", "BE"));
+            await db.SaveChangesAsync(Ct);
+        }
+
+        await using (IdentityDbContext db = _factory.CreateDbContext())
+        {
+            db.UserBehavioralProfiles.Add(NewEntity("user-1", "BE"));
+            await Should.ThrowAsync<DbUpdateException>(() => db.SaveChangesAsync(Ct));
+        }
+    }
+
+    [Fact]
+    public async Task Get_UnknownUser_ReturnsEmpty() =>
+        (await CreateStore().GetAsync("nobody", Ct)).ShouldBe(UserBehavioralProfile.Empty);
+
+    private static UserBehavioralProfileEntity NewEntity(string userId, string value) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        Kind = BehavioralObservationKind.Country,
+        Value = value,
+        Count = 1,
+        FirstSeenAt = T0,
+        LastSeenAt = T0,
+    };
+
+    private EfCoreUserBehavioralProfileStore CreateStore()
+    {
+        IGuidGenerator guid = Substitute.For<IGuidGenerator>();
+        guid.Create().Returns(_ => Guid.NewGuid());
+        return new EfCoreUserBehavioralProfileStore(_factory, guid);
+    }
+}


### PR DESCRIPTION
Part of #2669 (epic #2654) — **PR 1 of 3** (durable profile → geo confidence → "was this you?" feedback loop). Plan: durable, weighted habitual profile.

## Problem
The session anomaly detector is bounded by the `history` it is handed, and that history is built from **currently-active sessions only**. A legitimate-but-occasional location (a second residence visited monthly) drops out of active sessions between visits and is re-flagged `new_country` every time. High alerts are hard-locked (cannot be opted out, #2663), so this noise matters.

## What
A durable, recency/frequency-weighted habitual profile the detector consults so familiar countries/devices stop re-flagging.

- **Abstractions**: `UserBehavioralProfile` (observed `Country` / `DeviceFamily` / `CoarseLocation`, each with `Count` / `FirstSeenAt` / `LastSeenAt`, plus `IsHabitual`) + `IUserBehavioralProfileStore`, with an in-memory Null-Object default (`MemoryUserBehavioralProfileStore`, `TryAddSingleton`).
- **EF**: `UserBehavioralProfileEntity` + config (table `identity_user_behavioral_profiles`, unique `(UserId, Kind, Value)`) on the consolidated `IdentityDbContext`; durable `EfCoreUserBehavioralProfileStore` (upsert+increment, insert-race retry). Overrides the in-memory default.
- **Detector**: `new_country` / `new_device` are suppressed when the value is **habitual** — observed ≥ `MinObservationsForHabitual` (frequency) **or** within `HabitualRecencyWindow` (recency), and not older than `ProfileRetention`. The session-created handler records the candidate's observation **after** assessment, so a genuinely-new first sighting still scores and repeat visits then go quiet.
- **Options** (`Identity:AnomalyDetection`): `ProfileRetention` (180d), `MinObservationsForHabitual` (3), `HabitualRecencyWindow` (30d).

Conservative by design: the profile only **suppresses** signals (the `history.Count > 0` trigger is unchanged), so it cannot introduce new detections. Storage pruning of aged-out rows is left to a future cleanup job — reads already ignore entries beyond `ProfileRetention`, so correctness does not depend on it.

## Tests
Detector suppression (frequency, recency, retention boundary, country+device together); observation recorded post-assessment; not recorded for an unowned session; `MemoryUserBehavioralProfileStore` + `UserBehavioralProfile.IsHabitual`; `EfCoreUserBehavioralProfileStore` roundtrip / increment / unique-index / concurrent-race.

## Verification
- Builds: Identity.Abstractions, Identity.EntityFrameworkCore, Identity.AnomalyDetection ✅
- Tests: AnomalyDetection **20** (+4), Abstractions **32** (+11), EF **21** (+5) ✅
- `dotnet format --verify-no-changes` (all touched) ✅
- architecture shard **225** ✅

## Follow-ups (next PRs in #2669)
- PR2: geo confidence (`GeoLocation` accuracy/anonymising fields) so VPN / mobile-NAT don't fire High `impossible_travel`.
- PR3: "Was this you?" feedback loop (GET inspect / POST commit, single-use idempotent) — yes reinforces the profile + trusts the device, no revokes sessions + remediation Eto.