### PR TITLE
fix(queryengine): harden SingleValueObject column handling (equality/IN filtering + fail-loud on unsupported paths)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -47470,7 +47470,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs",
-      "line": 13,
+      "line": 14,
       "members": []
     },
     {

--- a/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
+++ b/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
@@ -14,12 +14,11 @@ public sealed class ManagedHostnameQueryDefinition : QueryDefinition<ManagedHost
     {
         builder
             // Host is a Hostname value object (SingleValueObject<string>). It is mapped by a
-            // ValueConverter, so it can be displayed and sorted (whole-value round-trips), but it
-            // cannot be substring-searched or filtered: EF Core cannot translate LIKE over a
-            // converter, and the engine cannot build a VO instance from a filter string. Hence no
-            // .Filterable() and no GlobalSearch on Host — selecting `e => e.Host.Value` to dodge
-            // this throws at definition build. See issue #2767.
-            .Column(e => e.Host, c => c.Label("Host").LabelKey("Hostnames.Columns.Host").Sortable())
+            // ValueConverter, so it supports equality/IN filtering and sorting (whole-value
+            // round-trips), but NOT substring search: EF Core cannot translate LIKE over a
+            // converter. Hence .Filterable()/.Sortable() but no GlobalSearch on Host — selecting
+            // `e => e.Host.Value` to dodge that throws at definition build. See issue #2767.
+            .Column(e => e.Host, c => c.Label("Host").LabelKey("Hostnames.Columns.Host").Filterable().Sortable())
             .Column(e => e.OwnerType, c => c.Label("Owner Type").LabelKey("Hostnames.Columns.OwnerType").Filterable().Sortable())
             .Column(e => e.OwnerId, c => c.Label("Owner Id").LabelKey("Hostnames.Columns.OwnerId").Filterable())
             .Column(e => e.IsPrimary, c => c.Label("Primary").LabelKey("Hostnames.Columns.IsPrimary").Filterable().Sortable())

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Granit.Domain;
 using Granit.QueryEngine.Filtering;
 using Granit.QueryEngine.Options;
 using Granit.QueryEngine.Search;
@@ -269,9 +270,12 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
     public QueryDefinitionBuilder<TEntity> AllowGroupBy<TProp>(
         Expression<Func<TEntity, TProp>> property)
     {
+        string propertyName = GetPropertyName(property);
+        ThrowIfValueObjectColumn<TProp>(propertyName, "grouped by", nameof(property));
+
         GroupByFields.Add(new GroupByDescriptor
         {
-            PropertyName = GetPropertyName(property),
+            PropertyName = propertyName,
             ClrType = typeof(TProp),
         });
 
@@ -290,9 +294,12 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
         AggregateFunction function,
         string alias)
     {
+        string propertyName = GetPropertyName(property);
+        ThrowIfValueObjectColumn<TProp>(propertyName, "aggregated", nameof(property));
+
         Aggregates.Add(new AggregateDescriptor
         {
-            PropertyName = GetPropertyName(property),
+            PropertyName = propertyName,
             ClrType = typeof(TProp),
             Function = function,
             Alias = alias,
@@ -391,7 +398,10 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
     public QueryDefinitionBuilder<TEntity> SupportsCursorPagination<TProp>(
         Expression<Func<TEntity, TProp>> property)
     {
-        CursorPropertyName = GetPropertyName(property);
+        string propertyName = GetPropertyName(property);
+        ThrowIfValueObjectColumn<TProp>(propertyName, "used as a cursor key", nameof(property));
+
+        CursorPropertyName = propertyName;
         return this;
     }
 
@@ -506,5 +516,25 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
         }
 
         return member.Member.Name;
+    }
+
+    // Rejects a SingleValueObject<T> column on paths that need an orderable/aggregatable scalar.
+    // The value object is mapped as an opaque whole-value ValueConverter, so cursor keyset
+    // comparisons, GROUP BY keys and aggregate functions over it either cannot translate or are
+    // meaningless. Equality/IN filtering and sorting remain supported. See issue #2767.
+    private static void ThrowIfValueObjectColumn<TProp>(string propertyName, string operation, string paramName)
+    {
+        Type openType = typeof(SingleValueObject<>);
+        for (Type? current = typeof(TProp); current is not null && current != typeof(object); current = current.BaseType)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == openType)
+            {
+                throw new ArgumentException(
+                    $"Property '{propertyName}' is a value object ({typeof(TProp).Name}) and cannot be " +
+                    $"{operation}: it is mapped as an opaque whole-value ValueConverter (no orderable/" +
+                    $"aggregatable scalar). Use a plain scalar column instead. See issue #2767.",
+                    paramName);
+            }
+        }
     }
 }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using Granit.Domain;
 using Granit.QueryEngine.EntityFrameworkCore.Diagnostics;
 using Granit.QueryEngine.Filtering;
 using Microsoft.EntityFrameworkCore;
