### PR TITLE
refactor(ai): migrate Granit.AI.Endpoints chat-stream to native SSE (#496)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4163,6 +4163,15 @@
       "members": []
     },
     {
+      "name": "AIChatStreamEvent",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatStreamEvent",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatStreamEvent.cs",
+      "line": 14,
+      "members": []
+    },
+    {
       "name": "AIChatUsageResponse",
       "fqn": "Granit.AI.Endpoints.Dtos.AIChatUsageResponse",
       "kind": "record",

--- a/src/Granit.AI.Endpoints/Dtos/AIChatStreamEvent.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIChatStreamEvent.cs
@@ -1,0 +1,19 @@
+namespace Granit.AI.Endpoints.Dtos;
+
+/// <summary>
+/// A frame streamed over Server-Sent Events for a chat completion. <see cref="Type"/> discriminates
+/// the frame: <c>delta</c> (an incremental <see cref="Content"/> chunk), <c>usage</c> (the token
+/// counts), or <c>error</c> (a provider failure that occurred after streaming started). End-of-stream
+/// is signalled by the SSE stream closing — there is no sentinel frame.
+/// </summary>
+/// <param name="Type">The frame discriminator: <c>delta</c>, <c>usage</c>, or <c>error</c>.</param>
+/// <param name="Content">The incremental content chunk for a <c>delta</c> frame.</param>
+/// <param name="InputTokens">Input token count for a <c>usage</c> frame.</param>
+/// <param name="OutputTokens">Output token count for a <c>usage</c> frame.</param>
+/// <param name="Error">The error message for an <c>error</c> frame.</param>
+public sealed record AIChatStreamEvent(
+    string Type,
+    string? Content = null,
+    int? InputTokens = null,
+    int? OutputTokens = null,
+    string? Error = null);

--- a/src/Granit.AI.Endpoints/Endpoints/AIChatEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIChatEndpoints.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using System.Text.Json;
+using System.Runtime.CompilerServices;
 using Granit.AI.Endpoints.Dtos;
 using Granit.AI.Endpoints.Internal;
 using Granit.AI.Exceptions;
@@ -32,12 +32,12 @@ internal static class AIChatEndpoints
             .WithName("AIChatStream")
             .WithSummary("Streams a chat completion response via Server-Sent Events.")
             .WithDescription(
-                "Opens an SSE stream that emits incremental content chunks as they arrive from the provider. "
-                + "The stream ends with a [DONE] sentinel. If the provider returns an error after streaming has "
-                + "started, an SSE 'error' event is emitted before closing. "
-                + "Returns 404 if the workspace does not exist, 422 if the model is not found, "
-                + "or 502/503 if the provider is unavailable.")
-            .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
+                "Opens an SSE stream that emits incremental 'delta' content frames as they arrive from the "
+                + "provider, then a 'usage' frame with the token counts; end-of-stream is the stream closing. "
+                + "A provider failure before any content is returned as an HTTP problem; a failure after "
+                + "streaming has started is emitted as an 'error' frame. Returns 404 if the workspace does "
+                + "not exist, or 502/503 if the provider is unavailable.")
+            .Produces<AIChatStreamEvent>(StatusCodes.Status200OK, "text/event-stream")
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status502BadGateway)
             .ProducesProblem(StatusCodes.Status503ServiceUnavailable);
@@ -88,14 +88,13 @@ internal static class AIChatEndpoints
             result.Duration));
     }
 
