### PR TITLE
feat(ai): per-user chat settings — default workspace, web-search policy, custom context (#2641)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -39,6 +39,7 @@
         "Granit.AI",
         "Granit.AI.Tools",
         "Granit.Guids",
+        "Granit.Settings",
         "Granit.TextExtraction"
       ],
       "framework": "net10.0"
@@ -3210,6 +3211,15 @@
       "members": []
     },
     {
+      "name": "ChatWorkspacesResponse",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.ChatWorkspacesResponse",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/ChatWorkspacesResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "ConversationResponse",
       "fqn": "Granit.AI.Chat.Endpoints.Dtos.ConversationResponse",
       "kind": "record",
@@ -3503,7 +3513,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/GranitAIChatModule.cs",
-      "line": 23,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -3682,6 +3692,40 @@
           "kind": "method",
           "signature": "new(StringComparer.OrdinalIgnoreCase)",
           "returnType": "HashSet<string> AllowedContentTypes { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "AIChatSettingNames",
+      "fqn": "Granit.AI.Chat.Settings.AIChatSettingNames",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Settings/AIChatSettingNames.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ChatWebSearchPolicy",
+      "fqn": "Granit.AI.Chat.Settings.ChatWebSearchPolicy",
+      "kind": "enum",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Settings/ChatWebSearchPolicy.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IChatWorkspaceCatalog",
+      "fqn": "Granit.AI.Chat.Settings.IChatWorkspaceCatalog",
+      "kind": "interface",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Settings/IChatWorkspaceCatalog.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetSelectableWorkspacesAsync",
+          "kind": "method",
+          "signature": "GetSelectableWorkspacesAsync(CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<IReadOnlyList<string>>"
         }
       ]
     },
@@ -47230,7 +47274,7 @@
           "name": "SettingDefinition",
           "kind": "method",
           "signature": "SettingDefinition(string name)",
-          "returnType": "IReadOnlyList<string>? AllowedValues { get; init; } public"
+          "returnType": "IReadOnlyList<string>? AllowedValues { get; init; } public int? MaxLength { get; init; } public"
         }
       ]
     },

--- a/src/Granit.AI.Chat.Endpoints/Dtos/ChatWorkspacesResponse.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/ChatWorkspacesResponse.cs
@@ -1,0 +1,8 @@
+namespace Granit.AI.Chat.Endpoints.Dtos;
+
+/// <summary>
+/// The workspaces a user may select as their default chat workspace: the reserved <c>Auto</c>
+/// option plus the chat-capable workspace names. Backs the settings UI dropdown.
+/// </summary>
+/// <param name="Workspaces">The selectable workspace names (<c>Auto</c> first).</param>
+public sealed record ChatWorkspacesResponse(IReadOnlyList<string> Workspaces);

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatWorkspaceEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatWorkspaceEndpoints.cs
@@ -1,0 +1,40 @@
+using Granit.AI.Chat.Endpoints.Dtos;
+using Granit.AI.Chat.Endpoints.Permissions;
+using Granit.AI.Chat.Settings;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.AI.Chat.Endpoints.Endpoints;
+
+/// <summary>Lists the chat-capable workspaces a user may pick as their default.</summary>
+internal static class ChatWorkspaceEndpoints
+{
+    internal static RouteGroupBuilder MapChatWorkspaceEndpoint(this RouteGroupBuilder group)
+    {
+        group.MapGet("/workspaces", GetSelectableWorkspacesAsync)
+            .WithName("ListChatWorkspaces")
+            .WithSummary("Lists the selectable default chat workspaces.")
+            .WithDescription(
+                "Returns the workspaces a user may set as their default chat workspace: the "
+                + "reserved 'Auto' option plus the chat-capable workspaces visible to the tenant. "
+                + "Vector/embedding-only workspaces are excluded.")
+            .Produces<ChatWorkspacesResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .RequireAuthorization(AIChatPermissions.Conversations.Read);
+
+        return group;
+    }
+
+    private static async Task<Ok<ChatWorkspacesResponse>> GetSelectableWorkspacesAsync(
+        [FromServices] IChatWorkspaceCatalog catalog,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<string> workspaces = await catalog
+            .GetSelectableWorkspacesAsync(cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Ok(new ChatWorkspacesResponse(workspaces));
+    }
+}

--- a/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class AIChatEndpointRouteBuilderExtensions
 
         group.MapConversationEndpoints();
         group.MapChatSendEndpoint();
+        group.MapChatWorkspaceEndpoint();
         return group;
     }
 }

--- a/src/Granit.AI.Chat.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Chat.Endpoints/packages.lock.json
@@ -98,6 +98,7 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
       },

--- a/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
@@ -129,6 +129,7 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
       },

--- a/src/Granit.AI.Chat/Granit.AI.Chat.csproj
+++ b/src/Granit.AI.Chat/Granit.AI.Chat.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
     <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />
     <ProjectReference Include="..\Granit.TextExtraction\Granit.TextExtraction.csproj" />
   </ItemGroup>
 

