### PR TITLE
fix(identity): serve the device facet from the BFF session backend

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29176,6 +29176,22 @@
       "members": []
     },
     {
+      "name": "UserDeviceGrouping",
+      "fqn": "Granit.Identity.UserDeviceGrouping",
+      "kind": "class",
+      "project": "Granit.Identity.Abstractions",
+      "file": "src/Granit.Identity.Abstractions/UserDeviceGrouping.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ByIpAddress",
+          "kind": "method",
+          "signature": "ByIpAddress(IReadOnlyList<UserSessionDescriptor> sessions)",
+          "returnType": "IReadOnlyList<UserDevice>"
+        }
+      ]
+    },
+    {
       "name": "UserSessionContextItems",
       "fqn": "Granit.Identity.UserSessionContextItems",
       "kind": "class",

--- a/src/Granit.Bff.UserSessions/Internal/BffUserSessionProvider.cs
+++ b/src/Granit.Bff.UserSessions/Internal/BffUserSessionProvider.cs
@@ -5,8 +5,10 @@ using Microsoft.Extensions.Options;
 namespace Granit.Bff.UserSessions.Internal;
 
 /// <summary>
-/// <see cref="IUserSessionProvider"/> backed by the BFF token store: a user's browser↔BFF sessions
-/// (one per device/login on this relying party), aggregated across every configured frontend.
+/// <see cref="IUserSessionProvider"/> and <see cref="IUserDeviceProvider"/> backed by the BFF token store: a
+/// user's browser↔BFF sessions (one per device/login on this relying party), aggregated across every configured
+/// frontend. Serving both facets from one store keeps the <c>/sessions</c> and <c>/devices</c> views consistent
+/// when the BFF wins the session facet by precedence.
 /// </summary>
 /// <remarks>
 /// Carries no policy — enrichment, audit and authorization live in <c>IUserSessionManager</c>. The
@@ -14,7 +16,7 @@ namespace Granit.Bff.UserSessions.Internal;
 /// </remarks>
 internal sealed class BffUserSessionProvider(
     IBffTokenStore tokenStore,
-    IOptions<GranitBffOptions> options) : IUserSessionProvider
+    IOptions<GranitBffOptions> options) : IUserSessionProvider, IUserDeviceProvider
 {
     public async Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(
         string userId, string? currentSessionId, CancellationToken cancellationToken = default)
@@ -50,6 +52,16 @@ internal sealed class BffUserSessionProvider(
         }
 
         return sessions;
+    }
+
+    public async Task<IReadOnlyList<UserDevice>> ListAsync(
+        string userId, CancellationToken cancellationToken = default)
+    {
+        // The BFF store exposes no stable device id of its own — synthesize one device per IP from the user's
+        // own BFF sessions, so the device list stays consistent with the session list from the same store.
+        IReadOnlyList<UserSessionDescriptor> sessions =
+            await ListAsync(userId, currentSessionId: null, cancellationToken).ConfigureAwait(false);
+        return UserDeviceGrouping.ByIpAddress(sessions);
     }
 
     public async Task<bool> RevokeAsync(

--- a/src/Granit.Identity.Abstractions/UserDeviceGrouping.cs
+++ b/src/Granit.Identity.Abstractions/UserDeviceGrouping.cs
@@ -1,0 +1,50 @@
+namespace Granit.Identity;
+
+/// <summary>
+/// Synthesises the <see cref="UserDevice"/> list for a backend that exposes no stable device identity of its
+/// own — only a stream of sessions (the BFF token store, the OpenIddict token store). One device is derived per
+/// distinct client IP, so the <c>/devices</c> view stays consistent with the <c>/sessions</c> view served by the
+/// same backend.
+/// </summary>
+public static class UserDeviceGrouping
+{
+    /// <summary>
+    /// Groups <paramref name="sessions"/> by client IP and projects one <see cref="UserDevice"/> per group:
+    /// the IP is the device signature, last-seen is the latest activity in the group, and the session count is
+    /// the group size. The kind is the most specific kind seen across the group's sessions (a declared
+    /// <c>MobileApp</c>/<c>Tv</c>/… beats a plain browser), defaulting to <see cref="DeviceKind.Browser"/> —
+    /// such a backend's devices are browser-based unless a session declares otherwise. OS, browser and location
+    /// are <see langword="null"/>: an IP-only backend does not expose them.
+    /// </summary>
+    public static IReadOnlyList<UserDevice> ByIpAddress(IReadOnlyList<UserSessionDescriptor> sessions)
+    {
+        ArgumentNullException.ThrowIfNull(sessions);
+
+        return
+        [
+            .. sessions
+                .GroupBy(s => s.IpAddress ?? "unknown")
+                .Select(g => new UserDevice(
+                    DeviceId: g.Key,
+                    Kind: ResolveGroupKind(g),
+                    OperatingSystem: null,
+                    Browser: null,
+                    LastSeen: g.Max(s => s.LastAccessedAt),
+                    SessionCount: g.Count(),
+                    LastLocation: null)),
+        ];
+    }
+
+    private static DeviceKind ResolveGroupKind(IEnumerable<UserSessionDescriptor> group)
+    {
+        foreach (DeviceKind kind in group.Select(s => s.Kind))
+        {
+            if (kind is not DeviceKind.Unknown and not DeviceKind.Browser)
+            {
+                return kind;
+            }
+        }
+
+        return DeviceKind.Browser;
+    }
+}

--- a/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
+++ b/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
@@ -235,34 +235,9 @@ internal sealed class OpenIddictUserSessionProvider(
         IReadOnlyList<UserSessionDescriptor> sessions =
             await ListAsync(userId, currentSessionId: null, cancellationToken).ConfigureAwait(false);
 
-        // The OpenIddict backend exposes no stable device id, OS or browser — only the raw IP. Group
-        // sessions by IP and synthesize a stable device signature from it; the kind comes from the client
-        // the session authenticated through (declared on the OIDC application, heuristic otherwise).
-        return [.. sessions
-            .GroupBy(s => s.IpAddress ?? "unknown")
-            .Select(g => new UserDevice(
-                DeviceId: g.Key,
-                Kind: ResolveGroupKind(g),
-                OperatingSystem: null,
-                Browser: null,
-                LastSeen: g.Max(s => s.LastAccessedAt),
-                SessionCount: g.Count(),
-                LastLocation: null))];
-    }
-
-    // A "device" here is an IP that may have sessions from several clients. Surface the most specific kind
-    // seen (a BrowserExtension/Tv/ApiClient is more informative than a plain browser), defaulting to Browser
-    // rather than Unknown — an IdP-SSO device is browser-based unless something more specific is known.
-    private static DeviceKind ResolveGroupKind(IEnumerable<UserSessionDescriptor> group)
-    {
-        foreach (DeviceKind kind in group.Select(s => s.Kind))
-        {
-            if (kind is not DeviceKind.Unknown and not DeviceKind.Browser)
-            {
-                return kind;
-            }
-        }
-
-        return DeviceKind.Browser;
+        // The OpenIddict backend exposes no stable device id, OS or browser — only the raw IP. Synthesize one
+        // device per IP from its own sessions; the kind carried on each session (declared on the OIDC
+        // application, heuristic otherwise) drives the group's device kind.
+        return UserDeviceGrouping.ByIpAddress(sessions);
     }
 }

