### PR TITLE
fix(queryengine): fail loud on SingleValueObject columns in global search & contains filters

### DIFF
--- a/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
+++ b/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
@@ -13,14 +13,20 @@ public sealed class ManagedHostnameQueryDefinition : QueryDefinition<ManagedHost
     protected override void Configure(QueryDefinitionBuilder<ManagedHostname> builder)
     {
         builder
-            .Column(e => e.Host.Value, c => c.Label("Host").LabelKey("Hostnames.Columns.Host").Filterable().Sortable())
+            // Host is a Hostname value object (SingleValueObject<string>). It is mapped by a
+            // ValueConverter, so it can be displayed and sorted (whole-value round-trips), but it
+            // cannot be substring-searched or filtered: EF Core cannot translate LIKE over a
+            // converter, and the engine cannot build a VO instance from a filter string. Hence no
+            // .Filterable() and no GlobalSearch on Host — selecting `e => e.Host.Value` to dodge
+            // this throws at definition build. See issue #2767.
+            .Column(e => e.Host, c => c.Label("Host").LabelKey("Hostnames.Columns.Host").Sortable())
             .Column(e => e.OwnerType, c => c.Label("Owner Type").LabelKey("Hostnames.Columns.OwnerType").Filterable().Sortable())
             .Column(e => e.OwnerId, c => c.Label("Owner Id").LabelKey("Hostnames.Columns.OwnerId").Filterable())
             .Column(e => e.IsPrimary, c => c.Label("Primary").LabelKey("Hostnames.Columns.IsPrimary").Filterable().Sortable())
             .Column(e => e.Status, c => c.Label("Status").LabelKey("Hostnames.Columns.Status").Filterable().Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("Hostnames.Columns.CreatedAt").Sortable())
             .Column(e => e.ModifiedAt, c => c.Label("Modified At").LabelKey("Hostnames.Columns.ModifiedAt").Sortable())
-            .GlobalSearch(e => e.Host.Value, e => e.OwnerType)
+            .GlobalSearch(e => e.OwnerType)
             .DateFilter(e => e.CreatedAt)
             .DefaultSort("host")
             .DefaultPageSize(25);

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -154,6 +154,25 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
     {
         foreach (Expression<Func<TEntity, string?>> property in properties)
         {
+            // Reject a value-object column smuggled in via its implicit string operator
+            // (e.g. a SingleValueObject<string> selected as `x => x.Host`): the compiler
+            // wraps the member access in a Convert node whose operand is the non-string VO
+            // type. Such a column is mapped by a ValueConverter, which EF Core treats as an
+            // opaque whole-value round-trip — LIKE never translates, so the search term is
+            // silently dropped and the whole (scoped) table is returned. Fail loud here
+            // instead of shipping a no-op global search. See issue #2767.
+            if (property.Body is UnaryExpression { NodeType: ExpressionType.Convert } convert
+                && convert.Operand.Type != typeof(string))
+            {
+                throw new ArgumentException(
+                    $"GlobalSearch property '{GetPropertyName(property)}' has CLR type " +
+                    $"'{convert.Operand.Type.Name}', not string. Value-object columns " +
+                    $"(SingleValueObject<string>) cannot be substring-searched: EF Core cannot " +
+                    $"translate LIKE over a ValueConverter, so the term would be silently ignored. " +
+                    $"Use a plain string column for global search. See issue #2767.",
+                    nameof(properties));
+            }
+
             GlobalSearchProperties.Add(GetPropertyName(property));
         }
 
@@ -469,8 +488,20 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
 
         if (member is null || member.Expression is not ParameterExpression)
         {
+            // A nested access such as `x => x.Host.Value` (drilling into a SingleValueObject
+            // to reach its primitive) is the common cause: the value object is mapped as a
+            // whole-value ValueConverter, so the inner `.Value` is not an independently
+            // queryable column. Point the author at the real constraint rather than emitting
+            // an opaque error. See issue #2767.
+            string hint = member?.Expression is MemberExpression inner
+                ? $" Nested access like 'x => x.{inner.Member.Name}.{member.Member.Name}' is not " +
+                  $"supported; if '{inner.Member.Name}' is a SingleValueObject, value-object columns " +
+                  $"cannot be substring-searched or filtered (see issue #2767) — select a plain " +
+                  $"string column instead."
+                : string.Empty;
+
             throw new ArgumentException(
-                "Expression must be a simple property access (e.g. x => x.Name).",
+                "Expression must be a simple property access (e.g. x => x.Name)." + hint,
                 nameof(expression));
         }
 

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Diagnostics/QueryEngineEfCoreLog.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Diagnostics/QueryEngineEfCoreLog.cs
@@ -27,4 +27,9 @@ internal static partial class QueryEngineEfCoreLog
         Message = "Stream limit reached for entity type {EntityType}: {Limit} items — results are truncated")]
     public static partial void StreamLimitReached(
         ILogger logger, string entityType, int limit);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Substring filter (contains/startsWith/endsWith) on field '{Field}' of non-string type {ColumnType} is ignored — EF Core cannot translate LIKE over a value-object/non-string column. See issue #2767.")]
