### PR TITLE
feat(ai): readiness health checks for OpenAI, Azure OpenAI, Anthropic providers

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3038,6 +3038,22 @@
       ]
     },
     {
+      "name": "AnthropicHealthChecksBuilderExtensions",
+      "fqn": "Granit.AI.Anthropic.Extensions.AnthropicHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Anthropic",
+      "file": "src/Granit.AI.Anthropic/Extensions/AnthropicHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitAnthropicHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitAnthropicHealthCheck(this IHealthChecksBuilder builder, string name = \"anthropic\", HealthStatus? failureStatus = null, TimeSpan? timeout = null)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
       "name": "GranitAIAnthropicModule",
       "fqn": "Granit.AI.Anthropic.GranitAIAnthropicModule",
       "kind": "class",
@@ -3099,6 +3115,22 @@
           "kind": "method",
           "signature": "AddGranitAIAzureOpenAI(this IHostApplicationBuilder builder)",
           "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "AzureOpenAIHealthChecksBuilderExtensions",
+      "fqn": "Granit.AI.AzureOpenAI.Extensions.AzureOpenAIHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.AzureOpenAI",
+      "file": "src/Granit.AI.AzureOpenAI/Extensions/AzureOpenAIHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitAzureOpenAIHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitAzureOpenAIHealthCheck(this IHealthChecksBuilder builder, string name = \"azure-openai\", HealthStatus? failureStatus = null, TimeSpan? timeout = null)",
+          "returnType": "IHealthChecksBuilder"
         }
       ]
     },
@@ -4990,6 +5022,22 @@
           "kind": "method",
           "signature": "AddGranitAIOpenAI(this IHostApplicationBuilder builder)",
           "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "OpenAIHealthChecksBuilderExtensions",
+      "fqn": "Granit.AI.OpenAI.Extensions.OpenAIHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.OpenAI",
+      "file": "src/Granit.AI.OpenAI/Extensions/OpenAIHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitOpenAIHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitOpenAIHealthCheck(this IHealthChecksBuilder builder, string name = \"openai\", HealthStatus? failureStatus = null, TimeSpan? timeout = null)",
+          "returnType": "IHealthChecksBuilder"
         }
       ]
     },
@@ -51301,6 +51349,22 @@
           "kind": "method",
           "signature": "AddTikaSidecarExtractor(this IServiceCollection services, Action<TikaSidecarOptions>? configure = null)",
           "returnType": "IHttpClientBuilder"
+        }
+      ]
+    },
+    {
+      "name": "TikaHealthChecksBuilderExtensions",
+      "fqn": "Granit.TextExtraction.Tika.Extensions.TikaHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.TextExtraction.Tika",
+      "file": "src/Granit.TextExtraction.Tika/Extensions/TikaHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitTikaHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitTikaHealthCheck(this IHealthChecksBuilder builder, string name = \"tika\", HealthStatus? failureStatus = null, TimeSpan? timeout = null)",
+          "returnType": "IHealthChecksBuilder"
         }
       ]
     },

--- a/src/Granit.AI.Anthropic/Extensions/AnthropicHealthChecksBuilderExtensions.cs
+++ b/src/Granit.AI.Anthropic/Extensions/AnthropicHealthChecksBuilderExtensions.cs
@@ -1,0 +1,40 @@
+using Granit.AI.Anthropic.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.AI.Anthropic.Extensions;
+
+/// <summary>
+/// Health-check registration for the Anthropic provider.
+/// </summary>
+public static class AnthropicHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Adds an Anthropic connectivity health check tagged <c>"readiness"</c> and <c>"startup"</c>.
+    /// Probes <c>GET https://api.anthropic.com/v1/models</c> with the host-level API key. When no
+    /// host-level key is configured the check reports healthy (per-tenant credentials are not
+    /// probed). The result message never leaks the credential.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Check name. Defaults to <c>"anthropic"</c>.</param>
+    /// <param name="failureStatus">Status on failure. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="timeout">Check timeout. Defaults to 10 seconds.</param>
+    public static IHealthChecksBuilder AddGranitAnthropicHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "anthropic",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddHttpClient(AnthropicHealthCheck.HttpClientName);
+        builder.Services.AddSingleton<AnthropicHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<AnthropicHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout ?? TimeSpan.FromSeconds(10)));
+    }
+}

