### PR TITLE
feat(ai): tenant-defined prompt categories (many-to-many) (#2645)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -5131,6 +5131,15 @@
       ]
     },
     {
+      "name": "PromptCategory",
+      "fqn": "Granit.AI.Prompts.Domain.PromptCategory",
+      "kind": "class",
+      "project": "Granit.AI.Prompts",
+      "file": "src/Granit.AI.Prompts/Domain/PromptCategory.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "PromptTemplate",
       "fqn": "Granit.AI.Prompts.Domain.PromptTemplate",
       "kind": "class",
@@ -5149,8 +5158,29 @@
           "kind": "property",
           "signature": "string Content",
           "returnType": "string"
+        },
+        {
+          "name": "Icon",
+          "kind": "property",
+          "signature": "string? Icon",
+          "returnType": "string?"
+        },
+        {
+          "name": "Edit",
+          "kind": "method",
+          "signature": "Edit(string name, string shortDescription, string content, string? icon, HexColor? iconColor)",
+          "returnType": "void"
         }
       ]
+    },
+    {
+      "name": "PromptTemplateCategory",
+      "fqn": "Granit.AI.Prompts.Domain.PromptTemplateCategory",
+      "kind": "class",
+      "project": "Granit.AI.Prompts",
+      "file": "src/Granit.AI.Prompts/Domain/PromptTemplateCategory.cs",
+      "line": 9,
+      "members": []
     },
     {
       "name": "AIPromptsEntityFrameworkCoreServiceCollectionExtensions",
@@ -5217,6 +5247,40 @@
       "file": "src/Granit.AI.Prompts/GranitAIPromptsModule.cs",
       "line": 11,
       "members": []
+    },
+    {
+      "name": "IPromptCategoryStore",
+      "fqn": "Granit.AI.Prompts.IPromptCategoryStore",
+      "kind": "interface",
+      "project": "Granit.AI.Prompts",
+      "file": "src/Granit.AI.Prompts/IPromptCategoryStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(PromptCategory category, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PromptCategory>"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PromptCategory?>"
+        },
+        {
+          "name": "GetByNameAsync",
+          "kind": "method",
+          "signature": "GetByNameAsync(string name, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PromptCategory?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<PromptCategory>>"
+        }
+      ]
     },
     {
       "name": "IPromptTemplateStore",

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/EntityConfigurations/PromptCategoryConfiguration.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/EntityConfigurations/PromptCategoryConfiguration.cs
@@ -1,0 +1,30 @@
+using Granit.AI.Prompts.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.AI.Prompts.EntityFrameworkCore.EntityConfigurations;
+
+/// <summary>EF Core configuration for the <see cref="PromptCategory"/> aggregate root.</summary>
+internal sealed class PromptCategoryConfiguration : IEntityTypeConfiguration<PromptCategory>
+{
+    public void Configure(EntityTypeBuilder<PromptCategory> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitAIPromptsDbProperties.DbTablePrefix + "categories",
+            GranitAIPromptsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Name).HasMaxLength(200).IsRequired();
+        builder.Property(e => e.CreatedBy).HasMaxLength(256);
+        builder.Property(e => e.ModifiedBy).HasMaxLength(256);
+        builder.Property(e => e.DeletedBy).HasMaxLength(256);
+
+        // Category names are unique within a tenant.
+        builder.HasIndex(e => new { e.TenantId, e.Name })
+            .IsUnique()
+            .HasDatabaseName($"ix_{GranitAIPromptsDbProperties.DbTablePrefix}categories_tenant_name");
+    }
+}

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/EntityConfigurations/PromptTemplateCategoryConfiguration.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/EntityConfigurations/PromptTemplateCategoryConfiguration.cs
@@ -1,0 +1,30 @@
+using Granit.AI.Prompts.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.AI.Prompts.EntityFrameworkCore.EntityConfigurations;
+
+/// <summary>EF Core configuration for the <see cref="PromptTemplateCategory"/> link entity.</summary>
+internal sealed class PromptTemplateCategoryConfiguration : IEntityTypeConfiguration<PromptTemplateCategory>
+{
+    public void Configure(EntityTypeBuilder<PromptTemplateCategory> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitAIPromptsDbProperties.DbTablePrefix + "template_categories",
+            GranitAIPromptsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.CreatedBy).HasMaxLength(256);
+
+        // A prompt is linked to a given category at most once.
+        builder.HasIndex(e => new { e.PromptTemplateId, e.CategoryId })
+            .IsUnique()
+            .HasDatabaseName($"ix_{GranitAIPromptsDbProperties.DbTablePrefix}template_categories_prompt_category");
+
+        builder.HasIndex(e => e.CategoryId)
+            .HasDatabaseName($"ix_{GranitAIPromptsDbProperties.DbTablePrefix}template_categories_category");
+    }
+}

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/EntityConfigurations/PromptTemplateConfiguration.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/EntityConfigurations/PromptTemplateConfiguration.cs
@@ -31,5 +31,10 @@ internal sealed class PromptTemplateConfiguration : IEntityTypeConfiguration<Pro
         // Catalogue listing: system prompts + the owner's, within the tenant, ordered by name.
         builder.HasIndex(e => new { e.TenantId, e.IsSystem, e.OwnerId, e.Name })
             .HasDatabaseName($"ix_{GranitAIPromptsDbProperties.DbTablePrefix}templates_tenant_system_owner_name");
