### PR TITLE
feat(timeline): surface federation provenance on stream entry response

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -52115,7 +52115,7 @@
       "kind": "record",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs",
-      "line": 24,
+      "line": 37,
       "members": []
     },
     {
@@ -52124,7 +52124,7 @@
       "kind": "record",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs",
-      "line": 12,
+      "line": 21,
       "members": []
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,8 @@ group.MapGet("/{id:guid}", GetByIdAsync)
 
 `Ok<T>`→`.Produces<T>()`, `Created<T>`→`.Produces<T>(201)`, `NotFound`→`.ProducesProblem(404)`, `ValidationProblem`→`.ProducesValidationProblem()`, `FileStreamHttpResult`→`.Produces(200, contentType: "application/octet-stream")`.
 
+Handlers are `private static` **named methods** referenced by method-group (`MapGet("/", GetByIdAsync)`) — never inline lambdas (lambdas can't carry OpenAPI metadata cleanly and aren't testable in isolation). `internal static` reserved for shared helpers/factories. Endpoints are tested at HTTP level via `Granit.Testing.Endpoints.GranitEndpointTestHost`, not by invoking handlers directly. Rare trampolines (`(...) => HandleXxxAsync(...)`) are allowed only where Minimal API can't bind the handler signature (streaming, manual `HttpContext`, OpenIddict transactions) — delegate to a named method, document inline.
+
 ### OpenAPI tags (STRICT)
 
 Every `*.Endpoints` module attaches `.WithTags(...)` on its root group. Format: `Title Case With Spaces` (`Blob Storage`, `Background Jobs`) — NEVER glued PascalCase, kebab-case, or snake_case. Multi-tag: `<Module> - <SubGroup>` (space-dash-space) — `AI - Workspaces`, `Identity - Webhook`. Expose via `TagName` on `*EndpointsOptions` (overridable per-app). `Granit.Http.ApiDocumentation` auto-emits a sorted `document.Tags` array.

--- a/src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs
+++ b/src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs
@@ -8,6 +8,15 @@ namespace Granit.Timeline.Endpoints.Dtos;
 /// only emojis with at least one reaction are present and the field itself
 /// is <see langword="null"/> when the entry has no reactions, keeping the
 /// wire payload tight (story C3).
+/// <para>
+/// Federation provenance is surfaced verbatim from the projection:
+/// <c>Origin</c> (<c>"Native"</c> for rows in the Timeline table, <c>"External"</c>
+/// for entries projected from an <c>ITimelineSource</c>), <c>SourceKey</c>
+/// (contributor key such as <c>"auditing"</c>; the reserved <c>"native"</c> for
+/// native rows — never <see langword="null"/>), <c>SourceId</c> (external
+/// primary key, <see langword="null"/> for native rows), and <c>EditedAt</c>
+/// (last body-edit timestamp, <see langword="null"/> if never edited).
+/// </para>
 /// </summary>
 public sealed record TimelineStreamEntryResponse(
     Guid Id,
@@ -18,6 +27,10 @@ public sealed record TimelineStreamEntryResponse(
     string Body,
     IReadOnlyList<TimelineAttachmentInfoResponse> Attachments,
     Guid? ParentEntryId,
+    TimelineEntryOrigin Origin,
+    string SourceKey,
+    string? SourceId,
+    DateTimeOffset? EditedAt,
     IReadOnlyDictionary<string, ReactionAggregateResponse>? Reactions = null);
 
 /// <summary>Attachment metadata.</summary>

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
@@ -89,6 +89,7 @@ internal static class TimelineEntryEndpoints
             await notifier.NotifyMentionedUsersAsync(entry, mentionedUserIds, cancellationToken).ConfigureAwait(false);
         }
 
+        // A freshly posted entry is always native and never edited.
         TimelineStreamEntryResponse result = new(
             entry.Id,
             entry.CreatedAt,
@@ -97,7 +98,11 @@ internal static class TimelineEntryEndpoints
             entry.AuthorName,
             entry.Body,
             [],
-            entry.ParentEntryId);
+            entry.ParentEntryId,
+            TimelineEntryOrigin.Native,
+            TimelineSourceKeys.Native,
+            SourceId: null,
+            EditedAt: null);
 
         return TypedResults.Created($"/api/timeline/{entityType}/{entityId}/entries/{entry.Id}", result);
     }

