### PR TITLE
feat(ai): prompt catalogue Query/Export pairing + conventions (#2649)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -133,7 +133,9 @@
       "name": "Granit.AI.Prompts",
       "deps": [
         "Granit",
-        "Granit.Localization"
+        "Granit.DataExchange.Abstractions",
+        "Granit.Localization",
+        "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -153,7 +155,8 @@
       "deps": [
         "Granit.AI.Prompts",
         "Granit.Guids",
-        "Granit.Persistence.EntityFrameworkCore"
+        "Granit.Persistence.EntityFrameworkCore",
+        "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -5375,7 +5378,7 @@
       "kind": "class",
       "project": "Granit.AI.Prompts.EntityFrameworkCore",
       "file": "src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitAIPromptsEntityFrameworkCore",
@@ -5434,12 +5437,28 @@
       ]
     },
     {
+      "name": "PromptTemplateExportDefinition",
+      "fqn": "Granit.AI.Prompts.Exports.PromptTemplateExportDefinition",
+      "kind": "class",
+      "project": "Granit.AI.Prompts",
+      "file": "src/Granit.AI.Prompts/Exports/PromptTemplateExportDefinition.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "GranitAIPromptsModule",
       "fqn": "Granit.AI.Prompts.GranitAIPromptsModule",
       "kind": "class",
       "project": "Granit.AI.Prompts",
       "file": "src/Granit.AI.Prompts/GranitAIPromptsModule.cs",
-      "line": 14,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",
@@ -5531,6 +5550,28 @@
       "file": "src/Granit.AI.Prompts/PromptTemplateEdit.cs",
       "line": 16,
       "members": []
+    },
+    {
+      "name": "PromptTemplateQueryDefinition",
+      "fqn": "Granit.AI.Prompts.Queries.PromptTemplateQueryDefinition",
+      "kind": "class",
+      "project": "Granit.AI.Prompts",
+      "file": "src/Granit.AI.Prompts/Queries/PromptTemplateQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(AIPromptsLocalizationResource)",
+          "returnType": "Type? LocalizationResourceType =>"
+        }
+      ]
     },
     {
       "name": "GenericPromptSeed",
@@ -15914,6 +15955,15 @@
       "project": "Granit.DataExchange.Abstractions",
       "file": "src/Granit.DataExchange.Abstractions/Export/ExportDefinitionBuilder.cs",
       "line": 20,
+      "members": []
+    },
+    {
+      "name": "ExportDefinitionBuilderAuditExtensions",
+      "fqn": "Granit.DataExchange.Export.ExportDefinitionBuilderAuditExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Abstractions",
+      "file": "src/Granit.DataExchange.Abstractions/Export/ExportDefinitionBuilderAuditExtensions.cs",
+      "line": 9,
       "members": []
     },
     {

--- a/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
+++ b/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
@@ -86,7 +86,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/src/Granit.AI.Chat.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Chat.Endpoints/packages.lock.json
@@ -107,7 +107,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
@@ -143,7 +143,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/src/Granit.AI.Chat.Privacy/packages.lock.json
+++ b/src/Granit.AI.Chat.Privacy/packages.lock.json
@@ -353,7 +353,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/src/Granit.AI.Chat/packages.lock.json
+++ b/src/Granit.AI.Chat/packages.lock.json
@@ -74,7 +74,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/src/Granit.AI.Prompts.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Prompts.Endpoints/packages.lock.json
@@ -63,7 +63,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.authorization": {

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
+using Granit.AI.Prompts.Domain;
 using Granit.AI.Prompts.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -37,6 +39,9 @@ public static class AIPromptsEntityFrameworkCoreServiceCollectionExtensions
 
         services.TryAddScoped<IPromptTemplateStore, EfPromptTemplateStore>();
         services.TryAddScoped<IPromptCategoryStore, EfPromptCategoryStore>();
+
+        // Backs the catalogue admin grid + export (PromptTemplateQueryDefinition / ExportDefinition).
+        services.TryAddScoped<IQueryableSource<PromptTemplate>, EfPromptTemplateQueryableSource>();
 
         return services;
     }

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Granit.AI.Prompts.EntityFrameworkCore.csproj
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Granit.AI.Prompts.EntityFrameworkCore.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\Granit.AI.Prompts\Granit.AI.Prompts.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptTemplateQueryableSource.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptTemplateQueryableSource.cs
@@ -1,0 +1,28 @@
+using Granit.AI.Prompts.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.AI.Prompts.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core <see cref="IQueryableSource{TEntity}"/> for <see cref="PromptTemplate"/>, backing the
+/// catalogue admin grid and export. When no tenant context is active (host admin) the multi-tenant
+/// query filter is bypassed so prompts are returned cross-tenant.
+/// </summary>
+internal sealed class EfPromptTemplateQueryableSource(
+    IDbContextFactory<AIPromptsDbContext> contextFactory,
+    ICurrentTenant currentTenant) : IQueryableSource<PromptTemplate>
+{
+    private readonly AIPromptsDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+
+    public IQueryable<PromptTemplate> GetQueryable()
+    {
+        IQueryable<PromptTemplate> query = _context.PromptTemplates.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+}

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/packages.lock.json
@@ -92,7 +92,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/src/Granit.AI.Prompts/Exports/PromptTemplateExportDefinition.cs
+++ b/src/Granit.AI.Prompts/Exports/PromptTemplateExportDefinition.cs
@@ -1,0 +1,31 @@
+using Granit.AI.Prompts.Domain;
+using Granit.DataExchange.Export;
+
+namespace Granit.AI.Prompts.Exports;
+
+/// <summary>
+/// Export definition for the prompt catalogue (ADR-020 pairing with
+/// <see cref="Queries.PromptTemplateQueryDefinition"/>). Emits the catalogue fields, including the
+/// instruction text, for admin take-out.
+/// </summary>
+public sealed class PromptTemplateExportDefinition : ExportDefinition<PromptTemplate>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.AI.Prompts.TemplatesExport";
+
+    /// <inheritdoc/>
+    protected override void Configure(ExportDefinitionBuilder<PromptTemplate> builder)
+    {
+        builder
+            .IncludeId()
+            .Field(p => p.Name)
+            .Field(p => p.ShortDescription)
+            .Field(p => p.Content)
+            .Field(p => p.Icon)
+            .Field(p => p.IsSystem)
+            .Field(p => p.Version)
+            .Field(p => p.OwnerId)
+            .Field(p => p.TenantId)
+            .IncludeAuditFields();
+    }
+}

