### PR TITLE
feat(ai): agentic orchestration loop with iteration + context guards (#2631)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -91,7 +91,8 @@
     {
       "name": "Granit.AI.Tools",
       "deps": [
-        "Granit"
+        "Granit",
+        "Granit.AI"
       ],
       "framework": "net10.0"
     },
@@ -4471,12 +4472,39 @@
       "members": []
     },
     {
+      "name": "AIOrchestrationRequest",
+      "fqn": "Granit.AI.Tools.AIOrchestrationRequest",
+      "kind": "record",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/AIOrchestrationRequest.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AIOrchestrationResult",
+      "fqn": "Granit.AI.Tools.AIOrchestrationResult",
+      "kind": "record",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/AIOrchestrationResult.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "AIToolInvocationContext",
       "fqn": "Granit.AI.Tools.AIToolInvocationContext",
       "kind": "record",
       "project": "Granit.AI.Tools",
       "file": "src/Granit.AI.Tools/AIToolInvocationContext.cs",
       "line": 14,
+      "members": []
+    },
+    {
+      "name": "AIToolInvocationOutcome",
+      "fqn": "Granit.AI.Tools.AIToolInvocationOutcome",
+      "kind": "record",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/AIToolInvocationOutcome.cs",
+      "line": 6,
       "members": []
     },
     {
@@ -4534,6 +4562,28 @@
       ]
     },
     {
+      "name": "AIToolsMetrics",
+      "fqn": "Granit.AI.Tools.Diagnostics.AIToolsMetrics",
+      "kind": "class",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/Diagnostics/AIToolsMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordTruncation",
+          "kind": "method",
+          "signature": "RecordTruncation(string? tenantId, string tool)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordIterations",
+          "kind": "method",
+          "signature": "RecordIterations(string? tenantId, int iterations)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "DuplicateAIToolException",
       "fqn": "Granit.AI.Tools.Exceptions.DuplicateAIToolException",
       "kind": "class",
@@ -4557,7 +4607,7 @@
       "kind": "class",
       "project": "Granit.AI.Tools",
       "file": "src/Granit.AI.Tools/Extensions/AIToolsServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitAITools",
@@ -4573,7 +4623,7 @@
       "kind": "class",
       "project": "Granit.AI.Tools",
       "file": "src/Granit.AI.Tools/GranitAIToolsModule.cs",
-      "line": 19,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",
@@ -4596,6 +4646,22 @@
           "kind": "method",
           "signature": "InvokeAsync(AIToolInvocationContext context, CancellationToken cancellationToken = default)",
           "returnType": "string Name { get; } string Description { get; } JsonElement ParameterSchema { get; } ValueTask<AIToolResult>"
+        }
+      ]
+    },
+    {
+      "name": "IAIToolOrchestrator",
+      "fqn": "Granit.AI.Tools.IAIToolOrchestrator",
+      "kind": "interface",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/IAIToolOrchestrator.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "RunAsync",
+          "kind": "method",
+          "signature": "RunAsync(AIOrchestrationRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AIOrchestrationResult>"
         }
       ]
     },
@@ -4634,6 +4700,28 @@
           "kind": "method",
           "signature": "TryGet(string name, [NotNullWhen(true)",
           "returnType": "IReadOnlyList<IAITool> Tools { get; } bool"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIToolsOrchestrationOptions",
+      "fqn": "Granit.AI.Tools.Options.GranitAIToolsOrchestrationOptions",
+      "kind": "class",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/Options/GranitAIToolsOrchestrationOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "MaxIterations",
+          "kind": "property",
+          "signature": "int MaxIterations",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxToolResultCharacters",
+          "kind": "property",
+          "signature": "int MaxToolResultCharacters",
+          "returnType": "int"
         }
       ]
     },

--- a/src/Granit.AI.Tools/AIOrchestrationRequest.cs
+++ b/src/Granit.AI.Tools/AIOrchestrationRequest.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.AI;
+
+namespace Granit.AI.Tools;
+
+/// <summary>
+/// Input to <see cref="IAIToolOrchestrator.RunAsync"/>: the conversation so far and the tools
+/// the agent may call for this run.
+/// </summary>
+public sealed record AIOrchestrationRequest
+{
+    /// <summary>
+    /// The chat-capable workspace to drive the loop, or <see langword="null"/> to use the
+    /// configured default workspace.
+    /// </summary>
+    public string? WorkspaceName { get; init; }
+
+    /// <summary>
+    /// The conversation so far (system / user / assistant / tool messages). The loop appends
+    /// assistant and tool messages to a copy of this list as it runs.
+    /// </summary>
+    public required IReadOnlyList<ChatMessage> Messages { get; init; }
+
+    /// <summary>
+    /// The tools the agent may call this run, or <see langword="null"/> to expose every tool in
+    /// the <see cref="IAIToolRegistry"/>. Pass a curated subset to narrow the agent's reach.
+    /// </summary>
+    public IReadOnlyList<IAITool>? Tools { get; init; }
+}

