### PR TITLE
feat(validation): add HttpsUrl() rule for HTTPS-only URLs

### DIFF
--- a/src/Granit.Validation/Extensions/NetworkValidatorExtensions.cs
+++ b/src/Granit.Validation/Extensions/NetworkValidatorExtensions.cs
@@ -52,6 +52,20 @@ public static partial class NetworkValidatorExtensions
             .WithErrorCodeAndMessage("Validation:Format:Url");
 
     /// <summary>
+    /// Validates an absolute URL with a required <c>https</c> scheme.
+    /// </summary>
+    /// <remarks>
+    /// Stricter than <see cref="Url{T}"/>, which also accepts <c>http</c>. Use this for
+    /// security-sensitive URLs that must never be transmitted in cleartext — OAuth/OIDC
+    /// redirect targets, webhook callbacks, payment-provider return URLs, etc. Rejects
+    /// relative URLs, non-HTTPS schemes (<c>http</c>, <c>javascript</c>, <c>ftp</c>, …) and null.
+    /// </remarks>
+    public static IRuleBuilderOptions<T, string?> HttpsUrl<T>(this IRuleBuilder<T, string?> ruleBuilder) =>
+        ruleBuilder
+            .Must(IsValidHttpsUrl)
+            .WithErrorCodeAndMessage("Validation:Format:UrlHttps");
+
+    /// <summary>
     /// Validates an IPv4 address per RFC 791.
     /// </summary>
     /// <remarks>
@@ -97,6 +111,11 @@ public static partial class NetworkValidatorExtensions
 
     internal static bool IsValidUrl(string? value) =>
         value is not null && UrlRegex().IsMatch(value.Trim());
+
+    internal static bool IsValidHttpsUrl(string? value) =>
+        value is not null
+        && Uri.TryCreate(value.Trim(), UriKind.Absolute, out Uri? uri)
+        && uri.Scheme == Uri.UriSchemeHttps;
 
     internal static bool IsValidIpv4Address(string? value) =>
         value is not null && Ipv4Regex().IsMatch(value.Trim());

--- a/src/Granit.Validation/ServerValidation/CoreServerValidatorContributor.cs
+++ b/src/Granit.Validation/ServerValidation/CoreServerValidatorContributor.cs
@@ -35,6 +35,7 @@ internal sealed class CoreServerValidatorContributor : IServerValidatorContribut
 
         // Network identifiers (regex + algorithm)
         yield return new DelegatingServerValidator("Validation:Format:Url", NetworkValidatorExtensions.IsValidUrl);
+        yield return new DelegatingServerValidator("Validation:Format:UrlHttps", NetworkValidatorExtensions.IsValidHttpsUrl);
         yield return new DelegatingServerValidator("Validation:Format:Ipv4Address", NetworkValidatorExtensions.IsValidIpv4Address);
         yield return new DelegatingServerValidator("Validation:Format:Ipv6Address", NetworkValidatorExtensions.IsValidIpv6Address);
         yield return new DelegatingServerValidator("Validation:Format:MacAddress", NetworkValidatorExtensions.IsValidMacAddress);

--- a/tests/Granit.Validation.Tests/CoreServerValidatorContributorTests.cs
+++ b/tests/Granit.Validation.Tests/CoreServerValidatorContributorTests.cs
@@ -14,9 +14,9 @@ public sealed class CoreServerValidatorContributorTests
     }
 
     [Fact]
-    public void GetValidators_Returns16Validators() =>
+    public void GetValidators_Returns17Validators() =>
         // IBAN / BIC/SWIFT / SEPA Creditor Identifier moved to Granit.Validation.Finance.
-        _validators.Count.ShouldBe(16);
+        _validators.Count.ShouldBe(17);
 
     [Fact]
     public void AllErrorCodes_AreUnique() =>
