### PR TITLE
fix(ai): translate permission ownership + Sonar code smells

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2010,37 +2010,7 @@
       "name": "Granit.OpenApi.Generator",
       "deps": [
         "Granit.OpenApi.Generation",
-        "Granit.AI.Chat.Endpoints",
-        "Granit.AI.Endpoints",
-        "Granit.AI.Prompts.Endpoints",
-        "Granit.Auditing.Endpoints",
-        "Granit.Authentication.ApiKeys.Endpoints",
-        "Granit.Authorization.Endpoints",
-        "Granit.BackgroundJobs.Endpoints",
-        "Granit.Bff.Endpoints",
-        "Granit.BlobStorage.Endpoints",
-        "Granit.DataExchange.Endpoints",
-        "Granit.DataLookup.Endpoints",
-        "Granit.Diagnostics.Endpoints",
-        "Granit.Features.Endpoints",
-        "Granit.Hostnames.Endpoints",
-        "Granit.Http.Cookies.Endpoints",
-        "Granit.Http.SecurityHeaders.Endpoints",
-        "Granit.Identity.Endpoints",
-        "Granit.Identity.Local.Endpoints",
-        "Granit.Localization.Endpoints",
-        "Granit.MultiTenancy.Endpoints",
-        "Granit.Notifications.Endpoints",
-        "Granit.OpenIddict.Endpoints",
-        "Granit.Presence.Endpoints",
-        "Granit.Privacy.Endpoints",
-        "Granit.Scheduling.Endpoints",
-        "Granit.Settings.Endpoints",
-        "Granit.Templating.Endpoints",
-        "Granit.Timeline.Endpoints",
-        "Granit.Validation.Endpoints",
-        "Granit.Webhooks.Endpoints",
-        "Granit.Workflow.Endpoints"
+        "Granit.*.Endpoints"
       ],
       "framework": "net10.0"
     },
@@ -5197,15 +5167,6 @@
       "project": "Granit.AI",
       "file": "src/Granit.AI/Permissions/AIPermissions.cs",
       "line": 6,
-      "members": []
-    },
-    {
-      "name": "ChatTools",
-      "fqn": "Granit.AI.Permissions.ChatTools",
-      "kind": "class",
-      "project": "Granit.AI",
-      "file": "src/Granit.AI/Permissions/AIPermissions.cs",
-      "line": 28,
       "members": []
     },
     {
@@ -33904,6 +33865,24 @@
           "returnType": "int"
         }
       ]
+    },
+    {
+      "name": "ChatTools",
+      "fqn": "Granit.Localization.AI.Permissions.ChatTools",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/Permissions/LocalizationAIPermissions.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "LocalizationAIPermissions",
+      "fqn": "Granit.Localization.AI.Permissions.LocalizationAIPermissions",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/Permissions/LocalizationAIPermissions.cs",
+      "line": 9,
+      "members": []
     },
     {
       "name": "TranslationItem",

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,7 @@ Seules les **dépendances directes** y figurent. Les dépendances transitives
 sont couvertes par leurs propres avis de licence, restaurés depuis NuGet par
 le consommateur (les packages Granit ne redistribuent pas leurs binaires).
 
-Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.TextExtraction.Ocr.Tesseract lit les dimensions via Granit.Imaging / Magick.NET ; ajout de Markdig pour Granit.TextExtraction.Text)
+Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.TextExtraction.Ocr.Tesseract lit les dimensions via Granit.Imaging / Magick.NET ; ajout de Markdig pour Granit.TextExtraction.Text ; montées de version : PuppeteerSharp 25.1.1, ModelContextProtocol 1.4.0, OpenTelemetry 1.16.0, Testcontainers.MsSql 4.12.0)
 
 ---
 
@@ -92,7 +92,7 @@ Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.
 | PdfPig | 0.1.14 | Copyright (c) Eliot Jones |
 | PDFtoImage | 5.2.1 | Copyright (c) David Sungaila |
 | Pgvector.EntityFrameworkCore | 0.3.0 | Copyright (c) Andrew Kane |
