### PR TITLE
feat(ai): suggested-actions contract + module hook (typed, deep-link, non-executing) (#2642)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3146,7 +3146,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 7,
+      "line": 8,
       "members": []
     },
     {
@@ -3155,8 +3155,15 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 35,
-      "members": []
+      "line": 36,
+      "members": [
+        {
+          "name": "ConversationId",
+          "kind": "property",
+          "signature": "required Guid ConversationId",
+          "returnType": "required Guid"
+        }
+      ]
     },
     {
       "name": "Conversation",
@@ -3207,7 +3214,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 33,
+      "line": 34,
       "members": []
     },
     {
@@ -3315,6 +3322,15 @@
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
       "line": 9,
+      "members": []
+    },
+    {
+      "name": "SuggestedActionResponse",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.SuggestedActionResponse",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
+      "line": 47,
       "members": []
     },
     {
@@ -3508,6 +3524,22 @@
       ]
     },
     {
+      "name": "AIChatSuggestionsServiceCollectionExtensions",
+      "fqn": "Granit.AI.Chat.Extensions.AIChatSuggestionsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Extensions/AIChatSuggestionsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitChatSuggestions",
+          "kind": "method",
+          "signature": "AddGranitChatSuggestions(this IServiceCollection services, Action<AISuggestionRegistrationBuilder> configure)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
       "name": "GranitAIChatModule",
       "fqn": "Granit.AI.Chat.GranitAIChatModule",
       "kind": "class",
@@ -3529,7 +3561,7 @@
       "kind": "interface",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 57,
+      "line": 64,
       "members": [
         {
           "name": "SendAsync",
@@ -3726,6 +3758,72 @@
           "kind": "method",
           "signature": "GetSelectableWorkspacesAsync(CancellationToken cancellationToken = default)",
           "returnType": "ValueTask<IReadOnlyList<string>>"
+        }
+      ]
+    },
+    {
+      "name": "AISuggestedAction",
+      "fqn": "Granit.AI.Chat.Suggestions.AISuggestedAction",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Suggestions/AISuggestedAction.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AISuggestionContext",
+      "fqn": "Granit.AI.Chat.Suggestions.AISuggestionContext",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Suggestions/AISuggestionContext.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AISuggestionRegistrationBuilder",
+      "fqn": "Granit.AI.Chat.Suggestions.AISuggestionRegistrationBuilder",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Suggestions/AISuggestionRegistrationBuilder.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Services",
+          "kind": "property",
+          "signature": "IServiceCollection Services",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IAISuggestionProvider",
+      "fqn": "Granit.AI.Chat.Suggestions.IAISuggestionProvider",
+      "kind": "interface",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Suggestions/IAISuggestionProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetSuggestionsAsync",
+          "kind": "method",
+          "signature": "GetSuggestionsAsync(AISuggestionContext context, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<IReadOnlyList<AISuggestedAction>>"
+        }
+      ]
+    },
+    {
+      "name": "IAISuggestionResolver",
+      "fqn": "Granit.AI.Chat.Suggestions.IAISuggestionResolver",
+      "kind": "interface",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Suggestions/IAISuggestionResolver.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(AISuggestionContext context, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<IReadOnlyList<AISuggestedAction>>"
         }
       ]
     },

--- a/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
@@ -28,11 +28,20 @@ public sealed record AttachmentRequest(string Reference, string FileName, string
 /// <summary>
 /// A frame streamed over SSE for a send. <see cref="Type"/> discriminates the frame:
 /// <c>conversation</c> (carries <see cref="ConversationId"/>), <c>delta</c> (carries a
-/// <see cref="Content"/> chunk), or <c>usage</c> (carries the token counts).
+/// <see cref="Content"/> chunk), <c>usage</c> (carries the token counts), or <c>suggestions</c>
+/// (carries the typed <see cref="SuggestedActions"/>).
 /// </summary>
 public sealed record ChatStreamEvent(
     string Type,
     string? Content = null,
     Guid? ConversationId = null,
     int? InputTokens = null,
-    int? OutputTokens = null);
+    int? OutputTokens = null,
+    IReadOnlyList<SuggestedActionResponse>? SuggestedActions = null);
+
+/// <summary>A typed, non-executing suggested action (a deep link the front renders).</summary>
+/// <param name="Type">The suggestion type, e.g. <c>calendar.connect</c>.</param>
+/// <param name="Label">The display label for the call-to-action.</param>
+/// <param name="DeepLink">The deep link the front navigates to. Never auto-invoked.</param>
+/// <param name="Description">An optional one-line explanation of the suggestion.</param>
+public sealed record SuggestedActionResponse(string Type, string Label, string DeepLink, string? Description = null);

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -98,6 +98,14 @@ internal static class ChatSendEndpoints
         }
 
         yield return new ChatStreamEvent("usage", InputTokens: result.InputTokens, OutputTokens: result.OutputTokens);
