### PR TITLE
feat(ai): query_data tool adapter over opted-in QueryDefinitions (#2633)

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -11,6 +11,7 @@
       "src/Granit.AI.Ollama/Granit.AI.Ollama.csproj",
       "src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj",
       "src/Granit.AI.StackExchangeRedis/Granit.AI.StackExchangeRedis.csproj",
+      "src/Granit.AI.Tools/Granit.AI.Tools.csproj",
       "src/Granit.AI.VectorData/Granit.AI.VectorData.csproj",
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2224,6 +2224,7 @@
       "name": "Granit.QueryEngine.AI",
       "deps": [
         "Granit.AI",
+        "Granit.AI.Tools",
         "Granit.QueryEngine.Abstractions",
         "Granit.Timing"
       ],
@@ -44641,6 +44642,22 @@
       "members": []
     },
     {
+      "name": "QueryDataToolRegistrationExtensions",
+      "fqn": "Granit.QueryEngine.AI.Extensions.QueryDataToolRegistrationExtensions",
+      "kind": "class",
+      "project": "Granit.QueryEngine.AI",
+      "file": "src/Granit.QueryEngine.AI/Extensions/QueryDataToolRegistrationExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AddQueryData",
+          "kind": "method",
+          "signature": "AddQueryData(this AIToolRegistrationBuilder tools, Action<QueryDataToolBuilder> configure)",
+          "returnType": "AIToolRegistrationBuilder"
+        }
+      ]
+    },
+    {
       "name": "QueryEngineAIHostApplicationBuilderExtensions",
       "fqn": "Granit.QueryEngine.AI.Extensions.QueryEngineAIHostApplicationBuilderExtensions",
       "kind": "class",
@@ -44662,7 +44679,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.AI",
       "file": "src/Granit.QueryEngine.AI/GranitQueryEngineAIModule.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -44709,6 +44726,15 @@
           "returnType": "int"
         }
       ]
