### PR TITLE
feat(identity): factor geo confidence into impossible-travel (#2669 PR2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -23914,6 +23914,18 @@
           "kind": "method",
           "signature": "FromDays(30)",
           "returnType": "TimeSpan HabitualRecencyWindow { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MaxGeoAccuracyRadiusKm",
+          "kind": "property",
+          "signature": "int MaxGeoAccuracyRadiusKm",
+          "returnType": "int"
+        },
+        {
+          "name": "SuppressTravelForAnonymizedIp",
+          "kind": "property",
+          "signature": "bool SuppressTravelForAnonymizedIp",
+          "returnType": "bool"
         }
       ]
     },

--- a/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
+++ b/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
@@ -5,6 +5,7 @@ using Granit.AI;
 using Granit.AI.RateLimiting;
 using Granit.Identity.AnomalyDetection.Diagnostics;
 using Granit.Identity.AnomalyDetection.Options;
+using Granit.IpGeolocation;
 using Granit.MultiTenancy;
 using Microsoft.Extensions.Options;
 
@@ -80,8 +81,8 @@ internal sealed class UserSessionAnomalyDetector(
         DateTimeOffset now)
     {
         List<string> reasons = [];
-        bool impossibleTravel = HasImpossibleTravel(candidate, history, opts.MaxTravelKilometersPerHour);
-        if (impossibleTravel)
+        TravelOutcome travel = EvaluateTravel(candidate, history, opts);
+        if (travel == TravelOutcome.Detected)
         {
             reasons.Add("impossible_travel");
         }
@@ -109,7 +110,7 @@ internal sealed class UserSessionAnomalyDetector(
             }
         }
 
-        UserSessionRiskLevel level = impossibleTravel
+        UserSessionRiskLevel level = travel == TravelOutcome.Detected
             ? UserSessionRiskLevel.High
             : reasons.Count >= 2
                 ? UserSessionRiskLevel.Medium
@@ -117,19 +118,37 @@ internal sealed class UserSessionAnomalyDetector(
                     ? UserSessionRiskLevel.Low
                     : UserSessionRiskLevel.None;
 
-        return new UserSessionRiskAssessment(level, ScoreFor(level), reasons);
+        // `low_geo_confidence` is explanatory — it records that a travel alert was withheld because the geo fix
+        // was untrustworthy, without itself inflating the risk level (so it can never manufacture a Medium).
+        IReadOnlyList<string> finalReasons = travel == TravelOutcome.SuppressedLowConfidence
+            ? [.. reasons, "low_geo_confidence"]
+            : reasons;
+
+        return new UserSessionRiskAssessment(level, ScoreFor(level), finalReasons);
     }
 
