### PR TITLE
fix(identity): identify current session from BFF middleware so revoke-others works

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10139,7 +10139,7 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs",
-      "line": 34,
+      "line": 35,
       "members": []
     },
     {
@@ -29052,6 +29052,15 @@
       "project": "Granit.Identity.Abstractions",
       "file": "src/Granit.Identity.Abstractions/UserDevice.cs",
       "line": 24,
+      "members": []
+    },
+    {
+      "name": "UserSessionContextItems",
+      "fqn": "Granit.Identity.UserSessionContextItems",
+      "kind": "class",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/UserSessionContextItems.cs",
+      "line": 15,
       "members": []
     },
     {

--- a/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Granit.Bff.Diagnostics;
 using Granit.Bff.Options;
 using Granit.Http.Cookies;
+using Granit.Identity;
 using Granit.Oidc.ClientAuthentication;
 using Granit.Oidc.ClientAuthentication.Internal;
 using Granit.Oidc.DPoP;
@@ -80,6 +81,11 @@ public sealed partial class BffTokenInjectionMiddleware
             await _next(context).ConfigureAwait(false);
             return;
         }
+
+        // Surface the BFF session id for in-process endpoints (e.g. canonical /sessions) so they can identify
+        // the caller's own session — the downstream access token carries no equivalent id. Set before token
+        // injection so it is visible even on a CSRF/refresh short-circuit; harmless when no such endpoint reads it.
+        context.Items[UserSessionContextItems.CurrentSessionId] = sessionId;
 
         using System.Diagnostics.Activity? activity = BffActivitySource.Source.StartActivity(BffActivitySource.Proxy);
         metrics.RecordProxyRequest(null);

--- a/src/Granit.Identity.Abstractions/UserSessionContextItems.cs
+++ b/src/Granit.Identity.Abstractions/UserSessionContextItems.cs
@@ -1,0 +1,19 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// Well-known <see cref="System.Collections.Generic.IDictionary{TKey,TValue}">HttpContext.Items</see> keys
+/// carrying the identifier of the request's own session, resolved by the session-bearing middleware.
+/// </summary>
+/// <remarks>
+/// The canonical <c>/sessions</c> endpoints flag and protect the current session by its id. When the BFF is the
+/// session backend, that id is the BFF cookie session id (the <c>IBffTokenStore</c> key) — a different identifier
+/// space from the OIDC <c>sid</c> claim, and one the downstream access token never carries. The in-process BFF
+/// token-injection middleware already resolves it from the cookie, so it stashes it here for the endpoint to read,
+/// letting the endpoint identify "current" without referencing the BFF cookie machinery. Absent for token-only
+/// backends (OpenIddict, Keycloak), where the endpoint falls back to the <c>sid</c> claim.
+/// </remarks>
+public static class UserSessionContextItems
+{
+    /// <summary>Item key for the id of the request's own session in the active session backend's identifier space.</summary>
+    public const string CurrentSessionId = "Granit:UserSession:CurrentSessionId";
+}

--- a/src/Granit.Identity.Endpoints/Endpoints/MyUserSessionEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/MyUserSessionEndpoints.cs
@@ -110,8 +110,14 @@ internal static class MyUserSessionEndpoints
     }
 #pragma warning restore GRAPI003
 
+    // Prefer the session id surfaced by the session backend's middleware (the BFF stashes its own cookie session
+    // id here — a different identifier space from the OIDC sid, and one the access token never carries). Fall back
+    // to the sid claim for token-only backends (OpenIddict, Keycloak).
     private static string? CurrentSessionId(HttpContext httpContext) =>
-        httpContext.User.FindFirst(SessionIdClaim)?.Value;
+        httpContext.Items.TryGetValue(UserSessionContextItems.CurrentSessionId, out object? id)
+        && id is string sessionId && !string.IsNullOrEmpty(sessionId)
+            ? sessionId
+            : httpContext.User.FindFirst(SessionIdClaim)?.Value;
 
     private static ProblemHttpResult NoSubject() =>
         TypedResults.Problem(

--- a/tests/Granit.Identity.Endpoints.Tests/UserSessionEndpointsHttpTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/UserSessionEndpointsHttpTests.cs
@@ -6,6 +6,7 @@ using Granit.IpGeolocation;
 using Granit.Testing.Endpoints;
 using Granit.Users;
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Shouldly;
@@ -23,6 +24,13 @@ public sealed class UserSessionEndpointsHttpTests : IAsyncDisposable
 
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
+    /// <summary>
+    /// Header a test client sets to have the pipeline stash a current-session id into
+    /// <see cref="UserSessionContextItems.CurrentSessionId"/>, standing in for what the in-process BFF
+    /// token-injection middleware does for cookie-backed sessions.
+    /// </summary>
+    private const string SessionIdHeader = "X-Test-Session-Id";
+
     public UserSessionEndpointsHttpTests()
     {
         _currentUser.UserId.Returns("user-1");
@@ -34,7 +42,20 @@ public sealed class UserSessionEndpointsHttpTests : IAsyncDisposable
                 services.AddSingleton(_manager);
                 services.AddSingleton(_currentUser);
             },
-            configureEndpoints: app => app.MapGranitUserSessions())
+            configureEndpoints: app =>
+            {
+                app.Use(async (ctx, next) =>
+                {
+                    if (ctx.Request.Headers.TryGetValue(SessionIdHeader, out Microsoft.Extensions.Primitives.StringValues sid)
+                        && !string.IsNullOrEmpty(sid))
+                    {
+                        ctx.Items[UserSessionContextItems.CurrentSessionId] = sid.ToString();
+                    }
+
+                    await next();
+                });
+                app.MapGranitUserSessions();
+            })
             .GetAwaiter().GetResult();
 
         _auth = _host.CreateAuthenticatedClient();