--- a/src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj
+++ b/src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Anthropic" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Granit.AI.Anthropic/HealthChecks/AnthropicHealthCheck.cs
+++ b/src/Granit.AI.Anthropic/HealthChecks/AnthropicHealthCheck.cs
@@ -1,0 +1,73 @@
+using Granit.AI.Anthropic.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.Anthropic.HealthChecks;
+
+/// <summary>
+/// Readiness health check that verifies the Anthropic API is reachable with the host-level
+/// credential by issuing a lightweight <c>GET https://api.anthropic.com/v1/models</c>.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item>2xx → <see cref="HealthCheckResult.Healthy"/></item>
+///   <item>Non-success status, transport failure, or timeout → <see cref="HealthCheckResult.Unhealthy"/></item>
+///   <item>No host-level API key configured → <see cref="HealthCheckResult.Healthy"/> (the host may
+///   rely solely on per-tenant / per-workspace credentials, out of scope for a host readiness probe)</item>
+/// </list>
+/// The result message never exposes the API key or any header (ISO 27001 / GDPR).
+/// </remarks>
+internal sealed class AnthropicHealthCheck(
+    IHttpClientFactory httpClientFactory,
+    IOptionsMonitor<AnthropicProviderOptions> options) : IHealthCheck
+{
+    /// <summary>Named <see cref="HttpClient"/> used for the probe.</summary>
+    internal const string HttpClientName = "GranitAIAnthropicHealthCheck";
+
+    private const string ModelsEndpoint = "https://api.anthropic.com/v1/models";
+    private const string ApiVersion = "2023-06-01";
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(10);
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        AnthropicProviderOptions current = options.CurrentValue;
+
+        if (string.IsNullOrWhiteSpace(current.ApiKey))
+        {
+            return HealthCheckResult.Healthy(
+                "No host-level Anthropic API key configured; per-tenant credentials are not probed.");
+        }
+
+        try
+        {
+            await ProbeAsync(current, cancellationToken)
+                .WaitAsync(s_timeout, cancellationToken)
+                .ConfigureAwait(false);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            // Sanitised: never leak the credential into the probe surface.
+            return HealthCheckResult.Unhealthy($"Anthropic API unreachable: {ex.GetType().Name}");
+        }
+    }
+
+    private async Task ProbeAsync(AnthropicProviderOptions current, CancellationToken cancellationToken)
+    {
+        using HttpClient client = httpClientFactory.CreateClient(HttpClientName);
+        client.Timeout = s_timeout;
+
+        using HttpRequestMessage request = new(HttpMethod.Get, ModelsEndpoint);
+        request.Headers.Add("x-api-key", current.ApiKey);
+        request.Headers.Add("anthropic-version", ApiVersion);
+
+        using HttpResponseMessage response = await client
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Granit.AI.Anthropic/packages.lock.json
+++ b/src/Granit.AI.Anthropic/packages.lock.json
@@ -17,6 +17,18 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -110,6 +122,11 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.AI.AzureOpenAI/Extensions/AzureOpenAIHealthChecksBuilderExtensions.cs
+++ b/src/Granit.AI.AzureOpenAI/Extensions/AzureOpenAIHealthChecksBuilderExtensions.cs
@@ -1,0 +1,41 @@
+using Granit.AI.AzureOpenAI.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.AI.AzureOpenAI.Extensions;
+
+/// <summary>
+/// Health-check registration for the Azure OpenAI provider.
+/// </summary>
+public static class AzureOpenAIHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Adds an Azure OpenAI connectivity health check tagged <c>"readiness"</c> and <c>"startup"</c>.
+    /// Probes <c>GET {Endpoint}/openai/models</c> with the host-level API key, or a Managed Identity
+    /// bearer token when no key is set and the fallback is enabled. When neither credential is
+    /// available the check reports healthy (per-tenant credentials are not probed). The result
+    /// message never leaks the endpoint, key, or token.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Check name. Defaults to <c>"azure-openai"</c>.</param>
+    /// <param name="failureStatus">Status on failure. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="timeout">Check timeout. Defaults to 10 seconds.</param>
+    public static IHealthChecksBuilder AddGranitAzureOpenAIHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "azure-openai",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddHttpClient(AzureOpenAIHealthCheck.HttpClientName);
+        builder.Services.AddSingleton<AzureOpenAIHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<AzureOpenAIHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout ?? TimeSpan.FromSeconds(10)));
+    }
+}

