### PR TITLE
test+ci(coverage): EF provider/Presence tests + fix coverlet 0% on hosted runner

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,6 +6,16 @@
     <!-- Granit analyzers target production code — test projects legitimately use
          Guid.NewGuid(), DateTimeOffset.UtcNow, and test secrets for setup/assertions. -->
     <NoWarn>$(NoWarn);GRSEC001;GRSEC002;GRSEC003;GRSEC004;GREF001;RS0030</NoWarn>
+    <!-- Coverage instrumentation needs the full reference closure on disk: the coverlet
+         collector (Mono.Cecil) must resolve every reference of the assembly-under-test.
+         PreserveCompilationContext copies the reference closure (including shared-framework
+         assemblies such as Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions) into
+         refs/, which CopyLocalLockFileAssemblies alone does NOT — framework assemblies are
+         marked non-copy-local. Without this, modules referencing those transitive deps fail
+         with CecilAssemblyResolutionException on the CI runner and silently report 0% in
+         SonarCloud (e.g. Granit.Persistence.EntityFrameworkCore.Postgres/.SqlServer). -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/NpgsqlHealthChecksBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Extensions/NpgsqlHealthChecksBuilderExtensionsTests.cs
@@ -1,0 +1,48 @@
+using Granit.Persistence.EntityFrameworkCore.Postgres.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Postgres.Tests.Extensions;
+
+public sealed class NpgsqlHealthChecksBuilderExtensionsTests
+{
+    // Malformed connection string: the NpgsqlConnection constructor rejects the unknown
+    // keyword synchronously, so the check's catch block runs without ever touching a real
+    // server — deterministic and fast, no PostgreSQL required.
+    private const string BadConnectionString = "NotAValidKeyword=1";
+
+    [Fact]
+    public async Task AddGranitPostgresHealthCheck_registers_default_named_check_reporting_failure()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddHealthChecks().AddGranitPostgresHealthCheck(BadConnectionString);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        HealthCheckService service = provider.GetRequiredService<HealthCheckService>();
+
+        HealthReport report = await service.CheckHealthAsync(TestContext.Current.CancellationToken);
+
+        report.Entries.ShouldContainKey("postgres");
+        report.Entries["postgres"].Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task AddGranitPostgresHealthCheck_honours_custom_name_and_tags()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddHealthChecks().AddGranitPostgresHealthCheck(
+            BadConnectionString, name: "primary-db", tags: ["custom"]);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        HealthCheckService service = provider.GetRequiredService<HealthCheckService>();
+
+        HealthReport report = await service.CheckHealthAsync(TestContext.Current.CancellationToken);
+
+        report.Entries.ShouldContainKey("primary-db");
+        report.Entries["primary-db"].Tags.ShouldContain("custom");
+    }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests.csproj
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Bogus" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Internal/NpgsqlTenantDbIsolatorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Internal/NpgsqlTenantDbIsolatorTests.cs
@@ -1,0 +1,47 @@
+using System.Data;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Postgres.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Postgres.Tests.Internal;
+
+/// <summary>
+/// Provider-agnostic behaviour of <see cref="NpgsqlTenantDbIsolator"/>: it resolves the
+/// tenant schema name, opens the underlying connection if needed, and delegates the
+/// <c>SET search_path</c> SQL to <see cref="ITenantSchemaActivator"/>. Verified against a
+/// SQLite in-memory connection so no live PostgreSQL is required — the isolator never
+/// emits Postgres-specific SQL itself (that lives in the activator).
+/// </summary>
+public sealed class NpgsqlTenantDbIsolatorTests
+{
+    [Fact]
+    public async Task IsolateAsync_resolves_schema_and_activates_it_on_an_opened_connection()
+    {
+        using SqliteConnection connection = new("DataSource=:memory:");
+        DbContextOptionsBuilder<IsolatorTestDbContext> optionsBuilder = new();
+        optionsBuilder.UseSqlite(connection);
+        await using var context = new IsolatorTestDbContext(optionsBuilder.Options);
+
+        var tenantId = Guid.NewGuid();
+
+        ITenantSchemaProvider schemaProvider = Substitute.For<ITenantSchemaProvider>();
+        schemaProvider.GetSchemaNameAsync(tenantId, Arg.Any<CancellationToken>())
+            .Returns("tenant_acme");
+        ITenantSchemaActivator schemaActivator = Substitute.For<ITenantSchemaActivator>();
+
+        NpgsqlTenantDbIsolator sut = new(schemaProvider, schemaActivator);
+
+        await sut.IsolateAsync(context, tenantId, TestContext.Current.CancellationToken);
+
+        connection.State.ShouldBe(ConnectionState.Open);
+        await schemaActivator.Received(1).ActivateSchemaAsync(
+            connection, "tenant_acme", Arg.Any<CancellationToken>());
+    }
+
+    private sealed class IsolatorTestDbContext(DbContextOptions<IsolatorTestDbContext> options)
+        : DbContext(options);
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/packages.lock.json
@@ -26,6 +26,21 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -134,6 +149,14 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -143,6 +166,20 @@
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -171,8 +208,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "RFYJR7APio/BiqdQunRq6DB+nDB6nc2qhHr77mlvZ0q0BT8PubMXN7XicmfzCbrDE/dzhBnUKBRXLTcqUiZDGg=="
+        "resolved": "10.0.9",
+        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -363,6 +400,33 @@
         "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
         "dependencies": {
           "Serilog": "4.2.0"
+        }
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "System.CodeDom": {

--- a/tests/Granit.Persistence.EntityFrameworkCore.SqlServer.Tests/Extensions/SqlServerDbContextOptionsExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.SqlServer.Tests/Extensions/SqlServerDbContextOptionsExtensionsTests.cs
@@ -1,0 +1,40 @@
+using Granit.Persistence.EntityFrameworkCore.SqlServer.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.SqlServer.Tests.Extensions;
+
+public sealed class SqlServerDbContextOptionsExtensionsTests
+{
+    private const string ConnectionString =
+        "Server=localhost;Database=test;User Id=test;Password=test;TrustServerCertificate=true";
+
+    [Fact]
+    public void UseGranitSqlServer_ReturnsOptionsBuilder()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        DbContextOptionsBuilder result = optionsBuilder.UseGranitSqlServer(ConnectionString);
+
+        result.ShouldBeSameAs(optionsBuilder);
+    }
+
+    [Fact]
+    public void UseGranitSqlServer_Generic_ReturnsGenericOptionsBuilder()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
+
+        DbContextOptionsBuilder<TestDbContext> result = optionsBuilder.UseGranitSqlServer(ConnectionString);
+
+        result.ShouldBeSameAs(optionsBuilder);
+    }
+
+    [Fact]
+    public void UseGranitSqlServer_WithCustomAction_DoesNotThrow() =>
+        Should.NotThrow(() => new DbContextOptionsBuilder().UseGranitSqlServer(
+            ConnectionString,
+            b => b.CommandTimeout(60)));
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options);
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.SqlServer.Tests/Extensions/SqlServerHealthChecksBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.SqlServer.Tests/Extensions/SqlServerHealthChecksBuilderExtensionsTests.cs
@@ -1,0 +1,48 @@
+using Granit.Persistence.EntityFrameworkCore.SqlServer.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.SqlServer.Tests.Extensions;
+
+public sealed class SqlServerHealthChecksBuilderExtensionsTests
+{
+    // Malformed connection string: the SqlConnection constructor rejects the unknown
+    // keyword synchronously, so the check's catch block runs without ever touching a
+    // real server — deterministic and fast, no SQL Server required.
+    private const string BadConnectionString = "NotAValidKeyword=1";
+
+    [Fact]
+    public async Task AddGranitSqlServerHealthCheck_registers_default_named_check_reporting_failure()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddHealthChecks().AddGranitSqlServerHealthCheck(BadConnectionString);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        HealthCheckService service = provider.GetRequiredService<HealthCheckService>();
+
+        HealthReport report = await service.CheckHealthAsync(TestContext.Current.CancellationToken);
+
+        report.Entries.ShouldContainKey("sqlserver");
+        report.Entries["sqlserver"].Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task AddGranitSqlServerHealthCheck_honours_custom_name_and_tags()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddHealthChecks().AddGranitSqlServerHealthCheck(
+            BadConnectionString, name: "primary-db", tags: ["custom"]);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        HealthCheckService service = provider.GetRequiredService<HealthCheckService>();
+
+        HealthReport report = await service.CheckHealthAsync(TestContext.Current.CancellationToken);
+
+        report.Entries.ShouldContainKey("primary-db");
+        report.Entries["primary-db"].Tags.ShouldContain("custom");
+    }
+}

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/Granit.Presence.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/Granit.Presence.EntityFrameworkCore.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/Internal/EfPresenceStoreTests.cs
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/Internal/EfPresenceStoreTests.cs
@@ -1,0 +1,126 @@
+using Granit.Presence.Domain;
+using Granit.Presence.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Presence.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// Behavioural coverage of <see cref="EfPresenceStore"/> against a real (SQLite in-memory)
+/// <see cref="PresenceDbContext"/>, which also exercises the DbContext model and the
+/// <c>UserPresence</c> entity configuration.
+/// </summary>
+public sealed class EfPresenceStoreTests
+{
+    private static readonly IClock Clock = BuildClock();
+
+    private static IClock BuildClock()
+    {
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(new DateTimeOffset(2026, 1, 15, 10, 0, 0, TimeSpan.Zero));
+        return clock;
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_null_when_no_presence_exists()
+    {
+        using var factory = TestPresenceDbContextFactory.Create();
+        EfPresenceStore store = new(factory);
+
+        UserPresence? result = await store.GetAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MutateAsync_creates_presence_when_absent_and_GetAsync_reads_it_back()
+    {
+        using var factory = TestPresenceDbContextFactory.Create();
+        EfPresenceStore store = new(factory);
+        var userId = Guid.NewGuid();
+
+        UserPresence created = await store.MutateAsync(
+            userId,
+            () => UserPresence.Create(userId, Clock),
+            _ => { },
+            TestContext.Current.CancellationToken);
+
+        created.UserId.ShouldBe(userId);
+
+        UserPresence? read = await store.GetAsync(userId, TestContext.Current.CancellationToken);
+        read.ShouldNotBeNull();
+        read.UserId.ShouldBe(userId);
+        read.ManualStatus.ShouldBe(ManualPresenceStatus.Available);
+    }
+
+    [Fact]
+    public async Task MutateAsync_updates_existing_presence()
+    {
+        using var factory = TestPresenceDbContextFactory.Create();
+        EfPresenceStore store = new(factory);
+        var userId = Guid.NewGuid();
+        var until = new DateTimeOffset(2026, 1, 16, 10, 0, 0, TimeSpan.Zero);
+
+        await store.MutateAsync(
+            userId, () => UserPresence.Create(userId, Clock), _ => { }, TestContext.Current.CancellationToken);
+
+        await store.MutateAsync(
+            userId,
+            () => UserPresence.Create(userId, Clock),
+            p => p.SetOverride(ManualPresenceStatus.Busy, until, Clock),
+            TestContext.Current.CancellationToken);
+
+        UserPresence? read = await store.GetAsync(userId, TestContext.Current.CancellationToken);
+        read.ShouldNotBeNull();
+        read.ManualStatus.ShouldBe(ManualPresenceStatus.Busy);
+        read.OverrideUntilUtc.ShouldBe(until);
+    }
+
+    [Fact]
+    public async Task GetManyAsync_returns_empty_dictionary_for_empty_input()
+    {
+        using var factory = TestPresenceDbContextFactory.Create();
+        EfPresenceStore store = new(factory);
+
+        IReadOnlyDictionary<Guid, UserPresence> result =
+            await store.GetManyAsync([], TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetManyAsync_returns_only_matching_rows()
+    {
+        using var factory = TestPresenceDbContextFactory.Create();
+        EfPresenceStore store = new(factory);
+        var present = Guid.NewGuid();
+        var absent = Guid.NewGuid();
+
+        await store.MutateAsync(
+            present, () => UserPresence.Create(present, Clock), _ => { }, TestContext.Current.CancellationToken);
+
+        IReadOnlyDictionary<Guid, UserPresence> result =
+            await store.GetManyAsync([present, absent], TestContext.Current.CancellationToken);
+
+        result.ShouldContainKey(present);
+        result.ShouldNotContainKey(absent);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_hard_deletes_the_presence_row()
+    {
+        using var factory = TestPresenceDbContextFactory.Create();
+        EfPresenceStore store = new(factory);
+        var userId = Guid.NewGuid();
+
+        await store.MutateAsync(
+            userId, () => UserPresence.Create(userId, Clock), _ => { }, TestContext.Current.CancellationToken);
+
+        await store.DeleteAsync(userId, TestContext.Current.CancellationToken);
+
+        UserPresence? read = await store.GetAsync(userId, TestContext.Current.CancellationToken);
+        read.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/Internal/TestPresenceDbContextFactory.cs
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/Internal/TestPresenceDbContextFactory.cs
@@ -1,0 +1,89 @@
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Presence.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Granit.Presence.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// Creates <see cref="PresenceDbContext"/> instances backed by SQLite in-memory for fast,
+/// isolated relational tests of <see cref="EfPresenceStore"/>. Mirrors the canonical
+/// pattern used by the other <c>*.EntityFrameworkCore.Tests</c> projects (see
+/// <c>Granit.Identity.EntityFrameworkCore.Tests.TestDbContextFactory</c>). A single open
+/// connection is shared so the in-memory database survives across the factory's
+/// per-operation contexts.
+/// </summary>
+internal sealed class TestPresenceDbContextFactory : IDbContextFactory<PresenceDbContext>, IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<PresenceDbContext> _options;
+
+    private TestPresenceDbContextFactory(SqliteConnection connection, DbContextOptions<PresenceDbContext> options)
+    {
+        _connection = connection;
+        _options = options;
+    }
+
+    public static TestPresenceDbContextFactory Create()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+
+        DbContextOptionsBuilder<PresenceDbContext> optionsBuilder = new();
+        optionsBuilder.UseSqlite(connection);
+        optionsBuilder.ReplaceService<IModelCustomizer, SqliteCompatibleModelCustomizer>();
+
+        DbContextOptions<PresenceDbContext> options = optionsBuilder.Options;
+
+        using (var db = new PresenceDbContext(options, GranitDesignTime.CurrentTenant))
+        {
+            db.Database.EnsureCreated();
+        }
+
+        return new TestPresenceDbContextFactory(connection, options);
+    }
+
+    public PresenceDbContext CreateDbContext() =>
+        new(_options, GranitDesignTime.CurrentTenant);
+
+    public void Dispose() => _connection.Dispose();
+
+    /// <summary>
+    /// Remaps PostgreSQL-specific <see cref="DateTimeOffset"/> columns to SQLite-compatible
+    /// storage with value converters. Same shape as the companion test factories.
+    /// </summary>
+    private sealed class SqliteCompatibleModelCustomizer(ModelCustomizerDependencies dependencies)
+        : RelationalModelCustomizer(dependencies)
+    {
+        private static readonly ValueConverter<DateTimeOffset, long> DateTimeOffsetConverter = new(
+            v => v.ToUnixTimeMilliseconds(),
+            v => DateTimeOffset.FromUnixTimeMilliseconds(v));
+
+        private static readonly ValueConverter<DateTimeOffset?, long?> NullableDateTimeOffsetConverter = new(
+            v => v.HasValue ? v.Value.ToUnixTimeMilliseconds() : null,
+            v => v.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds(v.Value) : null);
+
+        public override void Customize(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.Customize(modelBuilder, context);
+
+            foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                foreach (IMutableProperty property in entityType.GetProperties())
+                {
+                    if (property.ClrType == typeof(DateTimeOffset))
+                    {
+                        property.SetValueConverter(DateTimeOffsetConverter);
+                    }
+                    else if (property.ClrType == typeof(DateTimeOffset?))
+                    {
+                        property.SetValueConverter(NullableDateTimeOffsetConverter);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/packages.lock.json
@@ -31,6 +31,21 @@
           "Microsoft.Extensions.Logging": "10.0.9"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -112,6 +127,14 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -121,6 +144,20 @@
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -146,6 +183,11 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -237,6 +279,33 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",


### PR DESCRIPTION
## What

Two related changes that together make several persistence/presence assemblies report real coverage in SonarCloud instead of a false **0%**.

### 1. CI fix — `tests/Directory.Build.props`

The `XPlat Code Coverage` (coverlet) collector instruments each assembly-under-test through Mono.Cecil, which must resolve **every** reference of that assembly. Assemblies that ship in the shared framework — notably `Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions` — are marked non-copy-local, so on the GitHub-hosted runner they are absent from the test output directory. Cecil then throws `CecilAssemblyResolutionException` and **drops the whole module**, so SonarCloud reports 0% even though the tests pass.

Set `PreserveCompilationContext=true` (+ `CopyLocalLockFileAssemblies=true`) so every test project keeps its full reference closure (`refs/`) on disk.

**Root cause + fix validated end-to-end on the runner** via a throwaway diagnostic workflow:
- Before: `Granit.Persistence.EntityFrameworkCore.Postgres`/`.SqlServer` appear in **0** of 126 coverage reports; `[coverlet]Unable to instrument module ... CecilAssemblyResolutionException for 'Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions'`.
- After: both modules reappear with real coverage and zero resolution exceptions.

Affected beyond these two (same mechanism, other shards): `Granit.Presence.EntityFrameworkCore`, `Granit.Scheduling.BackgroundJobs`, `Granit.Identity.Federated.*.BackgroundJobs`.

### 2. New unit tests (DB-free)

Lift the real per-assembly coverage now that it is collected:

| Assembly | Before | After (local) |
| --- | --- | --- |
| `Granit.Presence.EntityFrameworkCore` | 11% | ~92% |
| `Granit.Persistence.EntityFrameworkCore.Postgres` | 51% | ~64% |
| `Granit.Persistence.EntityFrameworkCore.SqlServer` | 13% | ~31% |

- `EfPresenceStore` CRUD against a SQLite in-memory `PresenceDbContext` (also exercises the DbContext model + `UserPresence` configuration). `DeleteAsync` uses `ExecuteDeleteAsync`, unsupported by the InMemory provider, hence SQLite.
- `NpgsqlTenantDbIsolator` (SQLite connection) + `AddGranitPostgresHealthCheck`.
- `UseGranitSqlServer` + `AddGranitSqlServerHealthCheck`.

Health-check failure paths use a malformed connection string so the catch block runs without a live server. Adds `Microsoft.EntityFrameworkCore.Sqlite` to the Postgres and Presence test projects (lockfiles regenerated).

## Out of scope (follow-up)

The `sonarcloud` job currently fails on every run (quality gate) but is masked by `continue-on-error: true`, and the analysis step builds the full `Granit.slnx` rather than a scoped `.slnf`. Tracked separately.