### PR TITLE
chore(sonar): mechanical code-smell cleanup across modules

### DIFF
--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -45,8 +45,9 @@ public sealed class GranitAIChatModule : GranitModule
         // the application registers its own IAIAttachmentSource over its transient blob store.
         AIChatAttachmentsServiceCollectionExtensions.AddCoreServices(context.Services);
 
-        // Per-user setting definitions (Granit.AI.Chat.*) are auto-discovered by GranitSettingsModule;
-        // only the chat-capable workspace catalog for the settings UI needs registering here.
+        // Per-user setting definitions in the Granit AI Chat namespace are auto-discovered by
+        // GranitSettingsModule. Only the chat-capable workspace catalog for the settings UI is
+        // registered here.
         context.Services.TryAddScoped<IChatWorkspaceCatalog, ChatWorkspaceCatalog>();
 
         // The suggestion resolver is always present so a turn can carry suggested actions even

--- a/src/Granit.AI.Chat/Internal/RequestClarificationTool.cs
+++ b/src/Granit.AI.Chat/Internal/RequestClarificationTool.cs
@@ -14,6 +14,8 @@ namespace Granit.AI.Chat.Internal;
 /// </summary>
 internal sealed class RequestClarificationTool : IAITool, IAIToolInstructions
 {
+    private const string DescriptionKey = "description";
+
     private static readonly JsonElement Schema = BuildSchema();
 
     private static readonly JsonSerializerOptions PayloadOptions = JsonSerializerOptions.Web;
@@ -85,18 +87,18 @@ internal sealed class RequestClarificationTool : IAITool, IAIToolInstructions
             ["type"] = "object",
             ["properties"] = new JsonObject
             {
-                ["question"] = new JsonObject { ["type"] = "string", ["description"] = "The disambiguating question." },
+                ["question"] = new JsonObject { ["type"] = "string", [DescriptionKey] = "The disambiguating question." },
                 ["options"] = new JsonObject
                 {
                     ["type"] = "array",
-                    ["description"] = "The discrete choices (2-5 recommended).",
+                    [DescriptionKey] = "The discrete choices (2-5 recommended).",
                     ["items"] = new JsonObject
                     {
                         ["type"] = "object",
                         ["properties"] = new JsonObject
                         {
-                            ["label"] = new JsonObject { ["type"] = "string", ["description"] = "Display label." },
-                            ["value"] = new JsonObject { ["type"] = "string", ["description"] = "Optional value sent back when chosen." },
+                            ["label"] = new JsonObject { ["type"] = "string", [DescriptionKey] = "Display label." },
+                            ["value"] = new JsonObject { ["type"] = "string", [DescriptionKey] = "Optional value sent back when chosen." },
                         },
                         ["required"] = new JsonArray("label"),
                         ["additionalProperties"] = false,
@@ -105,7 +107,7 @@ internal sealed class RequestClarificationTool : IAITool, IAIToolInstructions
                 ["allow_other"] = new JsonObject
                 {
                     ["type"] = "boolean",
-                    ["description"] = "Offer an 'Other (describe)' free-text affordance.",
+                    [DescriptionKey] = "Offer an 'Other (describe)' free-text affordance.",
                 },
             },
             ["required"] = new JsonArray("question", "options"),

--- a/src/Granit.Bff.EntityFrameworkCore/Internal/EfCoreBffTokenStore.cs
+++ b/src/Granit.Bff.EntityFrameworkCore/Internal/EfCoreBffTokenStore.cs
@@ -176,11 +176,25 @@ internal sealed partial class EfCoreBffTokenStore(
         return JsonSerializer.Deserialize<BffTokenSet>(json, JsonOptions);
     }
 
-    private string? EncryptIp(string? ipAddress) =>
-        ipAddress is null ? null : _encryptionEnabled ? encryptionService!.Encrypt(ipAddress) : ipAddress;
+    private string? EncryptIp(string? ipAddress)
+    {
+        if (ipAddress is null)
+        {
+            return null;
+        }
 
-    private string? DecryptIp(string? stored) =>
-        stored is null ? null : _encryptionEnabled ? encryptionService!.Decrypt(stored) ?? stored : stored;
+        return _encryptionEnabled ? encryptionService!.Encrypt(ipAddress) : ipAddress;
+    }
+
+    private string? DecryptIp(string? stored)
+    {
+        if (stored is null)
+        {
+            return null;
+        }
+
+        return _encryptionEnabled ? encryptionService!.Decrypt(stored) ?? stored : stored;
+    }
 
     private static bool InitEncryption(IStringEncryptionService? service, ILogger logger)
     {

--- a/src/Granit.Bff.UserSessions/Internal/BffUserSessionProvider.cs
+++ b/src/Granit.Bff.UserSessions/Internal/BffUserSessionProvider.cs
@@ -23,16 +23,16 @@ internal sealed class BffUserSessionProvider(
     {
         List<UserSessionDescriptor> sessions = [];
 
-        foreach (BffFrontendOptions frontend in options.Value.Frontends)
+        foreach (string frontendName in options.Value.Frontends.Select(f => f.Name))
         {
             IReadOnlyList<string> sessionIds = await tokenStore
-                .GetSessionIdsByUserAsync(frontend.Name, userId, cancellationToken)
+                .GetSessionIdsByUserAsync(frontendName, userId, cancellationToken)
                 .ConfigureAwait(false);
 
             foreach (string sessionId in sessionIds)
             {
                 BffTokenSet? tokens = await tokenStore
-                    .GetAsync(frontend.Name, sessionId, cancellationToken)
+                    .GetAsync(frontendName, sessionId, cancellationToken)
                     .ConfigureAwait(false);
                 if (tokens is null)
                 {
@@ -67,17 +67,17 @@ internal sealed class BffUserSessionProvider(
     public async Task<bool> RevokeAsync(
         string userId, string sessionId, CancellationToken cancellationToken = default)
     {
-        foreach (BffFrontendOptions frontend in options.Value.Frontends)
+        foreach (string frontendName in options.Value.Frontends.Select(f => f.Name))
         {
             BffTokenSet? tokens = await tokenStore
-                .GetAsync(frontend.Name, sessionId, cancellationToken)
+                .GetAsync(frontendName, sessionId, cancellationToken)
                 .ConfigureAwait(false);
 
             // Only revoke a session that exists on this frontend AND belongs to the caller —
             // never let one user revoke another's session by guessing an id.
             if (tokens is not null && tokens.UserId == userId)
             {
-                await tokenStore.RemoveAsync(frontend.Name, sessionId, cancellationToken).ConfigureAwait(false);
+                await tokenStore.RemoveAsync(frontendName, sessionId, cancellationToken).ConfigureAwait(false);
                 return true;
             }
         }
@@ -90,10 +90,10 @@ internal sealed class BffUserSessionProvider(
     {
         int revoked = 0;
 
-        foreach (BffFrontendOptions frontend in options.Value.Frontends)
+        foreach (string frontendName in options.Value.Frontends.Select(f => f.Name))
         {
             IReadOnlyList<string> sessionIds = await tokenStore
-                .GetSessionIdsByUserAsync(frontend.Name, userId, cancellationToken)
+                .GetSessionIdsByUserAsync(frontendName, userId, cancellationToken)
                 .ConfigureAwait(false);
 
             foreach (string sessionId in sessionIds)
@@ -103,7 +103,7 @@ internal sealed class BffUserSessionProvider(
                     continue;
                 }
 
-                await tokenStore.RemoveAsync(frontend.Name, sessionId, cancellationToken).ConfigureAwait(false);
+                await tokenStore.RemoveAsync(frontendName, sessionId, cancellationToken).ConfigureAwait(false);
                 revoked++;
             }
         }

--- a/src/Granit.Features.Endpoints/Endpoints/FeaturesReadEndpoints.cs
+++ b/src/Granit.Features.Endpoints/Endpoints/FeaturesReadEndpoints.cs
@@ -65,12 +65,12 @@ internal static class FeaturesReadEndpoints
         IReadOnlyList<FeatureDefinition> definitions = definitionStore.GetAll();
         Dictionary<string, string> result = new(definitions.Count, StringComparer.Ordinal);
 
-        foreach (FeatureDefinition definition in definitions)
+        foreach (string name in definitions.Select(d => d.Name))
         {
             string value = await featureChecker
-                .GetValueAsync(definition.Name, cancellationToken)
+                .GetValueAsync(name, cancellationToken)
                 .ConfigureAwait(false);
-            result[definition.Name] = value;
+            result[name] = value;
         }
 
         return TypedResults.Ok<IReadOnlyDictionary<string, string>>(result);

--- a/src/Granit.Identity.Abstractions/UserDeviceGrouping.cs
+++ b/src/Granit.Identity.Abstractions/UserDeviceGrouping.cs
@@ -35,16 +35,7 @@ public static class UserDeviceGrouping
         ];
     }
 
-    private static DeviceKind ResolveGroupKind(IEnumerable<UserSessionDescriptor> group)
-    {
-        foreach (DeviceKind kind in group.Select(s => s.Kind))
-        {
-            if (kind is not DeviceKind.Unknown and not DeviceKind.Browser)
-            {
-                return kind;
-            }
-        }
-
-        return DeviceKind.Browser;
-    }
+    private static DeviceKind ResolveGroupKind(IEnumerable<UserSessionDescriptor> group) =>
+        group.Select(s => s.Kind)
+            .FirstOrDefault(kind => kind is not DeviceKind.Unknown and not DeviceKind.Browser, DeviceKind.Browser);
 }

--- a/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
+++ b/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
@@ -112,11 +112,12 @@ internal sealed class UserSessionAnomalyDetector(
 
         UserSessionRiskLevel level = travel == TravelOutcome.Detected
             ? UserSessionRiskLevel.High
-            : reasons.Count >= 2
-                ? UserSessionRiskLevel.Medium
-                : reasons.Count == 1
-                    ? UserSessionRiskLevel.Low
-                    : UserSessionRiskLevel.None;
+            : reasons.Count switch
+            {
+                >= 2 => UserSessionRiskLevel.Medium,
+                1 => UserSessionRiskLevel.Low,
+                _ => UserSessionRiskLevel.None,
+            };
 
         // `low_geo_confidence` is explanatory — it records that a travel alert was withheld because the geo fix
         // was untrustworthy, without itself inflating the risk level (so it can never manufacture a Medium).
@@ -160,7 +161,11 @@ internal sealed class UserSessionAnomalyDetector(
             double km = GeoDistance.HaversineKm(lat, lon, priorLat, priorLon);
             DateTimeOffset priorTime = prior.LastAccessedAt ?? prior.CreatedAt;
             double hours = Math.Abs((candidate.CreatedAt - priorTime).TotalHours);
-            double speed = hours > 0.01 ? km / hours : km > 50d ? double.PositiveInfinity : 0d;
+
+            // With effectively-zero elapsed time, treat a real >50 km gap as an impossible (infinite) speed and a
+            // sub-50 km gap as stationary noise; otherwise it's distance over time.
+            double zeroTimeSpeed = km > 50d ? double.PositiveInfinity : 0d;
+            double speed = hours > 0.01 ? km / hours : zeroTimeSpeed;
 
             if (speed <= opts.MaxTravelKilometersPerHour)
             {

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -41,6 +41,7 @@ internal sealed partial class EntraIdIdentityProvider(
     ILogger<EntraIdIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager, IUserSessionProvider, IUserDeviceProvider
 {
     private const string ProviderName = "entra-id";
+    private const string Unknown = "unknown";
 
     /// <summary>
     /// Detects authorisation failures from Microsoft Graph (401 Unauthorized / 403 Forbidden).
@@ -247,8 +248,8 @@ internal sealed partial class EntraIdIdentityProvider(
             return signIns
                 .GroupBy(s => new
                 {
-                    Ip = s.IpAddress ?? "unknown",
-                    Os = s.DeviceDetail?.OperatingSystem ?? "unknown"
+                    Ip = s.IpAddress ?? Unknown,
+                    Os = s.DeviceDetail?.OperatingSystem ?? Unknown
                 })
                 .Select(group =>
                 {
@@ -258,7 +259,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
                     return new UserDevice(
                         // Entra ID sign-in audits carry no stable device id — synthesize one from OS + browser.
-                        DeviceId: $"{os ?? "unknown"}/{browser ?? "unknown"}",
+                        DeviceId: $"{os ?? Unknown}/{browser ?? Unknown}",
                         Kind: DeviceKind.Browser, // IdP SSO sign-ins are browser-based unless the backend says otherwise.
                         OperatingSystem: os,
                         Browser: browser,

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -254,6 +254,30 @@ internal sealed partial class KeycloakIdentityProvider(
     }
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyList<UserDevice>> ListAsync(
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(userId);
+
+        using Activity? activity = IdentityKeycloakActivitySource.Source.StartActivity(IdentityKeycloakActivitySource.GetUserDeviceActivity);
+        activity?.SetTag(IdentityKeycloakActivitySource.TagUserId, userId);
+
+        try
+        {
+            return options.Value.UseTokenExchangeForDeviceActivity
+                ? await GetDevicesViaAccountApiAsync(userId, cancellationToken).ConfigureAwait(false)
+                : await GetDevicesViaAdminSessionsAsync(userId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            LogKeycloakGetDeviceActivityFailed(ex, userId);
+            return [];
+        }
+    }
+
+    /// <inheritdoc/>
     /// <remarks>
     /// Keycloak revokes a single user session via <c>DELETE /admin/realms/{realm}/sessions/{id}</c>.
     /// Publishes <see cref="UserSessionsRevokedEto"/> on success so downstream session caches
@@ -306,14 +330,14 @@ internal sealed partial class KeycloakIdentityProvider(
         List<KeycloakSessionRepresentation> sessions = await GetSessionsAsync(userId, cancellationToken).ConfigureAwait(false);
 
         int revoked = 0;
-        foreach (KeycloakSessionRepresentation session in sessions)
+        foreach (string sessionId in sessions.Select(s => s.Id))
         {
-            if (string.Equals(session.Id, currentSessionId, StringComparison.Ordinal))
+            if (string.Equals(sessionId, currentSessionId, StringComparison.Ordinal))
             {
                 continue;
             }
 
-            if (await RevokeAsync(userId, session.Id, cancellationToken).ConfigureAwait(false))
+            if (await RevokeAsync(userId, sessionId, cancellationToken).ConfigureAwait(false))
             {
                 revoked++;
             }
@@ -325,30 +349,6 @@ internal sealed partial class KeycloakIdentityProvider(
         metrics.RecordOperationDuration(null, "terminate_all_sessions", ProviderName, Stopwatch.GetElapsedTime(startTimestamp));
 
         return revoked;
-    }
-
-    /// <inheritdoc/>
-    public async Task<IReadOnlyList<UserDevice>> ListAsync(
-        string userId,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(userId);
-
-        using Activity? activity = IdentityKeycloakActivitySource.Source.StartActivity(IdentityKeycloakActivitySource.GetUserDeviceActivity);
-        activity?.SetTag(IdentityKeycloakActivitySource.TagUserId, userId);
-
-        try
-        {
-            return options.Value.UseTokenExchangeForDeviceActivity
-                ? await GetDevicesViaAccountApiAsync(userId, cancellationToken).ConfigureAwait(false)
-                : await GetDevicesViaAdminSessionsAsync(userId, cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-        {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            LogKeycloakGetDeviceActivityFailed(ex, userId);
-            return [];
-        }
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
@@ -25,6 +25,8 @@ namespace Granit.Identity.Local.Endpoints.Endpoints;
 
 internal static partial class AccountPasskeyEndpoints
 {
+    private const string PasskeyMethod = "passkey";
+
     internal static RouteGroupBuilder MapAccountPasskeyEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/passkeys", ListPasskeysAsync)
@@ -213,7 +215,7 @@ internal static partial class AccountPasskeyEndpoints
         await signInManager.SignInAsync(user, isPersistent: false).ConfigureAwait(false);
         await TryRaiseDeviceTrustToStrongAsync(httpContext, logger, user.Id.ToString(), cancellationToken)
             .ConfigureAwait(false);
-        metrics?.RecordAuthenticationSuccess(null, "passkey");
+        metrics?.RecordAuthenticationSuccess(null, PasskeyMethod);
         await TryWritePasskeyAuditAsync(httpContext, logger,
             userId: user.Id.ToString(), userName: user.UserName,
             failureReason: null, cancellationToken).ConfigureAwait(false);
@@ -258,10 +260,10 @@ internal static partial class AccountPasskeyEndpoints
             ? AuthenticationAuditEntry.CreateSuccess(
                 timeProvider.GetUtcNow(),
                 auditUserId,
-                userName, method: "passkey", tenantId, ipAddress, userAgent, correlationId)
+                userName, method: PasskeyMethod, tenantId, ipAddress, userAgent, correlationId)
             : AuthenticationAuditEntry.CreateFailure(
                 timeProvider.GetUtcNow(), userId, userName,
-                method: "passkey", reason: failureReason,
+                method: PasskeyMethod, reason: failureReason,
                 tenantId, ipAddress, userAgent, correlationId);
 
         try
@@ -315,7 +317,7 @@ internal static partial class AccountPasskeyEndpoints
             await trustStore.SetAsync(
                 userId,
                 deviceId,
-                new DeviceTrustVerdict(DeviceTrustLevel.Strong, now, now + options.TrustDuration, "passkey"),
+                new DeviceTrustVerdict(DeviceTrustLevel.Strong, now, now + options.TrustDuration, PasskeyMethod),
                 cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
+++ b/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
@@ -50,6 +50,18 @@ internal sealed class OpenIddictUserSessionProvider(
         return sessions;
     }
 
+    public async Task<IReadOnlyList<UserDevice>> ListAsync(
+        string userId, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<UserSessionDescriptor> sessions =
+            await ListAsync(userId, currentSessionId: null, cancellationToken).ConfigureAwait(false);
+
+        // The OpenIddict backend exposes no stable device id, OS or browser — only the raw IP. Synthesize one
+        // device per IP from its own sessions; the kind carried on each session (declared on the OIDC
+        // application, heuristic otherwise) drives the group's device kind.
+        return UserDeviceGrouping.ByIpAddress(sessions);
+    }
+
     // Maps a single OpenIddict token to a UserSessionDescriptor, or null when the token is not a
     // valid refresh token (the only kind that represents a live session) or carries no id.
     private async Task<UserSessionDescriptor?> MapTokenToSessionAsync(
@@ -213,31 +225,19 @@ internal sealed class OpenIddictUserSessionProvider(
             await ListAsync(userId, currentSessionId, cancellationToken).ConfigureAwait(false);
 
         int revoked = 0;
-        foreach (UserSessionDescriptor session in sessions)
+        foreach (string sessionId in sessions.Select(s => s.SessionId))
         {
-            if (session.SessionId == currentSessionId)
+            if (sessionId == currentSessionId)
             {
                 continue;
             }
 
-            if (await RevokeAsync(userId, session.SessionId, cancellationToken).ConfigureAwait(false))
+            if (await RevokeAsync(userId, sessionId, cancellationToken).ConfigureAwait(false))
             {
                 revoked++;
             }
         }
 
         return revoked;
-    }
-
-    public async Task<IReadOnlyList<UserDevice>> ListAsync(
-        string userId, CancellationToken cancellationToken = default)
-    {
-        IReadOnlyList<UserSessionDescriptor> sessions =
-            await ListAsync(userId, currentSessionId: null, cancellationToken).ConfigureAwait(false);
-
-        // The OpenIddict backend exposes no stable device id, OS or browser — only the raw IP. Synthesize one
-        // device per IP from its own sessions; the kind carried on each session (declared on the OIDC
-        // application, heuristic otherwise) drives the group's device kind.
-        return UserDeviceGrouping.ByIpAddress(sessions);
     }
 }

--- a/src/Granit.QueryEngine.AI/Internal/QueryDataSchema.cs
+++ b/src/Granit.QueryEngine.AI/Internal/QueryDataSchema.cs
@@ -13,6 +13,9 @@ namespace Granit.QueryEngine.AI.Internal;
 /// </summary>
 internal static class QueryDataSchema
 {
+    private const string DescriptionKey = "description";
+    private const string StringType = "string";
+
     /// <summary>Builds the tool parameter schema from a query definition's metadata.</summary>
     public static JsonElement Build(QueryMetadata metadata)
     {
@@ -29,15 +32,15 @@ internal static class QueryDataSchema
             properties["filters"] = new JsonObject
             {
                 ["type"] = "array",
-                ["description"] = "Filter clauses, ANDed together. Use only the listed fields and operators.",
+                [DescriptionKey] = "Filter clauses, ANDed together. Use only the listed fields and operators.",
                 ["items"] = new JsonObject
                 {
                     ["type"] = "object",
                     ["properties"] = new JsonObject
                     {
-                        ["field"] = new JsonObject { ["type"] = "string", ["enum"] = fieldNames },
-                        ["operator"] = new JsonObject { ["type"] = "string", ["enum"] = operators },
-                        ["value"] = new JsonObject { ["type"] = "string" },
+                        ["field"] = new JsonObject { ["type"] = StringType, ["enum"] = fieldNames },
+                        ["operator"] = new JsonObject { ["type"] = StringType, ["enum"] = operators },
+                        ["value"] = new JsonObject { ["type"] = StringType },
                     },
                     ["required"] = new JsonArray("field", "operator", "value"),
                     ["additionalProperties"] = false,
@@ -47,8 +50,8 @@ internal static class QueryDataSchema
 
         properties["search"] = new JsonObject
         {
-            ["type"] = "string",
-            ["description"] = "Free-text search across the definition's searchable fields, if any.",
+            ["type"] = StringType,
+            [DescriptionKey] = "Free-text search across the definition's searchable fields, if any.",
         };
 
         if (metadata.SortableFields.Count > 0)
@@ -56,8 +59,8 @@ internal static class QueryDataSchema
             string sortable = string.Join(", ", metadata.SortableFields.Select(s => s.Name));
             properties["sort"] = new JsonObject
             {
-                ["type"] = "string",
-                ["description"] = $"Comma-separated sort fields; prefix '-' for descending. Sortable: {sortable}.",
+                ["type"] = StringType,
+                [DescriptionKey] = $"Comma-separated sort fields; prefix '-' for descending. Sortable: {sortable}.",
             };
         }
 
@@ -67,7 +70,7 @@ internal static class QueryDataSchema
             ["type"] = "integer",
             ["minimum"] = 1,
             ["maximum"] = metadata.Pagination.MaxPageSize,
-            ["description"] = $"Defaults to {metadata.Pagination.DefaultPageSize}.",
+            [DescriptionKey] = $"Defaults to {metadata.Pagination.DefaultPageSize}.",
         };
 
         JsonObject schema = new()

--- a/tests/Granit.AI.AzureOpenAI.Tests/AzureOpenAIProviderOptionsValidatorTests.cs
+++ b/tests/Granit.AI.AzureOpenAI.Tests/AzureOpenAIProviderOptionsValidatorTests.cs
@@ -17,10 +17,8 @@ public sealed class AzureOpenAIProviderOptionsValidatorTests
     };
 
     [Fact]
-    public void Validate_ValidEndpoint_Succeeds()
-    {
+    public void Validate_ValidEndpoint_Succeeds() =>
         _validator.Validate(null, ValidOptions()).Succeeded.ShouldBeTrue();
-    }
 
     [Fact]
     public void Validate_EmptyEndpoint_Fails()

--- a/tests/Granit.AI.Chat.BackgroundJobs.Tests/GranitAIChatRetentionOptionsTests.cs
+++ b/tests/Granit.AI.Chat.BackgroundJobs.Tests/GranitAIChatRetentionOptionsTests.cs
@@ -7,12 +7,10 @@ namespace Granit.AI.Chat.BackgroundJobs.Tests;
 public sealed class GranitAIChatRetentionOptionsTests
 {
     [Fact]
-    public void SectionName_matches_namespace_aligned_canonical_path()
-    {
+    public void SectionName_matches_namespace_aligned_canonical_path() =>
         // Locked here so a rename of the project / namespace surfaces in CI before
         // it silently breaks host appsettings.json bindings.
         GranitAIChatRetentionOptions.SectionName.ShouldBe("AI:Chat:Retention");
-    }
 
     [Fact]
     public void Defaults_disable_retention_and_batch_in_bounded_chunks()

--- a/tests/Granit.AI.Chat.Tests/ConversationTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ConversationTests.cs
@@ -20,10 +20,8 @@ public sealed class ConversationTests
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void Create_rejects_blank_title(string title)
-    {
+    public void Create_rejects_blank_title(string title) =>
         Should.Throw<ArgumentException>(() => Conversation.Create(Guid.NewGuid(), Owner, title));
-    }
 
     [Fact]
     public void Rename_changes_the_title()

--- a/tests/Granit.AI.Chat.Tests/GranitAIChatAttachmentOptionsTests.cs
+++ b/tests/Granit.AI.Chat.Tests/GranitAIChatAttachmentOptionsTests.cs
@@ -6,12 +6,10 @@ namespace Granit.AI.Chat.Tests;
 public sealed class GranitAIChatAttachmentOptionsTests
 {
     [Fact]
-    public void SectionName_matches_namespace_aligned_canonical_path()
-    {
+    public void SectionName_matches_namespace_aligned_canonical_path() =>
         // Locked here so a rename of the project / namespace surfaces in CI before
         // it silently breaks host appsettings.json bindings.
         GranitAIChatAttachmentOptions.SectionName.ShouldBe("AI:Chat:Attachments");
-    }
 
     [Fact]
     public void Defaults_cap_attachment_count_and_size()

--- a/tests/Granit.AI.Chat.Tests/RequestClarificationToolTests.cs
+++ b/tests/Granit.AI.Chat.Tests/RequestClarificationToolTests.cs
@@ -15,10 +15,8 @@ public sealed class RequestClarificationToolTests
         await new RequestClarificationTool().InvokeAsync(Args(json), TestContext.Current.CancellationToken);
 
     [Fact]
-    public void Tool_is_named_request_clarification()
-    {
+    public void Tool_is_named_request_clarification() =>
         new RequestClarificationTool().Name.ShouldBe("request_clarification");
-    }
 
     [Fact]
     public async Task Valid_call_halts_the_loop_with_a_clarification_payload()

--- a/tests/Granit.AI.Prompts.Tests/PromptTemplateTests.cs
+++ b/tests/Granit.AI.Prompts.Tests/PromptTemplateTests.cs
@@ -55,8 +55,6 @@ public sealed class PromptTemplateTests
     [Theory]
     [InlineData("", "content")]
     [InlineData("name", "")]
-    public void Create_rejects_blank_name_or_content(string name, string content)
-    {
+    public void Create_rejects_blank_name_or_content(string name, string content) =>
         Should.Throw<ArgumentException>(() => PromptTemplate.Create(Guid.NewGuid(), Owner, name, "desc", content));
-    }
 }

--- a/tests/Granit.AI.Tests/Prompting/UntrustedDocumentEnvelopeTests.cs
+++ b/tests/Granit.AI.Tests/Prompting/UntrustedDocumentEnvelopeTests.cs
@@ -45,10 +45,8 @@ public sealed class UntrustedDocumentEnvelopeTests
     }
 
     [Fact]
-    public void Wrap_rejects_null()
-    {
+    public void Wrap_rejects_null() =>
         Should.Throw<ArgumentNullException>(() => UntrustedDocumentEnvelope.Wrap(null!));
-    }
 
     private static int CountOccurrences(string haystack, string needle)
     {

--- a/tests/Granit.AI.Tests/Sampling/AIContentSamplerTests.cs
+++ b/tests/Granit.AI.Tests/Sampling/AIContentSamplerTests.cs
@@ -6,22 +6,16 @@ namespace Granit.AI.Tests.Sampling;
 public sealed class AIContentSamplerTests
 {
     [Fact]
-    public void Returns_content_unchanged_when_shorter_than_cap()
-    {
+    public void Returns_content_unchanged_when_shorter_than_cap() =>
         AIContentSampler.TruncateOnCodePoint("short", 100).ShouldBe("short");
-    }
 
     [Fact]
-    public void Returns_content_unchanged_when_exactly_at_cap()
-    {
+    public void Returns_content_unchanged_when_exactly_at_cap() =>
         AIContentSampler.TruncateOnCodePoint("abcde", 5).ShouldBe("abcde");
-    }
 
     [Fact]
-    public void Truncates_to_cap_on_plain_ascii()
-    {
+    public void Truncates_to_cap_on_plain_ascii() =>
         AIContentSampler.TruncateOnCodePoint("abcdefghij", 4).ShouldBe("abcd");
-    }
 
     [Fact]
     public void Backs_off_one_unit_when_cut_would_split_a_surrogate_pair()

--- a/tests/Granit.AI.Tools.Search.Tests/SearchToolTests.cs
+++ b/tests/Granit.AI.Tools.Search.Tests/SearchToolTests.cs
@@ -60,7 +60,7 @@ public sealed class SearchToolTests
     {
         ISemanticSearchService svc = Substitute.For<ISemanticSearchService>();
         svc.SearchAsync("documentation", "how to deploy", Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new List<SemanticSearchResult> { new("doc-1", 0.91, "Deploy with the CLI.") });
+            .Returns([new("doc-1", 0.91, "Deploy with the CLI.")]);
         SearchTool tool = SemanticTool(svc);
 
         AIToolResult result = await tool.InvokeAsync(

--- a/tests/Granit.AI.Tools.Tests/AIToolRegistryTests.cs
+++ b/tests/Granit.AI.Tools.Tests/AIToolRegistryTests.cs
@@ -50,10 +50,8 @@ public sealed class AIToolRegistryTests
     [InlineData("has space")]
     [InlineData("bad!name")]
     [InlineData("dotted.name")]
-    public void Invalid_tool_names_throw(string name)
-    {
+    public void Invalid_tool_names_throw(string name) =>
         Should.Throw<InvalidAIToolNameException>(() => new AIToolRegistry([new FakeAITool(name: name)]));
-    }
 
     [Theory]
     [InlineData("query_data")]

--- a/tests/Granit.ArchitectureTests/IndexingArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/IndexingArchitectureTests.cs
@@ -192,10 +192,8 @@ public sealed partial class IndexingArchitectureTests
     /// </summary>
     [Theory]
     [MemberData(nameof(AllIndexingPackages))]
-    public void Granit_Indexing_packages_must_not_reference_Microsoft_AspNetCore(string packageName)
-    {
+    public void Granit_Indexing_packages_must_not_reference_Microsoft_AspNetCore(string packageName) =>
         AssertNoPackageReferenceStartsWith(packageName, "Microsoft.AspNetCore.");
-    }
 
     /// <summary>
     /// Layer purity: EF Core dependencies are confined to the

--- a/tests/Granit.ArchitectureTests/ResourcePresenceConventionsTests.cs
+++ b/tests/Granit.ArchitectureTests/ResourcePresenceConventionsTests.cs
@@ -16,22 +16,16 @@ public sealed partial class ResourcePresenceConventionsTests
     private static readonly string RepoRoot = FindRepoRoot();
 
     [Fact]
-    public void IResourcePresenceTracker_lives_in_abstractions_namespace()
-    {
+    public void IResourcePresenceTracker_lives_in_abstractions_namespace() =>
         typeof(IResourcePresenceTracker).Namespace.ShouldBe("Granit.Presence.Abstractions");
-    }
 
     [Fact]
-    public void IResourcePresenceVisibilityPolicy_lives_in_abstractions_namespace()
-    {
+    public void IResourcePresenceVisibilityPolicy_lives_in_abstractions_namespace() =>
         typeof(IResourcePresenceVisibilityPolicy).Namespace.ShouldBe("Granit.Presence.Abstractions");
-    }
 
     [Fact]
-    public void ResourceRef_lives_in_abstractions_namespace()
-    {
+    public void ResourceRef_lives_in_abstractions_namespace() =>
         typeof(ResourceRef).Namespace.ShouldBe("Granit.Presence.Abstractions");
-    }
 
     [Fact]
     public void FusionCacheResourcePresenceTracker_is_internal_sealed()

--- a/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
@@ -11,7 +11,7 @@ namespace Granit.ArchitectureTests;
 /// across the base package and the extractor providers (Email, Office, Pdf, Text, Tika,
 /// Ocr.AI, Ocr.Tesseract).
 /// </summary>
-public sealed class TextExtractionArchitectureTests
+public sealed partial class TextExtractionArchitectureTests
 {
     private static readonly string RepoRoot = FindRepoRoot();
     private static readonly string SrcRoot = Path.Join(RepoRoot, "src");
@@ -161,9 +161,7 @@ public sealed class TextExtractionArchitectureTests
         // and assert at least one references GranitTextExtractionModule. The looser
         // form keeps the pin honest for modules that legitimately depend on more
         // than one upstream module.
-        bool dependsOnBase = System.Text.RegularExpressions.Regex.IsMatch(
-            source,
-            @"\[DependsOn\([^\]]*typeof\(GranitTextExtractionModule\)[^\]]*\)\]");
+        bool dependsOnBase = DependsOnBaseModuleRegex().IsMatch(source);
 
         dependsOnBase.ShouldBeTrue(
             $"{projectName} must declare [DependsOn(... typeof(GranitTextExtractionModule) ...)] " +
@@ -222,37 +220,67 @@ public sealed class TextExtractionArchitectureTests
 
     private static readonly Regex[] ForbiddenNetworkingApiRegexes =
     [
-        new(@"\busing\s+System\.Net\.Http\b", RegexOptions.Compiled),
-        new(@"\busing\s+System\.Net\.Sockets\b", RegexOptions.Compiled),
-        new(@"\busing\s+System\.Net\s*;", RegexOptions.Compiled),
-        new(@"\bSystem\.Net\.Http\.", RegexOptions.Compiled),
-        new(@"\bSystem\.Net\.Sockets\.", RegexOptions.Compiled),
-        new(@"\bSystem\.Net\.(WebRequest|WebClient)\b", RegexOptions.Compiled),
-        new(@"\bHttpClient\b", RegexOptions.Compiled),
-        new(@"\bWebRequest\b", RegexOptions.Compiled),
-        new(@"\bWebClient\b", RegexOptions.Compiled),
+        UsingSystemNetHttpRegex(),
+        UsingSystemNetSocketsRegex(),
+        UsingSystemNetRegex(),
+        SystemNetHttpMemberRegex(),
+        SystemNetSocketsMemberRegex(),
+        SystemNetWebApiRegex(),
+        HttpClientRegex(),
+        WebRequestRegex(),
+        WebClientRegex(),
     ];
 
-    private static readonly Regex LineCommentRegex =
-        new(@"//.*?$", RegexOptions.Multiline | RegexOptions.Compiled);
+    [GeneratedRegex(@"\[DependsOn\([^\]]*typeof\(GranitTextExtractionModule\)[^\]]*\)\]")]
+    private static partial Regex DependsOnBaseModuleRegex();
 
-    private static readonly Regex BlockCommentRegex =
-        new(@"/\*.*?\*/", RegexOptions.Singleline | RegexOptions.Compiled);
+    [GeneratedRegex(@"\busing\s+System\.Net\.Http\b")]
+    private static partial Regex UsingSystemNetHttpRegex();
 
-    private static readonly Regex VerbatimStringRegex =
-        new(@"@""(?:""""|[^""])*""", RegexOptions.Compiled);
+    [GeneratedRegex(@"\busing\s+System\.Net\.Sockets\b")]
+    private static partial Regex UsingSystemNetSocketsRegex();
 
-    private static readonly Regex RegularStringRegex =
-        new(@"""(?:\\.|[^""\\])*""", RegexOptions.Compiled);
+    [GeneratedRegex(@"\busing\s+System\.Net\s*;")]
+    private static partial Regex UsingSystemNetRegex();
+
+    [GeneratedRegex(@"\bSystem\.Net\.Http\.")]
+    private static partial Regex SystemNetHttpMemberRegex();
+
+    [GeneratedRegex(@"\bSystem\.Net\.Sockets\.")]
+    private static partial Regex SystemNetSocketsMemberRegex();
+
+    [GeneratedRegex(@"\bSystem\.Net\.(WebRequest|WebClient)\b")]
+    private static partial Regex SystemNetWebApiRegex();
+
+    [GeneratedRegex(@"\bHttpClient\b")]
+    private static partial Regex HttpClientRegex();
+
+    [GeneratedRegex(@"\bWebRequest\b")]
+    private static partial Regex WebRequestRegex();
+
+    [GeneratedRegex(@"\bWebClient\b")]
+    private static partial Regex WebClientRegex();
+
+    [GeneratedRegex(@"//.*?$", RegexOptions.Multiline)]
+    private static partial Regex LineCommentRegex();
+
+    [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Singleline)]
+    private static partial Regex BlockCommentRegex();
+
+    [GeneratedRegex(@"@""(?:""""|[^""])*""")]
+    private static partial Regex VerbatimStringRegex();
+
+    [GeneratedRegex(@"""(?:\\.|[^""\\])*""")]
+    private static partial Regex RegularStringRegex();
 
     private static string StripCommentsAndStrings(string source)
     {
         // Comments first so a `// HttpClient is forbidden` xml-doc note doesn't trip
         // the scan, then strings so `"HttpClient.cs"` literals don't either.
-        string s = BlockCommentRegex.Replace(source, string.Empty);
-        s = LineCommentRegex.Replace(s, string.Empty);
-        s = VerbatimStringRegex.Replace(s, "\"\"");
-        s = RegularStringRegex.Replace(s, "\"\"");
+        string s = BlockCommentRegex().Replace(source, string.Empty);
+        s = LineCommentRegex().Replace(s, string.Empty);
+        s = VerbatimStringRegex().Replace(s, "\"\"");
+        s = RegularStringRegex().Replace(s, "\"\"");
         return s;
     }
 

--- a/tests/Granit.Authorization.Tests/ScopedPermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/ScopedPermissionCheckerTests.cs
@@ -13,10 +13,8 @@ public sealed class ScopedPermissionCheckerTests
     // --- TryCreate ---
 
     [Fact]
-    public void TryCreate_ReturnsNull_WhenScopeFactoryIsNull()
-    {
+    public void TryCreate_ReturnsNull_WhenScopeFactoryIsNull() =>
         ScopedPermissionChecker.TryCreate(null).ShouldBeNull();
-    }
 
     [Fact]
     public async Task TryCreate_ReturnsNull_WhenInnerCheckerNotRegistered()

--- a/tests/Granit.Hostnames.Tests/Domain/HostnameTests.cs
+++ b/tests/Granit.Hostnames.Tests/Domain/HostnameTests.cs
@@ -25,10 +25,8 @@ public sealed class HostnameTests
     [InlineData("-leading.com")]
     [InlineData("trailing-.com")]
     [InlineData("spaces in.com")]
-    public void Create_rejects_invalid_hostnames(string input)
-    {
+    public void Create_rejects_invalid_hostnames(string input) =>
         Should.Throw<ArgumentException>(() => Hostname.Create(input));
-    }
 
     [Theory]
     [InlineData("169.254.169.254")] // AWS metadata endpoint
@@ -36,11 +34,9 @@ public sealed class HostnameTests
     [InlineData("192.168.1.100")]   // RFC-1918 private
     [InlineData("127.0.0.1")]       // loopback
     [InlineData("8.8.8.8")]         // any all-numeric labels
-    public void Create_rejects_ip_address_literals(string input)
-    {
+    public void Create_rejects_ip_address_literals(string input) =>
         // RFC 1123 §2.1: the TLD must not be all-numeric.
         Should.Throw<ArgumentException>(() => Hostname.Create(input));
-    }
 
     [Fact]
     public void Create_rejects_hostnames_over_253_characters()

--- a/tests/Granit.Html.AngleSharp.Tests/AngleSharpConfigurationTests.cs
+++ b/tests/Granit.Html.AngleSharp.Tests/AngleSharpConfigurationTests.cs
@@ -5,7 +5,7 @@ using AngleSharpLib = global::AngleSharp;
 
 namespace Granit.Html.AngleSharp.Tests;
 
-public sealed class AngleSharpConfigurationTests
+public sealed partial class AngleSharpConfigurationTests
 {
     // Reach the type through the global alias so the test namespace (which ends in
     // ".AngleSharp") doesn't shadow the library's `AngleSharp` root.
@@ -51,7 +51,7 @@ public sealed class AngleSharpConfigurationTests
         // Strip line + block comments so xml-doc mentions of the method name don't trip the check.
         string code = StripComments(source);
 
-        bool callsWithDefaultLoader = WithDefaultLoaderCallRegex.IsMatch(code);
+        bool callsWithDefaultLoader = WithDefaultLoaderCallRegex().IsMatch(code);
 
         callsWithDefaultLoader.ShouldBeFalse(
             "AngleSharpConfiguration must not invoke WithDefaultLoader — that " +
@@ -60,18 +60,18 @@ public sealed class AngleSharpConfigurationTests
             "update this invariant deliberately.");
     }
 
-    private static readonly Regex WithDefaultLoaderCallRegex =
-        new(@"\.\s*WithDefaultLoader\s*\(", RegexOptions.Compiled);
+    [GeneratedRegex(@"\.\s*WithDefaultLoader\s*\(")]
+    private static partial Regex WithDefaultLoaderCallRegex();
 
-    private static readonly Regex LineCommentRegex =
-        new(@"//.*?$", RegexOptions.Multiline | RegexOptions.Compiled);
+    [GeneratedRegex(@"//.*?$", RegexOptions.Multiline)]
+    private static partial Regex LineCommentRegex();
 
-    private static readonly Regex BlockCommentRegex =
-        new(@"/\*.*?\*/", RegexOptions.Singleline | RegexOptions.Compiled);
+    [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Singleline)]
+    private static partial Regex BlockCommentRegex();
 
     private static string StripComments(string source)
     {
-        string withoutBlock = BlockCommentRegex.Replace(source, string.Empty);
-        return LineCommentRegex.Replace(withoutBlock, string.Empty);
+        string withoutBlock = BlockCommentRegex().Replace(source, string.Empty);
+        return LineCommentRegex().Replace(withoutBlock, string.Empty);
     }
 }

--- a/tests/Granit.Http.Abstractions.Tests/MinimumResponseTimeGuardTests.cs
+++ b/tests/Granit.Http.Abstractions.Tests/MinimumResponseTimeGuardTests.cs
@@ -11,16 +11,12 @@ namespace Granit.Http.Abstractions.Tests;
 public sealed class MinimumResponseTimeGuardTests
 {
     [Fact]
-    public void Begin_with_negative_minimum_throws()
-    {
+    public void Begin_with_negative_minimum_throws() =>
         Should.Throw<ArgumentOutOfRangeException>(() => MinimumResponseTimeGuard.Begin(-1, 10));
-    }
 
     [Fact]
-    public void Begin_with_maximum_less_than_minimum_throws()
-    {
+    public void Begin_with_maximum_less_than_minimum_throws() =>
         Should.Throw<ArgumentOutOfRangeException>(() => MinimumResponseTimeGuard.Begin(10, 5));
-    }
 
     [Fact]
     public void Begin_with_equal_minimum_and_maximum_is_allowed()

--- a/tests/Granit.Http.ApiDocumentation.Tests/OAuth2OptionsTests.cs
+++ b/tests/Granit.Http.ApiDocumentation.Tests/OAuth2OptionsTests.cs
@@ -76,12 +76,10 @@ public sealed class OAuth2OptionsTests
     }
 
     [Fact]
-    public void Defaults_RedirectUriIsNull()
-    {
+    public void Defaults_RedirectUriIsNull() =>
         // null means "let Scalar apply its (currently broken) default";
         // consumers must set this explicitly until upstream #8165/#8187 ship.
         new OAuth2Options().RedirectUri.ShouldBeNull();
-    }
 
     [Fact]
     public void RedirectUri_Roundtrips()

--- a/tests/Granit.Http.SecurityHeaders.Tests/Internal/RecordingLogger.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/Internal/RecordingLogger.cs
@@ -14,10 +14,8 @@ internal sealed class RecordingLogger<T> : ILogger<T>
 
     public void Log<TState>(
         LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-        Func<TState, Exception?, string> formatter)
-    {
+        Func<TState, Exception?, string> formatter) =>
         Entries.Add((logLevel, formatter(state, exception)));
-    }
 
     private sealed class NullScope : IDisposable
     {

--- a/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionCreatedHandlerTests.cs
+++ b/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionCreatedHandlerTests.cs
@@ -29,11 +29,11 @@ public sealed class UserSessionCreatedHandlerTests
 
         // The provider returns the user's sessions (candidate + one prior), locations unresolved.
         provider.ListAsync("user-1", "s-new", Arg.Any<CancellationToken>())
-            .Returns(new List<UserSessionDescriptor>
-            {
+            .Returns(
+            [
                 new("s-new", "user-1", IsCurrent: true, Now, null, "ua", "1.1.1.1", Location: null),
                 new("s-old", "user-1", IsCurrent: false, Now.AddDays(-1), Now.AddDays(-1), "ua2", "2.2.2.2", Location: null),
-            });
+            ]);
 
         IUserBehavioralProfileStore profileStore = Substitute.For<IUserBehavioralProfileStore>();
         TimeProvider timeProvider = Substitute.For<TimeProvider>();
@@ -67,10 +67,10 @@ public sealed class UserSessionCreatedHandlerTests
         tenant.IsAvailable.Returns(false);
         tenant.Change(Arg.Any<Guid?>()).Returns(Substitute.For<IDisposable>());
         provider.ListAsync("user-1", "s1", Arg.Any<CancellationToken>())
-            .Returns(new List<UserSessionDescriptor>
-            {
+            .Returns(
+            [
                 new("s1", "user-1", IsCurrent: true, Now, null, "ua", null, Location: null),
-            });
+            ]);
 
         IUserBehavioralProfileStore profileStore = Substitute.For<IUserBehavioralProfileStore>();
         TimeProvider timeProvider = Substitute.For<TimeProvider>();
@@ -96,10 +96,10 @@ public sealed class UserSessionCreatedHandlerTests
         // The active provider surfaces only an unrelated session — the candidate belongs to another topology
         // layer (e.g. an OpenIddict refresh-token event reaching a BFF deployment), so it must be ignored.
         provider.ListAsync("user-1", "oidc-token-id", Arg.Any<CancellationToken>())
-            .Returns(new List<UserSessionDescriptor>
-            {
+            .Returns(
+            [
                 new("bff-sid", "user-1", IsCurrent: true, Now, null, "ua", "1.1.1.1", Location: null),
-            });
+            ]);
 
         IUserBehavioralProfileStore profileStore = Substitute.For<IUserBehavioralProfileStore>();
         TimeProvider timeProvider = Substitute.For<TimeProvider>();

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetEmailTwoFactorServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetEmailTwoFactorServiceTests.cs
@@ -28,7 +28,7 @@ public sealed class AspNetEmailTwoFactorServiceTests
 
         _user = new LocalIdentity { Id = Guid.Parse(UserId), Email = "user@test.com", UserName = "testuser" };
         _userManager.FindByIdAsync(UserId).Returns(_user);
-        _userManager.GetClaimsAsync(_user).Returns(new List<Claim>());
+        _userManager.GetClaimsAsync(_user).Returns([]);
 
         _sut = new AspNetEmailTwoFactorService(_userManager, _eventBus);
     }
@@ -107,7 +107,7 @@ public sealed class AspNetEmailTwoFactorServiceTests
     [Fact]
     public async Task DisableAsync_NoOtherFactor_RemovesClaimAndDisablesMaster()
     {
-        _userManager.GetClaimsAsync(_user).Returns(new List<Claim> { new(EmailOtpClaim, "true") });
+        _userManager.GetClaimsAsync(_user).Returns([new(EmailOtpClaim, "true")]);
         _userManager.GetAuthenticatorKeyAsync(_user).Returns((string?)null);
 
         await _sut.DisableAsync(UserId, TestContext.Current.CancellationToken);
@@ -121,7 +121,7 @@ public sealed class AspNetEmailTwoFactorServiceTests
     [Fact]
     public async Task DisableAsync_AuthenticatorStillActive_KeepsMasterOn()
     {
-        _userManager.GetClaimsAsync(_user).Returns(new List<Claim> { new(EmailOtpClaim, "true") });
+        _userManager.GetClaimsAsync(_user).Returns([new(EmailOtpClaim, "true")]);
         _userManager.GetAuthenticatorKeyAsync(_user).Returns("STILL-HAS-AUTHENTICATOR");
 
         await _sut.DisableAsync(UserId, TestContext.Current.CancellationToken);
@@ -136,7 +136,7 @@ public sealed class AspNetEmailTwoFactorServiceTests
     [Fact]
     public async Task IsEnabledAsync_ClaimPresent_ReturnsTrue()
     {
-        _userManager.GetClaimsAsync(_user).Returns(new List<Claim> { new(EmailOtpClaim, "true") });
+        _userManager.GetClaimsAsync(_user).Returns([new(EmailOtpClaim, "true")]);
 
         bool enabled = await _sut.IsEnabledAsync(UserId, TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetTwoFactorServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetTwoFactorServiceTests.cs
@@ -27,7 +27,7 @@ public sealed class AspNetTwoFactorServiceTests
         _userManager.FindByIdAsync(UserId).Returns(_user);
 
         // Default: no email-OTP claim. Individual tests override.
-        _userManager.GetClaimsAsync(_user).Returns(new List<Claim>());
+        _userManager.GetClaimsAsync(_user).Returns([]);
 
         _sut = new AspNetTwoFactorService(_userManager);
     }
@@ -56,7 +56,7 @@ public sealed class AspNetTwoFactorServiceTests
         _userManager.GetAuthenticatorKeyAsync(_user).Returns((string?)null);
         _userManager.CountRecoveryCodesAsync(_user).Returns(0);
         _userManager.GetClaimsAsync(_user).Returns(
-            new List<Claim> { new("granit:2fa:email_otp", "true") });
+            [new("granit:2fa:email_otp", "true")]);
 
         TwoFactorStatus status = await _sut.GetStatusAsync(UserId, TestContext.Current.CancellationToken);
 
@@ -82,7 +82,7 @@ public sealed class AspNetTwoFactorServiceTests
         _userManager.GetAuthenticatorKeyAsync(_user).Returns("KEY");
         _userManager.CountRecoveryCodesAsync(_user).Returns(3);
         _userManager.GetClaimsAsync(_user).Returns(
-            new List<Claim> { new("granit:2fa:email_otp", "true") });
+            [new("granit:2fa:email_otp", "true")]);
 
         IReadOnlyList<TwoFactorMethod> methods = await _sut.GetAvailableMethodsAsync(
             UserId, TestContext.Current.CancellationToken);
@@ -108,7 +108,7 @@ public sealed class AspNetTwoFactorServiceTests
         _userManager.GetAuthenticatorKeyAsync(_user).Returns((string?)null);
         _userManager.CountRecoveryCodesAsync(_user).Returns(0);
         _userManager.GetClaimsAsync(_user).Returns(
-            new List<Claim> { new("granit:2fa:email_otp", "true") });
+            [new("granit:2fa:email_otp", "true")]);
 
         IReadOnlyList<TwoFactorMethod> methods = await _sut.GetAvailableMethodsAsync(
             UserId, TestContext.Current.CancellationToken);
@@ -122,7 +122,7 @@ public sealed class AspNetTwoFactorServiceTests
     public async Task DisableAllAsync_ClearsEveryFactorAndRotatesStamp()
     {
         _userManager.GetClaimsAsync(_user).Returns(
-            new List<Claim> { new("granit:2fa:email_otp", "true") });
+            [new("granit:2fa:email_otp", "true")]);
 
         await _sut.DisableAllAsync(UserId, TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -195,7 +195,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         twoFactorService.GetStatusAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new TwoFactorStatus(false, false, false, 0));
         twoFactorService.GetAvailableMethodsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<TwoFactorMethod>());
+            .Returns([]);
 
         // Default: no external logins
         externalLoginService.GetLoginsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())

--- a/tests/Granit.Indexing.BackgroundJobs.Tests/IndexingBackgroundJobsOptionsTests.cs
+++ b/tests/Granit.Indexing.BackgroundJobs.Tests/IndexingBackgroundJobsOptionsTests.cs
@@ -7,12 +7,10 @@ namespace Granit.Indexing.BackgroundJobs.Tests;
 public sealed class IndexingBackgroundJobsOptionsTests
 {
     [Fact]
-    public void SectionName_matches_namespace_aligned_canonical_path()
-    {
+    public void SectionName_matches_namespace_aligned_canonical_path() =>
         // Locked here so a rename of the project / namespace surfaces in CI before
         // it silently breaks host appsettings.json bindings.
         IndexingBackgroundJobsOptions.SectionName.ShouldBe("Indexing:BackgroundJobs");
-    }
 
     [Fact]
     public void Defaults_are_safe_for_production()

--- a/tests/Granit.LanguageDetection.Tests/CompositeLanguageDetectorTests.cs
+++ b/tests/Granit.LanguageDetection.Tests/CompositeLanguageDetectorTests.cs
@@ -56,13 +56,11 @@ public sealed class CompositeLanguageDetectorTests
     }
 
     [Fact]
-    public void Composite_does_not_implement_provider_marker()
-    {
+    public void Composite_does_not_implement_provider_marker() =>
         // Type-system guarantee that a composite cannot accidentally be passed back
         // into another composite's provider list — the bug the runtime filter used to
         // guard against is now impossible to express.
         typeof(ILanguageDetectorProvider).IsAssignableFrom(typeof(CompositeLanguageDetector)).ShouldBeFalse();
-    }
 
     [Fact]
     public void Composite_advertises_max_priority() =>

--- a/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
+++ b/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
@@ -38,7 +38,7 @@ public sealed class TranslateToolTests
         svc.SuggestTranslationsAsync("chat.translate", "Hello", "en",
                 Arg.Is<IReadOnlyList<string>>(t => t.Count == 1 && t[0] == "fr"),
                 TranslationContext.Description, Arg.Any<CancellationToken>())
-            .Returns(new List<TranslationSuggestion> { new("fr", "Bonjour") });
+            .Returns([new("fr", "Bonjour")]);
         TranslateTool tool = new(svc);
 
         AIToolResult result = await tool.InvokeAsync(

--- a/tests/Granit.Presence.Endpoints.Tests/PresencePermissionsTests.cs
+++ b/tests/Granit.Presence.Endpoints.Tests/PresencePermissionsTests.cs
@@ -7,20 +7,14 @@ namespace Granit.Presence.Endpoints.Tests;
 public sealed class PresencePermissionsTests
 {
     [Fact]
-    public void Self_Manage_constant_matches_canonical_form()
-    {
+    public void Self_Manage_constant_matches_canonical_form() =>
         PresencePermissions.Self.Manage.ShouldBe("Presence.Self.Manage");
-    }
 
     [Fact]
-    public void Users_Read_constant_matches_canonical_form()
-    {
+    public void Users_Read_constant_matches_canonical_form() =>
         PresencePermissions.Users.Read.ShouldBe("Presence.Users.Read");
-    }
 
     [Fact]
-    public void Group_name_matches_section_name()
-    {
+    public void Group_name_matches_section_name() =>
         PresencePermissions.GroupName.ShouldBe("Presence");
-    }
 }

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceDbPropertiesTests.cs
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceDbPropertiesTests.cs
@@ -6,8 +6,6 @@ namespace Granit.Presence.EntityFrameworkCore.Tests;
 public sealed class PresenceDbPropertiesTests
 {
     [Fact]
-    public void DbTablePrefix_defaults_to_presence_underscore()
-    {
+    public void DbTablePrefix_defaults_to_presence_underscore() =>
         GranitPresenceDbProperties.DbTablePrefix.ShouldBe("presence_");
-    }
 }

--- a/tests/Granit.Presence.Tests/Domain/UserPresenceTests.cs
+++ b/tests/Granit.Presence.Tests/Domain/UserPresenceTests.cs
@@ -29,10 +29,8 @@ public sealed class UserPresenceTests
     }
 
     [Fact]
-    public void Create_rejects_empty_user_id()
-    {
+    public void Create_rejects_empty_user_id() =>
         Should.Throw<ArgumentException>(() => UserPresence.Create(Guid.Empty, CreateClock()));
-    }
 
     [Fact]
     public void SetOverride_records_status_and_until()

--- a/tests/Granit.Privacy.Endpoints.Tests/PrivacyExportRateLimitPoliciesTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/PrivacyExportRateLimitPoliciesTests.cs
@@ -6,11 +6,9 @@ namespace Granit.Privacy.Endpoints.Tests;
 public sealed class PrivacyExportRateLimitPoliciesTests
 {
     [Fact]
-    public void ExportCreate_PolicyNameIsStable()
-    {
+    public void ExportCreate_PolicyNameIsStable() =>
         // The policy name is part of the package's public contract — hosts wire
         // their quota under `RateLimiting:Policies:privacy-export-create` in
         // appsettings.json. Renaming this constant is a breaking change.
         PrivacyExportRateLimitPolicies.ExportCreate.ShouldBe("privacy-export-create");
-    }
 }

--- a/tests/Granit.Privacy.Regulations.Tests/Internal/CompositeRegulationProfileMergerTests.cs
+++ b/tests/Granit.Privacy.Regulations.Tests/Internal/CompositeRegulationProfileMergerTests.cs
@@ -22,10 +22,8 @@ public sealed class CompositeRegulationProfileMergerTests
     }
 
     [Fact]
-    public void Merge_EmptyList_Throws()
-    {
+    public void Merge_EmptyList_Throws() =>
         Should.Throw<ArgumentException>(() => CompositeRegulationProfileMerger.Merge([]));
-    }
 
     [Fact]
     public void Merge_GdprPlusCcpa_OptInWins()

--- a/tests/Granit.Privacy.Vault.Tests/VaultExportHmacSignerTests.cs
+++ b/tests/Granit.Privacy.Vault.Tests/VaultExportHmacSignerTests.cs
@@ -63,11 +63,9 @@ public sealed class VaultExportHmacSignerTests
     }
 
     [Fact]
-    public void Verify_ReturnsFalse_ForLegacyEphemeralTagFormat()
-    {
+    public void Verify_ReturnsFalse_ForLegacyEphemeralTagFormat() =>
         // Tag from EphemeralExportHmacSigner — vN:base64 with no gpv1 prefix.
         _sut.Verify(MakeParameters(), "v1:abc123").ShouldBeFalse();
-    }
 
     [Fact]
     public void Verify_ReturnsFalse_WhenTagIsExpired()
@@ -93,8 +91,6 @@ public sealed class VaultExportHmacSignerTests
     }
 
     [Fact]
-    public void VerifyBytes_RejectsLegacyTagFormat()
-    {
+    public void VerifyBytes_RejectsLegacyTagFormat() =>
         _sut.VerifyBytes(Encoding.UTF8.GetBytes("manifest-bytes"), "v1:abc").ShouldBeFalse();
-    }
 }

--- a/tests/Granit.Settings.Tests/SettingDefinitionTests.cs
+++ b/tests/Granit.Settings.Tests/SettingDefinitionTests.cs
@@ -382,10 +382,8 @@ public sealed class SettingDefinitionTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void MaxLength_IsNull_ByDefault()
-    {
+    public void MaxLength_IsNull_ByDefault() =>
         new SettingDefinition("test").MaxLength.ShouldBeNull();
-    }
 
     [Fact]
     public void IsValidValue_RejectsValueLongerThanMaxLength()

--- a/tests/Granit.Tests/Domain/ValueObjects/AbsoluteUrlTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/AbsoluteUrlTests.cs
@@ -12,10 +12,8 @@ public sealed class AbsoluteUrlTests
     [InlineData("https://acme.com/about/team?x=1#frag")]
     [InlineData("http://localhost:3000/preview")] // dev / preview origins are http
     [InlineData("http://127.0.0.1:5000")]
-    public void Create_AbsoluteHttpOrHttps_Succeeds(string value)
-    {
+    public void Create_AbsoluteHttpOrHttps_Succeeds(string value) =>
         AbsoluteUrl.Create(value).Value.ShouldBe(value);
-    }
 
     [Theory]
     [InlineData("")]
@@ -25,10 +23,8 @@ public sealed class AbsoluteUrlTests
     [InlineData("ftp://acme.com/file")]
     [InlineData("mailto:hi@acme.com")]
     [InlineData("javascript:alert(1)")]
-    public void Create_NotAbsoluteHttpUrl_Throws(string value)
-    {
+    public void Create_NotAbsoluteHttpUrl_Throws(string value) =>
         Should.Throw<ArgumentException>(() => AbsoluteUrl.Create(value));
-    }
 
     [Fact]
     public void Create_TooLong_Throws()
@@ -55,8 +51,6 @@ public sealed class AbsoluteUrlTests
     }
 
     [Fact]
-    public void IsSingleValueObject()
-    {
+    public void IsSingleValueObject() =>
         AbsoluteUrl.Create("https://acme.com").ShouldBeAssignableTo<ValueObject>();
-    }
 }

--- a/tests/Granit.Tests/Domain/ValueObjects/HexColorTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/HexColorTests.cs
@@ -19,26 +19,20 @@ public sealed class HexColorTests
     }
 
     [Fact]
-    public void Create_normalises_to_upper_case_and_trims()
-    {
+    public void Create_normalises_to_upper_case_and_trims() =>
         HexColor.Create("  #8b5cf6  ").Value.ShouldBe("#8B5CF6");
-    }
 
     [Theory]
     [InlineData("8B5CF6")]      // missing '#'
     [InlineData("#12345")]      // 5 digits
     [InlineData("#GGGGGG")]     // non-hex
     [InlineData("#8B5CF")]      // too short
-    public void Create_rejects_malformed_values(string value)
-    {
+    public void Create_rejects_malformed_values(string value) =>
         Should.Throw<ArgumentException>(() => HexColor.Create(value));
-    }
 
     [Fact]
-    public void Create_rejects_null_or_whitespace()
-    {
+    public void Create_rejects_null_or_whitespace() =>
         Should.Throw<ArgumentException>(() => HexColor.Create("  "));
-    }
 
     [Fact]
     public void Implicit_conversions_round_trip_through_string()

--- a/tests/Granit.Tests/Domain/ValueObjects/ImageDimensionsTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/ImageDimensionsTests.cs
@@ -27,26 +27,20 @@ public sealed class ImageDimensionsTests
     [Theory]
     [InlineData(-1, 10)]
     [InlineData(10, -1)]
-    public void Ctor_NegativeDimension_Throws(int width, int height)
-    {
+    public void Ctor_NegativeDimension_Throws(int width, int height) =>
         Should.Throw<ArgumentOutOfRangeException>(() => new ImageDimensions(width, height));
-    }
 
     // -------------------------------------------------------------------------
     // Derived geometry
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void AspectRatio_DividesWidthByHeight()
-    {
+    public void AspectRatio_DividesWidthByHeight() =>
         new ImageDimensions(1600, 800).AspectRatio.ShouldBe(2d);
-    }
 
     [Fact]
-    public void AspectRatio_ZeroHeight_ReturnsZeroNotInfinity()
-    {
+    public void AspectRatio_ZeroHeight_ReturnsZeroNotInfinity() =>
         new ImageDimensions(100, 0).AspectRatio.ShouldBe(0d);
-    }
 
     [Theory]
     [InlineData(1200, 630, true, false, false)]
@@ -63,17 +57,13 @@ public sealed class ImageDimensionsTests
     }
 
     [Fact]
-    public void TotalPixels_DoesNotOverflowInt()
-    {
+    public void TotalPixels_DoesNotOverflowInt() =>
         // 50000 * 50000 = 2.5e9, beyond int.MaxValue (~2.147e9).
         new ImageDimensions(50_000, 50_000).TotalPixels.ShouldBe(2_500_000_000L);
-    }
 
     [Fact]
-    public void ToString_IsHumanReadable()
-    {
+    public void ToString_IsHumanReadable() =>
         new ImageDimensions(1200, 630).ToString().ShouldBe("1200x630px");
-    }
 
     // -------------------------------------------------------------------------
     // Value semantics
@@ -92,10 +82,8 @@ public sealed class ImageDimensionsTests
     }
 
     [Fact]
-    public void IsValueObject()
-    {
+    public void IsValueObject() =>
         new ImageDimensions(1, 1).ShouldBeAssignableTo<ValueObject>();
-    }
 
     // -------------------------------------------------------------------------
     // Serialization — only width/height; computed members are ignored

--- a/tests/Granit.Tests/Events/ScopedLocalEventBusTests.cs
+++ b/tests/Granit.Tests/Events/ScopedLocalEventBusTests.cs
@@ -12,10 +12,8 @@ public sealed class ScopedLocalEventBusTests
     private sealed record SampleEvent(string Value);
 
     [Fact]
-    public async Task TryCreate_ReturnsNull_WhenScopeFactoryIsNull()
-    {
+    public async Task TryCreate_ReturnsNull_WhenScopeFactoryIsNull() =>
         ScopedLocalEventBus.TryCreate(null).ShouldBeNull();
-    }
 
     [Fact]
     public async Task TryCreate_ReturnsNull_WhenInnerBusNotRegistered()

--- a/tests/Granit.Tests/SafeTypeLoaderTests.cs
+++ b/tests/Granit.Tests/SafeTypeLoaderTests.cs
@@ -64,12 +64,12 @@ public sealed class SafeTypeLoaderTests
         result.ShouldBeEmpty();
     }
 
-    public static TheoryData<Exception> MissingDependencyExceptions() => new()
-    {
+    public static TheoryData<Exception> MissingDependencyExceptions() =>
+    [
         new FileNotFoundException(),
         new FileLoadException(),
         new TypeLoadException(),
-    };
+    ];
 
     [Fact]
     public void Unexpected_exceptions_propagate()
@@ -79,8 +79,6 @@ public sealed class SafeTypeLoaderTests
     }
 
     [Fact]
-    public void Null_assembly_throws()
-    {
+    public void Null_assembly_throws() =>
         Should.Throw<ArgumentNullException>(() => ((Assembly)null!).GetLoadableTypes());
-    }
 }


### PR DESCRIPTION
## What

Resolves a batch of SonarQube **code smells** (the safe, mechanical ones) across source and test files. No behavioral change — verified by build + format + full test run on every touched project.

## Source fixes

| Rule | Fix | Files |
| ---- | --- | ----- |
| S3267 | Simplify loop with LINQ (`Select`/`FirstOrDefault`) | `BffUserSessionProvider`, `FeaturesReadEndpoints`, `KeycloakIdentityProvider`, `OpenIddictUserSessionProvider`, `UserDeviceGrouping` |
| S3358 | Extract nested ternary | `EfCoreBffTokenStore` (IP en/decrypt), `UserSessionAnomalyDetector` (risk-level → `switch`, travel speed) |
| S1192 | Constant for repeated literal | `RequestClarificationTool` + `QueryDataSchema` (`description`/`string`), `EntraIdIdentityProvider` (`unknown`), `AccountPasskeyEndpoints` (`passkey`) |
| S4136 | `ListAsync` overloads adjacent | `KeycloakIdentityProvider`, `OpenIddictUserSessionProvider` |
| S125 | Reword comment tripping the false positive | `GranitAIChatModule` |

## Test fixes

- **IDE0022** expression bodies, **IDE0028/0300** collection expressions, **SYSLIB1045** `[GeneratedRegex]` (architecture + AngleSharp suites) across ~28 test projects.

## Verification

- `dotnet build` clean (0 warnings) on all 39 touched projects.
- `dotnet format --verify-no-changes` clean.
- All **28** touched test projects pass (0 failures).

## Deliberately NOT done (need your call in Sonar)

- **S1118 "add static/protected ctor"** on 6 `*Handler` classes — these are **Wolverine handlers** (`public class` + `public static HandleAsync`, discovered by assembly scanning). Making them static breaks discovery; per `CLAUDE.md` this is a known false positive → **mark Won't Fix**: `AIChatPersonalDataExportHandler`, `AIPromptsPersonalDataExportHandler`, `HostnameVerified/VerificationFailedHandler`, `UserSessionCreatedHandler`, `SuspiciousUserSessionDetectedHandler`.
- **S125 "remove commented out code"** on 6 files (`PromptCatalogueEndpoints`, `BffEndpointRouteBuilderExtensions`, `ManagedHostnameConfiguration`, `DefaultIpGeolocationResolver`, `ExportRequestEntityConfiguration`, `HashiCorpTransitMacService`) — verified these are **explanatory comments, not dead code**. False positives → **Won't Fix**.
- **Out of scope** (deferred): the 5 cognitive-complexity refactors, retry-loop `do/while` rewrites, `TranslateTool`→`AIPermissions` architecture deviation, generic-type static-field, and the `BlobBackedExportSource` yield split — these need real review, not a mechanical pass.