-| PuppeteerSharp | 24.42.0 | PuppeteerSharp Contributors |
+| PuppeteerSharp | 25.1.1 | PuppeteerSharp Contributors |
 | Scalar.AspNetCore | 2.14.14 | Scalar Contributors |
 | Sep | 0.14.1 | Copyright (c) 2023 nietras |
 | SmartFormat | 3.6.1 | Copyright 2011-2025 SmartFormat Project |
@@ -135,17 +135,17 @@ Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.
 | Google.Cloud.Storage.V1 | 4.14.0 | Copyright (c) Google LLC |
 | Magick.NET-Q8-AnyCPU | 14.13.1 | Copyright 2013-2026 Dirk Lemstra |
 | MaxMind.GeoIP2 | 6.0.0 | Copyright (c) MaxMind, Inc. |
-| ModelContextProtocol | 1.3.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |
-| ModelContextProtocol.AspNetCore | 1.3.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |
+| ModelContextProtocol | 1.4.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |
+| ModelContextProtocol.AspNetCore | 1.4.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |
 | OpenIddict | 7.5.0 | Copyright (c) Kévin Chalet |
 | OpenIddict.EntityFrameworkCore | 7.5.0 | Copyright (c) Kévin Chalet |
 | OpenIddict.Server.AspNetCore | 7.5.0 | Copyright (c) Kévin Chalet |
 | OpenIddict.Validation.AspNetCore | 7.5.0 | Copyright (c) Kévin Chalet |
 | OpenIddict.Validation.SystemNetHttp | 7.5.0 | Copyright (c) Kévin Chalet |
-| OpenTelemetry | 1.15.3 | Copyright The OpenTelemetry Authors |
-| OpenTelemetry.Api | 1.15.3 | Copyright The OpenTelemetry Authors |
-| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.3 | Copyright The OpenTelemetry Authors |
-| OpenTelemetry.Extensions.Hosting | 1.15.3 | Copyright The OpenTelemetry Authors |
+| OpenTelemetry | 1.16.0 | Copyright The OpenTelemetry Authors |
+| OpenTelemetry.Api | 1.16.0 | Copyright The OpenTelemetry Authors |
+| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.16.0 | Copyright The OpenTelemetry Authors |
+| OpenTelemetry.Extensions.Hosting | 1.16.0 | Copyright The OpenTelemetry Authors |
 | OpenTelemetry.Instrumentation.AspNetCore | 1.15.2 | Copyright The OpenTelemetry Authors |
 | OpenTelemetry.Instrumentation.AWS | 1.15.1 | Copyright The OpenTelemetry Authors |
 | OpenTelemetry.Instrumentation.EntityFrameworkCore | 1.15.1-beta.1 | Copyright The OpenTelemetry Authors |
