### PR TITLE
feat(ai): prompt badge resolution + usage stamping (#2648)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37,6 +37,7 @@
       "deps": [
         "Granit",
         "Granit.AI",
+        "Granit.AI.Prompts",
         "Granit.AI.Tools",
         "Granit.Guids",
         "Granit.Settings",
@@ -3281,7 +3282,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 37,
+      "line": 44,
       "members": [
         {
           "name": "ConversationId",
@@ -3349,7 +3350,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 26,
+      "line": 28,
       "members": []
     },
     {
@@ -3358,7 +3359,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 34,
+      "line": 36,
       "members": []
     },
     {
@@ -3376,7 +3377,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 52,
+      "line": 54,
       "members": []
     },
     {
@@ -3385,7 +3386,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 47,
+      "line": 49,
       "members": []
     },
     {
@@ -3442,7 +3443,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 19,
+      "line": 21,
       "members": []
     },
     {
@@ -3483,7 +3484,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 9,
+      "line": 10,
       "members": []
     },
     {
@@ -3492,7 +3493,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 59,
+      "line": 61,
       "members": []
     },
     {
@@ -3707,7 +3708,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/GranitAIChatModule.cs",
-      "line": 27,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -3723,7 +3724,7 @@
       "kind": "interface",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 71,
+      "line": 78,
       "members": [
         {
           "name": "SendAsync",

--- a/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
+++ b/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
@@ -47,6 +47,11 @@
         "resolved": "10.0.9",
         "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -70,10 +75,18 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {
@@ -170,6 +183,18 @@
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -275,6 +300,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -312,6 +355,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
@@ -6,12 +6,14 @@ namespace Granit.AI.Chat.Endpoints.Dtos;
 /// <param name="WorkspaceName">The chat-capable workspace to use, or <see langword="null"/> for the default.</param>
 /// <param name="Mentions">Entities <c>@</c>-referenced for this turn, resolved to context under the caller's ACLs.</param>
 /// <param name="Attachments">Files attached to this turn, resolved to extracted text under the caller's ACLs.</param>
+/// <param name="PromptRefs">Catalogue prompts inserted as <c>/</c> badges, composed with the message under the caller's ACLs.</param>
 public sealed record SendMessageRequest(
     string Message,
     Guid? ConversationId = null,
     string? WorkspaceName = null,
     IReadOnlyList<MentionRequest>? Mentions = null,
-    IReadOnlyList<AttachmentRequest>? Attachments = null);
+    IReadOnlyList<AttachmentRequest>? Attachments = null,
+    IReadOnlyList<Guid>? PromptRefs = null);
 
 /// <summary>An <c>@</c> mention on a send: a typed reference to an application entity.</summary>
 /// <param name="Type">The mention type, matching an application-registered resolver.</param>

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -63,6 +63,7 @@ internal static class ChatSendEndpoints
                     Mentions = request.Mentions?.Select(m => new AIMention(m.Type, m.Id)).ToList(),
                     Attachments = request.Attachments?
                         .Select(a => new AIAttachment(a.Reference, a.FileName, a.ContentType, a.SizeBytes)).ToList(),
+                    PromptRefs = request.PromptRefs,
                 },
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/cs.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/cs.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Zpráva může odkazovat nejvýše na 25 položek.",
     "AIChat:Validation:TooManyAttachments": "Příliš mnoho příloh v jedné zprávě.",
     "AIChat:Validation:UnsupportedAttachmentType": "Tento typ souboru není podporován.",
-    "AIChat:Validation:AttachmentTooLarge": "Tento soubor překračuje maximální povolenou velikost."
+    "AIChat:Validation:AttachmentTooLarge": "Tento soubor překračuje maximální povolenou velikost.",
+    "AIChat:Validation:TooManyPromptRefs": "Zpráva může použít nejvýše 5 promptů."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/de.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/de.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Eine Nachricht kann höchstens 25 Elemente referenzieren.",
     "AIChat:Validation:TooManyAttachments": "Zu viele Anhänge in einer einzelnen Nachricht.",
     "AIChat:Validation:UnsupportedAttachmentType": "Dieser Dateityp wird nicht unterstützt.",
-    "AIChat:Validation:AttachmentTooLarge": "Diese Datei überschreitet die maximal zulässige Größe."
+    "AIChat:Validation:AttachmentTooLarge": "Diese Datei überschreitet die maximal zulässige Größe.",
+    "AIChat:Validation:TooManyPromptRefs": "Eine Nachricht kann höchstens 5 Prompts verwenden."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/en.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/en.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "A message can reference at most 25 items.",
     "AIChat:Validation:TooManyAttachments": "Too many attachments on a single message.",
     "AIChat:Validation:UnsupportedAttachmentType": "This file type is not supported.",
-    "AIChat:Validation:AttachmentTooLarge": "This file exceeds the maximum allowed size."
+    "AIChat:Validation:AttachmentTooLarge": "This file exceeds the maximum allowed size.",
+    "AIChat:Validation:TooManyPromptRefs": "A message can use at most 5 prompts."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/es.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/es.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Un mensaje puede referenciar como máximo 25 elementos.",
     "AIChat:Validation:TooManyAttachments": "Demasiados archivos adjuntos en un solo mensaje.",
     "AIChat:Validation:UnsupportedAttachmentType": "Este tipo de archivo no es compatible.",
-    "AIChat:Validation:AttachmentTooLarge": "Este archivo supera el tamaño máximo permitido."
+    "AIChat:Validation:AttachmentTooLarge": "Este archivo supera el tamaño máximo permitido.",
+    "AIChat:Validation:TooManyPromptRefs": "Un mensaje puede usar como máximo 5 prompts."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/fr.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/fr.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Un message peut référencer au maximum 25 éléments.",
     "AIChat:Validation:TooManyAttachments": "Trop de pièces jointes sur un même message.",
     "AIChat:Validation:UnsupportedAttachmentType": "Ce type de fichier n'est pas pris en charge.",
-    "AIChat:Validation:AttachmentTooLarge": "Ce fichier dépasse la taille maximale autorisée."
+    "AIChat:Validation:AttachmentTooLarge": "Ce fichier dépasse la taille maximale autorisée.",
+    "AIChat:Validation:TooManyPromptRefs": "Un message peut utiliser au maximum 5 prompts."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/hi.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/hi.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "एक संदेश अधिकतम 25 आइटम का संदर्भ दे सकता है।",
     "AIChat:Validation:TooManyAttachments": "एक ही संदेश में बहुत अधिक अनुलग्नक हैं।",
     "AIChat:Validation:UnsupportedAttachmentType": "यह फ़ाइल प्रकार समर्थित नहीं है।",
-    "AIChat:Validation:AttachmentTooLarge": "यह फ़ाइल अधिकतम अनुमत आकार से अधिक है।"
+    "AIChat:Validation:AttachmentTooLarge": "यह फ़ाइल अधिकतम अनुमत आकार से अधिक है।",
+    "AIChat:Validation:TooManyPromptRefs": "एक संदेश अधिकतम 5 प्रॉम्प्ट का उपयोग कर सकता है।"
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/it.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/it.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Un messaggio può fare riferimento ad al massimo 25 elementi.",
     "AIChat:Validation:TooManyAttachments": "Troppi allegati in un singolo messaggio.",
     "AIChat:Validation:UnsupportedAttachmentType": "Questo tipo di file non è supportato.",
-    "AIChat:Validation:AttachmentTooLarge": "Questo file supera la dimensione massima consentita."
+    "AIChat:Validation:AttachmentTooLarge": "Questo file supera la dimensione massima consentita.",
+    "AIChat:Validation:TooManyPromptRefs": "Un messaggio può usare al massimo 5 prompt."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ja.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ja.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "1 つのメッセージで参照できる項目は最大 25 件です。",
     "AIChat:Validation:TooManyAttachments": "1 つのメッセージに添付ファイルが多すぎます。",
     "AIChat:Validation:UnsupportedAttachmentType": "このファイル形式はサポートされていません。",
-    "AIChat:Validation:AttachmentTooLarge": "このファイルは最大許容サイズを超えています。"
+    "AIChat:Validation:AttachmentTooLarge": "このファイルは最大許容サイズを超えています。",
+    "AIChat:Validation:TooManyPromptRefs": "1 つのメッセージで使用できるプロンプトは最大 5 個です。"
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ko.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ko.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "메시지는 최대 25개 항목을 참조할 수 있습니다.",
     "AIChat:Validation:TooManyAttachments": "한 메시지에 첨부 파일이 너무 많습니다.",
     "AIChat:Validation:UnsupportedAttachmentType": "이 파일 형식은 지원되지 않습니다.",
-    "AIChat:Validation:AttachmentTooLarge": "이 파일은 최대 허용 크기를 초과합니다."
+    "AIChat:Validation:AttachmentTooLarge": "이 파일은 최대 허용 크기를 초과합니다.",
+    "AIChat:Validation:TooManyPromptRefs": "하나의 메시지는 최대 5개의 프롬프트를 사용할 수 있습니다."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/nl.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/nl.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Een bericht kan maximaal 25 items vermelden.",
     "AIChat:Validation:TooManyAttachments": "Te veel bijlagen in één bericht.",
     "AIChat:Validation:UnsupportedAttachmentType": "Dit bestandstype wordt niet ondersteund.",
-    "AIChat:Validation:AttachmentTooLarge": "Dit bestand overschrijdt de maximaal toegestane grootte."
+    "AIChat:Validation:AttachmentTooLarge": "Dit bestand overschrijdt de maximaal toegestane grootte.",
+    "AIChat:Validation:TooManyPromptRefs": "Een bericht kan maximaal 5 prompts gebruiken."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pl.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pl.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Wiadomość może odwoływać się do maksymalnie 25 elementów.",
     "AIChat:Validation:TooManyAttachments": "Zbyt wiele załączników w jednej wiadomości.",
     "AIChat:Validation:UnsupportedAttachmentType": "Ten typ pliku nie jest obsługiwany.",
-    "AIChat:Validation:AttachmentTooLarge": "Ten plik przekracza maksymalny dozwolony rozmiar."
+    "AIChat:Validation:AttachmentTooLarge": "Ten plik przekracza maksymalny dozwolony rozmiar.",
+    "AIChat:Validation:TooManyPromptRefs": "Wiadomość może użyć maksymalnie 5 promptów."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pt.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pt.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Uma mensagem pode referenciar no máximo 25 itens.",
     "AIChat:Validation:TooManyAttachments": "Demasiados anexos numa única mensagem.",
     "AIChat:Validation:UnsupportedAttachmentType": "Este tipo de ficheiro não é suportado.",
-    "AIChat:Validation:AttachmentTooLarge": "Este ficheiro excede o tamanho máximo permitido."
+    "AIChat:Validation:AttachmentTooLarge": "Este ficheiro excede o tamanho máximo permitido.",
+    "AIChat:Validation:TooManyPromptRefs": "Uma mensagem pode usar no máximo 5 prompts."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/sv.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/sv.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Ett meddelande kan referera till högst 25 objekt.",
     "AIChat:Validation:TooManyAttachments": "För många bilagor i ett enskilt meddelande.",
     "AIChat:Validation:UnsupportedAttachmentType": "Den här filtypen stöds inte.",
-    "AIChat:Validation:AttachmentTooLarge": "Den här filen överskrider den högsta tillåtna storleken."
+    "AIChat:Validation:AttachmentTooLarge": "Den här filen överskrider den högsta tillåtna storleken.",
+    "AIChat:Validation:TooManyPromptRefs": "Ett meddelande kan använda högst 5 prompter."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/tr.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/tr.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "Bir mesaj en fazla 25 öğeye başvurabilir.",
     "AIChat:Validation:TooManyAttachments": "Tek bir mesajda çok fazla ek var.",
     "AIChat:Validation:UnsupportedAttachmentType": "Bu dosya türü desteklenmiyor.",
-    "AIChat:Validation:AttachmentTooLarge": "Bu dosya izin verilen maksimum boyutu aşıyor."
+    "AIChat:Validation:AttachmentTooLarge": "Bu dosya izin verilen maksimum boyutu aşıyor.",
+    "AIChat:Validation:TooManyPromptRefs": "Bir mesaj en fazla 5 istem kullanabilir."
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/zh.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/zh.json
@@ -9,6 +9,7 @@
     "AIChat:Validation:TooManyMentions": "一条消息最多可引用 25 个项目。",
     "AIChat:Validation:TooManyAttachments": "单条消息的附件过多。",
     "AIChat:Validation:UnsupportedAttachmentType": "不支持此文件类型。",
-    "AIChat:Validation:AttachmentTooLarge": "此文件超过允许的最大大小。"
+    "AIChat:Validation:AttachmentTooLarge": "此文件超过允许的最大大小。",
+    "AIChat:Validation:TooManyPromptRefs": "一条消息最多可使用 5 个提示词。"
   }
 }

--- a/src/Granit.AI.Chat.Endpoints/Validators/SendMessageRequestValidator.cs
+++ b/src/Granit.AI.Chat.Endpoints/Validators/SendMessageRequestValidator.cs
@@ -16,6 +16,9 @@ internal sealed class SendMessageRequestValidator : GranitValidator<SendMessageR
     /// <summary>Maximum number of <c>@</c> mentions on a single turn.</summary>
     public const int MaxMentions = 25;
 
+    /// <summary>Maximum number of <c>/</c> prompt badges on a single turn.</summary>
+    public const int MaxPromptRefs = 5;
+
     public SendMessageRequestValidator(IOptions<GranitAIChatAttachmentOptions> attachmentOptions)
     {
         GranitAIChatAttachmentOptions limits = attachmentOptions.Value;
@@ -33,6 +36,10 @@ internal sealed class SendMessageRequestValidator : GranitValidator<SendMessageR
                 mention.RuleFor(m => m.Id).NotEmpty();
             })
             .When(x => x.Mentions is { Count: > 0 });
+
+        RuleFor(x => x.PromptRefs)
+            .Must(p => p is null || p.Count <= MaxPromptRefs)
+            .WithErrorCodeAndMessage("AIChat:Validation:TooManyPromptRefs");
 
         RuleFor(x => x.Attachments)
             .Must(a => a is null || a.Count <= limits.MaxAttachments)

--- a/src/Granit.AI.Chat.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Chat.Endpoints/packages.lock.json
@@ -96,10 +96,18 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
@@ -104,6 +104,11 @@
         "resolved": "10.0.9",
         "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -127,10 +132,18 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {
@@ -219,6 +232,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.persistence": {
@@ -362,6 +387,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -399,6 +442,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.Chat.Privacy/packages.lock.json
+++ b/src/Granit.AI.Chat.Privacy/packages.lock.json
@@ -342,10 +342,18 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/src/Granit.AI.Chat/Granit.AI.Chat.csproj
+++ b/src/Granit.AI.Chat/Granit.AI.Chat.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.AI.Prompts\Granit.AI.Prompts.csproj" />
     <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />

--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -1,6 +1,7 @@
 using Granit.AI.Chat.Extensions;
 using Granit.AI.Chat.Internal;
 using Granit.AI.Chat.Settings;
+using Granit.AI.Prompts;
 using Granit.AI.Tools;
 using Granit.Guids;
 using Granit.Modularity;
@@ -20,6 +21,7 @@ namespace Granit.AI.Chat;
 /// </summary>
 [DependsOn(
     typeof(GranitAIModule),
+    typeof(GranitAIPromptsModule),
     typeof(GranitAIToolsModule),
     typeof(GranitGuidsModule),
     typeof(GranitSettingsModule),
@@ -30,6 +32,10 @@ public sealed class GranitAIChatModule : GranitModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.TryAddScoped<IChatService, ChatService>();
+
+        // Badge resolution expands the turn's '/' prompt-catalogue references into the instruction
+        // (owner-scoped via IPromptTemplateStore). Always present; resolves to nothing when no refs.
+        context.Services.TryAddScoped<IPromptBadgeResolver, PromptBadgeResolver>();
 
         // The mention registry and context resolver are always present so a turn can carry
         // mentions even before the application opts any resolver in (they then resolve to nothing).

--- a/src/Granit.AI.Chat/IChatService.cs
+++ b/src/Granit.AI.Chat/IChatService.cs
@@ -31,6 +31,13 @@ public sealed record ChatSendRequest
     /// and injected ahead of the message as untrusted context. <see langword="null"/> or empty when none.
     /// </summary>
     public IReadOnlyList<AIAttachment>? Attachments { get; init; }
+
+    /// <summary>
+    /// Catalogue prompt templates the user inserted as <c>/</c> badges for this turn, resolved under
+    /// the caller's ACLs and composed with <see cref="Message"/> into the final instruction. The first
+    /// resolved prompt is stamped into the usage record. <see langword="null"/> or empty when none.
+    /// </summary>
+    public IReadOnlyList<Guid>? PromptRefs { get; init; }
 }
 
 /// <summary>The outcome of a send: the (possibly new) conversation and the assistant's answer.</summary>

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -29,6 +29,7 @@ internal sealed class ChatService(
     IAIMentionContextResolver mentionContextResolver,
     IAIAttachmentTextResolver attachmentTextResolver,
     IAISuggestionResolver suggestionResolver,
+    IPromptBadgeResolver promptBadgeResolver,
     ISettingProvider settingProvider,
     IGuidGenerator guidGenerator,
     IOptions<GranitAIOptions> aiOptions) : IChatService
@@ -86,7 +87,14 @@ internal sealed class ChatService(
             }
         }
 
-        loopMessages.Add(new ChatMessage(ChatRole.User, request.Message));
+        // Expand any '/' prompt badges (owner-scoped) and compose them with the free text into the
+        // final instruction. The composed text drives this turn only; the user's original message is
+        // what gets persisted, so the badge expansion stays ephemeral like mentions and attachments.
+        PromptBadgeResolution badges = request.PromptRefs is { Count: > 0 } promptRefs
+            ? await promptBadgeResolver.ResolveAsync(promptRefs, request.OwnerId, request.Message, cancellationToken).ConfigureAwait(false)
+            : new PromptBadgeResolution { ComposedMessage = request.Message };
+
+        loopMessages.Add(new ChatMessage(ChatRole.User, badges.ComposedMessage));
 
         AIOrchestrationResult result = await orchestrator.RunAsync(
             new AIOrchestrationRequest
@@ -94,6 +102,8 @@ internal sealed class ChatService(
                 WorkspaceName = workspaceName,
                 Messages = loopMessages,
                 UserCustomContext = await ResolveCustomContextAsync(cancellationToken).ConfigureAwait(false),
+                InvokedPromptName = badges.PrimaryPromptName,
+                InvokedPromptVersion = badges.PrimaryPromptVersion,
             },
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.AI.Chat/Internal/PromptBadgeResolver.cs
+++ b/src/Granit.AI.Chat/Internal/PromptBadgeResolver.cs
@@ -1,0 +1,70 @@
+using Granit.AI.Prompts;
+using Granit.AI.Prompts.Domain;
+
+namespace Granit.AI.Chat.Internal;
+
+/// <summary>
+/// The outcome of expanding a turn's <c>/</c> prompt badges: the composed instruction plus the
+/// primary referenced prompt's identity for usage stamping.
+/// </summary>
+internal sealed record PromptBadgeResolution
+{
+    /// <summary>The referenced prompt contents composed with the user's free text.</summary>
+    public required string ComposedMessage { get; init; }
+
+    /// <summary>The first resolved prompt's name, or <see langword="null"/> when none resolved.</summary>
+    public string? PrimaryPromptName { get; init; }
+
+    /// <summary>The first resolved prompt's version, or <see langword="null"/> when none resolved.</summary>
+    public int? PrimaryPromptVersion { get; init; }
+}
+
+/// <summary>
+/// Expands the catalogue prompt templates referenced as <c>/</c> badges (ADR-067) and composes them
+/// with the user's free text into the final instruction. Resolution is owner-scoped (system prompts
+/// plus the caller's own); references that resolve to nothing (deleted or another user's private
+/// prompt) are silently dropped, never leaked.
+/// </summary>
+internal interface IPromptBadgeResolver
+{
+    Task<PromptBadgeResolution> ResolveAsync(
+        IReadOnlyList<Guid> promptRefs, Guid ownerId, string message, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc cref="IPromptBadgeResolver"/>
+internal sealed class PromptBadgeResolver(IPromptTemplateStore store) : IPromptBadgeResolver
+{
+    public async Task<PromptBadgeResolution> ResolveAsync(
+        IReadOnlyList<Guid> promptRefs, Guid ownerId, string message, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(promptRefs);
+
+        List<PromptTemplate> resolved = [];
+        foreach (Guid id in promptRefs.Distinct())
+        {
+            PromptTemplate? prompt = await store.GetAsync(id, ownerId, cancellationToken).ConfigureAwait(false);
+            if (prompt is not null)
+            {
+                resolved.Add(prompt);
+            }
+        }
+
+        if (resolved.Count == 0)
+        {
+            return new PromptBadgeResolution { ComposedMessage = message };
+        }
+
+        IEnumerable<string> parts = resolved
+            .Select(p => p.Content)
+            .Append(message)
+            .Where(part => !string.IsNullOrWhiteSpace(part));
+
+        PromptTemplate primary = resolved[0];
+        return new PromptBadgeResolution
+        {
+            ComposedMessage = string.Join("\n\n", parts),
+            PrimaryPromptName = primary.Name,
+            PrimaryPromptVersion = primary.Version,
+        };
+    }
+}

--- a/src/Granit.AI.Chat/packages.lock.json
+++ b/src/Granit.AI.Chat/packages.lock.json
@@ -47,6 +47,11 @@
         "resolved": "10.0.9",
         "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -63,6 +68,13 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {
@@ -145,6 +157,18 @@
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -244,6 +268,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -281,6 +323,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.EntityFrameworkCore/Entities/AIUsageRecordEntity.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Entities/AIUsageRecordEntity.cs
@@ -29,6 +29,10 @@ internal sealed class AIUsageRecordEntity : CreationAuditedEntity, IMultiTenant
 
     public string? PromptVersion { get; set; }
 
+    public string? PromptTemplateName { get; set; }
+
+    public int? PromptTemplateVersion { get; set; }
+
     public static AIUsageRecordEntity FromRecord(AIUsageRecord record) => new()
     {
         Id = record.Id,
@@ -43,5 +47,7 @@ internal sealed class AIUsageRecordEntity : CreationAuditedEntity, IMultiTenant
         CostCurrency = record.CostCurrency,
         Duration = record.Duration,
         PromptVersion = record.PromptVersion,
+        PromptTemplateName = record.PromptTemplateName,
+        PromptTemplateVersion = record.PromptTemplateVersion,
     };
 }

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
@@ -53,6 +53,11 @@ internal sealed class AIUsageRecordEntityConfiguration : IEntityTypeConfiguratio
         builder.Property(e => e.PromptVersion)
             .HasMaxLength(50);
 
+        builder.Property(e => e.PromptTemplateName)
+            .HasMaxLength(200);
+
+        builder.Property(e => e.PromptTemplateVersion);
+
         builder.Property(e => e.CreatedAt)
             .IsRequired();
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
@@ -42,6 +42,9 @@ internal sealed class EfAIUsageQueryableSource(
             CostCurrency = e.CostCurrency,
             Timestamp = e.CreatedAt,
             Duration = e.Duration,
+            PromptVersion = e.PromptVersion,
+            PromptTemplateName = e.PromptTemplateName,
+            PromptTemplateVersion = e.PromptTemplateVersion,
         });
     }
 }