+
+        builder.HasMany(e => e.CategoryLinks)
+            .WithOne()
+            .HasForeignKey(l => l.PromptTemplateId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class AIPromptsEntityFrameworkCoreServiceCollectionExtensions
             configureTenantSchema);
 
         services.TryAddScoped<IPromptTemplateStore, EfPromptTemplateStore>();
+        services.TryAddScoped<IPromptCategoryStore, EfPromptCategoryStore>();
 
         return services;
     }

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsModelBuilderExtensions.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsModelBuilderExtensions.cs
@@ -15,6 +15,8 @@ public static class AIPromptsModelBuilderExtensions
         ArgumentNullException.ThrowIfNull(modelBuilder);
 
         modelBuilder.ApplyConfiguration(new PromptTemplateConfiguration());
+        modelBuilder.ApplyConfiguration(new PromptTemplateCategoryConfiguration());
+        modelBuilder.ApplyConfiguration(new PromptCategoryConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/AIPromptsDbContext.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/AIPromptsDbContext.cs
@@ -20,6 +20,9 @@ internal sealed class AIPromptsDbContext(
     /// <summary>Prompt templates.</summary>
     public DbSet<PromptTemplate> PromptTemplates => Set<PromptTemplate>();
 
+    /// <summary>Tenant-defined prompt categories.</summary>
+    public DbSet<PromptCategory> PromptCategories => Set<PromptCategory>();
+
     /// <inheritdoc/>
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptCategoryStore.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptCategoryStore.cs
@@ -1,0 +1,51 @@
+using Granit.AI.Prompts.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.AI.Prompts.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core <see cref="IPromptCategoryStore"/>. Categories are tenant-scoped (the tenant filter is
+/// applied by the DbContext).
+/// </summary>
+internal sealed class EfPromptCategoryStore(IDbContextFactory<AIPromptsDbContext> contextFactory) : IPromptCategoryStore
+{
+    public async Task<PromptCategory> CreateAsync(PromptCategory category, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(category);
+
+        await using AIPromptsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        context.PromptCategories.Add(category);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return category;
+    }
+
+    public async Task<PromptCategory?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        await using AIPromptsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.PromptCategories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<PromptCategory?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        await using AIPromptsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.PromptCategories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Name == name, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<PromptCategory>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        await using AIPromptsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.PromptCategories
+            .AsNoTracking()
+            .OrderBy(c => c.Name)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptTemplateStore.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptTemplateStore.cs
@@ -24,6 +24,7 @@ internal sealed class EfPromptTemplateStore(IDbContextFactory<AIPromptsDbContext
         await using AIPromptsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await context.PromptTemplates
             .AsNoTracking()
+            .Include(p => p.CategoryLinks)
             .FirstOrDefaultAsync(p => p.Id == id && (p.IsSystem || p.OwnerId == ownerId), cancellationToken)
             .ConfigureAwait(false);
     }
@@ -33,6 +34,7 @@ internal sealed class EfPromptTemplateStore(IDbContextFactory<AIPromptsDbContext
         await using AIPromptsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await context.PromptTemplates
             .AsNoTracking()
+            .Include(p => p.CategoryLinks)
             .Where(p => p.IsSystem || p.OwnerId == ownerId)
             .OrderByDescending(p => p.IsSystem)
             .ThenBy(p => p.Name)

--- a/src/Granit.AI.Prompts/Domain/PromptCategory.cs
+++ b/src/Granit.AI.Prompts/Domain/PromptCategory.cs
@@ -1,0 +1,60 @@
+using Granit.Domain;
+
+namespace Granit.AI.Prompts.Domain;
+
+/// <summary>
+/// A tenant-defined, free-form grouping for prompts in the catalogue (ADR-067). Defined by
+/// administrators; a prompt may belong to several categories (many-to-many). The well-known
+/// <see cref="GeneralName"/> category groups framework-seeded prompts that have no explicit category.
+/// </summary>
+public sealed class PromptCategory : FullAuditedAggregateRoot, IMultiTenant
+{
+    /// <summary>The well-known default category name for seeded / uncategorised prompts.</summary>
+    public const string GeneralName = "General";
+
+    private PromptCategory()
+    {
+    }
+
+    /// <summary>Creates a tenant-defined category.</summary>
+    public static PromptCategory Create(Guid id, string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return new PromptCategory { Id = id, Name = name, IsSystem = false };
+    }
+
+    /// <summary>
+    /// Creates a framework-defined system category (e.g. <see cref="GeneralName"/>) that the tenant
+    /// cannot delete.
+    /// </summary>
+    public static PromptCategory CreateSystem(Guid id, string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return new PromptCategory { Id = id, Name = name, IsSystem = true };
+    }
+
+    /// <summary>Display name.</summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>Whether this is a framework-defined category (not deletable by the tenant).</summary>
+    public bool IsSystem { get; private set; }
+
+    /// <summary>Owning tenant; stamped by the interceptor.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc/>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Renames the category.</summary>
+    public void Rename(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name;
+    }
+}

--- a/src/Granit.AI.Prompts/Domain/PromptTemplate.cs
+++ b/src/Granit.AI.Prompts/Domain/PromptTemplate.cs
@@ -101,12 +101,27 @@ public sealed class PromptTemplate : FullAuditedAggregateRoot, IMultiTenant, IOw
     /// <summary>Owning tenant; stamped by the interceptor.</summary>
     public Guid? TenantId { get; private set; }
 
+    /// <summary>The category links (many-to-many) for this prompt. A prompt may sit in several categories.</summary>
+    public List<PromptTemplateCategory> CategoryLinks { get; private set; } = [];
+
     /// <inheritdoc/>
     Guid? IMultiTenant.TenantId
     {
         get => TenantId;
         set => TenantId = value;
     }
+
+    /// <summary>Assigns the prompt to a category (idempotent — a repeated assignment is ignored).</summary>
+    public void AssignCategory(Guid linkId, Guid categoryId)
+    {
+        if (!CategoryLinks.Any(l => l.CategoryId == categoryId))
+        {
+            CategoryLinks.Add(PromptTemplateCategory.Create(linkId, Id, categoryId));
+        }
+    }
+
+    /// <summary>Removes all category assignments.</summary>
+    public void ClearCategories() => CategoryLinks.Clear();
 
     /// <summary>Updates the editable fields and bumps the <see cref="Version"/>.</summary>
     public void Edit(string name, string shortDescription, string content, string? icon, HexColor? iconColor)

--- a/src/Granit.AI.Prompts/Domain/PromptTemplateCategory.cs
+++ b/src/Granit.AI.Prompts/Domain/PromptTemplateCategory.cs
@@ -1,0 +1,23 @@
+using Granit.Domain;
+
+namespace Granit.AI.Prompts.Domain;
+
+/// <summary>
+/// Link row joining a <see cref="PromptTemplate"/> to a <see cref="PromptCategory"/> (many-to-many).
+/// Owned by the <see cref="PromptTemplate"/> aggregate; references the category by id.
+/// </summary>
+public sealed class PromptTemplateCategory : CreationAuditedEntity
+{
+    private PromptTemplateCategory()
+    {
+    }
+
+    internal static PromptTemplateCategory Create(Guid id, Guid promptTemplateId, Guid categoryId) =>
+        new() { Id = id, PromptTemplateId = promptTemplateId, CategoryId = categoryId };
+
+    /// <summary>The linked prompt.</summary>
+    public Guid PromptTemplateId { get; private set; }
+
+    /// <summary>The linked category.</summary>
+    public Guid CategoryId { get; private set; }
+}

--- a/src/Granit.AI.Prompts/IPromptCategoryStore.cs
+++ b/src/Granit.AI.Prompts/IPromptCategoryStore.cs
@@ -1,0 +1,22 @@
+using Granit.AI.Prompts.Domain;
+
+namespace Granit.AI.Prompts;
+
+/// <summary>
+/// Persistence for tenant-defined <see cref="PromptCategory"/> aggregates. Categories are shared
+/// across the tenant (admin-defined); tenant isolation is applied by the underlying DbContext.
+/// </summary>
+public interface IPromptCategoryStore
+{
+    /// <summary>Persists a new category and returns it.</summary>
+    Task<PromptCategory> CreateAsync(PromptCategory category, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the category by id, or <see langword="null"/>.</summary>
+    Task<PromptCategory?> GetAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the category with the given name, or <see langword="null"/>. Used to resolve the well-known "General".</summary>
+    Task<PromptCategory?> GetByNameAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns all categories defined for the tenant, ordered by name.</summary>
+    Task<IReadOnlyList<PromptCategory>> ListAsync(CancellationToken cancellationToken = default);
+}

--- a/tests/Granit.AI.Prompts.EntityFrameworkCore.Tests/EfPromptCategoryStoreTests.cs
+++ b/tests/Granit.AI.Prompts.EntityFrameworkCore.Tests/EfPromptCategoryStoreTests.cs
@@ -1,0 +1,50 @@
+using Granit.AI.Prompts.Domain;
+using Granit.AI.Prompts.EntityFrameworkCore.Internal;
+using Shouldly;
+
+namespace Granit.AI.Prompts.EntityFrameworkCore.Tests;
+
+public sealed class EfPromptCategoryStoreTests : IDisposable
+{
+    private readonly TestDbContextFactory _factory = TestDbContextFactory.Create();
+    private readonly EfPromptCategoryStore _sut;
+
+    public EfPromptCategoryStoreTests() => _sut = new EfPromptCategoryStore(_factory);
+
+    public void Dispose() => _factory.Dispose();
+
+    [Fact]
+    public async Task Create_then_get_round_trips()
+    {
+        PromptCategory created = await _sut.CreateAsync(
+            PromptCategory.Create(Guid.NewGuid(), "Marketing"), TestContext.Current.CancellationToken);
+
+        PromptCategory? loaded = await _sut.GetAsync(created.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Marketing");
+    }
+
+    [Fact]
+    public async Task GetByName_resolves_the_general_system_category()
+    {
+        await _sut.CreateAsync(
+            PromptCategory.CreateSystem(Guid.NewGuid(), PromptCategory.GeneralName), TestContext.Current.CancellationToken);
+
+        PromptCategory? general = await _sut.GetByNameAsync(PromptCategory.GeneralName, TestContext.Current.CancellationToken);
+
+        general.ShouldNotBeNull();
+        general.IsSystem.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task List_returns_categories_ordered_by_name()
+    {
+        await _sut.CreateAsync(PromptCategory.Create(Guid.NewGuid(), "Zeta"), TestContext.Current.CancellationToken);
+        await _sut.CreateAsync(PromptCategory.Create(Guid.NewGuid(), "Alpha"), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<PromptCategory> all = await _sut.ListAsync(TestContext.Current.CancellationToken);
+
+        all.Select(c => c.Name).ShouldBe(["Alpha", "Zeta"]);
+    }
+}

--- a/tests/Granit.AI.Prompts.EntityFrameworkCore.Tests/EfPromptTemplateStoreTests.cs
+++ b/tests/Granit.AI.Prompts.EntityFrameworkCore.Tests/EfPromptTemplateStoreTests.cs
@@ -49,6 +49,22 @@ public sealed class EfPromptTemplateStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task A_prompt_assigned_to_several_categories_round_trips_all_its_links()
+    {
+        var catA = Guid.NewGuid();
+        var catB = Guid.NewGuid();
+        var prompt = PromptTemplate.Create(Guid.NewGuid(), UserA, "Multi", "x", "y");
+        prompt.AssignCategory(Guid.NewGuid(), catA);
+        prompt.AssignCategory(Guid.NewGuid(), catB);
+        await _sut.CreateAsync(prompt, TestContext.Current.CancellationToken);
+
+        PromptTemplate? loaded = await _sut.GetAsync(prompt.Id, UserA, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.CategoryLinks.Select(l => l.CategoryId).ShouldBe([catA, catB], ignoreOrder: true);
+    }
+
+    [Fact]
     public async Task Catalogue_lists_system_prompts_first_then_the_owners_excluding_other_users()
     {
         await _sut.CreateAsync(PromptTemplate.CreateSystem(Guid.NewGuid(), "Zeta system", "x", "z"), TestContext.Current.CancellationToken);

--- a/tests/Granit.AI.Prompts.Tests/PromptCategoryTests.cs
+++ b/tests/Granit.AI.Prompts.Tests/PromptCategoryTests.cs
@@ -1,0 +1,51 @@
+using Granit.AI.Prompts.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.AI.Prompts.Tests;
+
+public sealed class PromptCategoryTests
+{
+    [Fact]
+    public void Create_is_a_tenant_defined_non_system_category()
+    {
+        var category = PromptCategory.Create(Guid.NewGuid(), "Marketing");
+
+        category.Name.ShouldBe("Marketing");
+        category.IsSystem.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CreateSystem_is_a_system_category()
+    {
+        var category = PromptCategory.CreateSystem(Guid.NewGuid(), PromptCategory.GeneralName);
+
+        category.Name.ShouldBe("General");
+        category.IsSystem.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AssignCategory_adds_links_and_is_idempotent()
+    {
+        var prompt = PromptTemplate.Create(Guid.NewGuid(), Guid.NewGuid(), "Draft", "d", "c");
+        var catA = Guid.NewGuid();
+        var catB = Guid.NewGuid();
+
+        prompt.AssignCategory(Guid.NewGuid(), catA);
+        prompt.AssignCategory(Guid.NewGuid(), catB);
+        prompt.AssignCategory(Guid.NewGuid(), catA); // duplicate — ignored
+
+        prompt.CategoryLinks.Select(l => l.CategoryId).ShouldBe([catA, catB], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void ClearCategories_removes_all_links()
+    {
+        var prompt = PromptTemplate.Create(Guid.NewGuid(), Guid.NewGuid(), "Draft", "d", "c");
+        prompt.AssignCategory(Guid.NewGuid(), Guid.NewGuid());
+
+        prompt.ClearCategories();
+
+        prompt.CategoryLinks.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Story

Closes #2645 — `As an Administrator, I want to organise prompts into tenant-defined categories, so
the / picker can group prompts the way my organisation thinks about them.`

## What

- **`PromptCategory`** aggregate (`FullAuditedAggregateRoot` + `IMultiTenant`) — free-form,
  tenant-scoped: `Name`, `IsSystem`. `Create` (tenant-defined) + `CreateSystem` (framework, e.g. the
  well-known `GeneralName` = `"General"`). Unique `(TenantId, Name)`.
- **`PromptTemplateCategory`** link entity **owned by `PromptTemplate`** (references the category by
  id — clean aggregate boundary). `PromptTemplate.AssignCategory` (idempotent) / `ClearCategories`.
  Unique `(PromptTemplateId, CategoryId)`, cascade with the prompt.
- **EF** — `PromptCategories` DbSet + configs; the prompt store now `Include`s `CategoryLinks`;
  `IPromptCategoryStore` / `EfPromptCategoryStore` (`Create`/`Get`/`GetByName`/`List`, tenant-scoped).

## Acceptance criteria

- ✅ A prompt assigned to several categories keeps a link to each (appears under each in the catalogue).
- ✅ The well-known `"General"` system category is resolvable for seeded/uncategorised prompts
  (seeds are assigned to it in #2646; uncategorised group under it at listing).

## Tests

- `PromptCategoryTests` (aggregate; `AssignCategory` idempotency; `ClearCategories`)
- `EfPromptTemplateStoreTests` (m2m round-trip — a prompt in several categories keeps all links)
- `EfPromptCategoryStoreTests` (CRUD; `GetByName("General")`; ordered list)
- Architecture suite green (225); format + markdownlint clean; no lockfile change.

## Related

- Epic #2626, Feature #2629, ADR-067