@@ -205,7 +205,7 @@ Dernière mise à jour : 2026-06-15 (retrait de SixLabors.ImageSharp — Granit.
 | Microsoft.NET.Test.Sdk | 18.5.1 | (c) Microsoft Corporation |
 | Testcontainers.Elasticsearch | 4.12.0 | Copyright (c) 2019-2026 Andre Hofmeister and other authors |
 | Testcontainers.Keycloak | 4.12.0 | Copyright (c) 2019-2026 Andre Hofmeister and other authors |
-| Testcontainers.MsSql | 4.11.0 | Copyright (c) 2019-2025 Andre Hofmeister |
+| Testcontainers.MsSql | 4.12.0 | Copyright (c) 2019-2026 Andre Hofmeister and other authors |
 | Testcontainers.PostgreSql | 4.12.0 | Copyright (c) 2019-2025 Andre Hofmeister |
 | Testcontainers.Redis | 4.12.0 | Copyright (c) 2019-2025 Andre Hofmeister |
 

--- a/scripts/_slnx_utils.py
+++ b/scripts/_slnx_utils.py
@@ -8,6 +8,7 @@ No external dependencies — runs with Python 3.8+.
 
 from __future__ import annotations
 
+import glob
 import json
 import re
 import sys
@@ -61,6 +62,14 @@ def parse_project_references(csproj: Path) -> list[Path]:
         rel = match.replace("\\", "/")
         # Skip MSBuild property references like $(MSBuildThisFileDirectory)
         if "$(" in rel:
+            continue
+        if "*" in rel:
+            # MSBuild wildcard ProjectReference (e.g. Granit.*.Endpoints/Granit.*.Endpoints.csproj).
+            # glob matches MSBuild's '*' semantics (no separator crossing) and resolves the '..'.
+            for matched in sorted(glob.glob(str(csproj.parent / rel))):
+                resolved = Path(matched).resolve()
+                if resolved.is_file() and resolved not in refs:
+                    refs.append(resolved)
             continue
         resolved = (csproj.parent / rel).resolve()
         if resolved.is_file():

--- a/src/Granit.AI/Diagnostics/TracingChatClient.cs
+++ b/src/Granit.AI/Diagnostics/TracingChatClient.cs
@@ -126,8 +126,23 @@ public abstract class TracingChatClient(
     /// <inheritdoc />
     public void Dispose()
     {
-        inner.Dispose();
+        Dispose(disposing: true);
         GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes the decorator. Releases the wrapped <see cref="IChatClient"/>; override to release
+    /// resources a provider subclass adds, always calling the base implementation.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true"/> when called from <see cref="Dispose()"/>; <see langword="false"/> from a finalizer.
+    /// </param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            inner.Dispose();
+        }
     }
 
     private Activity? StartActivity(string operationName)

--- a/src/Granit.AI/Permissions/AIPermissionDefinitionProvider.cs
+++ b/src/Granit.AI/Permissions/AIPermissionDefinitionProvider.cs
@@ -23,11 +23,5 @@ internal sealed class AIPermissionDefinitionProvider : IPermissionDefinitionProv
         group.AddPermission(
             AIPermissions.Credentials.Manage,
             LocalizableString.Create<AILocalizationResource>("Permission:AI.Credentials.Manage"));
-
-        // Per-tool gating for agentic chat capability tools (ADR-067). Off by default — an admin
-        // grants the tool's permission to enable it for a user or role.
-        group.AddPermission(
-            AIPermissions.ChatTools.Translate,
-            LocalizableString.Create<AILocalizationResource>("Permission:AI.ChatTools.Translate"));
     }
 }

--- a/src/Granit.AI/Permissions/AIPermissions.cs
+++ b/src/Granit.AI/Permissions/AIPermissions.cs
@@ -19,15 +19,4 @@ public static class AIPermissions
         /// </summary>
         public const string Manage = "AI.Credentials.Manage";
     }
-
-    /// <summary>
-    /// Per-tool permissions for agentic chat capability tools (ADR-067). A gated tool is offered
-    /// to a user only when they hold the matching permission, so admins enable capabilities tool
-    /// by tool. The action segment is the capability name (a domain-specific action).
-    /// </summary>
-    public static class ChatTools
-    {
-        /// <summary>Grants the right to use the <c>translate</c> chat tool (Localization.AI).</summary>
-        public const string Translate = "AI.ChatTools.Translate";
-    }
 }

--- a/src/Granit.Localization.AI/Internal/TranslateTool.cs
+++ b/src/Granit.Localization.AI/Internal/TranslateTool.cs
@@ -1,14 +1,14 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Granit.AI.Permissions;
 using Granit.AI.Tools;
+using Granit.Localization.AI.Permissions;
 
 namespace Granit.Localization.AI.Internal;
 
 /// <summary>
 /// A gated capability tool (ADR-067, "agent-as-tool" single-shot sub-agent) that wraps
 /// <see cref="ITranslationSuggestionService"/> as the <c>translate</c> chat tool. Gated by
-/// <see cref="AIPermissions.ChatTools.Translate"/> so admins enable it per user/role.
+/// <see cref="LocalizationAIPermissions.ChatTools.Translate"/> so admins enable it per user/role.
 /// </summary>
 /// <remarks>
 /// This is the reference pattern for wrapping an existing <c>*.AI</c> capability as a chat tool:
@@ -26,7 +26,7 @@ internal sealed class TranslateTool(ITranslationSuggestionService translationSer
     public string Description =>
         "Translate a short piece of text into a target language. Returns the translated text.";
 
-    public string RequiredPermission => AIPermissions.ChatTools.Translate;
+    public string RequiredPermission => LocalizationAIPermissions.ChatTools.Translate;
 
     public JsonElement ParameterSchema => Schema;
 

--- a/src/Granit.Localization.AI/Permissions/LocalizationAIPermissionDefinitionProvider.cs
+++ b/src/Granit.Localization.AI/Permissions/LocalizationAIPermissionDefinitionProvider.cs
@@ -1,0 +1,31 @@
+using Granit.AI;
+using Granit.Authorization;
+
+namespace Granit.Localization.AI.Permissions;
+
+/// <summary>
+/// Declares the permissions owned by <c>Granit.Localization.AI</c> — the per-tool gate for the
+/// <c>translate</c> chat capability (ADR-067) — under the shared <c>AI</c> group.
+/// </summary>
+/// <remarks>
+/// Auto-discovered by <c>GranitAuthorizationModule</c>'s reflection scan over module assemblies.
+/// The <c>AI</c> group is also declared by <c>Granit.AI</c>; <see cref="IPermissionDefinitionContext.AddGroup"/>
+/// has GetOrAdd semantics, so both providers contribute to the one group and the group's display
+/// strings stay in the shared <see cref="AILocalizationResource"/> bundle.
+/// </remarks>
+internal sealed class LocalizationAIPermissionDefinitionProvider : IPermissionDefinitionProvider
+{
+    /// <inheritdoc />
+    public void DefinePermissions(IPermissionDefinitionContext context)
+    {
+        PermissionGroup group = context.AddGroup(
+            LocalizationAIPermissions.GroupName,
+            LocalizableString.Create<AILocalizationResource>("PermissionGroup:AI"));
+
+        // Per-tool gating for the translate chat tool (ADR-067). Off by default — an admin grants
+        // the tool's permission to enable it for a user or role.
+        group.AddPermission(
+            LocalizationAIPermissions.ChatTools.Translate,
+            LocalizableString.Create<AILocalizationResource>("Permission:AI.ChatTools.Translate"));
+    }
+}

--- a/src/Granit.Localization.AI/Permissions/LocalizationAIPermissions.cs
+++ b/src/Granit.Localization.AI/Permissions/LocalizationAIPermissions.cs
@@ -1,0 +1,23 @@
+namespace Granit.Localization.AI.Permissions;
+
+/// <summary>
+/// Permission constants owned by <c>Granit.Localization.AI</c>. The translate chat tool
+/// (ADR-067) registers under the shared <c>AI</c> permission group, so its action name keeps
+/// the <c>AI.</c> prefix while ownership of the declaration lives with the module that ships
+/// the tool.
+/// </summary>
+public static class LocalizationAIPermissions
+{
+    /// <summary>Name of the shared <c>AI</c> permission group these permissions register under.</summary>
+    public const string GroupName = "AI";
+
+    /// <summary>
+    /// Per-tool permissions for agentic chat capability tools (ADR-067) contributed by
+    /// <c>Granit.Localization.AI</c>.
+    /// </summary>
+    public static class ChatTools
+    {
+        /// <summary>Grants the right to use the <c>translate</c> chat tool.</summary>
+        public const string Translate = "AI.ChatTools.Translate";
+    }
+}

--- a/src/Granit.OpenApi.Generator/Granit.OpenApi.Generator.csproj
+++ b/src/Granit.OpenApi.Generator/Granit.OpenApi.Generator.csproj
@@ -22,37 +22,11 @@
     <!-- Shared doc-gen orchestration: OpenApiContractGenerator.RunAsync (per-module slicing, infra
          neutralization, the minimal-API binding probe). Brings Granit + Granit.Http.ApiDocumentation. -->
     <ProjectReference Include="..\Granit.OpenApi.Generation\Granit.OpenApi.Generation.csproj" />
-    <ProjectReference Include="..\Granit.AI.Chat.Endpoints\Granit.AI.Chat.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.AI.Endpoints\Granit.AI.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.AI.Prompts.Endpoints\Granit.AI.Prompts.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Auditing.Endpoints\Granit.Auditing.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Authentication.ApiKeys.Endpoints\Granit.Authentication.ApiKeys.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Authorization.Endpoints\Granit.Authorization.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.BackgroundJobs.Endpoints\Granit.BackgroundJobs.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Bff.Endpoints\Granit.Bff.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.BlobStorage.Endpoints\Granit.BlobStorage.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.DataExchange.Endpoints\Granit.DataExchange.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.DataLookup.Endpoints\Granit.DataLookup.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Diagnostics.Endpoints\Granit.Diagnostics.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Features.Endpoints\Granit.Features.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Hostnames.Endpoints\Granit.Hostnames.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Http.Cookies.Endpoints\Granit.Http.Cookies.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Http.SecurityHeaders.Endpoints\Granit.Http.SecurityHeaders.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Identity.Endpoints\Granit.Identity.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Identity.Local.Endpoints\Granit.Identity.Local.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Localization.Endpoints\Granit.Localization.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.MultiTenancy.Endpoints\Granit.MultiTenancy.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Notifications.Endpoints\Granit.Notifications.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.OpenIddict.Endpoints\Granit.OpenIddict.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Presence.Endpoints\Granit.Presence.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Privacy.Endpoints\Granit.Privacy.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Scheduling.Endpoints\Granit.Scheduling.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Settings.Endpoints\Granit.Settings.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Templating.Endpoints\Granit.Templating.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Timeline.Endpoints\Granit.Timeline.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Validation.Endpoints\Granit.Validation.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Webhooks.Endpoints\Granit.Webhooks.Endpoints.csproj" />
-    <ProjectReference Include="..\Granit.Workflow.Endpoints\Granit.Workflow.Endpoints.csproj" />
+    <!-- Reference every Granit.{Module}.Endpoints via wildcard so a newly added endpoint module
+         is picked up automatically (no manual edit here). NOTE: this only auto-wires the compile
+         reference. The module still MUST be added to GeneratorModule's [DependsOn] (service config)
+         AND GeneratorEndpoints.All (slug + route mapping) — those drive generation, not the glob. -->
+    <ProjectReference Include="..\Granit.*.Endpoints\Granit.*.Endpoints.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests/IndexingLanguageMapTests.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests/IndexingLanguageMapTests.cs
@@ -10,44 +10,32 @@ public sealed class IndexingLanguageMapTests
     [InlineData("fr", "french")]
     [InlineData("ar", "arabic")]
     [InlineData("yi", "yiddish")]
-    public void GetPostgresDictionary_maps_known_iso_codes(string iso, string expected)
-    {
+    public void GetPostgresDictionary_maps_known_iso_codes(string iso, string expected) =>
         IndexingLanguageMap.GetPostgresDictionary(iso, "simple").ShouldBe(expected);
-    }
 
     [Fact]
-    public void GetPostgresDictionary_is_case_insensitive()
-    {
+    public void GetPostgresDictionary_is_case_insensitive() =>
         IndexingLanguageMap.GetPostgresDictionary("EN", "simple").ShouldBe("english");
-    }
 
     [Theory]
     [InlineData("zz")]   // unknown ISO code
     [InlineData(null)]   // no language detected
     [InlineData("")]     // empty
-    public void GetPostgresDictionary_returns_the_fallback_when_unmapped(string? iso)
-    {
+    public void GetPostgresDictionary_returns_the_fallback_when_unmapped(string? iso) =>
         IndexingLanguageMap.GetPostgresDictionary(iso, "simple").ShouldBe("simple");
-    }
 
     [Fact]
-    public void GetPostgresDictionary_requires_a_non_empty_fallback()
-    {
+    public void GetPostgresDictionary_requires_a_non_empty_fallback() =>
         Should.Throw<ArgumentException>(() => IndexingLanguageMap.GetPostgresDictionary("en", ""));
-    }
 
     [Theory]
     [InlineData("en", true)]
     [InlineData("DE", true)]
     [InlineData("zz", false)]
-    public void HasMapping_reflects_the_known_dictionary_set(string iso, bool expected)
-    {
+    public void HasMapping_reflects_the_known_dictionary_set(string iso, bool expected) =>
         IndexingLanguageMap.HasMapping(iso).ShouldBe(expected);
-    }
 
     [Fact]
-    public void HasMapping_requires_a_non_empty_code()
-    {
+    public void HasMapping_requires_a_non_empty_code() =>
         Should.Throw<ArgumentException>(() => IndexingLanguageMap.HasMapping(""));
-    }
 }

