### PR TITLE
feat(text-extraction): Tika readiness health check + convention audit follow-ups

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -50757,7 +50757,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction.Ocr.AI",
       "file": "src/Granit.TextExtraction.Ocr.AI/GranitTextExtractionOcrAIModule.cs",
-      "line": 13,
+      "line": 14,
       "members": []
     },
     {

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,7 @@ Seules les **dépendances directes** y figurent. Les dépendances transitives
 sont couvertes par leurs propres avis de licence, restaurés depuis NuGet par
 le consommateur (les packages Granit ne redistribuent pas leurs binaires).
 
-Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.TextExtraction.Ocr.Tesseract lit désormais les dimensions via Granit.Imaging / Magick.NET)
+Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.TextExtraction.Ocr.Tesseract lit les dimensions via Granit.Imaging / Magick.NET ; ajout de Markdig pour Granit.TextExtraction.Text)
 
 ---
 
@@ -19,7 +19,7 @@ Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.
 | MIT          | 95                 |
 | Apache-2.0   | 40                 |
 | BSD-3-Clause | 3                  |
-| BSD-2-Clause | 1                  |
+| BSD-2-Clause | 2                  |
 | PostgreSQL   | 2                  |
 
 ---
@@ -160,6 +160,7 @@ Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.
 
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
+| Markdig | 1.3.0 | Copyright (c) Alexandre Mutel |
 | Scriban | 7.2.1 | Copyright (c) Alexandre Mutel |
 
 ### BSD-3-Clause

--- a/src/Granit.TextExtraction.Ocr.AI/GranitTextExtractionOcrAIModule.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/GranitTextExtractionOcrAIModule.cs
@@ -1,3 +1,4 @@
+using Granit.AI;
 using Granit.Modularity;
 
 namespace Granit.TextExtraction.Ocr.AI;
@@ -9,5 +10,5 @@ namespace Granit.TextExtraction.Ocr.AI;
 /// the module itself does not auto-register anything because enabling vision OCR sends
 /// document bytes to a third-party LLM provider (GDPR Article 28 disclosure required).
 /// </summary>
-[DependsOn(typeof(GranitTextExtractionModule))]
+[DependsOn(typeof(GranitAIModule), typeof(GranitTextExtractionModule))]
 public sealed class GranitTextExtractionOcrAIModule : GranitModule;

--- a/src/Granit.TextExtraction.Tika/Extensions/TikaHealthChecksBuilderExtensions.cs
+++ b/src/Granit.TextExtraction.Tika/Extensions/TikaHealthChecksBuilderExtensions.cs
@@ -1,0 +1,40 @@
+using Granit.TextExtraction.Tika.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.TextExtraction.Tika.Extensions;
+
+/// <summary>
+/// Health-check registration for the Apache Tika sidecar.
+/// </summary>
+public static class TikaHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Adds a readiness health check that verifies the Apache Tika sidecar is reachable.
+    /// Call AFTER <see cref="ServiceCollectionExtensions.AddTikaSidecarExtractor"/> so the
+    /// <c>granit-tika</c> <see cref="System.Net.Http.HttpClient"/> (and its host-wired mTLS
+    /// handler) is available. Tagged <c>"readiness"</c> only — a Tika outage must hold traffic
+    /// at the ingress, never fail liveness and restart the pod.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Check name. Defaults to <c>"tika"</c>.</param>
+    /// <param name="failureStatus">Status on failure. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="timeout">Check timeout. Defaults to 10 seconds.</param>
+    public static IHealthChecksBuilder AddGranitTikaHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "tika",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddSingleton<TikaSidecarHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<TikaSidecarHealthCheck>(),
+            failureStatus,
+            ["readiness"],
+            timeout ?? TimeSpan.FromSeconds(10)));
+    }
+}

