### PR TITLE
feat(ai): send-message SSE endpoint + chat orchestration service (#2638)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3141,6 +3141,15 @@
       "members": []
     },
     {
+      "name": "ChatStreamEvent",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.ChatStreamEvent",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
+      "line": 17,
+      "members": []
+    },
+    {
       "name": "ConversationResponse",
       "fqn": "Granit.AI.Chat.Endpoints.Dtos.ConversationResponse",
       "kind": "record",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35,7 +35,10 @@
     {
       "name": "Granit.AI.Chat",
       "deps": [
-        "Granit"
+        "Granit",
+        "Granit.AI",
+        "Granit.AI.Tools",
+        "Granit.Guids"
       ],
       "framework": "net10.0"
     },
@@ -3086,6 +3089,24 @@
       ]
     },
     {
+      "name": "ChatSendRequest",
+      "fqn": "Granit.AI.Chat.ChatSendRequest",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/IChatService.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "ChatSendResult",
+      "fqn": "Granit.AI.Chat.ChatSendResult",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/IChatService.cs",
+      "line": 20,
+      "members": []
+    },
+    {
       "name": "Conversation",
       "fqn": "Granit.AI.Chat.Domain.Conversation",
       "kind": "class",
@@ -3198,6 +3219,15 @@
           "returnType": "ConversationSummaryResponse"
         }
       ]
