### PR TITLE
feat(ai): agent clarification questions with clickable choices (A/B/C + Other) (#2650)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3243,7 +3243,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 8,
+      "line": 9,
       "members": []
     },
     {
@@ -3252,7 +3252,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 36,
+      "line": 37,
       "members": [
         {
           "name": "ConversationId",
@@ -3261,6 +3261,24 @@
           "returnType": "required Guid"
         }
       ]
+    },
+    {
+      "name": "AIClarificationOption",
+      "fqn": "Granit.AI.Chat.Clarification.AIClarificationOption",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Clarification/AIClarificationRequest.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "AIClarificationRequest",
+      "fqn": "Granit.AI.Chat.Clarification.AIClarificationRequest",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Clarification/AIClarificationRequest.cs",
+      "line": 10,
+      "members": []
     },
     {
       "name": "Conversation",
@@ -3321,6 +3339,24 @@
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ChatWorkspacesResponse.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "ClarificationOptionResponse",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.ClarificationOptionResponse",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
+      "line": 52,
+      "members": []
+    },
+    {
+      "name": "ClarificationResponse",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.ClarificationResponse",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
+      "line": 47,
       "members": []
     },
     {
@@ -3427,7 +3463,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 47,
+      "line": 59,
       "members": []
     },
     {
@@ -3642,7 +3678,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/GranitAIChatModule.cs",
-      "line": 26,
+      "line": 27,
       "members": [
         {
           "name": "ConfigureServices",
@@ -3658,7 +3694,7 @@
       "kind": "interface",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 64,
+      "line": 71,
       "members": [
         {
           "name": "SendAsync",
@@ -5503,6 +5539,15 @@
       "members": []
     },
     {
+      "name": "AIToolInterrupt",
+      "fqn": "Granit.AI.Tools.AIToolInterrupt",
+      "kind": "record",
+      "project": "Granit.AI.Tools",
+      "file": "src/Granit.AI.Tools/AIToolInterrupt.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "AIToolInvocationContext",
       "fqn": "Granit.AI.Tools.AIToolInvocationContext",
       "kind": "record",
@@ -5548,12 +5593,18 @@
           "name": "Success",
           "kind": "method",
           "signature": "Success(string content)",
-          "returnType": "required string Content { get; init; } public bool IsError { get; init; } public AIToolResult"
+          "returnType": "required string Content { get; init; } public bool IsError { get; init; } public AIToolInterrupt? Interrupt { get; init; } public AIToolResult"
         },
         {
           "name": "Error",
           "kind": "method",
           "signature": "Error(string message)",
+          "returnType": "AIToolResult"
+        },
+        {
+          "name": "Halt",
+          "kind": "method",
+          "signature": "Halt(string kind, string payload, string content)",
           "returnType": "AIToolResult"
         }
       ]

--- a/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
@@ -37,7 +37,19 @@ public sealed record ChatStreamEvent(
     Guid? ConversationId = null,
     int? InputTokens = null,
     int? OutputTokens = null,
-    IReadOnlyList<SuggestedActionResponse>? SuggestedActions = null);
+    IReadOnlyList<SuggestedActionResponse>? SuggestedActions = null,
+    ClarificationResponse? Clarification = null);
+
+/// <summary>A typed clarification the front renders as clickable choices; the turn blocks until answered.</summary>
+/// <param name="Question">The disambiguating question.</param>
+/// <param name="Options">The discrete choices.</param>
+/// <param name="AllowOther">Whether to offer an "Other (describe)" free-text affordance.</param>
+public sealed record ClarificationResponse(string Question, IReadOnlyList<ClarificationOptionResponse> Options, bool AllowOther);
+
+/// <summary>One clickable choice of a <see cref="ClarificationResponse"/>.</summary>
+/// <param name="Label">The display label.</param>
+/// <param name="Value">The value sent back when chosen (falls back to <paramref name="Label"/> when null).</param>
+public sealed record ClarificationOptionResponse(string Label, string? Value);
 
 /// <summary>A typed, non-executing suggested action (a deep link the front renders).</summary>
 /// <param name="Type">The suggestion type, e.g. <c>calendar.connect</c>.</param>

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -106,6 +106,16 @@ internal static class ChatSendEndpoints
                 SuggestedActions: [.. result.SuggestedActions.Select(a =>
                     new SuggestedActionResponse(a.Type, a.Label, a.DeepLink, a.Description))]);
         }