+
+        if (result.SuggestedActions.Count > 0)
+        {
+            yield return new ChatStreamEvent(
+                "suggestions",
+                SuggestedActions: [.. result.SuggestedActions.Select(a =>
+                    new SuggestedActionResponse(a.Type, a.Label, a.DeepLink, a.Description))]);
+        }
     }
 
     /// <summary>Splits text into word-sized chunks (trailing space preserved) for token-like streaming.</summary>

--- a/src/Granit.AI.Chat/Extensions/AIChatSuggestionsServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Chat/Extensions/AIChatSuggestionsServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using Granit.AI.Chat.Internal;
+using Granit.AI.Chat.Suggestions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.AI.Chat.Extensions;
+
+/// <summary>
+/// Application-facing registration for the Granit chat suggested-action seam.
+/// </summary>
+public static class AIChatSuggestionsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Opens the opt-in builder so modules can contribute <see cref="IAISuggestionProvider"/> that
+    /// surface typed, non-executing suggested actions alongside the agent's answer.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Opt-in provider registrations.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddGranitChatSuggestions(
+        this IServiceCollection services,
+        Action<AISuggestionRegistrationBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        AddCoreServices(services);
+        configure(new AISuggestionRegistrationBuilder(services));
+        return services;
+    }
+
+    internal static void AddCoreServices(IServiceCollection services) =>
+        services.TryAddScoped<IAISuggestionResolver, AISuggestionResolver>();
+}

--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -41,5 +41,9 @@ public sealed class GranitAIChatModule : GranitModule
         // Per-user setting definitions (Granit.AI.Chat.*) are auto-discovered by GranitSettingsModule;
         // only the chat-capable workspace catalog for the settings UI needs registering here.
         context.Services.TryAddScoped<IChatWorkspaceCatalog, ChatWorkspaceCatalog>();
+
+        // The suggestion resolver is always present so a turn can carry suggested actions even
+        // before any module contributes a provider (it then resolves to none).
+        AIChatSuggestionsServiceCollectionExtensions.AddCoreServices(context.Services);
     }
 }

--- a/src/Granit.AI.Chat/IChatService.cs
+++ b/src/Granit.AI.Chat/IChatService.cs
@@ -1,5 +1,6 @@
 using Granit.AI.Chat.Attachments;
 using Granit.AI.Chat.Mentions;
+using Granit.AI.Chat.Suggestions;
 
 namespace Granit.AI.Chat;
 
@@ -48,6 +49,12 @@ public sealed record ChatSendResult
 
     /// <summary>Total output tokens, if reported.</summary>
     public int? OutputTokens { get; init; }
