### PR TITLE
refactor(text-extraction): drop SixLabors.ImageSharp (license), read headers via Granit.Imaging

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -47,6 +47,7 @@
       "src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj",
       "src/Granit.Identity.Local/Granit.Identity.Local.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
+      "src/Granit.Imaging/Granit.Imaging.csproj",
       "src/Granit.Indexing.BackgroundJobs/Granit.Indexing.BackgroundJobs.csproj",
       "src/Granit.Indexing.Elasticsearch/Granit.Indexing.Elasticsearch.csproj",
       "src/Granit.Indexing.Embeddings/Granit.Indexing.Embeddings.csproj",

--- a/.github/shard-filters/search.slnf
+++ b/.github/shard-filters/search.slnf
@@ -17,6 +17,7 @@
       "src/Granit.Html.AngleSharp/Granit.Html.AngleSharp.csproj",
       "src/Granit.Html/Granit.Html.csproj",
       "src/Granit.Http.ExceptionHandling/Granit.Http.ExceptionHandling.csproj",
+      "src/Granit.Imaging/Granit.Imaging.csproj",
       "src/Granit.Indexing.BackgroundJobs/Granit.Indexing.BackgroundJobs.csproj",
       "src/Granit.Indexing.Elasticsearch/Granit.Indexing.Elasticsearch.csproj",
       "src/Granit.Indexing.Embeddings/Granit.Indexing.Embeddings.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2570,6 +2570,7 @@
     {
       "name": "Granit.TextExtraction.Ocr.Tesseract",
       "deps": [
+        "Granit.Imaging",
         "Granit.TextExtraction"
       ],
       "framework": "net10.0"
@@ -31834,6 +31835,12 @@
           "kind": "method",
           "signature": "Load(ReadOnlyMemory<byte> source)",
           "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Identify",
+          "kind": "method",
+          "signature": "Identify(ReadOnlyMemory<byte> source)",
+          "returnType": "ImageInfo"
         }
       ]
     },
@@ -50807,7 +50814,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Ocr.Tesseract",
       "file": "src/Granit.TextExtraction.Ocr.Tesseract/GranitTextExtractionOcrTesseractModule.cs",
-      "line": 14,
+      "line": 17,
       "members": []
     },
     {
@@ -50860,7 +50867,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Ocr.Tesseract",
       "file": "src/Granit.TextExtraction.Ocr.Tesseract/TesseractOcrExtractor.cs",
-      "line": 32,
+      "line": 33,
       "members": [
         {
           "name": "CanHandle",
@@ -51294,6 +51301,22 @@
           "kind": "method",
           "signature": "AddTikaSidecarExtractor(this IServiceCollection services, Action<TikaSidecarOptions>? configure = null)",
           "returnType": "IHttpClientBuilder"
+        }
+      ]
+    },
+    {
+      "name": "TikaHealthChecksBuilderExtensions",
+      "fqn": "Granit.TextExtraction.Tika.Extensions.TikaHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.TextExtraction.Tika",
+      "file": "src/Granit.TextExtraction.Tika/Extensions/TikaHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitTikaHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitTikaHealthCheck(this IHealthChecksBuilder builder, string name = \"tika\", HealthStatus? failureStatus = null, TimeSpan? timeout = null)",
+          "returnType": "IHealthChecksBuilder"
         }
       ]
     },

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -124,6 +124,7 @@
       "src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj",
       "src/Granit.Identity.Local/Granit.Identity.Local.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
+      "src/Granit.Imaging/Granit.Imaging.csproj",
       "src/Granit.Indexing.AI/Granit.Indexing.AI.csproj",
       "src/Granit.Indexing.BackgroundJobs/Granit.Indexing.BackgroundJobs.csproj",
       "src/Granit.Indexing.Elasticsearch/Granit.Indexing.Elasticsearch.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -86,6 +86,7 @@
       "src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj",
       "src/Granit.Identity.Local/Granit.Identity.Local.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