-    private static async Task StreamAsync(
+    private static async Task<Results<ServerSentEventsResult<AIChatStreamEvent>, ProblemHttpResult>> StreamAsync(
         string workspaceName,
         AIChatRequest request,
         [FromServices] IAIChatClientFactory chatClientFactory,
         [FromServices] IAIWorkspaceProvider workspaceProvider,
         [FromServices] IAIUsageTracker usageTracker,
         [FromServices] IAIUsageRecordFactory usageRecordFactory,
-        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         AIWorkspace? workspace = await workspaceProvider
@@ -104,8 +103,7 @@ internal static class AIChatEndpoints
 
         if (workspace is null)
         {
-            httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
-            return;
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         IChatClient chatClient;
@@ -117,75 +115,90 @@ internal static class AIChatEndpoints
         }
         catch (Exception ex) when (ex is AIWorkspaceNotFoundException or AIProviderNotRegisteredException)
         {
-            // Do not echo ex.Message into the response body — return a stable, generic
-            // problem detail. The exception type already distinguishes the two config
-            // faults for server-side telemetry without leaking internal wiring detail.
-            httpContext.Response.StatusCode = StatusCodes.Status502BadGateway;
-            httpContext.Response.ContentType = "application/problem+json";
-            await JsonSerializer.SerializeAsync(
-                httpContext.Response.Body,
-                new { detail = "The requested AI workspace is not available.", status = 502 },
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-            return;
+            return AIProviderExceptionMapper.MapException(ex);
         }
-
-        // CreateAsync builds a fresh client per call (no cache). A using declaration here
-        // disposes it on every exit path of the method (early returns + fall-through).
-        using IChatClient _ = chatClient;
 
         var messages = request.Messages
             .Select(m => new ChatMessage(MapRole(m.Role), m.Content))
             .ToList();
 
-        httpContext.Response.ContentType = "text/event-stream";
-        httpContext.Response.Headers.CacheControl = "no-cache";
-        httpContext.Response.Headers.Connection = "keep-alive";
+        // Peek the first update so a provider failure before any content surfaces as an HTTP problem
+        // (rate limit, timeout, model-not-found) rather than a 200 stream — preserving the contract the
+        // hand-rolled implementation had via its "headers not sent yet" guard.
+        IAsyncEnumerator<ChatResponseUpdate> updates = chatClient
+            .GetStreamingResponseAsync(messages, cancellationToken: cancellationToken)
+            .GetAsyncEnumerator(cancellationToken);
 
-        var stopwatch = Stopwatch.StartNew();
-        bool headersSent = false;
-        UsageContent? accumulatedUsage = null;
-
+        bool hasFirst;
         try
         {
-            await foreach (ChatResponseUpdate? update in chatClient.GetStreamingResponseAsync(
-                messages, cancellationToken: cancellationToken).ConfigureAwait(false))
-            {
-                foreach (UsageContent usage in update.Contents.OfType<UsageContent>())
-                {
-                    accumulatedUsage = usage;
-                }
-
-                foreach (TextContent content in update.Contents.OfType<TextContent>())
-                {
-                    headersSent = true;
-                    await httpContext.Response.WriteAsync(
-                        $"data: {JsonSerializer.Serialize(new { content = content.Text })}\n\n",
-                        cancellationToken).ConfigureAwait(false);
-                    await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
-                }
-            }
+            hasFirst = await updates.MoveNextAsync().ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or IOException)
         {
-            if (!headersSent && !httpContext.Response.HasStarted)
-            {
-                httpContext.Response.ContentType = "application/problem+json";
-                ProblemHttpResult problem = AIProviderExceptionMapper.MapException(
-                    ex, workspace.Model, workspace.Provider);
-                await problem.ExecuteAsync(httpContext).ConfigureAwait(false);
-                return;
-            }
-
-            string errorMessage = AIProviderExceptionMapper.GetErrorMessage(
-                ex, workspace.Model, workspace.Provider);
-            await httpContext.Response.WriteAsync(
-                $"event: error\ndata: {JsonSerializer.Serialize(new { error = errorMessage })}\n\n",
-                CancellationToken.None).ConfigureAwait(false);
-            await httpContext.Response.Body.FlushAsync(CancellationToken.None).ConfigureAwait(false);
-            return;
+            await updates.DisposeAsync().ConfigureAwait(false);
+            chatClient.Dispose();
+            return AIProviderExceptionMapper.MapException(ex, workspace.Model, workspace.Provider);
         }
 
-        stopwatch.Stop();
+        return TypedResults.ServerSentEvents(StreamUpdatesAsync(
+            chatClient, updates, hasFirst, workspace, workspaceName, usageTracker, usageRecordFactory, cancellationToken));
+    }
+
+    private static async IAsyncEnumerable<AIChatStreamEvent> StreamUpdatesAsync(
+        IChatClient chatClient,
+        IAsyncEnumerator<ChatResponseUpdate> updates,
+        bool hasFirst,
+        AIWorkspace workspace,
+        string workspaceName,
+        IAIUsageTracker usageTracker,
+        IAIUsageRecordFactory usageRecordFactory,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        using IChatClient client = chatClient;
+        await using IAsyncEnumerator<ChatResponseUpdate> enumerator = updates;
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+        UsageContent? accumulatedUsage = null;
+        string? streamError = null;
+
+        bool hasCurrent = hasFirst;
+        while (hasCurrent)
+        {
+            ChatResponseUpdate update = enumerator.Current;
+
+            foreach (UsageContent usage in update.Contents.OfType<UsageContent>())
+            {
+                accumulatedUsage = usage;
+            }
+
+            foreach (TextContent content in update.Contents.OfType<TextContent>())
+            {
+                yield return new AIChatStreamEvent("delta", Content: content.Text);
+            }
+
+            try
+            {
+                hasCurrent = await enumerator.MoveNextAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or IOException)
+            {
+                // A cancelled request has no client left to receive an error frame; just stop.
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+
+                streamError = AIProviderExceptionMapper.GetErrorMessage(ex, workspace.Model, workspace.Provider);
+                break;
+            }
+        }
+
+        if (streamError is not null)
+        {
+            yield return new AIChatStreamEvent("error", Error: streamError);
+            yield break;
+        }
 
         if (accumulatedUsage is not null)
         {
@@ -198,19 +211,12 @@ internal static class AIChatEndpoints
                 workspace.Model,
                 inputTokens,
                 outputTokens,
-                stopwatch.Elapsed);
+                Stopwatch.GetElapsedTime(startTimestamp));
 
             await usageTracker.RecordAsync(usageRecord, CancellationToken.None).ConfigureAwait(false);
 
-            await httpContext.Response.WriteAsync(
-                $"event: usage\ndata: {JsonSerializer.Serialize(new { inputTokens, outputTokens })}\n\n",
-                cancellationToken).ConfigureAwait(false);
-            await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+            yield return new AIChatStreamEvent("usage", InputTokens: inputTokens, OutputTokens: outputTokens);
         }
-
-        await httpContext.Response.WriteAsync("data: [DONE]\n\n", cancellationToken)
-            .ConfigureAwait(false);
-        await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static ChatRole MapRole(string role) => role switch

--- a/tests/Granit.AI.Endpoints.Tests/AIChatStreamEndpointTests.cs
+++ b/tests/Granit.AI.Endpoints.Tests/AIChatStreamEndpointTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Granit.AI.Endpoints.Dtos;
+using Granit.AI.Endpoints.Endpoints;
+using Granit.AI.Workspaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.AI.Endpoints.Tests;
+
+/// <summary>Integration tests for the native-SSE chat streaming endpoint (#496 migration).</summary>
+public sealed class AIChatStreamEndpointTests : IAsyncDisposable
+{
+    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
+    private readonly IAIWorkspaceProvider _workspaceProvider = Substitute.For<IAIWorkspaceProvider>();
+    private readonly IAIUsageTracker _usageTracker = Substitute.For<IAIUsageTracker>();
+    private readonly IAIUsageRecordFactory _usageRecordFactory = Substitute.For<IAIUsageRecordFactory>();
+    private readonly WebApplication _app;
+    private readonly HttpClient _client;
+
+    public AIChatStreamEndpointTests()
+    {
+        _workspaceProvider.GetAsync("my-gpt4", Arg.Any<CancellationToken>())
+            .Returns(new AIWorkspace { Name = "my-gpt4", Provider = "OpenAI", Model = "gpt-4o" });
+        _usageRecordFactory.Create(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<int>(), Arg.Any<int>(), Arg.Any<TimeSpan?>())
+            .Returns(ci => new AIUsageRecord
+            {
+                Id = Guid.NewGuid(),
+                WorkspaceName = (string)ci[0],
+                Provider = (string)ci[1],
+                Model = (string)ci[2],
+                InputTokens = (int)ci[3],
+                OutputTokens = (int)ci[4],
+                Timestamp = DateTimeOffset.UnixEpoch,
+            });
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(_chatClientFactory);
+        builder.Services.AddSingleton(_workspaceProvider);
+        builder.Services.AddSingleton(_usageTracker);
+        builder.Services.AddSingleton(_usageRecordFactory);
+        builder.Services.AddSingleton(Substitute.For<IAIChatCompletionService>());
+
+        _app = builder.Build();
+        // Map the internal chat group directly — authorization is covered separately.
+        _app.MapGroup("").MapChatEndpoints();
+        _app.StartAsync().GetAwaiter().GetResult();
+        _client = _app.GetTestClient();
+    }
+
+    public async ValueTask DisposeAsync() => await _app.DisposeAsync();
+
+    [Fact]
+    public async Task Stream_emits_delta_then_usage_frames_and_records_usage()
+    {
+        _chatClientFactory.CreateAsync("my-gpt4", Arg.Any<CancellationToken>())
+            .Returns(new FakeChatClient([
+                Text("Hello"),
+                Text(" world"),
+                Usage(5, 2),
+            ]));
+
+        IReadOnlyList<AIChatStreamEvent> frames = await StreamAsync("my-gpt4");
+
+        frames.Where(f => f.Type == "delta").Select(f => f.Content).ShouldBe(["Hello", " world"]);
+        AIChatStreamEvent usage = frames.Single(f => f.Type == "usage");
+        usage.InputTokens.ShouldBe(5);
+        usage.OutputTokens.ShouldBe(2);
+        frames.ShouldNotContain(f => f.Type == "error");
+        await _usageTracker.Received(1).RecordAsync(
+            Arg.Is<AIUsageRecord>(r => r.InputTokens == 5 && r.OutputTokens == 2), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Stream_unknown_workspace_returns_404_not_a_stream()
+    {
+        _workspaceProvider.GetAsync("ghost", Arg.Any<CancellationToken>()).Returns((AIWorkspace?)null);
+
+        HttpResponseMessage response = await PostAsync("ghost");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.ShouldNotBe("text/event-stream");
+    }
+
+    [Fact]
+    public async Task Stream_provider_failure_before_any_content_returns_an_http_problem()
+    {
+        _chatClientFactory.CreateAsync("my-gpt4", Arg.Any<CancellationToken>())
+            .Returns(new FakeChatClient([], throwAfter: 0, exception: new HttpRequestException("boom")));
+
+        HttpResponseMessage response = await PostAsync("my-gpt4");
+
+        response.StatusCode.ShouldNotBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldNotBe("text/event-stream");
+    }
+
+    [Fact]
+    public async Task Stream_provider_failure_after_content_emits_an_error_frame()
+    {
+        _chatClientFactory.CreateAsync("my-gpt4", Arg.Any<CancellationToken>())
+            .Returns(new FakeChatClient([Text("partial")], throwAfter: 1, exception: new HttpRequestException("boom")));
+
+        IReadOnlyList<AIChatStreamEvent> frames = await StreamAsync("my-gpt4");
+
+        frames.ShouldContain(f => f.Type == "delta" && f.Content == "partial");
+        frames.ShouldContain(f => f.Type == "error" && !string.IsNullOrWhiteSpace(f.Error));
+        frames.ShouldNotContain(f => f.Type == "usage");
+    }
+
+    private Task<HttpResponseMessage> PostAsync(string workspace) =>
+        _client.PostAsJsonAsync(
+            $"/chat/{workspace}/stream",
+            new AIChatRequest([new AIChatMessageRequest("user", "hi")]),
+            TestContext.Current.CancellationToken);
+
+    private async Task<IReadOnlyList<AIChatStreamEvent>> StreamAsync(string workspace)
+    {
+        HttpResponseMessage response = await PostAsync(workspace);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe("text/event-stream");
+
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        List<AIChatStreamEvent> frames = [];
+        foreach (string line in body.Split('\n'))
+        {
+            if (line.StartsWith("data:", StringComparison.Ordinal))
+            {
+                string json = line["data:".Length..].Trim();
+                if (json.Length > 0)
+                {
+                    frames.Add(JsonSerializer.Deserialize<AIChatStreamEvent>(json, JsonSerializerOptions.Web)!);
+                }
+            }
+        }
+
+        return frames;
+    }
+
+    private static ChatResponseUpdate Text(string text) => new() { Contents = [new TextContent(text)] };
+
+    private static ChatResponseUpdate Usage(int input, int output) =>
+        new() { Contents = [new UsageContent(new UsageDetails { InputTokenCount = input, OutputTokenCount = output })] };
+
+    private sealed class FakeChatClient(
+        IReadOnlyList<ChatResponseUpdate> updates, int throwAfter = -1, Exception? exception = null) : IChatClient
+    {
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            for (int i = 0; i < updates.Count; i++)
+            {
+                if (i == throwAfter && exception is not null)
+                {
+                    throw exception;
+                }
+
+                yield return updates[i];
+                await Task.Yield();
+            }
+
+            if (throwAfter == updates.Count && exception is not null)
+            {
+                throw exception;
+            }
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Granit.AI.Endpoints.Tests/Granit.AI.Endpoints.Tests.csproj
+++ b/tests/Granit.AI.Endpoints.Tests/Granit.AI.Endpoints.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.AI.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Endpoints.Tests/packages.lock.json
@@ -14,6 +14,17 @@
         "resolved": "7.1.0",
         "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Mt+5CtYz+xmog1S1TJt2owVKU8YquZtNy9bmO+kfrrtjEDZPzCw1qZ7o97PLpIEpt3yy4F5YdAUh9nKPm0CX5Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Hosting": "10.0.9"
+        }
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
@@ -107,6 +118,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "mR4y30XFsVbn7EwV3Ic5/KMBO5QGwukTJE2ztGmpAST5ACX+Z+9r+Y6D1eibJojsOIW5KHpM4myo9/aRALJOyg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -134,6 +150,81 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "8D4HaqxWdm5M/nuhQffjPoR1ekhlpyKTXjFMAT5KlP0dvxkJe5JLAP6MAsuUEUxKWG09Bi5aAUaYMFKrMqWHqA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "JhKySWIL8+N4yFt4HPm1rGKCHooze+MBdTdpXc0bd/PGm31TrSUi2m0Nek1y441Wlv/RE6VH0W/DCv2xnmy8FA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NgLB9cYnIb0/djSDcnqo4GIGGWooxGmr/gCUe3/CRXcKqLizOFui8MyW4EVkTB/KNJL+oXdMXnD6ZRm3Y+qkrQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "LiFKJgc9jZEW+7RhcSfsvCwoikt1lDdOqOn+whZC5zVHyg/gExftHl2QPtmfiHsEdDNg+Y+BDr6835tOfj8Y7A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "ockJRreRW/HbGwoyHzYOxMucFBimvAZ8lKNwQLMHrS6mwkDUaCJMWzzeE+Rm9vgFlv2o/xqk8fm+FpqrDCnkTA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NLXI3PbTe39q6/sgs7JYhmfPf7bMzReUoAJ0q9Po6yhfM+0anZa7PrEva4W2SdiLWGyB9eKZS9THGt2BP40xJg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -148,6 +239,116 @@
         "resolved": "10.0.9",
         "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
         "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "zm8WVod4swgprGrkxkuSILlbXqdDRqF+3y6U0I7jlmj4PMyKN6d8pzXZHUn5lr/gZVULzk/+FeTYlTupt6akpg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "HTgnvmK0ubesUFO16pLC+i9+RS8lEGd6TmDouuy75FsAgIFrSwUVhYCqG2IENzBJwgxGc/6Rsulfsvd9ZG/XkA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.9",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Logging.Console": "10.0.9",
+          "Microsoft.Extensions.Logging.Debug": "10.0.9",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.9",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "bUth5ip7YsZMXWZS42IRTI0zDrPEqdE+xnsmcL0Pk784grWKApDvc5UoMi2tP2qYJ5ylFzeVDuDu08sFATq1bg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "WyZEG/O8jKqBOBF6/M6IJqiEyWFBUv6PDyzNoXDA0mBZwKtkuf7GiZ/0/8eU8OpLKKQL0O95oPOY1szrWIKofQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "r/A0ahpXmZH/8ltPjrFFWp12BIizK9cCVJXPcHyOad8e4eIX7P/geW+uBYdczkeCAaMebT4jEU7snOm4GnmKfA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "goAl30/WwmdnWDPRwATaDPIK0iuDBnQSMTH2XYGVB1SwReg7hglhvDNjjpNhT25US3GF4I5q6BhTNs6nFYzEfg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "System.Diagnostics.EventLog": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "tHynPVHbTicuaDpS2JVTxX0qA5VTg15CXgVKTwWvvudb5BvW5aVew8MMyek6LrDGAom7UbON1jf1T5GhpTilFA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
@@ -222,8 +423,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.9",
+        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -595,6 +796,12 @@
         "requested": "[10.*, )",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "mvRf9qOH/LslWIee/h+lsElnoUyKotEwoPL31soqScmO/eoxObaTCLCdx2DdqPdRi9LnB+7qKZ49jfyrLZuc+w=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Pays down the SSE debt noted during the agentic-chat Epic: the legacy
`Granit.AI.Endpoints` chat-stream endpoint hand-rolled `data: …\n\n` framing.

## What

`AIChatEndpoints.StreamAsync` now uses the native .NET 10 `TypedResults.ServerSentEvents`,
matching the canonical chat SSE shape introduced in `Granit.AI.Chat` (#2638).

- Frames are a typed **`AIChatStreamEvent`** record (`delta` / `usage` / `error`). The legacy
  `[DONE]` sentinel is dropped — the stream closing is the end-of-stream signal (consistent with
  `ChatStreamEvent`).
- Handler returns `Results<ServerSentEventsResult<AIChatStreamEvent>, ProblemHttpResult>` →
  satisfies `ApiConventionTests` (no more `Task` returning hand-written framing).
- **Error semantics preserved:** the first streaming update is peeked *before* the SSE result is
  returned, so a provider failure before any content (rate limit / timeout / model-not-found) still
  surfaces as an HTTP problem rather than a `200` stream — the pre-native "headers not sent yet"
  guard. A failure *after* streaming has started is emitted as an `error` frame. Usage is recorded
  and emitted unchanged.

## Wire-format change (pre-1.0, intentional)

Streaming consumers now receive typed JSON frames (`{"type":"delta","content":"…"}`,
`{"type":"usage",…}`, `{"type":"error",…}`) instead of the ad-hoc `{content}` / `event: usage` /
`event: error` / `data: [DONE]` shapes — aligned with `Granit.AI.Chat`.

## Tests

New integration tests (Mvc.Testing host + fake `IChatClient`): delta+usage happy path with usage
recording, unknown workspace → 404, pre-content failure → problem (not a stream), mid-stream failure
→ `error` frame. The streaming path previously had no test.

225/225 architecture tests; `dotnet format` clean; lockfile churn limited to the test project
(`Mvc.Testing`).