+
+        if (result.Clarification is { } clarification)
+        {
+            yield return new ChatStreamEvent(
+                "clarification",
+                Clarification: new ClarificationResponse(
+                    clarification.Question,
+                    [.. clarification.Options.Select(o => new ClarificationOptionResponse(o.Label, o.Value))],
+                    clarification.AllowOther));
+        }
     }
 
     /// <summary>Splits text into word-sized chunks (trailing space preserved) for token-like streaming.</summary>

--- a/src/Granit.AI.Chat/Clarification/AIClarificationRequest.cs
+++ b/src/Granit.AI.Chat/Clarification/AIClarificationRequest.cs
@@ -1,0 +1,35 @@
+namespace Granit.AI.Chat.Clarification;
+
+/// <summary>
+/// A typed clarification the agent surfaces when it needs disambiguation (ADR-067): a
+/// <see cref="Question"/> plus discrete <see cref="Options"/> the front renders as clickable
+/// choices, optionally with an "Other (describe)" free-text affordance. Unlike a suggested action
+/// (#2642), a clarification <strong>blocks the turn</strong> — the loop resumes only when the user
+/// answers (their choice becomes the next user turn). Single-select in v1.
+/// </summary>
+public sealed record AIClarificationRequest
+{
+    /// <summary>The interrupt kind that carries a clarification on the orchestration result.</summary>
+    public const string InterruptKind = "clarification";
+
+    /// <summary>The disambiguating question to show the user.</summary>
+    public required string Question { get; init; }
+
+    /// <summary>The discrete choices, each rendered as a button.</summary>
+    public required IReadOnlyList<AIClarificationOption> Options { get; init; }
+
+    /// <summary>Whether to offer an "Other (describe)" free-text affordance alongside the options.</summary>
+    public bool AllowOther { get; init; }
+}
+
+/// <summary>One clickable choice of an <see cref="AIClarificationRequest"/>.</summary>
+public sealed record AIClarificationOption
+{
+    /// <summary>The display label for the choice.</summary>
+    public required string Label { get; init; }
+
+    /// <summary>
+    /// The value sent back as the next turn when chosen. Falls back to <see cref="Label"/> when omitted.
+    /// </summary>
+    public string? Value { get; init; }
+}

--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -6,6 +6,7 @@ using Granit.Guids;
 using Granit.Modularity;
 using Granit.Settings;
 using Granit.TextExtraction;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.AI.Chat;
@@ -45,5 +46,9 @@ public sealed class GranitAIChatModule : GranitModule
         // The suggestion resolver is always present so a turn can carry suggested actions even
         // before any module contributes a provider (it then resolves to none).
         AIChatSuggestionsServiceCollectionExtensions.AddCoreServices(context.Services);
+
+        // The clarification tool is core chat behaviour — always available to the agent so it can
+        // ask clickable disambiguating questions (it halts the loop via the interrupt primitive).
+        context.Services.AddScoped<IAITool, RequestClarificationTool>();
     }
 }

--- a/src/Granit.AI.Chat/IChatService.cs
+++ b/src/Granit.AI.Chat/IChatService.cs
@@ -1,4 +1,5 @@
 using Granit.AI.Chat.Attachments;
+using Granit.AI.Chat.Clarification;
 using Granit.AI.Chat.Mentions;
 using Granit.AI.Chat.Suggestions;
 
@@ -55,6 +56,12 @@ public sealed record ChatSendResult
     /// renders). Empty when no provider offered any. See <see cref="AISuggestedAction"/>.
     /// </summary>
     public IReadOnlyList<AISuggestedAction> SuggestedActions { get; init; } = [];