+      "src/Granit.Imaging/Granit.Imaging.csproj",
       "src/Granit.Indexing.AI/Granit.Indexing.AI.csproj",
       "src/Granit.Indexing.BackgroundJobs/Granit.Indexing.BackgroundJobs.csproj",
       "src/Granit.Indexing.Elasticsearch/Granit.Indexing.Elasticsearch.csproj",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,10 +111,6 @@
   <ItemGroup Label="Imaging">
     <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.*" />
     <PackageVersion Include="MetadataExtractor" Version="2.*" />
-    <!-- Pinned to 2.* — Apache-2.0. SixLabors.ImageSharp 3.x switched to the
-         Six Labors Split License (commercial restrictions) which is incompatible
-         with Granit's clean Apache-2.0 OSS distribution. -->
-    <PackageVersion Include="SixLabors.ImageSharp" Version="2.*" />
   </ItemGroup>
   <ItemGroup Label="Office">
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,7 @@ Seules les **dépendances directes** y figurent. Les dépendances transitives
 sont couvertes par leurs propres avis de licence, restaurés depuis NuGet par
 le consommateur (les packages Granit ne redistribuent pas leurs binaires).
 
-Dernière mise à jour : 2026-06-12 (ajout de MaxMind.GeoIP2 pour le module Granit.IpGeolocation.MaxMind — géolocalisation IP hors-ligne)
+Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.TextExtraction.Ocr.Tesseract lit désormais les dimensions via Granit.Imaging / Magick.NET)
 
 ---
 
