### PR TITLE
refactor(openiddict): resolve Sonar S1751 in authorization endpoint

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -207,15 +207,17 @@ internal static partial class ConnectAuthorizationEndpoints
         ImmutableArray<string> scopes,
         CancellationToken cancellationToken)
     {
-        await foreach (object auth in authorizationManager.FindAsync(
+        await using IAsyncEnumerator<object> existing = authorizationManager.FindAsync(
             subject: subject,
             client: applicationId,
             status: OpenIddictConstants.Statuses.Valid,
             type: OpenIddictConstants.AuthorizationTypes.Permanent,
             scopes: scopes,
-            cancellationToken: cancellationToken).ConfigureAwait(false))
+            cancellationToken: cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+        if (await existing.MoveNextAsync().ConfigureAwait(false))
         {
-            return auth;
+            return existing.Current;
         }
 
         return await authorizationManager.CreateAsync(


### PR DESCRIPTION
## What

Resolves SonarQube **S1751** (`Major` bug) in [`ConnectAuthorizationEndpoints.cs`](src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs).

`ResolveOrCreateAuthorizationAsync` used an `await foreach` that returned on its first iteration — a *first-or-create* expressed as a single-iteration loop, which Sonar flags as a likely bug.

## Change

Drive the async enumerator explicitly: take the first match if present, otherwise create. Semantics are identical; intent now reads clearly and the loop smell is gone.

## Notes

Follow-up to the Sonar hotspot suppressions merged in #2759 (this S1751 commit was authored on that branch but not pushed before the squash-merge).

## DoD

- [x] Builds clean (`dotnet build src/Granit.OpenIddict.Endpoints`)
- [x] No behavioral change