--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -1,8 +1,10 @@
 using Granit.AI.Chat.Extensions;
 using Granit.AI.Chat.Internal;
+using Granit.AI.Chat.Settings;
 using Granit.AI.Tools;
 using Granit.Guids;
 using Granit.Modularity;
+using Granit.Settings;
 using Granit.TextExtraction;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -19,6 +21,7 @@ namespace Granit.AI.Chat;
     typeof(GranitAIModule),
     typeof(GranitAIToolsModule),
     typeof(GranitGuidsModule),
+    typeof(GranitSettingsModule),
     typeof(GranitTextExtractionModule))]
 public sealed class GranitAIChatModule : GranitModule
 {
@@ -34,5 +37,9 @@ public sealed class GranitAIChatModule : GranitModule
         // Likewise the attachment text resolver — with the Null source it resolves nothing until
         // the application registers its own IAIAttachmentSource over its transient blob store.
         AIChatAttachmentsServiceCollectionExtensions.AddCoreServices(context.Services);
+
+        // Per-user setting definitions (Granit.AI.Chat.*) are auto-discovered by GranitSettingsModule;
+        // only the chat-capable workspace catalog for the settings UI needs registering here.
+        context.Services.TryAddScoped<IChatWorkspaceCatalog, ChatWorkspaceCatalog>();
     }
 }

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -2,11 +2,13 @@ using Granit.AI.Chat.Attachments;
 using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Mentions;
+using Granit.AI.Chat.Settings;
 using Granit.AI.Exceptions;
 using Granit.AI.Options;
 using Granit.AI.Tools;
 using Granit.AI.Workspaces;
 using Granit.Guids;
+using Granit.Settings.Services;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 
@@ -23,6 +25,7 @@ internal sealed class ChatService(
     IAIWorkspaceCapabilityResolver capabilityResolver,
     IAIMentionContextResolver mentionContextResolver,
     IAIAttachmentTextResolver attachmentTextResolver,
+    ISettingProvider settingProvider,
     IGuidGenerator guidGenerator,
     IOptions<GranitAIOptions> aiOptions) : IChatService
 {
@@ -33,7 +36,7 @@ internal sealed class ChatService(
         ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.Message);
 
-        string workspaceName = request.WorkspaceName ?? aiOptions.Value.DefaultWorkspace;
+        string workspaceName = await ResolveWorkspaceNameAsync(request.WorkspaceName, cancellationToken).ConfigureAwait(false);
         AIWorkspace workspace = await workspaceProvider.GetAsync(workspaceName, cancellationToken).ConfigureAwait(false)
             ?? throw new AIWorkspaceNotFoundException(workspaceName);
 
@@ -86,6 +89,7 @@ internal sealed class ChatService(
             {
                 WorkspaceName = workspaceName,
                 Messages = loopMessages,
+                UserCustomContext = await ResolveCustomContextAsync(cancellationToken).ConfigureAwait(false),
             },
             cancellationToken).ConfigureAwait(false);
 
@@ -115,6 +119,46 @@ internal sealed class ChatService(
             InputTokens = result.InputTokens,
             OutputTokens = result.OutputTokens,
         };
+    }
+
+    /// <summary>
+    /// Resolves the workspace: an explicit per-request name wins; otherwise the user's default
+    /// (unless it is the reserved <c>Auto</c>); otherwise the configured default workspace.
+    /// </summary>
+    private async Task<string> ResolveWorkspaceNameAsync(string? explicitWorkspace, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitWorkspace))
+        {
+            return explicitWorkspace;
+        }
+
+        string? userDefault = await settingProvider
+            .GetOrNullAsync(AIChatSettingNames.DefaultWorkspace, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(userDefault)
+            && !string.Equals(userDefault, AIChatSettingNames.ReservedAutoWorkspace, StringComparison.OrdinalIgnoreCase))
+        {
+            return userDefault;
+        }
+
+        return aiOptions.Value.DefaultWorkspace;
+    }
+
+    /// <summary>
+    /// Reads the user's free-text custom context, capped at the configured maximum, for the
+    /// system-prompt composer. Returns <see langword="null"/> when unset or blank.
+    /// </summary>
+    private async Task<string?> ResolveCustomContextAsync(CancellationToken cancellationToken)
+    {
+        string? customContext = await settingProvider
+            .GetOrNullAsync(AIChatSettingNames.CustomContext, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(customContext))
+        {
+            return null;
+        }
+
+        return customContext.Length > AIChatSettingNames.MaxCustomContextLength
+            ? customContext[..AIChatSettingNames.MaxCustomContextLength]
+            : customContext;
     }
 
     private static ChatMessage ToChatMessage(Message message) =>