--- a/src/Granit.AI.Prompts/Granit.AI.Prompts.csproj
+++ b/src/Granit.AI.Prompts/Granit.AI.Prompts.csproj
@@ -17,7 +17,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.AI.Prompts/GranitAIPromptsModule.cs
+++ b/src/Granit.AI.Prompts/GranitAIPromptsModule.cs
@@ -1,6 +1,11 @@
+using Granit.AI.Prompts.Domain;
+using Granit.AI.Prompts.Exports;
+using Granit.AI.Prompts.Queries;
+using Granit.DataExchange.Extensions;
 using Granit.Localization;
 using Granit.Localization.Extensions;
 using Granit.Modularity;
+using Granit.QueryEngine.Extensions;
 
 namespace Granit.AI.Prompts;
 
@@ -14,6 +19,13 @@ namespace Granit.AI.Prompts;
 public sealed class GranitAIPromptsModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddLocalizationResource<AIPromptsLocalizationResource>();
+
+        // Admin-grid + take-out for the catalogue (ADR-020 Query↔Export pairing). The EF queryable
+        // source is registered by Granit.AI.Prompts.EntityFrameworkCore.
+        context.Services.AddQueryDefinition<PromptTemplate, PromptTemplateQueryDefinition>();
+        context.Services.AddExportDefinition<PromptTemplate, PromptTemplateExportDefinition>();
+    }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/cs.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/cs.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Denní přehled",
     "Prompt:DailyBrief:Description": "Stručný přehled toho, co dnes vyžaduje vaši pozornost.",
     "Prompt:FindRelated:Name": "Najít související",