--- a/src/Granit.AI.Tools/AIOrchestrationRequest.cs
+++ b/src/Granit.AI.Tools/AIOrchestrationRequest.cs
@@ -32,4 +32,16 @@ public sealed record AIOrchestrationRequest
     /// the guardrails.
     /// </summary>
     public string? UserCustomContext { get; init; }
+
+    /// <summary>
+    /// Name of the catalogue prompt template that drove this run (ADR-067 badge resolution), or
+    /// <see langword="null"/>. Stamped into the usage record for auditability; does not affect the loop.
+    /// </summary>
+    public string? InvokedPromptName { get; init; }
+
+    /// <summary>
+    /// Revision of the catalogue prompt template named by <see cref="InvokedPromptName"/>, or
+    /// <see langword="null"/>. Stamped into the usage record alongside the name.
+    /// </summary>
+    public int? InvokedPromptVersion { get; init; }
 }

--- a/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
+++ b/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
@@ -180,6 +180,8 @@ internal sealed partial class AIToolOrchestrator(
                 duration) with
             {
                 PromptVersion = systemPrompt.Guardrails.Version,
+                PromptTemplateName = request.InvokedPromptName,
+                PromptTemplateVersion = request.InvokedPromptVersion,
             };
 
             await usageTracker.RecordAsync(record, cancellationToken).ConfigureAwait(false);

