### PR TITLE
feat(ai): extract_text_from_image vision-as-tool, opt-in default-off (#2636)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1401,6 +1401,7 @@
       "name": "Granit.Imaging.AI",
       "deps": [
         "Granit.AI",
+        "Granit.AI.Tools",
         "Granit.Imaging"
       ],
       "framework": "net10.0"
@@ -29729,6 +29730,15 @@
       "members": []
     },
     {
+      "name": "AIImageData",
+      "fqn": "Granit.Imaging.AI.AIImageData",
+      "kind": "record",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/IAIImageSource.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "ImagingAIMetrics",
       "fqn": "Granit.Imaging.AI.Diagnostics.ImagingAIMetrics",
       "kind": "class",
@@ -29757,6 +29767,22 @@
       ]
     },
     {
+      "name": "ExtractTextFromImageToolRegistrationExtensions",
+      "fqn": "Granit.Imaging.AI.Extensions.ExtractTextFromImageToolRegistrationExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/Extensions/ExtractTextFromImageToolRegistrationExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddImageTextExtractionTool",
+          "kind": "method",
+          "signature": "AddImageTextExtractionTool(this AIToolRegistrationBuilder tools)",
+          "returnType": "AIToolRegistrationBuilder"
+        }
+      ]
+    },
+    {
       "name": "ImagingAIHostApplicationBuilderExtensions",
       "fqn": "Granit.Imaging.AI.Extensions.ImagingAIHostApplicationBuilderExtensions",
       "kind": "class",
@@ -29778,7 +29804,7 @@
       "kind": "class",
       "project": "Granit.Imaging.AI",
       "file": "src/Granit.Imaging.AI/GranitImagingAIModule.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -29805,12 +29831,53 @@
       ]
     },
     {
+      "name": "IAIImageSource",
+      "fqn": "Granit.Imaging.AI.IAIImageSource",
+      "kind": "interface",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/IAIImageSource.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetImageAsync",
+          "kind": "method",
+          "signature": "GetImageAsync(string reference, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AIImageData?>"
+        }
+      ]
+    },
+    {
+      "name": "IImageTextExtractor",
+      "fqn": "Granit.Imaging.AI.IImageTextExtractor",
+      "kind": "interface",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/IImageTextExtractor.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ExtractTextAsync",
+          "kind": "method",
+          "signature": "ExtractTextAsync(ReadOnlyMemory<byte> imageData, string contentType, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageTextExtractionResult?>"
+        }
+      ]
+    },
+    {
       "name": "ImageAnalysis",
       "fqn": "Granit.Imaging.AI.ImageAnalysis",
       "kind": "record",
       "project": "Granit.Imaging.AI",
       "file": "src/Granit.Imaging.AI/ImageAnalysis.cs",
       "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImageTextExtractionResult",
+      "fqn": "Granit.Imaging.AI.ImageTextExtractionResult",
+      "kind": "record",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/IImageTextExtractor.cs",
+      "line": 6,
       "members": []
     },
     {

--- a/.slnf/infrastructure.slnf
+++ b/.slnf/infrastructure.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "Granit.slnx",
     "projects": [
+      "src/Granit.AI.Tools/Granit.AI.Tools.csproj",
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",

--- a/src/Granit.Imaging.AI/Extensions/ExtractTextFromImageToolRegistrationExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ExtractTextFromImageToolRegistrationExtensions.cs
@@ -1,0 +1,28 @@
+using Granit.AI.Tools;
+using Granit.Imaging.AI.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Imaging.AI.Extensions;
+
+/// <summary>
+/// Registers the <c>extract_text_from_image</c> vision tool on the Granit AI tool registry.
+/// </summary>
+public static class ExtractTextFromImageToolRegistrationExtensions
+{
+    /// <summary>
+    /// Opts the <c>extract_text_from_image</c> tool in (default-off). The tool reads images via a
+    /// Vision-capable workspace and resolves image bytes through the registered
+    /// <see cref="IAIImageSource"/>; if neither is configured it degrades gracefully.
+    /// </summary>
+    /// <param name="tools">The AI tool registration builder.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <example>
+    /// <code>services.AddGranitAITools(tools => tools.AddImageTextExtractionTool());</code>
+    /// </example>
+    public static AIToolRegistrationBuilder AddImageTextExtractionTool(this AIToolRegistrationBuilder tools)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        tools.Services.AddScoped<IAITool, ExtractTextFromImageTool>();
+        return tools;
+    }
+}

--- a/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
@@ -38,6 +38,11 @@ public static class ImagingAIHostApplicationBuilderExtensions
         // The analyzer carries no singleton-justifying state.
         builder.Services.TryAddScoped<IAIImageAnalyzer, LlmImageAnalyzer>();
 
+        // Vision text extraction for the extract_text_from_image chat tool (ADR-067). The image
+        // source is application-provided; the Null default resolves nothing until one is registered.
+        builder.Services.TryAddScoped<IImageTextExtractor, LlmImageTextExtractor>();
+        builder.Services.TryAddScoped<IAIImageSource, NullAIImageSource>();
+
         return builder;
     }
 }