-    "Prompt:FindRelated:Description": "Najdi položky související s aktuálním kontextem."
+    "Prompt:FindRelated:Description": "Najdi položky související s aktuálním kontextem.",
+    "AIPrompts.Columns.Name": "Název",
+    "AIPrompts.Columns.Description": "Popis",
+    "AIPrompts.Columns.IsSystem": "Systémový",
+    "AIPrompts.Columns.Owner": "Vlastník",
+    "AIPrompts.Columns.Version": "Verze",
+    "AIPrompts.Columns.Tenant": "Nájemce",
+    "AIPrompts.Columns.CreatedAt": "Vytvořeno"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/de.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/de.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Tagesbriefing",
     "Prompt:DailyBrief:Description": "Eine knappe Übersicht, was heute Ihre Aufmerksamkeit erfordert.",
     "Prompt:FindRelated:Name": "Verwandtes finden",
-    "Prompt:FindRelated:Description": "Finde Elemente, die mit dem aktuellen Kontext zusammenhängen."
+    "Prompt:FindRelated:Description": "Finde Elemente, die mit dem aktuellen Kontext zusammenhängen.",
+    "AIPrompts.Columns.Name": "Name",
+    "AIPrompts.Columns.Description": "Beschreibung",
+    "AIPrompts.Columns.IsSystem": "System",
+    "AIPrompts.Columns.Owner": "Besitzer",
+    "AIPrompts.Columns.Version": "Version",
+    "AIPrompts.Columns.Tenant": "Mandant",
+    "AIPrompts.Columns.CreatedAt": "Erstellt am"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/en.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/en.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Daily brief",
     "Prompt:DailyBrief:Description": "A concise brief of what needs your attention today.",
     "Prompt:FindRelated:Name": "Find related",
-    "Prompt:FindRelated:Description": "Find items related to the current context."
+    "Prompt:FindRelated:Description": "Find items related to the current context.",
+    "AIPrompts.Columns.Name": "Name",
+    "AIPrompts.Columns.Description": "Description",
+    "AIPrompts.Columns.IsSystem": "System",
+    "AIPrompts.Columns.Owner": "Owner",
+    "AIPrompts.Columns.Version": "Version",
+    "AIPrompts.Columns.Tenant": "Tenant",
+    "AIPrompts.Columns.CreatedAt": "Created At"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/es.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/es.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Resumen diario",
     "Prompt:DailyBrief:Description": "Un resumen conciso de lo que requiere tu atención hoy.",
     "Prompt:FindRelated:Name": "Buscar relacionados",
-    "Prompt:FindRelated:Description": "Encuentra elementos relacionados con el contexto actual."
+    "Prompt:FindRelated:Description": "Encuentra elementos relacionados con el contexto actual.",
+    "AIPrompts.Columns.Name": "Nombre",
+    "AIPrompts.Columns.Description": "Descripción",
+    "AIPrompts.Columns.IsSystem": "Sistema",
+    "AIPrompts.Columns.Owner": "Propietario",
+    "AIPrompts.Columns.Version": "Versión",
+    "AIPrompts.Columns.Tenant": "Inquilino",
+    "AIPrompts.Columns.CreatedAt": "Creado el"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/fr.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/fr.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Brief du jour",
     "Prompt:DailyBrief:Description": "Un résumé concis de ce qui requiert votre attention aujourd'hui.",
     "Prompt:FindRelated:Name": "Trouver des éléments liés",
-    "Prompt:FindRelated:Description": "Trouve les éléments liés au contexte actuel."
+    "Prompt:FindRelated:Description": "Trouve les éléments liés au contexte actuel.",
+    "AIPrompts.Columns.Name": "Nom",
+    "AIPrompts.Columns.Description": "Description",
+    "AIPrompts.Columns.IsSystem": "Système",
+    "AIPrompts.Columns.Owner": "Propriétaire",
+    "AIPrompts.Columns.Version": "Version",
+    "AIPrompts.Columns.Tenant": "Locataire",
+    "AIPrompts.Columns.CreatedAt": "Créé le"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/hi.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/hi.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "दैनिक ब्रीफ",
     "Prompt:DailyBrief:Description": "आज आपके ध्यान की आवश्यकता वाली बातों का संक्षिप्त विवरण।",
     "Prompt:FindRelated:Name": "संबंधित खोजें",