--- a/src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj
+++ b/src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Granit.AI.AzureOpenAI/HealthChecks/AzureOpenAIHealthCheck.cs
+++ b/src/Granit.AI.AzureOpenAI/HealthChecks/AzureOpenAIHealthCheck.cs
@@ -1,0 +1,101 @@
+using System.Net.Http.Headers;
+using Azure.Core;
+using Azure.Identity;
+using Granit.AI.AzureOpenAI.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.AzureOpenAI.HealthChecks;
+
+/// <summary>
+/// Readiness health check that verifies the Azure OpenAI resource is reachable with the
+/// host-level credential by issuing a lightweight <c>GET {Endpoint}/openai/models</c>.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item>API key configured → probes with the <c>api-key</c> header.</item>
+///   <item>No API key + <see cref="AzureOpenAIProviderOptions.AllowManagedIdentityFallback"/> →
+///   acquires an AAD token via <see cref="DefaultAzureCredential"/> for the Cognitive Services
+///   scope and probes with a bearer token.</item>
+///   <item>No API key and Managed Identity fallback disabled → <see cref="HealthCheckResult.Healthy"/>
+///   (the host may rely solely on per-tenant credentials, out of scope for a host readiness probe).</item>
+/// </list>
+/// 2xx → Healthy; non-success status, transport failure, or timeout → Unhealthy. The result
+/// message never exposes the endpoint, key, or token (ISO 27001 / GDPR).
+/// </remarks>
+internal sealed class AzureOpenAIHealthCheck(
+    IHttpClientFactory httpClientFactory,
+    IOptionsMonitor<AzureOpenAIProviderOptions> options) : IHealthCheck
+{
+    /// <summary>Named <see cref="HttpClient"/> used for the probe.</summary>
+    internal const string HttpClientName = "GranitAIAzureOpenAIHealthCheck";
+
+    // Stable GA data-plane API version exposing the resource's model list.
+    private const string ApiVersion = "2024-10-21";
+
+    // AAD scope for the Azure OpenAI (Cognitive Services) data plane.
+    private const string CognitiveServicesScope = "https://cognitiveservices.azure.com/.default";
+
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(10);
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        AzureOpenAIProviderOptions current = options.CurrentValue;
+
+        bool hasApiKey = !string.IsNullOrWhiteSpace(current.ApiKey);
+        if (!hasApiKey && !current.AllowManagedIdentityFallback)
+        {
+            return HealthCheckResult.Healthy(
+                "No host-level Azure OpenAI credential configured (API key empty, Managed Identity " +
+                "fallback disabled); per-tenant credentials are not probed.");
+        }
+
+        try
+        {
+            await ProbeAsync(current, hasApiKey, cancellationToken)
+                .WaitAsync(s_timeout, cancellationToken)
+                .ConfigureAwait(false);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            // Sanitised: never leak the endpoint, key, or token into the probe surface.
+            return HealthCheckResult.Unhealthy($"Azure OpenAI unreachable: {ex.GetType().Name}");
+        }
+    }
+
+    private async Task ProbeAsync(
+        AzureOpenAIProviderOptions current, bool hasApiKey, CancellationToken cancellationToken)
+    {
+        string baseUrl = current.Endpoint.TrimEnd('/');
+
+        using HttpClient client = httpClientFactory.CreateClient(HttpClientName);
+        client.Timeout = s_timeout;
+
+        using HttpRequestMessage request = new(
+            HttpMethod.Get, $"{baseUrl}/openai/models?api-version={ApiVersion}");
+
+        if (hasApiKey)
+        {
+            request.Headers.Add("api-key", current.ApiKey);
+        }
+        else
+        {
+            // Managed Identity fallback: the SDK uses DefaultAzureCredential the same way, so the
+            // probe mirrors the live trust principal. Token acquisition is bounded by s_timeout.
+            AccessToken token = await new DefaultAzureCredential()
+                .GetTokenAsync(new TokenRequestContext([CognitiveServicesScope]), cancellationToken)
+                .ConfigureAwait(false);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+        }
+
+        using HttpResponseMessage response = await client
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Granit.AI.AzureOpenAI/packages.lock.json
+++ b/src/Granit.AI.AzureOpenAI/packages.lock.json
@@ -37,6 +37,18 @@
           "OpenAI": "2.11.0"
         }
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -149,6 +161,11 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.AI.OpenAI/Extensions/OpenAIHealthChecksBuilderExtensions.cs
+++ b/src/Granit.AI.OpenAI/Extensions/OpenAIHealthChecksBuilderExtensions.cs
@@ -1,0 +1,40 @@
+using Granit.AI.OpenAI.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.AI.OpenAI.Extensions;
+
+/// <summary>
+/// Health-check registration for the OpenAI provider.
+/// </summary>
+public static class OpenAIHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Adds an OpenAI connectivity health check tagged <c>"readiness"</c> and <c>"startup"</c>.
+    /// Probes <c>GET {Endpoint}/models</c> with the host-level API key. When no host-level key is
+    /// configured the check reports healthy (per-tenant credentials are not probed). The result
+    /// message never leaks the endpoint or credential.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Check name. Defaults to <c>"openai"</c>.</param>
+    /// <param name="failureStatus">Status on failure. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="timeout">Check timeout. Defaults to 10 seconds.</param>
+    public static IHealthChecksBuilder AddGranitOpenAIHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "openai",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddHttpClient(OpenAIHealthCheck.HttpClientName);
+        builder.Services.AddSingleton<OpenAIHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<OpenAIHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout ?? TimeSpan.FromSeconds(10)));
+    }
+}

