### PR TITLE
fix(identity): Keycloak client attributes are Map<String,String>, not List (#2668)

### DIFF
--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakClientRepresentation.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakClientRepresentation.cs
@@ -9,11 +9,12 @@ namespace Granit.Identity.Federated.Keycloak.Internal;
 /// <remarks>
 /// Only the fields needed are modeled (<c>id</c> = Keycloak's internal UUID, <c>clientId</c> = the OIDC
 /// client_id string, <c>attributes</c> = the client's custom attribute bag). Keycloak emits many more
-/// properties that <see cref="System.Text.Json"/> silently ignores. <c>attributes</c> is a
-/// <c>Map&lt;String, List&lt;String&gt;&gt;</c> in Keycloak (multi-valued) and is only populated on a
-/// single-client fetch (<c>GET /clients/{uuid}</c>), not on the list endpoint's lightweight projection.
+/// properties that <see cref="System.Text.Json"/> silently ignores. <c>attributes</c> on a
+/// <b>client</b> is a <c>Map&lt;String, String&gt;</c> (single string per key — unlike a <b>user</b>'s
+/// multi-valued <c>Map&lt;String, List&lt;String&gt;&gt;</c>), and is populated on both the list and the
+/// single-client fetch.
 /// </remarks>
 internal sealed record KeycloakClientRepresentation(
     [property: JsonPropertyName("id")] string Id,
     [property: JsonPropertyName("clientId")] string ClientId,
-    [property: JsonPropertyName("attributes")] Dictionary<string, List<string>>? Attributes = null);
+    [property: JsonPropertyName("attributes")] Dictionary<string, string>? Attributes = null);

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -1094,8 +1094,7 @@ internal sealed partial class KeycloakIdentityProvider(
                 .ConfigureAwait(false);
 
             if (rep?.Attributes is { } attributes
-                && attributes.TryGetValue(DeviceKindClientAttribute, out List<string>? values)
-                && values is [string raw, ..]
+                && attributes.TryGetValue(DeviceKindClientAttribute, out string? raw)
                 && Enum.TryParse(raw, ignoreCase: false, out DeviceKind kind)
                 && Enum.IsDefined(kind)
                 && kind != DeviceKind.Unknown)

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
@@ -621,7 +621,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         //           call 2 = GET /clients/uuid-1 → the client declares granit.device_kind = Tv.
         KeycloakIdentityProvider provider = CreateAdminSequenceProvider(
             """[{"id":"sess-1","ipAddress":"1.2.3.4","start":1700000000000,"lastAccess":1700001000000,"rememberMe":false,"clients":{"uuid-1":"tv-app"}}]""",
-            """{"id":"uuid-1","clientId":"tv-app","attributes":{"granit.device_kind":["Tv"]}}""");
+            """{"id":"uuid-1","clientId":"tv-app","attributes":{"granit.device_kind":"Tv"}}""");
 
         IReadOnlyList<UserDevice> result = await provider.ListAsync("user-1", TestContext.Current.CancellationToken);
 
@@ -632,9 +632,11 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
     [Fact]
     public async Task ListDevicesAsync_AdminSessions_ClientWithoutDeviceKind_DefaultsToBrowser()
     {
+        // Real Keycloak client attributes are single strings (Map<String,String>), not lists — include a couple
+        // so this also guards against mis-typing the attribute bag.
         KeycloakIdentityProvider provider = CreateAdminSequenceProvider(
             """[{"id":"sess-1","ipAddress":"1.2.3.4","start":1700000000000,"lastAccess":1700001000000,"rememberMe":false,"clients":{"uuid-1":"web-app"}}]""",
-            """{"id":"uuid-1","clientId":"web-app","attributes":{}}""");
+            """{"id":"uuid-1","clientId":"web-app","attributes":{"post.logout.redirect.uris":"+","oauth2.device.authorization.grant.enabled":"false"}}""");
 
         IReadOnlyList<UserDevice> result = await provider.ListAsync("user-1", TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
**Fixes develop**, broken by #2713 (merged): the `Granit.Identity.Federated.Keycloak.Tests.Integration` client-role-sync tests now fail.

## Root cause
#2713 added `attributes` to `KeycloakClientRepresentation` typed as `Dictionary<string, List<string>>?`. That's the shape of a **user**'s attribute bag — but a **client**'s `attributes` in Keycloak's `ClientRepresentation` is `Map<String, String>` (a single string per key, e.g. `post.logout.redirect.uris`). So any realistic client response fails to deserialize in `ResolveClientUuidAsync` (used by client-role sync) with:

> The JSON value could not be converted to `List<string>`. Path: `$[0].attributes['post.logout.redirect.uris']`

The unit tests passed only because they used a hand-crafted client JSON with a list value; the integration tests (realistic fixtures) caught it. (Exactly the "validate against a real Keycloak" caveat the #2713 PR flagged.)

## Fix
- `KeycloakClientRepresentation.Attributes` → `Dictionary<string, string>?`.
- The device-kind resolver reads `granit.device_kind` as a plain string.
- Unit test uses a string-valued attribute + a couple of realistic string attributes (`post.logout.redirect.uris`, …) to guard the typing going forward.

## Verification
- Keycloak unit tests: **181** ✅
- Keycloak **integration** tests: **7** ✅ (were failing on develop)
- `dotnet format --verify-no-changes` ✅