+    },
+    {
+      "name": "SendMessageRequest",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.SendMessageRequest",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
+      "line": 7,
+      "members": []
     },
     {
       "name": "AIChatEndpointRouteBuilderExtensions",
@@ -3329,13 +3359,54 @@
       "members": []
     },
     {
+      "name": "ConversationNotFoundException",
+      "fqn": "Granit.AI.Chat.Exceptions.ConversationNotFoundException",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Exceptions/ConversationNotFoundException.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "WorkspaceNotChatCapableException",
+      "fqn": "Granit.AI.Chat.Exceptions.WorkspaceNotChatCapableException",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Exceptions/WorkspaceNotChatCapableException.cs",
+      "line": 7,
+      "members": []
+    },
+    {
       "name": "GranitAIChatModule",
       "fqn": "Granit.AI.Chat.GranitAIChatModule",
       "kind": "class",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/GranitAIChatModule.cs",
-      "line": 11,
-      "members": []
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IChatService",
+      "fqn": "Granit.AI.Chat.IChatService",
+      "kind": "interface",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/IChatService.cs",
+      "line": 42,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(ChatSendRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ChatSendResult>"
+        }
+      ]
     },
     {
       "name": "IConversationStore",
@@ -3362,6 +3433,12 @@
           "kind": "method",
           "signature": "ListAsync(Guid ownerId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<Conversation>>"
+        },
+        {
+          "name": "AppendMessagesAsync",
+          "kind": "method",
+          "signature": "AppendMessagesAsync(Guid id, Guid ownerId, IReadOnlyList<Message> messages, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         },
         {
           "name": "RenameAsync",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -5,6 +5,7 @@
       "src/Granit.AI.Chat.Endpoints/Granit.AI.Chat.Endpoints.csproj",
       "src/Granit.AI.Chat/Granit.AI.Chat.csproj",
       "src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj",
+      "src/Granit.AI.Tools/Granit.AI.Tools.csproj",
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",

--- a/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
@@ -8,3 +8,15 @@ public sealed record SendMessageRequest(
     string Message,
     Guid? ConversationId = null,
     string? WorkspaceName = null);
+
+/// <summary>
+/// A frame streamed over SSE for a send. <see cref="Type"/> discriminates the frame:
+/// <c>conversation</c> (carries <see cref="ConversationId"/>), <c>delta</c> (carries a
+/// <see cref="Content"/> chunk), or <c>usage</c> (carries the token counts).
+/// </summary>
+public sealed record ChatStreamEvent(
+    string Type,
+    string? Content = null,
+    Guid? ConversationId = null,
+    int? InputTokens = null,
+    int? OutputTokens = null);

--- a/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
@@ -1,0 +1,10 @@
+namespace Granit.AI.Chat.Endpoints.Dtos;
+
+/// <summary>Request to send a message and receive a streamed answer.</summary>
+/// <param name="Message">The user's message.</param>
+/// <param name="ConversationId">The conversation to continue, or <see langword="null"/> to start a new one.</param>
+/// <param name="WorkspaceName">The chat-capable workspace to use, or <see langword="null"/> for the default.</param>
+public sealed record SendMessageRequest(
+    string Message,
+    Guid? ConversationId = null,
+    string? WorkspaceName = null);

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using Granit.AI.Chat.Endpoints.Dtos;
+using Granit.AI.Chat.Endpoints.Permissions;
+using Granit.AI.Chat.Exceptions;
+using Granit.AI.Exceptions;
+using Granit.Users;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.AI.Chat.Endpoints.Endpoints;
+
+/// <summary>The send-message endpoint: runs the agentic loop and streams the answer over SSE.</summary>
+internal static class ChatSendEndpoints
+{
+    internal static RouteGroupBuilder MapChatSendEndpoint(this RouteGroupBuilder group)
+    {
+        group.MapPost("/messages", SendAsync)
+            .WithName("SendChatMessage")
+            .WithSummary("Sends a message and streams a tool-grounded answer over SSE.")
+            .WithDescription(
+                "Runs the agentic loop within the caller's permissions, persists the user and "
+                + "assistant messages, and streams the answer as Server-Sent Events: a 'conversation' "
+                + "event with the (possibly new) conversation id, incremental 'data' content frames, a "
+                + "'usage' event, then '[DONE]'. Rejects a non-chat-capable workspace before streaming.")
+            .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .RequireAuthorization(AIChatPermissions.Conversations.Send);
+
+        return group;
+    }
+
+    private static async Task SendAsync(
+        SendMessageRequest request,
+        [FromServices] IChatService chatService,
+        [FromServices] ICurrentUserService currentUser,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        if (currentUser.UserGuid is not { } ownerId)
+        {
+            await WriteProblemAsync(httpContext, StatusCodes.Status401Unauthorized,
+                "The current identity has no user context.", cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        ChatSendResult result;
+        try
+        {
+            result = await chatService.SendAsync(
+                new ChatSendRequest
+                {
+                    ConversationId = request.ConversationId,
+                    OwnerId = ownerId,
+                    WorkspaceName = request.WorkspaceName,
+                    Message = request.Message,
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (WorkspaceNotChatCapableException ex)
+        {
+            await WriteProblemAsync(httpContext, StatusCodes.Status422UnprocessableEntity, ex.Message, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+        catch (AIWorkspaceNotFoundException ex)
+        {
+            await WriteProblemAsync(httpContext, StatusCodes.Status404NotFound, ex.Message, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+        catch (ConversationNotFoundException ex)
+        {
+            await WriteProblemAsync(httpContext, StatusCodes.Status404NotFound, ex.Message, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        httpContext.Response.ContentType = "text/event-stream";
+        httpContext.Response.Headers.CacheControl = "no-cache";
+        httpContext.Response.Headers.Connection = "keep-alive";
+
+        await WriteFrameAsync(httpContext, "conversation",
+            JsonSerializer.Serialize(new { conversationId = result.ConversationId }), cancellationToken).ConfigureAwait(false);
+
+        foreach (string chunk in Chunk(result.Content))
+        {
+            await WriteFrameAsync(httpContext, eventName: null,
+                JsonSerializer.Serialize(new { content = chunk }), cancellationToken).ConfigureAwait(false);
+        }
+
+        await WriteFrameAsync(httpContext, "usage",
+            JsonSerializer.Serialize(new { inputTokens = result.InputTokens, outputTokens = result.OutputTokens }),
+            cancellationToken).ConfigureAwait(false);
+
+        await httpContext.Response.WriteAsync("data: [DONE]\n\n", cancellationToken).ConfigureAwait(false);
+        await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteFrameAsync(HttpContext httpContext, string? eventName, string json, CancellationToken cancellationToken)
+    {
+        string frame = eventName is null ? $"data: {json}\n\n" : $"event: {eventName}\ndata: {json}\n\n";
+        await httpContext.Response.WriteAsync(frame, cancellationToken).ConfigureAwait(false);
+        await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteProblemAsync(HttpContext httpContext, int statusCode, string detail, CancellationToken cancellationToken)
+    {
+        httpContext.Response.StatusCode = statusCode;
+        httpContext.Response.ContentType = "application/problem+json";
+        await httpContext.Response.WriteAsync(
+            JsonSerializer.Serialize(new { detail, status = statusCode }), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Splits text into word-sized chunks (trailing space preserved) for token-like streaming.</summary>
+    private static IEnumerable<string> Chunk(string text)
+    {
+        int index = 0;
+        while (index < text.Length)
+        {
+            int space = text.IndexOf(' ', index);
+            if (space < 0)
+            {
+                yield return text[index..];
+                yield break;
+            }
+
+            yield return text[index..(space + 1)];
+            index = space + 1;
+        }
+    }
+}

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using System.Runtime.CompilerServices;
 using Granit.AI.Chat.Endpoints.Dtos;
 using Granit.AI.Chat.Endpoints.Permissions;
 using Granit.AI.Chat.Exceptions;
@@ -22,9 +22,9 @@ internal static class ChatSendEndpoints
             .WithDescription(
                 "Runs the agentic loop within the caller's permissions, persists the user and "
                 + "assistant messages, and streams the answer as Server-Sent Events: a 'conversation' "
-                + "event with the (possibly new) conversation id, incremental 'data' content frames, a "
-                + "'usage' event, then '[DONE]'. Rejects a non-chat-capable workspace before streaming.")
-            .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
+                + "frame with the (possibly new) conversation id, incremental 'delta' content frames, "
+                + "then a 'usage' frame. Rejects a non-chat-capable workspace before streaming.")
+            .Produces<ChatStreamEvent>(StatusCodes.Status200OK, "text/event-stream")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -34,18 +34,17 @@ internal static class ChatSendEndpoints
         return group;
     }
 
-    private static async Task SendAsync(
+    private static async Task<IResult> SendAsync(
         SendMessageRequest request,
         [FromServices] IChatService chatService,
         [FromServices] ICurrentUserService currentUser,
-        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         if (currentUser.UserGuid is not { } ownerId)
         {
-            await WriteProblemAsync(httpContext, StatusCodes.Status401Unauthorized,
-                "The current identity has no user context.", cancellationToken).ConfigureAwait(false);
-            return;
+            return TypedResults.Problem(
+                detail: "The current identity has no user context.",
+                statusCode: StatusCodes.Status401Unauthorized);
         }
 
         ChatSendResult result;
@@ -63,54 +62,36 @@ internal static class ChatSendEndpoints
         }
         catch (WorkspaceNotChatCapableException ex)
         {
-            await WriteProblemAsync(httpContext, StatusCodes.Status422UnprocessableEntity, ex.Message, cancellationToken).ConfigureAwait(false);
-            return;
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
         }
         catch (AIWorkspaceNotFoundException ex)
         {
-            await WriteProblemAsync(httpContext, StatusCodes.Status404NotFound, ex.Message, cancellationToken).ConfigureAwait(false);
-            return;
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
         }
         catch (ConversationNotFoundException ex)
         {
-            await WriteProblemAsync(httpContext, StatusCodes.Status404NotFound, ex.Message, cancellationToken).ConfigureAwait(false);
-            return;
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
         }
 
-        httpContext.Response.ContentType = "text/event-stream";
-        httpContext.Response.Headers.CacheControl = "no-cache";
-        httpContext.Response.Headers.Connection = "keep-alive";
+        // Native .NET SSE: the framework handles framing, content-type and per-item flushing.
+        return TypedResults.ServerSentEvents(StreamAsync(result, cancellationToken));
+    }
 
-        await WriteFrameAsync(httpContext, "conversation",
-            JsonSerializer.Serialize(new { conversationId = result.ConversationId }), cancellationToken).ConfigureAwait(false);
+    private static async IAsyncEnumerable<ChatStreamEvent> StreamAsync(
+        ChatSendResult result,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return new ChatStreamEvent("conversation", ConversationId: result.ConversationId);
 
         foreach (string chunk in Chunk(result.Content))
         {
-            await WriteFrameAsync(httpContext, eventName: null,
-                JsonSerializer.Serialize(new { content = chunk }), cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new ChatStreamEvent("delta", Content: chunk);
+            // Yield control between frames so each is flushed as its own SSE event.
+            await Task.Yield();
         }
 
-        await WriteFrameAsync(httpContext, "usage",
-            JsonSerializer.Serialize(new { inputTokens = result.InputTokens, outputTokens = result.OutputTokens }),
-            cancellationToken).ConfigureAwait(false);
-
-        await httpContext.Response.WriteAsync("data: [DONE]\n\n", cancellationToken).ConfigureAwait(false);
-        await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task WriteFrameAsync(HttpContext httpContext, string? eventName, string json, CancellationToken cancellationToken)
-    {
-        string frame = eventName is null ? $"data: {json}\n\n" : $"event: {eventName}\ndata: {json}\n\n";
-        await httpContext.Response.WriteAsync(frame, cancellationToken).ConfigureAwait(false);
-        await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task WriteProblemAsync(HttpContext httpContext, int statusCode, string detail, CancellationToken cancellationToken)
-    {
-        httpContext.Response.StatusCode = statusCode;
-        httpContext.Response.ContentType = "application/problem+json";
-        await httpContext.Response.WriteAsync(
-            JsonSerializer.Serialize(new { detail, status = statusCode }), cancellationToken).ConfigureAwait(false);
+        yield return new ChatStreamEvent("usage", InputTokens: result.InputTokens, OutputTokens: result.OutputTokens);
     }
 
     /// <summary>Splits text into word-sized chunks (trailing space preserved) for token-like streaming.</summary>

--- a/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class AIChatEndpointRouteBuilderExtensions
             .WithTags(options.TagName);
 
         group.MapConversationEndpoints();
+        group.MapChatSendEndpoint();
         return group;
     }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/cs.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/cs.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "AI chat",
     "Permission:AIChat.Conversations.Read": "Zobrazení vašich konverzací",
+    "Permission:AIChat.Conversations.Send": "Odesílání zpráv ve vašich konverzacích",
     "Permission:AIChat.Conversations.Manage": "Vytváření a přejmenování vašich konverzací",
     "Permission:AIChat.Conversations.Delete": "Mazání vašich konverzací"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/de.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/de.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "KI-Chat",
     "Permission:AIChat.Conversations.Read": "Ihre Konversationen anzeigen",
+    "Permission:AIChat.Conversations.Send": "Nachrichten in Ihren Konversationen senden",
     "Permission:AIChat.Conversations.Manage": "Ihre Konversationen erstellen und umbenennen",
     "Permission:AIChat.Conversations.Delete": "Ihre Konversationen löschen"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/en.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/en.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "AI Chat",
     "Permission:AIChat.Conversations.Read": "View your conversations",
+    "Permission:AIChat.Conversations.Send": "Send messages in your conversations",
     "Permission:AIChat.Conversations.Manage": "Create and rename your conversations",
     "Permission:AIChat.Conversations.Delete": "Delete your conversations"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/es.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/es.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "Chat de IA",
     "Permission:AIChat.Conversations.Read": "Ver tus conversaciones",
+    "Permission:AIChat.Conversations.Send": "Enviar mensajes en tus conversaciones",
     "Permission:AIChat.Conversations.Manage": "Crear y renombrar tus conversaciones",
     "Permission:AIChat.Conversations.Delete": "Eliminar tus conversaciones"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/fr.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/fr.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "Chat IA",
     "Permission:AIChat.Conversations.Read": "Consulter vos conversations",
+    "Permission:AIChat.Conversations.Send": "Envoyer des messages dans vos conversations",
     "Permission:AIChat.Conversations.Manage": "Créer et renommer vos conversations",
     "Permission:AIChat.Conversations.Delete": "Supprimer vos conversations"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/hi.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/hi.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "एआई चैट",
     "Permission:AIChat.Conversations.Read": "अपनी बातचीत देखें",
+    "Permission:AIChat.Conversations.Send": "अपनी बातचीत में संदेश भेजें",
     "Permission:AIChat.Conversations.Manage": "अपनी बातचीत बनाएँ और नाम बदलें",
     "Permission:AIChat.Conversations.Delete": "अपनी बातचीत हटाएँ"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/it.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/it.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "Chat IA",
     "Permission:AIChat.Conversations.Read": "Visualizzare le tue conversazioni",
+    "Permission:AIChat.Conversations.Send": "Inviare messaggi nelle tue conversazioni",
     "Permission:AIChat.Conversations.Manage": "Creare e rinominare le tue conversazioni",
     "Permission:AIChat.Conversations.Delete": "Eliminare le tue conversazioni"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ja.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ja.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "AIチャット",
     "Permission:AIChat.Conversations.Read": "自分の会話を表示する",
+    "Permission:AIChat.Conversations.Send": "自分の会話でメッセージを送信する",
     "Permission:AIChat.Conversations.Manage": "自分の会話を作成・名前変更する",
     "Permission:AIChat.Conversations.Delete": "自分の会話を削除する"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ko.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ko.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "AI 채팅",
     "Permission:AIChat.Conversations.Read": "내 대화 보기",
+    "Permission:AIChat.Conversations.Send": "내 대화에서 메시지 보내기",
     "Permission:AIChat.Conversations.Manage": "내 대화 만들기 및 이름 변경",
     "Permission:AIChat.Conversations.Delete": "내 대화 삭제"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/nl.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/nl.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "AI-chat",
     "Permission:AIChat.Conversations.Read": "Uw gesprekken bekijken",
+    "Permission:AIChat.Conversations.Send": "Berichten in uw gesprekken verzenden",
     "Permission:AIChat.Conversations.Manage": "Uw gesprekken aanmaken en hernoemen",
     "Permission:AIChat.Conversations.Delete": "Uw gesprekken verwijderen"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pl.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pl.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "Czat AI",
     "Permission:AIChat.Conversations.Read": "Przeglądanie swoich rozmów",
+    "Permission:AIChat.Conversations.Send": "Wysyłanie wiadomości w swoich rozmowach",
     "Permission:AIChat.Conversations.Manage": "Tworzenie i zmiana nazw swoich rozmów",
     "Permission:AIChat.Conversations.Delete": "Usuwanie swoich rozmów"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pt.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pt.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "Chat de IA",
     "Permission:AIChat.Conversations.Read": "Ver as suas conversas",
+    "Permission:AIChat.Conversations.Send": "Enviar mensagens nas suas conversas",
     "Permission:AIChat.Conversations.Manage": "Criar e renomear as suas conversas",
     "Permission:AIChat.Conversations.Delete": "Eliminar as suas conversas"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/sv.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/sv.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "AI-chatt",
     "Permission:AIChat.Conversations.Read": "Visa dina konversationer",
+    "Permission:AIChat.Conversations.Send": "Skicka meddelanden i dina konversationer",
     "Permission:AIChat.Conversations.Manage": "Skapa och byt namn på dina konversationer",
     "Permission:AIChat.Conversations.Delete": "Ta bort dina konversationer"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/tr.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/tr.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "Yapay Zeka Sohbeti",
     "Permission:AIChat.Conversations.Read": "Sohbetlerinizi görüntüleyin",
+    "Permission:AIChat.Conversations.Send": "Sohbetlerinizde mesaj gönderin",
     "Permission:AIChat.Conversations.Manage": "Sohbetlerinizi oluşturun ve yeniden adlandırın",
     "Permission:AIChat.Conversations.Delete": "Sohbetlerinizi silin"
   }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/zh.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/zh.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:AIChat": "AI 聊天",
     "Permission:AIChat.Conversations.Read": "查看您的对话",
+    "Permission:AIChat.Conversations.Send": "在您的对话中发送消息",
     "Permission:AIChat.Conversations.Manage": "创建和重命名您的对话",
     "Permission:AIChat.Conversations.Delete": "删除您的对话"
   }

--- a/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissionDefinitionProvider.cs
+++ b/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissionDefinitionProvider.cs
@@ -21,6 +21,10 @@ internal sealed class AIChatPermissionDefinitionProvider : IPermissionDefinition
             LocalizableString.Create<AIChatEndpointsLocalizationResource>("Permission:AIChat.Conversations.Read"));
 
         group.AddPermission(
+            AIChatPermissions.Conversations.Send,
+            LocalizableString.Create<AIChatEndpointsLocalizationResource>("Permission:AIChat.Conversations.Send"));
+
+        group.AddPermission(
             AIChatPermissions.Conversations.Manage,
             LocalizableString.Create<AIChatEndpointsLocalizationResource>("Permission:AIChat.Conversations.Manage"));
 

--- a/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissions.cs
+++ b/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissions.cs
@@ -15,6 +15,9 @@ public static class AIChatPermissions
         /// <summary>List and read one's own conversations.</summary>
         public const string Read = "AIChat.Conversations.Read";
 
+        /// <summary>Send messages and receive answers in one's own conversations.</summary>
+        public const string Send = "AIChat.Conversations.Send";
+
         /// <summary>Create and rename one's own conversations.</summary>
         public const string Manage = "AIChat.Conversations.Manage";
 

--- a/src/Granit.AI.Chat.Endpoints/Validators/SendMessageRequestValidator.cs
+++ b/src/Granit.AI.Chat.Endpoints/Validators/SendMessageRequestValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Granit.AI.Chat.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.AI.Chat.Endpoints.Validators;
+
+/// <summary>Validates <see cref="SendMessageRequest"/>.</summary>
+internal sealed class SendMessageRequestValidator : GranitValidator<SendMessageRequest>
+{
+    /// <summary>Maximum message length.</summary>
+    public const int MaxMessageLength = 16000;
+
+    public SendMessageRequestValidator()
+    {
+        RuleFor(x => x.Message).NotEmpty().MaximumLength(MaxMessageLength);
+    }
+}

--- a/src/Granit.AI.Chat.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Chat.Endpoints/packages.lock.json
@@ -41,6 +41,23 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -59,10 +76,36 @@
       "granit": {
         "type": "Project"
       },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.ai.chat": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -103,6 +146,16 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -111,6 +164,14 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
       "granit.guids": {
@@ -164,6 +225,16 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
@@ -233,6 +304,12 @@
           "Microsoft.OpenApi": "2.0.0"
         }
       },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.7.0",
+        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -270,6 +347,19 @@
         "requested": "[10.*, )",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
@@ -40,6 +40,25 @@ internal sealed class EfConversationStore(IDbContextFactory<AIChatDbContext> con
             .ConfigureAwait(false);
     }
 
+    public async Task<bool> AppendMessagesAsync(
+        Guid id, Guid ownerId, IReadOnlyList<Message> messages, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        bool owned = await context.Conversations
+            .AnyAsync(c => c.Id == id && c.OwnerId == ownerId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!owned)
+        {
+            return false;
+        }
+
+        context.Set<Message>().AddRange(messages);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
     public async Task<bool> RenameAsync(Guid id, Guid ownerId, string title, CancellationToken cancellationToken = default)
     {
         await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
@@ -42,6 +42,15 @@
         "resolved": "10.0.9",
         "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -98,7 +107,65 @@
       "granit": {
         "type": "Project"
       },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.ai.chat": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
@@ -108,6 +175,34 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
       "granit.guids": {
@@ -152,6 +247,16 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
@@ -159,6 +264,18 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.7.0",
+        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
@@ -180,6 +297,16 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -241,6 +368,53 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/src/Granit.AI.Chat/Exceptions/ConversationNotFoundException.cs
+++ b/src/Granit.AI.Chat/Exceptions/ConversationNotFoundException.cs
@@ -1,0 +1,12 @@
+namespace Granit.AI.Chat.Exceptions;
+
+/// <summary>
+/// Raised when a message targets a conversation that does not exist for the current owner
+/// (missing, or owned by someone else — the two are indistinguishable by design).
+/// </summary>
+public sealed class ConversationNotFoundException(Guid conversationId)
+    : InvalidOperationException($"Conversation '{conversationId}' was not found for the current user.")
+{
+    /// <summary>The conversation id that could not be resolved.</summary>
+    public Guid ConversationId { get; } = conversationId;
+}

--- a/src/Granit.AI.Chat/Exceptions/WorkspaceNotChatCapableException.cs
+++ b/src/Granit.AI.Chat/Exceptions/WorkspaceNotChatCapableException.cs
@@ -1,0 +1,12 @@
+namespace Granit.AI.Chat.Exceptions;
+
+/// <summary>
+/// Raised when a message is sent to a workspace whose model does not support chat completions
+/// (ADR-067). The request is rejected before the orchestration loop starts.
+/// </summary>
+public sealed class WorkspaceNotChatCapableException(string workspaceName)
+    : InvalidOperationException($"AI workspace '{workspaceName}' is not chat-capable and cannot be used for conversations.")
+{
+    /// <summary>The offending workspace name.</summary>
+    public string WorkspaceName { get; } = workspaceName;
+}

--- a/src/Granit.AI.Chat/Granit.AI.Chat.csproj
+++ b/src/Granit.AI.Chat/Granit.AI.Chat.csproj
@@ -13,6 +13,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
+    <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -1,11 +1,25 @@
+using Granit.AI.Chat.Internal;
+using Granit.AI.Tools;
+using Granit.Guids;
 using Granit.Modularity;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.AI.Chat;
 
 /// <summary>
 /// Granit module for conversational AI (ADR-067): the <see cref="Domain.Conversation"/> /
-/// <see cref="Domain.Message"/> aggregates and the <see cref="IConversationStore"/> abstraction.
-/// Persistence is provided by <c>Granit.AI.Chat.EntityFrameworkCore</c> and the HTTP surface by
-/// <c>Granit.AI.Chat.Endpoints</c>.
+/// <see cref="Domain.Message"/> aggregates, the <see cref="IConversationStore"/> abstraction, and
+/// the <see cref="IChatService"/> orchestration that drives a chat turn over the
+/// <c>Granit.AI.Tools</c> loop. Persistence is provided by <c>Granit.AI.Chat.EntityFrameworkCore</c>
+/// and the HTTP surface by <c>Granit.AI.Chat.Endpoints</c>.
 /// </summary>
-public sealed class GranitAIChatModule : GranitModule;
+[DependsOn(
+    typeof(GranitAIModule),
+    typeof(GranitAIToolsModule),
+    typeof(GranitGuidsModule))]
+public sealed class GranitAIChatModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.TryAddScoped<IChatService, ChatService>();
+}

--- a/src/Granit.AI.Chat/IChatService.cs
+++ b/src/Granit.AI.Chat/IChatService.cs
@@ -1,0 +1,48 @@
+namespace Granit.AI.Chat;
+
+/// <summary>A request to send a message and obtain a tool-grounded answer.</summary>
+public sealed record ChatSendRequest
+{
+    /// <summary>The existing conversation to continue, or <see langword="null"/> to start a new one.</summary>
+    public Guid? ConversationId { get; init; }
+
+    /// <summary>The user sending the message (owner of the conversation).</summary>
+    public required Guid OwnerId { get; init; }
+
+    /// <summary>The chat-capable workspace to use, or <see langword="null"/> for the default.</summary>
+    public string? WorkspaceName { get; init; }
+
+    /// <summary>The user's message.</summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>The outcome of a send: the (possibly new) conversation and the assistant's answer.</summary>
+public sealed record ChatSendResult
+{
+    /// <summary>The conversation the message was added to (new or existing).</summary>
+    public required Guid ConversationId { get; init; }
+
+    /// <summary>The assistant's final answer.</summary>
+    public required string Content { get; init; }
+
+    /// <summary>Whether the agent hit the iteration cap before settling.</summary>
+    public bool MaxIterationsReached { get; init; }
+
+    /// <summary>Total input tokens, if reported.</summary>
+    public int? InputTokens { get; init; }
+
+    /// <summary>Total output tokens, if reported.</summary>
+    public int? OutputTokens { get; init; }
+}
+
+/// <summary>
+/// Drives a chat turn (ADR-067): guards workspace chat-capability, runs the agentic tool loop over
+/// the conversation's history within the caller's ACLs, and persists the user and assistant messages.
+/// </summary>
+public interface IChatService
+{
+    /// <summary>Sends a message and returns the persisted, tool-grounded answer.</summary>
+    /// <exception cref="Exceptions.WorkspaceNotChatCapableException">The workspace is not chat-capable.</exception>
+    /// <exception cref="Exceptions.ConversationNotFoundException">The target conversation is not the caller's.</exception>
+    Task<ChatSendResult> SendAsync(ChatSendRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.AI.Chat/IConversationStore.cs
+++ b/src/Granit.AI.Chat/IConversationStore.cs
@@ -18,6 +18,15 @@ public interface IConversationStore
     /// <summary>Returns the owner's conversations (without messages), newest first.</summary>
     Task<IReadOnlyList<Conversation>> ListAsync(Guid ownerId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Appends messages to the owner's conversation; <see langword="false"/> if it is not theirs.
+    /// </summary>
+    Task<bool> AppendMessagesAsync(
+        Guid id,
+        Guid ownerId,
+        IReadOnlyList<Message> messages,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Renames the owner's conversation; <see langword="false"/> if it is not theirs.</summary>
     Task<bool> RenameAsync(Guid id, Guid ownerId, string title, CancellationToken cancellationToken = default);
 

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -1,0 +1,107 @@
+using Granit.AI.Chat.Domain;
+using Granit.AI.Chat.Exceptions;
+using Granit.AI.Exceptions;
+using Granit.AI.Options;
+using Granit.AI.Tools;
+using Granit.AI.Workspaces;
+using Granit.Guids;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.Chat.Internal;
+
+/// <summary>
+/// Default <see cref="IChatService"/>. Resolves and guards the workspace, runs the agentic tool
+/// loop over the conversation history, and persists the user and assistant turns.
+/// </summary>
+internal sealed class ChatService(
+    IConversationStore conversationStore,
+    IAIToolOrchestrator orchestrator,
+    IAIWorkspaceProvider workspaceProvider,
+    IAIWorkspaceCapabilityResolver capabilityResolver,
+    IGuidGenerator guidGenerator,
+    IOptions<GranitAIOptions> aiOptions) : IChatService
+{
+    private const int MaxTitleLength = 100;
+
+    public async Task<ChatSendResult> SendAsync(ChatSendRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Message);
+
+        string workspaceName = request.WorkspaceName ?? aiOptions.Value.DefaultWorkspace;
+        AIWorkspace workspace = await workspaceProvider.GetAsync(workspaceName, cancellationToken).ConfigureAwait(false)
+            ?? throw new AIWorkspaceNotFoundException(workspaceName);
+
+        // Reject a workspace the catalog reports as non-chat before any model work starts. An
+        // unknown capability set (null) is allowed — the catalog simply has no entry for the model.
+        AIModelCapabilities? capabilities = await capabilityResolver
+            .ResolveAsync(workspace.Provider, workspace.Model, cancellationToken)
+            .ConfigureAwait(false);
+        if (capabilities is { Chat: false })
+        {
+            throw new WorkspaceNotChatCapableException(workspaceName);
+        }
+
+        bool isNew = request.ConversationId is null;
+        Conversation conversation = isNew
+            ? Conversation.Create(guidGenerator.Create(), request.OwnerId, DeriveTitle(request.Message))
+            : await conversationStore.GetAsync(request.ConversationId!.Value, request.OwnerId, cancellationToken).ConfigureAwait(false)
+                ?? throw new ConversationNotFoundException(request.ConversationId.Value);
+
+        List<ChatMessage> loopMessages = [.. conversation.Messages.Select(ToChatMessage), new ChatMessage(ChatRole.User, request.Message)];
+
+        AIOrchestrationResult result = await orchestrator.RunAsync(
+            new AIOrchestrationRequest
+            {
+                WorkspaceName = workspaceName,
+                Messages = loopMessages,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (isNew)
+        {
+            conversation.AddMessage(guidGenerator.Create(), MessageRole.User, request.Message);
+            conversation.AddMessage(guidGenerator.Create(), MessageRole.Assistant, result.Content);
+            await conversationStore.CreateAsync(conversation, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await conversationStore.AppendMessagesAsync(
+                conversation.Id,
+                request.OwnerId,
+                [
+                    Message.Create(guidGenerator.Create(), conversation.Id, MessageRole.User, request.Message),
+                    Message.Create(guidGenerator.Create(), conversation.Id, MessageRole.Assistant, result.Content),
+                ],
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return new ChatSendResult
+        {
+            ConversationId = conversation.Id,
+            Content = result.Content,
+            MaxIterationsReached = result.MaxIterationsReached,
+            InputTokens = result.InputTokens,
+            OutputTokens = result.OutputTokens,
+        };
+    }
+
+    private static ChatMessage ToChatMessage(Message message) =>
+        new(MapRole(message.Role), message.Content);
+
+    private static ChatRole MapRole(MessageRole role) => role switch
+    {
+        MessageRole.User => ChatRole.User,
+        MessageRole.Assistant => ChatRole.Assistant,
+        MessageRole.System => ChatRole.System,
+        MessageRole.Tool => ChatRole.Tool,
+        _ => ChatRole.User,
+    };
+
+    private static string DeriveTitle(string message)
+    {
+        string firstLine = message.Trim().Split('\n', 2)[0].Trim();
+        return firstLine.Length <= MaxTitleLength ? firstLine : firstLine[..MaxTitleLength];
+    }
+}

--- a/src/Granit.AI.Chat/packages.lock.json
+++ b/src/Granit.AI.Chat/packages.lock.json
@@ -8,8 +8,298 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.7.0",
+        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
       }
     }
   }

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
@@ -32,8 +32,23 @@ public sealed class ConversationEndpointsUnitTests
         PermissionGroup group = context.Groups.ShouldHaveSingleItem();
         group.Name.ShouldBe("AIChat");
         group.Permissions.Select(p => p.Name).ShouldBe(
-            ["AIChat.Conversations.Read", "AIChat.Conversations.Manage", "AIChat.Conversations.Delete"],
+            [
+                "AIChat.Conversations.Read",
+                "AIChat.Conversations.Send",
+                "AIChat.Conversations.Manage",
+                "AIChat.Conversations.Delete",
+            ],
             ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Send_validator_rejects_blank_and_overlong_messages()
+    {
+        SendMessageRequestValidator validator = new();
+
+        validator.Validate(new SendMessageRequest("")).IsValid.ShouldBeFalse();
+        validator.Validate(new SendMessageRequest(new string('x', 16001))).IsValid.ShouldBeFalse();
+        validator.Validate(new SendMessageRequest("What changed last week?")).IsValid.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
@@ -117,6 +117,23 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -269,10 +286,28 @@
       "granit": {
         "type": "Project"
       },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.ai.chat": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )"
         }
       },
       "granit.ai.chat.endpoints": {
@@ -283,6 +318,14 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -323,6 +366,16 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -331,6 +384,14 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
       "granit.guids": {
@@ -384,6 +445,16 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
@@ -453,6 +524,12 @@
           "Microsoft.OpenApi": "2.0.0"
         }
       },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.7.0",
+        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -490,6 +567,19 @@
         "requested": "[10.*, )",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
@@ -75,6 +75,24 @@ public sealed class EfConversationStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task AppendMessages_adds_to_the_owner_conversation_and_rejects_others()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Chat", "first");
+
+        Message[] toAppend =
+        [
+            Message.Create(Guid.NewGuid(), seeded.Id, MessageRole.User, "second"),
+            Message.Create(Guid.NewGuid(), seeded.Id, MessageRole.Assistant, "answer"),
+        ];
+
+        (await _sut.AppendMessagesAsync(seeded.Id, UserB, toAppend, TestContext.Current.CancellationToken)).ShouldBeFalse();
+        (await _sut.AppendMessagesAsync(seeded.Id, UserA, toAppend, TestContext.Current.CancellationToken)).ShouldBeTrue();
+
+        Conversation? loaded = await _sut.GetAsync(seeded.Id, UserA, TestContext.Current.CancellationToken);
+        loaded!.Messages.Count.ShouldBe(3);
+    }
+
+    [Fact]
     public async Task Delete_succeeds_for_the_owner_and_fails_for_others()
     {
         Conversation seeded = await SeedAsync(UserA, "Doomed");

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
@@ -131,6 +131,15 @@
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -353,10 +362,28 @@
       "granit": {
         "type": "Project"
       },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.ai.chat": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )"
         }
       },
       "granit.ai.chat.entityframeworkcore": {
@@ -368,10 +395,78 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
       },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
       "granit.guids": {
@@ -416,12 +511,28 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.EntityFrameworkCore": {
@@ -448,6 +559,12 @@
           "Microsoft.Extensions.Logging": "10.0.9"
         }
       },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.7.0",
+        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -468,6 +585,16 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -529,6 +656,53 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -1,0 +1,118 @@
+using Granit.AI.Chat.Domain;
+using Granit.AI.Chat.Exceptions;
+using Granit.AI.Chat.Internal;
+using Granit.AI.Options;
+using Granit.AI.Tools;
+using Granit.AI.Workspaces;
+using Granit.Guids;
+using Microsoft.Extensions.AI;
+using NSubstitute;
+using Shouldly;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class ChatServiceTests
+{
+    private static readonly Guid Owner = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private readonly IConversationStore _store = Substitute.For<IConversationStore>();
+    private readonly IAIToolOrchestrator _orchestrator = Substitute.For<IAIToolOrchestrator>();
+    private readonly IAIWorkspaceProvider _workspaceProvider = Substitute.For<IAIWorkspaceProvider>();
+    private readonly IAIWorkspaceCapabilityResolver _capabilityResolver = Substitute.For<IAIWorkspaceCapabilityResolver>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+
+    private ChatService CreateService()
+    {
+        _guidGenerator.Create().Returns(_ => Guid.NewGuid());
+        _workspaceProvider.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AIWorkspace { Name = "default", Provider = "OpenAI", Model = "gpt-4o" });
+        _capabilityResolver.ResolveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Chat = true });
+        _orchestrator.RunAsync(Arg.Any<AIOrchestrationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AIOrchestrationResult
+            {
+                Content = "the answer",
+                Messages = [],
+                Iterations = 1,
+                MaxIterationsReached = false,
+                ToolInvocations = [],
+                InputTokens = 10,
+                OutputTokens = 4,
+            });
+
+        return new ChatService(_store, _orchestrator, _workspaceProvider, _capabilityResolver, _guidGenerator,
+            MsOptions.Create(new GranitAIOptions()));
+    }
+
+    private static ChatSendRequest Request(Guid? conversationId = null, string message = "hello") =>
+        new() { ConversationId = conversationId, OwnerId = Owner, Message = message };
+
+    [Fact]
+    public async Task New_conversation_runs_the_loop_and_persists_user_and_assistant_messages()
+    {
+        ChatService service = CreateService();
+
+        ChatSendResult result = await service.SendAsync(Request(message: "What changed?"), TestContext.Current.CancellationToken);
+
+        result.Content.ShouldBe("the answer");
+        result.InputTokens.ShouldBe(10);
+
+        await _store.Received(1).CreateAsync(
+            Arg.Is<Conversation>(c =>
+                c.OwnerId == Owner
+                && c.Messages.Count == 2
+                && c.Messages[0].Role == MessageRole.User
+                && c.Messages[1].Role == MessageRole.Assistant
+                && c.Messages[1].Content == "the answer"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Existing_conversation_feeds_history_to_the_loop_and_appends_messages()
+    {
+        var conversationId = Guid.NewGuid();
+        var existing = Conversation.Create(conversationId, Owner, "Earlier");
+        existing.AddMessage(Guid.NewGuid(), MessageRole.User, "previous");
+        _store.GetAsync(conversationId, Owner, Arg.Any<CancellationToken>()).Returns(existing);
+        _store.AppendMessagesAsync(conversationId, Owner, Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        ChatService service = CreateService();
+
+        await service.SendAsync(Request(conversationId, "follow up"), TestContext.Current.CancellationToken);
+
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r =>
+                r.Messages.Count == 2
+                && r.Messages[0].Role == ChatRole.User && r.Messages[0].Text == "previous"
+                && r.Messages[1].Text == "follow up"),
+            Arg.Any<CancellationToken>());
+        await _store.Received(1).AppendMessagesAsync(conversationId, Owner,
+            Arg.Is<IReadOnlyList<Message>>(m => m.Count == 2), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().CreateAsync(Arg.Any<Conversation>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Non_chat_capable_workspace_is_rejected_before_the_loop()
+    {
+        ChatService service = CreateService();
+        _capabilityResolver.ResolveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Chat = false });
+
+        await Should.ThrowAsync<WorkspaceNotChatCapableException>(
+            () => service.SendAsync(Request(), TestContext.Current.CancellationToken));
+
+        await _orchestrator.DidNotReceive().RunAsync(Arg.Any<AIOrchestrationRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Unknown_conversation_for_the_owner_throws()
+    {
+        var conversationId = Guid.NewGuid();
+        _store.GetAsync(conversationId, Owner, Arg.Any<CancellationToken>()).Returns((Conversation?)null);
+        ChatService service = CreateService();
+
+        await Should.ThrowAsync<ConversationNotFoundException>(
+            () => service.SendAsync(Request(conversationId), TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Granit.AI.Chat.Tests/Granit.AI.Chat.Tests.csproj
+++ b/tests/Granit.AI.Chat.Tests/Granit.AI.Chat.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.AI.Chat.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Tests/packages.lock.json
@@ -30,6 +30,15 @@
           "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "Shouldly": {
         "type": "Direct",
         "requested": "[4.*, )",
@@ -53,6 +62,14 @@
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
           "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "DiffEngine": {
@@ -83,6 +100,45 @@
         "type": "Transitive",
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -142,6 +198,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -221,10 +282,264 @@
       "granit": {
         "type": "Project"
       },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.ai.chat": {
         "type": "Project",
         "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.7.0",
+        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1546,7 +1546,10 @@
       "granit.ai.chat": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )"
         }
       },
       "granit.ai.chat.endpoints": {


### PR DESCRIPTION
## Summary

Second story of **Feature #2628 Granit.AI.Chat** (ADR-067): send a message and receive a streamed, tool-grounded answer. Builds on #2637 (data layer) and the `Granit.AI.Tools` orchestrator.

Epic #2626. Closes #2638.

## What's in it

**`Granit.AI.Chat` (base) — the orchestration service**
- `IChatService` / `ChatService`: the domain orchestration for a chat turn (lives in the base module per layer purity, not in `.Endpoints`):
  1. Resolves the workspace (or the configured default) and **guards chat-capability** — a model the catalog reports as non-chat is rejected (`WorkspaceNotChatCapableException`) **before the loop starts**.
  2. Runs the `Granit.AI.Tools` agentic loop (`IAIToolOrchestrator`) over the conversation history — tools execute **within the caller's ACLs** and ground the answer.
  3. Persists the user and assistant turns. A `null` conversation id starts a new conversation (title derived from the message); an existing one is appended (owner-scoped).
- `IConversationStore.AppendMessagesAsync` (owner-scoped); `WorkspaceNotChatCapableException` / `ConversationNotFoundException`.

**`Granit.AI.Chat.EntityFrameworkCore`**
- `EfConversationStore.AppendMessagesAsync` — verifies ownership, inserts the new messages.

**`Granit.AI.Chat.Endpoints`**
- `POST /conversations/messages` — runs the turn via `IChatService`, then **streams over SSE**: a `conversation` event (the new/continued id), incremental `data` content frames, a `usage` event, then `[DONE]`. A non-chat workspace / missing conversation are returned as `422` / `404` problems **before** any stream starts.
- New `AIChat.Conversations.Send` permission (provider + 15-base-culture localisation); `SendMessageRequest` validated.

## Acceptance criteria

- ✅ Chat-capable workspace + question → the answer streams over SSE and is persisted to the conversation.
- ✅ The agent calls the registered tools within the caller's ACLs and grounds the answer (the loop is `IAIToolOrchestrator`, ACL-gated from #2635).
- ✅ Non-chat-capable workspace → rejected before the loop (`422`).

## Design notes

- **Streaming**: the loop must complete before the final (tool-grounded) answer exists, so the endpoint streams the settled answer in word-sized SSE frames. Real provider-level token streaming of the *final* turn is a follow-up — it needs a streaming variant on the Tools orchestrator (kept out of scope here to avoid changing the merged `Granit.AI.Tools` contract).
- Badge/`@`/attachment resolution into the request is deferred to #2639/#2640; the send endpoint takes `message` + optional `conversationId`/`workspaceName`.
- Per-user default workspace is #2641; for now the body workspace or the global default is used.

## Verification

- All 3 packages build clean (0 warnings).
- Tests: **Chat 10** (domain + ChatService: new/existing turn, capability guard, unknown conversation), **Chat.EntityFrameworkCore 6** (append owner-scoped), **Chat.Endpoints 5** (permissions incl. Send, validators) — 21 total.
- `dotnet format --verify-no-changes` + markdownlint clean.
- **225/225** architecture tests pass (incl. permission convention + 15-culture completeness for the new `Send` permission).

## Next (Feature #2628)

- #2639 `@` mentions, #2640 attachments, #2641 per-user settings, #2642 suggested actions, #2643 Privacy, #2650 clarification questions.