--- a/src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj
+++ b/src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Granit.AI.OpenAI/HealthChecks/OpenAIHealthCheck.cs
+++ b/src/Granit.AI.OpenAI/HealthChecks/OpenAIHealthCheck.cs
@@ -1,0 +1,76 @@
+using System.Net.Http.Headers;
+using Granit.AI.OpenAI.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.OpenAI.HealthChecks;
+
+/// <summary>
+/// Readiness health check that verifies the OpenAI API is reachable with the host-level
+/// credential by issuing a lightweight <c>GET {Endpoint}/models</c>.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item>2xx → <see cref="HealthCheckResult.Healthy"/></item>
+///   <item>Non-success status, transport failure, or timeout → <see cref="HealthCheckResult.Unhealthy"/></item>
+///   <item>No host-level API key configured → <see cref="HealthCheckResult.Healthy"/> (the host may
+///   rely solely on per-tenant / per-workspace credentials, which are out of scope for a host
+///   readiness probe — failing here would wrongly hold traffic on a valid deployment)</item>
+/// </list>
+/// The result message never exposes the API key, endpoint, or any header (ISO 27001 / GDPR).
+/// </remarks>
+internal sealed class OpenAIHealthCheck(
+    IHttpClientFactory httpClientFactory,
+    IOptionsMonitor<OpenAIProviderOptions> options) : IHealthCheck
+{
+    /// <summary>Named <see cref="HttpClient"/> used for the probe.</summary>
+    internal const string HttpClientName = "GranitAIOpenAIHealthCheck";
+
+    private const string DefaultEndpoint = "https://api.openai.com/v1";
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(10);
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        OpenAIProviderOptions current = options.CurrentValue;
+
+        if (string.IsNullOrWhiteSpace(current.ApiKey))
+        {
+            return HealthCheckResult.Healthy(
+                "No host-level OpenAI API key configured; per-tenant credentials are not probed.");
+        }
+
+        try
+        {
+            await ProbeAsync(current, cancellationToken)
+                .WaitAsync(s_timeout, cancellationToken)
+                .ConfigureAwait(false);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            // Sanitised: never leak the endpoint or credential into the probe surface.
+            return HealthCheckResult.Unhealthy($"OpenAI API unreachable: {ex.GetType().Name}");
+        }
+    }
+
+    private async Task ProbeAsync(OpenAIProviderOptions current, CancellationToken cancellationToken)
+    {
+        string baseUrl =
+            (string.IsNullOrWhiteSpace(current.Endpoint) ? DefaultEndpoint : current.Endpoint).TrimEnd('/');
+
+        using HttpClient client = httpClientFactory.CreateClient(HttpClientName);
+        client.Timeout = s_timeout;
+
+        using HttpRequestMessage request = new(HttpMethod.Get, $"{baseUrl}/models");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", current.ApiKey);
+
+        using HttpResponseMessage response = await client
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Granit.AI.OpenAI/packages.lock.json
+++ b/src/Granit.AI.OpenAI/packages.lock.json
@@ -18,6 +18,18 @@
           "OpenAI": "2.11.0"
         }
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -111,6 +123,11 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",