--- a/tests/Granit.IpGeolocation.MaxMind.Tests/MaxMindIpGeolocationProviderTests.cs
+++ b/tests/Granit.IpGeolocation.MaxMind.Tests/MaxMindIpGeolocationProviderTests.cs
@@ -25,10 +25,8 @@ public sealed class MaxMindIpGeolocationProviderTests
     }
 
     [Fact]
-    public void ProviderName_comes_from_options()
-    {
+    public void ProviderName_comes_from_options() =>
         Build(providerName: "OnPremGeo").ProviderName.ShouldBe("OnPremGeo");
-    }
 
     [Fact]
     public async Task ResolveAsync_returns_a_location_for_a_known_address()

--- a/tests/Granit.LanguageDetection.Tests/Diagnostics/LanguageDetectionMetricsTests.cs
+++ b/tests/Granit.LanguageDetection.Tests/Diagnostics/LanguageDetectionMetricsTests.cs
@@ -51,10 +51,8 @@ public sealed class LanguageDetectionMetricsTests
     }
 
     [Fact]
-    public void Constructor_rejects_a_null_meter_factory()
-    {
+    public void Constructor_rejects_a_null_meter_factory() =>
         Should.Throw<ArgumentNullException>(() => new LanguageDetectionMetrics(null!));
-    }
 
     private sealed class Harness : IDisposable
     {

--- a/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
+++ b/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
-using Granit.AI.Permissions;
 using Granit.AI.Tools;
 using Granit.Localization.AI.Internal;
+using Granit.Localization.AI.Permissions;
 using NSubstitute;
 using Shouldly;
 
@@ -19,7 +19,7 @@ public sealed class TranslateToolTests
 
         tool.Name.ShouldBe("translate");
         tool.ShouldBeAssignableTo<IGatedAITool>();
-        ((IGatedAITool)tool).RequiredPermission.ShouldBe(AIPermissions.ChatTools.Translate);
+        ((IGatedAITool)tool).RequiredPermission.ShouldBe(LocalizationAIPermissions.ChatTools.Translate);
     }
 
     [Fact]

