### PR TITLE
fix(queryengine): register IQueryableSource for framework query definitions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -9548,7 +9548,7 @@
       "kind": "class",
       "project": "Granit.BackgroundJobs.EntityFrameworkCore",
       "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitBackgroundJobsEntityFrameworkCore",
@@ -13767,7 +13767,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.EntityFrameworkCore",
       "file": "src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitDataExchangeEntityFrameworkCore",
@@ -20589,7 +20589,7 @@
       "kind": "class",
       "project": "Granit.Hostnames.EntityFrameworkCore",
       "file": "src/Granit.Hostnames.EntityFrameworkCore/Extensions/HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitHostnamesEntityFrameworkCore",
@@ -24585,7 +24585,7 @@
       "kind": "class",
       "project": "Granit.Identity.EntityFrameworkCore",
       "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitIdentityEntityFrameworkCore",
@@ -35096,7 +35096,7 @@
       "kind": "class",
       "project": "Granit.Notifications.EntityFrameworkCore",
       "file": "src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitNotificationsEntityFrameworkCore",
@@ -38100,7 +38100,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 25,
+      "line": 26,
       "members": [
         {
           "name": "AddGranitOpenIddict",
@@ -46339,7 +46339,7 @@
       "kind": "class",
       "project": "Granit.Settings.EntityFrameworkCore",
       "file": "src/Granit.Settings.EntityFrameworkCore/Extensions/SettingsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitSettingsEntityFrameworkCore",
@@ -49771,7 +49771,7 @@
       "kind": "class",
       "project": "Granit.Timeline.EntityFrameworkCore",
       "file": "src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitTimelineEntityFrameworkCore",
@@ -54303,7 +54303,7 @@
       "kind": "class",
       "project": "Granit.Workflow.EntityFrameworkCore",
       "file": "src/Granit.Workflow.EntityFrameworkCore/Extensions/WorkflowEfCoreServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": []
     },
     {

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
+using Granit.BackgroundJobs.Domain;
 using Granit.BackgroundJobs.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -41,6 +43,9 @@ public static class BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExten
             ServiceDescriptor.Scoped<IBackgroundJobStoreReader>(sp => sp.GetRequiredService<EfBackgroundJobStore>()));
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IBackgroundJobStoreWriter>(sp => sp.GetRequiredService<EfBackgroundJobStore>()));
+
+        // Backs MapGranitQuery<BackgroundJobDefinition> + the analytics runner over BackgroundJobDefinitionQuery.
+        builder.Services.AddScoped<IQueryableSource<BackgroundJobDefinition>, EfBackgroundJobDefinitionQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/EfBackgroundJobDefinitionQueryableSource.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/EfBackgroundJobDefinitionQueryableSource.cs
@@ -1,0 +1,40 @@
+using Granit.BackgroundJobs.Domain;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.BackgroundJobs.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="BackgroundJobDefinition"/>,
+/// backing <c>MapGranitQuery&lt;BackgroundJobDefinition&gt;</c> and the analytics runner over
+/// <c>BackgroundJobDefinitionQuery</c>.
+/// </summary>
+/// <remarks>
+/// <see cref="BackgroundJobDefinition"/> is not <c>IMultiTenant</c> (recurring job definitions
+/// are host-global), so no query-filter bypass is required.
+/// </remarks>
+internal sealed class EfBackgroundJobDefinitionQueryableSource(
+    IDbContextFactory<BackgroundJobsDbContext> contextFactory)
+    : IQueryableSource<BackgroundJobDefinition>, IAsyncDisposable, IDisposable
+{
+    private BackgroundJobsDbContext? _context;
+
+    public IQueryable<BackgroundJobDefinition> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        return _context.Jobs.AsNoTracking();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        BackgroundJobsDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -3,9 +3,12 @@ using Granit.DataExchange.EntityFrameworkCore.Internal.Export;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Export.Stores;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Stores;
 using Granit.DataExchange.Export;
+using Granit.DataExchange.Export.Domain;
+using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Mapping;
 using Granit.DataExchange.Import.Pipeline;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -51,6 +54,11 @@ public static class DataExchangeEntityFrameworkCoreHostApplicationBuilderExtensi
         // Extra property support: replaces null-object defaults from Granit.DataExchange
         builder.Services.AddSingleton<IExtraExportFieldProvider, EfCoreExtraExportFieldProvider>();
         builder.Services.AddScoped<IExportExtraValueResolver, EfCoreExportExtraValueResolver>();
+
+        // Query engine sources — back MapGranitQuery<T> + the analytics runner over
+        // ImportJobQuery / ExportJobQuery.
+        builder.Services.AddScoped<IQueryableSource<ImportJob>, EfImportJobQueryableSource>();
+        builder.Services.AddScoped<IQueryableSource<ExportJob>, EfExportJobQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/EfExportJobQueryableSource.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/EfExportJobQueryableSource.cs
@@ -1,0 +1,43 @@
+using Granit.DataExchange.Export.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.DataExchange.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="ExportJob"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all export jobs are returned cross-tenant.
+/// </summary>
+internal sealed class EfExportJobQueryableSource(
+    IDbContextFactory<DataExchangeDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<ExportJob>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private DataExchangeDbContext? _context;
+
+    public IQueryable<ExportJob> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<ExportJob> query = _context.ExportJobs.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        DataExchangeDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/EfImportJobQueryableSource.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/EfImportJobQueryableSource.cs
@@ -1,0 +1,43 @@
+using Granit.DataExchange.Import.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.DataExchange.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="ImportJob"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all import jobs are returned cross-tenant.
+/// </summary>
+internal sealed class EfImportJobQueryableSource(
+    IDbContextFactory<DataExchangeDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<ImportJob>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private DataExchangeDbContext? _context;
+
+    public IQueryable<ImportJob> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<ImportJob> query = _context.ImportJobs.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        DataExchangeDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Hostnames.EntityFrameworkCore/Extensions/HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/Extensions/HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
 using Granit.Hostnames.Contracts;
+using Granit.Hostnames.Domain;
 using Granit.Hostnames.EntityFrameworkCore.Internal;
 using Granit.Hostnames.Options;
+using Granit.QueryEngine;
 using Granit.Workflow.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,6 +59,9 @@ public static class HostnamesEntityFrameworkCoreHostApplicationBuilderExtensions
             sp => sp.GetRequiredService<EfManagedHostnameStore>());
 
         builder.Services.TryAddScoped<IHostnameResolver, EfHostnameResolver>();
+
+        // Backs MapGranitQuery<ManagedHostname> + the analytics runner over ManagedHostnameQuery.
+        builder.Services.AddScoped<IQueryableSource<ManagedHostname>, EfManagedHostnameQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Hostnames.EntityFrameworkCore/Internal/EfManagedHostnameQueryableSource.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/Internal/EfManagedHostnameQueryableSource.cs
@@ -1,0 +1,43 @@
+using Granit.Hostnames.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Hostnames.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="ManagedHostname"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all managed hostnames are returned cross-tenant.
+/// </summary>
+internal sealed class EfManagedHostnameQueryableSource(
+    IDbContextFactory<HostnamesDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<ManagedHostname>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private HostnamesDbContext? _context;
+
+    public IQueryable<ManagedHostname> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<ManagedHostname> query = _context.ManagedHostnames.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        HostnamesDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
+using Granit.Identity.Domain;
 using Granit.Identity.EntityFrameworkCore.Internal;
 using Granit.Identity.Internal;
 using Granit.Identity.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Interceptors;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -38,6 +40,11 @@ public static class IdentityEntityFrameworkCoreServiceCollectionExtensions
 
         services.TryAddScoped<IUserDirectoryQueryableSource, EfUserDirectoryQueryableSource>();
         services.TryAddScoped<IUserDirectoryWriter, EfUserDirectoryWriter>();
+
+        // Backs MapGranitQuery<User> / the analytics runner over UserQuery — the query
+        // engine resolves the open generic IQueryableSource<User>, distinct from the
+        // IUserDirectoryQueryableSource directory contract above.
+        services.AddScoped<IQueryableSource<User>, EfUserQueryableSource>();
 
         // Lookup hasher backing User.EmailHash / User.PhoneNumberHash. Pepper
         // validated at first resolution (HmacUserLookupHasher ctor) — fail-fast

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfUserQueryableSource.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfUserQueryableSource.cs
@@ -1,0 +1,50 @@
+using Granit.Identity.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Identity.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="User"/>,
+/// backing <c>MapGranitQuery&lt;User&gt;</c> and the analytics runner over <c>UserQuery</c>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all users are returned cross-tenant.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="EfUserDirectoryQueryableSource"/> (which serves the
+/// <see cref="IUserDirectoryQueryableSource"/> directory contract): the query engine
+/// resolves the open generic <see cref="IQueryableSource{User}"/>, so it needs its own
+/// registration even though both project the same <see cref="IdentityDbContext.Users"/> set.
+/// </remarks>
+internal sealed class EfUserQueryableSource(
+    IDbContextFactory<IdentityDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<User>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private IdentityDbContext? _context;
+
+    public IQueryable<User> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<User> query = _context.Users.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        IdentityDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,9 +1,11 @@
 using Granit.Notifications.Abstractions;
+using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Internal;
 using Granit.Notifications.Internal;
 using Granit.Notifications.MobilePush;
 using Granit.Notifications.MobilePush.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -88,6 +90,11 @@ public static class NotificationsEntityFrameworkCoreHostApplicationBuilderExtens
             ServiceDescriptor.Scoped<IMobilePushTokenReader>(sp => sp.GetRequiredService<EfCoreMobilePushTokenStore>()));
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IMobilePushTokenWriter>(sp => sp.GetRequiredService<EfCoreMobilePushTokenStore>()));
+
+        // Query engine sources — back MapGranitQuery<T> + the analytics runner over
+        // UserNotificationQuery / NotificationPreferenceQuery.
+        builder.Services.AddScoped<IQueryableSource<UserNotification>, EfUserNotificationQueryableSource>();
+        builder.Services.AddScoped<IQueryableSource<NotificationPreference>, EfNotificationPreferenceQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfNotificationPreferenceQueryableSource.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfNotificationPreferenceQueryableSource.cs
@@ -1,0 +1,43 @@
+using Granit.MultiTenancy;
+using Granit.Notifications.Domain;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Notifications.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="NotificationPreference"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all notification preferences are returned cross-tenant.
+/// </summary>
+internal sealed class EfNotificationPreferenceQueryableSource(
+    IDbContextFactory<NotificationsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<NotificationPreference>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private NotificationsDbContext? _context;
+
+    public IQueryable<NotificationPreference> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<NotificationPreference> query = _context.Preferences.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        NotificationsDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfUserNotificationQueryableSource.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfUserNotificationQueryableSource.cs
@@ -1,0 +1,43 @@
+using Granit.MultiTenancy;
+using Granit.Notifications.Domain;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Notifications.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="UserNotification"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all user notifications are returned cross-tenant.
+/// </summary>
+internal sealed class EfUserNotificationQueryableSource(
+    IDbContextFactory<NotificationsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<UserNotification>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private NotificationsDbContext? _context;
+
+    public IQueryable<UserNotification> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<UserNotification> query = _context.UserNotifications.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        NotificationsDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -9,6 +9,7 @@ using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Server.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.SharedConnection;
+using Granit.QueryEngine;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -101,6 +102,18 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
         //    the authority wiring, so a host cannot enable OpenIddict auth and still silently serve the
         //    no-op session defaults (the failure mode when GranitOpenIddictModule is absent from the graph).
         builder.Services.AddOpenIddictUserSessionProvider();
+
+        // 8. Query engine sources for the identity entities owned by the consolidated
+        //    OpenIddictDbContext — back MapGranitQuery<T> + the analytics runner over
+        //    GranitRoleQuery / GranitUserGroupQuery (Granit.Identity.Local) and
+        //    ApplicationQuery / ScopeQuery (Granit.OpenIddict). Without these the grids and
+        //    analytics runners throw "No service for type IQueryableSource<T>" at first request.
+        builder.Services.AddScoped<IQueryableSource<GranitRole>, EfGranitRoleQueryableSource>();
+        builder.Services.AddScoped<IQueryableSource<GranitUserGroup>, EfGranitUserGroupQueryableSource>();
+        builder.Services.AddScoped<IQueryableSource<GranitOpenIddictApplication>,
+            EfGranitOpenIddictApplicationQueryableSource>();
+        builder.Services.AddScoped<IQueryableSource<GranitOpenIddictScope>,
+            EfGranitOpenIddictScopeQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitOpenIddictApplicationQueryableSource.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitOpenIddictApplicationQueryableSource.cs
@@ -1,0 +1,46 @@
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Entities.OpenIddict;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="GranitOpenIddictApplication"/>, backing <c>MapGranitQuery</c> and the analytics
+/// runner over <c>ApplicationQuery</c>. Projects from the OpenIddict-managed entity set on the
+/// consolidated <see cref="OpenIddictDbContext"/> (registered via <c>ReplaceDefaultEntities</c>).
+/// When no tenant context is active (host admin), the multi-tenant query filter is bypassed.
+/// </summary>
+internal sealed class EfGranitOpenIddictApplicationQueryableSource(
+    IDbContextFactory<OpenIddictDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<GranitOpenIddictApplication>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private OpenIddictDbContext? _context;
+
+    public IQueryable<GranitOpenIddictApplication> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<GranitOpenIddictApplication> query =
+            _context.Set<GranitOpenIddictApplication>().AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        OpenIddictDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitOpenIddictScopeQueryableSource.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitOpenIddictScopeQueryableSource.cs
@@ -1,0 +1,46 @@
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Entities.OpenIddict;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="GranitOpenIddictScope"/>, backing <c>MapGranitQuery</c> and the analytics runner
+/// over <c>ScopeQuery</c>. Projects from the OpenIddict-managed entity set on the consolidated
+/// <see cref="OpenIddictDbContext"/> (registered via <c>ReplaceDefaultEntities</c>).
+/// When no tenant context is active (host admin), the multi-tenant query filter is bypassed.
+/// </summary>
+internal sealed class EfGranitOpenIddictScopeQueryableSource(
+    IDbContextFactory<OpenIddictDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<GranitOpenIddictScope>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private OpenIddictDbContext? _context;
+
+    public IQueryable<GranitOpenIddictScope> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<GranitOpenIddictScope> query =
+            _context.Set<GranitOpenIddictScope>().AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        OpenIddictDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitRoleQueryableSource.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitRoleQueryableSource.cs
@@ -1,0 +1,41 @@
+using Granit.Identity.Local.Domain;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="GranitRole"/>,
+/// backing <c>MapGranitQuery&lt;GranitRole&gt;</c> and the analytics runner over <c>GranitRoleQuery</c>.
+/// Projects from the inherited ASP.NET Identity <c>Roles</c> set owned by the consolidated
+/// <see cref="OpenIddictDbContext"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="GranitRole"/> is not <c>IMultiTenant</c> (roles are host-global), so no
+/// query-filter bypass is required.
+/// </remarks>
+internal sealed class EfGranitRoleQueryableSource(
+    IDbContextFactory<OpenIddictDbContext> contextFactory)
+    : IQueryableSource<GranitRole>, IAsyncDisposable, IDisposable
+{
+    private OpenIddictDbContext? _context;
+
+    public IQueryable<GranitRole> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        return _context.Roles.AsNoTracking();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        OpenIddictDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitUserGroupQueryableSource.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitUserGroupQueryableSource.cs
@@ -1,0 +1,44 @@
+using Granit.Identity.Local.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="GranitUserGroup"/>,
+/// projecting from the consolidated <see cref="OpenIddictDbContext"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all user groups are returned cross-tenant.
+/// </summary>
+internal sealed class EfGranitUserGroupQueryableSource(
+    IDbContextFactory<OpenIddictDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<GranitUserGroup>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private OpenIddictDbContext? _context;
+
+    public IQueryable<GranitUserGroup> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<GranitUserGroup> query = _context.UserGroups.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        OpenIddictDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Settings.EntityFrameworkCore/Extensions/SettingsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Settings.EntityFrameworkCore/Extensions/SettingsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,4 +1,6 @@
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Granit.Settings.Domain;
 using Granit.Settings.EntityFrameworkCore.Internal;
 using Granit.Settings.EntityFrameworkCore.Options;
 using Granit.Settings.Values;
@@ -51,6 +53,9 @@ public static class SettingsEntityFrameworkCoreHostApplicationBuilderExtensions
 
         builder.Services.Replace(ServiceDescriptor.Scoped<ISettingStoreReader, EfCoreSettingStore>());
         builder.Services.Replace(ServiceDescriptor.Scoped<ISettingStoreWriter, EfCoreSettingStore>());
+
+        // Backs MapGranitQuery<SettingRecord> + the analytics runner over SettingRecordQuery.
+        builder.Services.AddScoped<IQueryableSource<SettingRecord>, EfSettingRecordQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Settings.EntityFrameworkCore/Internal/EfSettingRecordQueryableSource.cs
+++ b/src/Granit.Settings.EntityFrameworkCore/Internal/EfSettingRecordQueryableSource.cs
@@ -1,0 +1,39 @@
+using Granit.QueryEngine;
+using Granit.Settings.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Settings.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="SettingRecord"/>,
+/// backing <c>MapGranitQuery&lt;SettingRecord&gt;</c> and the analytics runner over <c>SettingRecordQuery</c>.
+/// </summary>
+/// <remarks>
+/// <see cref="SettingRecord"/> is not <c>IMultiTenant</c> (settings are scoped by the
+/// provider/key columns, not a tenant filter), so no query-filter bypass is required.
+/// </remarks>
+internal sealed class EfSettingRecordQueryableSource(
+    IDbContextFactory<SettingsDbContext> contextFactory)
+    : IQueryableSource<SettingRecord>, IAsyncDisposable, IDisposable
+{
+    private SettingsDbContext? _context;
+
+    public IQueryable<SettingRecord> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        return _context.SettingRecords.AsNoTracking();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        SettingsDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
+using Granit.Timeline.Domain;
 using Granit.Timeline.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,6 +48,9 @@ public static class TimelineEntityFrameworkCoreHostApplicationBuilderExtensions
             ServiceDescriptor.Scoped<IReactionReader>(sp => sp.GetRequiredService<EfCoreReactionStore>()));
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IReactionWriter>(sp => sp.GetRequiredService<EfCoreReactionStore>()));
+
+        // Backs MapGranitQuery<TimelineEntry> + the analytics runner over TimelineEntryQuery.
+        builder.Services.AddScoped<IQueryableSource<TimelineEntry>, EfTimelineEntryQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfTimelineEntryQueryableSource.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfTimelineEntryQueryableSource.cs
@@ -1,0 +1,43 @@
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Granit.Timeline.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Timeline.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="TimelineEntry"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all timeline entries are returned cross-tenant.
+/// </summary>
+internal sealed class EfTimelineEntryQueryableSource(
+    IDbContextFactory<TimelineDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<TimelineEntry>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private TimelineDbContext? _context;
+
+    public IQueryable<TimelineEntry> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<TimelineEntry> query = _context.TimelineEntries.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        TimelineDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Workflow.EntityFrameworkCore/Extensions/WorkflowEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/Extensions/WorkflowEfCoreServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Granit.QueryEngine;
+using Granit.Workflow.Domain;
 using Granit.Workflow.EntityFrameworkCore.Interceptors;
 using Granit.Workflow.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
@@ -39,6 +41,11 @@ public static class WorkflowEfCoreServiceCollectionExtensions
         services.TryAddScoped<WorkflowTransitionInterceptor>();
         services.TryAddScoped<IWorkflowHistoryQuery, DefaultWorkflowHistoryQuery<TDbContext>>();
         services.TryAddScoped<IWorkflowTransitionRecorder, EfWorkflowTransitionRecorder<TDbContext>>();
+
+        // Backs MapGranitQuery<WorkflowTransitionRecord> + the analytics runner over
+        // WorkflowTransitionRecordQuery, projecting from the host's IWorkflowDbContext.
+        services.TryAddScoped<IQueryableSource<WorkflowTransitionRecord>,
+            EfWorkflowTransitionRecordQueryableSource<TDbContext>>();
         return services;
     }
 

--- a/src/Granit.Workflow.EntityFrameworkCore/Internal/EfWorkflowTransitionRecordQueryableSource.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/Internal/EfWorkflowTransitionRecordQueryableSource.cs
@@ -1,0 +1,34 @@
+using Granit.QueryEngine;
+using Granit.Workflow.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Workflow.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="WorkflowTransitionRecord"/>, backing <c>MapGranitQuery&lt;WorkflowTransitionRecord&gt;</c>
+/// and the analytics runner over <c>WorkflowTransitionRecordQuery</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the other Granit query sources, workflow transition records are not stored in a
+/// framework-owned isolated DbContext: the host's own <typeparamref name="TDbContext"/>
+/// implements <see cref="IWorkflowDbContext"/> and owns the table. The scoped host context
+/// is therefore injected directly (the DI container owns its lifetime — no factory, no dispose
+/// here), exactly like <see cref="DefaultWorkflowHistoryQuery{TDbContext}"/>.
+/// </para>
+/// <para>
+/// No <c>IMultiTenant</c> query-filter bypass is applied: the named multi-tenant filter is not
+/// guaranteed to exist on an arbitrary host context (it is only present when the host context
+/// derives from <c>GranitDbContext</c> / applies <c>ApplyGranitConventions</c>), and calling
+/// <c>IgnoreQueryFilters</c> for an absent named filter throws. This mirrors the no-bypass
+/// behaviour of <see cref="DefaultWorkflowHistoryQuery{TDbContext}"/>.
+/// </para>
+/// </remarks>
+internal sealed class EfWorkflowTransitionRecordQueryableSource<TDbContext>(TDbContext dbContext)
+    : IQueryableSource<WorkflowTransitionRecord>
+    where TDbContext : DbContext, IWorkflowDbContext
+{
+    public IQueryable<WorkflowTransitionRecord> GetQueryable() =>
+        dbContext.WorkflowTransitionRecords.AsNoTracking();
+}

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsEfCoreQueryableSourceRegistrationTests.cs
@@ -1,0 +1,30 @@
+using Granit.BackgroundJobs.Domain;
+using Granit.BackgroundJobs.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BackgroundJobs.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: the query engine + analytics runner resolve
+/// <see cref="IQueryableSource{BackgroundJobDefinition}"/> for <c>BackgroundJobDefinitionQuery</c>.
+/// Without the registration the grid throws "No service for type
+/// IQueryableSource&lt;BackgroundJobDefinition&gt;" at first request.
+/// </summary>
+public sealed class BackgroundJobsEfCoreQueryableSourceRegistrationTests
+{
+    [Fact]
+    public void AddGranitBackgroundJobsEntityFrameworkCore_RegistersQueryableSource_ForBackgroundJobDefinition_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitBackgroundJobsEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<BackgroundJobDefinition>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/DataExchangeEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/DataExchangeEfCoreQueryableSourceRegistrationTests.cs
@@ -1,0 +1,42 @@
+using Granit.DataExchange.EntityFrameworkCore.Extensions;
+using Granit.DataExchange.Export.Domain;
+using Granit.DataExchange.Import.Domain;
+using Granit.QueryEngine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.DataExchange.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: the query engine + analytics runner resolve <see cref="IQueryableSource{T}"/>
+/// for <c>ImportJobQuery</c> / <c>ExportJobQuery</c>. Without the registrations the grids throw
+/// "No service for type IQueryableSource&lt;T&gt;" at first request.
+/// </summary>
+public sealed class DataExchangeEfCoreQueryableSourceRegistrationTests
+{
+    [Fact]
+    public void AddGranitDataExchangeEntityFrameworkCore_RegistersQueryableSource_ForImportJob_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitDataExchangeEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<ImportJob>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitDataExchangeEntityFrameworkCore_RegistersQueryableSource_ForExportJob_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitDataExchangeEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<ExportJob>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/HostnamesEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/HostnamesEfCoreQueryableSourceRegistrationTests.cs
@@ -1,0 +1,43 @@
+using Granit.Hostnames.Domain;
+using Granit.Hostnames.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Granit.Workflow.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Hostnames.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: the query engine + analytics runner resolve
+/// <see cref="IQueryableSource{ManagedHostname}"/> for <c>ManagedHostnameQuery</c>. The same
+/// registration call also wires <see cref="IQueryableSource{WorkflowTransitionRecord}"/> via
+/// <c>AddGranitWorkflowEntityFrameworkCore&lt;HostnamesDbContext&gt;</c>.
+/// </summary>
+public sealed class HostnamesEfCoreQueryableSourceRegistrationTests
+{
+    [Fact]
+    public void AddGranitHostnamesEntityFrameworkCore_RegistersQueryableSource_ForManagedHostname_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitHostnamesEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<ManagedHostname>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitHostnamesEntityFrameworkCore_RegistersQueryableSource_ForWorkflowTransitionRecord_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitHostnamesEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<WorkflowTransitionRecord>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/IdentityEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/IdentityEfCoreQueryableSourceRegistrationTests.cs
@@ -1,0 +1,31 @@
+using Granit.Identity.Domain;
+using Granit.Identity.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: <c>UserQuery</c> grids and the analytics runner resolve the open generic
+/// <see cref="IQueryableSource{User}"/>, distinct from the directory
+/// <c>IUserDirectoryQueryableSource</c> contract. Without the explicit registration the
+/// query engine throws "No service for type IQueryableSource&lt;User&gt;" at first request.
+/// </summary>
+public sealed class IdentityEfCoreQueryableSourceRegistrationTests
+{
+    [Fact]
+    public void AddGranitIdentityEntityFrameworkCore_RegistersQueryableSource_ForUser_AsScoped()
+    {
+        var services = new ServiceCollection();
+
+        // The provider callback is only invoked at context creation, not registration — an
+        // empty configure is enough to assert the DI descriptors without an EF provider package.
+        services.AddGranitIdentityEntityFrameworkCore(_ => { });
+
+        services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<User>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/NotificationsEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/NotificationsEfCoreQueryableSourceRegistrationTests.cs
@@ -1,0 +1,41 @@
+using Granit.Notifications.Domain;
+using Granit.Notifications.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: the query engine + analytics runner resolve <see cref="IQueryableSource{T}"/>
+/// for <c>UserNotificationQuery</c> / <c>NotificationPreferenceQuery</c>. Without the
+/// registrations the grids throw "No service for type IQueryableSource&lt;T&gt;" at first request.
+/// </summary>
+public sealed class NotificationsEfCoreQueryableSourceRegistrationTests
+{
+    [Fact]
+    public void AddGranitNotificationsEntityFrameworkCore_RegistersQueryableSource_ForUserNotification_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitNotificationsEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<UserNotification>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitNotificationsEntityFrameworkCore_RegistersQueryableSource_ForNotificationPreference_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitNotificationsEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<NotificationPreference>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictEfCoreQueryableSourceRegistrationTests.cs
@@ -1,0 +1,50 @@
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Entities.OpenIddict;
+using Granit.OpenIddict.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: the identity entities owned by the consolidated <c>OpenIddictDbContext</c>
+/// (<see cref="GranitRole"/>, <see cref="GranitUserGroup"/>, <see cref="GranitOpenIddictApplication"/>,
+/// <see cref="GranitOpenIddictScope"/>) must each have a resolvable
+/// <see cref="IQueryableSource{T}"/>, otherwise <c>GranitRoleQuery</c> / <c>GranitUserGroupQuery</c>
+/// / <c>ApplicationQuery</c> / <c>ScopeQuery</c> grids and analytics runners throw
+/// "No service for type IQueryableSource&lt;T&gt;" at first request.
+/// </summary>
+public sealed class OpenIddictEfCoreQueryableSourceRegistrationTests
+{
+    private static IServiceCollection Register()
+    {
+        // Development environment so AddGranitOpenIddictServer accepts ephemeral signing keys
+        // (forbidden elsewhere) — registration would otherwise throw before reaching the
+        // IQueryableSource registrations.
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(
+            new HostApplicationBuilderSettings { EnvironmentName = Environments.Development });
+        // The provider callback is only invoked at context creation, not registration — an
+        // empty configure is enough to assert the DI descriptors without an EF provider package.
+        builder.AddGranitOpenIddict(_ => { });
+        return builder.Services;
+    }
+
+    [Theory]
+    [InlineData(typeof(GranitRole))]
+    [InlineData(typeof(GranitUserGroup))]
+    [InlineData(typeof(GranitOpenIddictApplication))]
+    [InlineData(typeof(GranitOpenIddictScope))]
+    public void AddGranitOpenIddict_RegistersQueryableSource_AsScoped(Type entityType)
+    {
+        IServiceCollection services = Register();
+
+        Type sourceType = typeof(IQueryableSource<>).MakeGenericType(entityType);
+
+        services.ShouldContain(d =>
+            d.ServiceType == sourceType &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.Settings.EntityFrameworkCore.Tests/SettingsEfCoreDiRegistrationTests.cs
+++ b/tests/Granit.Settings.EntityFrameworkCore.Tests/SettingsEfCoreDiRegistrationTests.cs
@@ -1,3 +1,5 @@
+using Granit.QueryEngine;
+using Granit.Settings.Domain;
 using Granit.Settings.EntityFrameworkCore.Extensions;
 using Granit.Settings.Values;
 using Microsoft.EntityFrameworkCore;
@@ -40,6 +42,20 @@ public sealed class SettingsEfCoreDiRegistrationTests
             d.ServiceType == typeof(ISettingStoreWriter) &&
             d.Lifetime == ServiceLifetime.Scoped,
             "EfCoreSettingStore must be registered as Scoped for ISettingStoreWriter");
+    }
+
+    [Fact]
+    public void AddGranitSettingsEntityFrameworkCore_RegistersQueryableSource_ForSettingRecord_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitSettingsEntityFrameworkCore(
+            opts => opts.Configure = db => db.UseInMemoryDatabase("di-test-qs"));
+
+        // Backs MapGranitQuery<SettingRecord> / the analytics runner over SettingRecordQuery.
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<SettingRecord>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
     }
 
     [Fact]

--- a/tests/Granit.Timeline.EntityFrameworkCore.Tests/TimelineEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.Timeline.EntityFrameworkCore.Tests/TimelineEfCoreQueryableSourceRegistrationTests.cs
@@ -1,0 +1,29 @@
+using Granit.QueryEngine;
+using Granit.Timeline.Domain;
+using Granit.Timeline.EntityFrameworkCore.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression: the query engine + analytics runner resolve <see cref="IQueryableSource{TimelineEntry}"/>
+/// for <c>TimelineEntryQuery</c>. Without the registration the grid throws
+/// "No service for type IQueryableSource&lt;TimelineEntry&gt;" at first request.
+/// </summary>
+public sealed class TimelineEfCoreQueryableSourceRegistrationTests
+{
+    [Fact]
+    public void AddGranitTimelineEntityFrameworkCore_RegistersQueryableSource_ForTimelineEntry_AsScoped()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder([]);
+
+        builder.AddGranitTimelineEntityFrameworkCore(_ => { });
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IQueryableSource<TimelineEntry>) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/Granit.Workflow.EntityFrameworkCore.Tests/WorkflowEfCoreGenericExtensionsTests.cs
+++ b/tests/Granit.Workflow.EntityFrameworkCore.Tests/WorkflowEfCoreGenericExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Granit.QueryEngine;
 using Granit.Workflow.Domain;
 using Granit.Workflow.EntityFrameworkCore.Extensions;
 using Granit.Workflow.EntityFrameworkCore.Interceptors;
@@ -57,6 +58,22 @@ public sealed class WorkflowEfCoreGenericExtensionsTests
         // Assert
         ServiceDescriptor? descriptor = services.FirstOrDefault(
             d => d.ServiceType == typeof(IWorkflowTransitionRecorder));
+        descriptor.ShouldNotBeNull();
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddGranitWorkflowEntityFrameworkCore_Generic_ShouldRegisterQueryableSource()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        services.AddGranitWorkflowEntityFrameworkCore<TestWorkflowDbContext>();
+
+        // Assert — backs MapGranitQuery<WorkflowTransitionRecord> + the analytics runner.
+        ServiceDescriptor? descriptor = services.FirstOrDefault(
+            d => d.ServiceType == typeof(IQueryableSource<WorkflowTransitionRecord>));
         descriptor.ShouldNotBeNull();
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
     }


### PR DESCRIPTION
Closes #2715.

## What

Registers EF Core `IQueryableSource<TEntity>` implementations for the **14 framework
`QueryDefinition`s** that had none. Without them, `MapGranitQuery<T>` grids and the
granit-business analytics runner throw `InvalidOperationException: No service for type
IQueryableSource<T>` at the first request over each entity.

## Why

Surfaced by granit-business' `AnalyticsQueryableSourceStartupValidator` (boot-time gap report;
granit-business GitLab issue #9). The framework-owned half of the gaps is fixed here. This is
not analytics-only: a missing source breaks the QueryEngine grid endpoint too.

## Coverage (all 14 fixed, none deferred)

| Module | Entities |
| ------ | -------- |
| Identity | User |
| Identity.Local → OpenIddict ctx | GranitRole, GranitUserGroup |
| Notifications | UserNotification, NotificationPreference |
| Settings | SettingRecord |
| Timeline | TimelineEntry |
| Hostnames | ManagedHostname |
| Workflow | WorkflowTransitionRecord (generic over host `IWorkflowDbContext`) |
| BackgroundJobs | BackgroundJobDefinition |
| DataExchange | ImportJob, ExportJob |
| OpenIddict | GranitOpenIddictApplication, GranitOpenIddictScope |

## How

- `Ef{Entity}QueryableSource` in each `*.EntityFrameworkCore/Internal/`, mirroring the
  established `EfBlobQueryableSource` pattern (per-instance context from `IDbContextFactory`,
  lazy-create + dispose).
- Multi-tenant entities bypass the named `GranitFilterNames.MultiTenant` filter via
  `IgnoreQueryFilters` when no tenant context is active (host admin); non-tenant entities
  (`SettingRecord`, `BackgroundJobDefinition`, `GranitRole`) skip the bypass.
- The four OpenIddict-consolidated identity entities (`GranitRole`, `GranitUserGroup`,
  `GranitOpenIddictApplication`, `GranitOpenIddictScope`) share the single `OpenIddictDbContext`
  and register inside `AddGranitOpenIddict`.
- `WorkflowTransitionRecord` is generic over the host's `IWorkflowDbContext` and registered in
  `AddGranitWorkflowEntityFrameworkCore<TDbContext>` (no named-filter bypass — mirrors
  `DefaultWorkflowHistoryQuery<TDbContext>`, since the host owns the context).
- `AddScoped<IQueryableSource<TEntity>, …>` next to existing store registrations.

## Tests

One registration test per module (10 new/extended test classes) asserting each
`IQueryableSource<TEntity>` is registered `Scoped`. No new dependencies → no
`THIRD-PARTY-NOTICES` change.

## Follow-up (out of scope)

Architecture test pairing every `QueryDefinition` / `MetricDefinition` to a resolvable
`IQueryableSource<T>`; once all gaps close (here + granit-business), hosts can flip
`AnalyticsRunnerOptions.ThrowOnMissingQueryableSource = true`.