### PR TITLE
fix(ci): accept endpoints glob in generator test + fix MaxMind hot-reload race

### DIFF
--- a/src/Granit.IpGeolocation.MaxMind/Internal/MaxMindDatabaseProvider.cs
+++ b/src/Granit.IpGeolocation.MaxMind/Internal/MaxMindDatabaseProvider.cs
@@ -18,7 +18,11 @@ internal sealed partial class MaxMindDatabaseProvider : IDisposable
 {
     private readonly MaxMindIpGeolocationOptions _options;
     private readonly ILogger<MaxMindDatabaseProvider> _logger;
-    private readonly Lock _gate = new();
+
+    // Read/write lock (not System.Threading.Lock): lookups are concurrent readers held for the whole
+    // read, the hot-reload swap is the exclusive writer. Disposing the superseded reader under the write
+    // lock guarantees no in-flight lookup is still reading its memory-mapped buffer (ObjectDisposedException).
+    private readonly ReaderWriterLockSlim _gate = new();
     private DatabaseReader _reader;
     private bool _isCityDatabase;
     private FileSystemWatcher? _watcher;
@@ -40,15 +44,15 @@ internal sealed partial class MaxMindDatabaseProvider : IDisposable
     /// <summary>Looks up <paramref name="address"/>, returning <c>null</c> when it is absent from the database.</summary>
     public GeoLocation? Lookup(IPAddress address)
     {
-        DatabaseReader reader;
-        bool isCity;
-        lock (_gate)
+        _gate.EnterReadLock();
+        try
         {
-            reader = _reader;
-            isCity = _isCityDatabase;
+            return _isCityDatabase ? LookupCity(_reader, address) : LookupCountry(_reader, address);
         }
-
-        return isCity ? LookupCity(reader, address) : LookupCountry(reader, address);
+        finally
+        {
+            _gate.ExitReadLock();
+        }
     }
 
     private static GeoLocation? LookupCity(DatabaseReader reader, IPAddress address)
@@ -126,14 +130,22 @@ internal sealed partial class MaxMindDatabaseProvider : IDisposable
         {
             (DatabaseReader newReader, bool isCity) = Open();
             DatabaseReader previous;
-            lock (_gate)
+            _gate.EnterWriteLock();
+            try
             {
                 previous = _reader;
                 _reader = newReader;
                 _isCityDatabase = isCity;
+
+                // Dispose under the write lock: all concurrent lookups have drained, so the
+                // superseded reader's memory-mapped buffer can no longer be read mid-disposal.
+                previous.Dispose();
+            }
+            finally
+            {
+                _gate.ExitWriteLock();
             }
 
-            previous.Dispose();
             LogDatabaseReloaded();
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDatabaseException)
@@ -145,8 +157,20 @@ internal sealed partial class MaxMindDatabaseProvider : IDisposable
 
     public void Dispose()
     {
+        // Stop the watcher first so no reload races the teardown, then dispose the live reader
+        // under the write lock to wait out any in-flight lookup.
         _watcher?.Dispose();
-        _reader.Dispose();
+        _gate.EnterWriteLock();
+        try
+        {
+            _reader.Dispose();
+        }
+        finally
+        {
+            _gate.ExitWriteLock();
+        }
+
+        _gate.Dispose();
     }
 
     [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "MaxMind geolocation database reloaded.")]

--- a/tests/Granit.ArchitectureTests/OpenApiGeneratorCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/OpenApiGeneratorCompletenessTests.cs
@@ -43,9 +43,18 @@ public sealed partial class OpenApiGeneratorCompletenessTests
                 .Where(name => name.EndsWith(".Endpoints", StringComparison.Ordinal))
                 .OrderBy(name => name, StringComparer.Ordinal)];
 
+        // A single wildcard ProjectReference (Granit.*.Endpoints) compile-references every
+        // endpoints module by construction, so a new module is wired in automatically — there
+        // is nothing to drift. Accept it as exhaustive. (DependsOn + registry completeness are
+        // still enforced by the other two facts; the glob only auto-wires the compile reference.)
+        if (referenced is ["Granit.*.Endpoints"])
+        {
+            return;
+        }
+
         referenced.ShouldBe(EndpointsProjectNames,
             "Granit.OpenApi.Generator.csproj must <ProjectReference> exactly every src/Granit.*.Endpoints " +
-            "project — no missing modules, no stale references.");
+            "project (or the single Granit.*.Endpoints wildcard) — no missing modules, no stale references.");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes two independent failures surfaced on the `architecture` and IpGeolocation test shards.

## 1. `OpenApiGeneratorCompletenessTests.Generator_csproj_references_exactly_the_endpoints_projects`

Commit 0b02d97c9 deliberately switched `Granit.OpenApi.Generator.csproj` to a single `Granit.*.Endpoints` wildcard `ProjectReference` so new endpoint modules are picked up without a manual edit. The csproj completeness fact still expected an explicit, exhaustive list and read the literal glob as one stale entry, failing the build.

The wildcard reference is exhaustive **by construction** — a new module is compile-referenced automatically, so there is nothing to drift. The test now accepts the single `Granit.*.Endpoints` wildcard as complete. The other two facts (`GeneratorModule` `[DependsOn]` and `GeneratorEndpoints.All` registry) still enforce per-module wiring, since the glob only auto-wires the compile reference, not service config or route mounting.

## 2. `MaxMindDatabaseProviderTests.Hot_reload_swaps_in_the_new_database_on_file_change` — `ObjectDisposedException`

`MaxMindDatabaseProvider.Lookup` copied the `_reader` reference under the lock, **released the lock, then read** from that reader. A concurrent hot-reload (file watcher firing mid-lookup) swapped in a new reader and disposed the previous one while the lookup was still reading its memory-mapped buffer → `ObjectDisposedException: 'MemoryMapBuffer'`.

Replaced the `Lock` with a `ReaderWriterLockSlim`:
- `Lookup` holds a **read lock for the whole read** (lookups stay concurrent).
- `Reload`/`Dispose` take the **write lock** and dispose the superseded reader under it, guaranteeing every in-flight lookup has drained before the buffer is freed.

## Testing
- `dotnet test tests/Granit.IpGeolocation.MaxMind.Tests` — 15/15 pass
- `dotnet test tests/Granit.ArchitectureTests --filter ~OpenApiGeneratorCompletenessTests` — 3/3 pass
- `dotnet format --verify-no-changes` clean on both changed projects