--- a/src/Granit.AI/AIUsageRecord.cs
+++ b/src/Granit.AI/AIUsageRecord.cs
@@ -51,4 +51,16 @@ public sealed record AIUsageRecord
     /// which prompt version produced which interaction — without persisting prompt content.
     /// </summary>
     public string? PromptVersion { get; init; }
+
+    /// <summary>
+    /// Name of the catalogue prompt template the user invoked for this interaction (ADR-067), or
+    /// <c>null</c> when none was used. When several prompts are referenced, the first is stamped.
+    /// </summary>
+    public string? PromptTemplateName { get; init; }
+
+    /// <summary>
+    /// Revision of the invoked catalogue prompt template (see <see cref="PromptTemplateName"/>), or
+    /// <c>null</c> when none was used. Stamped for auditability without persisting prompt content.
+    /// </summary>
+    public int? PromptTemplateVersion { get; init; }
 }

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -421,6 +421,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",

--- a/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
@@ -279,6 +279,11 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -302,6 +307,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
@@ -313,6 +319,13 @@
         "dependencies": {
           "Granit.AI.Chat": "[0.1.0-dev, )",
           "Granit.BackgroundJobs": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {
@@ -409,6 +422,18 @@
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -514,6 +539,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -551,6 +594,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
@@ -101,6 +101,19 @@ public sealed class ConversationEndpointsUnitTests
     }
 
     [Fact]
+    public void Send_validator_rejects_too_many_prompt_refs()
+    {
+        SendMessageRequestValidator validator = CreateSendValidator();
+
+        validator.Validate(new SendMessageRequest("hi", PromptRefs: [Guid.NewGuid()])).IsValid.ShouldBeTrue();
+
+        var tooMany = Enumerable.Range(0, SendMessageRequestValidator.MaxPromptRefs + 1)
+            .Select(_ => Guid.NewGuid())
+            .ToList();
+        validator.Validate(new SendMessageRequest("hi", PromptRefs: tooMany)).IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
     public void Create_validator_rejects_blank_and_overlong_titles()
     {
         CreateConversationRequestValidator validator = new();

--- a/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
@@ -306,6 +306,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
@@ -320,6 +321,13 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
@@ -359,6 +359,11 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -382,6 +387,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
@@ -395,6 +401,13 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {
@@ -483,6 +496,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.persistence": {
@@ -650,6 +675,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -687,6 +730,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
@@ -569,6 +569,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
@@ -580,6 +581,13 @@
         "dependencies": {
           "Granit.AI.Chat": "[0.1.0-dev, )",
           "Granit.Privacy.BlobStorage": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -30,6 +30,7 @@ public sealed class ChatServiceTests
     private readonly IAIMentionContextResolver _mentionContextResolver = Substitute.For<IAIMentionContextResolver>();
     private readonly IAIAttachmentTextResolver _attachmentTextResolver = Substitute.For<IAIAttachmentTextResolver>();
     private readonly IAISuggestionResolver _suggestionResolver = Substitute.For<IAISuggestionResolver>();
+    private readonly IPromptBadgeResolver _promptBadgeResolver = Substitute.For<IPromptBadgeResolver>();
     private readonly ISettingProvider _settingProvider = Substitute.For<ISettingProvider>();
     private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
 
@@ -62,15 +63,16 @@ public sealed class ChatServiceTests
             .Returns([]);
 
         return new ChatService(_store, _orchestrator, _workspaceProvider, _capabilityResolver,
-            _mentionContextResolver, _attachmentTextResolver, _suggestionResolver, _settingProvider,
-            _guidGenerator, MsOptions.Create(new GranitAIOptions { DefaultWorkspace = "default" }));
+            _mentionContextResolver, _attachmentTextResolver, _suggestionResolver, _promptBadgeResolver,
+            _settingProvider, _guidGenerator, MsOptions.Create(new GranitAIOptions { DefaultWorkspace = "default" }));
     }
 
     private static ChatSendRequest Request(
         Guid? conversationId = null,
         string message = "hello",
         IReadOnlyList<AIMention>? mentions = null,
-        IReadOnlyList<AIAttachment>? attachments = null) =>
+        IReadOnlyList<AIAttachment>? attachments = null,
+        IReadOnlyList<Guid>? promptRefs = null) =>
         new()
         {
             ConversationId = conversationId,
@@ -78,6 +80,7 @@ public sealed class ChatServiceTests
             Message = message,
             Mentions = mentions,
             Attachments = attachments,
+            PromptRefs = promptRefs,
         };
 
     [Fact]
@@ -324,6 +327,59 @@ public sealed class ChatServiceTests
             Arg.Is<AIOrchestrationRequest>(r => r.WorkspaceName == "explicit"), Arg.Any<CancellationToken>());
         await _settingProvider.DidNotReceive()
             .GetOrNullAsync(AIChatSettingNames.DefaultWorkspace, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prompt_badges_drive_the_composed_instruction_and_stamp_the_primary_prompt()
+    {
+        ChatService service = CreateService();
+        var promptId = Guid.NewGuid();
+        _promptBadgeResolver
+            .ResolveAsync(Arg.Any<IReadOnlyList<Guid>>(), Owner, "my notes", Arg.Any<CancellationToken>())
+            .Returns(new PromptBadgeResolution
+            {
+                ComposedMessage = "Summarise the content.\n\nmy notes",
+                PrimaryPromptName = "Prompt:Summarize:Name",
+                PrimaryPromptVersion = 3,
+            });
+
+        await service.SendAsync(Request(message: "my notes", promptRefs: [promptId]), TestContext.Current.CancellationToken);
+
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r =>
+                r.Messages[r.Messages.Count - 1].Text == "Summarise the content.\n\nmy notes"
+                && r.InvokedPromptName == "Prompt:Summarize:Name"
+                && r.InvokedPromptVersion == 3),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prompt_badge_expansion_is_not_persisted_only_the_original_message_is()
+    {
+        ChatService service = CreateService();
+        _promptBadgeResolver
+            .ResolveAsync(Arg.Any<IReadOnlyList<Guid>>(), Owner, "my notes", Arg.Any<CancellationToken>())
+            .Returns(new PromptBadgeResolution { ComposedMessage = "Summarise the content.\n\nmy notes", PrimaryPromptName = "X", PrimaryPromptVersion = 1 });
+
+        await service.SendAsync(Request(message: "my notes", promptRefs: [Guid.NewGuid()]), TestContext.Current.CancellationToken);
+
+        await _store.Received(1).CreateAsync(
+            Arg.Is<Conversation>(c => c.Messages[0].Content == "my notes" && !c.Messages[0].Content.Contains("Summarise")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task No_prompt_refs_skips_badge_resolution()
+    {
+        ChatService service = CreateService();
+
+        await service.SendAsync(Request(message: "plain"), TestContext.Current.CancellationToken);
+
+        await _promptBadgeResolver.DidNotReceive()
+            .ResolveAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _orchestrator.Received(1).RunAsync(
+            Arg.Is<AIOrchestrationRequest>(r => r.InvokedPromptName == null && r.InvokedPromptVersion == null),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Granit.AI.Chat.Tests/PromptBadgeResolverTests.cs
+++ b/tests/Granit.AI.Chat.Tests/PromptBadgeResolverTests.cs
@@ -1,0 +1,74 @@
+using Granit.AI.Chat.Internal;
+using Granit.AI.Prompts;
+using Granit.AI.Prompts.Domain;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class PromptBadgeResolverTests
+{
+    private static readonly Guid Owner = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly IPromptTemplateStore _store = Substitute.For<IPromptTemplateStore>();
+
+    private PromptBadgeResolver CreateResolver() => new(_store);
+
+    [Fact]
+    public async Task Composes_prompt_contents_then_free_text_and_stamps_the_first_prompt()
+    {
+        var first = PromptTemplate.Create(Guid.NewGuid(), Owner, "Summarize", "d", "Summarise the content.");
+        var second = PromptTemplate.Create(Guid.NewGuid(), Owner, "Tone", "d", "Use a formal tone.");
+        _store.GetAsync(first.Id, Owner, Arg.Any<CancellationToken>()).Returns(first);
+        _store.GetAsync(second.Id, Owner, Arg.Any<CancellationToken>()).Returns(second);
+
+        PromptBadgeResolution result = await CreateResolver()
+            .ResolveAsync([first.Id, second.Id], Owner, "my notes", TestContext.Current.CancellationToken);
+
+        result.ComposedMessage.ShouldBe("Summarise the content.\n\nUse a formal tone.\n\nmy notes");
+        result.PrimaryPromptName.ShouldBe("Summarize");
+        result.PrimaryPromptVersion.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Drops_references_that_resolve_to_nothing()
+    {
+        var known = PromptTemplate.Create(Guid.NewGuid(), Owner, "Known", "d", "Known content.");
+        var missingId = Guid.NewGuid();
+        _store.GetAsync(known.Id, Owner, Arg.Any<CancellationToken>()).Returns(known);
+        _store.GetAsync(missingId, Owner, Arg.Any<CancellationToken>()).Returns((PromptTemplate?)null);
+
+        PromptBadgeResolution result = await CreateResolver()
+            .ResolveAsync([missingId, known.Id], Owner, "text", TestContext.Current.CancellationToken);
+
+        result.ComposedMessage.ShouldBe("Known content.\n\ntext");
+        result.PrimaryPromptName.ShouldBe("Known");
+    }
+
+    [Fact]
+    public async Task A_badge_only_turn_composes_just_the_prompt_content()
+    {
+        var prompt = PromptTemplate.CreateSystem(Guid.NewGuid(), "Prompt:DailyBrief:Name", "d", "Build my daily brief.");
+        _store.GetAsync(prompt.Id, Owner, Arg.Any<CancellationToken>()).Returns(prompt);
+
+        PromptBadgeResolution result = await CreateResolver()
+            .ResolveAsync([prompt.Id], Owner, "   ", TestContext.Current.CancellationToken);
+
+        result.ComposedMessage.ShouldBe("Build my daily brief.");
+        result.PrimaryPromptName.ShouldBe("Prompt:DailyBrief:Name");
+    }
+
+    [Fact]
+    public async Task No_resolved_prompts_returns_the_message_unchanged_with_no_stamp()
+    {
+        var missingId = Guid.NewGuid();
+        _store.GetAsync(missingId, Owner, Arg.Any<CancellationToken>()).Returns((PromptTemplate?)null);
+
+        PromptBadgeResolution result = await CreateResolver()
+            .ResolveAsync([missingId], Owner, "just text", TestContext.Current.CancellationToken);
+
+        result.ComposedMessage.ShouldBe("just text");
+        result.PrimaryPromptName.ShouldBeNull();
+        result.PrimaryPromptVersion.ShouldBeNull();
+    }
+}

--- a/tests/Granit.AI.Chat.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Tests/packages.lock.json
@@ -279,6 +279,11 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -302,10 +307,18 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ai.prompts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {
@@ -388,6 +401,18 @@
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -487,6 +512,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -524,6 +567,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
+++ b/tests/Granit.AI.Tools.Tests/AIToolOrchestratorTests.cs
@@ -262,6 +262,25 @@ public sealed class AIToolOrchestratorTests
     }
 
     [Fact]
+    public async Task Stamps_the_invoked_catalogue_prompt_into_the_usage_record()
+    {
+        ScriptedChatClient client = new(FinalText("done", input: 5, output: 2));
+        Harness harness = CreateHarness(client, []);
+
+        AIOrchestrationRequest request = UserSays("hi") with
+        {
+            InvokedPromptName = "Prompt:Summarize:Name",
+            InvokedPromptVersion = 4,
+        };
+
+        await harness.Orchestrator.RunAsync(request, TestContext.Current.CancellationToken);
+
+        await harness.UsageTracker.Received(1).RecordAsync(
+            Arg.Is<AIUsageRecord>(r => r.PromptTemplateName == "Prompt:Summarize:Name" && r.PromptTemplateVersion == 4),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Does_not_stamp_usage_when_the_provider_reports_none()
     {
         ScriptedChatClient client = new(FinalText("done"));

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1548,6 +1548,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",


### PR DESCRIPTION
Closes #2648. Part of Feature #2629 (Granit.AI.Prompts), Epic #2626 (ADR-067 agentic chat).

## What

The chat send now accepts **`promptRefs`** — catalogue prompt ids the front inserts as `/` badges.
The server expands them under the caller's ACLs, composes them with the free text into the final
instruction, and stamps the invoked prompt's name + version into the usage record.

### Acceptance criteria

- **Badge resolution** — a message with one or more `promptRefs` plus free text → the referenced
  prompts are expanded and composed into the final instruction.
- **Composition order** — `prompt contents… then the free text`, in ref order, blank-separated;
  unresolved refs (deleted / another user's private prompt) are silently dropped.
- **Usage stamping** — on completion the first resolved prompt's name + version land on the usage
  record.

## How

- `Granit.AI.Chat` now depends on `Granit.AI.Prompts`. New internal `IPromptBadgeResolver` resolves
  each ref via `IPromptTemplateStore` (owner-scoped: system + own) and composes the instruction.
  The composed text drives the turn; the user's **original** message is what gets persisted — badge
  expansion stays ephemeral, exactly like mentions and attachments.
- `ChatSendRequest` / `SendMessageRequest` gain `PromptRefs`; the send handler maps them. The
  validator caps a turn at **5** prompts (`AIChat:Validation:TooManyPromptRefs`, 18 cultures).
- `AIOrchestrationRequest` carries `InvokedPromptName` / `InvokedPromptVersion`; the orchestrator
  stamps them onto `AIUsageRecord` as **`PromptTemplateName` / `PromptTemplateVersion`** — distinct
  from the guardrail `PromptVersion`. New EF columns; the read projection now surfaces all three
  prompt fields (`PromptVersion` was previously unmapped).

> Consuming apps own the migration for the two new `ai_usage_records` columns (framework ships no migrations).

## Tests & wiring

- `PromptBadgeResolver`: composition order, drop-unresolved, badge-only turn, no-resolved.
- `ChatService`: badge wiring + stamping + ephemerality (original message persisted).
- Orchestrator: catalogue-prompt stamping into the usage record.
- Validator: prompt-refs cap.
- **225/225 architecture tests pass**; `dotnet format` clean; lockfiles regenerated (spurious
  DataExchange.Csv bumps reverted).

## Remaining in Feature #2629

- #2649 pairing / permissions / loc / shards finalisation