+    public static partial void SubstringFilterOnNonStringColumnIgnored(
+        ILogger logger, string field, string columnType);
 }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
@@ -74,9 +74,9 @@ internal static class FilterExpressionBuilder
         Expression? body = criteria.Operator switch
         {
             FilterOperator.Eq => BuildEqualsExpression(member, criteria.Value, propertyType, logger, criteria.Field),
-            FilterOperator.Contains => BuildStringMethodExpression(member, criteria.Value, StringContainsMethod),
-            FilterOperator.StartsWith => BuildStringMethodExpression(member, criteria.Value, StringStartsWithMethod),
-            FilterOperator.EndsWith => BuildStringMethodExpression(member, criteria.Value, StringEndsWithMethod),
+            FilterOperator.Contains => BuildStringMethodExpression(member, criteria.Value, StringContainsMethod, logger, criteria.Field),
+            FilterOperator.StartsWith => BuildStringMethodExpression(member, criteria.Value, StringStartsWithMethod, logger, criteria.Field),
+            FilterOperator.EndsWith => BuildStringMethodExpression(member, criteria.Value, StringEndsWithMethod, logger, criteria.Field),
             FilterOperator.Gt => BuildComparisonExpression(member, criteria.Value, propertyType, Expression.GreaterThan, logger, criteria.Field),
             FilterOperator.Gte => BuildComparisonExpression(member, criteria.Value, propertyType, Expression.GreaterThanOrEqual, logger, criteria.Field),
             FilterOperator.Lt => BuildComparisonExpression(member, criteria.Value, propertyType, Expression.LessThan, logger, criteria.Field),
@@ -109,10 +109,21 @@ internal static class FilterExpressionBuilder
     }
 
     private static BinaryExpression? BuildStringMethodExpression(
-        Expression member, string value, MethodInfo method)
+        Expression member, string value, MethodInfo method,
+        ILogger? logger = null, string? field = null)
     {
         if (member.Type != typeof(string))
         {
+            // A value-object column (SingleValueObject<string>) is mapped by a ValueConverter;
+            // EF Core cannot translate LIKE over it, so a substring filter would either be
+            // dropped or mistranslated. Surface it instead of silently returning no predicate
+            // (which previously made the criterion vanish from the query). See issue #2767.
+            if (logger is not null)
+            {
+                QueryEngineEfCoreLog.SubstringFilterOnNonStringColumnIgnored(
+                    logger, field ?? "(unknown)", member.Type.Name);
+            }
+
             return null;
         }
 

--- a/src/Granit.Webhooks/Queries/WebhookSubscriptionQueryDefinition.cs
+++ b/src/Granit.Webhooks/Queries/WebhookSubscriptionQueryDefinition.cs
@@ -22,7 +22,11 @@ public sealed class WebhookSubscriptionQueryDefinition : QueryDefinition<Webhook
         builder
             .Column(s => s.TenantId, c => c.Label("Tenant").LabelKey("Webhooks.Columns.Tenant").Filterable().Sortable())
             .Column(s => s.EventType, c => c.Label("Event Type").LabelKey("Webhooks.Columns.EventType").Filterable().Sortable())
-            .Column(s => s.TargetUrl, c => c.Label("Target URL").LabelKey("Webhooks.Columns.TargetUrl").Filterable())
+            // TargetUrl is a HttpsUrl value object (SingleValueObject<string>): mapped by a
+            // ValueConverter, so it is display-only here. It is not .Filterable() because the
+            // engine cannot build a VO instance from a filter string (an Eq filter would
+            // mistranslate, and substring filters cannot translate to LIKE). See issue #2767.
+            .Column(s => s.TargetUrl, c => c.Label("Target URL").LabelKey("Webhooks.Columns.TargetUrl"))
             .Column(s => s.Status, c => c.Label("Status").LabelKey("Webhooks.Columns.Status").Filterable().Sortable())
             .Column(s => s.ConsecutiveFailureCount, c => c.Label("Consecutive Failures").LabelKey("Webhooks.Columns.ConsecutiveFailures").Sortable())
             .Column(s => s.LastSuccessAt, c => c.Label("Last Success At").LabelKey("Webhooks.Columns.LastSuccessAt").Sortable())

--- a/tests/Granit.Hostnames.Tests/ManagedHostnameQueryDefinitionTests.cs
+++ b/tests/Granit.Hostnames.Tests/ManagedHostnameQueryDefinitionTests.cs
@@ -1,0 +1,46 @@
+using Granit.Hostnames.Domain;
+using Granit.Hostnames.Queries;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Hostnames.Tests;
+
+// Regression for issue #2767: the definition previously used `e => e.Host.Value` (drilling into
+// the Hostname value object), which threw ArgumentException at construction — the grid was
+// uninstantiable and untested. Host is now a display/sort-only column (value objects cannot be
+// substring-searched or filtered), and global search is on the plain-string OwnerType.
+public sealed class ManagedHostnameQueryDefinitionTests
+{
+    [Fact]
+    public void Definition_constructs_without_throwing()
+    {
+        ManagedHostnameQueryDefinition definition = new();
+
+        Should.NotThrow(() => definition.GetColumns());
+    }
+
+    [Fact]
+    public void Host_column_is_sortable_but_not_filterable()
+    {
+        ManagedHostnameQueryDefinition definition = new();
+
+        ColumnDescriptor host = definition.GetColumns()
+            .Single(c => c.PropertyName == nameof(ManagedHostname.Host));
+
+        host.IsSortable.ShouldBeTrue();
+        host.IsFilterable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GlobalSearch_targets_OwnerType_not_the_Host_value_object()
+    {
+        ManagedHostnameQueryDefinition definition = new();
+
+        IReadOnlyList<string> search = definition.GetGlobalSearchProperties();
+
+        search.ShouldContain(nameof(ManagedHostname.OwnerType));
+        search.ShouldNotContain(nameof(ManagedHostname.Host));
+        search.ShouldNotContain("Value");
+    }
+}

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionBuilderValueObjectGuardTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionBuilderValueObjectGuardTests.cs
@@ -1,0 +1,81 @@
+using Granit.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.Abstractions.Tests;
+
+// Guards against the QueryEngine SingleValueObject<string> search blind spot (issue #2767):
+// a value-object column cannot be substring-searched (EF Core cannot translate LIKE over a
+// ValueConverter), so the builder must reject it at definition time instead of registering a
+// silent no-op. Also covers the opaque error previously raised by `.Value` drill-in selectors.
+public sealed class QueryDefinitionBuilderValueObjectGuardTests
+{
+    [Fact]
+    public void GlobalSearch_on_value_object_column_throws()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(
+            () => builder.GlobalSearch(e => e.Slug));
+
+        ex.Message.ShouldContain(nameof(SampleSlug));
+        ex.Message.ShouldContain("#2767");
+    }
+
+    [Fact]
+    public void GlobalSearch_on_string_column_succeeds()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        builder.GlobalSearch(e => e.Name);
+
+        builder.GlobalSearchProperties.ShouldBe([nameof(SampleEntity.Name)]);
+    }
+
+    [Fact]
+    public void GlobalSearch_on_value_object_Value_drill_in_throws_with_hint()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(
+            () => builder.GlobalSearch(e => e.Slug.Value));
+
+        ex.Message.ShouldContain("#2767");
+        ex.Message.ShouldContain(nameof(SampleEntity.Slug));
+    }
+
+    [Fact]
+    public void Column_on_value_object_Value_drill_in_throws_with_hint()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(
+            () => builder.Column(e => e.Slug.Value));
+
+        ex.Message.ShouldContain("#2767");
+    }
+
+    [Fact]
+    public void Column_on_whole_value_object_is_allowed()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        builder.Column(e => e.Slug, c => c.Sortable());
+
+        builder.Columns.ShouldContain(c => c.PropertyName == nameof(SampleEntity.Slug));
+    }
+
+    private sealed class SampleEntity
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public SampleSlug Slug { get; set; } = null!;
+    }
+
+    private sealed class SampleSlug : SingleValueObject<string>
+    {
+        public override required string Value { get; init; }
+        public static SampleSlug Create(string value) => new() { Value = value };
+        public static implicit operator string(SampleSlug slug) => slug.Value;
+    }
+}

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/FilterExpressionBuilderNonStringSubstringTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/FilterExpressionBuilderNonStringSubstringTests.cs
@@ -1,0 +1,49 @@
+using System.Linq.Expressions;
+using Granit.QueryEngine.EntityFrameworkCore.Internal;
+using Granit.QueryEngine.Filtering;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Tests.Internal;
+
+// Issue #2767: a substring filter (contains/startsWith/endsWith) on a non-string column —
+// including a SingleValueObject<string> mapped via a ValueConverter — cannot translate to LIKE.
+// The builder must drop the criterion AND log a warning so it is observable, not silent.
+public sealed class FilterExpressionBuilderNonStringSubstringTests
+{
+    [Theory]
+    [InlineData(FilterOperator.Contains)]
+    [InlineData(FilterOperator.StartsWith)]
+    [InlineData(FilterOperator.EndsWith)]
+    public void Substring_on_non_string_column_returns_null_and_logs_warning(FilterOperator op)
+    {
+        CapturingLogger logger = new();
+        FilterCriteria criteria = new("Price", op, "5");
+
+        Expression<Func<TestProduct, bool>>? expr =
+            FilterExpressionBuilder.Build<TestProduct>(criteria, logger);
+
+        expr.ShouldBeNull();
+        logger.Levels.ShouldContain(LogLevel.Warning);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<LogLevel> Levels { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Levels.Add(logLevel);
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/Granit.Webhooks.Tests/WebhookSubscriptionQueryDefinitionTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSubscriptionQueryDefinitionTests.cs
@@ -1,0 +1,33 @@
+using Granit.QueryEngine;
+using Granit.Webhooks.Domain;
+using Granit.Webhooks.Queries;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Tests;
+
+// Issue #2767: TargetUrl is a HttpsUrl value object (SingleValueObject<string>) mapped via a
+// ValueConverter, so it cannot be filtered (an Eq filter mistranslates; substring cannot reach
+// LIKE). It must stay display-only — not .Filterable() — so the grid does not advertise a broken
+// filter affordance.
+public sealed class WebhookSubscriptionQueryDefinitionTests
+{
+    [Fact]
+    public void TargetUrl_value_object_column_is_not_filterable()
+    {
+        WebhookSubscriptionQueryDefinition definition = new();
+
+        ColumnDescriptor targetUrl = definition.GetColumns()
+            .Single(c => c.PropertyName == nameof(WebhookSubscription.TargetUrl));
+
+        targetUrl.IsFilterable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GlobalSearch_targets_the_plain_string_EventType()
+    {
+        WebhookSubscriptionQueryDefinition definition = new();
+
+        definition.GetGlobalSearchProperties().ShouldContain(nameof(WebhookSubscription.EventType));
+    }
+}


### PR DESCRIPTION
Closes #2767.

## Problem

`GlobalSearch` / `contains` filters on a `SingleValueObject<string>` column were a **silent no-op**: the column's CLR type is the value object (never `string`), so both `ContainsSearchStrategy` and `FilterExpressionBuilder` skipped it — a global search returned the whole (scoped) table and substring filters vanished, with no error and no failing test. EF Core cannot translate `LIKE` over a `ValueConverter`, so a VO column genuinely cannot be substring-searched (verified: SQLite + the real converter — see #2767).

Two definitions were affected in the wild:
- **`ManagedHostnameQueryDefinition` was uninstantiable** — it used `e => e.Host.Value` (drilling into the `Hostname` VO), which threw `ArgumentException` at construction. Untested.
- **`WebhookSubscriptionQueryDefinition.TargetUrl`** (`HttpsUrl`) was `.Filterable()` on a VO column → filter mistranslated/dropped.

## Changes

**Fail loud (framework-wide)**
- `QueryDefinitionBuilder.GlobalSearch` now throws at definition build when a selector resolves to a non-string (VO) column (detected via the implicit-operator `Convert` node), with a message citing the `LIKE`/`ValueConverter` limitation.
- `QueryDefinitionBuilder.GetPropertyName` gives a targeted hint for nested `.Value` drill-in selectors instead of an opaque "simple property access" error.
- `FilterExpressionBuilder` logs a `Warning` when a `contains`/`startsWith`/`endsWith` filter targets a non-string column, instead of silently dropping the criterion.

**Fixed sites**
- `ManagedHostnameQueryDefinition`: `Host` is now a display+sort-only column (no `.Filterable()`, removed from `GlobalSearch`); `OwnerType` (plain string) carries global search. Now constructible.
- `WebhookSubscriptionQueryDefinition`: dropped the broken `.Filterable()` on `TargetUrl`.

## Tests

13 new tests (builder guards, both fixed definitions, the substring-filter warning). Full suites green: QueryEngine.Abstractions (18), QueryEngine.EntityFrameworkCore (179), Hostnames (68), Webhooks (214). `dotnet format --verify-no-changes` clean.

## Out of scope (follow-up)

`Eq`/`In` filtering on a VO column is also broken (`ConvertValue` cannot build a VO from a filter string → emits a wrong `== null` predicate). That is why `Host`/`TargetUrl` are not filterable here. Enabling VO equality filtering is the bounded slice of option #3 in #2767 and deserves its own issue — not done here to keep this PR scoped.