+
+    /// <summary>
+    /// Typed, non-executing suggested actions surfaced alongside the answer (deep links the front
+    /// renders). Empty when no provider offered any. See <see cref="AISuggestedAction"/>.
+    /// </summary>
+    public IReadOnlyList<AISuggestedAction> SuggestedActions { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Granit.AI.Chat/Internal/AISuggestionResolver.cs
+++ b/src/Granit.AI.Chat/Internal/AISuggestionResolver.cs
@@ -1,0 +1,52 @@
+using Granit.AI.Chat.Suggestions;
+
+namespace Granit.AI.Chat.Internal;
+
+/// <summary>
+/// Default <see cref="IAISuggestionResolver"/>. Fans out to every registered
+/// <see cref="IAISuggestionProvider"/> and concatenates their suggestions, keeping the first of
+/// each <see cref="AISuggestedAction.Type"/>. A provider that throws is skipped so one module
+/// cannot break the turn.
+/// </summary>
+internal sealed class AISuggestionResolver(IEnumerable<IAISuggestionProvider> providers) : IAISuggestionResolver
+{
+    public async ValueTask<IReadOnlyList<AISuggestedAction>> ResolveAsync(
+        AISuggestionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        List<AISuggestedAction>? collected = null;
+        HashSet<string>? seenTypes = null;
+
+        foreach (IAISuggestionProvider provider in providers)
+        {
+            IReadOnlyList<AISuggestedAction> suggestions;
+            try
+            {
+                suggestions = await provider.GetSuggestionsAsync(context, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                // A misbehaving suggestion provider must never fail the turn — its answer stands.
+                continue;
+            }
+
+            foreach (AISuggestedAction suggestion in suggestions)
+            {
+                collected ??= [];
+                seenTypes ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (seenTypes.Add(suggestion.Type))
+                {
+                    collected.Add(suggestion);
+                }
+            }
+        }
+
+        return collected ?? [];
+    }
+}

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -3,6 +3,7 @@ using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Mentions;
 using Granit.AI.Chat.Settings;
+using Granit.AI.Chat.Suggestions;
 using Granit.AI.Exceptions;
 using Granit.AI.Options;
 using Granit.AI.Tools;
@@ -25,6 +26,7 @@ internal sealed class ChatService(
     IAIWorkspaceCapabilityResolver capabilityResolver,
     IAIMentionContextResolver mentionContextResolver,
     IAIAttachmentTextResolver attachmentTextResolver,
+    IAISuggestionResolver suggestionResolver,
     ISettingProvider settingProvider,
     IGuidGenerator guidGenerator,
     IOptions<GranitAIOptions> aiOptions) : IChatService
@@ -111,6 +113,12 @@ internal sealed class ChatService(
                 cancellationToken).ConfigureAwait(false);
         }
 
+        // Gather typed, non-executing suggested actions from registered providers under the
+        // caller's ACLs. Ephemeral — surfaced with the answer, never persisted.
+        IReadOnlyList<AISuggestedAction> suggestedActions = await suggestionResolver
+            .ResolveAsync(new AISuggestionContext(request.OwnerId, request.Message), cancellationToken)
+            .ConfigureAwait(false);
+
         return new ChatSendResult
         {
             ConversationId = conversation.Id,
@@ -118,6 +126,7 @@ internal sealed class ChatService(
             MaxIterationsReached = result.MaxIterationsReached,
             InputTokens = result.InputTokens,
             OutputTokens = result.OutputTokens,
+            SuggestedActions = suggestedActions,
         };
     }
 

--- a/src/Granit.AI.Chat/README.md
+++ b/src/Granit.AI.Chat/README.md
@@ -79,6 +79,36 @@ generic settings endpoints) tune the chat per user:
 
 The custom context never overrides the guardrails; it only refines behaviour.
 
+## Suggested actions
+
+The agent can surface typed, **non-executing** call-to-actions (deep links) alongside its answer —
+e.g. "connect a calendar" when none is linked. A module contributes a provider that detects its own
+gaps under the caller's ACLs; the framework gathers them onto the response (a `suggestions` SSE
+frame). v1 never executes a suggestion — it is display data plus a destination only.
+
+```csharp
+services.AddGranitChatSuggestions(s => s.Add<CalendarSuggestionProvider>());
+
+internal sealed class CalendarSuggestionProvider(ICalendarReader calendars, ICurrentUser user) : IAISuggestionProvider
+{
+    public async ValueTask<IReadOnlyList<AISuggestedAction>> GetSuggestionsAsync(
+        AISuggestionContext context, CancellationToken ct = default)
+    {
+        if (await calendars.IsConnectedAsync(ct))
+        {
+            return [];
+        }
+
+        return [new AISuggestedAction
+        {
+            Type = "calendar.connect",
+            Label = "Connect a calendar",
+            DeepLink = "/settings/integrations/calendar",
+        }];
+    }
+}
+```
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.Chat/Suggestions/AISuggestedAction.cs
+++ b/src/Granit.AI.Chat/Suggestions/AISuggestedAction.cs
@@ -1,0 +1,22 @@
+namespace Granit.AI.Chat.Suggestions;
+
+/// <summary>
+/// A typed, non-executing call-to-action the agent surfaces alongside its answer (ADR-067):
+/// a label and a deep link the front renders so the user can act on a detected gap (e.g.
+/// "connect a calendar"). v1 is purely declarative — there is no execution path; the record
+/// carries no handler or callback, only display data and a destination. Execution is phase 2.
+/// </summary>
+public sealed record AISuggestedAction
+{
+    /// <summary>The suggestion type, e.g. <c>calendar.connect</c>. Unique per action within a turn.</summary>
+    public required string Type { get; init; }
+
+    /// <summary>The display label for the call-to-action.</summary>
+    public required string Label { get; init; }
+
+    /// <summary>The deep link the front navigates to (a relative route or URL). Never auto-invoked.</summary>
+    public required string DeepLink { get; init; }
+
+    /// <summary>An optional one-line explanation of why the action is suggested.</summary>
+    public string? Description { get; init; }
+}