@@ -99,8 +101,12 @@ internal static class FilterExpressionBuilder
         ILogger? logger = null, string? field = null)
     {
         object? converted = ConvertValue(value, propertyType, logger, field);
-        if (converted is null && propertyType.IsValueType)
+        if (converted is null)
         {
+            // Conversion failed (unparseable value, or a value object the engine cannot build):
+            // drop the criterion. Previously, a null on a reference-typed column (e.g. a value
+            // object) fell through and built `column == null`, silently matching the wrong rows.
+            // See issue #2767.
             return null;
         }
 
@@ -141,6 +147,13 @@ internal static class FilterExpressionBuilder
         Func<Expression, Expression, BinaryExpression> comparison,
         ILogger? logger = null, string? field = null)
     {
+        // Value objects define no ordering operators — a Gt/Lt over one would throw at
+        // expression build. Range operators are not meaningful on an identifier-like VO. See #2767.
+        if (GetSingleValueObjectBase(member.Type) is not null)
+        {
+            return null;
+        }
+
         object? converted = ConvertValue(value, propertyType, logger, field);
         if (converted is null)
         {
@@ -210,6 +223,12 @@ internal static class FilterExpressionBuilder
         Expression member, string value, Type propertyType,
         ILogger? logger = null, string? field = null)
     {
+        // See BuildComparisonExpression — range operators are unsupported on value objects.
+        if (GetSingleValueObjectBase(member.Type) is not null)
+        {
+            return null;
+        }
+
         string[] parts = value.Split(',', StringSplitOptions.TrimEntries);
         if (parts.Length != 2)
         {
@@ -264,6 +283,17 @@ internal static class FilterExpressionBuilder
     {
         try
         {
+            // SingleValueObject<TPrimitive>: parse the string to the underlying primitive, then
+            // reconstruct the value object so EF Core compares it through its ValueConverter
+            // (whole-value equality / IN translate; substring/LIKE does not and is rejected on
+            // the substring paths). See issue #2767.
+            Type? svoBase = GetSingleValueObjectBase(targetType);
+            if (svoBase is not null)
+            {
+                object? primitive = ConvertValue(value, svoBase.GetGenericArguments()[0], logger, field);
+                return primitive is null ? null : ReconstructValueObject(targetType, primitive);
+            }
+
             if (targetType == typeof(string))
             {
                 return value;
@@ -317,5 +347,32 @@ internal static class FilterExpressionBuilder
 
             return null;
         }
+    }
+
+    // Returns the SingleValueObject<TPrimitive> base type for a value-object CLR type, or null.
+    private static Type? GetSingleValueObjectBase(Type type)
+    {
+        Type openType = typeof(SingleValueObject<>);
+        for (Type? current = type; current is not null && current != typeof(object); current = current.BaseType)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == openType)
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    // Builds a value object whose Value equals the parsed primitive, without running the
+    // domain factory's validation. The instance only feeds an EF Core comparison constant —
+    // an invalid filter value simply matches no rows — so this mirrors how
+    // SingleValueObjectConverter materialises rows from the database.
+    private static object ReconstructValueObject(Type valueObjectType, object primitive)
+    {
+        object instance = RuntimeHelpers.GetUninitializedObject(valueObjectType);
+        PropertyInfo valueProperty = valueObjectType.GetProperty(nameof(SingleValueObject<string>.Value))!;
+        valueProperty.SetValue(instance, primitive);
+        return instance;
     }
 }

--- a/src/Granit.Webhooks/Queries/WebhookSubscriptionQueryDefinition.cs
+++ b/src/Granit.Webhooks/Queries/WebhookSubscriptionQueryDefinition.cs
@@ -23,10 +23,10 @@ public sealed class WebhookSubscriptionQueryDefinition : QueryDefinition<Webhook
             .Column(s => s.TenantId, c => c.Label("Tenant").LabelKey("Webhooks.Columns.Tenant").Filterable().Sortable())
             .Column(s => s.EventType, c => c.Label("Event Type").LabelKey("Webhooks.Columns.EventType").Filterable().Sortable())
             // TargetUrl is a HttpsUrl value object (SingleValueObject<string>): mapped by a
-            // ValueConverter, so it is display-only here. It is not .Filterable() because the
-            // engine cannot build a VO instance from a filter string (an Eq filter would
-            // mistranslate, and substring filters cannot translate to LIKE). See issue #2767.
-            .Column(s => s.TargetUrl, c => c.Label("Target URL").LabelKey("Webhooks.Columns.TargetUrl"))
+            // ValueConverter, so it supports equality/IN filtering (whole-value round-trips) but
+            // not substring search/LIKE — hence .Filterable() but absent from GlobalSearch.
+            // See issue #2767.
+            .Column(s => s.TargetUrl, c => c.Label("Target URL").LabelKey("Webhooks.Columns.TargetUrl").Filterable())
             .Column(s => s.Status, c => c.Label("Status").LabelKey("Webhooks.Columns.Status").Filterable().Sortable())
             .Column(s => s.ConsecutiveFailureCount, c => c.Label("Consecutive Failures").LabelKey("Webhooks.Columns.ConsecutiveFailures").Sortable())
             .Column(s => s.LastSuccessAt, c => c.Label("Last Success At").LabelKey("Webhooks.Columns.LastSuccessAt").Sortable())

--- a/tests/Granit.Hostnames.Tests/ManagedHostnameQueryDefinitionTests.cs
+++ b/tests/Granit.Hostnames.Tests/ManagedHostnameQueryDefinitionTests.cs
@@ -8,8 +8,9 @@ namespace Granit.Hostnames.Tests;
 
 // Regression for issue #2767: the definition previously used `e => e.Host.Value` (drilling into
 // the Hostname value object), which threw ArgumentException at construction — the grid was
-// uninstantiable and untested. Host is now a display/sort-only column (value objects cannot be
-// substring-searched or filtered), and global search is on the plain-string OwnerType.
+// uninstantiable and untested. Host is now selected as the whole value object: filterable
+// (equality/IN) and sortable, but absent from global search (value objects cannot be
+// substring-searched). Global search is on the plain-string OwnerType.
 public sealed class ManagedHostnameQueryDefinitionTests
 {
     [Fact]
@@ -21,7 +22,7 @@ public sealed class ManagedHostnameQueryDefinitionTests
     }
 
     [Fact]
-    public void Host_column_is_sortable_but_not_filterable()
+    public void Host_column_is_filterable_and_sortable()
     {
         ManagedHostnameQueryDefinition definition = new();
 
@@ -29,7 +30,7 @@ public sealed class ManagedHostnameQueryDefinitionTests
             .Single(c => c.PropertyName == nameof(ManagedHostname.Host));
 
         host.IsSortable.ShouldBeTrue();
-        host.IsFilterable.ShouldBeFalse();
+        host.IsFilterable.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionBuilderValueObjectGuardTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionBuilderValueObjectGuardTests.cs
@@ -1,4 +1,5 @@
 using Granit.Domain;
+using Granit.QueryEngine.Filtering;
 using Shouldly;
 using Xunit;
 
@@ -63,6 +64,46 @@ public sealed class QueryDefinitionBuilderValueObjectGuardTests
         builder.Column(e => e.Slug, c => c.Sortable());
 
         builder.Columns.ShouldContain(c => c.PropertyName == nameof(SampleEntity.Slug));
+    }
+
+    [Fact]
+    public void AllowGroupBy_on_value_object_throws()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(() => builder.AllowGroupBy(e => e.Slug));
+        ex.Message.ShouldContain("#2767");
+        ex.Message.ShouldContain(nameof(SampleEntity.Slug));
+    }
+
+    [Fact]
+    public void Aggregate_on_value_object_throws()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(
+            () => builder.Aggregate(e => e.Slug, AggregateFunction.Count, "slugCount"));
+        ex.Message.ShouldContain("#2767");
+    }
+
+    [Fact]
+    public void SupportsCursorPagination_on_value_object_throws()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(
+            () => builder.SupportsCursorPagination(e => e.Slug));
+        ex.Message.ShouldContain("#2767");
+    }
+
+    [Fact]
+    public void AllowGroupBy_on_scalar_column_succeeds()
+    {
+        QueryDefinitionBuilder<SampleEntity> builder = new();
+
+        builder.AllowGroupBy(e => e.Name);
+
+        builder.GroupByFields.ShouldContain(g => g.PropertyName == nameof(SampleEntity.Name));
     }
 
     private sealed class SampleEntity

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Granit.QueryEngine.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Granit.QueryEngine.EntityFrameworkCore.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/FilterExpressionBuilderValueObjectTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/FilterExpressionBuilderValueObjectTests.cs
@@ -1,0 +1,87 @@
+using System.Linq.Expressions;
+using Granit.Domain;
+using Granit.QueryEngine.EntityFrameworkCore.Internal;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Tests.Internal;
+
+// Issue #2767 follow-up: equality/IN filters on a SingleValueObject<string> column must build a
+// real value-object comparison (EF Core translates whole-value equality through the converter),
+// not the previous wrong `column == null` predicate. Substring/range operators stay unsupported.
+public sealed class FilterExpressionBuilderValueObjectTests
+{
+    private static readonly VoProbe[] Rows =
+    [
+        new() { Slug = ProbeSlug.Create("alpha") },
+        new() { Slug = ProbeSlug.Create("beta") },
+        new() { Slug = ProbeSlug.Create("gamma") },
+    ];
+
+    [Fact]
+    public void Eq_on_value_object_builds_a_value_comparison_not_a_null_comparison()
+    {
+        FilterCriteria criteria = new("Slug", FilterOperator.Eq, "beta");
+
+        Expression<Func<VoProbe, bool>>? expr = FilterExpressionBuilder.Build<VoProbe>(criteria);
+
+        // EF Core translates whole-value equality through the converter (proven against SQLite in
+        // the #2767 spike); here we assert the builder produced a real value-object constant — the
+        // regression being the previous `column == null` predicate. (Expression.Equal compiled
+        // in-memory would use reference equality, so we inspect the tree rather than run it.)
+        expr.ShouldNotBeNull();
+
+        ConstantCollector collector = new();
+        collector.Visit(expr);
+        ConstantExpression constant = collector.Constants.Single(c => c.Type == typeof(ProbeSlug));
+        constant.Value.ShouldNotBeNull();
+        ((ProbeSlug)constant.Value!).Value.ShouldBe("beta");
+    }
+
+    [Fact]
+    public void In_on_value_object_matches_the_listed_values()
+    {
+        FilterCriteria criteria = new("Slug", FilterOperator.In, "alpha,gamma");
+
+        Expression<Func<VoProbe, bool>>? expr = FilterExpressionBuilder.Build<VoProbe>(criteria);
+
+        expr.ShouldNotBeNull();
+        Func<VoProbe, bool> match = expr.Compile();
+        Rows.Where(match).Select(r => r.Slug.Value).ShouldBe(["alpha", "gamma"], ignoreOrder: true);
+    }
+
+    [Theory]
+    [InlineData(FilterOperator.Gt)]
+    [InlineData(FilterOperator.Lt)]
+    [InlineData(FilterOperator.Between)]
+    public void Range_operators_on_value_object_are_dropped(FilterOperator op)
+    {
+        FilterCriteria criteria = new("Slug", op, "alpha,gamma");
+
+        FilterExpressionBuilder.Build<VoProbe>(criteria).ShouldBeNull();
+    }
+
+    private sealed class ConstantCollector : ExpressionVisitor
+    {
+        public List<ConstantExpression> Constants { get; } = [];
+
+        protected override Expression VisitConstant(ConstantExpression node)
+        {
+            Constants.Add(node);
+            return base.VisitConstant(node);
+        }
+    }
+
+    private sealed class VoProbe
+    {
+        public ProbeSlug Slug { get; set; } = null!;
+    }
+
+    private sealed class ProbeSlug : SingleValueObject<string>
+    {
+        public override required string Value { get; init; }
+        public static ProbeSlug Create(string value) => new() { Value = value };
+        public static implicit operator string(ProbeSlug slug) => slug.Value;
+    }
+}

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/ValueObjectColumnTranslationTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/ValueObjectColumnTranslationTests.cs
@@ -1,0 +1,103 @@
+using System.Linq.Expressions;
+using Granit.Domain;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine.EntityFrameworkCore.Internal;
+using Granit.QueryEngine.Filtering;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Tests.Internal;
+
+// Issue #2767/#2770: end-to-end proof against real SQLite + the real SingleValueObjectConverter
+// (wired by ApplyGranitConventions) that filtering/sorting a SingleValueObject<string> column is
+// safe. Equality/IN translate through the converter; substring/range operators are dropped (never
+// silently mistranslated or thrown); sorting translates. Nothing else in the suite exercises EF
+// translation for value-object columns, so this guards the core promise of the fix.
+public sealed class ValueObjectColumnTranslationTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<VoCtx> _options;
+
+    public ValueObjectColumnTranslationTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<VoCtx>().UseSqlite(_connection).Options;
+
+        using VoCtx seed = new(_options);
+        seed.Database.EnsureCreated();
+        seed.Probes.AddRange(
+            new VoProbe { Id = Guid.NewGuid(), Slug = Slug.Create("alpha") },
+            new VoProbe { Id = Guid.NewGuid(), Slug = Slug.Create("beta") },
+            new VoProbe { Id = Guid.NewGuid(), Slug = Slug.Create("gamma") });
+        seed.SaveChanges();
+    }
+
+    [Fact]
+    public void Eq_filter_translates_and_matches_the_value()
+    {
+        Query(new("Slug", FilterOperator.Eq, "beta")).ShouldBe(["beta"]);
+    }
+
+    [Fact]
+    public void In_filter_translates_to_sql_in()
+    {
+        Query(new("Slug", FilterOperator.In, "alpha,gamma"))
+            .ShouldBe(["alpha", "gamma"], ignoreOrder: true);
+    }
+
+    [Theory]
+    [InlineData(FilterOperator.Contains)]
+    [InlineData(FilterOperator.StartsWith)]
+    [InlineData(FilterOperator.EndsWith)]
+    [InlineData(FilterOperator.Gt)]
+    [InlineData(FilterOperator.Lt)]
+    public void Unsupported_operators_are_dropped_not_thrown(FilterOperator op)
+    {
+        // The criterion produces no predicate (dropped) — never a mistranslation or a throw.
+        FilterExpressionBuilder.Build<VoProbe>(new("Slug", op, "beta")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Sorting_by_a_value_object_column_translates()
+    {
+        using VoCtx ctx = new(_options);
+
+        List<string> sorted = [.. ctx.Probes.OrderBy(e => e.Slug).Select(e => e.Slug.Value)];
+
+        sorted.ShouldBe(["alpha", "beta", "gamma"]);
+    }
+
+    private List<string> Query(FilterCriteria criteria)
+    {
+        Expression<Func<VoProbe, bool>>? expr = FilterExpressionBuilder.Build<VoProbe>(criteria);
+        expr.ShouldNotBeNull();
+
+        using VoCtx ctx = new(_options);
+        return [.. ctx.Probes.Where(expr).Select(e => e.Slug.Value)];
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private sealed class Slug : SingleValueObject<string>
+    {
+        public override required string Value { get; init; }
+        public static Slug Create(string value) => new() { Value = value };
+        public static implicit operator string(Slug s) => s.Value;
+    }
+
+    private sealed class VoProbe
+    {
+        public Guid Id { get; set; }
+        public Slug Slug { get; set; } = null!;
+    }
+
+    private sealed class VoCtx(DbContextOptions<VoCtx> options) : DbContext(options)
+    {
+        public DbSet<VoProbe> Probes => Set<VoProbe>();
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ApplyGranitConventions();
+    }
+}

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/packages.lock.json
@@ -31,6 +31,21 @@
           "Microsoft.Extensions.Logging": "10.0.9"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -112,6 +127,14 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -121,6 +144,20 @@
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
@@ -137,6 +174,11 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -228,6 +270,33 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",

--- a/tests/Granit.Webhooks.Tests/WebhookSubscriptionQueryDefinitionTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSubscriptionQueryDefinitionTests.cs
@@ -7,20 +7,19 @@ using Xunit;
 namespace Granit.Webhooks.Tests;
 
 // Issue #2767: TargetUrl is a HttpsUrl value object (SingleValueObject<string>) mapped via a
-// ValueConverter, so it cannot be filtered (an Eq filter mistranslates; substring cannot reach
-// LIKE). It must stay display-only — not .Filterable() — so the grid does not advertise a broken
-// filter affordance.
+// ValueConverter. It supports equality/IN filtering (whole-value round-trips), but not substring
+// search/LIKE — so it is .Filterable() yet absent from GlobalSearch.
 public sealed class WebhookSubscriptionQueryDefinitionTests
 {
     [Fact]
-    public void TargetUrl_value_object_column_is_not_filterable()
+    public void TargetUrl_value_object_column_is_filterable()
     {
         WebhookSubscriptionQueryDefinition definition = new();
 
         ColumnDescriptor targetUrl = definition.GetColumns()
             .Single(c => c.PropertyName == nameof(WebhookSubscription.TargetUrl));
 
-        targetUrl.IsFilterable.ShouldBeFalse();
+        targetUrl.IsFilterable.ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #2771.

Follow-up to #2769 (which made VO columns fail loud on substring/global search). This fixes the **equality/IN** half of the value-object filtering gap.

## Problem

Filtering a `SingleValueObject<string>` column with `Eq`/`In` was broken: `FilterExpressionBuilder.ConvertValue` could not build a value object from the filter string, so:
- `Eq` fell through and emitted a wrong **`column == null`** predicate (matched the wrong rows, silently);
- `In` dropped all values;
- `Gt`/`Lt`/`Between` would have thrown at expression build (value objects define no ordering operators).

This is why #2769 left `ManagedHostname.Host` and `WebhookSubscription.TargetUrl` non-filterable. Unlike substring/`LIKE` (which genuinely can't translate over a `ValueConverter`), **whole-value equality does translate** — `e.Vo == Vo.Create("x")` was proven against SQLite in the #2767 spike.

## Changes

- `ConvertValue` reconstructs a `SingleValueObject<TPrimitive>` from its parsed primitive, so EF Core compares it through the converter — enabling `Eq` and `In`.
- `BuildEqualsExpression` drops the criterion on any failed conversion instead of building `== null`.
- `BuildComparisonExpression` / `BuildBetweenExpression` drop range operators on value objects (unsupported; would otherwise throw).
- Re-enabled `.Filterable()` on `ManagedHostname.Host` and `WebhookSubscription.TargetUrl` (equality/IN filtering + sorting; still absent from global search — substring stays unsupported).

## Tests

New `FilterExpressionBuilderValueObjectTests`: `Eq` builds a real value-object constant (not `== null`), `In` matches the listed values, range operators are dropped. Updated the two definition tests (columns filterable again). Full suites green: QueryEngine.EntityFrameworkCore (184), Hostnames (68), Webhooks (214). `dotnet format --verify-no-changes` clean.

Refs #2767, #2769.

## Additional fail-loud guards (cursor / group-by / aggregate)

Rounds out SingleValueObject column safety. A VO column has no orderable/aggregatable scalar (opaque whole-value `ValueConverter`), so `SupportsCursorPagination`, `AllowGroupBy` and `Aggregate` now throw `ArgumentException` at definition build when given a VO selector (consistent with the `GlobalSearch` guard) rather than failing obscurely at query time — a cursor keyset comparison would throw, and `GROUP BY` / aggregate over a converter cannot translate or is meaningless. Equality/IN filtering and sorting remain supported. Verified no existing `QueryDefinition` uses a VO column on these paths.