--- a/src/Granit.AI.Chat/Internal/ChatWorkspaceCatalog.cs
+++ b/src/Granit.AI.Chat/Internal/ChatWorkspaceCatalog.cs
@@ -1,0 +1,36 @@
+using Granit.AI.Chat.Settings;
+using Granit.AI.Workspaces;
+
+namespace Granit.AI.Chat.Internal;
+
+/// <summary>
+/// Default <see cref="IChatWorkspaceCatalog"/>. Filters the tenant's workspaces to the
+/// chat-capable ones via <see cref="IAIWorkspaceCapabilityResolver"/> and prepends the reserved
+/// <c>Auto</c> option.
+/// </summary>
+internal sealed class ChatWorkspaceCatalog(
+    IAIWorkspaceProvider workspaceProvider,
+    IAIWorkspaceCapabilityResolver capabilityResolver) : IChatWorkspaceCatalog
+{
+    public async ValueTask<IReadOnlyList<string>> GetSelectableWorkspacesAsync(CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<AIWorkspace> workspaces = await workspaceProvider.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        List<string> selectable = [AIChatSettingNames.ReservedAutoWorkspace];
+        foreach (AIWorkspace workspace in workspaces)
+        {
+            AIModelCapabilities? capabilities = await capabilityResolver
+                .ResolveAsync(workspace.Provider, workspace.Model, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Include unless the catalog reports the model as explicitly non-chat — an unknown
+            // capability set (null) is treated as chat-capable, mirroring the send-time guard.
+            if (capabilities is not { Chat: false })
+            {
+                selectable.Add(workspace.Name);
+            }
+        }
+
+        return selectable;
+    }
+}

--- a/src/Granit.AI.Chat/README.md
+++ b/src/Granit.AI.Chat/README.md
@@ -66,6 +66,19 @@ internal sealed class BlobAttachmentSource(IBlobStore store, ICurrentUser user) 
 Type/size limits (`AI:Chat:Attachments`) are enforced at the endpoint (request validation) and
 re-checked against the resolved bytes server-side.
 
+## Per-user settings
+
+Three per-user settings (declared on the `Granit.Settings` `"U"` scope, read/written through the
+generic settings endpoints) tune the chat per user:
+
+| Setting | Effect |
+| ------- | ------ |
+| `Granit.AI.Chat.DefaultWorkspace` | Default chat workspace, or `Auto` to fall back to the configured default. Selectable list served by `GET {prefix}/workspaces` (chat-capable only). |
+| `Granit.AI.Chat.WebSearchPolicy` | `Deny` / `Allow` / `AlwaysAsk` (the web-search provider is phase 2). |
+| `Granit.AI.Chat.CustomContext` | Free text (≤ 4000 chars) layered into the system prompt below the framework guardrails. |
+
+The custom context never overrides the guardrails; it only refines behaviour.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.Chat/Settings/AIChatSettingDefinitionProvider.cs
+++ b/src/Granit.AI.Chat/Settings/AIChatSettingDefinitionProvider.cs
@@ -1,0 +1,51 @@
+using Granit.Settings.Definitions;
+
+namespace Granit.AI.Chat.Settings;
+
+/// <summary>
+/// Declares the per-user chat settings (ADR-067): default workspace, web-search policy and a
+/// free-text custom context. All settable at User scope and visible to clients (the settings UI
+/// reads/writes them via the generic <c>Granit.Settings.Endpoints</c> user endpoints).
+/// Auto-discovered by <c>GranitSettingsModule</c> — no manual registration needed.
+/// </summary>
+internal sealed class AIChatSettingDefinitionProvider : ISettingDefinitionProvider
+{
+    public void Define(ISettingDefinitionContext context)
+    {
+        context.Add(new SettingDefinition(AIChatSettingNames.DefaultWorkspace)
+        {
+            IsVisibleToClients = true,
+            DisplayName = "Default chat workspace",
+            Description = "The chat-capable workspace used by default for your conversations, or "
+                + "'Auto' to let the system choose. The selectable list is served by the chat "
+                + "workspaces endpoint (chat-capable workspaces only).",
+            Providers = { "U" },
+        });
+
+        context.Add(new SettingDefinition(AIChatSettingNames.WebSearchPolicy)
+        {
+            IsVisibleToClients = true,
+            DisplayName = "Web-search policy",
+            Description = "Whether the chat agent may search the web: Deny, Allow, or AlwaysAsk "
+                + "(ask for confirmation first). The web-search provider is deferred to phase 2.",
+            Providers = { "U" },
+            DefaultValue = nameof(ChatWebSearchPolicy.Deny),
+            AllowedValues =
+            [
+                nameof(ChatWebSearchPolicy.Deny),
+                nameof(ChatWebSearchPolicy.Allow),
+                nameof(ChatWebSearchPolicy.AlwaysAsk),
+            ],
+        });
+
+        context.Add(new SettingDefinition(AIChatSettingNames.CustomContext)
+        {
+            IsVisibleToClients = true,
+            DisplayName = "Custom context",
+            Description = "Free-text context layered into the system prompt for your conversations. "
+                + "It refines behaviour but never overrides the framework guardrails.",
+            Providers = { "U" },
+            MaxLength = AIChatSettingNames.MaxCustomContextLength,
+        });
+    }
+}

--- a/src/Granit.AI.Chat/Settings/AIChatSettingNames.cs
+++ b/src/Granit.AI.Chat/Settings/AIChatSettingNames.cs
@@ -1,0 +1,29 @@
+namespace Granit.AI.Chat.Settings;
+
+/// <summary>
+/// Canonical names of the per-user chat settings (ADR-067), declared by
+/// <c>AIChatSettingDefinitionProvider</c> on the User (<c>"U"</c>) scope. Consumers should
+/// reference these constants rather than literal strings.
+/// </summary>
+public static class AIChatSettingNames
+{
+    private const string Prefix = "Granit.AI.Chat.";
+
+    /// <summary>The user's default chat workspace, or <see cref="ReservedAutoWorkspace"/> for automatic routing.</summary>
+    public const string DefaultWorkspace = Prefix + "DefaultWorkspace";
+
+    /// <summary>The user's web-search policy (a <see cref="ChatWebSearchPolicy"/> name).</summary>
+    public const string WebSearchPolicy = Prefix + "WebSearchPolicy";
+
+    /// <summary>The user's free-text custom context, layered into the system prompt.</summary>
+    public const string CustomContext = Prefix + "CustomContext";
+
+    /// <summary>
+    /// Reserved <see cref="DefaultWorkspace"/> value meaning "let the system choose". Automatic
+    /// routing is phase 2; until then it resolves to the configured default workspace.
+    /// </summary>
+    public const string ReservedAutoWorkspace = "Auto";
+
+    /// <summary>Maximum length, in characters, of <see cref="CustomContext"/>.</summary>
+    public const int MaxCustomContextLength = 4000;
+}

--- a/src/Granit.AI.Chat/Settings/ChatWebSearchPolicy.cs
+++ b/src/Granit.AI.Chat/Settings/ChatWebSearchPolicy.cs
@@ -1,0 +1,17 @@
+namespace Granit.AI.Chat.Settings;
+
+/// <summary>
+/// The user's policy for the chat agent using web search (ADR-067). The web-search provider
+/// itself is deferred to phase 2; this setting captures the user's intent in advance.
+/// </summary>
+public enum ChatWebSearchPolicy
+{
+    /// <summary>The agent must not search the web.</summary>
+    Deny,
+
+    /// <summary>The agent may search the web without asking.</summary>
+    Allow,
+
+    /// <summary>The agent must ask for confirmation before searching the web.</summary>
+    AlwaysAsk,
+}

--- a/src/Granit.AI.Chat/Settings/IChatWorkspaceCatalog.cs
+++ b/src/Granit.AI.Chat/Settings/IChatWorkspaceCatalog.cs
@@ -1,0 +1,16 @@
+namespace Granit.AI.Chat.Settings;
+
+/// <summary>
+/// Lists the workspaces a user may pick as their default chat workspace (ADR-067): the
+/// chat-capable workspaces visible to the current tenant, plus the reserved
+/// <see cref="AIChatSettingNames.ReservedAutoWorkspace"/> option. Backs the settings UI dropdown.
+/// </summary>
+public interface IChatWorkspaceCatalog
+{
+    /// <summary>
+    /// Returns the selectable default-workspace options: <c>Auto</c> first, then every
+    /// chat-capable workspace name. A workspace with an unknown capability set is treated as
+    /// chat-capable (the catalog simply has no entry for the model).
+    /// </summary>
+    ValueTask<IReadOnlyList<string>> GetSelectableWorkspacesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -423,6 +423,7 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
       },

--- a/src/Granit.Settings.Endpoints/Endpoints/UserSettingsWriteEndpoints.cs
+++ b/src/Granit.Settings.Endpoints/Endpoints/UserSettingsWriteEndpoints.cs
@@ -62,6 +62,11 @@ internal static class UserSettingsWriteEndpoints
             return SettingsResponseMapper.ProviderNotAllowed(name, "User");
         }
 