--- a/src/Granit.AI.Chat/Suggestions/AISuggestionContext.cs
+++ b/src/Granit.AI.Chat/Suggestions/AISuggestionContext.cs
@@ -1,0 +1,10 @@
+namespace Granit.AI.Chat.Suggestions;
+
+/// <summary>
+/// The context handed to each <see cref="IAISuggestionProvider"/> for a turn: who is asking and
+/// what they said. Providers also run under the caller's scoped services (current user, ACLs), so
+/// most gap detection (e.g. "is a calendar connected?") needs only the ambient identity.
+/// </summary>
+/// <param name="OwnerId">The user the turn belongs to.</param>
+/// <param name="Message">The user's message this turn, for intent-relevant suggestions.</param>
+public sealed record AISuggestionContext(Guid OwnerId, string Message);

--- a/src/Granit.AI.Chat/Suggestions/AISuggestionRegistrationBuilder.cs
+++ b/src/Granit.AI.Chat/Suggestions/AISuggestionRegistrationBuilder.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.AI.Chat.Suggestions;
+
+/// <summary>
+/// Fluent surface for a module to contribute <see cref="IAISuggestionProvider"/> implementations.
+/// Obtained from <c>AddGranitChatSuggestions(builder =&gt; ...)</c>.
+/// </summary>
+public sealed class AISuggestionRegistrationBuilder(IServiceCollection services)
+{
+    /// <summary>The underlying service collection, for advanced registration scenarios.</summary>
+    public IServiceCollection Services { get; } = services;
+
+    /// <summary>
+    /// Registers a suggestion provider, resolved per scope so it can use scoped dependencies
+    /// (DbContext, current user, …) and therefore stay bound to the caller's ACLs.
+    /// </summary>
+    /// <typeparam name="TProvider">The provider implementation.</typeparam>
+    public AISuggestionRegistrationBuilder Add<TProvider>()
+        where TProvider : class, IAISuggestionProvider
+    {
+        Services.AddScoped<IAISuggestionProvider, TProvider>();
+        return this;
+    }
+}