+
+    /// <summary>
+    /// Set when the agent asked a clarifying question instead of answering (the turn is blocked
+    /// until the user picks an option). <see cref="Content"/> then carries the question text.
+    /// </summary>
+    public AIClarificationRequest? Clarification { get; init; }
 }
 
 /// <summary>

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Granit.AI.Chat.Attachments;
+using Granit.AI.Chat.Clarification;
 using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Mentions;
@@ -95,10 +97,16 @@ internal sealed class ChatService(
             },
             cancellationToken).ConfigureAwait(false);
 
+        // A clarification halts the loop: the assistant turn records the question and the structured
+        // request is surfaced so the front can render clickable options. The user's choice arrives
+        // as the next turn and resumes the loop normally.
+        AIClarificationRequest? clarification = TryReadClarification(result.Interrupt);
+        string assistantContent = clarification?.Question ?? result.Content;
+
         if (isNew)
         {
             conversation.AddMessage(guidGenerator.Create(), MessageRole.User, request.Message);
-            conversation.AddMessage(guidGenerator.Create(), MessageRole.Assistant, result.Content);
+            conversation.AddMessage(guidGenerator.Create(), MessageRole.Assistant, assistantContent);
             await conversationStore.CreateAsync(conversation, cancellationToken).ConfigureAwait(false);
         }
         else
@@ -108,7 +116,7 @@ internal sealed class ChatService(
                 request.OwnerId,
                 [
                     Message.Create(guidGenerator.Create(), conversation.Id, MessageRole.User, request.Message),
-                    Message.Create(guidGenerator.Create(), conversation.Id, MessageRole.Assistant, result.Content),
+                    Message.Create(guidGenerator.Create(), conversation.Id, MessageRole.Assistant, assistantContent),
                 ],
                 cancellationToken).ConfigureAwait(false);
         }
