### PR TITLE
feat(ai): translate capability tool + per-tool permission gating (#2635)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1536,6 +1536,7 @@
       "name": "Granit.Localization.AI",
       "deps": [
         "Granit.AI",
+        "Granit.AI.Tools",
         "Granit.Localization"
       ],
       "framework": "net10.0"
@@ -4036,6 +4037,15 @@
       "members": []
     },
     {
+      "name": "ChatTools",
+      "fqn": "Granit.AI.Permissions.ChatTools",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Permissions/AIPermissions.cs",
+      "line": 28,
+      "members": []
+    },
+    {
       "name": "Credentials",
       "fqn": "Granit.AI.Permissions.Credentials",
       "kind": "class",
@@ -4660,6 +4670,22 @@
       ]
     },
     {
+      "name": "IAIToolAuthorizer",
+      "fqn": "Granit.AI.Tools.IAIToolAuthorizer",
+      "kind": "interface",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/IAIToolAuthorizer.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "FilterAuthorizedAsync",
+          "kind": "method",
+          "signature": "FilterAuthorizedAsync(IReadOnlyList<IAITool> tools, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IAITool>>"
+        }
+      ]
+    },
+    {
       "name": "IAIToolInstructions",
       "fqn": "Granit.AI.Tools.IAIToolInstructions",
       "kind": "interface",
@@ -4721,6 +4747,15 @@
           "returnType": "IReadOnlyList<IAITool> Tools { get; } bool"
         }
       ]