@@ -94,10 +115,42 @@ public sealed class UserSessionEndpointsHttpTests : IAsyncDisposable
     [Fact]
     public async Task RevokeOthers_WithoutCurrentSession_Returns400()
     {
-        // The test principal carries no 'sid' claim, so the current session cannot be identified.
+        // The test principal carries no 'sid' claim and no session id was stashed, so the current
+        // session cannot be identified.
         HttpResponseMessage response = await _auth.DeleteAsync("/sessions", Ct);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task RevokeOthers_WithSessionIdFromContextItems_RevokesUsingThatId()
+    {
+        // A BFF-backed session has no 'sid' claim; the in-process middleware surfaces the cookie session
+        // id via HttpContext.Items instead. The endpoint must honour it rather than failing with 400.
+        _manager.RevokeOthersAsync("user-1", "bff-session-7", Arg.Any<CancellationToken>()).Returns(3);
+        using var request = new HttpRequestMessage(HttpMethod.Delete, "/sessions");
+        request.Headers.Add(SessionIdHeader, "bff-session-7");
+
+        HttpResponseMessage response = await _auth.SendAsync(request, Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        UserSessionsRevokedResponse? body = await response.Content.ReadFromJsonAsync<UserSessionsRevokedResponse>(Ct);
+        body!.RevokedCount.ShouldBe(3);
+        await _manager.Received(1).RevokeOthersAsync("user-1", "bff-session-7", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListSessions_PassesContextItemsSessionIdAsCurrent()
+    {
+        // The stashed BFF session id flows through as the "current" id so the backend can flag IsCurrent.
+        _manager.ListAsync("user-1", "bff-session-7", Arg.Any<CancellationToken>()).Returns([]);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/sessions");
+        request.Headers.Add(SessionIdHeader, "bff-session-7");
+
+        HttpResponseMessage response = await _auth.SendAsync(request, Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await _manager.Received(1).ListAsync("user-1", "bff-session-7", Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`DELETE /api/v1/sessions` (revoke-others) and the `IsCurrent` flag on `GET /sessions` identify the caller's own session **solely from the OIDC `sid` claim** ([`MyUserSessionEndpoints.CurrentSessionId`](../blob/develop/src/Granit.Identity.Endpoints/Endpoints/MyUserSessionEndpoints.cs)).

Once the BFF is wired as the `/sessions` backend (#2692), every session is keyed by the **BFF cookie session id** (the `IBffTokenStore` key) — a different identifier space the downstream access token never carries. So `sid` is absent, `CurrentSessionId` returns `null`, and revoke-others always fails with `400 "current session could not be identified"`. The 400 is the *safe* failure mode (without it, revoke-others would kill the current session), but the feature is unusable for BFF-backed apps.

This is a framework gap from #2692, not a consumer bug.

## Fix

Mirror the established `DeviceTrustContextItems` pattern:

- **`Granit.Identity.Abstractions`** — new `UserSessionContextItems.CurrentSessionId` well-known `HttpContext.Items` key.
- **`BffTokenInjectionMiddleware`** (in-process path) — stashes the resolved BFF session id into `HttpContext.Items` right after a live session is confirmed.
- **`MyUserSessionEndpoints.CurrentSessionId`** — reads `Items` first, falls back to the `sid` claim for token-only backends (OpenIddict, Keycloak).

Fixes both revoke-others **and** the `IsCurrent` flag, for every backend.

## Out of scope — YARP follow-up

The YARP reverse-proxy transform (`BffTokenInjectionTransform`) proxies to a **separate process**, where `HttpContext.Items` do not cross the boundary. That path needs session-id **header forwarding** (with an inbound-spoof strip on the API side) — a different, security-sensitive mechanism that deserves its own PR. The showcase uses the in-process middleware, not YARP, so this PR fully resolves the reported issue. Follow-up to be filed.

## Tests

- `RevokeOthers_WithSessionIdFromContextItems_RevokesUsingThatId` — Items id → 200 + passed through to `RevokeOthersAsync`.
- `ListSessions_PassesContextItemsSessionIdAsCurrent` — Items id flows as the current id (drives `IsCurrent`).
- `RevokeOthers_WithoutCurrentSession_Returns400` — unchanged (no claim, no Items → 400).

Green locally: `Granit.Identity.Endpoints.Tests` (8), `Granit.Bff.Endpoints.Tests` (108), `Granit.ArchitectureTests` (225). `dotnet format --verify-no-changes` clean on all touched projects.