--- a/tests/Granit.Tests/SafeTypeLoaderTests.cs
+++ b/tests/Granit.Tests/SafeTypeLoaderTests.cs
@@ -55,21 +55,18 @@ public sealed class SafeTypeLoaderTests
     }
 
     [Theory]
-    [MemberData(nameof(MissingDependencyExceptions))]
-    public void Missing_dependency_failures_return_empty(Exception exception)
+    [InlineData(typeof(FileNotFoundException))]
+    [InlineData(typeof(FileLoadException))]
+    [InlineData(typeof(TypeLoadException))]
+    public void Missing_dependency_failures_return_empty(Type exceptionType)
     {
+        var exception = (Exception)Activator.CreateInstance(exceptionType)!;
+
         IReadOnlyList<Type> result = SafeTypeLoader.Load(
             typeof(SafeTypeLoader).Assembly, _ => throw exception);
 
         result.ShouldBeEmpty();
     }
-
-    public static TheoryData<Exception> MissingDependencyExceptions() =>
-    [
-        new FileNotFoundException(),
-        new FileLoadException(),
-        new TypeLoadException(),
-    ];
 
     [Fact]
     public void Unexpected_exceptions_propagate()

--- a/tests/Granit.TextExtraction.Email.Tests/EmlFixtures.cs
+++ b/tests/Granit.TextExtraction.Email.Tests/EmlFixtures.cs
@@ -127,16 +127,18 @@ internal static class EmlFixtures
         // Build a multipart/encrypted body shaped like an OpenPGP-MIME message
         // without any real cryptographic material — the extractor only inspects
         // the wrapper type to decide to short-circuit.