+        if (!definition.IsValidValue(body.Value))
+        {
+            return SettingsResponseMapper.ValidationFailed(name);
+        }
+
         ICurrentUserService currentUser =
             context.RequestServices.GetRequiredService<ICurrentUserService>();
         ISettingManager settingManager =

--- a/src/Granit.Settings.Endpoints/Internal/SettingsResponseMapper.cs
+++ b/src/Granit.Settings.Endpoints/Internal/SettingsResponseMapper.cs
@@ -76,6 +76,12 @@ internal static class SettingsResponseMapper
             detail: $"Setting '{name}' does not allow the {scope} scope.",
             statusCode: StatusCodes.Status400BadRequest);
 
+    /// <summary>400 problem when a value fails the setting's validation (kind, allow-list, length).</summary>
+    public static ProblemHttpResult ValidationFailed(string name) =>
+        TypedResults.Problem(
+            detail: $"The value for setting '{name}' does not match its expected format, allow-list or length.",
+            statusCode: StatusCodes.Status400BadRequest);
+
     /// <summary>400 problem when no tenant context is available.</summary>
     public static ProblemHttpResult NoTenantContext() =>
         TypedResults.Problem(

--- a/src/Granit.Settings/Definitions/SettingDefinition.cs
+++ b/src/Granit.Settings/Definitions/SettingDefinition.cs
@@ -55,6 +55,13 @@ public sealed class SettingDefinition
     /// </summary>
     public IReadOnlyList<string>? AllowedValues { get; init; }
 
+    /// <summary>
+    /// Optional maximum length, in characters, for a <see cref="ValueKind.String"/> setting. When
+    /// set, any write longer than this is rejected. Use for free-text settings (e.g. a custom
+    /// prompt context) that have no closed <see cref="AllowedValues"/> list.
+    /// </summary>
+    public int? MaxLength { get; init; }
+
     public SettingDefinition(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -95,6 +102,21 @@ public sealed class SettingDefinition
                     $"Setting '{Name}': AllowedValues entry '{unparseable}' is not parseable as {ValueKind}.");
             }
         }
