### PR TITLE
refactor(sonar): higher-effort code smells (re-targeted to develop)

### DIFF
--- a/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
+++ b/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
@@ -90,6 +90,60 @@ internal sealed partial class AIToolOrchestrator(
         List<AIToolInvocationOutcome> outcomes = [];
         long startTimestamp = timeProvider.GetTimestamp();
 
+        ConversationOutcome outcome = await RunConversationAsync(
+            chatClient, transcript, chatOptions, toolMap, options, maxIterations, tenantId, outcomes, cancellationToken)
+            .ConfigureAwait(false);
+
+        TimeSpan duration = timeProvider.GetElapsedTime(startTimestamp);
+        metrics.RecordIterations(tenantId, outcome.Iterations);
+
+        if (outcome.AnyUsage)
+        {
+            AIUsageRecord record = usageRecordFactory.Create(
+                workspaceName,
+                workspace.Provider,
+                workspace.Model,
+                (int)outcome.TotalInput,
+                (int)outcome.TotalOutput,
+                duration) with
+            {
+                PromptVersion = systemPrompt.Guardrails.Version,
+                PromptTemplateName = request.InvokedPromptName,
+                PromptTemplateVersion = request.InvokedPromptVersion,
+            };
+
+            await usageTracker.RecordAsync(record, cancellationToken).ConfigureAwait(false);
+        }
+
+        LogRunCompleted(workspaceName, outcome.Iterations, outcomes.Count, outcome.MaxReached);
+
+        return new AIOrchestrationResult
+        {
+            Content = outcome.FinalText,
+            Messages = transcript,
+            Iterations = outcome.Iterations,
+            MaxIterationsReached = outcome.MaxReached,
+            ToolInvocations = outcomes,
+            InputTokens = outcome.AnyUsage ? (int)outcome.TotalInput : null,
+            OutputTokens = outcome.AnyUsage ? (int)outcome.TotalOutput : null,
+            Duration = duration,
+            Interrupt = outcome.Interrupt,
+        };
+    }
+
+    // The think → call → execute → repeat loop. Drives the chat client, accumulates usage, dispatches each
+    // round of tool calls, and stops on a text-only response, the iteration cap, or a tool-requested interrupt.
+    private async Task<ConversationOutcome> RunConversationAsync(
+        IChatClient chatClient,
+        List<ChatMessage> transcript,
+        ChatOptions chatOptions,
+        Dictionary<string, IAITool> toolMap,
+        GranitAIToolsOrchestrationOptions options,
+        int maxIterations,
+        string? tenantId,
+        List<AIToolInvocationOutcome> outcomes,
+        CancellationToken cancellationToken)
+    {
         long totalInput = 0;
         long totalOutput = 0;
         bool anyUsage = false;
@@ -133,36 +187,11 @@ internal sealed partial class AIToolOrchestrator(
                 break;
             }
 
-            List<AIContent> results = new(calls.Count);
-            foreach (FunctionCallContent call in calls)
-            {
-                (string content, bool succeeded, bool truncated, AIToolInterrupt? callInterrupt) =
-                    await ExecuteToolAsync(call, toolMap, options, cancellationToken).ConfigureAwait(false);
-
-                results.Add(new FunctionResultContent(call.CallId, content));
-                outcomes.Add(new AIToolInvocationOutcome
-                {
-                    ToolName = call.Name,
-                    CallId = call.CallId,
-                    Iteration = iteration,
-                    Succeeded = succeeded,
-                    Truncated = truncated,
-                });
-
-                // The model can emit (or be steered into emitting) arbitrary function-call names, so
-                // tag metrics by the resolved tool only — an unrecognised name collapses to a single
-                // bounded value, keeping tool-name cardinality bounded by the registered tool set.
-                string toolTag = toolMap.ContainsKey(call.Name) ? call.Name : UnknownToolTag;
-                metrics.RecordInvocation(tenantId, toolTag, succeeded ? "success" : "error");
-                if (truncated)
-                {
-                    metrics.RecordTruncation(tenantId, toolTag);
-                }
-
-                interrupt ??= callInterrupt;
-            }
+            (List<AIContent> results, AIToolInterrupt? callsInterrupt) = await ExecuteCallsAsync(
+                calls, toolMap, options, tenantId, iteration, outcomes, cancellationToken).ConfigureAwait(false);
 
             transcript.Add(new ChatMessage(ChatRole.Tool, results));
+            interrupt ??= callsInterrupt;
 
             // A tool asked to halt the loop (e.g. a clarification request) — surface it and stop
             // rather than feeding the result back to the model.
@@ -173,42 +202,63 @@ internal sealed partial class AIToolOrchestrator(
             }
         }
 
