### PR TITLE
feat(identity): resolve device kind from a Keycloak client attribute (#2668)

### DIFF
--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakClientRepresentation.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakClientRepresentation.cs
@@ -7,10 +7,13 @@ namespace Granit.Identity.Federated.Keycloak.Internal;
 /// Maps to the Keycloak <c>ClientRepresentation</c> schema.
 /// </summary>
 /// <remarks>
-/// Only the fields needed by the client-role sync are modeled (<c>id</c> = Keycloak's
-/// internal UUID, <c>clientId</c> = the OIDC client_id string). Keycloak emits many more
-/// properties that <see cref="System.Text.Json"/> silently ignores.
+/// Only the fields needed are modeled (<c>id</c> = Keycloak's internal UUID, <c>clientId</c> = the OIDC
+/// client_id string, <c>attributes</c> = the client's custom attribute bag). Keycloak emits many more
+/// properties that <see cref="System.Text.Json"/> silently ignores. <c>attributes</c> is a
+/// <c>Map&lt;String, List&lt;String&gt;&gt;</c> in Keycloak (multi-valued) and is only populated on a
+/// single-client fetch (<c>GET /clients/{uuid}</c>), not on the list endpoint's lightweight projection.
 /// </remarks>
 internal sealed record KeycloakClientRepresentation(
     [property: JsonPropertyName("id")] string Id,
-    [property: JsonPropertyName("clientId")] string ClientId);
+    [property: JsonPropertyName("clientId")] string ClientId,
+    [property: JsonPropertyName("attributes")] Dictionary<string, List<string>>? Attributes = null);

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Granit.Diagnostics;
 using Granit.Events;
 using Granit.Identity.Diagnostics;