--- a/src/Granit.AI.Chat/Suggestions/IAISuggestionProvider.cs
+++ b/src/Granit.AI.Chat/Suggestions/IAISuggestionProvider.cs
@@ -1,0 +1,22 @@
+namespace Granit.AI.Chat.Suggestions;
+
+/// <summary>
+/// Module-implemented hook that contributes typed <see cref="AISuggestedAction"/> for a turn
+/// (ADR-067). A module registers a provider to surface its own suggestion types — e.g. a calendar
+/// module proposing "connect a calendar" when none is linked. Providers are resolved per scope so
+/// they run under the caller's identity and ACLs, and must return only suggestions the caller may
+/// see and act on.
+/// </summary>
+/// <remarks>
+/// Return an empty list when nothing applies. Suggestions are declarative deep links only — a
+/// provider must never perform the action it suggests (the non-executing guarantee, v1).
+/// </remarks>
+public interface IAISuggestionProvider
+{
+    /// <summary>Returns the suggestions this provider offers for the turn, or an empty list.</summary>
+    /// <param name="context">The turn context (owner and message).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask<IReadOnlyList<AISuggestedAction>> GetSuggestionsAsync(
+        AISuggestionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.AI.Chat/Suggestions/IAISuggestionResolver.cs
+++ b/src/Granit.AI.Chat/Suggestions/IAISuggestionResolver.cs
@@ -1,0 +1,19 @@
+namespace Granit.AI.Chat.Suggestions;
+
+/// <summary>
+/// Gathers the typed suggested actions for a turn from every registered
+/// <see cref="IAISuggestionProvider"/>, under the caller's ACLs, de-duplicated by
+/// <see cref="AISuggestedAction.Type"/>.
+/// </summary>
+public interface IAISuggestionResolver
+{
+    /// <summary>
+    /// Collects the suggestions every provider offers for <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The turn context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The combined, de-duplicated suggestions (possibly empty).</returns>
+    ValueTask<IReadOnlyList<AISuggestedAction>> ResolveAsync(
+        AISuggestionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/Granit.AI.Chat.Tests/AISuggestionResolverTests.cs
+++ b/tests/Granit.AI.Chat.Tests/AISuggestionResolverTests.cs
@@ -1,0 +1,69 @@
+using Granit.AI.Chat.Internal;
+using Granit.AI.Chat.Suggestions;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class AISuggestionResolverTests
+{
+    private static readonly AISuggestionContext Context = new(Guid.NewGuid(), "hello");
+
+    private sealed class StubProvider(params AISuggestedAction[] suggestions) : IAISuggestionProvider
+    {
+        public ValueTask<IReadOnlyList<AISuggestedAction>> GetSuggestionsAsync(
+            AISuggestionContext context, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IReadOnlyList<AISuggestedAction>>(suggestions);
+    }
+
+    private sealed class ThrowingProvider : IAISuggestionProvider
+    {
+        public ValueTask<IReadOnlyList<AISuggestedAction>> GetSuggestionsAsync(
+            AISuggestionContext context, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("boom");
+    }
+
+    private static AISuggestedAction Action(string type) =>
+        new() { Type = type, Label = $"do {type}", DeepLink = $"/{type}" };
+
+    [Fact]
+    public async Task No_providers_resolve_to_empty()
+    {
+        var resolver = new AISuggestionResolver([]);
+
+        (await resolver.ResolveAsync(Context, TestContext.Current.CancellationToken)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Aggregates_suggestions_from_all_providers()
+    {
+        var resolver = new AISuggestionResolver(
+            [new StubProvider(Action("calendar.connect")), new StubProvider(Action("billing.setup"))]);
+
+        IReadOnlyList<AISuggestedAction> result = await resolver.ResolveAsync(Context, TestContext.Current.CancellationToken);
+
+        result.Select(a => a.Type).ShouldBe(["calendar.connect", "billing.setup"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task Deduplicates_by_type_keeping_the_first()
+    {
+        var first = new AISuggestedAction { Type = "calendar.connect", Label = "first", DeepLink = "/a" };
+        var second = new AISuggestedAction { Type = "calendar.connect", Label = "second", DeepLink = "/b" };
+        var resolver = new AISuggestionResolver([new StubProvider(first), new StubProvider(second)]);
+
+        IReadOnlyList<AISuggestedAction> result = await resolver.ResolveAsync(Context, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Label.ShouldBe("first");
+    }
+
+    [Fact]
+    public async Task A_throwing_provider_is_skipped_and_others_survive()
+    {
+        var resolver = new AISuggestionResolver(
+            [new ThrowingProvider(), new StubProvider(Action("calendar.connect"))]);
+
+        IReadOnlyList<AISuggestedAction> result = await resolver.ResolveAsync(Context, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem().Type.ShouldBe("calendar.connect");
+    }
+}

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -4,6 +4,7 @@ using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Internal;
 using Granit.AI.Chat.Mentions;
 using Granit.AI.Chat.Settings;
+using Granit.AI.Chat.Suggestions;
 using Granit.AI.Options;
 using Granit.AI.Tools;
 using Granit.AI.Workspaces;
@@ -26,6 +27,7 @@ public sealed class ChatServiceTests
     private readonly IAIWorkspaceCapabilityResolver _capabilityResolver = Substitute.For<IAIWorkspaceCapabilityResolver>();
     private readonly IAIMentionContextResolver _mentionContextResolver = Substitute.For<IAIMentionContextResolver>();
     private readonly IAIAttachmentTextResolver _attachmentTextResolver = Substitute.For<IAIAttachmentTextResolver>();
+    private readonly IAISuggestionResolver _suggestionResolver = Substitute.For<IAISuggestionResolver>();
     private readonly ISettingProvider _settingProvider = Substitute.For<ISettingProvider>();
     private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
 
@@ -54,10 +56,12 @@ public sealed class ChatServiceTests
             .Returns((string?)null);
         _settingProvider.GetOrNullAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
+        _suggestionResolver.ResolveAsync(Arg.Any<AISuggestionContext>(), Arg.Any<CancellationToken>())
+            .Returns([]);
 
         return new ChatService(_store, _orchestrator, _workspaceProvider, _capabilityResolver,
-            _mentionContextResolver, _attachmentTextResolver, _settingProvider, _guidGenerator,
-            MsOptions.Create(new GranitAIOptions { DefaultWorkspace = "default" }));
+            _mentionContextResolver, _attachmentTextResolver, _suggestionResolver, _settingProvider,
+            _guidGenerator, MsOptions.Create(new GranitAIOptions { DefaultWorkspace = "default" }));
     }
 
     private static ChatSendRequest Request(
@@ -227,6 +231,20 @@ public sealed class ChatServiceTests
 
         await Should.ThrowAsync<ConversationNotFoundException>(
             () => service.SendAsync(Request(conversationId), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Suggested_actions_are_gathered_and_returned()
+    {
+        ChatService service = CreateService();
+        _suggestionResolver.ResolveAsync(Arg.Any<AISuggestionContext>(), Arg.Any<CancellationToken>())
+            .Returns([new AISuggestedAction { Type = "calendar.connect", Label = "Connect", DeepLink = "/settings/calendar" }]);
+
+        ChatSendResult result = await service.SendAsync(Request(), TestContext.Current.CancellationToken);
+
+        AISuggestedAction action = result.SuggestedActions.ShouldHaveSingleItem();
+        action.Type.ShouldBe("calendar.connect");
+        action.DeepLink.ShouldBe("/settings/calendar");
     }
 
     [Fact]


### PR DESCRIPTION
## Story

Closes #2642 — `As an Authenticated User, I want the agent to propose configuration/setup actions as
non-executing suggestions, so I can act on gaps (e.g. connect a calendar) without the agent doing it
for me.`

## What

Adds the suggested-action seam to `Granit.AI.Chat` (ADR-067). Modules contribute typed CTAs (deep
links) that the front renders; the agent never executes them (v1).

- **`AISuggestedAction`** — declarative contract: `Type`, `Label`, `DeepLink`, `Description`. No
  handler/callback and no execution endpoint — the **non-executing guarantee** is structural, not a
  runtime check.
- **`IAISuggestionProvider`** — module hook, resolved **scoped** so it runs under the caller's ACLs;
  returns `[]` when nothing applies. `AISuggestionContext` carries the owner + the turn's message.
- **`IAISuggestionResolver` / `AISuggestionResolver`** — fans out to every provider, concatenates,
  **de-duplicates by `Type`**, and **skips a throwing provider** so one module can't break the turn.
- **Opt-in** `AddGranitChatSuggestions(s => s.Add<TProvider>())`; the core resolver is always
  registered (resolves to none until a module contributes).
- **Wiring** — `ChatService` gathers suggestions after the answer and returns them on
  `ChatSendResult.SuggestedActions`; `ChatSendEndpoints` emits a `suggestions` SSE frame
  (`SuggestedActionResponse`). Ephemeral — never persisted.

## Acceptance criteria

- ✅ When a provider detects a gap, the response includes a typed suggested action (label + deep
  link) that does not execute anything.
- ✅ A module that contributes a suggestion type can surface it when its condition holds.

## Tests

- `AISuggestionResolverTests` (aggregation, dedupe-by-type, throwing-provider isolation, empty)
- `ChatServiceTests` (suggestions gathered and returned)
- Architecture suite green (225); format + markdownlint clean; no lockfile change.

## Related

- Epic #2626, Feature #2628, ADR-067