-    private static bool HasImpossibleTravel(
+    private enum TravelOutcome
+    {
+        None,
+        Detected,
+        SuppressedLowConfidence,
+    }
+
+    // A travel hit only counts when both endpoints are a trustworthy fix. A coarse (large accuracy radius) or
+    // anonymising (VPN/proxy/hosting) endpoint produces an apparent jump that is an artefact of the lookup, not
+    // real movement — so such a pairing is suppressed and surfaced as low_geo_confidence rather than a
+    // hard-locked High. A genuine high-confidence jump still wins.
+    private static TravelOutcome EvaluateTravel(
         UserSessionDescriptor candidate,
         IReadOnlyList<UserSessionDescriptor> history,
-        double maxKilometersPerHour)
+        IdentityAnomalyDetectionOptions opts)
     {
         if (candidate.Location is not { Latitude: { } lat, Longitude: { } lon })
         {
-            return false;
+            return TravelOutcome.None;
         }
 
+        bool suppressed = false;
         foreach (UserSessionDescriptor prior in history)
         {
             if (prior.SessionId == candidate.SessionId
@@ -143,13 +162,37 @@ internal sealed class UserSessionAnomalyDetector(
             double hours = Math.Abs((candidate.CreatedAt - priorTime).TotalHours);
             double speed = hours > 0.01 ? km / hours : km > 50d ? double.PositiveInfinity : 0d;
 
-            if (speed > maxKilometersPerHour)
+            if (speed <= opts.MaxTravelKilometersPerHour)
             {
-                return true;
+                continue;
             }
+
+            if (IsLowConfidence(candidate.Location, opts) || IsLowConfidence(prior.Location, opts))
+            {
+                suppressed = true;
+                continue;
+            }
+
+            return TravelOutcome.Detected;
         }
 
-        return false;
+        return suppressed ? TravelOutcome.SuppressedLowConfidence : TravelOutcome.None;
+    }
+
+    // A fix is low-confidence when its reported accuracy radius is too coarse, or the IP is flagged anonymising
+    // (and the deployment opts to suppress those). null fields mean "the provider does not classify this" — they
+    // are never treated as a negative signal.
+    private static bool IsLowConfidence(GeoLocation location, IdentityAnomalyDetectionOptions opts)
+    {
+        if (opts.MaxGeoAccuracyRadiusKm > 0
+            && location.AccuracyRadiusKm is { } radius
+            && radius > opts.MaxGeoAccuracyRadiusKm)
+        {
+            return true;
+        }
+
+        return opts.SuppressTravelForAnonymizedIp
+            && (location.IsAnonymousProxy == true || location.IsVpn == true || location.IsHostingProvider == true);
     }
 
     private async Task<UserSessionRiskAssessment?> TryAssessWithAiAsync(

--- a/src/Granit.Identity.AnomalyDetection/Options/IdentityAnomalyDetectionOptions.cs
+++ b/src/Granit.Identity.AnomalyDetection/Options/IdentityAnomalyDetectionOptions.cs
@@ -65,6 +65,22 @@ public sealed class IdentityAnomalyDetectionOptions
     public TimeSpan HabitualRecencyWindow { get; set; } = TimeSpan.FromDays(30);
 
     /// <summary>
+    /// A geolocation fix whose reported accuracy radius (km) exceeds this is too coarse to support an
+    /// impossible-travel verdict — mobile-carrier NAT and sparse data routinely produce huge apparent jumps. A
+    /// travel hit involving such a fix is suppressed (recorded as <c>low_geo_confidence</c>) instead of raising a
+    /// hard-locked High. Set to <c>0</c> to disable the accuracy check. Default: 200 km.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int MaxGeoAccuracyRadiusKm { get; set; } = 200;
+
+    /// <summary>
+    /// When <c>true</c>, a travel hit involving an IP the provider flags as anonymising (VPN / proxy / hosting)
+    /// is suppressed (recorded as <c>low_geo_confidence</c>) rather than raising a hard-locked High — the exit
+    /// node's apparent position is not the user's. Default: <c>true</c>.
+    /// </summary>
+    public bool SuppressTravelForAnonymizedIp { get; set; } = true;
+
+    /// <summary>
     /// When <c>true</c>, the raw client IP is carried on <c>SuspiciousUserSessionDetectedEto</c> so a
     /// downstream consumer (e.g. the alert email) can display it. <strong>Opt-in</strong>: the default
     /// (<c>false</c>) keeps alerts location-only. <strong>GDPR note:</strong> enabling this re-introduces the

--- a/src/Granit.IpGeolocation.Abstractions/GeoLocation.cs
+++ b/src/Granit.IpGeolocation.Abstractions/GeoLocation.cs
@@ -28,4 +28,30 @@ public sealed record GeoLocation
 
     /// <summary>Approximate longitude in decimal degrees, when available.</summary>
     public double? Longitude { get; init; }
+
+    /// <summary>
+    /// Radius in kilometres within which the true position lies with ~67% confidence, when the source reports
+    /// it. A large radius means a coarse, low-confidence fix (mobile-carrier NAT, satellite, sparse data) —
+    /// consumers should not treat distance computed against it as precise. <c>null</c> when unknown.
+    /// </summary>
+    public int? AccuracyRadiusKm { get; init; }
+
+    /// <summary>
+    /// Whether the IP is a known anonymising proxy (e.g. Tor / open proxy), when the source classifies it.
+    /// <c>null</c> when the source does not provide anonymising-IP data.
+    /// </summary>
+    public bool? IsAnonymousProxy { get; init; }
+
+    /// <summary>
+    /// Whether the IP belongs to a hosting/datacenter provider, when the source classifies it. Datacenter
+    /// egress (cloud, server-side fetch) frequently geolocates far from the human behind it. <c>null</c> when
+    /// the source does not provide it.
+    /// </summary>
+    public bool? IsHostingProvider { get; init; }
+
+    /// <summary>
+    /// Whether the IP is a known VPN exit node, when the source classifies it. <c>null</c> when the source
+    /// does not provide it.
+    /// </summary>
+    public bool? IsVpn { get; init; }
 }

--- a/src/Granit.IpGeolocation.IpInfo/Internal/IpInfoIpGeolocationProvider.cs
+++ b/src/Granit.IpGeolocation.IpInfo/Internal/IpInfoIpGeolocationProvider.cs
@@ -100,6 +100,11 @@ internal sealed partial class IpInfoIpGeolocationProvider(
             return null;
         }
 
+        // Privacy flags only when the token carries the privacy add-on; null (unknown) otherwise. proxy/tor both
+        // mean "anonymising proxy" for our purposes.
+        IpInfoPrivacy? privacy = body.Privacy;
+        bool? anonymousProxy = privacy is null ? null : privacy.Proxy == true || privacy.Tor == true;
+
         return new GeoLocation
         {
             City = body.City,
@@ -107,6 +112,9 @@ internal sealed partial class IpInfoIpGeolocationProvider(
             CountryCode = body.Country,
             Latitude = latitude,
             Longitude = longitude,
+            IsAnonymousProxy = anonymousProxy,
+            IsHostingProvider = privacy?.Hosting,
+            IsVpn = privacy?.Vpn,
         };
     }
 

--- a/src/Granit.IpGeolocation.IpInfo/Internal/IpInfoResponse.cs
+++ b/src/Granit.IpGeolocation.IpInfo/Internal/IpInfoResponse.cs
@@ -22,4 +22,30 @@ internal sealed record IpInfoResponse
 
     [JsonPropertyName("bogon")]
     public bool? Bogon { get; init; }
+
+    /// <summary>
+    /// Privacy-detection block, present only when the API token has the privacy add-on. Absent (<c>null</c>) on
+    /// the free tier, in which case the anonymising flags are left unknown.
+    /// </summary>
+    [JsonPropertyName("privacy")]
+    public IpInfoPrivacy? Privacy { get; init; }
+}
+
+/// <summary>
+/// ipinfo.io privacy-detection sub-object (paid add-on). Each flag is <c>true</c> when the IP matches that
+/// category.
+/// </summary>
+internal sealed record IpInfoPrivacy
+{
+    [JsonPropertyName("vpn")]
+    public bool? Vpn { get; init; }
+
+    [JsonPropertyName("proxy")]
+    public bool? Proxy { get; init; }
+
+    [JsonPropertyName("tor")]
+    public bool? Tor { get; init; }
+
+    [JsonPropertyName("hosting")]
+    public bool? Hosting { get; init; }
 }

--- a/src/Granit.IpGeolocation.MaxMind/Internal/MaxMindDatabaseProvider.cs
+++ b/src/Granit.IpGeolocation.MaxMind/Internal/MaxMindDatabaseProvider.cs
@@ -66,6 +66,11 @@ internal sealed partial class MaxMindDatabaseProvider : IDisposable
             CountryCode = response.Country?.IsoCode,
             Latitude = response.Location?.Latitude,
             Longitude = response.Location?.Longitude,
+            // The City database supplies an accuracy radius (km) — the primary low-confidence signal (mobile
+            // NAT / sparse data give a large radius). Anonymising-IP classification (VPN/proxy/hosting) needs a
+            // separate MaxMind Anonymous-IP database and is left to the IpInfo privacy provider / a follow-up,
+            // so those flags stay null here.
+            AccuracyRadiusKm = response.Location?.AccuracyRadius,
         };
     }
 