@@ -29,6 +29,8 @@ public sealed class CoreServerValidatorContributorTests
     [InlineData("Validation:Format:Slug", "UPPER CASE", false)]
     [InlineData("Validation:Format:Url", "https://example.com", true)]
     [InlineData("Validation:Format:Url", "not a url", false)]
+    [InlineData("Validation:Format:UrlHttps", "https://example.com", true)]
+    [InlineData("Validation:Format:UrlHttps", "http://example.com", false)]
     [InlineData("Validation:Format:Ipv4Address", "192.168.1.1", true)]
     [InlineData("Validation:Format:Ipv4Address", "999.999.999.999", false)]
     [InlineData("Validation:Format:Iso3166Alpha2", "BE", true)]

--- a/tests/Granit.Validation.Tests/NetworkValidatorExtensionsTests.cs
+++ b/tests/Granit.Validation.Tests/NetworkValidatorExtensionsTests.cs
@@ -62,6 +62,46 @@ public sealed class NetworkValidatorExtensionsTests
     }
 
     // =========================================================================
+    // HttpsUrl
+    // =========================================================================
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("https://example.com/path?q=1&b=2")]
+    [InlineData("https://sub.example.com:8443/path")]
+    [InlineData("HTTPS://example.com")] // scheme is case-insensitive
+    public void HttpsUrl_ValidValues_PassValidation(string url)
+    {
+        InlineValidator<TestModel> validator = [];
+        validator.RuleFor(x => x.Value).HttpsUrl();
+
+        ValidationResult result = validator.Validate(new TestModel(url));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("http://example.com")]        // plaintext scheme rejected
+    [InlineData("example.com")]               // no scheme
+    [InlineData("/relative/path")]            // not absolute
+    [InlineData("javascript:alert(1)")]       // non-HTTPS scheme
+    [InlineData("ftp://example.com")]         // non-HTTPS scheme
+    [InlineData("not a url")]
+    public void HttpsUrl_InvalidValues_FailValidation(string? url)
+    {
+        InlineValidator<TestModel> validator = [];
+        validator.RuleFor(x => x.Value).HttpsUrl();
+
+        ValidationResult result = validator.Validate(new TestModel(url));
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors[0].ErrorMessage.ShouldBe("Validation:Format:UrlHttps");
+        result.Errors[0].ErrorCode.ShouldBe("Validation:Format:UrlHttps");
+    }
+
+    // =========================================================================
     // Ipv4Address
     // =========================================================================
 


### PR DESCRIPTION
## Summary

Adds a reusable `HttpsUrl()` FluentValidation rule to `Granit.Validation` (`NetworkValidatorExtensions`) that requires an **absolute `https://` URL**. Stricter than the existing `Url()` (which also accepts `http`) and `AbsoluteUri()` (any scheme).

## Why

HTTPS-only URL validation was a recurring, hand-rolled need — `Granit.Webhooks` has its own `BeAValidHttpsUrl`, and the SEPA Direct Debit mandate `RedirectUrl` needs the same (open-redirect / phishing hardening on a provider-hosted signature flow). The `Validation:Format:UrlHttps` loc key already existed in all 18 cultures (added in the ADR-066 key migration) but no rule consumed it — this wires it up.

## Changes

- `HttpsUrl<T>()` + internal `IsValidHttpsUrl` (absolute + `UriSchemeHttps`) in `NetworkValidatorExtensions`
- Registered as a server-side validator in `CoreServerValidatorContributor` (parity with `Url`/`Ipv4`/…)
- Tests: valid/invalid theories for `HttpsUrl()`; server-validator count 16→17 + `UrlHttps` row

## DoD

- ✅ `Granit.Validation.Tests` — 470 passed
- ✅ `dotnet format --verify-no-changes` clean
- ✅ `ValidationKeyConventionTests` green (key already conforms; no new key)
- No new loc key needed (reuses `Validation:Format:UrlHttps`)

## Follow-up

`Granit.Webhooks` `BeAValidHttpsUrl` could adopt this rule to de-duplicate (separate PR).