-    "Prompt:FindRelated:Description": "वर्तमान संदर्भ से संबंधित आइटम खोजें।"
+    "Prompt:FindRelated:Description": "वर्तमान संदर्भ से संबंधित आइटम खोजें।",
+    "AIPrompts.Columns.Name": "नाम",
+    "AIPrompts.Columns.Description": "विवरण",
+    "AIPrompts.Columns.IsSystem": "सिस्टम",
+    "AIPrompts.Columns.Owner": "स्वामी",
+    "AIPrompts.Columns.Version": "संस्करण",
+    "AIPrompts.Columns.Tenant": "किरायेदार",
+    "AIPrompts.Columns.CreatedAt": "निर्मित"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/it.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/it.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Brief giornaliero",
     "Prompt:DailyBrief:Description": "Una sintesi concisa di ciò che richiede la tua attenzione oggi.",
     "Prompt:FindRelated:Name": "Trova correlati",
-    "Prompt:FindRelated:Description": "Trova elementi correlati al contesto attuale."
+    "Prompt:FindRelated:Description": "Trova elementi correlati al contesto attuale.",
+    "AIPrompts.Columns.Name": "Nome",
+    "AIPrompts.Columns.Description": "Descrizione",
+    "AIPrompts.Columns.IsSystem": "Sistema",
+    "AIPrompts.Columns.Owner": "Proprietario",
+    "AIPrompts.Columns.Version": "Versione",
+    "AIPrompts.Columns.Tenant": "Tenant",
+    "AIPrompts.Columns.CreatedAt": "Creato il"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/ja.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/ja.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "デイリーブリーフ",
     "Prompt:DailyBrief:Description": "今日注意すべき事項の簡潔なまとめ。",
     "Prompt:FindRelated:Name": "関連を検索",
-    "Prompt:FindRelated:Description": "現在のコンテキストに関連する項目を探します。"
+    "Prompt:FindRelated:Description": "現在のコンテキストに関連する項目を探します。",
+    "AIPrompts.Columns.Name": "名前",
+    "AIPrompts.Columns.Description": "説明",
+    "AIPrompts.Columns.IsSystem": "システム",
+    "AIPrompts.Columns.Owner": "所有者",
+    "AIPrompts.Columns.Version": "バージョン",
+    "AIPrompts.Columns.Tenant": "テナント",
+    "AIPrompts.Columns.CreatedAt": "作成日時"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/ko.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/ko.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "일일 브리핑",
     "Prompt:DailyBrief:Description": "오늘 주의가 필요한 사항에 대한 간결한 요약입니다.",
     "Prompt:FindRelated:Name": "관련 항목 찾기",
-    "Prompt:FindRelated:Description": "현재 컨텍스트와 관련된 항목을 찾습니다."
+    "Prompt:FindRelated:Description": "현재 컨텍스트와 관련된 항목을 찾습니다.",
+    "AIPrompts.Columns.Name": "이름",
+    "AIPrompts.Columns.Description": "설명",
+    "AIPrompts.Columns.IsSystem": "시스템",
+    "AIPrompts.Columns.Owner": "소유자",
+    "AIPrompts.Columns.Version": "버전",
+    "AIPrompts.Columns.Tenant": "테넌트",
+    "AIPrompts.Columns.CreatedAt": "생성일"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/nl.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/nl.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Dagelijkse briefing",
     "Prompt:DailyBrief:Description": "Een beknopt overzicht van wat vandaag uw aandacht vraagt.",
     "Prompt:FindRelated:Name": "Gerelateerde zoeken",
-    "Prompt:FindRelated:Description": "Zoek items die verband houden met de huidige context."
+    "Prompt:FindRelated:Description": "Zoek items die verband houden met de huidige context.",
+    "AIPrompts.Columns.Name": "Naam",
+    "AIPrompts.Columns.Description": "Beschrijving",
+    "AIPrompts.Columns.IsSystem": "Systeem",
+    "AIPrompts.Columns.Owner": "Eigenaar",
+    "AIPrompts.Columns.Version": "Versie",
+    "AIPrompts.Columns.Tenant": "Tenant",
+    "AIPrompts.Columns.CreatedAt": "Aangemaakt op"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/pl.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/pl.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Dzienny przegląd",
     "Prompt:DailyBrief:Description": "Zwięzłe podsumowanie tego, co dziś wymaga Twojej uwagi.",
     "Prompt:FindRelated:Name": "Znajdź powiązane",