+
+        if (MaxLength is { } maxLength)
+        {
+            if (maxLength <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Setting '{Name}': MaxLength must be positive.");
+            }
+
+            if (DefaultValue is not null && DefaultValue.Length > maxLength)
+            {
+                throw new InvalidOperationException(
+                    $"Setting '{Name}': DefaultValue exceeds MaxLength ({maxLength}).");
+            }
+        }
     }
 
     /// <summary>
@@ -116,6 +138,11 @@ public sealed class SettingDefinition
         }
 
         if (AllowedValues is { Count: > 0 } && !AllowedValues.Contains(value))
+        {
+            return false;
+        }
+
+        if (MaxLength is { } maxLength && value.Length > maxLength)
         {
             return false;
         }

--- a/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
@@ -308,6 +308,7 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
@@ -384,6 +384,7 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.AI.Chat.Tests/AIChatSettingDefinitionProviderTests.cs
+++ b/tests/Granit.AI.Chat.Tests/AIChatSettingDefinitionProviderTests.cs
@@ -1,0 +1,69 @@
+using Granit.AI.Chat.Settings;
+using Granit.Settings.Definitions;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class AIChatSettingDefinitionProviderTests
+{
+    private sealed class CapturingContext : ISettingDefinitionContext
+    {
+        public Dictionary<string, SettingDefinition> Definitions { get; } = new(StringComparer.Ordinal);
+
+        public void Add(SettingDefinition definition) => Definitions[definition.Name] = definition;
+
+        public SettingDefinition? GetOrNull(string name) =>
+            Definitions.GetValueOrDefault(name);
+    }
+
+    private static CapturingContext Define()
+    {
+        CapturingContext context = new();
+        new AIChatSettingDefinitionProvider().Define(context);
+        return context;
+    }
+
+    [Fact]
+    public void Declares_the_three_user_scoped_chat_settings()
+    {
+        CapturingContext context = Define();
+
+        context.Definitions.Keys.ShouldBe(
+            [
+                AIChatSettingNames.DefaultWorkspace,
+                AIChatSettingNames.WebSearchPolicy,
+                AIChatSettingNames.CustomContext,
+            ],
+            ignoreOrder: true);
+
+        foreach (SettingDefinition definition in context.Definitions.Values)
+        {
+            definition.IsVisibleToClients.ShouldBeTrue();
+            definition.Providers.ShouldBe(["U"]);
+        }
+    }
+
+    [Fact]
+    public void Web_search_policy_is_constrained_to_the_three_policies_with_a_safe_default()
+    {
+        SettingDefinition definition = Define().Definitions[AIChatSettingNames.WebSearchPolicy];
+
+        definition.DefaultValue.ShouldBe(nameof(ChatWebSearchPolicy.Deny));
+        definition.AllowedValues.ShouldBe(
+            [nameof(ChatWebSearchPolicy.Deny), nameof(ChatWebSearchPolicy.Allow), nameof(ChatWebSearchPolicy.AlwaysAsk)],
+            ignoreOrder: true);
+
+        definition.IsValidValue("Allow").ShouldBeTrue();
+        definition.IsValidValue("Sometimes").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Custom_context_enforces_the_max_length()
+    {
+        SettingDefinition definition = Define().Definitions[AIChatSettingNames.CustomContext];
+
+        definition.MaxLength.ShouldBe(AIChatSettingNames.MaxCustomContextLength);
+        definition.IsValidValue(new string('x', AIChatSettingNames.MaxCustomContextLength)).ShouldBeTrue();
+        definition.IsValidValue(new string('x', AIChatSettingNames.MaxCustomContextLength + 1)).ShouldBeFalse();
+    }
+}

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -3,10 +3,12 @@ using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Internal;
 using Granit.AI.Chat.Mentions;
+using Granit.AI.Chat.Settings;
 using Granit.AI.Options;
 using Granit.AI.Tools;
 using Granit.AI.Workspaces;
 using Granit.Guids;
+using Granit.Settings.Services;
 using Microsoft.Extensions.AI;
 using NSubstitute;
 using Shouldly;
@@ -24,6 +26,7 @@ public sealed class ChatServiceTests
     private readonly IAIWorkspaceCapabilityResolver _capabilityResolver = Substitute.For<IAIWorkspaceCapabilityResolver>();
     private readonly IAIMentionContextResolver _mentionContextResolver = Substitute.For<IAIMentionContextResolver>();
     private readonly IAIAttachmentTextResolver _attachmentTextResolver = Substitute.For<IAIAttachmentTextResolver>();
+    private readonly ISettingProvider _settingProvider = Substitute.For<ISettingProvider>();
     private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
 
     private ChatService CreateService()
@@ -49,9 +52,12 @@ public sealed class ChatServiceTests
             .Returns((string?)null);
         _attachmentTextResolver.ResolveContextAsync(Arg.Any<IReadOnlyList<AIAttachment>>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
+        _settingProvider.GetOrNullAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
 
         return new ChatService(_store, _orchestrator, _workspaceProvider, _capabilityResolver,
-            _mentionContextResolver, _attachmentTextResolver, _guidGenerator, MsOptions.Create(new GranitAIOptions()));
+            _mentionContextResolver, _attachmentTextResolver, _settingProvider, _guidGenerator,
+            MsOptions.Create(new GranitAIOptions { DefaultWorkspace = "default" }));
     }
 
     private static ChatSendRequest Request(
@@ -221,5 +227,76 @@ public sealed class ChatServiceTests
 
         await Should.ThrowAsync<ConversationNotFoundException>(
             () => service.SendAsync(Request(conversationId), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task User_default_workspace_setting_is_used_when_no_explicit_workspace()
+    {
+        ChatService service = CreateService();
+        _settingProvider.GetOrNullAsync(AIChatSettingNames.DefaultWorkspace, Arg.Any<CancellationToken>())
+            .Returns("my-workspace");
+
+        await service.SendAsync(Request(), TestContext.Current.CancellationToken);
+
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r => r.WorkspaceName == "my-workspace"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reserved_auto_default_workspace_falls_back_to_the_configured_default()
+    {
+        ChatService service = CreateService();
+        _settingProvider.GetOrNullAsync(AIChatSettingNames.DefaultWorkspace, Arg.Any<CancellationToken>())
+            .Returns(AIChatSettingNames.ReservedAutoWorkspace);
+
+        await service.SendAsync(Request(), TestContext.Current.CancellationToken);
+
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r => r.WorkspaceName == "default"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Explicit_request_workspace_overrides_the_user_default_setting()
+    {
+        ChatService service = CreateService();
+        _settingProvider.GetOrNullAsync(AIChatSettingNames.DefaultWorkspace, Arg.Any<CancellationToken>())
+            .Returns("user-default");
+
+        await service.SendAsync(
+            Request() with { WorkspaceName = "explicit" }, TestContext.Current.CancellationToken);
+
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r => r.WorkspaceName == "explicit"), Arg.Any<CancellationToken>());
+        await _settingProvider.DidNotReceive()
+            .GetOrNullAsync(AIChatSettingNames.DefaultWorkspace, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task User_custom_context_is_passed_to_the_orchestrator()
+    {
+        ChatService service = CreateService();
+        _settingProvider.GetOrNullAsync(AIChatSettingNames.CustomContext, Arg.Any<CancellationToken>())
+            .Returns("Always answer in British English.");
+
+        await service.SendAsync(Request(), TestContext.Current.CancellationToken);
+
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r => r.UserCustomContext == "Always answer in British English."),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task User_custom_context_is_capped_at_the_maximum_length()
+    {
+        ChatService service = CreateService();
+        _settingProvider.GetOrNullAsync(AIChatSettingNames.CustomContext, Arg.Any<CancellationToken>())
+            .Returns(new string('x', AIChatSettingNames.MaxCustomContextLength + 500));
+
+        await service.SendAsync(Request(), TestContext.Current.CancellationToken);
+
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r =>
+                r.UserCustomContext!.Length == AIChatSettingNames.MaxCustomContextLength),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.AI.Chat.Tests/ChatWorkspaceCatalogTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatWorkspaceCatalogTests.cs
@@ -1,0 +1,52 @@
+using Granit.AI.Chat.Internal;
+using Granit.AI.Chat.Settings;
+using Granit.AI.Workspaces;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class ChatWorkspaceCatalogTests
+{
+    private readonly IAIWorkspaceProvider _workspaceProvider = Substitute.For<IAIWorkspaceProvider>();
+    private readonly IAIWorkspaceCapabilityResolver _capabilityResolver = Substitute.For<IAIWorkspaceCapabilityResolver>();
+
+    private static AIWorkspace Workspace(string name, string model) =>
+        new() { Name = name, Provider = "OpenAI", Model = model };
+
+    [Fact]
+    public async Task Lists_auto_first_then_chat_capable_workspaces_excluding_non_chat()
+    {
+        _workspaceProvider.GetAllAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            Workspace("chat", "gpt-4o"),
+            Workspace("embed", "text-embedding-3"),
+            Workspace("unknown", "mystery"),
+        ]);
+        _capabilityResolver.ResolveAsync("OpenAI", "gpt-4o", Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Chat = true });
+        _capabilityResolver.ResolveAsync("OpenAI", "text-embedding-3", Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Chat = false });
+        _capabilityResolver.ResolveAsync("OpenAI", "mystery", Arg.Any<CancellationToken>())
+            .Returns((AIModelCapabilities?)null);
+
+        var catalog = new ChatWorkspaceCatalog(_workspaceProvider, _capabilityResolver);
+        IReadOnlyList<string> result = await catalog.GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
+
+        result[0].ShouldBe(AIChatSettingNames.ReservedAutoWorkspace);
+        result.ShouldContain("chat");
+        result.ShouldContain("unknown"); // unknown capability => treated as chat-capable
+        result.ShouldNotContain("embed"); // explicitly non-chat => excluded
+    }
+
+    [Fact]
+    public async Task Returns_only_auto_when_no_workspaces()
+    {
+        _workspaceProvider.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+        var catalog = new ChatWorkspaceCatalog(_workspaceProvider, _capabilityResolver);
+
+        IReadOnlyList<string> result = await catalog.GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().ShouldBe(AIChatSettingNames.ReservedAutoWorkspace);
+    }
+}

--- a/tests/Granit.AI.Chat.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Tests/packages.lock.json
@@ -304,6 +304,7 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1550,6 +1550,7 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Settings.Endpoints.Tests/UserSettingsEndpointTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/UserSettingsEndpointTests.cs
@@ -54,6 +54,7 @@ public sealed class UserSettingsEndpointTests : IAsyncDisposable
         builder.Services.AddSingleton(_settingManager);
         builder.Services.AddSingleton(_currentUserService);
         builder.Services.AddSingleton<ISettingDefinitionProvider, WellKnownSettingDefinitionProvider>();
+        builder.Services.AddSingleton<ISettingDefinitionProvider, ConstrainedSettingDefinitionProvider>();
         builder.Services.AddSingleton(sp =>
             new SettingDefinitionManager(sp.GetServices<ISettingDefinitionProvider>()));
 
@@ -201,6 +202,41 @@ public sealed class UserSettingsEndpointTests : IAsyncDisposable
     }
 
     [Fact]
