### PR TITLE
feat(persistence): map ImageDimensions value object to flat EF Core columns

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -41299,6 +41299,15 @@
       ]
     },
     {
+      "name": "ImageDimensionsModelBuilderExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.ImageDimensionsModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/ImageDimensionsModelBuilderExtensions.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "JsonPropertyBuilderExtensions",
       "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.JsonPropertyBuilderExtensions",
       "kind": "class",

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ImageDimensionsModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ImageDimensionsModelBuilderExtensions.cs
@@ -1,0 +1,47 @@
+using System.Linq.Expressions;
+using Granit.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Persistence.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Maps the framework <see cref="ImageDimensions"/> value object to two flat, typed columns
+/// (<c>Width</c> / <c>Height</c>) via EF Core's <c>ComplexProperty</c> — the convention-sanctioned
+/// alternative to the default JSON serialization for multi-field value objects (see
+/// <c>ApplyGranitConventions</c>). Use this when the dimensions must stay queryable / sortable /
+/// indexable as discrete integer columns rather than living inside a JSON blob.
+/// </summary>
+public static class ImageDimensionsModelBuilderExtensions
+{
+    /// <summary>
+    /// Maps an <see cref="ImageDimensions"/> property to two flat columns. The property may be
+    /// optional (<c>ImageDimensions?</c>) — EF Core 10 maps a nullable complex type to nullable
+    /// columns. Because the property is configured as a complex type, the value-object convention
+    /// leaves it untouched (it is never an entity type).
+    /// </summary>
+    /// <typeparam name="TEntity">The owning entity type.</typeparam>
+    /// <param name="builder">The entity type builder.</param>
+    /// <param name="selector">Selects the <see cref="ImageDimensions"/> property to map.</param>
+    /// <param name="widthColumnName">Column name for <see cref="ImageDimensions.Width"/>.</param>
+    /// <param name="heightColumnName">Column name for <see cref="ImageDimensions.Height"/>.</param>
+    /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+    public static EntityTypeBuilder<TEntity> MapImageDimensions<TEntity>(
+        this EntityTypeBuilder<TEntity> builder,
+        Expression<Func<TEntity, ImageDimensions?>> selector,
+        string widthColumnName = "Width",
+        string heightColumnName = "Height")
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(selector);
+
+        builder.ComplexProperty(selector, dimensions =>
+        {
+            dimensions.Property(d => d.Width).HasColumnName(widthColumnName);
+            dimensions.Property(d => d.Height).HasColumnName(heightColumnName);
+        });
+
+        return builder;
+    }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ImageDimensionsModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ImageDimensionsModelBuilderExtensionsTests.cs
@@ -1,0 +1,73 @@
+using Granit.Domain.ValueObjects;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class ImageDimensionsModelBuilderExtensionsTests
+{
+    [Fact]
+    public void MapImageDimensions_MapsToFlatColumns_AndIsNotAnEntityType()
+    {
+        using MediaDbContext context = new(new DbContextOptionsBuilder<MediaDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+        IReadOnlyList<string> entityNames = [.. context.Model.GetEntityTypes().Select(et => et.ClrType.Name)];
+        entityNames.ShouldNotContain(nameof(ImageDimensions), "ImageDimensions must be a complex type, not an entity");
+
+        IEntityType owner = context.Model.FindEntityType(typeof(MediaEntity))!;
+        IComplexProperty complex = owner.FindComplexProperty(nameof(MediaEntity.Dimensions))
+            .ShouldNotBeNull("Dimensions must be mapped as a complex property");
+
+        complex.IsNullable.ShouldBeTrue("an ImageDimensions? property must map to a nullable complex type");
+        complex.ComplexType.GetProperties().Select(p => p.GetColumnName())
+            .ShouldBe(["Width", "Height"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void MapImageDimensions_HonoursCustomColumnNames()
+    {
+        using CustomColumnDbContext context = new(new DbContextOptionsBuilder<CustomColumnDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+        IComplexProperty complex = context.Model
+            .FindEntityType(typeof(MediaEntity))!
+            .FindComplexProperty(nameof(MediaEntity.Dimensions))!;
+
+        complex.ComplexType.GetProperties().Select(p => p.GetColumnName())
+            .ShouldBe(["px_w", "px_h"], ignoreOrder: true);
+    }
+
+    public sealed class MediaEntity
+    {
+        public Guid Id { get; set; }
+        public ImageDimensions? Dimensions { get; set; }
+    }
+
+    private sealed class MediaDbContext(DbContextOptions<MediaDbContext> options) : DbContext(options)
+    {
+        public DbSet<MediaEntity> Media => Set<MediaEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<MediaEntity>().MapImageDimensions(e => e.Dimensions);
+            modelBuilder.ApplyGranitConventions();
+        }
+    }
+
+    private sealed class CustomColumnDbContext(DbContextOptions<CustomColumnDbContext> options) : DbContext(options)
+    {
+        public DbSet<MediaEntity> Media => Set<MediaEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<MediaEntity>().MapImageDimensions(e => e.Dimensions, "px_w", "px_h");
+            modelBuilder.ApplyGranitConventions();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `MapImageDimensions`, a public `*ModelBuilderExtensions` helper that maps the framework `ImageDimensions` value object to two discrete `Width` / `Height` integer columns via EF Core's `ComplexProperty`, instead of the default JSON serialization.

Use it when the dimensions must stay **queryable / sortable / indexable** as flat columns rather than living inside a JSON blob. Nullable (`ImageDimensions?`) properties map to nullable columns (EF Core 10). Column names are overridable.

Consistent with the framework rule that host apps own migrations — this only configures the mapping.

## Tests

2 cases in `ImageDimensionsModelBuilderExtensionsTests` (mapping to flat columns + custom column names). Green.