--- a/src/Granit.AI.Tools/AIOrchestrationResult.cs
+++ b/src/Granit.AI.Tools/AIOrchestrationResult.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.AI;
+
+namespace Granit.AI.Tools;
+
+/// <summary>
+/// Outcome of an <see cref="IAIToolOrchestrator.RunAsync"/> run.
+/// </summary>
+public sealed record AIOrchestrationResult
+{
+    /// <summary>The final assistant text after the loop settled (no further tool calls).</summary>
+    public required string Content { get; init; }
+
+    /// <summary>
+    /// The full transcript including the assistant tool-call messages and the tool-result
+    /// messages produced during the loop.
+    /// </summary>
+    public required IReadOnlyList<ChatMessage> Messages { get; init; }
+
+    /// <summary>The number of model round-trips the loop made.</summary>
+    public required int Iterations { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the loop stopped because it hit
+    /// <see cref="Options.GranitAIToolsOrchestrationOptions.MaxIterations"/> while the model was
+    /// still requesting tools, rather than settling on a final answer.
+    /// </summary>
+    public required bool MaxIterationsReached { get; init; }
+
+    /// <summary>The audit trail of every tool call executed during the run, in order.</summary>
+    public required IReadOnlyList<AIToolInvocationOutcome> ToolInvocations { get; init; }
+
+    /// <summary>Total input tokens across all iterations, or <see langword="null"/> if unreported.</summary>
+    public int? InputTokens { get; init; }
+
+    /// <summary>Total output tokens across all iterations, or <see langword="null"/> if unreported.</summary>
+    public int? OutputTokens { get; init; }
+
+    /// <summary>Wall-clock duration of the whole run.</summary>
+    public TimeSpan Duration { get; init; }
+}

--- a/src/Granit.AI.Tools/AIToolInvocationOutcome.cs
+++ b/src/Granit.AI.Tools/AIToolInvocationOutcome.cs
@@ -1,0 +1,25 @@
+namespace Granit.AI.Tools;
+
+/// <summary>
+/// Audit entry for a single tool call executed during an orchestration run.
+/// </summary>
+public sealed record AIToolInvocationOutcome
+{
+    /// <summary>The tool name the model requested.</summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>The provider call id correlating the request and its result.</summary>
+    public required string CallId { get; init; }
+
+    /// <summary>The loop iteration (1-based) on which the call ran.</summary>
+    public required int Iteration { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the tool returned a non-error result. A missing tool or a
+    /// thrown exception is recorded as <see langword="false"/>.
+    /// </summary>
+    public required bool Succeeded { get; init; }
+
+    /// <summary><see langword="true"/> when the result was truncated to fit the context window.</summary>
+    public required bool Truncated { get; init; }
+}

--- a/src/Granit.AI.Tools/Diagnostics/AIToolsActivitySource.cs
+++ b/src/Granit.AI.Tools/Diagnostics/AIToolsActivitySource.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace Granit.AI.Tools.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry activity source for the Granit AI tools orchestration loop.
+/// </summary>
+internal static class AIToolsActivitySource
+{
+    public const string Name = "Granit.AI.Tools";
+
+    internal static readonly ActivitySource Instance = new(Name);
+}

--- a/src/Granit.AI.Tools/Diagnostics/AIToolsMetrics.cs
+++ b/src/Granit.AI.Tools/Diagnostics/AIToolsMetrics.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.AI.Tools.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the Granit AI tools orchestration loop.
+/// Meter: <c>Granit.AI.Tools</c>.
+/// </summary>
+public sealed class AIToolsMetrics
+{
+    public const string MeterName = "Granit.AI.Tools";
+
+    private readonly Counter<long> _invocations;
+    private readonly Counter<long> _truncations;
+    private readonly Histogram<int> _iterations;
+
+    public AIToolsMetrics(IMeterFactory meterFactory)
+    {
+        Meter meter = meterFactory.Create(MeterName);
+
+        _invocations = meter.CreateCounter<long>(
+            "granit.ai.tools.invocations",
+            description: "Number of tool calls executed by the orchestration loop.");
+
+        _truncations = meter.CreateCounter<long>(
+            "granit.ai.tools.truncations",
+            description: "Number of tool results truncated to fit the context window.");
+
+        _iterations = meter.CreateHistogram<int>(
+            "granit.ai.tools.iterations",
+            unit: "{iteration}",
+            description: "Model round-trips per orchestration run.");
+    }
+
+    public void RecordInvocation(string? tenantId, string tool, string outcome) =>
+        _invocations.Add(1, new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+            { "tool", tool },
+            { "outcome", outcome },
+        });
+
+    public void RecordTruncation(string? tenantId, string tool) =>
+        _truncations.Add(1, new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+            { "tool", tool },
+        });
+
+    public void RecordIterations(string? tenantId, int iterations) =>
+        _iterations.Record(iterations, new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+        });
+}