-    "Prompt:FindRelated:Description": "Znajdź elementy powiązane z bieżącym kontekstem."
+    "Prompt:FindRelated:Description": "Znajdź elementy powiązane z bieżącym kontekstem.",
+    "AIPrompts.Columns.Name": "Nazwa",
+    "AIPrompts.Columns.Description": "Opis",
+    "AIPrompts.Columns.IsSystem": "Systemowy",
+    "AIPrompts.Columns.Owner": "Właściciel",
+    "AIPrompts.Columns.Version": "Wersja",
+    "AIPrompts.Columns.Tenant": "Najemca",
+    "AIPrompts.Columns.CreatedAt": "Utworzono"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/pt.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/pt.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Resumo diário",
     "Prompt:DailyBrief:Description": "Um resumo conciso do que precisa da tua atenção hoje.",
     "Prompt:FindRelated:Name": "Encontrar relacionados",
-    "Prompt:FindRelated:Description": "Encontra itens relacionados com o contexto atual."
+    "Prompt:FindRelated:Description": "Encontra itens relacionados com o contexto atual.",
+    "AIPrompts.Columns.Name": "Nome",
+    "AIPrompts.Columns.Description": "Descrição",
+    "AIPrompts.Columns.IsSystem": "Sistema",
+    "AIPrompts.Columns.Owner": "Proprietário",
+    "AIPrompts.Columns.Version": "Versão",
+    "AIPrompts.Columns.Tenant": "Inquilino",
+    "AIPrompts.Columns.CreatedAt": "Criado em"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/sv.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/sv.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Daglig översikt",
     "Prompt:DailyBrief:Description": "En kortfattad översikt av vad som kräver din uppmärksamhet idag.",
     "Prompt:FindRelated:Name": "Hitta relaterat",
-    "Prompt:FindRelated:Description": "Hitta objekt som är relaterade till det aktuella sammanhanget."
+    "Prompt:FindRelated:Description": "Hitta objekt som är relaterade till det aktuella sammanhanget.",
+    "AIPrompts.Columns.Name": "Namn",
+    "AIPrompts.Columns.Description": "Beskrivning",
+    "AIPrompts.Columns.IsSystem": "System",
+    "AIPrompts.Columns.Owner": "Ägare",
+    "AIPrompts.Columns.Version": "Version",
+    "AIPrompts.Columns.Tenant": "Klient",
+    "AIPrompts.Columns.CreatedAt": "Skapad"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/tr.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/tr.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "Günlük özet",
     "Prompt:DailyBrief:Description": "Bugün dikkatini gerektiren şeylerin kısa bir özeti.",
     "Prompt:FindRelated:Name": "İlgili öğeleri bul",
-    "Prompt:FindRelated:Description": "Geçerli bağlamla ilgili öğeleri bul."
+    "Prompt:FindRelated:Description": "Geçerli bağlamla ilgili öğeleri bul.",
+    "AIPrompts.Columns.Name": "Ad",
+    "AIPrompts.Columns.Description": "Açıklama",
+    "AIPrompts.Columns.IsSystem": "Sistem",
+    "AIPrompts.Columns.Owner": "Sahip",
+    "AIPrompts.Columns.Version": "Sürüm",
+    "AIPrompts.Columns.Tenant": "Kiracı",
+    "AIPrompts.Columns.CreatedAt": "Oluşturulma"
   }
 }

--- a/src/Granit.AI.Prompts/Localization/AIPrompts/zh.json
+++ b/src/Granit.AI.Prompts/Localization/AIPrompts/zh.json
@@ -8,6 +8,13 @@
     "Prompt:DailyBrief:Name": "每日简报",
     "Prompt:DailyBrief:Description": "简要概述今天需要你关注的内容。",
     "Prompt:FindRelated:Name": "查找相关",
-    "Prompt:FindRelated:Description": "查找与当前上下文相关的条目。"
+    "Prompt:FindRelated:Description": "查找与当前上下文相关的条目。",
+    "AIPrompts.Columns.Name": "名称",
+    "AIPrompts.Columns.Description": "描述",
+    "AIPrompts.Columns.IsSystem": "系统",
+    "AIPrompts.Columns.Owner": "所有者",
+    "AIPrompts.Columns.Version": "版本",
+    "AIPrompts.Columns.Tenant": "租户",
+    "AIPrompts.Columns.CreatedAt": "创建时间"
   }
 }

