### PR TITLE
fix(text-extraction): register IImageProcessor in Tesseract OCR integration test

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -47,6 +47,7 @@
       "src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj",
       "src/Granit.Identity.Local/Granit.Identity.Local.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
+      "src/Granit.Imaging.MagickNet/Granit.Imaging.MagickNet.csproj",
       "src/Granit.Imaging/Granit.Imaging.csproj",
       "src/Granit.Indexing.BackgroundJobs/Granit.Indexing.BackgroundJobs.csproj",
       "src/Granit.Indexing.Elasticsearch/Granit.Indexing.Elasticsearch.csproj",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -124,6 +124,7 @@
       "src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj",
       "src/Granit.Identity.Local/Granit.Identity.Local.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
+      "src/Granit.Imaging.MagickNet/Granit.Imaging.MagickNet.csproj",
       "src/Granit.Imaging/Granit.Imaging.csproj",
       "src/Granit.Indexing.AI/Granit.Indexing.AI.csproj",
       "src/Granit.Indexing.BackgroundJobs/Granit.Indexing.BackgroundJobs.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -86,6 +86,7 @@
       "src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj",
       "src/Granit.Identity.Local/Granit.Identity.Local.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
+      "src/Granit.Imaging.MagickNet/Granit.Imaging.MagickNet.csproj",
       "src/Granit.Imaging/Granit.Imaging.csproj",
       "src/Granit.Indexing.AI/Granit.Indexing.AI.csproj",
       "src/Granit.Indexing.BackgroundJobs/Granit.Indexing.BackgroundJobs.csproj",

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Imaging.MagickNet\Granit.Imaging.MagickNet.csproj" />
     <ProjectReference Include="..\..\src\Granit.TextExtraction.Ocr.Tesseract\Granit.TextExtraction.Ocr.Tesseract.csproj" />
     <ProjectReference Include="..\..\src\Granit.TextExtraction\Granit.TextExtraction.csproj" />
   </ItemGroup>

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
@@ -1,3 +1,4 @@
+using Granit.Imaging.MagickNet.Extensions;
 using Granit.TextExtraction.Ocr.Tesseract.Extensions;
 using ImageMagick;
 using Microsoft.Extensions.Configuration;
@@ -77,6 +78,10 @@ public sealed class LiveTesseractRecognizerTests
         ServiceCollection services = [];
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddLogging();
+        // TesseractOcrExtractor depends on IImageProcessor for its pre-decode pixel-bomb guard
+        // (the host must register an imaging provider — see the module docs). Magick.NET is the
+        // reference provider and is already used below to render the test fixtures.
+        services.AddGranitImagingMagickNet();
         services.AddTesseractOcrExtractor(o =>
         {
             o.DataPath = TessdataPath;

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
@@ -281,6 +281,13 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
+      "granit.imaging.magicknet": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Imaging": "[0.1.0-dev, )",
+          "Magick.NET-Q8-AnyCPU": "[14.*, )"
+        }
+      },
       "granit.textextraction": {
         "type": "Project",
         "dependencies": {


### PR DESCRIPTION
## Problem

CI `integration` shard fails:

```
System.InvalidOperationException : Unable to resolve service for type
'Granit.Imaging.IImageProcessor' while attempting to activate
'Granit.TextExtraction.Ocr.Tesseract.TesseractOcrExtractor'.
  at …LiveTesseractRecognizerTests.TesseractOcrExtractor_round_trip_returns_recognised_text
```

## Root cause

The imagesharp-removal (#2753) switched `TesseractOcrExtractor`'s pre-decode pixel-bomb guard from `SixLabors.ImageSharp` to `Granit.Imaging`'s `IImageProcessor`, so the extractor now constructor-injects `IImageProcessor`. The live integration test's `BuildHost()` registers `AddTesseractOcrExtractor(...)` but **no imaging provider**, so resolving the full extractor throws. (The sibling test that resolves only `ITesseractRecognizer` has no such dependency and passed, which is why this slipped through.)

## Fix

Register the reference Magick.NET provider (`AddGranitImagingMagickNet()`) in `BuildHost()` — Magick.NET is already used in the same test to render the PNG fixtures — and add the `Granit.Imaging.MagickNet` project reference. This matches the module contract that the **host** wires an imaging provider (per the Tesseract module docs).

## Verification

- Integration test project builds clean (refs + usings resolve). The failure was a DI-resolution error that occurs *before* any native libtesseract call; the fix registers exactly the missing `IImageProcessor`.
- The live OCR assertions remain gated on `TESSDATA_PREFIX` (set in the CI integration shard); the CI run will confirm green end-to-end.