@@ -122,12 +130,34 @@ internal sealed class ChatService(
         return new ChatSendResult
         {
             ConversationId = conversation.Id,
-            Content = result.Content,
+            Content = assistantContent,
             MaxIterationsReached = result.MaxIterationsReached,
             InputTokens = result.InputTokens,
             OutputTokens = result.OutputTokens,
             SuggestedActions = suggestedActions,
+            Clarification = clarification,
         };
+    }
+
+    /// <summary>
+    /// Parses a clarification from a loop interrupt, or <see langword="null"/> when the interrupt is
+    /// absent, of another kind, or malformed (a malformed payload must not fail the turn).
+    /// </summary>
+    private static AIClarificationRequest? TryReadClarification(AIToolInterrupt? interrupt)
+    {
+        if (interrupt is null || interrupt.Kind != AIClarificationRequest.InterruptKind)
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<AIClarificationRequest>(interrupt.Payload, JsonSerializerOptions.Web);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Granit.AI.Chat/Internal/RequestClarificationTool.cs
+++ b/src/Granit.AI.Chat/Internal/RequestClarificationTool.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Granit.AI.Chat.Clarification;
+using Granit.AI.Tools;
+
+namespace Granit.AI.Chat.Internal;
+
+/// <summary>
+/// The <c>request_clarification</c> chat tool (ADR-067). When the agent is ambiguous about the
+/// user's intent it calls this tool with a question and discrete options; the tool halts the
+/// agentic loop and surfaces a typed <see cref="AIClarificationRequest"/> to the caller instead of
+/// answering. The front renders the options as buttons; the user's choice becomes the next turn.
+/// Always available to chat agents (registered by <c>GranitAIChatModule</c>).
+/// </summary>
+internal sealed class RequestClarificationTool : IAITool, IAIToolInstructions
+{
+    private static readonly JsonElement Schema = BuildSchema();
+
+    private static readonly JsonSerializerOptions PayloadOptions = JsonSerializerOptions.Web;
+
+    public string Name => "request_clarification";
+
+    public string Description =>
+        "Ask the user a clarifying question with discrete clickable options when their intent is "
+        + "ambiguous. Halts until the user answers — do not also answer in prose.";
+
+    public string Instructions =>
+        "When the request is ambiguous, call 'request_clarification' with a concise 'question' and "
+        + "2-5 'options' (each a short 'label'), instead of guessing. Set 'allow_other' when a "
+        + "free-text answer should also be offered. Do not call it for trivial or rhetorical asks.";
+
+    public JsonElement ParameterSchema => Schema;
+
+    public ValueTask<AIToolResult> InvokeAsync(
+        AIToolInvocationContext context, CancellationToken cancellationToken = default)
+    {
+        string? question = ReadString(context.Arguments, "question");
+        if (string.IsNullOrWhiteSpace(question))
+        {
+            return ValueTask.FromResult(AIToolResult.Error("The 'question' argument is required."));
+        }
+
+        List<AIClarificationOption> options = ReadOptions(context.Arguments);
+        if (options.Count == 0)
+        {
+            return ValueTask.FromResult(AIToolResult.Error("At least one 'options' entry with a 'label' is required."));
+        }
+
+        var clarification = new AIClarificationRequest
+        {
+            Question = question,
+            Options = options,
+            AllowOther = ReadBool(context.Arguments, "allow_other"),
+        };
+
+        string payload = JsonSerializer.Serialize(clarification, PayloadOptions);
+        return ValueTask.FromResult(AIToolResult.Halt(
+            AIClarificationRequest.InterruptKind, payload, "Clarification requested; awaiting the user's choice."));
+    }
+
+    private static List<AIClarificationOption> ReadOptions(JsonElement arguments)
+    {
+        List<AIClarificationOption> options = [];
+        if (arguments.ValueKind == JsonValueKind.Object
+            && arguments.TryGetProperty("options", out JsonElement array)
+            && array.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in array.EnumerateArray())
+            {
+                string? label = ReadString(item, "label");
+                if (!string.IsNullOrWhiteSpace(label))
+                {
+                    options.Add(new AIClarificationOption { Label = label, Value = ReadString(item, "value") });
+                }
+            }
+        }
+
+        return options;
+    }
+
+    private static JsonElement BuildSchema()
+    {
+        JsonObject schema = new()
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["question"] = new JsonObject { ["type"] = "string", ["description"] = "The disambiguating question." },
+                ["options"] = new JsonObject
+                {
+                    ["type"] = "array",
+                    ["description"] = "The discrete choices (2-5 recommended).",
+                    ["items"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["properties"] = new JsonObject
+                        {
+                            ["label"] = new JsonObject { ["type"] = "string", ["description"] = "Display label." },
+                            ["value"] = new JsonObject { ["type"] = "string", ["description"] = "Optional value sent back when chosen." },
+                        },
+                        ["required"] = new JsonArray("label"),
+                        ["additionalProperties"] = false,
+                    },
+                },
+                ["allow_other"] = new JsonObject
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Offer an 'Other (describe)' free-text affordance.",
+                },
+            },
+            ["required"] = new JsonArray("question", "options"),
+            ["additionalProperties"] = false,
+        };
+
+        return JsonSerializer.SerializeToElement(schema);
+    }
+
+    private static string? ReadString(JsonElement element, string name) =>
+        element.ValueKind == JsonValueKind.Object
+        && element.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static bool ReadBool(JsonElement element, string name) =>
+        element.ValueKind == JsonValueKind.Object
+        && element.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+        && value.GetBoolean();
+}