-        TimeSpan duration = timeProvider.GetElapsedTime(startTimestamp);
-        metrics.RecordIterations(tenantId, iteration);
+        return new ConversationOutcome(finalText, maxReached, interrupt, totalInput, totalOutput, anyUsage, iteration);
+    }
 
-        if (anyUsage)
+    // Executes every tool call in one round, recording the outcome and metrics for each, and returns the
+    // tool-result contents plus the first interrupt a tool raised (null when none asked to halt).
+    private async Task<(List<AIContent> Results, AIToolInterrupt? Interrupt)> ExecuteCallsAsync(
+        List<FunctionCallContent> calls,
+        Dictionary<string, IAITool> toolMap,
+        GranitAIToolsOrchestrationOptions options,
+        string? tenantId,
+        int iteration,
+        List<AIToolInvocationOutcome> outcomes,
+        CancellationToken cancellationToken)
+    {
+        List<AIContent> results = new(calls.Count);
+        AIToolInterrupt? interrupt = null;
+
+        foreach (FunctionCallContent call in calls)
         {
-            AIUsageRecord record = usageRecordFactory.Create(
-                workspaceName,
-                workspace.Provider,
-                workspace.Model,
-                (int)totalInput,
-                (int)totalOutput,
-                duration) with
-            {
-                PromptVersion = systemPrompt.Guardrails.Version,
-                PromptTemplateName = request.InvokedPromptName,
-                PromptTemplateVersion = request.InvokedPromptVersion,
-            };
+            (string content, bool succeeded, bool truncated, AIToolInterrupt? callInterrupt) =
+                await ExecuteToolAsync(call, toolMap, options, cancellationToken).ConfigureAwait(false);
 
-            await usageTracker.RecordAsync(record, cancellationToken).ConfigureAwait(false);
+            results.Add(new FunctionResultContent(call.CallId, content));
+            outcomes.Add(new AIToolInvocationOutcome
+            {
+                ToolName = call.Name,
+                CallId = call.CallId,
+                Iteration = iteration,
+                Succeeded = succeeded,
+                Truncated = truncated,
+            });
+
+            // The model can emit (or be steered into emitting) arbitrary function-call names, so
+            // tag metrics by the resolved tool only — an unrecognised name collapses to a single
+            // bounded value, keeping tool-name cardinality bounded by the registered tool set.
+            string toolTag = toolMap.ContainsKey(call.Name) ? call.Name : UnknownToolTag;
+            metrics.RecordInvocation(tenantId, toolTag, succeeded ? "success" : "error");
+            if (truncated)
+            {
+                metrics.RecordTruncation(tenantId, toolTag);
+            }
+
+            interrupt ??= callInterrupt;
         }
 
-        LogRunCompleted(workspaceName, iteration, outcomes.Count, maxReached);
-
-        return new AIOrchestrationResult
-        {
-            Content = finalText,
-            Messages = transcript,
-            Iterations = iteration,
-            MaxIterationsReached = maxReached,
-            ToolInvocations = outcomes,
-            InputTokens = anyUsage ? (int)totalInput : null,
-            OutputTokens = anyUsage ? (int)totalOutput : null,
-            Duration = duration,
-            Interrupt = interrupt,
-        };
+        return (results, interrupt);
     }