--- a/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionAnomalyDetectorTests.cs
+++ b/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionAnomalyDetectorTests.cs
@@ -236,11 +236,73 @@ public sealed class UserSessionAnomalyDetectorTests
         result.Level.ShouldBe(UserSessionRiskLevel.Low);
     }
 
-    private UserSessionAnomalyDetector CreateDetector(bool useAi = false) =>
+    // ── Geo confidence: a low-confidence / anonymising fix must not raise a hard-locked High travel alert ──
+
+    [Fact]
+    public async Task AssessAsync_ImpossibleTravelButCoarseFix_SuppressedAsLowGeoConfidence()
+    {
+        UserSessionAnomalyDetector sut = CreateDetector();
+        // Same jump as the High impossible-travel test, but the candidate fix is coarse (500 km > 200 km).
+        UserSessionDescriptor candidate = Session("s2", Brussels with { AccuracyRadiusKm = 500 }, Desktop, Now);
+        UserSessionDescriptor prior = Session("s1", Sydney, Desktop, Now.AddHours(-1));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldNotContain("impossible_travel");
+        result.Reasons.ShouldContain("low_geo_confidence");
+        // new_country still fires (BE vs AU) → Low; low_geo_confidence must NOT inflate it to Medium/High.
+        result.Level.ShouldBe(UserSessionRiskLevel.Low);
+    }
+
+    [Fact]
+    public async Task AssessAsync_ImpossibleTravelFromVpn_SuppressedAsLowGeoConfidence()
+    {
+        UserSessionAnomalyDetector sut = CreateDetector();
+        UserSessionDescriptor candidate = Session("s2", Brussels with { IsVpn = true }, Desktop, Now);
+        UserSessionDescriptor prior = Session("s1", Sydney, Desktop, Now.AddHours(-1));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldNotContain("impossible_travel");
+        result.Reasons.ShouldContain("low_geo_confidence");
+    }
+
+    [Fact]
+    public async Task AssessAsync_HighConfidenceJump_StillImpossibleTravel()
+    {
+        UserSessionAnomalyDetector sut = CreateDetector();
+        // A precise fix (small radius, no anonymising flags) must keep firing the High verdict.
+        UserSessionDescriptor candidate = Session("s2", Brussels with { AccuracyRadiusKm = 10 }, Desktop, Now);
+        UserSessionDescriptor prior = Session("s1", Sydney with { AccuracyRadiusKm = 10 }, Desktop, Now.AddHours(-1));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldContain("impossible_travel");
+        result.Level.ShouldBe(UserSessionRiskLevel.High);
+    }
+
+    [Fact]
+    public async Task AssessAsync_AnonymizedIp_NotSuppressed_WhenOptionDisabled()
+    {
+        UserSessionAnomalyDetector sut = CreateDetector(suppressAnonymizedIp: false);
+        UserSessionDescriptor candidate = Session("s2", Brussels with { IsVpn = true }, Desktop, Now);
+        UserSessionDescriptor prior = Session("s1", Sydney, Desktop, Now.AddHours(-1));
+
+        UserSessionRiskAssessment result = await sut.AssessAsync(candidate, [prior], Ct);
+
+        result.Reasons.ShouldContain("impossible_travel");
+        result.Level.ShouldBe(UserSessionRiskLevel.High);
+    }
+
+    private UserSessionAnomalyDetector CreateDetector(bool useAi = false, bool suppressAnonymizedIp = true) =>
         new(
             _structuredCompletion,
             _rateLimiter,
-            Microsoft.Extensions.Options.Options.Create(new IdentityAnomalyDetectionOptions { UseAi = useAi }),
+            Microsoft.Extensions.Options.Options.Create(new IdentityAnomalyDetectionOptions
+            {
+                UseAi = useAi,
+                SuppressTravelForAnonymizedIp = suppressAnonymizedIp,
+            }),
             _currentTenant,
             _profileStore,
             _timeProvider,

--- a/tests/Granit.IpGeolocation.IpInfo.Tests/IpInfoIpGeolocationProviderTests.cs
+++ b/tests/Granit.IpGeolocation.IpInfo.Tests/IpInfoIpGeolocationProviderTests.cs
@@ -35,6 +35,38 @@ public sealed class IpInfoIpGeolocationProviderTests
     }
 
     [Fact]