--- a/src/Granit.AI.Chat/README.md
+++ b/src/Granit.AI.Chat/README.md
@@ -109,6 +109,18 @@ internal sealed class CalendarSuggestionProvider(ICalendarReader calendars, ICur
 }
 ```
 
+## Clarification questions
+
+When the agent is ambiguous it can ask a clarifying question with clickable choices instead of
+guessing. It calls the built-in `request_clarification` tool, which **halts the agentic loop** (via
+the `Granit.AI.Tools` interrupt primitive) and surfaces a typed `AIClarificationRequest`
+(question + options + optional "Other") on `ChatSendResult.Clarification` — emitted as a
+`clarification` SSE frame. The user's choice arrives as the next turn and resumes the loop; the
+question and the answer are both persisted in history. Single-select in v1.
+
+Unlike a [suggested action](#suggested-actions) (a non-executing CTA), a clarification **blocks the
+turn until answered**. The tool is always available to chat agents — no opt-in needed.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.Tools/AIOrchestrationResult.cs
+++ b/src/Granit.AI.Tools/AIOrchestrationResult.cs
@@ -37,4 +37,11 @@ public sealed record AIOrchestrationResult
 
     /// <summary>Wall-clock duration of the whole run.</summary>
     public TimeSpan Duration { get; init; }
+
+    /// <summary>
+    /// Set when a tool halted the loop (e.g. a clarification request). When non-null,
+    /// <see cref="Content"/> is empty and the caller should act on the interrupt rather than
+    /// treat the run as a settled answer.
+    /// </summary>
+    public AIToolInterrupt? Interrupt { get; init; }
 }

--- a/src/Granit.AI.Tools/AIToolInterrupt.cs
+++ b/src/Granit.AI.Tools/AIToolInterrupt.cs
@@ -1,0 +1,13 @@
+namespace Granit.AI.Tools;
+
+/// <summary>
+/// A signal from a tool that the agentic loop must stop and hand a structured payload back to the
+/// caller instead of feeding the tool result to the model and continuing (ADR-067). The
+/// orchestrator is agnostic to the <see cref="Kind"/> — it surfaces the interrupt on
+/// <see cref="AIOrchestrationResult.Interrupt"/> and the caller decides what to do. The first user
+/// is the chat clarification flow (<c>request_clarification</c>), which blocks the turn until the
+/// user answers.
+/// </summary>
+/// <param name="Kind">A discriminator for the interrupt, e.g. <c>clarification</c>.</param>
+/// <param name="Payload">The interrupt's structured payload (typically JSON) for the caller to parse.</param>
+public sealed record AIToolInterrupt(string Kind, string Payload);

--- a/src/Granit.AI.Tools/AIToolResult.cs
+++ b/src/Granit.AI.Tools/AIToolResult.cs
@@ -19,9 +19,23 @@ public sealed record AIToolResult
     /// </summary>
     public bool IsError { get; init; }
 
+    /// <summary>
+    /// When set, the loop stops after this call and the interrupt is surfaced on
+    /// <see cref="AIOrchestrationResult.Interrupt"/> instead of being fed back to the model.
+    /// </summary>
+    public AIToolInterrupt? Interrupt { get; init; }
+
     /// <summary>Creates a successful result carrying <paramref name="content"/>.</summary>
     public static AIToolResult Success(string content) => new() { Content = content };
 
     /// <summary>Creates an error result carrying a model-facing <paramref name="message"/>.</summary>
     public static AIToolResult Error(string message) => new() { Content = message, IsError = true };
+
+    /// <summary>
+    /// Creates a result that halts the loop, surfacing a structured <paramref name="payload"/> of
+    /// the given <paramref name="kind"/> to the caller. <paramref name="content"/> is the
+    /// model-facing transcript note for the (now last) tool call.
+    /// </summary>
+    public static AIToolResult Halt(string kind, string payload, string content) =>
+        new() { Content = content, Interrupt = new AIToolInterrupt(kind, payload) };
 }

--- a/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
+++ b/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
@@ -93,6 +93,7 @@ internal sealed partial class AIToolOrchestrator(
         int iteration = 0;
         bool maxReached = false;
         string finalText = string.Empty;
+        AIToolInterrupt? interrupt = null;
 
         while (true)
         {
@@ -132,7 +133,7 @@ internal sealed partial class AIToolOrchestrator(
             List<AIContent> results = new(calls.Count);
             foreach (FunctionCallContent call in calls)
             {
-                (string content, bool succeeded, bool truncated) =
+                (string content, bool succeeded, bool truncated, AIToolInterrupt? callInterrupt) =
                     await ExecuteToolAsync(call, toolMap, options, cancellationToken).ConfigureAwait(false);
 
                 results.Add(new FunctionResultContent(call.CallId, content));
@@ -150,9 +151,19 @@ internal sealed partial class AIToolOrchestrator(
                 {
                     metrics.RecordTruncation(tenantId, call.Name);
                 }
+
+                interrupt ??= callInterrupt;
             }
 
             transcript.Add(new ChatMessage(ChatRole.Tool, results));
+
+            // A tool asked to halt the loop (e.g. a clarification request) — surface it and stop
+            // rather than feeding the result back to the model.
+            if (interrupt is not null)
+            {
+                LogInterrupted(interrupt.Kind);
+                break;
+            }
         }
 
         TimeSpan duration = timeProvider.GetElapsedTime(startTimestamp);
@@ -186,10 +197,11 @@ internal sealed partial class AIToolOrchestrator(
             InputTokens = anyUsage ? (int)totalInput : null,
             OutputTokens = anyUsage ? (int)totalOutput : null,
             Duration = duration,
+            Interrupt = interrupt,
         };
     }
 
-    private async Task<(string Content, bool Succeeded, bool Truncated)> ExecuteToolAsync(
+    private async Task<(string Content, bool Succeeded, bool Truncated, AIToolInterrupt? Interrupt)> ExecuteToolAsync(
         FunctionCallContent call,
         Dictionary<string, IAITool> toolMap,
         GranitAIToolsOrchestrationOptions options,
@@ -198,7 +210,7 @@ internal sealed partial class AIToolOrchestrator(
         if (!toolMap.TryGetValue(call.Name, out IAITool? tool))
         {
             LogUnknownTool(call.Name);
-            return ($"Error: no tool named '{call.Name}' is available.", false, false);
+            return ($"Error: no tool named '{call.Name}' is available.", false, false, null);
         }
 
         JsonElement arguments = SerializeArguments(call.Arguments);
@@ -217,12 +229,12 @@ internal sealed partial class AIToolOrchestrator(
         catch (Exception ex)
         {
             LogToolFailed(ex, call.Name);
-            return ($"Error: tool '{call.Name}' failed and could not complete the request.", false, false);
+            return ($"Error: tool '{call.Name}' failed and could not complete the request.", false, false, null);
         }
 
         (string content, bool truncated) = Guard(result.Content, options.MaxToolResultCharacters);
         LogToolInvoked(call.Name, result.IsError, truncated);
-        return (content, !result.IsError, truncated);
+        return (content, !result.IsError, truncated, result.Interrupt);
     }
 
     private static JsonElement SerializeArguments(IDictionary<string, object?>? arguments) =>
@@ -252,6 +264,9 @@ internal sealed partial class AIToolOrchestrator(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "AI orchestration loop hit the iteration cap of {MaxIterations} before settling.")]
     private partial void LogMaxIterationsReached(int maxIterations);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "AI orchestration loop interrupted by a '{Kind}' tool; awaiting caller.")]
+    private partial void LogInterrupted(string kind);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "AI orchestration run on workspace '{Workspace}' completed in {Iterations} iteration(s) with {ToolCalls} tool call(s) (maxReached={MaxReached}).")]
     private partial void LogRunCompleted(string workspace, int iterations, int toolCalls, bool maxReached);

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Granit.AI.Chat.Attachments;
+using Granit.AI.Chat.Clarification;
 using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Internal;
@@ -231,6 +233,41 @@ public sealed class ChatServiceTests
 
         await Should.ThrowAsync<ConversationNotFoundException>(
             () => service.SendAsync(Request(conversationId), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Clarification_interrupt_is_surfaced_and_the_question_is_persisted()
+    {
+        ChatService service = CreateService();
+        var clarification = new AIClarificationRequest
+        {
+            Question = "Which environment?",
+            Options = [new AIClarificationOption { Label = "Prod" }, new AIClarificationOption { Label = "Test" }],
+            AllowOther = true,
+        };
+        string payload = JsonSerializer.Serialize(clarification, JsonSerializerOptions.Web);
+        _orchestrator.RunAsync(Arg.Any<AIOrchestrationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AIOrchestrationResult
+            {
+                Content = string.Empty,
+                Messages = [],
+                Iterations = 1,
+                MaxIterationsReached = false,
+                ToolInvocations = [],
+                Interrupt = new AIToolInterrupt(AIClarificationRequest.InterruptKind, payload),
+            });
+
+        ChatSendResult result = await service.SendAsync(Request(message: "deploy"), TestContext.Current.CancellationToken);
+
+        result.Clarification.ShouldNotBeNull();
+        result.Clarification.Question.ShouldBe("Which environment?");
+        result.Clarification.Options.Count.ShouldBe(2);
+        result.Clarification.AllowOther.ShouldBeTrue();
+        // The question text becomes the assistant content and is persisted in history.
+        result.Content.ShouldBe("Which environment?");
+        await _store.Received(1).CreateAsync(
+            Arg.Is<Conversation>(c => c.Messages.Count == 2 && c.Messages[1].Content == "Which environment?"),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Granit.AI.Chat.Tests/RequestClarificationToolTests.cs
+++ b/tests/Granit.AI.Chat.Tests/RequestClarificationToolTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using Granit.AI.Chat.Clarification;
+using Granit.AI.Chat.Internal;
+using Granit.AI.Tools;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class RequestClarificationToolTests
+{
+    private static AIToolInvocationContext Args(string json) =>
+        new() { Arguments = JsonDocument.Parse(json).RootElement.Clone() };
+
+    private static async Task<AIToolResult> InvokeAsync(string json) =>
+        await new RequestClarificationTool().InvokeAsync(Args(json), TestContext.Current.CancellationToken);
+
+    [Fact]
+    public void Tool_is_named_request_clarification()
+    {
+        new RequestClarificationTool().Name.ShouldBe("request_clarification");
+    }
+
+    [Fact]
+    public async Task Valid_call_halts_the_loop_with_a_clarification_payload()
+    {
+        AIToolResult result = await InvokeAsync(
+            """{"question":"Which environment?","options":[{"label":"Prod","value":"prod"},{"label":"Test"}],"allow_other":true}""");
+
+        result.Interrupt.ShouldNotBeNull();
+        result.Interrupt.Kind.ShouldBe(AIClarificationRequest.InterruptKind);
+
+        AIClarificationRequest? clarification =
+            JsonSerializer.Deserialize<AIClarificationRequest>(result.Interrupt.Payload, JsonSerializerOptions.Web);
+        clarification.ShouldNotBeNull();
+        clarification.Question.ShouldBe("Which environment?");
+        clarification.AllowOther.ShouldBeTrue();
+        clarification.Options.Count.ShouldBe(2);
+        clarification.Options[0].Label.ShouldBe("Prod");
+        clarification.Options[0].Value.ShouldBe("prod");
+        clarification.Options[1].Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Missing_question_is_an_error_not_an_interrupt()
+    {
+        AIToolResult result = await InvokeAsync("""{"options":[{"label":"A"}]}""");
+
+        result.IsError.ShouldBeTrue();
+        result.Interrupt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task No_options_is_an_error_not_an_interrupt()
+    {
+        AIToolResult result = await InvokeAsync("""{"question":"Pick one","options":[]}""");
+
+        result.IsError.ShouldBeTrue();
+        result.Interrupt.ShouldBeNull();
+    }
+}

--- a/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
+++ b/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
@@ -112,6 +112,28 @@ public sealed class AIToolOrchestratorTests
     }
 
     [Fact]
+    public async Task A_halting_tool_stops_the_loop_and_surfaces_the_interrupt()
+    {
+        FakeAITool ask = new(name: "ask", result: "asked", interrupt: new AIToolInterrupt("clarification", "PAYLOAD"));
+        ScriptedChatClient client = new(
+            ToolCall("c1", "ask"),
+            FinalText("should never be reached"));
+        Harness harness = CreateHarness(client, [ask]);
+
+        AIOrchestrationResult result = await harness.Orchestrator.RunAsync(
+            UserSays("ambiguous"), TestContext.Current.CancellationToken);
+
+        result.Interrupt.ShouldNotBeNull();
+        result.Interrupt.Kind.ShouldBe("clarification");
+        result.Interrupt.Payload.ShouldBe("PAYLOAD");
+        result.Content.ShouldBeEmpty();
+        result.Iterations.ShouldBe(1);
+        // The loop halted: the model was only called once (no feed-back round-trip).
+        harness.ChatClient.Calls.Count.ShouldBe(1);
+        result.ToolInvocations.ShouldHaveSingleItem();
+    }
+
+    [Fact]
     public async Task Feeds_the_tool_result_back_into_the_next_model_call()
     {
         FakeAITool echo = new(name: "echo", result: "tool-said-hi");

--- a/tests/Granit.AI.Tools.Tests/FakeAITool.cs
+++ b/tests/Granit.AI.Tools.Tests/FakeAITool.cs
@@ -9,7 +9,8 @@ namespace Granit.AI.Tools.Tests;
 internal sealed class FakeAITool(
     string name = "fake_tool",
     string description = "A fake tool.",
-    string result = "ok") : IAITool
+    string result = "ok",
+    AIToolInterrupt? interrupt = null) : IAITool
 {
     public string Name { get; } = name;
 
@@ -25,6 +26,8 @@ internal sealed class FakeAITool(
         CancellationToken cancellationToken = default)
     {
         LastArgumentsJson = context.Arguments.GetRawText();
-        return ValueTask.FromResult(AIToolResult.Success(result));
+        return ValueTask.FromResult(interrupt is null
+            ? AIToolResult.Success(result)
+            : new AIToolResult { Content = result, Interrupt = interrupt });
     }
 }


### PR DESCRIPTION
## Story

Closes #2650 — `As an Authenticated User, I want the agent to ask clarifying questions with
clickable choices, so I can answer in one click.`

## What

When the agent is ambiguous it asks a typed clarifying question (with discrete clickable options)
**instead of guessing**, blocking the turn until the user answers (ADR-067).

### Generic loop-interrupt primitive (`Granit.AI.Tools`)

- `AIToolResult.Halt(kind, payload, content)` + `AIToolInterrupt`. The orchestrator stops the loop
  when a tool halts and surfaces it on `AIOrchestrationResult.Interrupt` instead of feeding the
  result back to the model. Reusable; clarification is the first consumer.

### Clarification (`Granit.AI.Chat`)

- **`AIClarificationRequest`** — question + options (`label` + optional `value`) + `AllowOther`. Single-select v1.
- **`request_clarification`** tool — always available to chat agents; builds the clarification and
  halts the loop. `ChatService` reads the interrupt → `ChatSendResult.Clarification` and records the
  **question as the assistant turn**. The user's choice arrives as the **next turn** and resumes the
  loop — no special resume path. A malformed payload never fails the turn.
- **Endpoints** emit a `clarification` SSE frame (`ClarificationResponse`).

## Acceptance criteria

- ✅ Ambiguous intent → response carries a typed clarification (question + options + "Other").
- ✅ The clicked/typed choice is sent as the next turn and the loop resumes with it (history retained).
- ✅ The question and the answer are both persisted in conversation history.

## Tests

- `AIToolOrchestratorTests` — a halting tool stops the loop and surfaces the interrupt (no feed-back round-trip).
- `RequestClarificationToolTests` — valid call halts with payload; missing-question / no-options → error.
- `ChatServiceTests` — clarification surfaced + question persisted as the assistant turn.
- Architecture suite green (225); format + markdownlint clean; no lockfile change.

## Related

- Epic #2626, Feature #2628, ADR-067 — **completes Feature #2628 Granit.AI.Chat.**