--- a/src/Granit.AI.Prompts/Queries/PromptTemplateQueryDefinition.cs
+++ b/src/Granit.AI.Prompts/Queries/PromptTemplateQueryDefinition.cs
@@ -1,0 +1,33 @@
+using Granit.AI.Prompts.Domain;
+using Granit.QueryEngine;
+
+namespace Granit.AI.Prompts.Queries;
+
+/// <summary>
+/// Query definition for the prompt catalogue — declares the admin-grid columns, filters, sorting, and
+/// search for the query engine (ADR-020 pairing with <see cref="Exports.PromptTemplateExportDefinition"/>).
+/// </summary>
+public sealed class PromptTemplateQueryDefinition : QueryDefinition<PromptTemplate>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.AI.Prompts.TemplatesQuery";
+
+    /// <inheritdoc/>
+    public override Type? LocalizationResourceType => typeof(AIPromptsLocalizationResource);
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<PromptTemplate> builder)
+    {
+        builder
+            .Column(p => p.Name, c => c.Label("Name").LabelKey("AIPrompts.Columns.Name").Filterable().Sortable())
+            .Column(p => p.ShortDescription, c => c.Label("Description").LabelKey("AIPrompts.Columns.Description").Filterable())
+            .Column(p => p.IsSystem, c => c.Label("System").LabelKey("AIPrompts.Columns.IsSystem").Filterable().Sortable())
+            .Column(p => p.OwnerId, c => c.Label("Owner").LabelKey("AIPrompts.Columns.Owner").Filterable())
+            .Column(p => p.Version, c => c.Label("Version").LabelKey("AIPrompts.Columns.Version").Sortable())
+            .Column(p => p.TenantId, c => c.Label("Tenant").LabelKey("AIPrompts.Columns.Tenant").Filterable())
+            .Column(p => p.CreatedAt, c => c.Label("Created At").LabelKey("AIPrompts.Columns.CreatedAt").Sortable())
+            .GlobalSearch(p => p.Name)
+            .DefaultSort("-createdAt")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.AI.Prompts/README.md
+++ b/src/Granit.AI.Prompts/README.md
@@ -11,6 +11,10 @@ abstraction. Persistence is provided by `Granit.AI.Prompts.EntityFrameworkCore`.
 Framework-seeded generic prompts are flagged `IsSystem` and owned by no user; a user's own prompts
 are private (v1, sharing deferred to phase 2).
 
+The catalogue ships an admin-grid `QueryDefinition` and a take-out `ExportDefinition` for
+`PromptTemplate` (ADR-020 pairing), registered by `GranitAIPromptsModule`; the EF queryable source
+is registered by `Granit.AI.Prompts.EntityFrameworkCore`.
+
 Part of the [granit](https://granit-fx.dev) framework.
 
 ## Installation
@@ -22,6 +26,9 @@ dotnet add package Granit.AI.Prompts
 ## Dependencies
 
 - `Granit`
+- `Granit.Localization`
+- `Granit.QueryEngine.Abstractions`
+- `Granit.DataExchange.Abstractions`
 
 ## Documentation
 

--- a/src/Granit.DataExchange.Abstractions/Export/ExportDefinitionBuilderAuditExtensions.cs
+++ b/src/Granit.DataExchange.Abstractions/Export/ExportDefinitionBuilderAuditExtensions.cs
@@ -1,0 +1,42 @@
+using Granit.Domain;
+
+namespace Granit.DataExchange.Export;
+
+/// <summary>
+/// Convenience extensions for declaring the standard audit fields on an
+/// <see cref="ExportDefinitionBuilder{TEntity}"/> without repeating them in every definition.
+/// </summary>
+public static class ExportDefinitionBuilderAuditExtensions
+{
+    /// <summary>
+    /// Appends the creation audit fields — <see cref="ICreationAuditedObject.CreatedAt"/> (round-trip
+    /// <c>"O"</c> format) and <see cref="ICreationAuditedObject.CreatedBy"/>.
+    /// </summary>
+    public static ExportDefinitionBuilder<TEntity> IncludeCreationAuditFields<TEntity>(
+        this ExportDefinitionBuilder<TEntity> builder)
+        where TEntity : class, ICreationAuditedObject
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder
+            .Field(e => e.CreatedAt, f => f.Format("O"))
+            .Field(e => e.CreatedBy);
+    }
+
+    /// <summary>
+    /// Appends the full creation + modification audit fields — <c>CreatedAt</c>, <c>CreatedBy</c>,
+    /// <c>ModifiedAt</c> (round-trip <c>"O"</c> format) and <c>ModifiedBy</c> — the shape shared by every
+    /// <see cref="IModificationAuditedObject"/>. Replaces the four field declarations repeated across
+    /// export definitions.
+    /// </summary>
+    public static ExportDefinitionBuilder<TEntity> IncludeAuditFields<TEntity>(
+        this ExportDefinitionBuilder<TEntity> builder)
+        where TEntity : class, ICreationAuditedObject, IModificationAuditedObject
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder
+            .Field(e => e.CreatedAt, f => f.Format("O"))
+            .Field(e => e.CreatedBy)
+            .Field(e => e.ModifiedAt, f => f.Format("O"))
+            .Field(e => e.ModifiedBy);
+    }
+}

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -452,7 +452,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.prompts.endpoints": {

