### PR TITLE
refactor(data-exchange): use IncludeAuditFields() across export definitions

### DIFF
--- a/src/Granit.Auditing/Exports/AuditEntryExportDefinition.cs
+++ b/src/Granit.Auditing/Exports/AuditEntryExportDefinition.cs
@@ -19,7 +19,6 @@ public sealed class AuditEntryExportDefinition : ExportDefinition<AuditEntry>
             .Field(e => e.UserAgent)
             .Field(e => e.CorrelationId)
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy);
+            .IncludeCreationAuditFields();
     }
 }

--- a/src/Granit.Authentication.ApiKeys/Exports/ApiKeyEntryExportDefinition.cs
+++ b/src/Granit.Authentication.ApiKeys/Exports/ApiKeyEntryExportDefinition.cs
@@ -32,7 +32,6 @@ public sealed class ApiKeyEntryExportDefinition : ExportDefinition<ApiKeyEntry>
             .Field(e => e.RevokedAt, f => f.Format("O"))
             .Field(e => e.CacheBehavior)
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy);
+            .IncludeCreationAuditFields();
     }
 }

--- a/src/Granit.Authorization/Exports/PermissionGrantExportDefinition.cs
+++ b/src/Granit.Authorization/Exports/PermissionGrantExportDefinition.cs
@@ -15,9 +15,6 @@ public sealed class PermissionGrantExportDefinition : ExportDefinition<Permissio
             .Field(p => p.ProviderName)
             .Field(p => p.ProviderKey)
             .Field(p => p.TenantId)
