### PR TITLE
fix(ai+persistence): Chat/Prompts audit findings + IQueryableSource DbContext leak

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3260,7 +3260,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat.BackgroundJobs",
       "file": "src/Granit.AI.Chat.BackgroundJobs/Options/GranitAIChatRetentionOptions.cs",
-      "line": 8,
+      "line": 10,
       "members": [
         {
           "name": "RetentionDays",
@@ -3899,7 +3899,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/Options/GranitAIChatAttachmentOptions.cs",
-      "line": 8,
+      "line": 10,
       "members": [
         {
           "name": "MaxAttachments",
@@ -5446,6 +5446,22 @@
       ]
     },
     {
+      "name": "PromptCategoryExportDefinition",
+      "fqn": "Granit.AI.Prompts.Exports.PromptCategoryExportDefinition",
+      "kind": "class",
+      "project": "Granit.AI.Prompts",
+      "file": "src/Granit.AI.Prompts/Exports/PromptCategoryExportDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "PromptTemplateExportDefinition",
       "fqn": "Granit.AI.Prompts.Exports.PromptTemplateExportDefinition",
       "kind": "class",
@@ -5559,6 +5575,28 @@
       "file": "src/Granit.AI.Prompts/PromptTemplateEdit.cs",
       "line": 16,
       "members": []
+    },
+    {
+      "name": "PromptCategoryQueryDefinition",
+      "fqn": "Granit.AI.Prompts.Queries.PromptCategoryQueryDefinition",
+      "kind": "class",
+      "project": "Granit.AI.Prompts",
+      "file": "src/Granit.AI.Prompts/Queries/PromptCategoryQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(AIPromptsLocalizationResource)",
+          "returnType": "Type? LocalizationResourceType =>"
+        }
+      ]
     },
     {
       "name": "PromptTemplateQueryDefinition",

--- a/src/Granit.AI.Chat.BackgroundJobs/GranitAIChatBackgroundJobsModule.cs
+++ b/src/Granit.AI.Chat.BackgroundJobs/GranitAIChatBackgroundJobsModule.cs
@@ -22,7 +22,9 @@ public sealed class GranitAIChatBackgroundJobsModule : GranitModule
     {
         context.Services
             .AddOptions<GranitAIChatRetentionOptions>()
-            .BindConfiguration(GranitAIChatRetentionOptions.SectionName);
+            .BindConfiguration(GranitAIChatRetentionOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
         context.Services.TryAddTransient<IConversationRetentionService, ConversationRetentionService>();
     }

--- a/src/Granit.AI.Chat.BackgroundJobs/Options/GranitAIChatRetentionOptions.cs
+++ b/src/Granit.AI.Chat.BackgroundJobs/Options/GranitAIChatRetentionOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Granit.AI.Chat.BackgroundJobs.Options;
 
 /// <summary>
@@ -14,8 +16,10 @@ public sealed class GranitAIChatRetentionOptions
     /// Conversations whose last activity is older than this many days are purged. 0 (default)
     /// disables retention purging entirely.
     /// </summary>
+    [Range(0, int.MaxValue)]
     public int RetentionDays { get; set; }
 
     /// <summary>Number of conversations deleted per batch. Default 500.</summary>
+    [Range(1, int.MaxValue)]
     public int CleanupBatchSize { get; set; } = 500;
 }

--- a/src/Granit.AI.Chat.Endpoints/Options/AIChatEndpointsOptions.cs
+++ b/src/Granit.AI.Chat.Endpoints/Options/AIChatEndpointsOptions.cs
@@ -3,9 +3,6 @@ namespace Granit.AI.Chat.Endpoints.Options;
 /// <summary>Configuration for the chat conversation endpoints.</summary>
 public sealed class AIChatEndpointsOptions
 {
-    /// <summary>Configuration section path.</summary>
-    public const string SectionName = "AI:Chat:Endpoints";
-
     /// <summary>Route prefix. Default: <c>conversations</c>.</summary>
     public string RoutePrefix { get; set; } = "conversations";
 

--- a/src/Granit.AI.Chat.Privacy/DataExport/ConversationPrivacyDataProvider.cs
+++ b/src/Granit.AI.Chat.Privacy/DataExport/ConversationPrivacyDataProvider.cs
@@ -54,36 +54,36 @@ public sealed class ConversationPrivacyDataProvider(
             yield break;
         }
 
-        var dto = new ConversationsExportDto(
+        var export = new ConversationsExport(
             UserId: context.SubjectUserId,
             ConversationCount: conversations.Count,
             Conversations: [.. conversations.Select(Map)]);
 
         yield return await fragmentBuilder
-            .BuildJsonAsync(context, ProviderName, "ai-chat-conversations.json", dto, cancellationToken)
+            .BuildJsonAsync(context, ProviderName, "ai-chat-conversations.json", export, cancellationToken)
             .ConfigureAwait(false);
     }
 
-    private static ConversationExportDto Map(Conversation conversation) =>
+    private static ConversationExport Map(Conversation conversation) =>
         new(
             conversation.Id,
             conversation.Title,
             conversation.CreatedAt,
-            [.. conversation.Messages.Select(m => new MessageExportDto(m.Role.ToString(), m.Content, m.CreatedAt))]);
+            [.. conversation.Messages.Select(m => new MessageExport(m.Role.ToString(), m.Content, m.CreatedAt))]);
 }
 