@@ -41,6 +42,13 @@ internal sealed partial class KeycloakIdentityProvider(
 {
     private const string ProviderName = "keycloak";
     private const string GetUserOperation = "get_user";
+
+    /// <summary>
+    /// Keycloak client attribute (operator-set on the client in Keycloak) declaring the device kind of the
+    /// devices that authenticate through it — the federated equivalent of the OpenIddict application's declared
+    /// kind. Value is a <see cref="DeviceKind"/> name (e.g. <c>"MobileApp"</c>, <c>"Tv"</c>).
+    /// </summary>
+    private const string DeviceKindClientAttribute = "granit.device_kind";
 
     /// <summary>
     /// Detects authorisation failures wrapped in <see cref="HttpRequestException"/>.
@@ -1008,17 +1016,101 @@ internal sealed partial class KeycloakIdentityProvider(
         string userId, CancellationToken cancellationToken)
     {
         List<KeycloakSessionRepresentation> sessions = await GetSessionsAsync(userId, cancellationToken).ConfigureAwait(false);
+        if (sessions.Count == 0)
+        {
+            return [];
+        }
 
-        // The admin sessions endpoint exposes no device metadata, so each session maps to its
-        // own browser-kind device keyed by the session id (the only stable signature available).
-        return sessions.ConvertAll(s => new UserDevice(
-            DeviceId: s.Id,
-            Kind: DeviceKind.Browser,
-            OperatingSystem: null,
-            Browser: null,
-            LastSeen: DateTimeOffset.FromUnixTimeMilliseconds(s.LastAccess),
-            SessionCount: 1,
-            LastLocation: null));
+        // The admin sessions endpoint exposes no device metadata, so each session maps to its own device keyed
+        // by the session id. The kind comes from the Keycloak client the session authenticated through, when
+        // that client declares one; otherwise Browser.
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        Dictionary<string, DeviceKind> kindByClientUuid = new(StringComparer.Ordinal);
+
+        var devices = new List<UserDevice>(sessions.Count);
+        foreach (KeycloakSessionRepresentation session in sessions)
+        {
+            DeviceKind kind = await ResolveSessionDeviceKindAsync(
+                client, session.Clients, kindByClientUuid, cancellationToken).ConfigureAwait(false);
+            devices.Add(new UserDevice(
+                DeviceId: session.Id,
+                Kind: kind,
+                OperatingSystem: null,
+                Browser: null,
+                LastSeen: DateTimeOffset.FromUnixTimeMilliseconds(session.LastAccess),
+                SessionCount: 1,
+                LastLocation: null));
+        }
+
+        return devices;
+    }
+
+    // The Keycloak client a session authenticated through declares its device kind via the client attribute
+    // "granit.device_kind" (e.g. "MobileApp" / "Tv"). A session can span several clients; the most specific
+    // declared kind wins. Absent / unparseable / Unknown — or any lookup failure — falls back to Browser, since
+    // an IdP-SSO session is browser-based unless the client says otherwise. Operators set the attribute on the
+    // client in Keycloak (Granit does not manage federated client config), so this path is read-only.
+    private async ValueTask<DeviceKind> ResolveSessionDeviceKindAsync(
+        HttpClient client,
+        Dictionary<string, string>? clients,
+        Dictionary<string, DeviceKind> cache,
+        CancellationToken cancellationToken)
+    {
+        if (clients is not { Count: > 0 })
+        {
+            return DeviceKind.Browser;
+        }
+
+        foreach (string clientUuid in clients.Keys)
+        {
+            DeviceKind kind = await ResolveClientDeviceKindAsync(client, clientUuid, cache, cancellationToken)
+                .ConfigureAwait(false);
+            if (kind is not DeviceKind.Browser)
+            {
+                return kind;
+            }
+        }
+
+        return DeviceKind.Browser;
+    }
+
+    private async ValueTask<DeviceKind> ResolveClientDeviceKindAsync(
+        HttpClient client,
+        string clientUuid,
+        Dictionary<string, DeviceKind> cache,
+        CancellationToken cancellationToken)
+    {
+        if (cache.TryGetValue(clientUuid, out DeviceKind cached))
+        {
+            return cached;
+        }
+
+        DeviceKind resolved = DeviceKind.Browser;
+        try
+        {
+            KeycloakClientRepresentation? rep = await client
+                .GetFromJsonAsync<KeycloakClientRepresentation>(
+                    options.Value.GetClientByUuidEndpoint(clientUuid), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (rep?.Attributes is { } attributes
+                && attributes.TryGetValue(DeviceKindClientAttribute, out List<string>? values)
+                && values is [string raw, ..]
+                && Enum.TryParse(raw, ignoreCase: false, out DeviceKind kind)
+                && Enum.IsDefined(kind)
+                && kind != DeviceKind.Unknown)
+            {
+                resolved = kind;
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or NotSupportedException)
+        {
+            // A client we cannot read (gone, forbidden, malformed) must not break device listing — default Browser.
+            LogKeycloakClientDeviceKindUnresolved(ex, clientUuid);
+        }
+
+        cache[clientUuid] = resolved;
+        return resolved;
     }
 
     private async Task<HttpClient> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
@@ -1160,6 +1252,9 @@ internal sealed partial class KeycloakIdentityProvider(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to get device activity for user {UserId} from Keycloak. Returning empty list")]
     private partial void LogKeycloakGetDeviceActivityFailed(Exception exception, string userId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Could not read the device kind for Keycloak client {ClientUuid}; defaulting to Browser.")]
+    private partial void LogKeycloakClientDeviceKindUnresolved(Exception exception, string clientUuid);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to get credentials for user {UserId} from Keycloak. Returning null")]
     private partial void LogKeycloakGetCredentialsFailed(Exception exception, string userId);

--- a/src/Granit.Identity.Federated.Keycloak/Options/KeycloakAdminOptions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Options/KeycloakAdminOptions.cs
@@ -182,6 +182,13 @@ public sealed class KeycloakAdminOptions
             : $"{BaseUrl.TrimEnd('/')}/admin/realms/{Realm}/clients?clientId={Uri.EscapeDataString(clientId)}";
 
     /// <summary>
+    /// Builds the Admin API URL for a single client by its internal UUID — the full representation,
+    /// including the client's <c>attributes</c> bag (used to read the declared device kind).
+    /// </summary>
+    internal string GetClientByUuidEndpoint(string clientUuid) =>
+        $"{BaseUrl.TrimEnd('/')}/admin/realms/{Realm}/clients/{Uri.EscapeDataString(clientUuid)}";
+
+    /// <summary>
     /// Builds the Admin API URL for listing client-scope roles of the given Keycloak client
     /// (identified by its internal UUID, not the OIDC client_id).
     /// </summary>

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
@@ -614,6 +614,52 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
             () => _provider.ListAsync(null!, TestContext.Current.CancellationToken));
     }
 
+    [Fact]
+    public async Task ListDevicesAsync_AdminSessions_ClientDeclaresDeviceKind_ResolvesIt()
+    {
+        // Sequence: call 1 = GET sessions (one session bound to client uuid-1);
+        //           call 2 = GET /clients/uuid-1 → the client declares granit.device_kind = Tv.
+        KeycloakIdentityProvider provider = CreateAdminSequenceProvider(
+            """[{"id":"sess-1","ipAddress":"1.2.3.4","start":1700000000000,"lastAccess":1700001000000,"rememberMe":false,"clients":{"uuid-1":"tv-app"}}]""",
+            """{"id":"uuid-1","clientId":"tv-app","attributes":{"granit.device_kind":["Tv"]}}""");
+
+        IReadOnlyList<UserDevice> result = await provider.ListAsync("user-1", TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        result[0].Kind.ShouldBe(DeviceKind.Tv);
+    }
+
+    [Fact]
+    public async Task ListDevicesAsync_AdminSessions_ClientWithoutDeviceKind_DefaultsToBrowser()
+    {
+        KeycloakIdentityProvider provider = CreateAdminSequenceProvider(
+            """[{"id":"sess-1","ipAddress":"1.2.3.4","start":1700000000000,"lastAccess":1700001000000,"rememberMe":false,"clients":{"uuid-1":"web-app"}}]""",
+            """{"id":"uuid-1","clientId":"web-app","attributes":{}}""");
+
+        IReadOnlyList<UserDevice> result = await provider.ListAsync("user-1", TestContext.Current.CancellationToken);
+
+        result[0].Kind.ShouldBe(DeviceKind.Browser);
+    }
+
+    // Builds a provider whose admin "KeycloakAdmin" client serves the given responses in order (the admin-token
+    // service keeps its own separate handler, so it never consumes from this sequence).
+    private KeycloakIdentityProvider CreateAdminSequenceProvider(params string[] responses)
+    {
+        MockSequenceHttpMessageHandler seqHandler = new(responses);
+        HttpClient seqClient = new(seqHandler) { BaseAddress = new Uri("https://keycloak.test/") };
+        IHttpClientFactory seqFactory = Substitute.For<IHttpClientFactory>();
+        seqFactory.CreateClient("KeycloakAdmin").Returns(seqClient);
+
+        return new KeycloakIdentityProvider(
+            _tokenService,
+            _tokenExchangeService,
+            seqFactory,
+            Microsoft.Extensions.Options.Options.Create(_options),
+            _distributedEventBus,
+            _metrics,
+            NullLogger<KeycloakIdentityProvider>.Instance);
+    }
+
     // --- GetPasswordChangedAtAsync tests ---
 
     [Fact]


### PR DESCRIPTION
Part of #2654 — completes the **federated Keycloak** slice of #2668 (the OpenIddict-native path shipped in #2706).

## What
A Keycloak client declares the device kind of the devices that authenticate through it via the operator-set client attribute **`granit.device_kind`** (a `DeviceKind` name, e.g. `MobileApp` / `Tv`). The Keycloak device adapter now reads it.

- `KeycloakClientRepresentation` gains the `attributes` bag; `KeycloakAdminOptions.GetClientByUuidEndpoint` fetches the single client (whose representation carries `attributes`).
- `GetDevicesViaAdminSessionsAsync` (the **default** device path) resolves each session's kind from the Keycloak client it authenticated through — most-specific declared kind across the session's clients wins, **cached per client UUID**; absent / unparseable / `Unknown`, or any lookup failure, falls back to `Browser`.
- **Read-only**: operators own the client config in Keycloak, so there is no Granit-side seeding/admin surface (unlike the OpenIddict path).

## Scope / follow-ups
- **Admin-sessions path only** (the default). The opt-in account-API path (`UseTokenExchangeForDeviceActivity`) and the **EntraId** provider stay `Browser` — a minor documented follow-up (the account path would mix service-account admin calls into the user-token flow; EntraId exposes no client-attribute mechanism).
- **Live-Keycloak validation recommended** before production: the unit tests mock the admin HTTP; the `GET /clients/{uuid}` attribute shape + the session `clients` UUID key should be confirmed against a real Keycloak.

## Tests
`ListDevicesAsync_AdminSessions_ClientDeclaresDeviceKind_ResolvesIt` (Tv), `…_ClientWithoutDeviceKind_DefaultsToBrowser`; existing admin/account device tests unaffected.

## Verification
- Build `Granit.Identity.Federated.Keycloak` ✅
- Tests: Keycloak **181** (+2) ✅
- `dotnet format --verify-no-changes` (src + tests) ✅
- architecture shard **225** ✅