-            .Field(p => p.CreatedAt, f => f.Format("O"))
-            .Field(p => p.CreatedBy)
-            .Field(p => p.ModifiedAt, f => f.Format("O"))
-            .Field(p => p.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Authorization/Exports/RoleMetadataExportDefinition.cs
+++ b/src/Granit.Authorization/Exports/RoleMetadataExportDefinition.cs
@@ -19,9 +19,6 @@ public sealed class RoleMetadataExportDefinition : ExportDefinition<RoleMetadata
             .Field(r => r.IsSystem)
             .Field(r => r.IsOrphaned)
             .Field(r => r.OrphanedAt, f => f.Format("O"))
-            .Field(r => r.CreatedAt, f => f.Format("O"))
-            .Field(r => r.CreatedBy)
-            .Field(r => r.ModifiedAt, f => f.Format("O"))
-            .Field(r => r.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.DataExchange/Exports/ExportJobExportDefinition.cs
+++ b/src/Granit.DataExchange/Exports/ExportJobExportDefinition.cs
@@ -20,9 +20,6 @@ public sealed class ExportJobExportDefinition : ExportDefinition<ExportJob>
             .Field(e => e.ErrorMessage)
             .Field(e => e.CompletedAt, f => f.Format("O"))
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.DataExchange/Exports/ImportJobExportDefinition.cs
+++ b/src/Granit.DataExchange/Exports/ImportJobExportDefinition.cs
@@ -20,9 +20,6 @@ public sealed class ImportJobExportDefinition : ExportDefinition<ImportJob>
             .Field(e => e.Status)
             .Field(e => e.CompletedAt, f => f.Format("O"))
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Hostnames/Exports/ManagedHostnameExportDefinition.cs
+++ b/src/Granit.Hostnames/Exports/ManagedHostnameExportDefinition.cs
@@ -19,9 +19,6 @@ public sealed class ManagedHostnameExportDefinition : ExportDefinition<ManagedHo
             .Field(e => e.OwnerId)
             .Field(e => e.IsPrimary)
             .Field(e => e.Status)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Identity.Federated/Exports/FederatedIdentityExportDefinition.cs
+++ b/src/Granit.Identity.Federated/Exports/FederatedIdentityExportDefinition.cs
@@ -21,10 +21,7 @@ public sealed class FederatedIdentityExportDefinition : ExportDefinition<Federat
             // as a JSON string). Preserved as-is for round-trip; re-hydrated from IdP on login.
             .Field(u => u.MetadataJson)
             .Field(u => u.TenantId)
-            .Field(u => u.CreatedAt, f => f.Format("O"))
-            .Field(u => u.CreatedBy)
-            .Field(u => u.ModifiedAt, f => f.Format("O"))
-            .Field(u => u.ModifiedBy);
+            .IncludeAuditFields();
         // Intentionally excluded: Username, Email, FirstName, LastName ([Encrypted]+[SensitiveData]),
         // EmailHash (peppered hash — security artifact, not portable). FederatedIdentity is a
         // cache entry re-hydrated from the IdP at login — PII export would expose plaintext

--- a/src/Granit.Identity.Local/Exports/GranitUserGroupExportDefinition.cs
+++ b/src/Granit.Identity.Local/Exports/GranitUserGroupExportDefinition.cs
@@ -14,9 +14,6 @@ public sealed class GranitUserGroupExportDefinition : ExportDefinition<GranitUse
             .Field(g => g.Name)
             .Field(g => g.Description)
             .Field(g => g.TenantId)
-            .Field(g => g.CreatedAt, f => f.Format("O"))
-            .Field(g => g.CreatedBy)
-            .Field(g => g.ModifiedAt, f => f.Format("O"))
-            .Field(g => g.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Localization/Exports/LocalizationOverrideExportDefinition.cs
+++ b/src/Granit.Localization/Exports/LocalizationOverrideExportDefinition.cs
@@ -16,9 +16,6 @@ public sealed class LocalizationOverrideExportDefinition : ExportDefinition<Loca
             .Field(e => e.Key)
             .Field(e => e.Value)
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.MultiTenancy/Exports/TenantExportDefinition.cs
+++ b/src/Granit.MultiTenancy/Exports/TenantExportDefinition.cs
@@ -20,9 +20,6 @@ public sealed class TenantExportDefinition : ExportDefinition<Tenant>
             .Field(t => t.IsDeleted)
             .Field(t => t.DeletedAt, f => f.Format("O"))
             .Field(t => t.DeletedBy)
-            .Field(t => t.CreatedAt, f => f.Format("O"))
-            .Field(t => t.CreatedBy)
-            .Field(t => t.ModifiedAt, f => f.Format("O"))
-            .Field(t => t.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Notifications/Exports/NotificationPreferenceExportDefinition.cs
+++ b/src/Granit.Notifications/Exports/NotificationPreferenceExportDefinition.cs
@@ -16,9 +16,6 @@ public sealed class NotificationPreferenceExportDefinition : ExportDefinition<No
             .Field(e => e.ChannelName)
             .Field(e => e.IsEnabled)
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Scheduling/Exports/ScheduledActionExportDefinition.cs
+++ b/src/Granit.Scheduling/Exports/ScheduledActionExportDefinition.cs
@@ -20,9 +20,6 @@ public sealed class ScheduledActionExportDefinition : ExportDefinition<Scheduled
             .Field(e => e.CancelledBy)
             .Field(e => e.FailureReason)
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Settings/Exports/SettingRecordExportDefinition.cs
+++ b/src/Granit.Settings/Exports/SettingRecordExportDefinition.cs
@@ -15,9 +15,6 @@ public sealed class SettingRecordExportDefinition : ExportDefinition<SettingReco
             .Field(e => e.ProviderName)
             .Field(e => e.ProviderKey)
             .Field(e => e.Value)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy);
+            .IncludeAuditFields();
     }
 }

--- a/src/Granit.Webhooks/Exports/WebhookSubscriptionExportDefinition.cs
+++ b/src/Granit.Webhooks/Exports/WebhookSubscriptionExportDefinition.cs
@@ -21,10 +21,7 @@ public sealed class WebhookSubscriptionExportDefinition : ExportDefinition<Webho
             .Field(e => e.SuspendedAt, f => f.Format("O"))
             .Field(e => e.SuspendedBy)
             .Field(e => e.TenantId)
-            .Field(e => e.CreatedAt, f => f.Format("O"))
-            .Field(e => e.CreatedBy)
-            .Field(e => e.ModifiedAt, f => f.Format("O"))
-            .Field(e => e.ModifiedBy)
+            .IncludeAuditFields()
             .ComplexField("SigningKeys", e => e.SigningKeys
                 .Select(k => new WebhookSigningKeySnapshot(k.Id, k.Status, k.CreatedAt, k.ExpiresAt, k.RevokedAt))
                 .ToList());


### PR DESCRIPTION
Follow-up to #2649: applies the `ExportDefinitionBuilder.IncludeAuditFields()` /
`IncludeCreationAuditFields()` helper repo-wide, removing the four repeated
`CreatedAt / CreatedBy / ModifiedAt / ModifiedBy` field declarations.

**Behaviour-identical** — the helper expands to the exact same fields with the same
round-trip (`"O"`) timestamp format. Confirmed by the existing per-definition export tests
(e.g. `WebhookSubscriptionExportDefinitionTests`, 212/212).

## Swept (15)

`Localization`, `Webhooks`, `DataExchange` (Export/Import jobs), `Identity.Local` (UserGroup),
`Notifications` (Preference), `Settings`, `MultiTenancy` (Tenant — the Created/Modified block;
its soft-delete fields are kept), `Authorization` (RoleMetadata, PermissionGrant), `Scheduling`,
`Hostnames`, `Identity.Federated`; creation-only → `IncludeCreationAuditFields()`: `Auditing`
(AuditEntry), `Authentication.ApiKeys`.

## Left as-is (non-standard audit shape)

- `Timeline` — interleaved Deleted + Created, no Modified.
- `BlobStorage` — Created + Deleted, no `*By`.
- `Notifications` UserNotification — `CreatedAt` only.
- `Identity` User export — uses `Header(...)` labels, not `"O"` format.

## Gates

- 225/225 architecture tests; `dotnet format` clean.
- No `.csproj` changes (helper already shipped in #2649) → no lockfile churn; code-index unchanged.