--- a/src/Granit.AI.Tools/Extensions/AIToolsServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Tools/Extensions/AIToolsServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
+using Granit.AI.Tools.Diagnostics;
 using Granit.AI.Tools.Internal;
+using Granit.AI.Tools.Options;
+using Granit.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -44,7 +47,15 @@ public static class AIToolsServiceCollectionExtensions
 
     private static void AddCoreServices(IServiceCollection services)
     {
+        services.AddOptions<GranitAIToolsOrchestrationOptions>()
+            .BindConfiguration(GranitAIToolsOrchestrationOptions.SectionName);
+
         services.TryAddScoped<IAIToolRegistry, AIToolRegistry>();
         services.TryAddScoped<IAIToolProjector, AIToolProjector>();
+        services.TryAddScoped<IAIToolOrchestrator, AIToolOrchestrator>();
+        services.TryAddSingleton<AIToolsMetrics>();
+        services.TryAddSingleton(TimeProvider.System);
+
+        GranitActivitySourceRegistry.Register(AIToolsActivitySource.Name);
     }
 }

--- a/src/Granit.AI.Tools/Granit.AI.Tools.csproj
+++ b/src/Granit.AI.Tools/Granit.AI.Tools.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.AI.Tools/GranitAIToolsModule.cs
+++ b/src/Granit.AI.Tools/GranitAIToolsModule.cs
@@ -5,17 +5,19 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Granit.AI.Tools;
 
 /// <summary>
-/// Granit module for the agentic AI tool seam (ADR-067). Registers the
-/// <see cref="IAIToolRegistry"/> and <see cref="IAIToolProjector"/> so an application can
-/// expose a curated, ACL-bound set of tools to the chat orchestrator.
+/// Granit module for the agentic AI tool seam and orchestration loop (ADR-067). Registers the
+/// <see cref="IAIToolRegistry"/>, <see cref="IAIToolProjector"/> and
+/// <see cref="IAIToolOrchestrator"/> so an application can expose a curated, ACL-bound set of
+/// tools to the chat agent and drive a bounded think → call → execute loop over them.
 /// </summary>
 /// <remarks>
 /// Tools are opted in by application code via
 /// <see cref="AIToolsServiceCollectionExtensions.AddGranitAITools(IServiceCollection, System.Action{AIToolRegistrationBuilder})"/>,
-/// not by a framework-wide attribute. This module only wires the registry and projector;
-/// it adds no tools of its own. The base module is dependency-free — the seam needs only
-/// the module system and <c>Microsoft.Extensions.AI.Abstractions</c>.
+/// not by a framework-wide attribute. This module wires the registry, projector and
+/// orchestrator; it adds no tools of its own. It depends on <c>Granit.AI</c> for the chat
+/// client and usage tracking the loop drives.
 /// </remarks>