@@ -17,7 +17,7 @@ Dernière mise à jour : 2026-06-12 (ajout de MaxMind.GeoIP2 pour le module Gran
 | Licence      | Nombre de packages |
 | ------------ | ------------------ |
 | MIT          | 95                 |
-| Apache-2.0   | 41                 |
+| Apache-2.0   | 40                 |
 | BSD-3-Clause | 3                  |
 | BSD-2-Clause | 1                  |
 | PostgreSQL   | 2                  |
@@ -153,7 +153,6 @@ Dernière mise à jour : 2026-06-12 (ajout de MaxMind.GeoIP2 pour le module Gran
 | OpenTelemetry.Instrumentation.StackExchangeRedis | 1.15.1-beta.1 | Copyright The OpenTelemetry Authors |
 | Serilog.AspNetCore | 10.0.0 | Serilog Contributors |
 | Serilog.Sinks.OpenTelemetry | 4.2.0 | Serilog Contributors |
-| SixLabors.ImageSharp | 2.1.13 | Copyright (c) Six Labors |
 | Tesseract | 5.2.0 | Copyright (c) Charles Weld |
 | VaultSharp | 1.17.5.1 | Copyright (c) 2024 Raja Nadar |
 
@@ -401,15 +400,6 @@ et s'aligner sur l'exigence transitive de MailKit 4.16.0.
 Ce SDK est utilisé par les modules `Granit.*.AI` pour l'intégration avec des
 modèles de langage locaux via Ollama. Les données restent sur l'infrastructure
 de l'organisation (aucun appel vers des services cloud externes).
-
-### SixLabors.ImageSharp
-
-Ce package est utilisé par `Granit.TextExtraction.Ocr.Tesseract` uniquement pour
-identifier les dimensions d'une image (entête du format) AVANT décodage —
-défense contre les attaques pixel-bomb. La version est épinglée à
-**2.\*** car la branche 3.x est passée sous la Six Labors Split License, incompatible
-avec la distribution Apache-2.0 propre de Granit. Aucune donnée de santé ne transite
-par les serveurs Six Labors (bibliothèque purement locale).
 
 ### Tesseract
 

--- a/src/Granit.Imaging.MagickNet/Internal/MagickNetImageProcessor.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/MagickNetImageProcessor.cs
@@ -48,6 +48,30 @@ internal sealed class MagickNetImageProcessor(ImagingMetrics metrics, ImagingMag
         return new MagickNetImagePipeline(image, metrics);
     }
 
+    /// <inheritdoc/>
+    public ImageInfo Identify(ReadOnlyMemory<byte> source)
+    {
+        // Header-only: deliberately NO size validation here. Identify never allocates a
+        // decoded surface, so a large byte buffer is harmless — and callers rely on it
+        // precisely to vet declared pixel dimensions BEFORE deciding whether to decode.
+        if (!ImageFormatDetector.IsSafeRasterFormat(source.Span))
+        {
+            throw new UnsupportedImageFormatException("unknown");
+        }
+
+        try
+        {
+            MagickImageInfo info = new(source.Span);
+            return new ImageInfo(
+                new ImageSize((int)info.Width, (int)info.Height),
+                MagickFormatMapper.FromMagickFormat(info.Format));
+        }
+        catch (MagickException ex)
+        {
+            throw new UnsupportedImageFormatException("unreadable", ex);
+        }
+    }
+
     private void ValidateInputSize(long length)
     {
         if (options.MaxInputBytes > 0 && length > options.MaxInputBytes)

--- a/src/Granit.Imaging/Exceptions/UnsupportedImageFormatException.cs
+++ b/src/Granit.Imaging/Exceptions/UnsupportedImageFormatException.cs
@@ -17,4 +17,14 @@ public sealed class UnsupportedImageFormatException : Exception
     public UnsupportedImageFormatException(string detectedFormat)
         : base("The uploaded image format is not supported.") =>
         DetectedFormat = detectedFormat;
+
+    /// <summary>
+    /// Initializes a new <see cref="UnsupportedImageFormatException"/> wrapping the
+    /// underlying decoder failure (e.g. a corrupt or truncated header).
+    /// </summary>
+    /// <param name="detectedFormat">The format identifier that could not be mapped.</param>
+    /// <param name="innerException">The decoder exception that triggered this failure.</param>
+    public UnsupportedImageFormatException(string detectedFormat, Exception innerException)
+        : base("The uploaded image format is not supported.", innerException) =>
+        DetectedFormat = detectedFormat;
 }

--- a/src/Granit.Imaging/IImageProcessor.cs
+++ b/src/Granit.Imaging/IImageProcessor.cs
@@ -32,4 +32,17 @@ public interface IImageProcessor
     /// <param name="source">The byte buffer containing the image data.</param>
     /// <returns>A fluent pipeline for chaining image operations.</returns>
     IImagePipeline Load(ReadOnlyMemory<byte> source);
+
+    /// <summary>
+    /// Reads the image dimensions and format from the header WITHOUT decoding the pixel
+    /// buffer. Use this as a pre-decode guard (e.g. pixel-bomb defence): it inspects only
+    /// the format header, so a hostile file declaring enormous dimensions never allocates
+    /// a decoded surface.
+    /// </summary>
+    /// <param name="source">The byte buffer containing the image data.</param>
+    /// <returns>The header-only <see cref="ImageInfo"/>.</returns>
+    /// <exception cref="Exceptions.UnsupportedImageFormatException">
+    /// The data is not a recognized raster format, or its header cannot be read.
+    /// </exception>
+    ImageInfo Identify(ReadOnlyMemory<byte> source);
 }

--- a/src/Granit.Imaging/ImageInfo.cs
+++ b/src/Granit.Imaging/ImageInfo.cs
@@ -1,0 +1,8 @@
+namespace Granit.Imaging;
+
+/// <summary>
+/// Header-only metadata about an image, read without decoding the pixel buffer.
+/// </summary>
+/// <param name="Size">The image dimensions in pixels.</param>
+/// <param name="Format">The detected image format.</param>
+public readonly record struct ImageInfo(ImageSize Size, ImageFormat Format);

--- a/src/Granit.TextExtraction.Ocr.Tesseract/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/Extensions/ServiceCollectionExtensions.cs
@@ -18,7 +18,9 @@ public static class ServiceCollectionExtensions
     /// <see cref="ITesseractRecognizer"/>. The host MUST also ensure native
     /// <c>libtesseract</c> is on the loader path and that the configured
     /// <see cref="TesseractOcrOptions.DataPath"/> contains the requested
-    /// <c>*.traineddata</c> files.
+    /// <c>*.traineddata</c> files, and register an imaging provider (e.g.
+    /// <c>AddGranitImagingMagickNet()</c>) so the extractor can resolve
+    /// <c>IImageProcessor</c> for its pre-decode pixel-bomb guard.
     /// </summary>
     public static IServiceCollection AddTesseractOcrExtractor(
         this IServiceCollection services,

--- a/src/Granit.TextExtraction.Ocr.Tesseract/Granit.TextExtraction.Ocr.Tesseract.csproj
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/Granit.TextExtraction.Ocr.Tesseract.csproj
@@ -13,13 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="Tesseract" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Imaging\Granit.Imaging.csproj" />
     <ProjectReference Include="..\Granit.TextExtraction\Granit.TextExtraction.csproj" />
   </ItemGroup>
 

--- a/src/Granit.TextExtraction.Ocr.Tesseract/GranitTextExtractionOcrTesseractModule.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/GranitTextExtractionOcrTesseractModule.cs
@@ -1,3 +1,4 @@
+using Granit.Imaging;
 using Granit.Modularity;
 
 namespace Granit.TextExtraction.Ocr.Tesseract;
@@ -8,7 +9,9 @@ namespace Granit.TextExtraction.Ocr.Tesseract;
 /// <see cref="Extensions.ServiceCollectionExtensions.AddTesseractOcrExtractor"/>;
 /// the module itself does not auto-register anything because enabling OCR requires native
 /// <c>libtesseract</c> plus traineddata files on disk — both of which are host-specific
-/// deployment concerns.
+/// deployment concerns. The extractor also resolves <see cref="IImageProcessor"/> for its
+/// pre-decode pixel-bomb guard, so the host must register an imaging provider (e.g.
+/// <c>Granit.Imaging.MagickNet</c>).
 /// </summary>
-[DependsOn(typeof(GranitTextExtractionModule))]
+[DependsOn(typeof(GranitImagingModule), typeof(GranitTextExtractionModule))]
 public sealed class GranitTextExtractionOcrTesseractModule : GranitModule;

--- a/src/Granit.TextExtraction.Ocr.Tesseract/TesseractOcrExtractor.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/TesseractOcrExtractor.cs
@@ -1,8 +1,9 @@
+using Granit.Imaging;
+using Granit.Imaging.Exceptions;
 using Granit.TextExtraction.Ocr.Tesseract.Options;
 using Granit.TextExtraction.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using SixLabors.ImageSharp;
 
 namespace Granit.TextExtraction.Ocr.Tesseract;
 
@@ -35,6 +36,7 @@ public sealed partial class TesseractOcrExtractor : ITextExtractor
     public const string ExtractorName = "granit.text-extraction.ocr-tesseract";
 
     private readonly ITesseractRecognizer _recognizer;
+    private readonly IImageProcessor _imageProcessor;
     private readonly GranitTextExtractionOptions _extractionOptions;
     private readonly TesseractOcrOptions _ocrOptions;
     private readonly ILogger<TesseractOcrExtractor> _logger;
@@ -42,16 +44,19 @@ public sealed partial class TesseractOcrExtractor : ITextExtractor
 
     public TesseractOcrExtractor(
         ITesseractRecognizer recognizer,
+        IImageProcessor imageProcessor,
         IOptions<GranitTextExtractionOptions> extractionOptions,
         IOptions<TesseractOcrOptions> ocrOptions,
         ILogger<TesseractOcrExtractor> logger)
     {
         ArgumentNullException.ThrowIfNull(recognizer);
+        ArgumentNullException.ThrowIfNull(imageProcessor);
         ArgumentNullException.ThrowIfNull(extractionOptions);
         ArgumentNullException.ThrowIfNull(ocrOptions);
         ArgumentNullException.ThrowIfNull(logger);
 
         _recognizer = recognizer;
+        _imageProcessor = imageProcessor;
         _extractionOptions = extractionOptions.Value;
         _ocrOptions = ocrOptions.Value;
         _logger = logger;
@@ -93,27 +98,21 @@ public sealed partial class TesseractOcrExtractor : ITextExtractor
         // Pixel-bomb defence — identify dimensions from the format header without
         // decoding. A 100 KB PNG can claim 100 000 × 100 000 pixels (~40 GB RGBA buffer);
         // we reject those before they hit Leptonica.
-        IImageInfo? info;
+        ImageInfo info;
         try
         {
-            info = Image.Identify(bytes);
+            info = _imageProcessor.Identify(bytes);
         }
-        catch (Exception ex) when (ex is UnknownImageFormatException or InvalidImageContentException)
+        catch (UnsupportedImageFormatException ex)
         {
             LogUnreadableImageSkipped(ex, contentType);
             return Skipped();
         }
 
-        if (info is null)
-        {
-            LogUnreadableImageSkipped(null, contentType);
-            return Skipped();
-        }
-
-        long pixels = (long)info.Width * info.Height;
+        long pixels = (long)info.Size.Width * info.Size.Height;
         if (pixels > _ocrOptions.MaxImagePixels)
         {
-            LogImageRejectedByPixelCap(info.Width, info.Height, _ocrOptions.MaxImagePixels);
+            LogImageRejectedByPixelCap(info.Size.Width, info.Size.Height, _ocrOptions.MaxImagePixels);
             return Skipped();
         }
 

--- a/src/Granit.TextExtraction.Ocr.Tesseract/packages.lock.json
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/packages.lock.json
@@ -31,12 +31,6 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
-      "SixLabors.ImageSharp": {
-        "type": "Direct",
-        "requested": "[2.*, )",
-        "resolved": "2.1.13",
-        "contentHash": "zmVHZR13XE477TBAVXE71VcMhqhiv1PbzMWIfuIDytVdBPl3KZlvYYBkqcuQSDdszVY2XHanW98VmDffoNzSSw=="
-      },
       "Tesseract": {
         "type": "Direct",
         "requested": "[5.*, )",
@@ -84,6 +78,13 @@
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.imaging": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
       },
       "granit.textextraction": {
         "type": "Project",

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Metrics;
 using Granit.Imaging.Diagnostics;
+using Granit.Imaging.Exceptions;
 using Granit.Imaging.MagickNet.Internal;
 using Granit.Imaging.MagickNet.Options;
 using NSubstitute;
@@ -58,6 +59,30 @@ public sealed class MagickNetImageProcessorTests
         // Assert
         pipeline.SourceFormat.ShouldBe(ImageFormat.Png);
         pipeline.SourceSize.ShouldBe(new ImageSize(100, 100));
+    }
+
+    [Fact]
+    public void Identify_FromReadOnlyMemory_ReturnsHeaderInfoWithoutDecoding()
+    {
+        // Arrange
+        ReadOnlyMemory<byte> bytes = GetTestImageBytes();
+
+        // Act
+        ImageInfo info = _processor.Identify(bytes);
+
+        // Assert
+        info.Format.ShouldBe(ImageFormat.Png);
+        info.Size.ShouldBe(new ImageSize(100, 100));
+    }
+
+    [Fact]
+    public void Identify_UnknownFormat_ThrowsUnsupportedImageFormat()
+    {
+        // Arrange — random bytes with no recognized raster header.
+        ReadOnlyMemory<byte> junk = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+
+        // Act / Assert
+        Should.Throw<UnsupportedImageFormatException>(() => _processor.Identify(junk));
     }
 
     [Fact]

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/Granit.TextExtraction.Ocr.Tesseract.Tests.csproj
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/Granit.TextExtraction.Ocr.Tesseract.Tests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Imaging\Granit.Imaging.csproj" />
     <ProjectReference Include="..\..\src\Granit.TextExtraction.Ocr.Tesseract\Granit.TextExtraction.Ocr.Tesseract.csproj" />
   </ItemGroup>
 

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/TesseractOcrExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/TesseractOcrExtractorTests.cs
@@ -1,10 +1,10 @@
+using Granit.Imaging;
+using Granit.Imaging.Exceptions;
 using Granit.TextExtraction.Ocr.Tesseract.Options;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Shouldly;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 using ExtractionOptions = Granit.TextExtraction.Options.GranitTextExtractionOptions;
 using MEOptions = Microsoft.Extensions.Options.Options;
@@ -18,7 +18,8 @@ public sealed class TesseractOcrExtractorTests
     private static (TesseractOcrExtractor extractor, ITesseractRecognizer recognizer) CreateExtractor(
         string recognizedText = "recognised text",
         ExtractionOptions? extractionOptions = null,
-        TesseractOcrOptions? ocrOptions = null)
+        TesseractOcrOptions? ocrOptions = null,
+        IImageProcessor? imageProcessor = null)
     {
         ITesseractRecognizer recognizer = Substitute.For<ITesseractRecognizer>();
         recognizer.RecognizeAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
@@ -26,6 +27,7 @@ public sealed class TesseractOcrExtractorTests
 
         TesseractOcrExtractor extractor = new(
             recognizer,
+            imageProcessor ?? ImageProcessorReturning(32, 32),
             MEOptions.Create(extractionOptions ?? new ExtractionOptions()),
             MEOptions.Create(ocrOptions ?? new TesseractOcrOptions { DataPath = "/tmp/tessdata" }),
             NullLogger<TesseractOcrExtractor>.Instance);
@@ -33,13 +35,19 @@ public sealed class TesseractOcrExtractorTests
         return (extractor, recognizer);
     }
 
-    private static byte[] PngBytes(int width, int height)
+    // The real header read lives in Granit.Imaging.MagickNet (covered by its own tests and the
+    // OCR .Tests.Integration project). Here we mock IImageProcessor so the extractor's pixel-bomb
+    // and skip logic can be exercised deterministically without a native imaging dependency.
+    private static IImageProcessor ImageProcessorReturning(int width, int height)
     {
-        using Image<Rgba32> img = new(width, height);
-        using MemoryStream ms = new();
-        img.SaveAsPng(ms);
-        return ms.ToArray();
+        IImageProcessor processor = Substitute.For<IImageProcessor>();
+        processor.Identify(Arg.Any<ReadOnlyMemory<byte>>())
+            .Returns(new ImageInfo(new ImageSize(width, height), ImageFormat.Png));
+        return processor;
     }
+
+    private static byte[] SampleImageBytes(int length = 64) =>
+        [.. Enumerable.Range(0, length).Select(static i => (byte)i)];
 
     [Theory]
     [InlineData("image/png", true)]
@@ -62,7 +70,7 @@ public sealed class TesseractOcrExtractorTests
         (TesseractOcrExtractor extractor, ITesseractRecognizer recognizer) =
             CreateExtractor("Hello, OCR!");
 
-        byte[] imageBytes = PngBytes(32, 32);
+        byte[] imageBytes = SampleImageBytes();
         using MemoryStream input = new(imageBytes);
 
         TextExtractionResult result = await extractor.ExtractAsync(
@@ -82,7 +90,7 @@ public sealed class TesseractOcrExtractorTests
     public async Task Truncates_when_recognition_exceeds_max_char_length()
     {
         (TesseractOcrExtractor extractor, _) = CreateExtractor(new string('x', 5_000));
-        using MemoryStream input = new(PngBytes(16, 16));
+        using MemoryStream input = new(SampleImageBytes());
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 100,
@@ -95,16 +103,16 @@ public sealed class TesseractOcrExtractorTests
     [Fact]
     public async Task Pixel_bomb_is_rejected_before_calling_recognizer()
     {
-        // 32×32 image = 1024 pixels, cap at 4 → exceeds, soft-skip.
+        // IImageProcessor reports 32×32 = 1024 pixels; cap at 4 → exceeds, soft-skip.
         TesseractOcrOptions tight = new()
         {
             DataPath = "/tmp/tessdata",
             MaxImagePixels = 4,
         };
         (TesseractOcrExtractor extractor, ITesseractRecognizer recognizer) =
-            CreateExtractor(ocrOptions: tight);
+            CreateExtractor(ocrOptions: tight, imageProcessor: ImageProcessorReturning(32, 32));
 
-        using MemoryStream input = new(PngBytes(32, 32));
+        using MemoryStream input = new(SampleImageBytes());
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024,
@@ -121,9 +129,13 @@ public sealed class TesseractOcrExtractorTests
     [Fact]
     public async Task Malformed_image_bytes_soft_skip()
     {
-        (TesseractOcrExtractor extractor, ITesseractRecognizer recognizer) = CreateExtractor();
+        IImageProcessor unreadable = Substitute.For<IImageProcessor>();
+        unreadable.Identify(Arg.Any<ReadOnlyMemory<byte>>())
+            .Throws(new UnsupportedImageFormatException("unknown"));
+        (TesseractOcrExtractor extractor, ITesseractRecognizer recognizer) =
+            CreateExtractor(imageProcessor: unreadable);
 
-        // Random bytes — no PNG/JPEG/etc header → ImageSharp throws UnknownImageFormatException.
+        // No PNG/JPEG/etc header → the imaging provider rejects it as an unsupported format.
         byte[] junk = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
         using MemoryStream input = new(junk);
 
@@ -146,11 +158,12 @@ public sealed class TesseractOcrExtractorTests
 
         TesseractOcrExtractor extractor = new(
             recognizer,
+            ImageProcessorReturning(16, 16),
             MEOptions.Create(new ExtractionOptions()),
             MEOptions.Create(new TesseractOcrOptions { DataPath = "/tmp/tessdata" }),
             NullLogger<TesseractOcrExtractor>.Instance);
 
-        using MemoryStream input = new(PngBytes(16, 16));
+        using MemoryStream input = new(SampleImageBytes());
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024,
@@ -166,8 +179,8 @@ public sealed class TesseractOcrExtractorTests
         ExtractionOptions extraction = new() { MaxBodySizeBytes = 16 };
         (TesseractOcrExtractor extractor, _) = CreateExtractor(extractionOptions: extraction);
 
-        // A real PNG even of 1×1 is ~70 bytes — exceeds the 16-byte cap easily.
-        using MemoryStream input = new(PngBytes(8, 8));
+        // 64-byte payload exceeds the 16-byte body cap, which trips before the image is identified.
+        using MemoryStream input = new(SampleImageBytes());
 
         TextExtraction.Exceptions.TextExtractionException tex =
             await Should.ThrowAsync<TextExtraction.Exceptions.TextExtractionException>(
@@ -182,15 +195,17 @@ public sealed class TesseractOcrExtractorTests
     public void Constructor_rejects_null_arguments()
     {
         ITesseractRecognizer recognizer = Substitute.For<ITesseractRecognizer>();
+        IImageProcessor imageProcessor = Substitute.For<IImageProcessor>();
         Microsoft.Extensions.Options.IOptions<ExtractionOptions> extraction =
             MEOptions.Create(new ExtractionOptions());
         Microsoft.Extensions.Options.IOptions<TesseractOcrOptions> ocr =
             MEOptions.Create(new TesseractOcrOptions { DataPath = "/tmp/tessdata" });
         NullLogger<TesseractOcrExtractor> logger = NullLogger<TesseractOcrExtractor>.Instance;
 
-        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(null!, extraction, ocr, logger));
-        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(recognizer, null!, ocr, logger));
-        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(recognizer, extraction, null!, logger));
-        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(recognizer, extraction, ocr, null!));
+        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(null!, imageProcessor, extraction, ocr, logger));
+        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(recognizer, null!, extraction, ocr, logger));
+        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(recognizer, imageProcessor, null!, ocr, logger));
+        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(recognizer, imageProcessor, extraction, null!, logger));
+        Should.Throw<ArgumentNullException>(() => new TesseractOcrExtractor(recognizer, imageProcessor, extraction, ocr, null!));
     }
 }

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/packages.lock.json
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/packages.lock.json
@@ -49,12 +49,6 @@
           "EmptyFiles": "4.4.0"
         }
       },