+
+    // Carries the result of the conversation loop back to the orchestration entry point.
+    private readonly record struct ConversationOutcome(
+        string FinalText,
+        bool MaxReached,
+        AIToolInterrupt? Interrupt,
+        long TotalInput,
+        long TotalOutput,
+        bool AnyUsage,
+        int Iterations);
 
     private async Task<(string Content, bool Succeeded, bool Truncated, AIToolInterrupt? Interrupt)> ExecuteToolAsync(
         FunctionCallContent call,

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -235,20 +235,11 @@ internal static partial class BffLoginEndpoints
         Activity? activity = BffActivitySource.Source.StartActivity(BffActivitySource.Callback);
         using IDisposable? activityScope = activity;
 
-        if (!string.IsNullOrEmpty(error))
+        RedirectHttpResult? parameterError = await ValidateCallbackParametersAsync(
+            httpContext, frontend, code, state, error, cancellationToken).ConfigureAwait(false);
+        if (parameterError is not null)
         {
-            string safeError = KnownOidcErrors.Contains(error) ? error : "unknown_error";
-            LogCallbackError(logger, safeError, frontend.Name);
-            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
-                failureReason: safeError, cancellationToken).ConfigureAwait(false);
-            return RedirectToError(frontend, safeError);
-        }
-
-        if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
-        {
-            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
-                failureReason: "missing_code_or_state", cancellationToken).ConfigureAwait(false);
-            return RedirectToError(frontend, "missing_code_or_state");
+            return parameterError;
         }
 
         // Verify authorization response issuer (RFC 9207, FAPI 2.0 §5.3.3.2)
@@ -282,7 +273,7 @@ internal static partial class BffLoginEndpoints
         string pathPrefix = string.IsNullOrEmpty(frontend.PathPrefix) ? "" : frontend.PathPrefix;
         string callbackUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{pathPrefix}/bff/callback";
         BffTokenSet? tokens = await ExchangeCodeForTokensAsync(
-            services, frontend, code, pkceState.CodeVerifier, callbackUrl,
+            services, frontend, code!, pkceState.CodeVerifier, callbackUrl,
             pkceState.DPoPPrivateKeyJwk, cancellationToken)
             .ConfigureAwait(false);
 
@@ -354,6 +345,38 @@ internal static partial class BffLoginEndpoints
             : frontend.EffectivePostLoginRedirectPath;
 
         return TypedResults.Redirect(redirectUrl);
+    }
+
+    // Rejects malformed callback parameters before any state is consumed: a provider-reported error, or a
+    // missing authorization code / state. Returns an error redirect (audited) or null when the basics are sound.
+    private static async Task<RedirectHttpResult?> ValidateCallbackParametersAsync(
+        HttpContext httpContext,
+        BffFrontendOptions frontend,
+        string? code,
+        string? state,
+        string? error,
+        CancellationToken cancellationToken)
+    {
+        ILogger logger = httpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(LoggerCategory);
+
+        if (!string.IsNullOrEmpty(error))
+        {
+            string safeError = KnownOidcErrors.Contains(error) ? error : "unknown_error";
+            LogCallbackError(logger, safeError, frontend.Name);
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: safeError, cancellationToken).ConfigureAwait(false);
+            return RedirectToError(frontend, safeError);
+        }
+
+        if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
+        {
+            await TryWriteAuthAuditAsync(httpContext, logger, userId: null, userName: null,
+                failureReason: "missing_code_or_state", cancellationToken).ConfigureAwait(false);
+            return RedirectToError(frontend, "missing_code_or_state");
+        }
+
+        return null;
     }
 
 #pragma warning disable GRSEC003 // Method handles tokens — server-side only

--- a/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
+++ b/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
@@ -172,7 +172,7 @@ internal sealed class UserSessionAnomalyDetector(
                 continue;
             }
 