--- a/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
@@ -325,7 +325,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
@@ -327,7 +327,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
@@ -407,7 +407,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
@@ -587,7 +587,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/tests/Granit.AI.Chat.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Tests/packages.lock.json
@@ -318,7 +318,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.tools": {

--- a/tests/Granit.AI.Prompts.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Prompts.Endpoints.Tests/packages.lock.json
@@ -273,7 +273,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.prompts.endpoints": {

--- a/tests/Granit.AI.Prompts.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.Prompts.EntityFrameworkCore.Tests/packages.lock.json
@@ -371,7 +371,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.prompts.entityframeworkcore": {
@@ -379,7 +381,8 @@
         "dependencies": {
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )"
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.AI.Prompts.Tests/PromptCatalogueDefinitionsTests.cs
+++ b/tests/Granit.AI.Prompts.Tests/PromptCatalogueDefinitionsTests.cs
@@ -1,0 +1,31 @@
+using Granit.AI.Prompts.Exports;
+using Granit.AI.Prompts.Queries;
+using Shouldly;
+using Xunit;
+
+namespace Granit.AI.Prompts.Tests;
+
+public sealed class PromptCatalogueDefinitionsTests
+{
+    [Fact]
+    public void Query_definition_exposes_the_catalogue_columns()
+    {
+        PromptTemplateQueryDefinition definition = new();
+
+        definition.Name.ShouldBe("Granit.AI.Prompts.TemplatesQuery");
+        definition.LocalizationResourceType.ShouldBe(typeof(AIPromptsLocalizationResource));
+        definition.GetColumns().ShouldContain(c => c.PropertyName.Equals("name", StringComparison.OrdinalIgnoreCase));
+        definition.GetColumns().ShouldContain(c => c.PropertyName.Equals("isSystem", StringComparison.OrdinalIgnoreCase));
+        definition.GetGlobalSearchProperties().ShouldContain(p => p.Equals("name", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Export_definition_includes_the_id_and_the_content_field()
+    {
+        PromptTemplateExportDefinition definition = new();
+
+        definition.Name.ShouldBe("Granit.AI.Prompts.TemplatesExport");
+        definition.GetIncludeId().ShouldBeTrue();
+        definition.GetFields().ShouldContain(f => f.PropertyPath.Equals("content", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Granit.AI.Prompts.Tests/packages.lock.json
+++ b/tests/Granit.AI.Prompts.Tests/packages.lock.json
@@ -252,7 +252,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1638,7 +1638,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.prompts.endpoints": {
@@ -1656,7 +1658,8 @@
         "dependencies": {
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )"
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.stackexchangeredis": {

--- a/tests/Granit.DataExchange.Abstractions.Tests/ExportDefinitionBuilderAuditExtensionsTests.cs
+++ b/tests/Granit.DataExchange.Abstractions.Tests/ExportDefinitionBuilderAuditExtensionsTests.cs
@@ -1,0 +1,53 @@
+using Granit.DataExchange.Export;
+using Granit.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.DataExchange.Abstractions.Tests;
+
+public sealed class ExportDefinitionBuilderAuditExtensionsTests
+{
+    private sealed class AuditedThing : ICreationAuditedObject, IModificationAuditedObject
+    {
+        public DateTimeOffset CreatedAt { get; set; }
+        public string CreatedBy { get; set; } = string.Empty;
+        public DateTimeOffset? ModifiedAt { get; set; }
+        public string? ModifiedBy { get; set; }
+    }
+
+    private sealed class CreationOnlyThing : ICreationAuditedObject
+    {
+        public DateTimeOffset CreatedAt { get; set; }
+        public string CreatedBy { get; set; } = string.Empty;
+    }
+
+    private sealed class AuditedThingExport : ExportDefinition<AuditedThing>
+    {
+        public override string Name => "Test.AuditedThing";
+        protected override void Configure(ExportDefinitionBuilder<AuditedThing> builder) => builder.IncludeAuditFields();
+    }
+
+    private sealed class CreationOnlyExport : ExportDefinition<CreationOnlyThing>
+    {
+        public override string Name => "Test.CreationOnly";
+        protected override void Configure(ExportDefinitionBuilder<CreationOnlyThing> builder) => builder.IncludeCreationAuditFields();
+    }
+
+    [Fact]
+    public void IncludeAuditFields_appends_the_four_audit_fields_with_roundtrip_timestamps()
+    {
+        IReadOnlyList<ExportFieldDescriptor> fields = new AuditedThingExport().GetFields();
+
+        fields.Select(f => f.PropertyPath).ShouldBe(["CreatedAt", "CreatedBy", "ModifiedAt", "ModifiedBy"]);
+        fields.Single(f => f.PropertyPath == "CreatedAt").Format.ShouldBe("O");
+        fields.Single(f => f.PropertyPath == "ModifiedAt").Format.ShouldBe("O");
+    }
+
+    [Fact]
+    public void IncludeCreationAuditFields_appends_only_the_creation_fields()
+    {
+        IReadOnlyList<ExportFieldDescriptor> fields = new CreationOnlyExport().GetFields();
+
+        fields.Select(f => f.PropertyPath).ShouldBe(["CreatedAt", "CreatedBy"]);
+    }
+}


### PR DESCRIPTION
Closes #2649. **Completes Feature #2629** (Granit.AI.Prompts), Epic #2626 (ADR-067 agentic chat).

## What

Brings the prompt catalogue in line with the framework cross-cutting conventions.

### Query ↔ Export pairing (ADR-020)

- **`PromptTemplateQueryDefinition`** — admin-grid columns (Name, Description, System, Owner, Version,
  Tenant, Created), filters, global search, default sort; localized column labels.
- **`PromptTemplateExportDefinition`** — take-out incl. the instruction text.
- Both live in the base module (`Queries/`, `Exports/`), referencing the QueryEngine / DataExchange
  **Abstractions** (never the engines directly). Registered by `GranitAIPromptsModule`.
- **`EfPromptTemplateQueryableSource`** (tenant-scoped, host-admin cross-tenant bypass) registered by
  `Granit.AI.Prompts.EntityFrameworkCore` so the grid/export actually execute.

### Localisation / docs

- Column labels added across the **18 AIPrompts cultures** (`AIPrompts.Columns.*`).
- README documents the admin query/export. The `granit-docs` page is a separate handoff (docs repo).

## Audit-field helper (review feedback)

The four `CreatedAt / CreatedBy / ModifiedAt / ModifiedBy` field declarations are repeated across ~19
export definitions. New **`ExportDefinitionBuilder.IncludeAuditFields()`** (and
`IncludeCreationAuditFields()`) in `Granit.DataExchange.Abstractions` collapses them, constrained to
`ICreationAuditedObject` / `IModificationAuditedObject`. Applied here to `PromptTemplateExportDefinition`.

> A repo-wide sweep of the other ~18 export definitions onto the helper can follow as a separate PR
> (each needs a quick check for non-standard ordering / soft-delete fields).

## Tests & gates

- Query/Export definition shape; audit-field helper (full + creation-only).
- **225/225 architecture tests pass** (pairing now satisfied for `PromptTemplate`).
- `dotnet format` + markdownlint clean; lockfiles regenerated (spurious DataExchange.Csv bumps reverted).

## Feature #2629 — done

#2644 aggregate · #2645 categories · #2646 seed · #2647 endpoints · #2648 badge resolution · **#2649 conventions**.