### PR TITLE
refactor(sonar): resolve safe higher-effort code smells

### DIFF
--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -235,20 +235,11 @@ internal static partial class BffLoginEndpoints
         Activity? activity = BffActivitySource.Source.StartActivity(BffActivitySource.Callback);
         using IDisposable? activityScope = activity;
 
-        if (!string.IsNullOrEmpty(error))
+        RedirectHttpResult? parameterError = await ValidateCallbackParametersAsync(
+            httpContext, frontend, code, state, error, cancellationToken).ConfigureAwait(false);
+        if (parameterError is not null)
         {
-            string safeError = KnownOidcErrors.Contains(error) ? error : "unknown_error";
-            LogCallbackError(logger, safeError, frontend.Name);
-            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
-                failureReason: safeError, cancellationToken).ConfigureAwait(false);
-            return RedirectToError(frontend, safeError);
-        }
-
-        if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
-        {
-            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
-                failureReason: "missing_code_or_state", cancellationToken).ConfigureAwait(false);
-            return RedirectToError(frontend, "missing_code_or_state");
+            return parameterError;
         }
 
         // Verify authorization response issuer (RFC 9207, FAPI 2.0 §5.3.3.2)
@@ -282,7 +273,7 @@ internal static partial class BffLoginEndpoints
         string pathPrefix = string.IsNullOrEmpty(frontend.PathPrefix) ? "" : frontend.PathPrefix;
         string callbackUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{pathPrefix}/bff/callback";
         BffTokenSet? tokens = await ExchangeCodeForTokensAsync(
-            services, frontend, code, pkceState.CodeVerifier, callbackUrl,
+            services, frontend, code!, pkceState.CodeVerifier, callbackUrl,
             pkceState.DPoPPrivateKeyJwk, cancellationToken)
             .ConfigureAwait(false);
 
@@ -354,6 +345,38 @@ internal static partial class BffLoginEndpoints
             : frontend.EffectivePostLoginRedirectPath;
 
         return TypedResults.Redirect(redirectUrl);
+    }
+
+    // Rejects malformed callback parameters before any state is consumed: a provider-reported error, or a
+    // missing authorization code / state. Returns an error redirect (audited) or null when the basics are sound.
+    private static async Task<RedirectHttpResult?> ValidateCallbackParametersAsync(
+        HttpContext httpContext,
+        BffFrontendOptions frontend,
+        string? code,
+        string? state,
+        string? error,
+        CancellationToken cancellationToken)
+    {
+        ILogger logger = httpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(LoggerCategory);
+
+        if (!string.IsNullOrEmpty(error))
+        {
+            string safeError = KnownOidcErrors.Contains(error) ? error : "unknown_error";
+            LogCallbackError(logger, safeError, frontend.Name);
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: safeError, cancellationToken).ConfigureAwait(false);
+            return RedirectToError(frontend, safeError);
+        }
+
+        if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
+        {
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: "missing_code_or_state", cancellationToken).ConfigureAwait(false);
+            return RedirectToError(frontend, "missing_code_or_state");
+        }
+
+        return null;
     }
 
 #pragma warning disable GRSEC003 // Method handles tokens — server-side only

--- a/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
+++ b/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
@@ -172,7 +172,7 @@ internal sealed class UserSessionAnomalyDetector(
                 continue;
             }
 
