### PR TITLE
fix(ai): regenerate OpenApi.Generator lockfile for Granit.AI.Tools dep

### DIFF
--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -419,7 +419,10 @@
       "granit.ai.chat": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Tools": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )"
         }
       },
       "granit.ai.chat.endpoints": {
@@ -440,6 +443,14 @@
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.tools": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )"
         }
       },
       "granit.auditing": {


### PR DESCRIPTION
## Problem

`develop` build is red. #2638 (PR #2728) added a `Granit.AI.Chat -> Granit.AI.Tools`
project reference. `Granit.OpenApi.Generator` references `Granit.AI.Chat` transitively
(via `Granit.AI.Chat.Endpoints`), but its `packages.lock.json` was never regenerated, so
locked-mode restore on the `src-only` shard fails:

```
error NU1004: A new project reference to Granit.AI.Tools was found for net10.0 ...
The packages lock file is inconsistent with the project dependencies ...
```

## Fix

Regenerated `src/Granit.OpenApi.Generator/packages.lock.json` only (adds the
`Granit.AI.Tools` transitive entry). Reverted the unrelated `Granit.DataExchange.Csv`
`Sep` 0.14.1->0.15.0 bumps that `--force-evaluate` pulls in.

## Verification

- `dotnet restore .github/shard-filters/src-only.slnf --locked-mode` -> exit 0 (was NU1004).

## Related

- Follows #2728 / #2638
- Epic #2626, Feature #2628