-        MultipartEncrypted encrypted = new();
+        MultipartEncrypted encrypted =
+        [
+            new MimePart("application", "pgp-encrypted")
+            {
+                Content = new MimeContent(new MemoryStream(Encoding.ASCII.GetBytes("Version: 1\n"))),
+            },
+            new MimePart("application", "octet-stream")
+            {
+                Content = new MimeContent(new MemoryStream(Encoding.ASCII.GetBytes("encrypted-blob"))),
+            },
+        ];
         encrypted.ContentType.Parameters["protocol"] = "application/pgp-encrypted";
-        encrypted.Add(new MimePart("application", "pgp-encrypted")
-        {
-            Content = new MimeContent(new MemoryStream(Encoding.ASCII.GetBytes("Version: 1\n"))),
-        });
-        encrypted.Add(new MimePart("application", "octet-stream")
-        {
-            Content = new MimeContent(new MemoryStream(Encoding.ASCII.GetBytes("encrypted-blob"))),
-        });
         message.Body = encrypted;
         return Serialize(message);
     }


### PR DESCRIPTION
## Summary

Resolves a batch of SonarQube findings (headlined by an architecture deviation), plus build-tooling housekeeping.

### Architecture (High) — `TranslateTool → AIPermissions`
The `translate` chat tool lives in `Granit.Localization.AI` but its permission was declared in `Granit.AI`, creating a disallowed reference to `AIPermissions`. Ownership now follows *each module owns its registrations*:
- New `LocalizationAIPermissions.ChatTools.Translate` + `LocalizationAIPermissionDefinitionProvider` in the owning module.
- The provider contributes to the shared `AI` permission group via the context's **GetOrAdd** semantics (auto-discovered over `ModuleAssemblies`).
- Localization keys (`Permission:AI.ChatTools.Translate`, 18 cultures) stay in the shared `AI` resource bundle — no L10n files moved.

### Code smells
- **`TracingChatClient`** (Major, S3881): conform to the `IDisposable` pattern with `protected virtual void Dispose(bool)` — unsealed base for per-provider subclasses.
- **`SafeTypeLoaderTests`** (Info): serializable theory data (`[InlineData(typeof(...))]`) so Test Explorer enumerates rows.
- **`EmlFixtures`** (Info): collection initializer for `MultipartEncrypted`.
- **Indexing / MaxMind / LanguageDetection tests** (Info): expression-bodied methods.

### Build tooling (2nd commit)
- `Granit.OpenApi.Generator`: reference `Granit.*.Endpoints` via wildcard so new endpoint modules are picked up automatically (still requires the module in `GeneratorModule` `[DependsOn]` + `GeneratorEndpoints.All` to drive generation).
- `scripts/_slnx_utils.parse_project_references`: **expand MSBuild wildcard ProjectReferences via glob** — without this the `*` refs resolve to no file and ~50 projects silently drop out of `.slnf/framework-only.slnf` / `.slnf/platform.slnf`. After the fix, regenerated filters show **no diff**.
- `THIRD-PARTY-NOTICES`: catch up to already-bumped floating versions (PuppeteerSharp 25.1.1, ModelContextProtocol 1.4.0, OpenTelemetry 1.16.0, Testcontainers.MsSql 4.12.0).

### Note — already-resolved finding
`BlobBackedExportSource` (Major, S4456 yield split) was **already fixed** by #2616 — no change here; mark Resolved in SonarQube.

## Verification
- Builds: 0 warnings across all touched projects (incl. `Granit.OpenApi.Generator` with the glob).
- Tests: Granit.AI (77), Localization.AI (44), Granit.Tests (546), Email (26), Indexing.EFCore (26), MaxMind (15), LanguageDetection (15), ArchitectureTests permission/namespace/dependency (40) — all green.
- `dotnet format --verify-no-changes` clean; `.slnf` + shard filters regenerate with no diff.