-      "SixLabors.ImageSharp": {
-        "type": "Direct",
-        "requested": "[2.*, )",
-        "resolved": "2.1.13",
-        "contentHash": "zmVHZR13XE477TBAVXE71VcMhqhiv1PbzMWIfuIDytVdBPl3KZlvYYBkqcuQSDdszVY2XHanW98VmDffoNzSSw=="
-      },
       "xunit.runner.visualstudio": {
         "type": "Direct",
         "requested": "[3.1.*, )",
@@ -288,6 +282,13 @@
       "granit": {
         "type": "Project"
       },
+      "granit.imaging": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
       "granit.textextraction": {
         "type": "Project",
         "dependencies": {
@@ -300,10 +301,10 @@
       "granit.textextraction.ocr.tesseract": {
         "type": "Project",
         "dependencies": {
+          "Granit.Imaging": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
-          "SixLabors.ImageSharp": "[2.*, )",
           "Tesseract": "[5.*, )"
         }
       },


### PR DESCRIPTION
## Why

`SixLabors.ImageSharp` was pinned to `2.*` because **3.x+ moved to the Six Labors Split License** (commercial restrictions), incompatible with Granit's Apache-2.0 distribution. That left the package stuck on a maintenance-only branch and flagged on every `dotnet outdated`.

It was used in **one place only**: `Granit.TextExtraction.Ocr.Tesseract` called `Image.Identify` for a header-only dimension read (the pixel-bomb guard) — no decode, resize, or conversion. Meanwhile Granit already ships an imaging abstraction (`Granit.Imaging`) backed by Magick.NET (Apache-2.0). The OCR extractor was simply bypassing it.

## What

- Add **`IImageProcessor.Identify(ReadOnlyMemory<byte>)`** → `ImageInfo { Size, Format }`, a header-only read that never decodes the pixel buffer (pixel-bomb-safe).
- Implement it in the Magick.NET provider via **`MagickImageInfo`** (pings the header); wraps decoder failures as `UnsupportedImageFormatException`.
- Route `TesseractOcrExtractor` through `IImageProcessor`; OCR module now `[DependsOn(GranitImagingModule)]` and hosts must register an imaging provider (`AddGranitImagingMagickNet`).
- **Remove `SixLabors.ImageSharp`** entirely: OCR csprojs, the central pin in `Directory.Packages.props`, and `THIRD-PARTY-NOTICES.md` (Apache-2.0 count 41 → 40).

## Alternatives considered

Magick.NET (chosen — already in the framework, no new native dependency) over SkiaSharp/NetVips (MIT, but a second native imaging stack just to read 4 header types) and a hand-rolled header parser (zero deps, but we'd own a security-sensitive parser).

## Tests

- `Granit.Imaging.MagickNet.Tests` — **83** (incl. 2 new `Identify` tests: 100×100 PNG header read; unknown-format rejection).
- `Granit.TextExtraction.Ocr.Tesseract.Tests` — **19** (now mocks `IImageProcessor`; no ImageSharp).
- Architecture (TextExtraction / ProjectDependency / ModuleConvention) — **35**.
- `dotnet format` clean, markdownlint clean, zero remaining `SixLabors` references.