--- a/src/Granit.Imaging.AI/Granit.Imaging.AI.csproj
+++ b/src/Granit.Imaging.AI/Granit.Imaging.AI.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.Imaging\Granit.Imaging.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Imaging.AI/GranitImagingAIModule.cs
+++ b/src/Granit.Imaging.AI/GranitImagingAIModule.cs
@@ -1,4 +1,5 @@
 using Granit.AI;
+using Granit.AI.Tools;
 using Granit.Imaging.AI.Extensions;
 using Granit.Modularity;
 
@@ -15,7 +16,7 @@ namespace Granit.Imaging.AI;
 /// via <c>Granit.AI</c> workspaces.
 /// </para>
 /// </remarks>
-[DependsOn(typeof(GranitAIModule), typeof(GranitImagingModule))]
+[DependsOn(typeof(GranitAIModule), typeof(GranitAIToolsModule), typeof(GranitImagingModule))]
 public sealed class GranitImagingAIModule : GranitModule
 {
     /// <inheritdoc />

--- a/src/Granit.Imaging.AI/IAIImageSource.cs
+++ b/src/Granit.Imaging.AI/IAIImageSource.cs
@@ -1,0 +1,19 @@
+namespace Granit.Imaging.AI;
+
+/// <summary>Image bytes plus their MIME type.</summary>
+public sealed record AIImageData(ReadOnlyMemory<byte> Bytes, string ContentType);
+
+/// <summary>
+/// Application-provided seam that resolves a model-supplied image reference (an attachment id,
+/// blob key, …) to its bytes for the <c>extract_text_from_image</c> tool. The framework does not
+/// know how an application stores images, so the default <see cref="Internal.NullAIImageSource"/>
+/// resolves nothing — register an implementation to enable the tool against your store.
+/// </summary>
+public interface IAIImageSource
+{
+    /// <summary>
+    /// Returns the image for <paramref name="reference"/>, or <see langword="null"/> when it cannot
+    /// be resolved or the caller is not allowed to access it.
+    /// </summary>
+    Task<AIImageData?> GetImageAsync(string reference, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Imaging.AI/IImageTextExtractor.cs
+++ b/src/Granit.Imaging.AI/IImageTextExtractor.cs
@@ -1,0 +1,26 @@
+namespace Granit.Imaging.AI;
+
+/// <summary>The text read from an image, plus the workspace that produced it.</summary>
+/// <param name="Text">The extracted text (may be empty when the image contains none).</param>
+/// <param name="Workspace">The vision-capable workspace that performed the extraction.</param>
+public sealed record ImageTextExtractionResult(string Text, string Workspace);
+
+/// <summary>
+/// Reads text out of an image using a vision-capable AI workspace, decoupled from the chat
+/// workspace (ADR-067). Routing resolves a Vision-capable workspace via the capability resolver;
+/// the call stamps its own usage record.
+/// </summary>
+public interface IImageTextExtractor
+{
+    /// <summary>
+    /// Extracts text from the image, or returns <see langword="null"/> when no vision-capable
+    /// workspace is configured (default-off — the caller degrades gracefully).
+    /// </summary>
+    /// <param name="imageData">The raw image bytes.</param>
+    /// <param name="contentType">The image MIME type (e.g. <c>image/png</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<ImageTextExtractionResult?> ExtractTextAsync(
+        ReadOnlyMemory<byte> imageData,
+        string contentType,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Imaging.AI/Internal/ExtractTextFromImageTool.cs
+++ b/src/Granit.Imaging.AI/Internal/ExtractTextFromImageTool.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Granit.AI.Tools;
+
+namespace Granit.Imaging.AI.Internal;
+
+/// <summary>
+/// Opt-in, default-off <see cref="IAITool"/> that reads text from an image via a Vision-capable
+/// workspace (ADR-067). The image bytes are resolved from a model-supplied reference through the
+/// application's <see cref="IAIImageSource"/>; the extraction itself routes to a vision workspace,
+/// so a text-only chat workspace can still read images. When no vision workspace is configured the
+/// tool degrades gracefully with an error result rather than failing the run.
+/// </summary>
+internal sealed class ExtractTextFromImageTool(
+    IAIImageSource imageSource,
+    IImageTextExtractor textExtractor) : IAITool, IAIToolInstructions
+{
+    private static readonly JsonElement Schema = BuildSchema();
+
+    public string Name => "extract_text_from_image";
+
+    public string Description =>
+        "Read and return the text contained in an image you cannot otherwise see. "
+        + "Pass the reference of the image to read.";
+
+    public JsonElement ParameterSchema => Schema;
+
+    public string Instructions =>
+        "Use 'extract_text_from_image' when the user refers to an image and you need the text "
+        + "inside it. Pass the image reference from the conversation as 'image'.";
+
+    public async ValueTask<AIToolResult> InvokeAsync(
+        AIToolInvocationContext context, CancellationToken cancellationToken = default)
+    {
+        string? reference = ReadString(context.Arguments, "image");
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            return AIToolResult.Error("The 'image' argument is required (an image reference).");
+        }
+
+        AIImageData? image = await imageSource.GetImageAsync(reference, cancellationToken).ConfigureAwait(false);
+        if (image is null)
+        {
+            return AIToolResult.Error($"Image '{reference}' is not available.");
+        }
+
+        ImageTextExtractionResult? extraction = await textExtractor
+            .ExtractTextAsync(image.Bytes, image.ContentType, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (extraction is null)
+        {
+            return AIToolResult.Error("No vision-capable workspace is configured, so images cannot be read.");
+        }
+
+        var payload = new
+        {
+            image = reference,
+            workspace = extraction.Workspace,
+            text = extraction.Text,
+        };
+
+        return AIToolResult.Success(JsonSerializer.Serialize(payload, JsonSerializerOptions.Web));
+    }
+
+    private static JsonElement BuildSchema()
+    {
+        JsonObject schema = new()
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["image"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["description"] = "Reference of the image to read (as it appears in the conversation).",
+                },
+            },
+            ["required"] = new JsonArray("image"),
+            ["additionalProperties"] = false,
+        };
+
+        return JsonSerializer.SerializeToElement(schema);
+    }
+
+    private static string? ReadString(JsonElement arguments, string name) =>
+        arguments.ValueKind == JsonValueKind.Object
+        && arguments.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/src/Granit.Imaging.AI/Internal/LlmImageTextExtractor.cs
+++ b/src/Granit.Imaging.AI/Internal/LlmImageTextExtractor.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using Granit.AI;
+using Granit.AI.Workspaces;
+using Granit.Imaging.AI.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Imaging.AI.Internal;
+
+/// <summary>
+/// Default <see cref="IImageTextExtractor"/>. Resolves a Vision-capable workspace (an explicitly
+/// configured one is trusted; otherwise the first workspace whose model reports
+/// <see cref="AIModelCapabilities.Vision"/>), sends the image as a <see cref="DataContent"/> with a
+/// bounded extraction instruction, and stamps a dedicated usage record for the vision call.
+/// </summary>
+internal sealed partial class LlmImageTextExtractor(
+    IAIChatClientFactory chatClientFactory,
+    IAIWorkspaceProvider workspaceProvider,
+    IAIWorkspaceCapabilityResolver capabilityResolver,
+    IAIUsageRecordFactory usageRecordFactory,
+    IAIUsageTracker usageTracker,
+    IOptions<ImagingAIOptions> options,
+    ILogger<LlmImageTextExtractor> logger) : IImageTextExtractor
+{
+    private const string ExtractionPrompt =
+        "Extract and return all text visible in this image, verbatim and in reading order. "
+        + "Return only the extracted text with no commentary. If the image contains no text, "
+        + "return an empty response.";
+
+    public async Task<ImageTextExtractionResult?> ExtractTextAsync(
+        ReadOnlyMemory<byte> imageData,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+
+        AIWorkspace? workspace = await ResolveVisionWorkspaceAsync(cancellationToken).ConfigureAwait(false);
+        if (workspace is null)
+        {
+            LogNoVisionWorkspace();
+            return null;
+        }
+
+        ImagingAIOptions opts = options.Value;
+        long startTimestamp = Stopwatch.GetTimestamp();
+
+        using IChatClient client = await chatClientFactory
+            .CreateAsync(workspace.Name, cancellationToken)
+            .ConfigureAwait(false);
+
+        ChatMessage message = new(ChatRole.User,
+        [
+            new TextContent(ExtractionPrompt),
+            new DataContent(imageData, contentType),
+        ]);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(opts.TimeoutSeconds));
+
+        ChatResponse response = await client
+            .GetResponseAsync([message], cancellationToken: timeoutCts.Token)
+            .ConfigureAwait(false);
+
+        if (response.Usage is { } usage)
+        {
+            AIUsageRecord record = usageRecordFactory.Create(
+                workspace.Name,
+                workspace.Provider,
+                workspace.Model,
+                (int)(usage.InputTokenCount ?? 0),
+                (int)(usage.OutputTokenCount ?? 0),
+                Stopwatch.GetElapsedTime(startTimestamp));
+
+            await usageTracker.RecordAsync(record, cancellationToken).ConfigureAwait(false);
+        }
+
+        return new ImageTextExtractionResult(response.Text ?? string.Empty, workspace.Name);
+    }
+
+    private async Task<AIWorkspace?> ResolveVisionWorkspaceAsync(CancellationToken cancellationToken)
+    {
+        string? configured = options.Value.WorkspaceName;
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            // Explicitly configured workspace is trusted — the admin opted into it for vision.
+            return await workspaceProvider.GetAsync(configured, cancellationToken).ConfigureAwait(false);
+        }
+
+        IReadOnlyList<AIWorkspace> all = await workspaceProvider.GetAllAsync(cancellationToken).ConfigureAwait(false);
+        foreach (AIWorkspace candidate in all)
+        {
+            AIModelCapabilities? capabilities = await capabilityResolver
+                .ResolveAsync(candidate.Provider, candidate.Model, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (capabilities?.Vision == true)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "No vision-capable AI workspace is configured; extract_text_from_image is unavailable.")]
+    private partial void LogNoVisionWorkspace();
+}

--- a/src/Granit.Imaging.AI/Internal/NullAIImageSource.cs
+++ b/src/Granit.Imaging.AI/Internal/NullAIImageSource.cs
@@ -1,0 +1,11 @@
+namespace Granit.Imaging.AI.Internal;
+
+/// <summary>
+/// Default <see cref="IAIImageSource"/> that resolves no images. Applications register their own
+/// implementation (over their blob/attachment store) to enable image-reading tools.
+/// </summary>
+internal sealed class NullAIImageSource : IAIImageSource
+{
+    public Task<AIImageData?> GetImageAsync(string reference, CancellationToken cancellationToken = default) =>
+        Task.FromResult<AIImageData?>(null);
+}

--- a/src/Granit.Imaging.AI/README.md
+++ b/src/Granit.Imaging.AI/README.md
@@ -11,9 +11,26 @@ Part of the [granit](https://granit-fx.dev) framework.
 dotnet add package Granit.Imaging.AI
 ```
 
+## `extract_text_from_image` chat tool
+
+Exposes vision text extraction as an opt-in, default-off agentic-chat tool (ADR-067). It routes
+to a Vision-capable workspace (decoupled from the chat workspace), so a text-only chat model can
+still read images, and stamps its own usage record:
+
+```csharp
+services.AddGranitAITools(tools => tools.AddImageTextExtractionTool());
+
+// Provide image bytes for a model-supplied reference (attachment id, blob key, …):
+services.AddScoped<IAIImageSource, MyBlobImageSource>();
+```
+
+If no Vision-capable workspace is configured (or no `IAIImageSource` is registered) the tool
+degrades gracefully — the agent is told it cannot read the image rather than failing the run.
+
 ## Dependencies
 
 - `Granit.AI` — AI workspace and chat client factory
+- `Granit.AI.Tools` — agentic tool seam
 - `Granit.Imaging` — Image processing abstractions
 
 ## Configuration

--- a/src/Granit.Imaging.AI/packages.lock.json
+++ b/src/Granit.Imaging.AI/packages.lock.json
@@ -116,6 +116,14 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2828,6 +2828,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Imaging": "[0.1.0-dev, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
         }

--- a/tests/Granit.Imaging.AI.Tests/ExtractTextFromImageToolTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/ExtractTextFromImageToolTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using Granit.AI.Tools;
+using Granit.Imaging.AI.Internal;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Imaging.AI.Tests;
+
+public sealed class ExtractTextFromImageToolTests
+{
+    private static readonly ReadOnlyMemory<byte> Image = new byte[] { 1, 2, 3 };
+
+    private static AIToolInvocationContext Args(object value) =>
+        new() { Arguments = JsonSerializer.SerializeToElement(value) };
+
+    [Fact]
+    public void Has_the_expected_name_and_required_argument()
+    {
+        ExtractTextFromImageTool tool = new(
+            Substitute.For<IAIImageSource>(), Substitute.For<IImageTextExtractor>());
+
+        tool.Name.ShouldBe("extract_text_from_image");
+        tool.ParameterSchema.GetProperty("required")[0].GetString().ShouldBe("image");
+    }
+
+    [Fact]
+    public async Task Missing_image_reference_returns_an_error()
+    {
+        ExtractTextFromImageTool tool = new(
+            Substitute.For<IAIImageSource>(), Substitute.For<IImageTextExtractor>());
+
+        AIToolResult result = await tool.InvokeAsync(Args(new { }), TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Unresolvable_image_returns_an_error()
+    {
+        IAIImageSource source = Substitute.For<IAIImageSource>();
+        source.GetImageAsync("img-1", Arg.Any<CancellationToken>()).Returns((AIImageData?)null);
+        ExtractTextFromImageTool tool = new(source, Substitute.For<IImageTextExtractor>());
+
+        AIToolResult result = await tool.InvokeAsync(
+            Args(new { image = "img-1" }), TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBeTrue();
+        result.Content.ShouldContain("img-1");
+    }
+
+    [Fact]
+    public async Task Degrades_gracefully_when_no_vision_workspace_is_available()
+    {
+        IAIImageSource source = Substitute.For<IAIImageSource>();
+        source.GetImageAsync("img-1", Arg.Any<CancellationToken>())
+            .Returns(new AIImageData(Image, "image/png"));
+        IImageTextExtractor extractor = Substitute.For<IImageTextExtractor>();
+        extractor.ExtractTextAsync(Arg.Any<ReadOnlyMemory<byte>>(), "image/png", Arg.Any<CancellationToken>())
+            .Returns((ImageTextExtractionResult?)null);
+        ExtractTextFromImageTool tool = new(source, extractor);
+
+        AIToolResult result = await tool.InvokeAsync(
+            Args(new { image = "img-1" }), TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBeTrue();
+        result.Content.ShouldContain("vision");
+    }
+
+    [Fact]
+    public async Task Returns_the_extracted_text_on_success()
+    {
+        IAIImageSource source = Substitute.For<IAIImageSource>();
+        source.GetImageAsync("img-1", Arg.Any<CancellationToken>())
+            .Returns(new AIImageData(Image, "image/png"));
+        IImageTextExtractor extractor = Substitute.For<IImageTextExtractor>();
+        extractor.ExtractTextAsync(Arg.Any<ReadOnlyMemory<byte>>(), "image/png", Arg.Any<CancellationToken>())
+            .Returns(new ImageTextExtractionResult("HELLO", "vision"));
+        ExtractTextFromImageTool tool = new(source, extractor);
+
+        AIToolResult result = await tool.InvokeAsync(
+            Args(new { image = "img-1" }), TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBeFalse();
+        using var payload = JsonDocument.Parse(result.Content);
+        payload.RootElement.GetProperty("text").GetString().ShouldBe("HELLO");
+        payload.RootElement.GetProperty("workspace").GetString().ShouldBe("vision");
+    }
+}

--- a/tests/Granit.Imaging.AI.Tests/ImagingAIServiceRegistrationTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/ImagingAIServiceRegistrationTests.cs
@@ -1,4 +1,5 @@
 using Granit.AI;
+using Granit.AI.Workspaces;
 using Granit.Imaging.AI.Extensions;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
@@ -25,8 +26,13 @@ public sealed class ImagingAIServiceRegistrationTests
         builder.Services.AddLogging();
         builder.Services.AddMetrics();
 
-        // Minimal stand-in for Granit.AI: register the scoped factory contract used by the analyzer.
+        // Minimal stand-in for Granit.AI: the scoped contracts the analyzer and the
+        // vision text-extractor capture.
         builder.Services.TryAddScoped(_ => Substitute.For<IAIChatClientFactory>());
+        builder.Services.TryAddScoped(_ => Substitute.For<IAIWorkspaceProvider>());
+        builder.Services.TryAddScoped(_ => Substitute.For<IAIWorkspaceCapabilityResolver>());
+        builder.Services.TryAddScoped(_ => Substitute.For<IAIUsageRecordFactory>());
+        builder.Services.TryAddScoped(_ => Substitute.For<IAIUsageTracker>());
 
         builder.AddGranitImagingAI();
 

--- a/tests/Granit.Imaging.AI.Tests/LlmImageTextExtractorTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/LlmImageTextExtractorTests.cs
@@ -1,0 +1,96 @@
+using Granit.AI;
+using Granit.AI.Workspaces;
+using Granit.Imaging.AI.Internal;
+using Granit.Imaging.AI.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.Imaging.AI.Tests;
+
+public sealed class LlmImageTextExtractorTests
+{
+    private static readonly ReadOnlyMemory<byte> Image = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+
+    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
+    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IAIWorkspaceProvider _workspaceProvider = Substitute.For<IAIWorkspaceProvider>();
+    private readonly IAIWorkspaceCapabilityResolver _capabilityResolver = Substitute.For<IAIWorkspaceCapabilityResolver>();
+    private readonly IAIUsageRecordFactory _usageRecordFactory = Substitute.For<IAIUsageRecordFactory>();
+    private readonly IAIUsageTracker _usageTracker = Substitute.For<IAIUsageTracker>();
+
+    private static AIWorkspace Workspace(string name, string provider = "OpenAI", string model = "gpt-4o") =>
+        new() { Name = name, Provider = provider, Model = model };
+
+    private void SetupResponse(string text, int? input = 10, int? output = 4)
+    {
+        ChatResponse response = new(new ChatMessage(ChatRole.Assistant, text));
+        if (input is not null || output is not null)
+        {
+            response.Usage = new UsageDetails { InputTokenCount = input, OutputTokenCount = output };
+        }
+
+        _chatClient.GetResponseAsync(Arg.Any<IEnumerable<ChatMessage>>(), Arg.Any<ChatOptions>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+        _chatClientFactory.CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(_chatClient);
+    }
+
+    private LlmImageTextExtractor CreateExtractor(string? workspaceName) =>
+        new(_chatClientFactory, _workspaceProvider, _capabilityResolver, _usageRecordFactory, _usageTracker,
+            MsOptions.Create(new ImagingAIOptions { WorkspaceName = workspaceName, TimeoutSeconds = 30 }),
+            NullLogger<LlmImageTextExtractor>.Instance);
+
+    [Fact]
+    public async Task Uses_the_explicitly_configured_workspace_and_stamps_usage()
+    {
+        _workspaceProvider.GetAsync("vision", Arg.Any<CancellationToken>()).Returns(Workspace("vision"));
+        SetupResponse("INVOICE #42");
+        _usageRecordFactory.Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<TimeSpan?>())
+            .Returns(new AIUsageRecord { Id = Guid.Empty, WorkspaceName = "vision", Provider = "OpenAI", Model = "gpt-4o", Timestamp = DateTimeOffset.UnixEpoch });
+
+        LlmImageTextExtractor extractor = CreateExtractor("vision");
+
+        ImageTextExtractionResult? result = await extractor.ExtractTextAsync(Image, "image/png", TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Text.ShouldBe("INVOICE #42");
+        result.Workspace.ShouldBe("vision");
+        await _usageTracker.Received(1).RecordAsync(Arg.Any<AIUsageRecord>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Returns_null_when_no_workspace_is_configured_or_discoverable()
+    {
+        _workspaceProvider.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+
+        LlmImageTextExtractor extractor = CreateExtractor(workspaceName: null);
+
+        ImageTextExtractionResult? result = await extractor.ExtractTextAsync(Image, "image/png", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+        await _chatClientFactory.DidNotReceive().CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Auto_discovers_the_first_vision_capable_workspace()
+    {
+        AIWorkspace textOnly = Workspace("chat", model: "gpt-text");
+        AIWorkspace vision = Workspace("vision-ws", model: "gpt-4o");
+        _workspaceProvider.GetAllAsync(Arg.Any<CancellationToken>()).Returns([textOnly, vision]);
+        _capabilityResolver.ResolveAsync("OpenAI", "gpt-text", Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Vision = false });
+        _capabilityResolver.ResolveAsync("OpenAI", "gpt-4o", Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Vision = true });
+        SetupResponse("text");
+
+        LlmImageTextExtractor extractor = CreateExtractor(workspaceName: null);
+
+        ImageTextExtractionResult? result = await extractor.ExtractTextAsync(Image, "image/png", TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Workspace.ShouldBe("vision-ws");
+    }
+}

--- a/tests/Granit.Imaging.AI.Tests/packages.lock.json
+++ b/tests/Granit.Imaging.AI.Tests/packages.lock.json
@@ -303,6 +303,14 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -388,6 +396,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Imaging": "[0.1.0-dev, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",


### PR DESCRIPTION
## Summary

Final story of the **Granit.AI.Tools** feature (#2627, ADR-067). Adds `extract_text_from_image` — an opt-in, default-off agentic tool that reads text from an image via a **Vision-capable workspace decoupled from the chat workspace**, so a text-only chat model can still read images.

Builds on #2630–#2635 (merged). Closes #2636.

## What's in it (all in `Granit.Imaging.AI`)

- **`IImageTextExtractor` / `LlmImageTextExtractor`** — the vision capability:
  - Resolves a Vision-capable workspace: an explicitly configured `Imaging:AI:WorkspaceName` is trusted; otherwise it auto-discovers the first workspace whose model reports `AIModelCapabilities.Vision` via `IAIWorkspaceCapabilityResolver`.
  - Sends the image as `DataContent` with a **bounded** extraction instruction (fixed prompt, not user-controlled) and returns the text.
  - Stamps its **own** `AIUsageRecord` for the vision sub-call.
  - Returns `null` when no vision workspace exists → graceful default-off.
- **`IAIImageSource` / `NullAIImageSource`** — application-provided seam mapping a model-supplied image reference (attachment id, blob key, …) to bytes. The framework doesn't know how an app stores images; the Null default resolves nothing until the app registers one. (Keeps Imaging.AI decoupled from BlobStorage and the not-yet-built attachment layer.)
- **`ExtractTextFromImageTool : IAITool, IAIToolInstructions`** — wraps the two; opt-in via `services.AddGranitAITools(t => t.AddImageTextExtractionTool())`. An unresolvable image or missing vision workspace returns an error result (graceful) rather than failing the run.

## Acceptance criteria

- ✅ Vision workspace configured + tool enabled → text extracted via the Vision workspace and returned, **with its own usage record**.
- ✅ No vision workspace configured → tool degrades gracefully (default-off; returns an error result the agent can recover from).

## Design notes

- **Decoupling** is the point: the tool routes to a vision workspace via the capability resolver, independent of the chat workspace (ADR-067 decision 2).
- Not permission-gated: control is via opt-in registration + vision-workspace configuration, matching the AC (no `IGatedAITool`). Easy to add later if desired.
- Image delivery via `IAIImageSource` avoids premature coupling to attachment/blob infrastructure; the chat-attachment story will provide a concrete implementation.

## Verification

- Builds clean (0 warnings).
- **Granit.Imaging.AI.Tests 20** pass (8 new: extractor uses configured workspace + stamps usage, returns null when none discoverable, auto-discovers first vision-capable; tool name/required-arg, missing-reference error, unresolvable-image error, graceful no-vision-workspace, success payload). The existing scope-validation regression test was extended to register the extractor's scoped deps.
- `dotnet format --verify-no-changes` + markdownlint clean.
- **225/225** architecture tests pass (Imaging.AI is in the arch graph; the arch lockfile gains the `Granit.Imaging.AI → Granit.AI.Tools` edge).

## Feature complete

This closes the last story of **#2627 Granit.AI.Tools**. The Tools layer now ships: seam + registry (#2630), orchestration loop (#2631), guardrails + composition (#2632), `query_data` (#2633), `search` (#2634), `translate` + permission gating (#2635), and `extract_text_from_image` (#2636). Next feature: **#2628 Granit.AI.Chat** (conversations, streaming endpoint, settings) which consumes this layer.