+[DependsOn(typeof(GranitAIModule))]
 public sealed class GranitAIToolsModule : GranitModule
 {
     /// <inheritdoc />

--- a/src/Granit.AI.Tools/IAIToolOrchestrator.cs
+++ b/src/Granit.AI.Tools/IAIToolOrchestrator.cs
@@ -1,0 +1,18 @@
+namespace Granit.AI.Tools;
+
+/// <summary>
+/// Drives the agentic loop (ADR-067): send the conversation to the model with the available
+/// tool declarations, execute any tools the model requests, feed the results back, and repeat
+/// until the model stops requesting tools — bounded by an iteration cap and per-result context
+/// guards, and stamping usage on completion.
+/// </summary>
+public interface IAIToolOrchestrator
+{
+    /// <summary>Runs the loop to completion for a single request.</summary>
+    /// <param name="request">The conversation and the tools to expose.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The final answer plus the transcript, audit trail, and usage totals.</returns>
+    Task<AIOrchestrationResult> RunAsync(
+        AIOrchestrationRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
+++ b/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Granit.AI.Exceptions;
+using Granit.AI.Options;
+using Granit.AI.Tools.Diagnostics;
+using Granit.AI.Tools.Options;
+using Granit.AI.Workspaces;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.Tools.Internal;
+
+/// <summary>
+/// Default <see cref="IAIToolOrchestrator"/>. Runs the think → call → execute → repeat loop
+/// against the workspace's <see cref="IChatClient"/>, executing tools through the registry,
+/// bounding iterations and tool-result size, and stamping usage on completion (ADR-067).
+/// </summary>
+internal sealed partial class AIToolOrchestrator(
+    IAIChatClientFactory chatClientFactory,
+    IAIWorkspaceProvider workspaceProvider,
+    IAIToolProjector projector,
+    IAIToolRegistry registry,
+    IAIUsageRecordFactory usageRecordFactory,
+    IAIUsageTracker usageTracker,
+    IOptions<GranitAIToolsOrchestrationOptions> orchestrationOptions,
+    IOptions<GranitAIOptions> aiOptions,
+    AIToolsMetrics metrics,
+    TimeProvider timeProvider,
+    ILogger<AIToolOrchestrator> logger) : IAIToolOrchestrator
+{
+    private static readonly JsonSerializerOptions ArgumentSerializerOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private static readonly JsonElement EmptyArguments =
+        JsonDocument.Parse("{}").RootElement.Clone();
+
+    public async Task<AIOrchestrationResult> RunAsync(
+        AIOrchestrationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        GranitAIToolsOrchestrationOptions options = orchestrationOptions.Value;
+        int maxIterations = Math.Max(1, options.MaxIterations);
+
+        string workspaceName = request.WorkspaceName ?? aiOptions.Value.DefaultWorkspace;
+        AIWorkspace workspace = await workspaceProvider.GetAsync(workspaceName, cancellationToken).ConfigureAwait(false)
+            ?? throw new AIWorkspaceNotFoundException(workspaceName);
+        string? tenantId = workspace.TenantId?.ToString();
+
+        IReadOnlyList<IAITool> tools = request.Tools ?? registry.Tools;
+        Dictionary<string, IAITool> toolMap = new(tools.Count, StringComparer.Ordinal);
+        foreach (IAITool tool in tools)
+        {
+            toolMap[tool.Name] = tool;
+        }
+
+        ChatOptions chatOptions = new();
+        if (toolMap.Count > 0)
+        {
+            chatOptions.Tools = [.. projector.Project(tools)];
+            chatOptions.ToolMode = ChatToolMode.Auto;
+        }
+
+        using Activity? activity = AIToolsActivitySource.Instance.StartActivity("ai.tools.orchestrate");
+        activity?.SetTag("ai.workspace", workspaceName);
+
+        using IChatClient chatClient = await chatClientFactory.CreateAsync(workspaceName, cancellationToken).ConfigureAwait(false);
+
+        List<ChatMessage> transcript = [.. request.Messages];
+        List<AIToolInvocationOutcome> outcomes = [];
+        long startTimestamp = timeProvider.GetTimestamp();
+
+        long totalInput = 0;
+        long totalOutput = 0;
+        bool anyUsage = false;
+        int iteration = 0;
+        bool maxReached = false;
+        string finalText = string.Empty;
+
+        while (true)
+        {
+            iteration++;
+
+            ChatResponse response = await chatClient
+                .GetResponseAsync(transcript, chatOptions, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (response.Usage is { } usage)
+            {
+                anyUsage = true;
+                totalInput += usage.InputTokenCount ?? 0;
+                totalOutput += usage.OutputTokenCount ?? 0;
+            }
+
+            transcript.AddRange(response.Messages);
+
+            List<FunctionCallContent> calls = [.. response.Messages
+                .SelectMany(message => message.Contents)
+                .OfType<FunctionCallContent>()];
+
+            if (calls.Count == 0)
+            {
+                finalText = response.Text ?? string.Empty;
+                break;
+            }
+
+            if (iteration >= maxIterations)
+            {
+                maxReached = true;
+                finalText = response.Text ?? string.Empty;
+                LogMaxIterationsReached(maxIterations);
+                break;
+            }
+
+            List<AIContent> results = new(calls.Count);
+            foreach (FunctionCallContent call in calls)
+            {
+                (string content, bool succeeded, bool truncated) =
+                    await ExecuteToolAsync(call, toolMap, options, cancellationToken).ConfigureAwait(false);
+
+                results.Add(new FunctionResultContent(call.CallId, content));
+                outcomes.Add(new AIToolInvocationOutcome
+                {
+                    ToolName = call.Name,
+                    CallId = call.CallId,
+                    Iteration = iteration,
+                    Succeeded = succeeded,
+                    Truncated = truncated,
+                });
+
+                metrics.RecordInvocation(tenantId, call.Name, succeeded ? "success" : "error");
+                if (truncated)
+                {
+                    metrics.RecordTruncation(tenantId, call.Name);
+                }
+            }
+
+            transcript.Add(new ChatMessage(ChatRole.Tool, results));
+        }
+
+        TimeSpan duration = timeProvider.GetElapsedTime(startTimestamp);
+        metrics.RecordIterations(tenantId, iteration);
+
+        if (anyUsage)
+        {
+            AIUsageRecord record = usageRecordFactory.Create(
+                workspaceName,
+                workspace.Provider,
+                workspace.Model,
+                (int)totalInput,
+                (int)totalOutput,
+                duration);
+
+            await usageTracker.RecordAsync(record, cancellationToken).ConfigureAwait(false);
+        }
+
+        LogRunCompleted(workspaceName, iteration, outcomes.Count, maxReached);
+
+        return new AIOrchestrationResult
+        {
+            Content = finalText,
+            Messages = transcript,
+            Iterations = iteration,
+            MaxIterationsReached = maxReached,
+            ToolInvocations = outcomes,
+            InputTokens = anyUsage ? (int)totalInput : null,
+            OutputTokens = anyUsage ? (int)totalOutput : null,
+            Duration = duration,
+        };
+    }
+
+    private async Task<(string Content, bool Succeeded, bool Truncated)> ExecuteToolAsync(
+        FunctionCallContent call,
+        Dictionary<string, IAITool> toolMap,
+        GranitAIToolsOrchestrationOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (!toolMap.TryGetValue(call.Name, out IAITool? tool))
+        {
+            LogUnknownTool(call.Name);
+            return ($"Error: no tool named '{call.Name}' is available.", false, false);
+        }
+
+        JsonElement arguments = SerializeArguments(call.Arguments);
+
+        AIToolResult result;
+        try
+        {
+            result = await tool
+                .InvokeAsync(new AIToolInvocationContext { Arguments = arguments }, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogToolFailed(ex, call.Name);
+            return ($"Error: tool '{call.Name}' failed and could not complete the request.", false, false);
+        }
+
+        (string content, bool truncated) = Guard(result.Content, options.MaxToolResultCharacters);
+        LogToolInvoked(call.Name, result.IsError, truncated);
+        return (content, !result.IsError, truncated);
+    }
+
+    private static JsonElement SerializeArguments(IDictionary<string, object?>? arguments) =>
+        arguments is null || arguments.Count == 0
+            ? EmptyArguments
+            : JsonSerializer.SerializeToElement(arguments, ArgumentSerializerOptions);
+
+    private static (string Content, bool Truncated) Guard(string content, int maxCharacters)
+    {
+        if (maxCharacters <= 0 || content.Length <= maxCharacters)
+        {
+            return (content, false);
+        }
+
+        int dropped = content.Length - maxCharacters;
+        return ($"{content[..maxCharacters]}\n\n[truncated {dropped} characters to fit the context window]", true);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "AI tool '{Tool}' invoked (isError={IsError}, truncated={Truncated}).")]
+    private partial void LogToolInvoked(string tool, bool isError, bool truncated);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI agent requested unknown tool '{Tool}'.")]
+    private partial void LogUnknownTool(string tool);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "AI tool '{Tool}' threw during invocation.")]
+    private partial void LogToolFailed(Exception exception, string tool);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI orchestration loop hit the iteration cap of {MaxIterations} before settling.")]
+    private partial void LogMaxIterationsReached(int maxIterations);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "AI orchestration run on workspace '{Workspace}' completed in {Iterations} iteration(s) with {ToolCalls} tool call(s) (maxReached={MaxReached}).")]
+    private partial void LogRunCompleted(string workspace, int iterations, int toolCalls, bool maxReached);
+}

