### PR TITLE
fix(indexing): align Elasticsearch integration test + docs with v9 client

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -51305,22 +51305,6 @@
       ]
     },
     {
-      "name": "TikaHealthChecksBuilderExtensions",
-      "fqn": "Granit.TextExtraction.Tika.Extensions.TikaHealthChecksBuilderExtensions",
-      "kind": "class",
-      "project": "Granit.TextExtraction.Tika",
-      "file": "src/Granit.TextExtraction.Tika/Extensions/TikaHealthChecksBuilderExtensions.cs",
-      "line": 10,
-      "members": [
-        {
-          "name": "AddGranitTikaHealthCheck",
-          "kind": "method",
-          "signature": "AddGranitTikaHealthCheck(this IHealthChecksBuilder builder, string name = \"tika\", HealthStatus? failureStatus = null, TimeSpan? timeout = null)",
-          "returnType": "IHealthChecksBuilder"
-        }
-      ]
-    },
-    {
       "name": "GranitTextExtractionTikaModule",
       "fqn": "Granit.TextExtraction.Tika.GranitTextExtractionTikaModule",
       "kind": "class",

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -123,7 +123,7 @@ Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.
 | AWSSDK.SecretsManager | 4.0.4.24 | Amazon Web Services, Inc. |
 | AWSSDK.SimpleEmailV2 | 4.0.13 | Amazon Web Services, Inc. |
 | AWSSDK.SimpleNotificationService | 4.0.2.34 | Amazon Web Services, Inc. |
-| Elastic.Clients.Elasticsearch | 8.18.0 | Copyright Elasticsearch B.V. |
+| Elastic.Clients.Elasticsearch | 9.4.2 | Copyright Elasticsearch B.V. |
 | Fido2 | 4.0.1 | Copyright (c) 2018 Anders Åberg / passwordless-lib contributors |
 | Fido2.AspNet | 4.0.1 | Copyright (c) 2018 Anders Åberg / passwordless-lib contributors |
 | Fido2.Models | 4.0.1 | Copyright (c) 2018 Anders Åberg / passwordless-lib contributors |

--- a/src/Granit.Indexing.Elasticsearch/Granit.Indexing.Elasticsearch.csproj
+++ b/src/Granit.Indexing.Elasticsearch/Granit.Indexing.Elasticsearch.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.Indexing.Elasticsearch</PackageId>
-    <Description>Elasticsearch 8.x backend for Granit.Indexing — opt-in BM25 search over per-language analyzers with shared / per-tenant index strategies. Replaces the default EF/tsvector implementations at registration time.</Description>
+    <Description>Elasticsearch 9.x backend for Granit.Indexing — opt-in BM25 search over per-language analyzers with shared / per-tenant index strategies. Replaces the default EF/tsvector implementations at registration time.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.Indexing.Elasticsearch/README.md
+++ b/src/Granit.Indexing.Elasticsearch/README.md
@@ -1,6 +1,6 @@
 # Granit.Indexing.Elasticsearch
 
-Opt-in Elasticsearch 8.x backend for `Granit.Indexing`. Replaces the default EF/tsvector
+Opt-in Elasticsearch 9.x backend for `Granit.Indexing`. Replaces the default EF/tsvector
 implementations with a BM25 multi-field search over per-language analyzers.
 
 ## Why use it

--- a/tests/Granit.Indexing.Elasticsearch.Tests.Integration/ElasticsearchFixture.cs
+++ b/tests/Granit.Indexing.Elasticsearch.Tests.Integration/ElasticsearchFixture.cs
@@ -4,12 +4,12 @@ using Xunit;
 namespace Granit.Indexing.Elasticsearch.Tests.Integration;
 
 /// <summary>
-/// Elasticsearch 8.x container shared across the integration suite. Boots once; tests
+/// Elasticsearch 9.x container shared across the integration suite. Boots once; tests
 /// use unique index prefixes to avoid cross-pollution.
 /// </summary>
 public sealed class ElasticsearchFixture : IAsyncLifetime
 {
-    private readonly ElasticsearchContainer _container = new ElasticsearchBuilder("elasticsearch:8.15.3")
+    private readonly ElasticsearchContainer _container = new ElasticsearchBuilder("elasticsearch:9.4.2")
         // Disable disk-based shard allocation: in CI the runner disk may be >85% full,
         // triggering the high watermark and blocking even PRIMARY shard allocation →
         // 503 unavailable_shards_exception after a 1-minute timeout on every IndexAsync.


### PR DESCRIPTION
## Context

The `Elastic.Clients.Elasticsearch` 8 → 9.4.2 bump landed in #2753, but the integration suite started failing:

```
status_exception: Accept version must be either version 8 or 7, but found 9.
Accept=application/vnd.elasticsearch+json;compatible-with=9
```

The v9 client only speaks the `compatible-with=9` wire protocol, which the `elasticsearch:8.15.3` test container (and any ES 8.x server) rejects with HTTP 400. The module now requires an **Elasticsearch 9.x** server.

## Changes

- Test container `elasticsearch:8.15.3` → `elasticsearch:9.4.2` (matches the client version)
- Module `Description`, README and `THIRD-PARTY-NOTICES` updated from `8.x` → `9.x` / `9.4.2`

## Notes

- Docs site updated separately in granit-docs PR #143.
- Integration tests require Docker; not runnable locally — validated by CI.