--- a/tests/Granit.AI.Anthropic.Tests/AnthropicHealthCheckTests.cs
+++ b/tests/Granit.AI.Anthropic.Tests/AnthropicHealthCheckTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using Granit.AI.Anthropic.HealthChecks;
+using Granit.AI.Anthropic.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+
+namespace Granit.AI.Anthropic.Tests;
+
+public sealed class AnthropicHealthCheckTests
+{
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Calls { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls.Add(request);
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private static AnthropicHealthCheck Create(StubHandler handler, AnthropicProviderOptions options) =>
+        new(new StubFactory(handler), new TestOptionsMonitor<AnthropicProviderOptions>(options));
+
+    private static AnthropicProviderOptions WithKey() => new()
+    {
+        ApiKey = "sk-ant-test-123",
+        DefaultModel = "claude-sonnet-4-6",
+    };
+
+    [Fact]
+    public async Task Healthy_when_api_returns_success()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        AnthropicHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_when_api_returns_error_status()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        AnthropicHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task Healthy_and_no_call_when_host_api_key_absent()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        AnthropicProviderOptions noKey = WithKey();
+        noKey.ApiKey = string.Empty;
+        AnthropicHealthCheck check = Create(handler, noKey);
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        handler.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Probe_targets_models_endpoint_with_api_key_and_version_headers()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        AnthropicHealthCheck check = Create(handler, WithKey());
+
+        await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        handler.Calls.ShouldHaveSingleItem();
+        handler.Calls[0].RequestUri!.ToString().ShouldBe("https://api.anthropic.com/v1/models");
+        handler.Calls[0].Headers.Contains("x-api-key").ShouldBeTrue();
+        handler.Calls[0].Headers.Contains("anthropic-version").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Unhealthy_message_does_not_leak_credential()
+    {
+        StubHandler handler = new(_ => throw new HttpRequestException("boom sk-ant-test-123"));
+        AnthropicHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldNotContain("sk-ant-test-123");
+    }
+}

--- a/tests/Granit.AI.Anthropic.Tests/packages.lock.json
+++ b/tests/Granit.AI.Anthropic.Tests/packages.lock.json
@@ -145,6 +145,11 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
+      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -330,6 +335,7 @@
         "dependencies": {
           "Anthropic": "[12.*, )",
           "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Http": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
@@ -493,6 +499,18 @@
         "requested": "[10.*, )",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.AzureOpenAI.Tests/AzureOpenAIHealthCheckTests.cs
+++ b/tests/Granit.AI.AzureOpenAI.Tests/AzureOpenAIHealthCheckTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using Granit.AI.AzureOpenAI.HealthChecks;
+using Granit.AI.AzureOpenAI.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+
+namespace Granit.AI.AzureOpenAI.Tests;
+
+public sealed class AzureOpenAIHealthCheckTests
+{
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Calls { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls.Add(request);
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private static AzureOpenAIHealthCheck Create(StubHandler handler, AzureOpenAIProviderOptions options) =>
+        new(new StubFactory(handler), new TestOptionsMonitor<AzureOpenAIProviderOptions>(options));
+
+    private static AzureOpenAIProviderOptions WithKey() => new()
+    {
+        Endpoint = "https://test.openai.azure.com",
+        ApiKey = "azure-test-key",
+        DefaultDeployment = "gpt-4o",
+        DefaultEmbeddingDeployment = "text-embedding-3-small",
+    };
+
+    [Fact]
+    public async Task Healthy_when_api_returns_success()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        AzureOpenAIHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_when_api_returns_error_status()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        AzureOpenAIHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task Healthy_and_no_call_when_no_key_and_managed_identity_disabled()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        AzureOpenAIProviderOptions noCred = WithKey();
+        noCred.ApiKey = string.Empty;
+        noCred.AllowManagedIdentityFallback = false;
+        AzureOpenAIHealthCheck check = Create(handler, noCred);
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        handler.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Probe_targets_models_endpoint_with_api_key_header()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        AzureOpenAIHealthCheck check = Create(handler, WithKey());
+
+        await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        handler.Calls.ShouldHaveSingleItem();
+        handler.Calls[0].RequestUri!.ToString()
+            .ShouldBe("https://test.openai.azure.com/openai/models?api-version=2024-10-21");
+        handler.Calls[0].Headers.Contains("api-key").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Unhealthy_message_does_not_leak_credential()
+    {
+        StubHandler handler = new(_ => throw new HttpRequestException("boom azure-test-key"));
+        AzureOpenAIHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldNotContain("azure-test-key");
+    }
+}

--- a/tests/Granit.AI.AzureOpenAI.Tests/packages.lock.json
+++ b/tests/Granit.AI.AzureOpenAI.Tests/packages.lock.json
@@ -159,6 +159,11 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
+      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -397,6 +402,7 @@
           "Azure.Identity": "[1.*, )",
           "Granit.AI": "[0.1.0-dev, )",
           "Microsoft.Extensions.AI.OpenAI": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Http": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
@@ -580,6 +586,18 @@
         "requested": "[10.*, )",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.OpenAI.Tests/OpenAIHealthCheckTests.cs
+++ b/tests/Granit.AI.OpenAI.Tests/OpenAIHealthCheckTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using Granit.AI.OpenAI.HealthChecks;
+using Granit.AI.OpenAI.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+
+namespace Granit.AI.OpenAI.Tests;
+
+public sealed class OpenAIHealthCheckTests
+{
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Calls { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls.Add(request);
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private static OpenAIHealthCheck Create(StubHandler handler, OpenAIProviderOptions options) =>
+        new(new StubFactory(handler), new TestOptionsMonitor<OpenAIProviderOptions>(options));
+
+    private static OpenAIProviderOptions WithKey() => new()
+    {
+        ApiKey = "sk-test-key-123",
+        DefaultModel = "gpt-4o",
+        DefaultEmbeddingModel = "text-embedding-3-small",
+    };
+
+    [Fact]
+    public async Task Healthy_when_api_returns_success()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        OpenAIHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_when_api_returns_error_status()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        OpenAIHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task Healthy_and_no_call_when_host_api_key_absent()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        OpenAIProviderOptions noKey = WithKey();
+        noKey.ApiKey = string.Empty;
+        OpenAIHealthCheck check = Create(handler, noKey);
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        handler.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Probe_targets_models_endpoint_with_bearer_auth()
+    {
+        StubHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        OpenAIHealthCheck check = Create(handler, WithKey());
+
+        await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        handler.Calls.ShouldHaveSingleItem();
+        handler.Calls[0].RequestUri!.ToString().ShouldBe("https://api.openai.com/v1/models");
+        handler.Calls[0].Headers.Authorization!.Scheme.ShouldBe("Bearer");
+    }
+
+    [Fact]
+    public async Task Unhealthy_message_does_not_leak_credential()
+    {
+        StubHandler handler = new(_ => throw new HttpRequestException("boom sk-test-key-123"));
+        OpenAIHealthCheck check = Create(handler, WithKey());
+
+        HealthCheckResult result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldNotContain("sk-test-key-123");
+    }
+}

--- a/tests/Granit.AI.OpenAI.Tests/packages.lock.json
+++ b/tests/Granit.AI.OpenAI.Tests/packages.lock.json
@@ -151,6 +151,11 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
+      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -360,6 +365,7 @@
         "dependencies": {
           "Granit.AI": "[0.1.0-dev, )",
           "Microsoft.Extensions.AI.OpenAI": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Http": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
@@ -524,6 +530,18 @@
         "requested": "[10.*, )",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## What

Adds readiness health checks for the three cloud AI providers — `Granit.AI.OpenAI`, `Granit.AI.AzureOpenAI`, `Granit.AI.Anthropic` — which previously shipped **none**. Only `Granit.AI.Ollama` exposed a health check (`AddGranitOllamaHealthCheck`), so a host wiring AI vision OCR (or any AI feature) on a cloud provider had no readiness probe for that dependency anywhere.

Each provider gains an opt-in `AddGranit{Provider}HealthCheck(this IHealthChecksBuilder)`, tagged **`"readiness"` + `"startup"`** (mirroring Ollama), probing a lightweight models-list endpoint with the **host-level** credential:

| Provider | Probe | Auth |
| --- | --- | --- |
| OpenAI | `GET {Endpoint}/models` | `Authorization: Bearer {ApiKey}` |
| Anthropic | `GET https://api.anthropic.com/v1/models` | `x-api-key` + `anthropic-version` |
| Azure OpenAI | `GET {Endpoint}/openai/models?api-version=2024-10-21` | `api-key`, or `DefaultAzureCredential` bearer token when Managed Identity fallback is enabled |

## Design notes
- **No host-level credential → `Healthy`.** OpenAI/Anthropic host `ApiKey` is optional (tenants may bring their own via `Granit.Settings`/workspace); Azure may run per-tenant only. A host readiness probe can't verify per-tenant credentials, so it reports healthy rather than wrongly holding traffic on a valid deployment.
- **No secret leakage.** Result messages contain only the exception type — never the endpoint, key, or token (ISO 27001 / GDPR).
- **Probe hygiene.** 10s defensive timeout; dedicated single-attempt named `HttpClient` (no resilience/retry on a probe).
- **Readiness, not liveness** — an AI-provider outage holds traffic at the ingress; it must never restart the pod.

## Verification
- `dotnet test` green: OpenAI (35), Anthropic (36), Azure OpenAI (29) — incl. healthy / error-status / no-credential-skip / probe-shape / no-secret-leak.
- `dotnet format --verify-no-changes` clean across all six touched projects.

## Follow-up (not in this PR)
The Azure Managed-Identity branch (`DefaultAzureCredential`) is environment-dependent and not unit-tested; the api-key path and the no-credential path are covered.