+    public async Task ResolveAsync_PrivacyBlock_MapsAnonymizingFlags()
+    {
+        const string json = """
+            {"ip":"8.8.8.8","city":"X","country":"US","loc":"1,2",
+             "privacy":{"vpn":true,"proxy":false,"tor":true,"hosting":true,"relay":false}}
+            """;
+        IpInfoIpGeolocationProvider sut = CreateProvider(JsonResponse(json), out _);
+
+        GeoLocation? result = await sut.ResolveAsync(PublicIp, Ct);
+
+        result.ShouldNotBeNull();
+        result.IsVpn.ShouldBe(true);
+        result.IsHostingProvider.ShouldBe(true);
+        result.IsAnonymousProxy.ShouldBe(true); // proxy OR tor
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoPrivacyBlock_LeavesAnonymizingFlagsNull()
+    {
+        IpInfoIpGeolocationProvider sut = CreateProvider(
+            JsonResponse("""{"ip":"8.8.8.8","country":"US","loc":"1,2"}"""), out _);
+
+        GeoLocation? result = await sut.ResolveAsync(PublicIp, Ct);
+
+        result.ShouldNotBeNull();
+        result.IsVpn.ShouldBeNull();
+        result.IsAnonymousProxy.ShouldBeNull();
+        result.IsHostingProvider.ShouldBeNull();
+        result.AccuracyRadiusKm.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task ResolveAsync_WithToken_SendsBearerAuthorizationHeader()
     {
         IpInfoIpGeolocationProvider sut = CreateProvider(


### PR DESCRIPTION
Part of #2669 (epic #2654) — **PR 2 of 3** (durable profile ✅ #2708 → **geo confidence** → "was this you?"). Independent of PR1.

## Problem
The biggest source of false **High** alerts is geolocation inaccuracy — VPN/proxy exit nodes, mobile-carrier NAT, low-accuracy lookups — which produce huge apparent jumps that fire `impossible_travel`. High alerts are hard-locked (#2663), so a fix we can't trust must not raise one.

## What
- **`GeoLocation`** gains best-effort **nullable** fields: `AccuracyRadiusKm`, `IsAnonymousProxy`, `IsHostingProvider`, `IsVpn`. `null` = the source does not classify it → today's behaviour. (init-only props, no consumer breaks.)
- **MaxMind** populates `AccuracyRadiusKm` from the City DB — the primary low-confidence signal. Anonymising-IP classification needs a separate MaxMind Anonymous-IP DB (the `Traits` flags are deprecated in favour of it), so those flags stay `null` here — a documented follow-up.
- **IpInfo** maps its `privacy` block (`vpn`/`proxy`/`tor`/`hosting`) when the token has the privacy add-on; `null` on the free tier.
- **Detector**: an `impossible_travel` hit is **suppressed** when either endpoint is low-confidence — accuracy radius > `MaxGeoAccuracyRadiusKm` (default 200 km, `0` disables) or flagged anonymising (when `SuppressTravelForAnonymizedIp`, default true). It records `low_geo_confidence` instead of raising High. That reason is **explanatory and never inflates the level** (it can't manufacture a Medium). A genuine high-confidence jump still fires High.

## Tests
Coarse-fix → suppressed (+ proves `low_geo_confidence` stays Low, not Medium); VPN → suppressed; precise jump → still High; option-off → still High; IpInfo privacy mapping + null-when-absent. (No MaxMind unit test — the harness ships no `.mmdb` fixture and the mapping is a one-field passthrough exercised via the detector.)

## Verification
- Builds: IpGeolocation.Abstractions / MaxMind / IpInfo, Identity.AnomalyDetection ✅
- Tests: AnomalyDetection **24** (+4), IpInfo **24** (+2), IpGeolocation core **44** / Abstractions **3** unaffected ✅
- `dotnet format --verify-no-changes` (all touched) ✅
- architecture shard **225** ✅

## Follow-ups
- MaxMind Anonymous-IP DB support to populate the anonymising flags offline.
- PR3 (#2669): "Was this you?" feedback loop (GET inspect / POST commit, single-use idempotent).