-            if (IsLowConfidence(candidate.Location, opts) || IsLowConfidence(prior.Location, opts))
+            if (PairIsLowConfidence(candidate.Location, prior.Location, opts))
             {
                 suppressed = true;
                 continue;
@@ -183,6 +183,11 @@ internal sealed class UserSessionAnomalyDetector(
 
         return suppressed ? TravelOutcome.SuppressedLowConfidence : TravelOutcome.None;
     }
+
+    // A travel pair is low-confidence when either endpoint's fix is untrustworthy.
+    private static bool PairIsLowConfidence(
+        GeoLocation candidate, GeoLocation prior, IdentityAnomalyDetectionOptions opts) =>
+        IsLowConfidence(candidate, opts) || IsLowConfidence(prior, opts);
 
     // A fix is low-confidence when its reported accuracy radius is too coarse, or the IP is flagged anonymising
     // (and the deployment opts to suppress those). null fields mean "the provider does not classify this" — they

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreDeviceTrustStore.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreDeviceTrustStore.cs
@@ -21,8 +21,9 @@ internal sealed class EfCoreDeviceTrustStore(
 
         // Upsert with one retry: two concurrent "trust this device" writes for the same (userId, deviceId)
         // both miss the existing row and insert, tripping the unique index. On that conflict, re-read and
-        // update the row the winner created. Provider-agnostic (no ON CONFLICT).
-        for (int attempt = 0; ; attempt++)
+        // update the row the winner created. Provider-agnostic (no ON CONFLICT). The second attempt's own
+        // DbUpdateException is no longer caught (filter is attempt == 0), so it surfaces — bounding the loop.
+        for (int attempt = 0; attempt <= 1; attempt++)
         {
             await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserBehavioralProfileStore.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserBehavioralProfileStore.cs
@@ -48,7 +48,8 @@ internal sealed class EfCoreUserBehavioralProfileStore(
         // Upsert+increment each signal with one retry: two concurrent observations of the same
         // (userId, kind, value) can both miss the existing row and both insert, tripping the unique index. On
         // that conflict, re-read and increment the winner's row instead of surfacing the DbUpdateException.
-        for (int attempt = 0; ; attempt++)
+        // The second attempt's own DbUpdateException is not caught (filter is attempt == 0), so it surfaces.
+        for (int attempt = 0; attempt <= 1; attempt++)
         {
             await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserSessionRiskStore.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfCoreUserSessionRiskStore.cs
@@ -27,7 +27,8 @@ internal sealed class EfCoreUserSessionRiskStore(
         // Upsert with one retry: two concurrent assessments of the same (userId, sessionId) both miss the
         // existing row and both insert, tripping the unique index. On that conflict, re-read and update the
         // row the winner created instead of surfacing the DbUpdateException. Provider-agnostic (no ON CONFLICT).
-        for (int attempt = 0; ; attempt++)
+        // The second attempt's own DbUpdateException is not caught (filter is attempt == 0), so it surfaces.
+        for (int attempt = 0; attempt <= 1; attempt++)
         {
             await using IdentityDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -342,32 +342,9 @@ internal static class AdminOidcEndpoints
             descriptor.ConsentType = request.ConsentType;
         }
 
-        if (request.Permissions is not null)
-        {
-            descriptor.Permissions.Clear();
-            foreach (string permission in request.Permissions)
-            {
-                descriptor.Permissions.Add(permission);
-            }
-        }
-
-        if (request.RedirectUris is not null)
-        {
-            descriptor.RedirectUris.Clear();
-            foreach (string uri in request.RedirectUris)
-            {
-                descriptor.RedirectUris.Add(new Uri(uri));
-            }
-        }
-
-        if (request.PostLogoutRedirectUris is not null)
-        {
-            descriptor.PostLogoutRedirectUris.Clear();
-            foreach (string uri in request.PostLogoutRedirectUris)
-            {
-                descriptor.PostLogoutRedirectUris.Add(new Uri(uri));
-            }
-        }
+        ReplaceCollection(descriptor.Permissions, request.Permissions, static p => p);
+        ReplaceCollection(descriptor.RedirectUris, request.RedirectUris, static u => new Uri(u));
+        ReplaceCollection(descriptor.PostLogoutRedirectUris, request.PostLogoutRedirectUris, static u => new Uri(u));
 
         if (request.SigningKeyJwk is not null)
         {
@@ -386,6 +363,23 @@ internal static class AdminOidcEndpoints
         {
             // SetDeviceKind treats Unknown as "clear the declaration".
             descriptor.SetDeviceKind(request.DeviceKind.Value);
+        }
+    }
+
+    // Replaces the full contents of a descriptor collection from a request field: null leaves it untouched,
+    // a present field clears then refills it (mapping each raw string through <paramref name="map"/>).
+    private static void ReplaceCollection<T>(
+        ICollection<T> target, IReadOnlyList<string>? source, Func<string, T> map)
+    {
+        if (source is null)
+        {
+            return;
+        }
+
+        target.Clear();
+        foreach (string item in source)
+        {
+            target.Add(map(item));
         }
     }
 

--- a/src/Granit.QueryEngine.AI/Internal/QueryDataTool.cs
+++ b/src/Granit.QueryEngine.AI/Internal/QueryDataTool.cs
@@ -19,12 +19,6 @@ internal sealed class QueryDataTool<TEntity>(
     IQueryableSource<TEntity> source) : IAITool, IAIToolInstructions
     where TEntity : class
 {
-    private static readonly JsonSerializerOptions ResultSerializerOptions = new(JsonSerializerDefaults.Web)
-    {
-        ReferenceHandler = ReferenceHandler.IgnoreCycles,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     private readonly QueryMetadata _metadata = engine.GetMetadata();
 
     public string Name => $"query_{name}";
@@ -61,6 +55,20 @@ internal sealed class QueryDataTool<TEntity>(
             items = result.Items,
         };
 
-        return AIToolResult.Success(JsonSerializer.Serialize(payload, ResultSerializerOptions));
+        return AIToolResult.Success(JsonSerializer.Serialize(payload, QueryDataToolSerialization.ResultSerializerOptions));
     }
+}
+
+/// <summary>
+/// Holds the JSON options shared by every closed <see cref="QueryDataTool{TEntity}"/>. A non-generic holder so
+/// the options are allocated once, not once per <c>TEntity</c> (a static field in a generic type is per close
+/// constructed type).
+/// </summary>
+file static class QueryDataToolSerialization
+{
+    public static readonly JsonSerializerOptions ResultSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
 }


### PR DESCRIPTION
## Why this PR exists

**#2763 was merged into the stale `chore/sonar-mechanical-cleanup` branch, not `develop`.** #2761 had already merged that branch into develop *before* #2763 landed on it, so #2763's content never reached develop (the stacked-PR hazard). This PR re-applies that work **plus** the new `AIToolOrchestrator` refactor, cleanly based on current `develop`.

## Contents

Two commits, 8 files, behaviour-preserving:

**1. Safe higher-effort smells** (was #2763)
| Fix | File |
| --- | ---- |
| Bound the upsert retry loops so the stop condition tests `attempt` (behaviour identical) | `EfCoreDeviceTrustStore`, `EfCoreUserBehavioralProfileStore`, `EfCoreUserSessionRiskStore` |
| Move shared `JsonSerializerOptions` to a `file`-scoped non-generic holder (S2743) | `QueryDataTool` |
| Cognitive complexity 16→15 — `PairIsLowConfidence` | `UserSessionAnomalyDetector.EvaluateTravel` |
| Cognitive complexity 17→15 — generic `ReplaceCollection` | `AdminOidcEndpoints.ApplyRequestedUpdates` |
| Cognitive complexity 18→15 — `ValidateCallbackParametersAsync` (pure early-format guards only; issuer/PKCE order-sensitive logic untouched) | `BffLoginEndpoints.HandleCallbackAsync` |

**2. AIToolOrchestrator** (new)
| Fix | File |
| --- | ---- |
| Cognitive complexity 25→15 — decomposed into `RunConversationAsync` (the loop → `ConversationOutcome`) + `ExecuteCallsAsync` (one round of tool calls) | `AIToolOrchestrator.RunAsync` |

## Still deliberately skipped

- **`TranslateTool`** (architecture: disallowed relationship to `AIPermissions`) — a framework/ADR design decision (inline the permission string vs. relocate permission constants to a shared package). This file is the documented *reference pattern* for gated tools; needs design sign-off, not a mechanical edit.
- **`BlobBackedExportSource`** — already implements the param-check/iterator split; stale Sonar issue, clears on rescan.
- Two **Info** test nits left intentionally: `SafeTypeLoaderTests` L58 (theory data must be `Exception`), `EmlFixtures` L130 (no valid `[...]` conversion).

## Verification

- `dotnet build` + `dotnet format --verify-no-changes` clean.
- All 6 touched test projects green (360 tests): BFF endpoints (108), OIDC endpoints (122), AI.Tools (42), AnomalyDetection (24), Identity.EFCore (26), QueryEngine.AI (38).