+    public async Task Put_Value_Outside_AllowList_Returns_400()
+    {
+        HttpResponseMessage response = await _authClient.PutAsJsonAsync(
+            $"{Prefix}/{ConstrainedSettingDefinitionProvider.PolicyName}",
+            new UpdateSettingValueRequest("nope"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        await _settingManager.DidNotReceive().SetForUserAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Put_Value_Exceeding_MaxLength_Returns_400()
+    {
+        HttpResponseMessage response = await _authClient.PutAsJsonAsync(
+            $"{Prefix}/{ConstrainedSettingDefinitionProvider.TextName}",
+            new UpdateSettingValueRequest("toolong"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Put_Valid_Constrained_Value_Returns_204()
+    {
+        HttpResponseMessage response = await _authClient.PutAsJsonAsync(
+            $"{Prefix}/{ConstrainedSettingDefinitionProvider.PolicyName}",
+            new UpdateSettingValueRequest("a"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
     public async Task Put_Unknown_Setting_Returns_404()
     {
         HttpResponseMessage response = await _authClient.PutAsJsonAsync(
@@ -274,5 +310,29 @@ public sealed class UserSettingsEndpointTests : IAsyncDisposable
         HttpClient client = _app.GetTestClient();
         client.DefaultRequestHeaders.Add(TestAuthHandler.PermissionsHeader, AuthenticatedMarker);
         return client;
+    }
+
+    /// <summary>Declares user-scoped settings with an allow-list and a max length, to exercise write validation.</summary>
+    private sealed class ConstrainedSettingDefinitionProvider : ISettingDefinitionProvider
+    {
+        public const string PolicyName = "Test.Policy";
+        public const string TextName = "Test.Text";
+
+        public void Define(ISettingDefinitionContext context)
+        {
+            context.Add(new SettingDefinition(PolicyName)
+            {
+                IsVisibleToClients = true,
+                Providers = { "U" },
+                AllowedValues = ["a", "b"],
+            });
+
+            context.Add(new SettingDefinition(TextName)
+            {
+                IsVisibleToClients = true,
+                Providers = { "U" },
+                MaxLength = 3,
+            });
+        }
     }
 }

--- a/tests/Granit.Settings.Tests/SettingDefinitionTests.cs
+++ b/tests/Granit.Settings.Tests/SettingDefinitionTests.cs
@@ -376,4 +376,38 @@ public sealed class SettingDefinitionTests
         def.IsValidValue("42").ShouldBeTrue();
         def.IsValidValue("abc").ShouldBeFalse();
     }
+
+    // -------------------------------------------------------------------------
+    // MaxLength
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MaxLength_IsNull_ByDefault()
+    {
+        new SettingDefinition("test").MaxLength.ShouldBeNull();
+    }
+
+    [Fact]
+    public void IsValidValue_RejectsValueLongerThanMaxLength()
+    {
+        var def = new SettingDefinition("test") { MaxLength = 5 };
+
+        def.IsValidValue("12345").ShouldBeTrue();
+        def.IsValidValue("123456").ShouldBeFalse();
+        def.IsValidValue(null).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ValidateInvariants_NonPositiveMaxLength_Throws()
+    {
+        Should.Throw<InvalidOperationException>(
+            () => new SettingDefinition("test") { MaxLength = 0 }.ValidateInvariants());
+    }
+
+    [Fact]
+    public void ValidateInvariants_DefaultValueExceedingMaxLength_Throws()
+    {
+        Should.Throw<InvalidOperationException>(
+            () => new SettingDefinition("test") { MaxLength = 3, DefaultValue = "toolong" }.ValidateInvariants());
+    }
 }


### PR DESCRIPTION
## Story

Closes #2641 — `As an Authenticated User, I want to set my AI preferences (default workspace,
web-search policy, custom context) so the chat behaves the way I want by default.`

## What

Three per-user chat settings on the `Granit.Settings` **"U"** scope (ADR-067), read/written through
the existing generic settings endpoints — the module only declares definitions.

| Setting | Behaviour |
| ------- | --------- |
| `Granit.AI.Chat.DefaultWorkspace` | Default chat workspace, or `Auto` → configured default. |
| `Granit.AI.Chat.WebSearchPolicy` | `Deny` (default) / `Allow` / `AlwaysAsk`; provider deferred to phase 2. |
| `Granit.AI.Chat.CustomContext` | Free text ≤ 4000 chars, layered into the system prompt. |

- **`AIChatSettingDefinitionProvider`** — auto-discovered; all User-scoped + client-visible.
  `WebSearchPolicy` constrained to a `ChatWebSearchPolicy` allow-list; `CustomContext` `MaxLength`=4000.
- **`ChatService`** reads them via `ISettingProvider`: default-workspace resolution (explicit request
  wins → user default → `Auto`/unset falls back to the configured default); custom context flows into
  `AIOrchestrationRequest.UserCustomContext` (composed into the system prompt by #2632), capped defensively.
  `Granit.AI.Chat` now `DependsOn` `GranitSettingsModule`.
- **`IChatWorkspaceCatalog` + `GET {prefix}/workspaces`** (`AIChat.Conversations.Read`) lists the
  selectable default workspaces: `Auto` plus chat-capable workspaces (unknown capability treated as
  chat-capable, mirroring the send-time guard).

## Settings module improvements (enable the above + close a gap)

- **`SettingDefinition.MaxLength`** (optional, string settings) — enforced in `IsValidValue` and
  `ValidateInvariants`. Lets a free-text setting bound length without a closed `AllowedValues` list.
- **User-scope `PUT` now validates** the value via `IsValidValue` before persisting. Previously only
  the *admin* write path validated, so user writes silently bypassed `AllowedValues`/`ValueKind`/`MaxLength`.
  Added `SettingsResponseMapper.ValidationFailed` (400).

## Acceptance criteria

- ✅ Default-workspace picker lists chat-capable workspaces + `Auto` (`GET /workspaces`).
- ✅ Custom context ≤ 4000 chars saved → injected into the system prompt (over-length rejected, 400).
- ✅ `WebSearchPolicy` accepts only the three policies (behaviour deferred to phase 2).

## Tests

- `ChatServiceTests` (default-workspace resolution incl. `Auto`/explicit override; custom-context inject + cap)
- `ChatWorkspaceCatalogTests` (chat-capable filtering + `Auto`)
- `AIChatSettingDefinitionProviderTests` (3 settings, scope, allow-list, max length)
- `SettingDefinitionTests` (`MaxLength` validation)
- `UserSettingsEndpointTests` (user PUT now rejects out-of-allow-list / over-length with 400)
- Architecture suite green (225); format + markdownlint clean; lockfiles consistent.

## Related

- Epic #2626, Feature #2628, ADR-067