-internal sealed record ConversationsExportDto(
+internal sealed record ConversationsExport(
     Guid UserId,
     int ConversationCount,
-    IReadOnlyList<ConversationExportDto> Conversations);
+    IReadOnlyList<ConversationExport> Conversations);
 
-internal sealed record ConversationExportDto(
+internal sealed record ConversationExport(
     Guid Id,
     string Title,
     DateTimeOffset CreatedAt,
-    IReadOnlyList<MessageExportDto> Messages);
+    IReadOnlyList<MessageExport> Messages);
 
-internal sealed record MessageExportDto(
+internal sealed record MessageExport(
     string Role,
     string Content,
     DateTimeOffset CreatedAt);

--- a/src/Granit.AI.Chat/Extensions/AIChatAttachmentsServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Chat/Extensions/AIChatAttachmentsServiceCollectionExtensions.cs
@@ -39,7 +39,9 @@ public static class AIChatAttachmentsServiceCollectionExtensions
     internal static void AddCoreServices(IServiceCollection services)
     {
         services.AddOptions<GranitAIChatAttachmentOptions>()
-            .BindConfiguration(GranitAIChatAttachmentOptions.SectionName);
+            .BindConfiguration(GranitAIChatAttachmentOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
         services.TryAddScoped<IAIAttachmentSource, NullAIAttachmentSource>();
         services.TryAddScoped<IAIAttachmentTextResolver, AIAttachmentTextResolver>();

--- a/src/Granit.AI.Chat/Options/GranitAIChatAttachmentOptions.cs
+++ b/src/Granit.AI.Chat/Options/GranitAIChatAttachmentOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Granit.AI.Chat.Options;
 
 /// <summary>
@@ -11,9 +13,11 @@ public sealed class GranitAIChatAttachmentOptions
     public const string SectionName = "AI:Chat:Attachments";
 
     /// <summary>Maximum number of attachments on a single turn. Default 5.</summary>
+    [Range(1, int.MaxValue)]
     public int MaxAttachments { get; set; } = 5;
 
     /// <summary>Maximum size, in bytes, of a single attachment. Default 10 MiB.</summary>
+    [Range(1, long.MaxValue)]
     public long MaxAttachmentBytes { get; set; } = 10 * 1024 * 1024;
 
     /// <summary>

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
@@ -15,13 +15,14 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 internal sealed class EfAIUsageQueryableSource(
     IDbContextFactory<AIDbContext> contextFactory,
     ICurrentTenant currentTenant)
-    : IQueryableSource<AIUsageRecord>
+    : IQueryableSource<AIUsageRecord>, IAsyncDisposable, IDisposable
 {
-    private readonly AIDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private AIDbContext? _context;
 
     public IQueryable<AIUsageRecord> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<AIUsageRecordEntity> query = _context.UsageRecords.AsNoTracking();
         if (_bypassTenantFilter)
         {
@@ -46,5 +47,18 @@ internal sealed class EfAIUsageQueryableSource(
             PromptTemplateName = e.PromptTemplateName,
             PromptTemplateVersion = e.PromptTemplateVersion,
         });
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        AIDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.AI.Prompts.Endpoints/Endpoints/PromptCatalogueEndpoints.cs
+++ b/src/Granit.AI.Prompts.Endpoints/Endpoints/PromptCatalogueEndpoints.cs
@@ -47,20 +47,22 @@ internal static class PromptCatalogueEndpoints
         group.MapPost("/", CreateAsync)
             .WithName("CreatePrompt")
             .WithSummary("Creates a prompt owned by the caller.")
-            .WithDescription("Creates a private prompt with the given content, decoration, and categories, owned by the caller.")
+            .WithDescription("Creates a private prompt with the given content, decoration, and categories, owned by the caller. Returns 422 when a referenced category does not exist.")
             .Produces<PromptResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(AIPromptsPermissions.Templates.Manage);
 
         group.MapPut("/{id:guid}", UpdateAsync)
             .WithName("UpdatePrompt")
             .WithSummary("Updates one of the caller's own prompts.")
-            .WithDescription("Updates the prompt and bumps its version. System prompts are read-only and reported as not found; customise one to get an editable copy.")
+            .WithDescription("Updates the prompt and bumps its version. System prompts are read-only and reported as not found; customise one to get an editable copy. Returns 422 when a referenced category does not exist.")
             .Produces<PromptResponse>()
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(AIPromptsPermissions.Templates.Manage);
 
         group.MapPost("/{id:guid}/customise", CustomiseAsync)
@@ -340,7 +342,7 @@ internal static class PromptCatalogueEndpoints
     }
 
     private static ProblemHttpResult UnknownCategory() =>
-        TypedResults.Problem(detail: "One or more categories do not exist.", statusCode: StatusCodes.Status400BadRequest);
+        TypedResults.Problem(detail: "One or more categories do not exist.", statusCode: StatusCodes.Status422UnprocessableEntity);
 
     private static HexColor? ParseColor(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : HexColor.Create(value);

--- a/src/Granit.AI.Prompts.Endpoints/Options/AIPromptsEndpointsOptions.cs
+++ b/src/Granit.AI.Prompts.Endpoints/Options/AIPromptsEndpointsOptions.cs
@@ -3,9 +3,6 @@ namespace Granit.AI.Prompts.Endpoints.Options;
 /// <summary>Configuration for the prompt-catalogue endpoints.</summary>
 public sealed class AIPromptsEndpointsOptions
 {
-    /// <summary>Configuration section path.</summary>
-    public const string SectionName = "AI:Prompts:Endpoints";
-
     /// <summary>Route prefix. Default: <c>prompts</c>.</summary>
     public string RoutePrefix { get; set; } = "prompts";
 

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Extensions/AIPromptsEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class AIPromptsEntityFrameworkCoreServiceCollectionExtensions
 
         // Backs the catalogue admin grid + export (PromptTemplateQueryDefinition / ExportDefinition).
         services.TryAddScoped<IQueryableSource<PromptTemplate>, EfPromptTemplateQueryableSource>();
+        services.TryAddScoped<IQueryableSource<PromptCategory>, EfPromptCategoryQueryableSource>();
 
         return services;
     }

--- a/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptCategoryQueryableSource.cs
+++ b/src/Granit.AI.Prompts.EntityFrameworkCore/Internal/EfPromptCategoryQueryableSource.cs
@@ -7,22 +7,22 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.AI.Prompts.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// EF Core <see cref="IQueryableSource{TEntity}"/> for <see cref="PromptTemplate"/>, backing the
-/// catalogue admin grid and export. When no tenant context is active (host admin) the multi-tenant
-/// query filter is bypassed so prompts are returned cross-tenant.
+/// EF Core <see cref="IQueryableSource{TEntity}"/> for <see cref="PromptCategory"/>, backing the
+/// category admin grid and export. When no tenant context is active (host admin) the multi-tenant
+/// query filter is bypassed so categories are returned cross-tenant.
 /// </summary>
-internal sealed class EfPromptTemplateQueryableSource(
+internal sealed class EfPromptCategoryQueryableSource(
     IDbContextFactory<AIPromptsDbContext> contextFactory,
     ICurrentTenant currentTenant)
-    : IQueryableSource<PromptTemplate>, IAsyncDisposable, IDisposable
+    : IQueryableSource<PromptCategory>, IAsyncDisposable, IDisposable
 {
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
     private AIPromptsDbContext? _context;
 
-    public IQueryable<PromptTemplate> GetQueryable()
+    public IQueryable<PromptCategory> GetQueryable()
     {
         _context ??= contextFactory.CreateDbContext();
-        IQueryable<PromptTemplate> query = _context.PromptTemplates.AsNoTracking();
+        IQueryable<PromptCategory> query = _context.PromptCategories.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;

--- a/src/Granit.AI.Prompts/Exports/PromptCategoryExportDefinition.cs
+++ b/src/Granit.AI.Prompts/Exports/PromptCategoryExportDefinition.cs
@@ -1,0 +1,25 @@
+using Granit.AI.Prompts.Domain;
+using Granit.DataExchange.Export;
+
+namespace Granit.AI.Prompts.Exports;
+
+/// <summary>
+/// Export definition for prompt categories (ADR-020 pairing with
+/// <see cref="Queries.PromptCategoryQueryDefinition"/>). Emits the category fields for admin take-out.
+/// </summary>
+public sealed class PromptCategoryExportDefinition : ExportDefinition<PromptCategory>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.AI.Prompts.CategoriesExport";
+
+    /// <inheritdoc/>
+    protected override void Configure(ExportDefinitionBuilder<PromptCategory> builder)
+    {
+        builder
+            .IncludeId()
+            .Field(c => c.Name)
+            .Field(c => c.IsSystem)
+            .Field(c => c.TenantId)
+            .IncludeAuditFields();
+    }
+}

--- a/src/Granit.AI.Prompts/GranitAIPromptsModule.cs
+++ b/src/Granit.AI.Prompts/GranitAIPromptsModule.cs
@@ -27,5 +27,7 @@ public sealed class GranitAIPromptsModule : GranitModule
         // source is registered by Granit.AI.Prompts.EntityFrameworkCore.
         context.Services.AddQueryDefinition<PromptTemplate, PromptTemplateQueryDefinition>();
         context.Services.AddExportDefinition<PromptTemplate, PromptTemplateExportDefinition>();
+        context.Services.AddQueryDefinition<PromptCategory, PromptCategoryQueryDefinition>();
+        context.Services.AddExportDefinition<PromptCategory, PromptCategoryExportDefinition>();
     }
 }

--- a/src/Granit.AI.Prompts/Queries/PromptCategoryQueryDefinition.cs
+++ b/src/Granit.AI.Prompts/Queries/PromptCategoryQueryDefinition.cs
@@ -1,0 +1,30 @@
+using Granit.AI.Prompts.Domain;
+using Granit.QueryEngine;
+
+namespace Granit.AI.Prompts.Queries;
+
+/// <summary>
+/// Query definition for prompt categories — declares the admin-grid columns, filters, sorting, and
+/// search for the query engine (ADR-020 pairing with <see cref="Exports.PromptCategoryExportDefinition"/>).
+/// </summary>
+public sealed class PromptCategoryQueryDefinition : QueryDefinition<PromptCategory>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.AI.Prompts.CategoriesQuery";
+
+    /// <inheritdoc/>
+    public override Type? LocalizationResourceType => typeof(AIPromptsLocalizationResource);
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<PromptCategory> builder)
+    {
+        builder
+            .Column(c => c.Name, col => col.Label("Name").LabelKey("AIPrompts.Columns.Name").Filterable().Sortable())
+            .Column(c => c.IsSystem, col => col.Label("System").LabelKey("AIPrompts.Columns.IsSystem").Filterable().Sortable())
+            .Column(c => c.TenantId, col => col.Label("Tenant").LabelKey("AIPrompts.Columns.Tenant").Filterable())
+            .Column(c => c.CreatedAt, col => col.Label("Created At").LabelKey("AIPrompts.Columns.CreatedAt").Sortable())
+            .GlobalSearch(c => c.Name)
+            .DefaultSort("name")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/EfAuditEntityChangeQueryableSource.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/EfAuditEntityChangeQueryableSource.cs
@@ -14,16 +14,31 @@ namespace Granit.Auditing.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfAuditEntityChangeQueryableSource(
     IDbContextFactory<AuditingDbContext> contextFactory,
-    ICurrentTenant currentTenant) : IQueryableSource<AuditEntityChange>
+    ICurrentTenant currentTenant)
+    : IQueryableSource<AuditEntityChange>, IAsyncDisposable, IDisposable
 {
-    private readonly AuditingDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private AuditingDbContext? _context;
 
     public IQueryable<AuditEntityChange> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<AuditEntityChange> query = _context.AuditEntityChanges.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        AuditingDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.Auditing.EntityFrameworkCore/Internal/EfAuditEntryQueryableSource.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Internal/EfAuditEntryQueryableSource.cs
@@ -13,16 +13,31 @@ namespace Granit.Auditing.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfAuditEntryQueryableSource(
     IDbContextFactory<AuditingDbContext> contextFactory,
-    ICurrentTenant currentTenant) : IQueryableSource<AuditEntry>
+    ICurrentTenant currentTenant)
+    : IQueryableSource<AuditEntry>, IAsyncDisposable, IDisposable
 {
-    private readonly AuditingDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private AuditingDbContext? _context;
 
     public IQueryable<AuditEntry> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<AuditEntry> query = _context.AuditEntries.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        AuditingDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfApiKeyEntryQueryableSource.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfApiKeyEntryQueryableSource.cs
@@ -14,16 +14,31 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfApiKeyEntryQueryableSource(
     IDbContextFactory<AuthenticationApiKeysDbContext> contextFactory,
-    ICurrentTenant currentTenant) : IQueryableSource<ApiKeyEntry>
+    ICurrentTenant currentTenant)
+    : IQueryableSource<ApiKeyEntry>, IAsyncDisposable, IDisposable
 {
-    private readonly AuthenticationApiKeysDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private AuthenticationApiKeysDbContext? _context;
 
     public IQueryable<ApiKeyEntry> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<ApiKeyEntry> query = _context.ApiKeys.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        AuthenticationApiKeysDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.Localization.EntityFrameworkCore/Internal/EfLocalizationOverrideQueryableSource.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Internal/EfLocalizationOverrideQueryableSource.cs
@@ -14,16 +14,31 @@ namespace Granit.Localization.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfLocalizationOverrideQueryableSource(
     IDbContextFactory<LocalizationDbContext> contextFactory,
-    ICurrentTenant currentTenant) : IQueryableSource<LocalizationOverride>
+    ICurrentTenant currentTenant)
+    : IQueryableSource<LocalizationOverride>, IAsyncDisposable, IDisposable
 {
-    private readonly LocalizationDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private LocalizationDbContext? _context;
 
     public IQueryable<LocalizationOverride> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<LocalizationOverride> query = _context.LocalizationOverrides.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        LocalizationDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfTenantQueryableSource.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfTenantQueryableSource.cs
@@ -10,12 +10,26 @@ namespace Granit.MultiTenancy.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfTenantQueryableSource(
     IDbContextFactory<MultiTenancyDbContext> contextFactory)
-    : IQueryableSource<Tenant>, IDisposable
+    : IQueryableSource<Tenant>, IAsyncDisposable, IDisposable
 {
-    private readonly MultiTenancyDbContext _context = contextFactory.CreateDbContext();
+    private MultiTenancyDbContext? _context;
 
-    public IQueryable<Tenant> GetQueryable() =>
-        _context.Tenants.AsNoTracking();
+    public IQueryable<Tenant> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        return _context.Tenants.AsNoTracking();
+    }
 
-    public void Dispose() => _context.Dispose();
+    public ValueTask DisposeAsync()
+    {
+        MultiTenancyDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
 }

--- a/src/Granit.Scheduling.EntityFrameworkCore/Internal/EfScheduledActionQueryableSource.cs
+++ b/src/Granit.Scheduling.EntityFrameworkCore/Internal/EfScheduledActionQueryableSource.cs
@@ -13,16 +13,31 @@ namespace Granit.Scheduling.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfScheduledActionQueryableSource(
     IDbContextFactory<SchedulingDbContext> contextFactory,
-    ICurrentTenant currentTenant) : IQueryableSource<ScheduledAction>
+    ICurrentTenant currentTenant)
+    : IQueryableSource<ScheduledAction>, IAsyncDisposable, IDisposable
 {
-    private readonly SchedulingDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private SchedulingDbContext? _context;
 
     public IQueryable<ScheduledAction> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<ScheduledAction> query = _context.ScheduledActions.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        SchedulingDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/EfTemplateSummaryQueryableSource.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/EfTemplateSummaryQueryableSource.cs
@@ -22,13 +22,14 @@ namespace Granit.Templating.EntityFrameworkCore.Internal;
 internal sealed class EfTemplateSummaryQueryableSource(
     IDbContextFactory<TemplatingDbContext> contextFactory,
     ICurrentTenant currentTenant)
-    : IQueryableSource<TemplateSummary>
+    : IQueryableSource<TemplateSummary>, IAsyncDisposable, IDisposable
 {
-    private readonly TemplatingDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private TemplatingDbContext? _context;
 
     public IQueryable<TemplateSummary> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<TemplateRevisionEntity> query = _context.TemplateRevisions
             .AsNoTracking()
             .IgnoreQueryFilters([GranitFilterNames.Publishable])
@@ -56,5 +57,18 @@ internal sealed class EfTemplateSummaryQueryableSource(
                 LayoutName = g.OrderByDescending(r => r.CreatedAt).Select(r => r.LayoutName).First(),
                 CategoryId = g.OrderByDescending(r => r.CreatedAt).Select(r => r.CategoryId).First(),
             });
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        TemplatingDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
@@ -13,16 +13,31 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfWebhookDeliveryAttemptQueryableSource(
     IDbContextFactory<WebhooksDbContext> contextFactory,
-    ICurrentTenant currentTenant) : IQueryableSource<WebhookDeliveryAttempt>
+    ICurrentTenant currentTenant)
+    : IQueryableSource<WebhookDeliveryAttempt>, IAsyncDisposable, IDisposable
 {
-    private readonly WebhooksDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private WebhooksDbContext? _context;
 
     public IQueryable<WebhookDeliveryAttempt> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<WebhookDeliveryAttempt> query = _context.WebhookDeliveryAttempts.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        WebhooksDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
@@ -13,16 +13,31 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfWebhookSubscriptionQueryableSource(
     IDbContextFactory<WebhooksDbContext> contextFactory,
-    ICurrentTenant currentTenant) : IQueryableSource<WebhookSubscription>
+    ICurrentTenant currentTenant)
+    : IQueryableSource<WebhookSubscription>, IAsyncDisposable, IDisposable
 {
-    private readonly WebhooksDbContext _context = contextFactory.CreateDbContext();
     private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private WebhooksDbContext? _context;
 
     public IQueryable<WebhookSubscription> GetQueryable()
     {
+        _context ??= contextFactory.CreateDbContext();
         IQueryable<WebhookSubscription> query = _context.WebhookSubscriptions.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : query;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        WebhooksDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
     }
 }

--- a/tests/Granit.AI.Chat.BackgroundJobs.Tests/GranitAIChatRetentionOptionsTests.cs
+++ b/tests/Granit.AI.Chat.BackgroundJobs.Tests/GranitAIChatRetentionOptionsTests.cs
@@ -1,0 +1,26 @@
+using Granit.AI.Chat.BackgroundJobs.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.AI.Chat.BackgroundJobs.Tests;
+
+public sealed class GranitAIChatRetentionOptionsTests
+{
+    [Fact]
+    public void SectionName_matches_namespace_aligned_canonical_path()
+    {
+        // Locked here so a rename of the project / namespace surfaces in CI before
+        // it silently breaks host appsettings.json bindings.
+        GranitAIChatRetentionOptions.SectionName.ShouldBe("AI:Chat:Retention");
+    }
+
+    [Fact]
+    public void Defaults_disable_retention_and_batch_in_bounded_chunks()
+    {
+        var options = new GranitAIChatRetentionOptions();
+
+        // Retention is opt-in: 0 days means the cleanup job purges nothing.
+        options.RetentionDays.ShouldBe(0);
+        options.CleanupBatchSize.ShouldBe(500);
+    }
+}

--- a/tests/Granit.AI.Chat.Privacy.Tests/ConversationPrivacyDataProviderTests.cs
+++ b/tests/Granit.AI.Chat.Privacy.Tests/ConversationPrivacyDataProviderTests.cs
@@ -78,7 +78,7 @@ public sealed class ConversationPrivacyDataProviderTests
             Arg.Any<PrivacyExportContext>(),
             "ai-chat",
             "ai-chat-conversations.json",
-            Arg.Is<ConversationsExportDto>(d => d.ConversationCount == 1 && d.Conversations[0].Messages.Count == 1),
+            Arg.Is<ConversationsExport>(d => d.ConversationCount == 1 && d.Conversations[0].Messages.Count == 1),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.AI.Chat.Tests/GranitAIChatAttachmentOptionsTests.cs
+++ b/tests/Granit.AI.Chat.Tests/GranitAIChatAttachmentOptionsTests.cs
@@ -1,0 +1,25 @@
+using Granit.AI.Chat.Options;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class GranitAIChatAttachmentOptionsTests
+{
+    [Fact]
+    public void SectionName_matches_namespace_aligned_canonical_path()
+    {
+        // Locked here so a rename of the project / namespace surfaces in CI before
+        // it silently breaks host appsettings.json bindings.
+        GranitAIChatAttachmentOptions.SectionName.ShouldBe("AI:Chat:Attachments");
+    }
+
+    [Fact]
+    public void Defaults_cap_attachment_count_and_size()
+    {
+        var options = new GranitAIChatAttachmentOptions();
+
+        options.MaxAttachments.ShouldBe(5);
+        options.MaxAttachmentBytes.ShouldBe(10 * 1024 * 1024);
+        options.AllowedContentTypes.ShouldContain("application/pdf");
+    }
+}

--- a/tests/Granit.ArchitectureTests/QueryableSourceDisposalConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryableSourceDisposalConventionTests.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces DbContext lifetime hygiene for query sources: any <see cref="IQueryableSource{TEntity}"/>
+/// implementation that creates its own context via an injected <c>IDbContextFactory&lt;&gt;</c> MUST
+/// implement <see cref="IAsyncDisposable"/> and <see cref="IDisposable"/> so the factory-created
+/// context (and its pooled connection) is released when the scoped source is disposed.
+/// </summary>
+/// <remarks>
+/// A factory-created context held in a field with no disposal leaks a DbContext / connection on
+/// every resolution (the query engine resolves the source per request). Sources that instead inject
+/// a DI-owned scoped DbContext directly (e.g. host-owned <c>IWorkflowDbContext</c>) are exempt — the
+/// container owns that lifetime and they must NOT dispose it. Reference impl:
+/// <c>EfNotificationPreferenceQueryableSource</c> (lazy create + dispose).
+/// </remarks>
+public sealed class QueryableSourceDisposalConventionTests
+{
+    [Fact]
+    public void Factory_based_QueryableSource_implementations_must_be_disposable()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(QueryableSourceDisposalConventionTests).Assembly.Location)!;
+
+        Assembly[] granitAssemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path => !Path.GetFileNameWithoutExtension(path).Contains("Tests"))
+            .Select(TryLoadAssembly)
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<string> violations = [];
+
+        foreach (Assembly assembly in granitAssemblies)
+        {
+            Type[] sources;
+            try
+            {
+                sources = [.. assembly.GetTypes()
+                    .Where(t => !t.IsAbstract && !t.IsInterface)
+                    .Where(ImplementsQueryableSource)
+                    .Where(CreatesOwnContextViaFactory)];
+            }
+            catch (ReflectionTypeLoadException)
+            {
+                continue;
+            }
+
+            foreach (Type source in sources)
+            {
+                bool disposable = typeof(IDisposable).IsAssignableFrom(source);
+                bool asyncDisposable = typeof(IAsyncDisposable).IsAssignableFrom(source);
+                if (disposable && asyncDisposable)
+                {
+                    continue;
+                }
+
+                string missing = (asyncDisposable, disposable) switch
+                {
+                    (false, false) => "IAsyncDisposable and IDisposable",
+                    (false, true) => "IAsyncDisposable",
+                    _ => "IDisposable",
+                };
+
+                violations.Add(
+                    $"{assembly.GetName().Name}: {source.Name} injects an IDbContextFactory<> and creates " +
+                    $"its own DbContext but does not implement {missing}. Create the context lazily and " +
+                    "dispose it (mirror EfNotificationPreferenceQueryableSource).");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Factory-based IQueryableSource implementations must dispose the DbContext they create:"
+            + Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    private static bool ImplementsQueryableSource(Type type) =>
+        type.GetInterfaces().Any(i =>
+            i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQueryableSource<>));
+
+    private static bool CreatesOwnContextViaFactory(Type type) =>
+        type.GetConstructors().Any(ctor =>
+            ctor.GetParameters().Any(p =>
+                p.ParameterType.IsGenericType
+                && p.ParameterType.GetGenericTypeDefinition() is { Name: "IDbContextFactory`1", Namespace: "Microsoft.EntityFrameworkCore" }));
+
+    private static Assembly? TryLoadAssembly(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileLoadException)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Context

Follow-up to a `/audit` of `Granit.AI.Chat*` / `Granit.AI.Prompts*` / `Granit.AI.Tools*`. While fixing the Prompts `IQueryableSource` DbContext leak, a repo-wide scan surfaced the **same leak across 7 more modules**, so this PR also fixes those and adds an architecture test to prevent regressions.

## Commit 1 — `fix(ai)`: Chat/Prompts audit findings

**Prompts**
- **BREAKING contract fix**: prompt-catalogue *unknown category* returned an **undeclared 400**; now returns **422** (business validation), with `422` + validation problem declared on create/update.
- `EfPromptTemplateQueryableSource`: lazy DbContext + `IAsyncDisposable`/`IDisposable` (was leaking a context/connection per resolution).
- Add **`PromptCategory` Query/Export pair** + `IQueryableSource<PromptCategory>` (ADR-020 pairing — category is tenant business data, not `[INFRA]`).
- Remove vestigial `AIPromptsEndpointsOptions.SectionName` (route options are code-first via `Action<>`).

**Chat**
- Rename `*ExportDto` privacy records → `*Export` (DTO suffix ban).
- Harden retention/attachment options: `[Range]` DataAnnotations + `ValidateDataAnnotations().ValidateOnStart()`, plus `SectionName`-pinning `OptionsTests`.
- Remove vestigial `AIChatEndpointsOptions.SectionName`.

_Tools_: audited, no changes needed (findings were intentional design).

## Commit 2 — `fix(persistence)`: IQueryableSource DbContext lifetime leak

Query sources that create their own `DbContext` via `IDbContextFactory<>` held it in a field and never disposed it — leaking a context/connection on every per-request resolution. Made the context lazy + `IAsyncDisposable`/`IDisposable` across:

`AI` (usage), `Authentication.ApiKeys`, `Webhooks` (×2), `Localization`, `Auditing` (×2), `Templating`, `Scheduling`, `MultiTenancy`.

Sources that inject a **DI-owned scoped DbContext** directly (`Workflow`, `Authorization`) are unchanged — the container owns that lifetime.

**New architecture test** `QueryableSourceDisposalConventionTests`: any `IQueryableSource<>` injecting an `IDbContextFactory<>` must implement `IAsyncDisposable` + `IDisposable`. (It caught `EfTenantQueryableSource`, which only had `IDisposable`.)

## Verification
- All touched src + test projects build clean, 0 warnings.
- Affected unit/EFCore tests green (Chat, Prompts, Auditing, Webhooks, Localization, Scheduling, Templating, ApiKeys, MultiTenancy).
- **Architecture shard: 226/226** (incl. the new convention test).
- `dotnet format --verify-no-changes` clean on all touched projects.