### PR TITLE
fix(identity): resolve password-reset link from account tenant, not ambient context

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33889,6 +33889,12 @@
           "kind": "method",
           "signature": "ResolveBaseUrlAsync(CancellationToken cancellationToken = default)",
           "returnType": "Task<string>"
+        },
+        {
+          "name": "ResolveBaseUrlAsync",
+          "kind": "method",
+          "signature": "ResolveBaseUrlAsync(Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
         }
       ]
     },

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasswordEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasswordEndpoints.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Events;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Http.Timing;
@@ -108,6 +110,7 @@ internal static class AccountPasswordEndpoints
 
     private static async Task<Accepted<string>> ForgotPasswordAsync(
         AccountForgotPasswordRequest request,
+        HttpContext httpContext,
         [FromServices] IPasswordResetService passwordResetService,
         CancellationToken cancellationToken)
     {
@@ -125,8 +128,17 @@ internal static class AccountPasswordEndpoints
         // Always return 202 regardless of whether the email exists (prevents enumeration).
         // IPasswordResetService.RequestResetAsync publishes PasswordResetRequestedEto
         // which a subscriber (Granit.Notifications or app-level) consumes to send the email.
-        await passwordResetService.RequestResetAsync(request.Email, cancellationToken)
-            .ConfigureAwait(false);
+        //
+        // Disable the multi-tenant filter for the email lookup: a host account
+        // (TenantId == null) requesting a reset while a tenant is resolved from the
+        // request domain would be hidden by a tenant-scoped query, so no email is sent.
+        // RequireUniqueEmail=true guarantees no cross-tenant ambiguity. Mirrors /login.
+        IDataFilter? dataFilter = httpContext.RequestServices.GetService<IDataFilter>();
+        using (dataFilter?.Disable<IMultiTenant>())
+        {
+            await passwordResetService.RequestResetAsync(request.Email, cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         return TypedResults.Accepted((string?)null, (string?)null);
     }
@@ -140,6 +152,14 @@ internal static class AccountPasswordEndpoints
         using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
             IdentityLocalActivitySource.PasswordReset);
         activity?.SetTag(IdentityLocalActivitySource.TagProvider, "reset-token");
+
+        // Disable the multi-tenant filter for the user lookup: the reset link may land
+        // on any domain (e.g. a tenant subdomain), making ICurrentTenant resolve to a
+        // tenant that does not own a host account (TenantId == null). A tenant-scoped
+        // FindByIdAsync would then return null and reject a valid token. Mirrors /login
+        // and /forgot-password; RequireUniqueEmail=true guarantees no ambiguity.
+        IDataFilter? dataFilter = httpContext.RequestServices.GetService<IDataFilter>();
+        using IDisposable? tenantFilterScope = dataFilter?.Disable<IMultiTenant>();
 
         try
         {

--- a/src/Granit.Identity.Local.Notifications/Handlers/EmailChangeRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/EmailChangeRequestedHandler.cs
@@ -37,8 +37,10 @@ public class EmailChangeRequestedHandler
         // Confirmation to the new email — override recipient so the email
         // goes to the new address, not the one currently on file.
         IdentityNotificationOptions opts = options.Value;
+        // Resolve the link from the account's own tenant (carried on the event),
+        // not the ambient context — see PasswordResetRequestedHandler for the rationale.
         string? resolvedUrl = urlResolver is not null
-            ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
+            ? await urlResolver.ResolveBaseUrlAsync(evt.TenantId, cancellationToken).ConfigureAwait(false)
             : null;
         string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.FrontendBaseUrl;
 

--- a/src/Granit.Identity.Local.Notifications/Handlers/EmailConfirmationRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/EmailConfirmationRequestedHandler.cs
@@ -30,8 +30,10 @@ public class EmailConfirmationRequestedHandler
         }
 
         IdentityNotificationOptions opts = options.Value;
+        // Resolve the link from the account's own tenant (carried on the event),
+        // not the ambient context — see PasswordResetRequestedHandler for the rationale.
         string? resolvedUrl = urlResolver is not null
-            ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
+            ? await urlResolver.ResolveBaseUrlAsync(evt.TenantId, cancellationToken).ConfigureAwait(false)
             : null;
         string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.FrontendBaseUrl;
 

--- a/src/Granit.Identity.Local.Notifications/Handlers/PasswordResetRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/PasswordResetRequestedHandler.cs
@@ -21,8 +21,11 @@ public class PasswordResetRequestedHandler
         CancellationToken cancellationToken = default)
     {
         IdentityNotificationOptions opts = options.Value;
+        // Resolve the link from the account's own tenant (carried on the event),
+        // not the ambient context — a host account (TenantId == null) that requested
+        // the reset from a tenant domain must still get the host/fallback URL.
         string? resolvedUrl = urlResolver is not null
-            ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
+            ? await urlResolver.ResolveBaseUrlAsync(evt.TenantId, cancellationToken).ConfigureAwait(false)
             : null;
         string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.FrontendBaseUrl;
 

--- a/src/Granit.MultiTenancy/Url/TenantUrlResolver.cs
+++ b/src/Granit.MultiTenancy/Url/TenantUrlResolver.cs
@@ -37,15 +37,18 @@ internal sealed class TenantUrlResolver(
     private readonly MultiTenancyOptions _options = options.Value;
 
     /// <inheritdoc/>
-    public async Task<string> ResolveBaseUrlAsync(CancellationToken cancellationToken = default)
+    public Task<string> ResolveBaseUrlAsync(CancellationToken cancellationToken = default) =>
+        ResolveBaseUrlAsync(currentTenant.IsAvailable ? currentTenant.Id : null, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<string> ResolveBaseUrlAsync(Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        if (_options.UrlStrategy == TenantUrlStrategy.Shared || !currentTenant.IsAvailable)
+        if (_options.UrlStrategy == TenantUrlStrategy.Shared || tenantId is null)
         {
             return GetFallbackUrl();
         }
 
-        Guid tenantId = currentTenant.Id!.Value;
-        TenantUrlData? urlData = await GetOrLoadUrlDataAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        TenantUrlData? urlData = await GetOrLoadUrlDataAsync(tenantId.Value, cancellationToken).ConfigureAwait(false);
 
         if (urlData is null)
         {

--- a/src/Granit/MultiTenancy/ITenantUrlResolver.cs
+++ b/src/Granit/MultiTenancy/ITenantUrlResolver.cs
@@ -43,4 +43,27 @@ public interface ITenantUrlResolver
     /// Returns an empty string when no URL can be resolved.
     /// </returns>
     Task<string> ResolveBaseUrlAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the base URL for an explicit tenant, ignoring the ambient
+    /// <see cref="ICurrentTenant"/> context.
+    /// </summary>
+    /// <remarks>
+    /// Background handlers that act on behalf of a specific account (e.g. password
+    /// reset, email confirmation) must resolve the URL from the account's own tenant
+    /// — carried on the integration event — not from the ambient context, which is
+    /// whatever tenant the originating HTTP request happened to resolve. A host
+    /// account (<paramref name="tenantId"/> is <see langword="null"/>) requesting a
+    /// reset from a tenant domain would otherwise receive a tenant-scoped link.
+    /// </remarks>
+    /// <param name="tenantId">
+    /// The tenant to resolve the URL for, or <see langword="null"/> for a host/global
+    /// account. <see langword="null"/> (and the <b>Shared</b> strategy) yields the
+    /// static fallback URL.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The base URL without trailing slash, or an empty string when none can be resolved.
+    /// </returns>
+    Task<string> ResolveBaseUrlAsync(Guid? tenantId, CancellationToken cancellationToken = default);
 }

--- a/src/Granit/MultiTenancy/NullTenantUrlResolver.cs
+++ b/src/Granit/MultiTenancy/NullTenantUrlResolver.cs
@@ -9,4 +9,7 @@ internal sealed class NullTenantUrlResolver : ITenantUrlResolver
 {
     public Task<string> ResolveBaseUrlAsync(CancellationToken cancellationToken = default) =>
         Task.FromResult(string.Empty);
+
+    public Task<string> ResolveBaseUrlAsync(Guid? tenantId, CancellationToken cancellationToken = default) =>
+        Task.FromResult(string.Empty);
 }

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -181,6 +181,41 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task ForgotPassword_DisablesMultiTenantFilterForLookup()
+    {
+        _server.PasswordResetService
+            .RequestResetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/account/forgot-password",
+            new AccountForgotPasswordRequest("host-admin@example.com"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+
+        // A host account (TenantId == null) requesting a reset while a tenant is
+        // resolved from the request domain must stay visible — otherwise the email
+        // is silently never sent. The filter must be disabled for the lookup.
+        _server.DataFilter.Received().Disable<IMultiTenant>();
+    }
+
+    [Fact]
+    public async Task ResetPassword_DisablesMultiTenantFilterForLookup()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/account/reset-password",
+            new AccountPasswordResetRequest("user-id-1", "valid-token", "NewP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        // The reset link can land on any domain; a tenant-scoped FindByIdAsync would
+        // hide a host account and reject a valid token. The filter must be disabled.
+        _server.DataFilter.Received().Disable<IMultiTenant>();
+    }
+
     // -------------------------------------------------------------------------
     // Profile endpoints
     // -------------------------------------------------------------------------

--- a/tests/Granit.Identity.Local.Notifications.Tests/Handlers/HandlerTests.cs
+++ b/tests/Granit.Identity.Local.Notifications.Tests/Handlers/HandlerTests.cs
@@ -3,6 +3,7 @@ using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Notifications.Handlers;
 using Granit.Identity.Local.Notifications.NotificationTypes;
 using Granit.Identity.Local.Notifications.Options;
+using Granit.MultiTenancy;
 using Granit.Notifications;
 using Granit.Notifications.Abstractions;
 using Microsoft.Extensions.Options;
@@ -19,6 +20,7 @@ public sealed class HandlerTests
     {
         FrontendBaseUrl = "https://app.example.com",
     });
+    private readonly ITenantUrlResolver _urlResolver = Substitute.For<ITenantUrlResolver>();
 
     // --- UserRegisteredHandler ---
 
@@ -73,6 +75,49 @@ public sealed class HandlerTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task PasswordReset_HostAccount_ResolvesUrlForNullTenant()
+    {
+        // Regression: a host account (TenantId == null) must resolve the link from its
+        // own (null) tenant, never the ambient context the originating request resolved.
+        _urlResolver.ResolveBaseUrlAsync(Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns("https://host.example.com");
+        var evt = new PasswordResetRequestedEto(
+            Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            "alice@test.com", "reset-token-123", TenantId: null);
+
+        await PasswordResetRequestedHandler.HandleAsync(
+            evt, _options, _publisher, _urlResolver, TestContext.Current.CancellationToken);
+
+        await _urlResolver.Received(1).ResolveBaseUrlAsync(null, Arg.Any<CancellationToken>());
+        await _publisher.Received(1).PublishAsync(
+            PasswordResetNotificationType.Instance,
+            Arg.Is<PasswordResetNotificationData>(d => d.ResetLink.StartsWith("https://host.example.com/")),
+            Arg.Is<IReadOnlyList<string>>(r => r.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PasswordReset_TenantAccount_ResolvesUrlForOwnTenant()
+    {
+        var tenantId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        _urlResolver.ResolveBaseUrlAsync(tenantId, Arg.Any<CancellationToken>())
+            .Returns("https://acme.example.com");
+        var evt = new PasswordResetRequestedEto(
+            Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            "alice@test.com", "reset-token-123", tenantId);
+
+        await PasswordResetRequestedHandler.HandleAsync(
+            evt, _options, _publisher, _urlResolver, TestContext.Current.CancellationToken);
+
+        await _urlResolver.Received(1).ResolveBaseUrlAsync(tenantId, Arg.Any<CancellationToken>());
+        await _publisher.Received(1).PublishAsync(
+            PasswordResetNotificationType.Instance,
+            Arg.Is<PasswordResetNotificationData>(d => d.ResetLink.StartsWith("https://acme.example.com/")),
+            Arg.Is<IReadOnlyList<string>>(r => r.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
     // --- EmailConfirmationRequestedHandler ---
 
     [Fact]
@@ -110,6 +155,27 @@ public sealed class HandlerTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task EmailConfirmation_ResolvesUrlForOwnTenant()
+    {
+        SetupUser("alice@test.com");
+        var tenantId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        _urlResolver.ResolveBaseUrlAsync(tenantId, Arg.Any<CancellationToken>())
+            .Returns("https://acme.example.com");
+        var evt = new EmailConfirmationRequestedEto(
+            Guid.Parse("00000000-0000-0000-0000-000000000001"), "confirm-token-456", tenantId);
+
+        await EmailConfirmationRequestedHandler.HandleAsync(
+            evt, _userReader, _options, _publisher, _urlResolver, TestContext.Current.CancellationToken);
+
+        await _urlResolver.Received(1).ResolveBaseUrlAsync(tenantId, Arg.Any<CancellationToken>());
+        await _publisher.Received(1).PublishAsync(
+            EmailConfirmationNotificationType.Instance,
+            Arg.Is<EmailConfirmationNotificationData>(d => d.ConfirmLink.StartsWith("https://acme.example.com/")),
+            Arg.Is<IReadOnlyList<string>>(r => r.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
     // --- EmailChangeRequestedHandler (dual notification) ---
 
     [Fact]
@@ -134,6 +200,30 @@ public sealed class HandlerTests
             EmailChangeConfirmationNotificationType.Instance,
             Arg.Is<EmailChangeConfirmationNotificationData>(d =>
                 d.NewEmail == "new@test.com" && d.ConfirmLink.Contains("change-token")),
+            Arg.Is<IReadOnlyList<string>>(r => r.Count == 1),
+            Arg.Is<RecipientInfo>(r => r.Email == "new@test.com"),
+            Arg.Any<EntityReference?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EmailChange_ResolvesUrlForOwnTenant()
+    {
+        var tenantId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        _urlResolver.ResolveBaseUrlAsync(tenantId, Arg.Any<CancellationToken>())
+            .Returns("https://acme.example.com");
+        var evt = new EmailChangeRequestedEto(
+            Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            "old@test.com", "new@test.com", "change-token", tenantId);
+
+        await EmailChangeRequestedHandler.HandleAsync(
+            evt, _options, _publisher, _urlResolver, TestContext.Current.CancellationToken);
+
+        await _urlResolver.Received(1).ResolveBaseUrlAsync(tenantId, Arg.Any<CancellationToken>());
+        await _publisher.Received(1).PublishAsync(
+            EmailChangeConfirmationNotificationType.Instance,
+            Arg.Is<EmailChangeConfirmationNotificationData>(d =>
+                d.ConfirmLink.StartsWith("https://acme.example.com/")),
             Arg.Is<IReadOnlyList<string>>(r => r.Count == 1),
             Arg.Is<RecipientInfo>(r => r.Email == "new@test.com"),
             Arg.Any<EntityReference?>(),

--- a/tests/Granit.MultiTenancy.Tests/TenantUrlResolverTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantUrlResolverTests.cs
@@ -1,0 +1,60 @@
+using Granit.MultiTenancy.Options;
+using Granit.MultiTenancy.Stores;
+using Granit.MultiTenancy.Url;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.MultiTenancy.Tests;
+
+public sealed class TenantUrlResolverTests
+{
+    private static TenantUrlResolver CreateResolver(
+        ICurrentTenant currentTenant, ITenantReader reader, TenantUrlStrategy strategy) =>
+        new(currentTenant, reader, Microsoft.Extensions.Options.Options.Create(new MultiTenancyOptions
+        {
+            UrlStrategy = strategy,
+            DomainTemplate = "{0}.example.com",
+            UrlScheme = "https",
+            FallbackBaseUrl = "https://host.example.com",
+        }));
+
+    [Fact]
+    public async Task ResolveBaseUrlAsync_NullTenant_ReturnsFallbackEvenUnderSubdomainStrategy()
+    {
+        // A host account carries TenantId == null. It must resolve the static fallback
+        // (host) URL, not a tenant-derived one — regardless of the strategy.
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        ITenantReader reader = Substitute.For<ITenantReader>();
+        TenantUrlResolver resolver = CreateResolver(currentTenant, reader, TenantUrlStrategy.Subdomain);
+
+        string url = await resolver.ResolveBaseUrlAsync((Guid?)null, TestContext.Current.CancellationToken);
+
+        url.ShouldBe("https://host.example.com");
+        await reader.DidNotReceiveWithAnyArgs().FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveBaseUrlAsync_ExplicitTenant_IgnoresAmbientContext()
+    {
+        // Ambient context points at a DIFFERENT tenant: the overload must use the
+        // tenant it is given, proving background handlers resolve the account's own URL.
+        var ambientTenant = Guid.NewGuid();
+        var accountTenant = Guid.NewGuid();
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(ambientTenant);
+
+        ITenantReader reader = Substitute.For<ITenantReader>();
+        reader.FindByIdAsync(accountTenant, Arg.Any<CancellationToken>())
+            .Returns(new TenantData(accountTenant, "Acme", "acme", null, true, null, DateTimeOffset.UnixEpoch));
+
+        TenantUrlResolver resolver = CreateResolver(currentTenant, reader, TenantUrlStrategy.Subdomain);
+
+        string url = await resolver.ResolveBaseUrlAsync(accountTenant, TestContext.Current.CancellationToken);
+
+        url.ShouldBe("https://acme.example.com");
+        await reader.DidNotReceive().FindByIdAsync(ambientTenant, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Problem

A **Host** account (`TenantId == null`) requesting *forgot password* received an email whose reset link pointed at a **tenant** front, and clicking it could not complete the reset.

Two root causes:

1. **Wrong URL source.** The notification handlers (password reset, email confirmation, email change) resolved the link's base URL from the *ambient* `ICurrentTenant` — propagated via the Wolverine header from whatever tenant the originating HTTP request resolved — instead of the account's own tenant. A host account that requested the reset from a tenant domain therefore got a tenant-scoped link.
2. **Filter not disabled.** `/forgot-password` and `/reset-password` did **not** disable the multi-tenant filter for the user lookup, unlike `/login`. When a tenant is resolved from the request domain, a tenant-scoped query hides a host account (`TenantId == null`): no email is sent, and a valid reset token is rejected with 400.

## Changes

- Add `ITenantUrlResolver.ResolveBaseUrlAsync(Guid? tenantId, …)` overload that resolves from an **explicit** tenant (ignoring ambient context); `null` ⇒ static fallback. The parameterless overload now delegates to it using the ambient context (unchanged behaviour for existing callers — `AppGlobalContext`, `EmailNotificationChannel`).
- The 3 `Granit.Identity.Local.Notifications` handlers pass `evt.TenantId` (all three Etos already carry it).
- `AccountPasswordEndpoints` wraps the lookup in both forgot/reset endpoints with `IDataFilter.Disable<IMultiTenant>()`, mirroring `AccountLoginEndpoints`. `RequireUniqueEmail=true` guarantees no cross-tenant ambiguity.

## Notes

- Under the **Shared** URL strategy host and tenant still collapse to a single `FrontendBaseUrl` — this fix is the correct behaviour for `Subdomain`/`CustomDomain`/`Hybrid` deployments and fixes the filter correctness bug. Separating host↔tenant fronts under Shared (e.g. an optional `HostBaseUrl` used when `evt.TenantId is null`) is intentionally deferred.
- No public-API baseline or other `ITenantUrlResolver` implementers affected.

## Tests

- `HandlerTests`: host (`null`) and tenant routing for password-reset, email-confirmation, email-change handlers.
- `AccountEndpointsIntegrationTests`: forgot + reset disable the multi-tenant filter.
- New `TenantUrlResolverTests`: `null` ⇒ fallback; explicit tenant ignores ambient context.

All affected projects build; `dotnet format --verify-no-changes` clean; tests green (115 + 472 + 174).