--- a/src/Granit.AI.Tools/Options/GranitAIToolsOrchestrationOptions.cs
+++ b/src/Granit.AI.Tools/Options/GranitAIToolsOrchestrationOptions.cs
@@ -1,0 +1,24 @@
+namespace Granit.AI.Tools.Options;
+
+/// <summary>
+/// Safety bounds for the agentic orchestration loop (ADR-067). Keeps an agent from running
+/// away on cost or overflowing the context window.
+/// </summary>
+public sealed class GranitAIToolsOrchestrationOptions
+{
+    /// <summary>Configuration section path.</summary>
+    public const string SectionName = "AI:Tools:Orchestration";
+
+    /// <summary>
+    /// Maximum number of think → call → execute iterations before the loop stops and returns
+    /// whatever the model produced last. Must be at least 1. Default 8.
+    /// </summary>
+    public int MaxIterations { get; set; } = 8;
+
+    /// <summary>
+    /// Maximum number of characters of a single tool result fed back to the model. Longer
+    /// results are truncated and the truncation is signalled to the model. Set to 0 to disable
+    /// truncation (not recommended). Default 8000.
+    /// </summary>
+    public int MaxToolResultCharacters { get; set; } = 8000;
+}

--- a/src/Granit.AI.Tools/README.md
+++ b/src/Granit.AI.Tools/README.md
@@ -26,15 +26,24 @@ services.AddGranitAITools(tools =>
 });
 ```
 
-The orchestrator emits declarations automatically:
+The orchestrator drives the agentic loop (think → call → execute → repeat), bounded by an
+iteration cap and per-result context guards, stamping usage on completion:
 
 ```csharp