+    },
+    {
+      "name": "IGatedAITool",
+      "fqn": "Granit.AI.Tools.IGatedAITool",
+      "kind": "interface",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/IGatedAITool.cs",
+      "line": 10,
+      "members": []
     },
     {
       "name": "GranitAIToolsOrchestrationOptions",
@@ -31861,12 +31896,28 @@
       ]
     },
     {
+      "name": "TranslateToolRegistrationExtensions",
+      "fqn": "Granit.Localization.AI.Extensions.TranslateToolRegistrationExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/Extensions/TranslateToolRegistrationExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddTranslateTool",
+          "kind": "method",
+          "signature": "AddTranslateTool(this AIToolRegistrationBuilder tools)",
+          "returnType": "AIToolRegistrationBuilder"
+        }
+      ]
+    },
+    {
       "name": "GranitLocalizationAIModule",
       "fqn": "Granit.Localization.AI.GranitLocalizationAIModule",
       "kind": "class",
       "project": "Granit.Localization.AI",
       "file": "src/Granit.Localization.AI/GranitLocalizationAIModule.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.AI.Tools/Extensions/AIToolsServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Tools/Extensions/AIToolsServiceCollectionExtensions.cs
@@ -53,6 +53,7 @@ public static class AIToolsServiceCollectionExtensions
 
         services.TryAddScoped<IAIToolRegistry, AIToolRegistry>();
         services.TryAddScoped<IAIToolProjector, AIToolProjector>();
+        services.TryAddScoped<IAIToolAuthorizer, PermissionAIToolAuthorizer>();
         services.TryAddScoped<IAIToolOrchestrator, AIToolOrchestrator>();
         services.TryAddSingleton<IAIGuardrailProvider, DefaultAIGuardrailProvider>();
         services.TryAddSingleton<IAISystemPromptComposer, DefaultAISystemPromptComposer>();

--- a/src/Granit.AI.Tools/IAIToolAuthorizer.cs
+++ b/src/Granit.AI.Tools/IAIToolAuthorizer.cs
@@ -1,0 +1,13 @@
+namespace Granit.AI.Tools;
+
+/// <summary>
+/// Filters a set of tools down to those the current caller is allowed to use, enforcing the
+/// per-tool permission gate (<see cref="IGatedAITool"/>). Ungated tools always pass.
+/// </summary>
+public interface IAIToolAuthorizer
+{
+    /// <summary>Returns the subset of <paramref name="tools"/> available to the current caller.</summary>
+    Task<IReadOnlyList<IAITool>> FilterAuthorizedAsync(
+        IReadOnlyList<IAITool> tools,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.AI.Tools/IGatedAITool.cs
+++ b/src/Granit.AI.Tools/IGatedAITool.cs
@@ -1,0 +1,17 @@
+namespace Granit.AI.Tools;
+
+/// <summary>
+/// Optional companion to <see cref="IAITool"/> declaring a permission the caller must hold for the
+/// tool to be offered (ADR-067). A tool that does not implement this interface is ungated and
+/// always available (subject to its own data ACLs); a gated tool is filtered out of the agent's
+/// available set for any user who lacks <see cref="RequiredPermission"/>, so admins can enable
+/// capabilities tool by tool.
+/// </summary>
+public interface IGatedAITool
+{
+    /// <summary>
+    /// The permission name (<c>[Group].[Resource].[Action]</c>) the caller must be granted, e.g.
+    /// <c>AI.ChatTools.Translate</c>.
+    /// </summary>
+    string RequiredPermission { get; }
+}

--- a/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
+++ b/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
@@ -22,6 +22,7 @@ internal sealed partial class AIToolOrchestrator(
     IAIWorkspaceProvider workspaceProvider,
     IAIToolProjector projector,
     IAIToolRegistry registry,
+    IAIToolAuthorizer toolAuthorizer,
     IAISystemPromptComposer systemPromptComposer,
     IAIUsageRecordFactory usageRecordFactory,
     IAIUsageTracker usageTracker,
@@ -51,7 +52,11 @@ internal sealed partial class AIToolOrchestrator(
             ?? throw new AIWorkspaceNotFoundException(workspaceName);
         string? tenantId = workspace.TenantId?.ToString();
 
-        IReadOnlyList<IAITool> tools = request.Tools ?? registry.Tools;
+        // Gate the candidate set to what the caller may use, so unauthorized tools are never
+        // declared to the model nor executable this run (per-tool permission gate, ADR-067).
+        IReadOnlyList<IAITool> tools = await toolAuthorizer
+            .FilterAuthorizedAsync(request.Tools ?? registry.Tools, cancellationToken)
+            .ConfigureAwait(false);
         Dictionary<string, IAITool> toolMap = new(tools.Count, StringComparer.Ordinal);
         foreach (IAITool tool in tools)
         {

--- a/src/Granit.AI.Tools/Internal/PermissionAIToolAuthorizer.cs
+++ b/src/Granit.AI.Tools/Internal/PermissionAIToolAuthorizer.cs
@@ -1,0 +1,36 @@
+using Granit.Authorization;
+
+namespace Granit.AI.Tools.Internal;
+
+/// <summary>
+/// Default <see cref="IAIToolAuthorizer"/>: keeps every ungated tool and every gated tool whose
+/// <see cref="IGatedAITool.RequiredPermission"/> is granted to the current caller, resolved via
+/// <see cref="IPermissionChecker"/> (one batched check for all gated permissions).
+/// </summary>
+internal sealed class PermissionAIToolAuthorizer(IPermissionChecker permissionChecker) : IAIToolAuthorizer
+{
+    public async Task<IReadOnlyList<IAITool>> FilterAuthorizedAsync(
+        IReadOnlyList<IAITool> tools,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+
+        List<string> gatedPermissions = [.. tools
+            .OfType<IGatedAITool>()
+            .Select(t => t.RequiredPermission)
+            .Distinct(StringComparer.Ordinal)];
+
+        if (gatedPermissions.Count == 0)
+        {
+            return tools;
+        }
+
+        IReadOnlyList<string> granted = await permissionChecker
+            .GetGrantedAsync(gatedPermissions, cancellationToken)
+            .ConfigureAwait(false);
+        HashSet<string> grantedSet = [.. granted];
+
+        return [.. tools.Where(tool =>
+            tool is not IGatedAITool gated || grantedSet.Contains(gated.RequiredPermission))];
+    }
+}

--- a/src/Granit.AI.Tools/README.md
+++ b/src/Granit.AI.Tools/README.md
@@ -26,6 +26,13 @@ services.AddGranitAITools(tools =>
 });
 ```
 
+### Per-tool permission gating
+
+A tool may implement `IGatedAITool` to declare a required permission
+(`[Group].[Resource].[Action]`). The `IAIToolAuthorizer` filters such tools out of the agent's
+available set for any caller who lacks the permission, so admins enable capabilities tool by
+tool. Ungated tools are always available (subject to their own data ACLs).
+
 The orchestrator drives the agentic loop (think → call → execute → repeat), bounded by an
 iteration cap and per-result context guards, stamping usage on completion:
 

--- a/src/Granit.AI/Localization/AI/cs.json
+++ b/src/Granit.AI/Localization/AI/cs.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Použít nástroj překladu AI"
   }
 }

--- a/src/Granit.AI/Localization/AI/de.json
+++ b/src/Granit.AI/Localization/AI/de.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Zeitstempel",
     "AI.Columns.Duration": "Dauer",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "KI-Übersetzungstool verwenden"
   }
 }

--- a/src/Granit.AI/Localization/AI/en.json
+++ b/src/Granit.AI/Localization/AI/en.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Use the AI translation tool"
   }
 }

--- a/src/Granit.AI/Localization/AI/es.json
+++ b/src/Granit.AI/Localization/AI/es.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Marca de tiempo",
     "AI.Columns.Duration": "Duración",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Usar la herramienta de traducción de IA"
   }
 }

--- a/src/Granit.AI/Localization/AI/fr.json
+++ b/src/Granit.AI/Localization/AI/fr.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Horodatage",
     "AI.Columns.Duration": "Durée",
     "PermissionGroup:AI": "IA",
-    "Permission:AI.Credentials.Manage": "Gérer les identifiants IA"
+    "Permission:AI.Credentials.Manage": "Gérer les identifiants IA",
+    "Permission:AI.ChatTools.Translate": "Utiliser l'outil de traduction IA"
   }
 }

--- a/src/Granit.AI/Localization/AI/hi.json
+++ b/src/Granit.AI/Localization/AI/hi.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "एआई अनुवाद टूल का उपयोग करें"
   }
 }

--- a/src/Granit.AI/Localization/AI/it.json
+++ b/src/Granit.AI/Localization/AI/it.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Usare lo strumento di traduzione IA"
   }
 }

--- a/src/Granit.AI/Localization/AI/ja.json
+++ b/src/Granit.AI/Localization/AI/ja.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "AI翻訳ツールを使用する"
   }
 }

--- a/src/Granit.AI/Localization/AI/ko.json
+++ b/src/Granit.AI/Localization/AI/ko.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "AI 번역 도구 사용"
   }
 }

--- a/src/Granit.AI/Localization/AI/nl.json
+++ b/src/Granit.AI/Localization/AI/nl.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Tijdstempel",
     "AI.Columns.Duration": "Duur",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "De AI-vertaaltool gebruiken"
   }
 }

--- a/src/Granit.AI/Localization/AI/pl.json
+++ b/src/Granit.AI/Localization/AI/pl.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Korzystanie z narzędzia tłumaczenia AI"
   }
 }

--- a/src/Granit.AI/Localization/AI/pt.json
+++ b/src/Granit.AI/Localization/AI/pt.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Usar a ferramenta de tradução de IA"
   }
 }

--- a/src/Granit.AI/Localization/AI/sv.json
+++ b/src/Granit.AI/Localization/AI/sv.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Använd AI-översättningsverktyget"
   }
 }

--- a/src/Granit.AI/Localization/AI/tr.json
+++ b/src/Granit.AI/Localization/AI/tr.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "Yapay zeka çeviri aracını kullan"
   }
 }

--- a/src/Granit.AI/Localization/AI/zh.json
+++ b/src/Granit.AI/Localization/AI/zh.json
@@ -16,6 +16,7 @@
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration",
     "PermissionGroup:AI": "AI",
-    "Permission:AI.Credentials.Manage": "Manage AI credentials"
+    "Permission:AI.Credentials.Manage": "Manage AI credentials",
+    "Permission:AI.ChatTools.Translate": "使用 AI 翻译工具"
   }
 }

--- a/src/Granit.AI/Permissions/AIPermissionDefinitionProvider.cs
+++ b/src/Granit.AI/Permissions/AIPermissionDefinitionProvider.cs
@@ -23,5 +23,11 @@ internal sealed class AIPermissionDefinitionProvider : IPermissionDefinitionProv
         group.AddPermission(
             AIPermissions.Credentials.Manage,
             LocalizableString.Create<AILocalizationResource>("Permission:AI.Credentials.Manage"));
+
+        // Per-tool gating for agentic chat capability tools (ADR-067). Off by default — an admin
+        // grants the tool's permission to enable it for a user or role.
+        group.AddPermission(
+            AIPermissions.ChatTools.Translate,
+            LocalizableString.Create<AILocalizationResource>("Permission:AI.ChatTools.Translate"));
     }
 }

--- a/src/Granit.AI/Permissions/AIPermissions.cs
+++ b/src/Granit.AI/Permissions/AIPermissions.cs
@@ -19,4 +19,15 @@ public static class AIPermissions
         /// </summary>
         public const string Manage = "AI.Credentials.Manage";
     }
+
+    /// <summary>
+    /// Per-tool permissions for agentic chat capability tools (ADR-067). A gated tool is offered
+    /// to a user only when they hold the matching permission, so admins enable capabilities tool
+    /// by tool. The action segment is the capability name (a domain-specific action).
+    /// </summary>
+    public static class ChatTools
+    {
+        /// <summary>Grants the right to use the <c>translate</c> chat tool (Localization.AI).</summary>
+        public const string Translate = "AI.ChatTools.Translate";
+    }
 }

--- a/src/Granit.Localization.AI/Extensions/TranslateToolRegistrationExtensions.cs
+++ b/src/Granit.Localization.AI/Extensions/TranslateToolRegistrationExtensions.cs
@@ -1,0 +1,28 @@
+using Granit.AI.Tools;
+using Granit.Localization.AI.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Localization.AI.Extensions;
+
+/// <summary>
+/// Registers the <c>translate</c> capability tool on the Granit AI tool registry.
+/// </summary>
+public static class TranslateToolRegistrationExtensions
+{
+    /// <summary>
+    /// Opts the <c>translate</c> tool in. It is gated by <c>AI.ChatTools.Translate</c>, so it is
+    /// only offered to users granted that permission. Requires <c>ITranslationSuggestionService</c>
+    /// (Localization.AI) to be registered.
+    /// </summary>
+    /// <param name="tools">The AI tool registration builder.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <example>
+    /// <code>services.AddGranitAITools(tools => tools.AddTranslateTool());</code>
+    /// </example>
+    public static AIToolRegistrationBuilder AddTranslateTool(this AIToolRegistrationBuilder tools)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        tools.Services.AddScoped<IAITool, TranslateTool>();
+        return tools;
+    }
+}

--- a/src/Granit.Localization.AI/Granit.Localization.AI.csproj
+++ b/src/Granit.Localization.AI/Granit.Localization.AI.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Localization.AI/GranitLocalizationAIModule.cs
+++ b/src/Granit.Localization.AI/GranitLocalizationAIModule.cs
@@ -1,4 +1,5 @@
 using Granit.AI;
+using Granit.AI.Tools;
 using Granit.Modularity;
 
 namespace Granit.Localization.AI;
@@ -11,5 +12,5 @@ namespace Granit.Localization.AI;
 /// across the 17 supported cultures using an LLM. Requires a registered AI provider
 /// (e.g. <c>Granit.AI.OpenAI</c>) to function.
 /// </remarks>
-[DependsOn(typeof(GranitAIModule), typeof(GranitLocalizationModule))]
+[DependsOn(typeof(GranitAIModule), typeof(GranitAIToolsModule), typeof(GranitLocalizationModule))]
 public sealed class GranitLocalizationAIModule : GranitModule;

--- a/src/Granit.Localization.AI/Internal/TranslateTool.cs
+++ b/src/Granit.Localization.AI/Internal/TranslateTool.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Granit.AI.Permissions;
+using Granit.AI.Tools;
+
+namespace Granit.Localization.AI.Internal;
+
+/// <summary>
+/// A gated capability tool (ADR-067, "agent-as-tool" single-shot sub-agent) that wraps
+/// <see cref="ITranslationSuggestionService"/> as the <c>translate</c> chat tool. Gated by
+/// <see cref="AIPermissions.ChatTools.Translate"/> so admins enable it per user/role.
+/// </summary>
+/// <remarks>
+/// This is the reference pattern for wrapping an existing <c>*.AI</c> capability as a chat tool:
+/// implement <see cref="IAITool"/> (declaration + invocation that delegates to the capability
+/// service), add <see cref="IGatedAITool"/> with the capability's permission, and register it
+/// through an opt-in extension on <c>AIToolRegistrationBuilder</c>.
+/// </remarks>
+internal sealed class TranslateTool(ITranslationSuggestionService translationService)
+    : IAITool, IGatedAITool, IAIToolInstructions
+{
+    private static readonly JsonElement Schema = BuildSchema();
+
+    public string Name => "translate";
+
+    public string Description =>
+        "Translate a short piece of text into a target language. Returns the translated text.";
+
+    public string RequiredPermission => AIPermissions.ChatTools.Translate;
+
+    public JsonElement ParameterSchema => Schema;
+
+    public string Instructions =>
+        "Use 'translate' to render text in another language. Provide the target language as a "
+        + "culture code (e.g. 'fr', 'de', 'pt-BR'); pass 'source_language' when you know it.";
+
+    public async ValueTask<AIToolResult> InvokeAsync(
+        AIToolInvocationContext context, CancellationToken cancellationToken = default)
+    {
+        string? text = ReadString(context.Arguments, "text");
+        string? target = ReadString(context.Arguments, "target_language");
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return AIToolResult.Error("The 'text' argument is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return AIToolResult.Error("The 'target_language' argument is required (a culture code).");
+        }
+
+        string source = ReadString(context.Arguments, "source_language") ?? "en";
+
+        IReadOnlyList<TranslationSuggestion> suggestions = await translationService
+            .SuggestTranslationsAsync(
+                key: "chat.translate",
+                sourceValue: text,
+                sourceCulture: source,
+                targetCultures: [target],
+                context: TranslationContext.Description,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        TranslationSuggestion? suggestion = suggestions.Count > 0 ? suggestions[0] : null;
+        if (suggestion is null)
+        {
+            return AIToolResult.Error("Translation is unavailable right now.");
+        }
+
+        var payload = new
+        {
+            source_language = source,
+            target_language = suggestion.Culture,
+            translation = suggestion.Value,
+        };
+
+        return AIToolResult.Success(JsonSerializer.Serialize(payload, JsonSerializerOptions.Web));
+    }
+
+    private static JsonElement BuildSchema()
+    {
+        JsonObject schema = new()
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["text"] = new JsonObject { ["type"] = "string", ["description"] = "The text to translate." },
+                ["target_language"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["description"] = "Target culture code, e.g. 'fr', 'de', 'pt-BR'.",
+                },
+                ["source_language"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["description"] = "Source culture code; defaults to 'en' when omitted.",
+                },
+            },
+            ["required"] = new JsonArray("text", "target_language"),
+            ["additionalProperties"] = false,
+        };
+
+        return JsonSerializer.SerializeToElement(schema);
+    }
+
+    private static string? ReadString(JsonElement arguments, string name) =>
+        arguments.ValueKind == JsonValueKind.Object
+        && arguments.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/src/Granit.Localization.AI/README.md
+++ b/src/Granit.Localization.AI/README.md
@@ -10,9 +10,22 @@ Part of the [granit](https://granit-fx.dev) framework.
 dotnet add package Granit.Localization.AI
 ```
 
+## `translate` chat tool
+
+Exposes the translation capability as a gated agentic-chat tool (ADR-067):
+
+```csharp
+services.AddGranitAITools(tools => tools.AddTranslateTool());
+```
+
+The tool is gated by the `AI.ChatTools.Translate` permission — it is only offered to users who
+have been granted it, so admins enable it per user/role. This is the reference pattern for
+wrapping any `*.AI` capability as a permission-gated chat tool.
+
 ## Dependencies
 
 - `Granit.AI`
+- `Granit.AI.Tools`
 - `Granit.Localization`
 
 ## Documentation

--- a/src/Granit.Localization.AI/packages.lock.json
+++ b/src/Granit.Localization.AI/packages.lock.json
@@ -92,6 +92,14 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
+++ b/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
@@ -65,11 +65,16 @@ public sealed class AIToolOrchestratorTests
 
         IAIUsageTracker usageTracker = Substitute.For<IAIUsageTracker>();
 
+        IAIToolAuthorizer authorizer = Substitute.For<IAIToolAuthorizer>();
+        authorizer.FilterAuthorizedAsync(Arg.Any<IReadOnlyList<IAITool>>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<IReadOnlyList<IAITool>>()));
+
         AIToolOrchestrator orchestrator = new(
             factory,
             workspaceProvider,
             projector,
             registry,
+            authorizer,
             new DefaultAISystemPromptComposer(new DefaultAIGuardrailProvider()),
             recordFactory,
             usageTracker,

--- a/tests/Granit.AI.Tools.Tests/PermissionAIToolAuthorizerTests.cs
+++ b/tests/Granit.AI.Tools.Tests/PermissionAIToolAuthorizerTests.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using Granit.AI.Tools.Internal;
+using Granit.Authorization;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.AI.Tools.Tests;
+
+public sealed class PermissionAIToolAuthorizerTests
+{
+    private sealed class GatedTool(string name, string permission) : IAITool, IGatedAITool
+    {
+        public string Name => name;
+        public string Description => "gated";
+        public string RequiredPermission => permission;
+        public JsonElement ParameterSchema => AIToolSchema.Empty;
+
+        public ValueTask<AIToolResult> InvokeAsync(
+            AIToolInvocationContext context, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(AIToolResult.Success("ok"));
+    }
+
+    private static PermissionAIToolAuthorizer Authorizer(params string[] granted)
+    {
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.GetGrantedAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult<IReadOnlyList<string>>(
+                [.. ci.Arg<IReadOnlyList<string>>().Where(granted.Contains)]));
+        return new PermissionAIToolAuthorizer(checker);
+    }
+
+    [Fact]
+    public async Task Ungated_tools_always_pass()
+    {
+        PermissionAIToolAuthorizer authorizer = Authorizer();
+        IReadOnlyList<IAITool> tools = [new FakeAITool("query_data"), new FakeAITool("search")];
+
+        IReadOnlyList<IAITool> result = await authorizer.FilterAuthorizedAsync(
+            tools, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(tools);
+    }
+
+    [Fact]
+    public async Task Gated_tool_is_kept_when_its_permission_is_granted()
+    {
+        PermissionAIToolAuthorizer authorizer = Authorizer("AI.ChatTools.Translate");
+        IReadOnlyList<IAITool> tools = [new GatedTool("translate", "AI.ChatTools.Translate")];
+
+        IReadOnlyList<IAITool> result = await authorizer.FilterAuthorizedAsync(
+            tools, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Name.ShouldBe("translate");
+    }
+
+    [Fact]
+    public async Task Gated_tool_is_removed_when_its_permission_is_missing()
+    {
+        PermissionAIToolAuthorizer authorizer = Authorizer(); // nothing granted
+        IReadOnlyList<IAITool> tools =
+        [
+            new FakeAITool("search"),
+            new GatedTool("translate", "AI.ChatTools.Translate"),
+        ];
+
+        IReadOnlyList<IAITool> result = await authorizer.FilterAuthorizedAsync(
+            tools, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Name.ShouldBe("search");
+    }
+
+    [Fact]
+    public async Task No_permission_check_runs_when_no_tool_is_gated()
+    {
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        PermissionAIToolAuthorizer authorizer = new(checker);
+
+        await authorizer.FilterAuthorizedAsync([new FakeAITool("search")], TestContext.Current.CancellationToken);
+
+        await checker.DidNotReceive().GetGrantedAsync(
+            Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2962,6 +2962,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
+++ b/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Granit.AI.Permissions;
+using Granit.AI.Tools;
+using Granit.Localization.AI.Internal;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Localization.AI.Tests;
+
+public sealed class TranslateToolTests
+{
+    private static AIToolInvocationContext Args(object value) =>
+        new() { Arguments = JsonSerializer.SerializeToElement(value) };
+
+    [Fact]
+    public void Is_gated_by_the_translate_permission()
+    {
+        TranslateTool tool = new(Substitute.For<ITranslationSuggestionService>());
+
+        tool.Name.ShouldBe("translate");
+        tool.ShouldBeAssignableTo<IGatedAITool>();
+        ((IGatedAITool)tool).RequiredPermission.ShouldBe(AIPermissions.ChatTools.Translate);
+    }
+
+    [Fact]
+    public void Schema_requires_text_and_target_language()
+    {
+        TranslateTool tool = new(Substitute.For<ITranslationSuggestionService>());
+
+        string[] required = [.. tool.ParameterSchema.GetProperty("required").EnumerateArray().Select(e => e.GetString()!)];
+        required.ShouldBe(["text", "target_language"]);
+    }
+
+    [Fact]
+    public async Task Delegates_to_the_translation_service_and_returns_the_translation()
+    {
+        ITranslationSuggestionService svc = Substitute.For<ITranslationSuggestionService>();
+        svc.SuggestTranslationsAsync("chat.translate", "Hello", "en",
+                Arg.Is<IReadOnlyList<string>>(t => t.Count == 1 && t[0] == "fr"),
+                TranslationContext.Description, Arg.Any<CancellationToken>())
+            .Returns(new List<TranslationSuggestion> { new("fr", "Bonjour") });
+        TranslateTool tool = new(svc);
+
+        AIToolResult result = await tool.InvokeAsync(
+            Args(new { text = "Hello", target_language = "fr" }), TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBeFalse();
+        using var payload = JsonDocument.Parse(result.Content);
+        payload.RootElement.GetProperty("translation").GetString().ShouldBe("Bonjour");
+        payload.RootElement.GetProperty("target_language").GetString().ShouldBe("fr");
+    }
+
+    [Fact]
+    public async Task Missing_target_language_returns_an_error()
+    {
+        TranslateTool tool = new(Substitute.For<ITranslationSuggestionService>());
+
+        AIToolResult result = await tool.InvokeAsync(
+            Args(new { text = "Hello" }), TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Empty_service_result_returns_an_error()
+    {
+        ITranslationSuggestionService svc = Substitute.For<ITranslationSuggestionService>();
+        svc.SuggestTranslationsAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<string>>(), Arg.Any<TranslationContext>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        TranslateTool tool = new(svc);
+
+        AIToolResult result = await tool.InvokeAsync(
+            Args(new { text = "Hello", target_language = "fr" }), TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.Localization.AI.Tests/packages.lock.json
+++ b/tests/Granit.Localization.AI.Tests/packages.lock.json
@@ -302,6 +302,14 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -392,6 +400,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"


### PR DESCRIPTION
## Summary

Sixth story of the agentic AI chat initiative (ADR-067). Adds the **per-tool permission gate** to the tool seam and the first **wrapped `*.AI` capability tool** (`translate`), so the agent can reuse framework capabilities and admins can enable them tool by tool.

Builds on #2630–#2634 (merged). Closes #2635.

## What's in it

**Gate — `Granit.AI.Tools`**
- **`IGatedAITool`** — optional companion to `IAITool` declaring a `RequiredPermission`. Ungated tools (e.g. `query_data`, `search`) stay always-available, subject to their own data ACLs.
- **`IAIToolAuthorizer` / `PermissionAIToolAuthorizer`** — filters the candidate set via `IPermissionChecker` (one batched `GetGrantedAsync`). The orchestrator gates tools **before** declaring them, so an unauthorized tool is never offered to the model nor executable that run (defense in depth).

**Permission — `Granit.AI`**
- **`AIPermissions.ChatTools.Translate` = `"AI.ChatTools.Translate"`** — defined by `AIPermissionDefinitionProvider` under the existing `AI` group, with `Permission:` localization keys across all **15 base cultures**. 3-segment per the convention (Group `AI`, Resource `ChatTools`, Action `Translate` — a domain-specific action). Off by default; an admin grants it to enable the tool.

**`translate` tool — `Granit.Localization.AI`**
- **`TranslateTool : IAITool, IGatedAITool, IAIToolInstructions`** — wraps `ITranslationSuggestionService` as a single-shot sub-agent (agent-as-tool). Opt-in via `services.AddGranitAITools(t => t.AddTranslateTool())`.
- This is the **reference pattern** for wrapping any `*.AI` capability as a permission-gated chat tool (documented inline + in the README).

## Acceptance criteria

- ✅ `translate` enabled for a tenant → the agent calls it, Localization.AI performs the translation, result fed back.
- ✅ A user without `AI.ChatTools.Translate` → the tool is filtered out of their available set (not offered, not executable).

## Design notes

- The issue's `[AI].[Chat].UseTool.{Tool}` notation collapses to the convention-compliant 3-segment `AI.ChatTools.{Tool}` (4 segments would fail `PermissionConventionTests`). Documented in the constant.
- The permission lives in `Granit.AI` (owner of the `AI` group + chat-tool permission namespace), reusing its existing 18-culture localization rather than scaffolding a new resource. The tool in Localization.AI references the constant.
- The gate uses `IPermissionChecker` available transitively (`AI.Tools → AI → Authorization`); no new project reference or circular dependency.

## Verification

- Builds clean (0 warnings).
- Tests: **Granit.AI.Tools.Tests 40** (incl. 4 authorizer: ungated pass, gated kept/removed by permission, no-check-when-none-gated), **Granit.Localization.AI.Tests 44** (incl. 5 translate: gated permission, required args, service delegation, empty-result error), **Granit.AI.Tests 77** (no regression).
- `dotnet format --verify-no-changes` + markdownlint clean.
- **225/225** architecture tests pass — including `PermissionConventionTests` (3-segment) and `PermissionLocalizationCompletenessTests` (15 cultures).

## Next

- #2636 `extract_text_from_image` vision-as-tool (opt-in, default-off) — last Tools story.