--- a/src/Granit.TextExtraction.Tika/Granit.TextExtraction.Tika.csproj
+++ b/src/Granit.TextExtraction.Tika/Granit.TextExtraction.Tika.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Granit.TextExtraction.Tika/HealthChecks/TikaSidecarHealthCheck.cs
+++ b/src/Granit.TextExtraction.Tika/HealthChecks/TikaSidecarHealthCheck.cs
@@ -1,0 +1,60 @@
+using Granit.TextExtraction.Tika.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.TextExtraction.Tika.HealthChecks;
+
+/// <summary>
+/// Readiness health check that verifies the Apache Tika sidecar is reachable by issuing a
+/// lightweight <c>GET {Uri}version</c> over the same secured <c>granit-tika</c>
+/// <see cref="HttpClient"/> (and therefore the same host-wired mTLS handler) the extractor uses.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item>2xx → <see cref="HealthCheckResult.Healthy"/></item>
+///   <item>Non-success status, transport failure, or timeout → <see cref="HealthCheckResult.Unhealthy"/></item>
+/// </list>
+/// The result message never exposes the sidecar URI, host, port, or any header (ISO 27001 / GDPR).
+/// </remarks>
+internal sealed class TikaSidecarHealthCheck(
+    IHttpClientFactory httpClientFactory,
+    IOptions<TikaSidecarOptions> options) : IHealthCheck
+{
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(10);
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await ProbeAsync(cancellationToken)
+                .WaitAsync(s_timeout, cancellationToken)
+                .ConfigureAwait(false);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            // Sanitised: never leak the sidecar URI / host / port into the probe surface.
+            return HealthCheckResult.Unhealthy($"Tika sidecar unreachable: {ex.GetType().Name}");
+        }
+    }
+
+    private async Task ProbeAsync(CancellationToken cancellationToken)
+    {
+        TikaSidecarOptions tika = options.Value;
+
+        using HttpClient client = httpClientFactory.CreateClient(TikaSidecarTextExtractor.HttpClientName);
+        client.Timeout = s_timeout;
+
+        // Tika's /version endpoint returns the banner ("Apache Tika x.y.z") with 200 — the
+        // cheapest reachability probe that still proves the parser farm is up, not just the port.
+        Uri endpoint = new(tika.Uri, "version");
+        using HttpResponseMessage response = await client
+            .GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Granit.TextExtraction.Tika/packages.lock.json
+++ b/src/Granit.TextExtraction.Tika/packages.lock.json
@@ -8,6 +8,18 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -101,6 +113,11 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",

--- a/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrOptionsTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrOptionsTests.cs
@@ -1,0 +1,12 @@
+using Granit.TextExtraction.Ocr.AI.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.TextExtraction.Ocr.AI.Tests;
+
+public sealed class AIVisionOcrOptionsTests
+{
+    [Fact]
+    public void Section_name_matches_convention() =>
+        AIVisionOcrOptions.SectionName.ShouldBe("TextExtraction:Ocr:AI");
+}

--- a/tests/Granit.TextExtraction.Ocr.AI.Tests/GranitTextExtractionOcrAIModuleTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.AI.Tests/GranitTextExtractionOcrAIModuleTests.cs
@@ -1,3 +1,4 @@
+using Granit.AI;
 using Granit.Modularity;
 using Shouldly;
 using Xunit;
@@ -21,6 +22,17 @@ public sealed class GranitTextExtractionOcrAIModuleTests
             .GetCustomAttributes(typeof(DependsOnAttribute), inherit: true);
 
         attrs.SelectMany(a => a.DependedTypes).ShouldContain(typeof(GranitTextExtractionModule));
+    }
+
+    [Fact]
+    public void Module_DependsOn_GranitAIModule()
+    {
+        // The module references Granit.AI directly (IAIChatClientFactory), so it must
+        // declare GranitAIModule in [DependsOn] like every other AI-consuming module.
+        var attrs = (DependsOnAttribute[])typeof(GranitTextExtractionOcrAIModule)
+            .GetCustomAttributes(typeof(DependsOnAttribute), inherit: true);
+
+        attrs.SelectMany(a => a.DependedTypes).ShouldContain(typeof(GranitAIModule));
     }
 
     [Fact]

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/TesseractOcrOptionsTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/TesseractOcrOptionsTests.cs
@@ -1,0 +1,12 @@
+using Granit.TextExtraction.Ocr.Tesseract.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.TextExtraction.Ocr.Tesseract.Tests;
+
+public sealed class TesseractOcrOptionsTests
+{
+    [Fact]
+    public void Section_name_matches_convention() =>
+        TesseractOcrOptions.SectionName.ShouldBe("TextExtraction:Ocr:Tesseract");
+}

--- a/tests/Granit.TextExtraction.Pdf.Ocr.Tests/PdfOcrOptionsTests.cs
+++ b/tests/Granit.TextExtraction.Pdf.Ocr.Tests/PdfOcrOptionsTests.cs
@@ -1,0 +1,12 @@
+using Granit.TextExtraction.Pdf.Ocr.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.TextExtraction.Pdf.Ocr.Tests;
+
+public sealed class PdfOcrOptionsTests
+{
+    [Fact]
+    public void Section_name_matches_convention() =>
+        PdfOcrOptions.SectionName.ShouldBe("TextExtraction:Pdf:Ocr");
+}