-            if (IsLowConfidence(candidate.Location, opts) || IsLowConfidence(prior.Location, opts))
+            if (PairIsLowConfidence(candidate.Location, prior.Location, opts))
             {
                 suppressed = true;
                 continue;
@@ -183,6 +183,11 @@ internal sealed class UserSessionAnomalyDetector(
 
         return suppressed ? TravelOutcome.SuppressedLowConfidence : TravelOutcome.None;
     }
+
+    // A travel pair is low-confidence when either endpoint's fix is untrustworthy.
+    private static bool PairIsLowConfidence(
+        GeoLocation candidate, GeoLocation prior, IdentityAnomalyDetectionOptions opts) =>
+        IsLowConfidence(candidate, opts) || IsLowConfidence(prior, opts);
 
     // A fix is low-confidence when its reported accuracy radius is too coarse, or the IP is flagged anonymising
     // (and the deployment opts to suppress those). null fields mean "the provider does not classify this" — they

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreDeviceTrustStore.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreDeviceTrustStore.cs
@@ -21,8 +21,9 @@ internal sealed class EfCoreDeviceTrustStore(
 
         // Upsert with one retry: two concurrent "trust this device" writes for the same (userId, deviceId)
         // both miss the existing row and insert, tripping the unique index. On that conflict, re-read and
-        // update the row the winner created. Provider-agnostic (no ON CONFLICT).
-        for (int attempt = 0; ; attempt++)
+        // update the row the winner created. Provider-agnostic (no ON CONFLICT). The second attempt's own
+        // DbUpdateException is no longer caught (filter is attempt == 0), so it surfaces — bounding the loop.
+        for (int attempt = 0; attempt <= 1; attempt++)
         {
             await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserBehavioralProfileStore.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserBehavioralProfileStore.cs
@@ -48,7 +48,8 @@ internal sealed class EfCoreUserBehavioralProfileStore(
         // Upsert+increment each signal with one retry: two concurrent observations of the same
         // (userId, kind, value) can both miss the existing row and both insert, tripping the unique index. On
         // that conflict, re-read and increment the winner's row instead of surfacing the DbUpdateException.
-        for (int attempt = 0; ; attempt++)
+        // The second attempt's own DbUpdateException is not caught (filter is attempt == 0), so it surfaces.
+        for (int attempt = 0; attempt <= 1; attempt++)
         {
             await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserSessionRiskStore.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserSessionRiskStore.cs
@@ -27,7 +27,8 @@ internal sealed class EfCoreUserSessionRiskStore(
         // Upsert with one retry: two concurrent assessments of the same (userId, sessionId) both miss the
         // existing row and both insert, tripping the unique index. On that conflict, re-read and update the
         // row the winner created instead of surfacing the DbUpdateException. Provider-agnostic (no ON CONFLICT).
-        for (int attempt = 0; ; attempt++)
+        // The second attempt's own DbUpdateException is not caught (filter is attempt == 0), so it surfaces.
+        for (int attempt = 0; attempt <= 1; attempt++)
         {
             await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -342,32 +342,9 @@ internal static class AdminOidcEndpoints
             descriptor.ConsentType = request.ConsentType;
         }
 
-        if (request.Permissions is not null)
-        {
-            descriptor.Permissions.Clear();
-            foreach (string permission in request.Permissions)
-            {
-                descriptor.Permissions.Add(permission);
-            }
-        }
-
-        if (request.RedirectUris is not null)
-        {
-            descriptor.RedirectUris.Clear();
-            foreach (string uri in request.RedirectUris)
-            {
-                descriptor.RedirectUris.Add(new Uri(uri));
-            }
-        }
-
-        if (request.PostLogoutRedirectUris is not null)
-        {
-            descriptor.PostLogoutRedirectUris.Clear();
-            foreach (string uri in request.PostLogoutRedirectUris)
-            {
-                descriptor.PostLogoutRedirectUris.Add(new Uri(uri));
-            }
-        }
+        ReplaceCollection(descriptor.Permissions, request.Permissions, static p => p);
+        ReplaceCollection(descriptor.RedirectUris, request.RedirectUris, static u => new Uri(u));
+        ReplaceCollection(descriptor.PostLogoutRedirectUris, request.PostLogoutRedirectUris, static u => new Uri(u));
 
         if (request.SigningKeyJwk is not null)
         {
@@ -386,6 +363,23 @@ internal static class AdminOidcEndpoints
         {
             // SetDeviceKind treats Unknown as "clear the declaration".
             descriptor.SetDeviceKind(request.DeviceKind.Value);
+        }
+    }
+
+    // Replaces the full contents of a descriptor collection from a request field: null leaves it untouched,
+    // a present field clears then refills it (mapping each raw string through <paramref name="map"/>).
+    private static void ReplaceCollection<T>(
+        ICollection<T> target, IReadOnlyList<string>? source, Func<string, T> map)
+    {
+        if (source is null)
+        {
+            return;
+        }
+
+        target.Clear();
+        foreach (string item in source)
+        {
+            target.Add(map(item));
         }
     }
 

--- a/src/Granit.QueryEngine.AI/Internal/QueryDataTool.cs
+++ b/src/Granit.QueryEngine.AI/Internal/QueryDataTool.cs
@@ -19,12 +19,6 @@ internal sealed class QueryDataTool<TEntity>(
     IQueryableSource<TEntity> source) : IAITool, IAIToolInstructions
     where TEntity : class
 {
-    private static readonly JsonSerializerOptions ResultSerializerOptions = new(JsonSerializerDefaults.Web)
-    {
-        ReferenceHandler = ReferenceHandler.IgnoreCycles,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     private readonly QueryMetadata _metadata = engine.GetMetadata();
 
     public string Name => $"query_{name}";
@@ -61,6 +55,20 @@ internal sealed class QueryDataTool<TEntity>(
             items = result.Items,
         };
 
-        return AIToolResult.Success(JsonSerializer.Serialize(payload, ResultSerializerOptions));
+        return AIToolResult.Success(JsonSerializer.Serialize(payload, QueryDataToolSerialization.ResultSerializerOptions));
     }
+}
+
+/// <summary>
+/// Holds the JSON options shared by every closed <see cref="QueryDataTool{TEntity}"/>. A non-generic holder so
+/// the options are allocated once, not once per <c>TEntity</c> (a static field in a generic type is per close
+/// constructed type).
+/// </summary>
+file static class QueryDataToolSerialization
+{
+    public static readonly JsonSerializerOptions ResultSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
 }


### PR DESCRIPTION
## What

The higher-effort SonarQube code smells — doing the ones that are **safe and behaviour-preserving**, skipping only genuine design decisions (per the "don't do it if it's too risky" guidance).

> ⚠️ **Stacked on #2761** (`chore/sonar-mechanical-cleanup`). It touches `UserSessionAnomalyDetector`, which #2761 also modifies (same `EvaluateTravel` method), so basing here avoids a merge conflict. **Retarget to `develop` once #2761 merges.**

## Done

| Rule | Fix | File |
| ---- | --- | ---- |
| Retry-loop stop condition tests no variable | Bounded `for (… ; attempt <= 1; …)` — behaviour identical, the 2nd attempt's own conflict still surfaces | `EfCoreDeviceTrustStore`, `EfCoreUserBehavioralProfileStore`, `EfCoreUserSessionRiskStore` |
| S2743 static field in generic type | Moved shared `JsonSerializerOptions` to a `file`-scoped non-generic holder | `QueryDataTool` |
| Cognitive complexity 16→15 | Extracted `PairIsLowConfidence` | `UserSessionAnomalyDetector.EvaluateTravel` |
| Cognitive complexity 17→15 | Extracted generic `ReplaceCollection` helper (descriptor mapper, not auth logic) | `AdminOidcEndpoints.ApplyRequestedUpdates` |
| Cognitive complexity 18→15 | Extracted `ValidateCallbackParametersAsync` (the two pure early-format guards only; issuer/PKCE order-sensitive logic left in place) | `BffLoginEndpoints.HandleCallbackAsync` |
| Cognitive complexity 25→15 | Decomposed into `RunConversationAsync` (the loop → `ConversationOutcome`) + `ExecuteCallsAsync` (one round of tool calls). Verified by 42 tests. | `AIToolOrchestrator.RunAsync` |

## Already satisfied (no change)

- **`BlobBackedExportSource`** — public `StreamAsync` already validates args + delegates to the private `StreamCoreAsync` iterator. Stale Sonar issue; clears on rescan.

## Deliberately SKIPPED (design decision, not mechanical)

- **`TranslateTool`** (architecture: disallowed relationship to `AIPermissions`). `Granit.Localization.AI` reaches `AIPermissions.ChatTools.Translate` transitively via `Granit.AI.Tools`. Removing it means inlining the permission string (violates const-over-literal) or relocating permission constants to a shared abstractions package — a **framework/ADR decision**. This file is the documented *reference pattern* for gated tools, so it should not change unilaterally. Needs design sign-off.

## Verification

- `dotnet build` + `dotnet format --verify-no-changes` clean on all changed projects.
- All touched test projects green: `Granit.Bff.Endpoints.Tests` (108), `Granit.OpenIddict.Endpoints.Tests` (122), `Granit.AI.Tools.Tests` (42), `Granit.Identity.AnomalyDetection.Tests` (24), `Granit.Identity.EntityFrameworkCore.Tests` (26), `Granit.QueryEngine.AI.Tests` (38).