-chatOptions.Tools = [.. projector.ProjectAll()];
+var result = await orchestrator.RunAsync(new AIOrchestrationRequest
+{
+    WorkspaceName = "support-chat",
+    Messages = [new ChatMessage(ChatRole.User, "What changed last week?")],
+});
 ```
+
+Bounds are configured under `AI:Tools:Orchestration` (`MaxIterations`,
+`MaxToolResultCharacters`).
 
 ## Dependencies
 
 - `Granit`
+- `Granit.AI`
 
 ## Documentation
 

--- a/src/Granit.AI.Tools/packages.lock.json
+++ b/src/Granit.AI.Tools/packages.lock.json
@@ -14,8 +14,284 @@
         "resolved": "10.7.0",
         "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
       }
     }
   }

--- a/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
+++ b/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
@@ -1,0 +1,223 @@
+using Granit.AI.Options;
+using Granit.AI.Tools.Diagnostics;
+using Granit.AI.Tools.Internal;
+using Granit.AI.Tools.Options;
+using Granit.AI.Tools.Tests.Fakes;
+using Granit.AI.Workspaces;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.AI.Tools.Tests;
+
+public sealed class AIToolOrchestratorTests
+{
+    private static ChatResponse ToolCall(string callId, string name, IDictionary<string, object?>? args = null) =>
+        new(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent(callId, name, args)]));
+
+    private static ChatResponse FinalText(string text, int? input = null, int? output = null)
+    {
+        ChatResponse response = new(new ChatMessage(ChatRole.Assistant, text));
+        if (input is not null || output is not null)
+        {
+            response.Usage = new UsageDetails { InputTokenCount = input, OutputTokenCount = output };
+        }
+
+        return response;
+    }
+
+    private sealed record Harness(
+        AIToolOrchestrator Orchestrator,
+        ScriptedChatClient ChatClient,
+        IAIUsageTracker UsageTracker);
+
+    private static Harness CreateHarness(
+        ScriptedChatClient chatClient,
+        IEnumerable<IAITool> tools,
+        GranitAIToolsOrchestrationOptions? options = null)
+    {
+        AIToolRegistry registry = new(tools);
+        AIToolProjector projector = new(registry);
+
+        IAIChatClientFactory factory = Substitute.For<IAIChatClientFactory>();
+        factory.CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(chatClient);
+
+        IAIWorkspaceProvider workspaceProvider = Substitute.For<IAIWorkspaceProvider>();
+        workspaceProvider.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AIWorkspace { Name = "default", Provider = "OpenAI", Model = "gpt-4o" });
+
+        IAIUsageRecordFactory recordFactory = Substitute.For<IAIUsageRecordFactory>();
+        recordFactory.Create(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<int>(), Arg.Any<int>(), Arg.Any<TimeSpan?>())
+            .Returns(call => new AIUsageRecord
+            {
+                Id = Guid.Empty,
+                WorkspaceName = (string)call[0],
+                Provider = (string)call[1],
+                Model = (string)call[2],
+                InputTokens = (int)call[3],
+                OutputTokens = (int)call[4],
+                Timestamp = DateTimeOffset.UnixEpoch,
+            });
+
+        IAIUsageTracker usageTracker = Substitute.For<IAIUsageTracker>();
+
+        AIToolOrchestrator orchestrator = new(
+            factory,
+            workspaceProvider,
+            projector,
+            registry,
+            recordFactory,
+            usageTracker,
+            MsOptions.Create(options ?? new GranitAIToolsOrchestrationOptions()),
+            MsOptions.Create(new GranitAIOptions()),
+            new AIToolsMetrics(new TestMeterFactory()),
+            TimeProvider.System,
+            NullLogger<AIToolOrchestrator>.Instance);
+
+        return new Harness(orchestrator, chatClient, usageTracker);
+    }
+
+    private static AIOrchestrationRequest UserSays(string text) =>
+        new() { Messages = [new ChatMessage(ChatRole.User, text)] };
+
+    [Fact]
+    public async Task Executes_a_tool_call_then_settles_on_the_final_answer()
+    {
+        FakeAITool echo = new(name: "echo", result: "tool-said-hi");
+        ScriptedChatClient client = new(
+            ToolCall("c1", "echo"),
+            FinalText("final answer"));
+        Harness harness = CreateHarness(client, [echo]);
+
+        AIOrchestrationResult result = await harness.Orchestrator.RunAsync(
+            UserSays("hi"), TestContext.Current.CancellationToken);
+
+        result.Content.ShouldBe("final answer");
+        result.Iterations.ShouldBe(2);
+        result.MaxIterationsReached.ShouldBeFalse();
+        result.ToolInvocations.ShouldHaveSingleItem();
+        result.ToolInvocations[0].ToolName.ShouldBe("echo");
+        result.ToolInvocations[0].Succeeded.ShouldBeTrue();
+        result.ToolInvocations[0].Iteration.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Feeds_the_tool_result_back_into_the_next_model_call()
+    {
+        FakeAITool echo = new(name: "echo", result: "tool-said-hi");
+        ScriptedChatClient client = new(
+            ToolCall("c1", "echo"),
+            FinalText("done"));
+        Harness harness = CreateHarness(client, [echo]);
+
+        await harness.Orchestrator.RunAsync(UserSays("hi"), TestContext.Current.CancellationToken);
+
+        // Second model call must include a Tool message carrying the tool result.
+        IReadOnlyList<ChatMessage> secondCall = harness.ChatClient.Calls[1];
+        FunctionResultContent resultContent = secondCall
+            .SelectMany(m => m.Contents)
+            .OfType<FunctionResultContent>()
+            .ShouldHaveSingleItem();
+        resultContent.CallId.ShouldBe("c1");
+        resultContent.Result?.ToString().ShouldBe("tool-said-hi");
+    }
+
+    [Fact]
+    public async Task Stops_at_the_iteration_cap_when_the_model_keeps_calling_tools()
+    {
+        FakeAITool echo = new(name: "echo");
+        ScriptedChatClient client = new(
+            ToolCall("c1", "echo"),
+            ToolCall("c2", "echo"),
+            ToolCall("c3", "echo"));
+        Harness harness = CreateHarness(client, [echo],
+            new GranitAIToolsOrchestrationOptions { MaxIterations = 2 });
+
+        AIOrchestrationResult result = await harness.Orchestrator.RunAsync(
+            UserSays("loop"), TestContext.Current.CancellationToken);
+
+        result.MaxIterationsReached.ShouldBeTrue();
+        result.Iterations.ShouldBe(2);
+        // Only iteration 1 executes tools; iteration 2 hits the cap before executing.
+        result.ToolInvocations.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task Truncates_an_oversized_tool_result_and_signals_it()
+    {
+        FakeAITool big = new(name: "big", result: new string('x', 50));
+        ScriptedChatClient client = new(
+            ToolCall("c1", "big"),
+            FinalText("ok"));
+        Harness harness = CreateHarness(client, [big],
+            new GranitAIToolsOrchestrationOptions { MaxToolResultCharacters = 10 });
+
+        AIOrchestrationResult result = await harness.Orchestrator.RunAsync(
+            UserSays("go"), TestContext.Current.CancellationToken);
+
+        result.ToolInvocations[0].Truncated.ShouldBeTrue();
+
+        FunctionResultContent fed = harness.ChatClient.Calls[1]
+            .SelectMany(m => m.Contents)
+            .OfType<FunctionResultContent>()
+            .Single();
+        fed.Result.ShouldBeOfType<string>().ShouldContain("[truncated 40 characters");
+    }
+
+    [Fact]
+    public async Task An_unknown_tool_yields_an_error_result_and_the_loop_continues()
+    {
+        ScriptedChatClient client = new(
+            ToolCall("c1", "ghost"),
+            FinalText("recovered"));
+        Harness harness = CreateHarness(client, []);
+
+        AIOrchestrationResult result = await harness.Orchestrator.RunAsync(
+            UserSays("call ghost"), TestContext.Current.CancellationToken);
+
+        result.Content.ShouldBe("recovered");
+        result.ToolInvocations[0].Succeeded.ShouldBeFalse();
+
+        FunctionResultContent fed = harness.ChatClient.Calls[1]
+            .SelectMany(m => m.Contents)
+            .OfType<FunctionResultContent>()
+            .Single();
+        fed.Result.ShouldBeOfType<string>().ShouldContain("no tool named 'ghost'");
+    }
+
+    [Fact]
+    public async Task Stamps_a_usage_record_with_summed_tokens()
+    {
+        FakeAITool echo = new(name: "echo");
+        ScriptedChatClient client = new(
+            FinalText("done", input: 30, output: 12));
+        Harness harness = CreateHarness(client, [echo]);
+
+        AIOrchestrationResult result = await harness.Orchestrator.RunAsync(
+            UserSays("hi"), TestContext.Current.CancellationToken);
+
+        result.InputTokens.ShouldBe(30);
+        result.OutputTokens.ShouldBe(12);
+        await harness.UsageTracker.Received(1).RecordAsync(
+            Arg.Is<AIUsageRecord>(r => r.InputTokens == 30 && r.OutputTokens == 12),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Does_not_stamp_usage_when_the_provider_reports_none()
+    {
+        ScriptedChatClient client = new(FinalText("done"));
+        Harness harness = CreateHarness(client, []);
+
+        AIOrchestrationResult result = await harness.Orchestrator.RunAsync(
+            UserSays("hi"), TestContext.Current.CancellationToken);
+
+        result.InputTokens.ShouldBeNull();
+        await harness.UsageTracker.DidNotReceive().RecordAsync(
+            Arg.Any<AIUsageRecord>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.AI.Tools.Tests/Fakes/ScriptedChatClient.cs
+++ b/tests/Granit.AI.Tools.Tests/Fakes/ScriptedChatClient.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.AI;
+
+namespace Granit.AI.Tools.Tests.Fakes;
+
+/// <summary>
+/// An <see cref="IChatClient"/> that returns a pre-scripted sequence of responses and records
+/// the messages it was handed on each call, so a test can assert what was fed back into the loop.
+/// </summary>
+internal sealed class ScriptedChatClient(params ChatResponse[] responses) : IChatClient
+{
+    private readonly Queue<ChatResponse> _responses = new(responses);
+
+    /// <summary>A snapshot of the messages passed on each <see cref="GetResponseAsync"/> call.</summary>
+    public List<IReadOnlyList<ChatMessage>> Calls { get; } = [];
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Calls.Add([.. messages]);
+        return Task.FromResult(_responses.Dequeue());
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("Streaming is not used by the orchestration loop tests.");
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/Granit.AI.Tools.Tests/Fakes/TestMeterFactory.cs
+++ b/tests/Granit.AI.Tools.Tests/Fakes/TestMeterFactory.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.Metrics;
+
+namespace Granit.AI.Tools.Tests.Fakes;
+
+/// <summary>Minimal <see cref="IMeterFactory"/> for constructing metrics in tests.</summary>
+internal sealed class TestMeterFactory : IMeterFactory
+{
+    private readonly List<Meter> _meters = [];
+
+    public Meter Create(MeterOptions options)
+    {
+        Meter meter = new(options);
+        _meters.Add(meter);
+        return meter;
+    }
+
+    public void Dispose()
+    {
+        foreach (Meter meter in _meters)
+        {
+            meter.Dispose();
+        }
+
+        _meters.Clear();
+    }
+}

--- a/tests/Granit.AI.Tools.Tests/packages.lock.json
+++ b/tests/Granit.AI.Tools.Tests/packages.lock.json
@@ -101,6 +101,45 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
         "resolved": "1.9.1",
@@ -243,11 +282,132 @@
       "granit": {
         "type": "Project"
       },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.ai.tools": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.Extensions.AI.Abstractions": {
@@ -255,6 +415,123 @@
         "requested": "[10.*, )",
         "resolved": "10.7.0",
         "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Second story of the agentic AI chat initiative (ADR-067). Adds **`IAIToolOrchestrator`** to `Granit.AI.Tools` — the think → call → execute → repeat loop that drives an agent over the tools registered in #2630.

Builds on #2630 (PR #2719). Closes #2631.

## What's in it

- **The loop** — sends the conversation to the workspace `IChatClient` with the auto-projected tool declarations (`ChatToolMode.Auto`), executes every `FunctionCallContent` the model returns through the registry, feeds `FunctionResultContent` back, and repeats until the model stops calling tools.
- **Iteration cap** — `GranitAIToolsOrchestrationOptions.MaxIterations` (default 8). When the model keeps requesting tools past the cap, the loop stops and reports `MaxIterationsReached = true` with whatever the model last produced.
- **Context guard** — a single tool result longer than `MaxToolResultCharacters` (default 8000) is truncated and the truncation is **signalled to the model** (`[truncated N characters …]`) rather than overflowing the window. ADR-067 calls this out as a deliberate design point.
- **Resilience** — an unknown tool or a tool that throws produces an error result fed back to the model; the loop recovers rather than crashing.
- **Usage stamping** — on completion, one `AIUsageRecord` is stamped with the workspace, provider, model and **summed** input/output tokens across all iterations.
- **Observability** — per-call structured audit logs, `AIToolsMetrics` (invocations / truncations / iterations, `tenant_id`-tagged) and a `Granit.AI.Tools` `ActivitySource`.
- **Result** — final answer + full transcript (incl. tool-call/result messages) + per-call audit trail + token totals.

## Acceptance criteria

- ✅ Model requests a tool → it's executed, result fed back, iteration continues, bounded by the max-iteration cap.
- ✅ Oversized tool result → capped/signalled, not overflowing.
- ✅ Completed interaction → `AIUsageRecord` stamped with the workspace used.

## Design notes

- `Granit.AI.Tools` now depends on `Granit.AI` (`[DependsOn(typeof(GranitAIModule))]`) for `IAIChatClientFactory` + usage tracking.
- The loop is a **generic engine**: it does not enforce workspace chat-capability (ADR decision 4) — that gating lands with the chat endpoint story (#2637), where the capability resolver lives. Kept out here so the engine stays reusable.
- `AIOrchestrationRequest.Tools` lets a caller expose a curated subset instead of the whole registry.

## Verification

- Builds clean (0 warnings).
- **29/29** unit tests pass (loop settle, result-feedback round-trip, iteration cap, truncation signalling, unknown-tool recovery, usage stamping present/absent) via a scripted `IChatClient`.
- `dotnet format --verify-no-changes` + markdownlint clean.
- **225/225** architecture tests pass.

## Next

- #2632 + following Tools stories.
- Chat feature (#2637+) consumes this orchestrator behind the streaming endpoint and enforces chat-capable workspace selection.