--- a/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarHealthCheckTests.cs
+++ b/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarHealthCheckTests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using Granit.TextExtraction.Tika.HealthChecks;
+using Granit.TextExtraction.Tika.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+using Xunit;
+using MEOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.TextExtraction.Tika.Tests;
+
+public sealed class TikaSidecarHealthCheckTests
+{
+    private static readonly Uri TikaUri = new("https://tika.test/");
+
+    private static TikaSidecarHealthCheck Create(StubHttpMessageHandler stub)
+    {
+        ServiceCollection services = new();
+        services.AddHttpClient(TikaSidecarTextExtractor.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => stub);
+        ServiceProvider sp = services.BuildServiceProvider();
+        IHttpClientFactory factory = sp.GetRequiredService<IHttpClientFactory>();
+
+        TikaSidecarOptions opts = new() { Uri = TikaUri, AllowedHosts = ["tika.test"] };
+        return new TikaSidecarHealthCheck(factory, MEOptions.Create(opts));
+    }
+
+    [Fact]
+    public async Task Healthy_when_sidecar_returns_success()
+    {
+        TikaSidecarHealthCheck check = Create(
+            StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "Apache Tika 2.9.1"));
+
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_when_sidecar_returns_error_status()
+    {
+        TikaSidecarHealthCheck check = Create(
+            StubHttpMessageHandler.RespondWith(HttpStatusCode.ServiceUnavailable, string.Empty));
+
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_message_does_not_leak_sidecar_host()
+    {
+        TikaSidecarHealthCheck check = Create(
+            StubHttpMessageHandler.Throws(new HttpRequestException("connection refused to tika.test")));
+
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldNotContain("tika.test");
+    }
+
+    [Fact]
+    public async Task Probes_the_version_endpoint()
+    {
+        var stub =
+            StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "Apache Tika 2.9.1");
+        TikaSidecarHealthCheck check = Create(stub);
+
+        await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        stub.Calls.ShouldHaveSingleItem();
+        stub.Calls[0].RequestUri!.AbsolutePath.ShouldBe("/version");
+        stub.Calls[0].Method.ShouldBe(HttpMethod.Get);
+    }
+}

--- a/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarOptionsTests.cs
+++ b/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarOptionsTests.cs
@@ -1,0 +1,12 @@
+using Granit.TextExtraction.Tika.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.TextExtraction.Tika.Tests;
+
+public sealed class TikaSidecarOptionsTests
+{
+    [Fact]
+    public void Section_name_matches_convention() =>
+        TikaSidecarOptions.SectionName.ShouldBe("TextExtraction:Tika");
+}

--- a/tests/Granit.TextExtraction.Tika.Tests/packages.lock.json
+++ b/tests/Granit.TextExtraction.Tika.Tests/packages.lock.json
@@ -145,6 +145,11 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
+      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -323,6 +328,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.TextExtraction": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Http": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
@@ -344,6 +350,18 @@
         "requested": "[10.*, )",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## What

Follow-ups from a framework convention audit of the `Granit.TextExtraction*` family (`/audit Granit.TextExtraction*`), plus a small operational feature.

### `fix(text-extraction)` — convention audit
- **`GranitTextExtractionOcrAIModule`** now declares `[DependsOn(typeof(GranitAIModule), typeof(GranitTextExtractionModule))]`. It references `Granit.AI` directly (`IAIChatClientFactory`) but was the only AI-consuming module omitting `GranitAIModule` from `[DependsOn]` (~30 other modules declare it). Locked in by a new test.
- **`SectionName` convention tests** added for the four satellite options that lacked one: `TikaSidecarOptions`, `AIVisionOcrOptions`, `TesseractOcrOptions`, `PdfOcrOptions`.
- **THIRD-PARTY-NOTICES.md**: list **Markdig** (BSD-2-Clause), consumed by `Granit.TextExtraction.Text` — previously missing.

### `feat(text-extraction)` — Tika sidecar readiness health check
- `TikaSidecarHealthCheck` + `AddGranitTikaHealthCheck(this IHealthChecksBuilder)`: probes `GET {Uri}version` over the secured `granit-tika` `HttpClient` (same client/mTLS handler the extractor uses).
- Tagged **`"readiness"` only** — a Tika outage must hold traffic at the ingress, never fail liveness and restart the pod. The result message never leaks the sidecar host/port (ISO 27001 / GDPR).
- Opt-in, mirroring the SMTP / Ollama health-check pattern.

## Why not AI OCR health check
The AI vision OCR extractor deliberately ships **no** health check: AI readiness is a provider concern (e.g. `Granit.AI.Ollama` already exposes `AddGranitOllamaHealthCheck`), and probing would bill an LLM call against the tenant quota on every kubelet poll.

## Verification
- `dotnet test` green: Tika (36, incl. 4 health-check tests), Ocr.AI (23), Ocr.Tesseract (20), Pdf.Ocr (17).
- `dotnet format --verify-no-changes` clean; `markdownlint` 0 errors.