+    },
+    {
+      "name": "QueryDataToolBuilder",
+      "fqn": "Granit.QueryEngine.AI.QueryDataToolBuilder",
+      "kind": "class",
+      "project": "Granit.QueryEngine.AI",
+      "file": "src/Granit.QueryEngine.AI/QueryDataToolBuilder.cs",
+      "line": 12,
+      "members": []
     },
     {
       "name": "QueryRequestBinder",

--- a/.slnf/application.slnf
+++ b/.slnf/application.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "Granit.slnx",
     "projects": [
+      "src/Granit.AI.Tools/Granit.AI.Tools.csproj",
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",

--- a/src/Granit.QueryEngine.AI/Extensions/QueryDataToolRegistrationExtensions.cs
+++ b/src/Granit.QueryEngine.AI/Extensions/QueryDataToolRegistrationExtensions.cs
@@ -1,0 +1,35 @@
+using Granit.AI.Tools;
+
+namespace Granit.QueryEngine.AI.Extensions;
+
+/// <summary>
+/// Registers <c>query_data</c> tools on the Granit AI tool registry.
+/// </summary>
+public static class QueryDataToolRegistrationExtensions
+{
+    /// <summary>
+    /// Opts query definitions in as ACL-bound <c>query_data</c> tools the chat agent can call.
+    /// </summary>
+    /// <param name="tools">The AI tool registration builder.</param>
+    /// <param name="configure">Selects which definitions to expose.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// services.AddGranitAITools(tools => tools.AddQueryData(q =>
+    /// {
+    ///     q.Add&lt;Order&gt;("orders", "Customer orders with status and totals");
+    ///     q.Add&lt;Product&gt;("products");
+    /// }));
+    /// </code>
+    /// </example>
+    public static AIToolRegistrationBuilder AddQueryData(
+        this AIToolRegistrationBuilder tools,
+        Action<QueryDataToolBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(new QueryDataToolBuilder(tools.Services));
+        return tools;
+    }
+}

--- a/src/Granit.QueryEngine.AI/Granit.QueryEngine.AI.csproj
+++ b/src/Granit.QueryEngine.AI/Granit.QueryEngine.AI.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>

--- a/src/Granit.QueryEngine.AI/GranitQueryEngineAIModule.cs
+++ b/src/Granit.QueryEngine.AI/GranitQueryEngineAIModule.cs
@@ -1,4 +1,5 @@
 using Granit.AI;
+using Granit.AI.Tools;
 using Granit.Diagnostics;
 using Granit.Modularity;
 using Granit.QueryEngine.AI.Diagnostics;
@@ -16,6 +17,7 @@ namespace Granit.QueryEngine.AI;
 /// </remarks>
 [DependsOn(
     typeof(GranitAIModule),
+    typeof(GranitAIToolsModule),
     typeof(GranitQueryEngineAbstractionsModule))]
 public sealed class GranitQueryEngineAIModule : GranitModule
 {

--- a/src/Granit.QueryEngine.AI/Internal/QueryDataSchema.cs
+++ b/src/Granit.QueryEngine.AI/Internal/QueryDataSchema.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Granit.QueryEngine.Filtering;
+using Granit.QueryEngine.Meta;
+
+namespace Granit.QueryEngine.AI.Internal;
+
+/// <summary>
+/// Projects a <see cref="QueryMetadata"/> into the JSON Schema for a <c>query_data</c> tool and
+/// maps the model-supplied arguments back into a validated <see cref="QueryRequest"/>. Only the
+/// fields and operators the definition exposes are accepted — unknown ones are dropped and
+/// reported, never forwarded.
+/// </summary>
+internal static class QueryDataSchema
+{
+    /// <summary>Builds the tool parameter schema from a query definition's metadata.</summary>
+    public static JsonElement Build(QueryMetadata metadata)
+    {
+        JsonObject properties = [];
+
+        if (metadata.FilterableFields.Count > 0)
+        {
+            JsonArray fieldNames = [.. metadata.FilterableFields.Select(f => (JsonNode)f.Name)];
+            JsonArray operators = [.. metadata.FilterableFields
+                .SelectMany(f => f.Operators)
+                .Distinct()
+                .Select(op => (JsonNode)OperatorCode(op))];
+
+            properties["filters"] = new JsonObject
+            {
+                ["type"] = "array",
+                ["description"] = "Filter clauses, ANDed together. Use only the listed fields and operators.",
+                ["items"] = new JsonObject
+                {
+                    ["type"] = "object",
+                    ["properties"] = new JsonObject
+                    {
+                        ["field"] = new JsonObject { ["type"] = "string", ["enum"] = fieldNames },
+                        ["operator"] = new JsonObject { ["type"] = "string", ["enum"] = operators },
+                        ["value"] = new JsonObject { ["type"] = "string" },
+                    },
+                    ["required"] = new JsonArray("field", "operator", "value"),
+                    ["additionalProperties"] = false,
+                },
+            };
+        }
+
+        properties["search"] = new JsonObject
+        {
+            ["type"] = "string",
+            ["description"] = "Free-text search across the definition's searchable fields, if any.",
+        };
+
+        if (metadata.SortableFields.Count > 0)
+        {
+            string sortable = string.Join(", ", metadata.SortableFields.Select(s => s.Name));
+            properties["sort"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = $"Comma-separated sort fields; prefix '-' for descending. Sortable: {sortable}.",
+            };
+        }
+
+        properties["page"] = new JsonObject { ["type"] = "integer", ["minimum"] = 1 };
+        properties["pageSize"] = new JsonObject
+        {
+            ["type"] = "integer",
+            ["minimum"] = 1,
+            ["maximum"] = metadata.Pagination.MaxPageSize,
+            ["description"] = $"Defaults to {metadata.Pagination.DefaultPageSize}.",
+        };
+
+        JsonObject schema = new()
+        {
+            ["type"] = "object",
+            ["properties"] = properties,
+            ["additionalProperties"] = false,
+        };
+
+        return JsonSerializer.SerializeToElement(schema);
+    }
+
+    /// <summary>
+    /// Maps the model arguments onto a validated <see cref="QueryRequest"/>, returning any filter
+    /// keys that were rejected because they are not exposed by the definition.
+    /// </summary>
+    public static (QueryRequest Request, IReadOnlyList<string> IgnoredFilters) BuildRequest(
+        JsonElement arguments, QueryMetadata metadata)
+    {
+        HashSet<string> allowedKeys = [.. metadata.FilterableFields
+            .SelectMany(f => f.Operators.Select(op => $"{f.Name}.{OperatorCode(op)}"))];
+
+        Dictionary<string, string> filter = new(StringComparer.Ordinal);
+        List<string> ignored = [];
+
+        if (arguments.ValueKind == JsonValueKind.Object
+            && arguments.TryGetProperty("filters", out JsonElement filters)
+            && filters.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement clause in filters.EnumerateArray())
+            {
+                if (clause.ValueKind != JsonValueKind.Object
+                    || !clause.TryGetProperty("field", out JsonElement fieldEl)
+                    || !clause.TryGetProperty("operator", out JsonElement opEl)
+                    || !clause.TryGetProperty("value", out JsonElement valueEl))
+                {
+                    continue;
+                }
+
+                string key = $"{fieldEl.GetString()}.{opEl.GetString()?.ToLowerInvariant()}";
+                if (allowedKeys.Contains(key))
+                {
+                    filter[key] = valueEl.GetString() ?? string.Empty;
+                }
+                else
+                {
+                    ignored.Add(key);
+                }
+            }
+        }
+
+        QueryRequest request = new()
+        {
+            Filter = filter.Count > 0 ? filter : null,
+            Search = ReadString(arguments, "search"),
+            Sort = ReadString(arguments, "sort"),
+            Page = ReadInt(arguments, "page"),
+            PageSize = ClampPageSize(ReadInt(arguments, "pageSize"), metadata.Pagination),
+        };
+
+        return (request, ignored);
+    }
+
+    private static int ClampPageSize(int? requested, PaginationMeta pagination)
+    {
+        int size = requested ?? pagination.DefaultPageSize;
+        return Math.Clamp(size, 1, pagination.MaxPageSize);
+    }
+
+    private static string? ReadString(JsonElement arguments, string name) =>
+        arguments.ValueKind == JsonValueKind.Object
+        && arguments.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int? ReadInt(JsonElement arguments, string name) =>
+        arguments.ValueKind == JsonValueKind.Object
+        && arguments.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind == JsonValueKind.Number
+        && value.TryGetInt32(out int parsed)
+            ? parsed
+            : null;
+
+    private static string OperatorCode(FilterOperator op) => op.ToString().ToLowerInvariant();
+}

--- a/src/Granit.QueryEngine.AI/Internal/QueryDataTool.cs
+++ b/src/Granit.QueryEngine.AI/Internal/QueryDataTool.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.AI.Tools;
+using Granit.QueryEngine.Meta;
+
+namespace Granit.QueryEngine.AI.Internal;
+
+/// <summary>
+/// An <see cref="IAITool"/> over a single opted-in <c>QueryDefinition</c>. Exposes the
+/// definition's filterable structure as a tool schema and executes a structured
+/// <see cref="QueryRequest"/> against the caller-scoped <see cref="IQueryableSource{TEntity}"/> —
+/// so results are bounded by the same tenant and ACL filters the user is subject to everywhere
+/// else (ADR-067). Only definitions the application registers are exposed.
+/// </summary>
+internal sealed class QueryDataTool<TEntity>(
+    string name,
+    string? description,
+    IQueryEngine<TEntity> engine,
+    IQueryableSource<TEntity> source) : IAITool, IAIToolInstructions
+    where TEntity : class
+{
+    private static readonly JsonSerializerOptions ResultSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly QueryMetadata _metadata = engine.GetMetadata();
+
+    public string Name => $"query_{name}";
+
+    public string Description => description
+        ?? $"Query '{name}' records the current user is allowed to see. Returns a page of matching records as JSON.";
+
+    public JsonElement ParameterSchema { get; } = QueryDataSchema.Build(engine.GetMetadata());
+
+    public string Instructions =>
+        $"Use '{Name}' to read '{name}' data. Filter with the listed fields/operators only, keep "
+        + "pageSize small, and sort to surface the most relevant rows. Results are already "
+        + "restricted to what the current user may access — never claim otherwise.";
+
+    public async ValueTask<AIToolResult> InvokeAsync(
+        AIToolInvocationContext context,
+        CancellationToken cancellationToken = default)
+    {
+        (QueryRequest request, IReadOnlyList<string> ignored) =
+            QueryDataSchema.BuildRequest(context.Arguments, _metadata);
+
+        IQueryable<TEntity> queryable = source.GetQueryable();
+        PagedResult<TEntity> result = await engine
+            .ExecuteAsync(queryable, request, cancellationToken)
+            .ConfigureAwait(false);
+
+        var payload = new
+        {
+            entity = name,
+            totalCount = result.TotalCount,
+            hasMore = result.HasMore,
+            count = result.Items.Count,
+            ignoredFilters = ignored.Count > 0 ? ignored : null,
+            items = result.Items,
+        };
+
+        return AIToolResult.Success(JsonSerializer.Serialize(payload, ResultSerializerOptions));
+    }
+}

--- a/src/Granit.QueryEngine.AI/QueryDataToolBuilder.cs
+++ b/src/Granit.QueryEngine.AI/QueryDataToolBuilder.cs
@@ -1,0 +1,36 @@
+using Granit.AI.Tools;
+using Granit.QueryEngine.AI.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.QueryEngine.AI;
+
+/// <summary>
+/// Opt-in surface for exposing <c>QueryDefinition</c>s as ACL-bound <c>query_data</c> tools.
+/// Each <see cref="Add{TEntity}"/> registers one tool; a definition that is never added is never
+/// exposed to the agent and cannot be invoked.
+/// </summary>
+public sealed class QueryDataToolBuilder(IServiceCollection services)
+{
+    /// <summary>
+    /// Exposes the query definition for <typeparamref name="TEntity"/> as a tool named
+    /// <c>query_{name}</c>. Requires <c>IQueryEngine&lt;TEntity&gt;</c> and a caller-scoped
+    /// <c>IQueryableSource&lt;TEntity&gt;</c> to be registered — the latter is what binds results
+    /// to the current user's tenant and ACLs.
+    /// </summary>
+    /// <typeparam name="TEntity">The queried entity.</typeparam>
+    /// <param name="name">Short, tool-name-safe identifier (e.g. <c>orders</c>).</param>
+    /// <param name="description">Optional model-facing description; a default is generated.</param>
+    public QueryDataToolBuilder Add<TEntity>(string name, string? description = null)
+        where TEntity : class
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        services.AddScoped<IAITool>(sp => new QueryDataTool<TEntity>(
+            name,
+            description,
+            sp.GetRequiredService<IQueryEngine<TEntity>>(),
+            sp.GetRequiredService<IQueryableSource<TEntity>>()));
+
+        return this;
+    }
+}

--- a/src/Granit.QueryEngine.AI/README.md
+++ b/src/Granit.QueryEngine.AI/README.md
@@ -1,8 +1,22 @@
 # Granit.QueryEngine.AI
 
-Natural Language Query (NLQ) for Granit.QueryEngine. Translates natural language into structured QueryRequest objects using LLM.
+Natural Language Query (NLQ) for Granit.QueryEngine. Translates natural language into structured QueryRequest objects using LLM, and exposes opted-in query definitions as ACL-bound `query_data` tools for the agentic chat (ADR-067).
 
 Part of the [granit](https://granit-fx.dev) framework.
+
+## `query_data` tools
+
+Opt definitions in to expose them to the chat agent. Each becomes a `query_<name>` tool whose
+schema is projected from the definition's metadata; it executes a structured query over the
+caller-scoped `IQueryableSource<TEntity>`, so results stay bounded by the user's tenant and ACLs.
+
+```csharp
+services.AddGranitAITools(tools => tools.AddQueryData(q =>
+{
+    q.Add<Order>("orders", "Customer orders with status and totals");
+    q.Add<Product>("products");
+}));
+```
 
 ## Installation
 

--- a/src/Granit.QueryEngine.AI/packages.lock.json
+++ b/src/Granit.QueryEngine.AI/packages.lock.json
@@ -87,6 +87,14 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1596,6 +1596,14 @@
           "StackExchange.Redis": "[2.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.ai.vectordata": {
         "type": "Project",
         "dependencies": {
@@ -3595,6 +3603,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"
         }
@@ -5012,8 +5021,8 @@
       "Sep": {
         "type": "CentralTransitive",
         "requested": "[0.*, )",
-        "resolved": "0.14.1",
-        "contentHash": "yliFcwYWxcLXwCR+XI0IviKCChtMWP6Tx4DWs3rW9QYhj147zW7ZLKQteg5v7T9zIB/Ki0Bo2FM0F4ndcaPP+A==",
+        "resolved": "0.15.0",
+        "contentHash": "x4euJeBMZaHwPx4vqYu2MUo5uefllW3CkSu0X/pdX0bn6sHTl3af2lDC+p5MuQLMfCHi7bOpt/rwdmcY42zbPg==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }

--- a/tests/Granit.QueryEngine.AI.Tests/QueryDataToolTests.cs
+++ b/tests/Granit.QueryEngine.AI.Tests/QueryDataToolTests.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using Granit.AI.Tools;
+using Granit.AI.Tools.Extensions;
+using Granit.QueryEngine.AI.Extensions;
+using Granit.QueryEngine.AI.Internal;
+using Granit.QueryEngine.Filtering;
+using Granit.QueryEngine.Meta;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.QueryEngine.AI.Tests;
+
+public sealed class QueryDataToolTests
+{
+    public sealed class Thing
+    {
+        public string Name { get; init; } = "";
+        public int Amount { get; init; }
+    }
+
+    private static QueryMetadata Metadata() => new()
+    {
+        Columns = [],
+        FilterableFields =
+        [
+            new FilterableField("name", "string", [FilterOperator.Eq, FilterOperator.Contains]),
+            new FilterableField("amount", "number", [FilterOperator.Gte, FilterOperator.Lte]),
+        ],
+        SortableFields = [new SortableField("name"), new SortableField("amount")],
+        PresetFilterGroups = [],
+        QuickFilters = [],
+        DateFilters = [],
+        GroupByFields = [],
+        Pagination = new PaginationMeta(20, 100, 1000, SupportsCursor: false),
+    };
+
+    private static (QueryDataTool<Thing> Tool, IQueryEngine<Thing> Engine, IQueryable<Thing> Source)
+        CreateTool(PagedResult<Thing>? result = null)
+    {
+        IQueryEngine<Thing> engine = Substitute.For<IQueryEngine<Thing>>();
+        engine.GetMetadata().Returns(Metadata());
+        engine.ExecuteAsync(Arg.Any<IQueryable<Thing>>(), Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(result ?? new PagedResult<Thing>([], 0, false));
+
+        IQueryable<Thing> queryable = new[] { new Thing { Name = "a", Amount = 1 } }.AsQueryable();
+        IQueryableSource<Thing> source = Substitute.For<IQueryableSource<Thing>>();
+        source.GetQueryable().Returns(queryable);
+
+        return (new QueryDataTool<Thing>("things", null, engine, source), engine, queryable);
+    }
+
+    [Fact]
+    public void Tool_name_is_prefixed_with_query()
+    {
+        (QueryDataTool<Thing> tool, _, _) = CreateTool();
+        tool.Name.ShouldBe("query_things");
+    }
+
+    [Fact]
+    public void Schema_projects_filterable_fields_and_operators()
+    {
+        (QueryDataTool<Thing> tool, _, _) = CreateTool();
+
+        JsonElement itemProps = tool.ParameterSchema
+            .GetProperty("properties").GetProperty("filters")
+            .GetProperty("items").GetProperty("properties");
+
+        string[] fields = [.. itemProps.GetProperty("field").GetProperty("enum").EnumerateArray().Select(e => e.GetString()!)];
+        string[] operators = [.. itemProps.GetProperty("operator").GetProperty("enum").EnumerateArray().Select(e => e.GetString()!)];
+
+        fields.ShouldBe(["name", "amount"]);
+        operators.ShouldBe(["eq", "contains", "gte", "lte"]);
+        tool.ParameterSchema.GetProperty("properties").GetProperty("pageSize").GetProperty("maximum").GetInt32().ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task Maps_valid_filters_into_the_query_request_and_drops_unknown_ones()
+    {
+        (QueryDataTool<Thing> tool, IQueryEngine<Thing> engine, _) = CreateTool();
+
+        JsonElement args = JsonSerializer.SerializeToElement(new
+        {
+            filters = new[]
+            {
+                new { field = "name", @operator = "contains", value = "abc" },
+                new { field = "ghost", @operator = "eq", value = "x" },
+            },
+            pageSize = 5,
+        });
+
+        AIToolResult result = await tool.InvokeAsync(
+            new AIToolInvocationContext { Arguments = args }, TestContext.Current.CancellationToken);
+
+        await engine.Received(1).ExecuteAsync(
+            Arg.Any<IQueryable<Thing>>(),
+            Arg.Is<QueryRequest>(r =>
+                r.Filter != null
+                && r.Filter["name.contains"] == "abc"
+                && !r.Filter.ContainsKey("ghost.eq")
+                && r.PageSize == 5),
+            Arg.Any<CancellationToken>());
+
+        using var payload = JsonDocument.Parse(result.Content);
+        payload.RootElement.GetProperty("ignoredFilters")[0].GetString().ShouldBe("ghost.eq");
+    }
+
+    [Fact]
+    public async Task Clamps_page_size_to_the_definition_maximum()
+    {
+        (QueryDataTool<Thing> tool, IQueryEngine<Thing> engine, _) = CreateTool();
+
+        JsonElement args = JsonSerializer.SerializeToElement(new { pageSize = 99999 });
+
+        await tool.InvokeAsync(new AIToolInvocationContext { Arguments = args }, TestContext.Current.CancellationToken);
+
+        await engine.Received(1).ExecuteAsync(
+            Arg.Any<IQueryable<Thing>>(),
+            Arg.Is<QueryRequest>(r => r.PageSize == 100),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Executes_against_the_caller_scoped_queryable_source()
+    {
+        (QueryDataTool<Thing> tool, IQueryEngine<Thing> engine, IQueryable<Thing> source) = CreateTool();
+
+        await tool.InvokeAsync(
+            new AIToolInvocationContext { Arguments = JsonSerializer.SerializeToElement(new { }) },
+            TestContext.Current.CancellationToken);
+
+        // The ACL/tenant-scoped queryable from IQueryableSource is what gets executed.
+        await engine.Received(1).ExecuteAsync(source, Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Result_reports_entity_and_paging_metadata()
+    {
+        PagedResult<Thing> paged = new([new Thing { Name = "x", Amount = 7 }], TotalCount: 42, HasMore: true);
+        (QueryDataTool<Thing> tool, _, _) = CreateTool(paged);
+
+        AIToolResult result = await tool.InvokeAsync(
+            new AIToolInvocationContext { Arguments = JsonSerializer.SerializeToElement(new { }) },
+            TestContext.Current.CancellationToken);
+
+        using var payload = JsonDocument.Parse(result.Content);
+        JsonElement root = payload.RootElement;
+        root.GetProperty("entity").GetString().ShouldBe("things");
+        root.GetProperty("totalCount").GetInt32().ShouldBe(42);
+        root.GetProperty("hasMore").GetBoolean().ShouldBeTrue();
+        root.GetProperty("count").GetInt32().ShouldBe(1);
+        root.GetProperty("items")[0].GetProperty("name").GetString().ShouldBe("x");
+    }
+
+    [Fact]
+    public void Only_opted_in_definitions_are_exposed_as_tools()
+    {
+        IQueryEngine<Thing> engine = Substitute.For<IQueryEngine<Thing>>();
+        engine.GetMetadata().Returns(Metadata());
+        IQueryableSource<Thing> source = Substitute.For<IQueryableSource<Thing>>();
+
+        ServiceCollection services = new();
+        services.AddSingleton(engine);
+        services.AddScoped(_ => source);
+        services.AddGranitAITools(tools => tools.AddQueryData(q => q.Add<Thing>("things")));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        IAIToolRegistry registry = scope.ServiceProvider.GetRequiredService<IAIToolRegistry>();
+
+        registry.TryGet("query_things", out _).ShouldBeTrue();
+        registry.TryGet("query_orders", out _).ShouldBeFalse();
+        registry.Tools.ShouldHaveSingleItem();
+    }
+}

--- a/tests/Granit.QueryEngine.AI.Tests/packages.lock.json
+++ b/tests/Granit.QueryEngine.AI.Tests/packages.lock.json
@@ -297,6 +297,14 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -382,6 +390,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",


### PR DESCRIPTION
## Summary

Fourth story of the agentic AI chat initiative (ADR-067). Turns opted-in `QueryDefinition`s into **ACL-bound `query_data` tools** the chat agent can call to read application data — placed in `Granit.QueryEngine.AI` (the existing AI bridge for QueryEngine), built on the tool seam from #2630.

Builds on #2630/#2631/#2632 (merged). Closes #2633.

## What's in it

- **`QueryDataTool<TEntity>`** — one `IAITool` per opted-in definition, named `query_<name>` (e.g. `query_orders`). Its parameter schema is **projected from the definition's `QueryMetadata`**: filterable fields + their operators (as enums), free-text `search`, `sort`, and `page`/`pageSize` (capped at the definition's max). The model fills structured arguments directly — no NL round-trip.
- **ACL boundary** — execution runs a validated `QueryRequest` through `IQueryEngine<TEntity>` over the **caller-scoped `IQueryableSource<TEntity>`**, the same source the HTTP query endpoints use. Results are therefore bounded by the user's tenant and ACL filters; the tool adds no authorization of its own and can read nothing the user couldn't. Unknown filter fields/operators are dropped and reported back in `ignoredFilters`, never forwarded.
- **Opt-in** — `services.AddGranitAITools(t => t.AddQueryData(q => q.Add<Order>("orders", "…")))`. A definition that is never added is never exposed and cannot be invoked.

## Acceptance criteria

- ✅ Opted-in definition → `query_data` executes a structured `QueryRequest`, results filtered by the caller's ACLs (via the scoped `IQueryableSource`).
- ✅ Not opted in → not registered as a tool, not invokable (DI-level test).

## Design notes

- The tool name is `query_<name>`; "query_data" is the capability family. One tool per definition gives the model a precise per-entity schema (better tool selection, an explicit ADR concern) and makes the opt-in boundary structural.
- The existing `INaturalLanguageQueryTranslator` (single-shot NL→query) is untouched; the agentic tool relies on the model producing structured args, which is more deterministic and unit-testable without an LLM.
- `Granit.QueryEngine.AI` now `[DependsOn(GranitAIToolsModule)]`. This is the first arch-graph consumer of `Granit.AI.Tools`, hence the `ArchitectureTests` lockfile gains `granit.ai.tools` (required for CI locked-mode restore).

## Verification

- Builds clean (0 warnings).
- **38/38** QueryEngine.AI tests pass (7 new: schema projection of fields/operators, tool naming, valid-filter mapping + unknown-filter dropping/reporting, page-size clamping, execution over the caller-scoped source, result shape, opt-in boundary).
- `dotnet format --verify-no-changes` + markdownlint clean.
- **225/225** architecture tests pass.

## Next

- #2634 `search` (full-text + semantic RAG), #2635 `translate` + per-tool permission gating (ACL), #2636 vision-as-tool.