--- a/src/Granit.Timeline.Endpoints/Internal/TimelineResponseMapper.cs
+++ b/src/Granit.Timeline.Endpoints/Internal/TimelineResponseMapper.cs
@@ -9,7 +9,8 @@ internal static class TimelineResponseMapper
         TimelineStreamEntry entry,
         IReadOnlyDictionary<string, ReactionAggregateResponse>? reactions = null) =>
         new(entry.Id, entry.OccurredAt, entry.EntryType, entry.AuthorId, entry.AuthorName, entry.Body,
-            [.. entry.Attachments.Select(ToResponse)], entry.ParentEntryId, reactions);
+            [.. entry.Attachments.Select(ToResponse)], entry.ParentEntryId,
+            entry.Origin, entry.SourceKey, entry.SourceId, entry.EditedAt, reactions);
 
     internal static TimelineAttachmentInfoResponse ToResponse(TimelineAttachmentInfo attachment) =>
         new(attachment.Id, attachment.BlobId, attachment.FileName, attachment.ContentType, attachment.SizeBytes);

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
@@ -111,6 +111,11 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
         result!.Id.ShouldBe(entryId);
         result.Body.ShouldBe("Test comment");
         result.EntryType.ShouldBe(TimelineStreamEntryType.Comment);
+        // A freshly posted entry is always native and never edited.
+        result.Origin.ShouldBe(TimelineEntryOrigin.Native);
+        result.SourceKey.ShouldBe(TimelineSourceKeys.Native);
+        result.SourceId.ShouldBeNull();
+        result.EditedAt.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineResponseMapperFederationTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineResponseMapperFederationTests.cs
@@ -1,0 +1,72 @@
+using Granit.Timeline.Abstractions;
+using Granit.Timeline.Endpoints.Dtos;
+using Granit.Timeline.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.Endpoints.Tests;
+
+public sealed class TimelineResponseMapperFederationTests
+{
+    [Fact]
+    public void ToResponse_maps_native_entry_with_native_source_key_and_no_external_provenance()
+    {
+        var entry = new TimelineStreamEntry
+        {
+            Id = Guid.NewGuid(),
+            OccurredAt = DateTimeOffset.UtcNow,
+            EntryType = TimelineStreamEntryType.Comment,
+            AuthorId = "user-1",
+            AuthorName = "Alice",
+            Body = "Hello",
+            // Origin / SourceKey default to Native / "native"; SourceId / EditedAt default to null.
+        };
+
+        TimelineStreamEntryResponse response = TimelineResponseMapper.ToResponse(entry);
+
+        response.Origin.ShouldBe(TimelineEntryOrigin.Native);
+        response.SourceKey.ShouldBe(TimelineSourceKeys.Native);
+        response.SourceId.ShouldBeNull();
+        response.EditedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_maps_external_entry_provenance_verbatim()
+    {
+        var entry = new TimelineStreamEntry
+        {
+            Id = Guid.NewGuid(),
+            OccurredAt = DateTimeOffset.UtcNow,
+            EntryType = TimelineStreamEntryType.SystemLog,
+            Body = "Audit event",
+            Origin = TimelineEntryOrigin.External,
+            SourceKey = "auditing",
+            SourceId = "audit-42",
+        };
+
+        TimelineStreamEntryResponse response = TimelineResponseMapper.ToResponse(entry);
+
+        response.Origin.ShouldBe(TimelineEntryOrigin.External);
+        response.SourceKey.ShouldBe("auditing");
+        response.SourceId.ShouldBe("audit-42");
+        response.EditedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_maps_edited_at_timestamp()
+    {
+        DateTimeOffset editedAt = DateTimeOffset.UtcNow;
+        var entry = new TimelineStreamEntry
+        {
+            Id = Guid.NewGuid(),
+            OccurredAt = DateTimeOffset.UtcNow,
+            EntryType = TimelineStreamEntryType.Comment,
+            Body = "Edited body",
+            EditedAt = editedAt,
+        };
+
+        TimelineStreamEntryResponse response = TimelineResponseMapper.ToResponse(entry);
+
+        response.EditedAt.ShouldBe(editedAt);
+    }
+}

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineStreamEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineStreamEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using Granit.Authorization;
 using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
+using Granit.Timeline.Endpoints.Dtos;
 using Granit.Timeline.Endpoints.Extensions;
 using Granit.Timeline.Endpoints.Permissions;
 using Microsoft.AspNetCore.Authentication;
@@ -106,6 +107,69 @@ public sealed class TimelineStreamEndpointsTests : IAsyncDisposable
         page.Items.Count.ShouldBe(1);
         page.Items[0].Body.ShouldBe("Hello");
         page.Items[0].AuthorName.ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task GetStream_surfaces_external_federation_fields()
+    {
+        // Arrange — an external (projected) entry carries provenance the front renders.
+        var entry = new TimelineStreamEntry
+        {
+            Id = Guid.NewGuid(),
+            OccurredAt = DateTimeOffset.UtcNow,
+            EntryType = TimelineStreamEntryType.SystemLog,
+            Body = "Audit event",
+            Origin = TimelineEntryOrigin.External,
+            SourceKey = "auditing",
+            SourceId = "audit-42",
+        };
+
+        _reader.GetStreamAsync("Patient", "42", 1, QueryEngineDefaults.DefaultPageSize, Arg.Any<CancellationToken>())
+            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>([entry], 1, HasMore: false), []));
+
+        // Act
+        HttpResponseMessage response = await _authClient.GetAsync(
+            $"{Prefix}/Patient/42", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        PagedResult<TimelineStreamEntryResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<TimelineStreamEntryResponse>>(TestContext.Current.CancellationToken);
+        TimelineStreamEntryResponse item = page!.Items[0];
+
+        item.Origin.ShouldBe(TimelineEntryOrigin.External);
+        item.SourceKey.ShouldBe("auditing");
+        item.SourceId.ShouldBe("audit-42");
+        item.EditedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetStream_emits_native_source_key_for_native_entries()
+    {
+        var entry = new TimelineStreamEntry
+        {
+            Id = Guid.NewGuid(),
+            OccurredAt = DateTimeOffset.UtcNow,
+            EntryType = TimelineStreamEntryType.Comment,
+            AuthorId = "user-1",
+            AuthorName = "Alice",
+            Body = "Hello",
+        };
+
+        _reader.GetStreamAsync("Patient", "42", 1, QueryEngineDefaults.DefaultPageSize, Arg.Any<CancellationToken>())
+            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>([entry], 1, HasMore: false), []));
+
+        HttpResponseMessage response = await _authClient.GetAsync(
+            $"{Prefix}/Patient/42", TestContext.Current.CancellationToken);
+
+        PagedResult<TimelineStreamEntryResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<TimelineStreamEntryResponse>>(TestContext.Current.CancellationToken);
+        TimelineStreamEntryResponse item = page!.Items[0];
+
+        item.Origin.ShouldBe(TimelineEntryOrigin.Native);
+        // Native rows emit the reserved "native" key (never null) so the front can rely on a string.
+        item.SourceKey.ShouldBe(TimelineSourceKeys.Native);
+        item.SourceId.ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Why

`TimelineStreamEntryResponse` dropped four fields the projection (`TimelineStreamEntry`) already carries, so the front had no way to render the federation badge or the "edited" badge:

- `Origin` — `"Native"` vs `"External"` (entries projected from an `ITimelineSource`)
- `SourceKey` — contributor key (e.g. `"auditing"`); `"native"` for native rows
- `SourceId` — external primary key; `null` for native rows
- `EditedAt` — last body-edit timestamp; `null` if never edited

## What

- Add the four fields to the response DTO.
- Map them at **both** construction sites: the stream mapper (`TimelineResponseMapper`) and the POST handler (a freshly posted entry is always native and never edited).
- `SourceKey` emits the reserved `"native"` so the wire value is never null. `SourceId`/`EditedAt` are **required keys with nullable values** (always-present-but-may-be-null), per the DTO convention.

## Contract

OpenAPI regenerated and verified — all four fields land in `required`, `origin` serializes as the string enum `["Native","External"]`, `sourceId`/`editedAt` are `["null","string"]`, `reactions` stays optional. The front will re-sync `timeline.json` and register the response in its oracle; no front change required.

## Notes

- JSON key order is `…, parentEntryId, origin, sourceKey, sourceId, editedAt, reactions` — `reactions` stays last because it is the only optional (defaulted) parameter; key order is not semantically part of the OpenAPI contract.
- `EditedAt` is intentionally **not** the audit `ModifiedAt`: `TimelineEntry` is `CreationAuditedAggregateRoot` and stamps `EditedAt` only on a body edit (paired with `TimelineEntryEditedEvent`), never on soft-delete — it is the precise "edited" semantic, not generic row modification.
- Also folds in a small CLAUDE.md clarification on the named-handler / method-group endpoint convention.

## Tests

`Granit.Timeline.Endpoints.Tests` — 21 green (new mapper-federation unit tests + endpoint coverage for native and external provenance). `dotnet format --verify-no-changes` clean.