--- a/tests/Granit.Bff.UserSessions.Tests/BffUserSessionProviderTests.cs
+++ b/tests/Granit.Bff.UserSessions.Tests/BffUserSessionProviderTests.cs
@@ -1,6 +1,8 @@
 using Granit.Bff.Options;
 using Granit.Bff.UserSessions.Internal;
 using Granit.Identity;
+using Granit.Identity.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -51,6 +53,60 @@ public sealed class BffUserSessionProviderTests
         result[0].CreatedAt.ShouldBe(Now);
         result[1].IsCurrent.ShouldBeFalse();
     }
+
+    // --- IUserDeviceProvider facet: devices synthesized from the SAME BFF sessions ---
+
+    [Fact]
+    public async Task ListDevicesAsync_GroupsSessionsByIp_WithSessionCountAndLatestLastSeen()
+    {
+        _store.GetSessionIdsByUserAsync("host", "user-1", Ct).Returns(["s1", "s2", "s3"]);
+        _store.GetAsync("host", "s1", Ct).Returns(Session("1.1.1.1", Now));
+        _store.GetAsync("host", "s2", Ct).Returns(Session("1.1.1.1", Now.AddHours(2)));
+        _store.GetAsync("host", "s3", Ct).Returns(Session("2.2.2.2", Now.AddHours(1)));
+
+        IReadOnlyList<UserDevice> devices = await _sut.ListAsync("user-1", Ct);
+
+        devices.Count.ShouldBe(2);
+
+        UserDevice ip1 = devices.Single(d => d.DeviceId == "1.1.1.1");
+        ip1.SessionCount.ShouldBe(2);
+        ip1.LastSeen.ShouldBe(Now.AddHours(2));
+        ip1.Kind.ShouldBe(DeviceKind.Browser);
+        ip1.OperatingSystem.ShouldBeNull();
+
+        devices.Single(d => d.DeviceId == "2.2.2.2").SessionCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ListDevicesAsync_NoSessions_ReturnsEmpty()
+    {
+        _store.GetSessionIdsByUserAsync("host", "user-1", Ct).Returns(Array.Empty<string>());
+
+        (await _sut.ListAsync("user-1", Ct)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Registration_winsBothSessionAndDeviceFacets()
+    {
+        ServiceCollection services = [];
+
+        services.SetUserSessionProvider<BffUserSessionProvider>(UserSessionProviderPrecedence.Bff);
+
+        // BFF now serves devices too, so both facets are recorded at the BFF precedence — the device list
+        // stops falling through to a lower backend (e.g. OpenIddict) and stays consistent with sessions.
+        services.GetUserSessionProviderPrecedence()
+            .ShouldBe((UserSessionProviderPrecedence.Bff, UserSessionProviderPrecedence.Bff));
+    }
+
+    private static BffTokenSet Session(string ip, DateTimeOffset lastAccess) =>
+        new("at", null, null, Now.AddHours(1))
+        {
+            UserId = "user-1",
+            UserAgent = "curl",
+            SessionCreatedAt = Now,
+            LastAccessedAt = lastAccess,
+            IpAddress = ip,
+        };
 
     [Fact]
     public async Task RevokeAsync_OnlyRevokesOwnSession()

--- a/tests/Granit.Identity.Abstractions.Tests/UserDeviceGroupingTests.cs
+++ b/tests/Granit.Identity.Abstractions.Tests/UserDeviceGroupingTests.cs
@@ -1,0 +1,50 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Abstractions.Tests;
+
+public sealed class UserDeviceGroupingTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private static UserSessionDescriptor Session(string? ip, DateTimeOffset lastSeen, DeviceKind kind = DeviceKind.Unknown) =>
+        new("s", "u", IsCurrent: false, T0, lastSeen, "ua", ip, Location: null, kind);
+
+    [Fact]
+    public void ByIpAddress_GroupsByIp_WithSessionCountAndLatestLastSeen()
+    {
+        IReadOnlyList<UserDevice> devices = UserDeviceGrouping.ByIpAddress(
+        [
+            Session("1.1.1.1", T0),
+            Session("1.1.1.1", T0.AddHours(2)),
+            Session("2.2.2.2", T0.AddHours(1)),
+        ]);
+
+        devices.Count.ShouldBe(2);
+        UserDevice ip1 = devices.Single(d => d.DeviceId == "1.1.1.1");
+        ip1.SessionCount.ShouldBe(2);
+        ip1.LastSeen.ShouldBe(T0.AddHours(2));
+        devices.Single(d => d.DeviceId == "2.2.2.2").SessionCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ByIpAddress_MostSpecificKindWins_ElseBrowser()
+    {
+        // A group with a declared MobileApp session and a plain one surfaces MobileApp.
+        UserDeviceGrouping.ByIpAddress(
+            [Session("1.1.1.1", T0, DeviceKind.Browser), Session("1.1.1.1", T0, DeviceKind.MobileApp)])
+            .Single().Kind.ShouldBe(DeviceKind.MobileApp);
+
+        // A group with only Unknown/Browser defaults to Browser (never surfaces Unknown).
+        UserDeviceGrouping.ByIpAddress([Session("2.2.2.2", T0, DeviceKind.Unknown)])
+            .Single().Kind.ShouldBe(DeviceKind.Browser);
+    }
+
+    [Fact]
+    public void ByIpAddress_NoSessions_ReturnsEmpty() =>
+        UserDeviceGrouping.ByIpAddress([]).ShouldBeEmpty();
+
+    [Fact]
+    public void ByIpAddress_NullIp_BucketsUnderUnknownSignature() =>
+        UserDeviceGrouping.ByIpAddress([Session(null, T0)]).Single().DeviceId.ShouldBe("unknown");
+}

--- a/tests/Granit.OpenIddict.Tests/UserSessionProviderRegistrationTests.cs
+++ b/tests/Granit.OpenIddict.Tests/UserSessionProviderRegistrationTests.cs
@@ -78,10 +78,12 @@ public sealed class UserSessionProviderRegistrationTests
     [Theory]
     [InlineData(true)]  // OpenIddict registered first
     [InlineData(false)] // BFF registered first
-    public void OpenIddict_and_Bff_together_Bff_wins_session_OpenIddict_wins_device_either_order(bool openIddictFirst)
+    public void OpenIddict_and_Bff_together_Bff_wins_both_facets_either_order(bool openIddictFirst)
     {
         // The contested case (OpenIddict authority + BFF gateway on one host). The winner must be
-        // deterministic, NOT an accident of which one registered last.
+        // deterministic, NOT an accident of which one registered last. BFF now serves BOTH facets, so the
+        // device list comes from the same store as the session list (they used to split — BFF sessions but
+        // OpenIddict devices — leaving /devices reading an unrelated backend).
         IServiceCollection services = NewServices();
         RunModule(services, new GranitIdentityAbstractionsModule());
 
@@ -97,6 +99,6 @@ public sealed class UserSessionProviderRegistrationTests
         }
 
         services.GetUserSessionProviderPrecedence()
-            .ShouldBe((UserSessionProviderPrecedence.Bff, UserSessionProviderPrecedence.OpenIddict));
+            .ShouldBe((UserSessionProviderPrecedence.Bff, UserSessionProviderPrecedence.Bff));
     }
 }


### PR DESCRIPTION
## Bug
An admin viewing a user at `/identity/users/{id}` saw an empty **Device activity** card ("No device activity") while the **Sessions** card showed an active session. The two cards read **different backends**.

## Root cause (verified)
Session/device providers register **per-facet** with explicit precedence (`Federated=10`, `OpenIddict=20`, `Bff=30`), and `SetUserSessionProvider<T>` wires the **device** facet only when `T : IUserDeviceProvider`. `BffUserSessionProvider` implemented `IUserSessionProvider` **only**, so in a BFF + OpenIddict deployment:
- session facet → **BFF** (30): the browser↔BFF session;
- device facet → **OpenIddict** (20): OpenIddict refresh-token grants.

Two unrelated stores → a user with a BFF session but no enumerable OpenIddict grant got **1 session / 0 devices**. (Confirmed: `DefaultUserSessionManager.ListSessionsAsync`/`ListDevicesAsync` both route through the registered providers; `BffUserSessionProvider` carried no `IUserDeviceProvider`; git history shows it was created session-only in #2670, no deliberate reason.)

## Fix
- **`BffUserSessionProvider` now also implements `IUserDeviceProvider`** → the device facet is served by the **same** backend that wins the session facet, so `/devices` and `/sessions` stay consistent. No DI change: the registration auto-wires the device factory once the interface is implemented (`SetUserSessionProvider<BffUserSessionProvider>(Bff)` now sets **both** facets at precedence 30).
- Extracted the IP-grouping device synthesis (group sessions by IP → one device each, most-specific kind wins, default `Browser`; OS/Browser/Location null) into a shared **`UserDeviceGrouping`** helper in Abstractions, and **refactored `OpenIddictUserSessionProvider` onto it** rather than duplicating the logic.

## Tests
- BFF device list: N sessions across M IPs → M devices with correct `SessionCount`/`LastSeen`; zero sessions → zero devices.
- BFF registration wins **both** facets (`GetUserSessionProviderPrecedence` → `(Bff, Bff)`).
- `UserDeviceGrouping` unit tests (grouping, most-specific-kind, empty, null-IP).
- **Updated** `UserSessionProviderRegistrationTests` which pinned the old split-facet behaviour (`Bff` session / `OpenIddict` device) → now asserts both facets resolve to BFF.

## Verification
- Builds: Abstractions, OpenIddict, Bff.UserSessions ✅
- Tests: Abstractions **40** (+5), Bff.UserSessions **7** (+3), OpenIddict **321** (device refactor + updated registration test) ✅
- `dotnet format --verify-no-changes` (6 projects) ✅
- architecture shard **225** ✅