### PR TITLE
feat: enrich response DTOs that drop fields their source already carries

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7677,7 +7677,7 @@
       "kind": "record",
       "project": "Granit.Auditing.Endpoints",
       "file": "src/Granit.Auditing.Endpoints/Dtos/AuditEntryDetailResponse.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -15837,7 +15837,7 @@
       "kind": "record",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs",
-      "line": 17,
+      "line": 20,
       "members": []
     },
     {
@@ -44906,7 +44906,7 @@
       "kind": "record",
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyExportStatusResponse.cs",
-      "line": 17,
+      "line": 19,
       "members": []
     },
     {
@@ -49466,7 +49466,7 @@
       "kind": "record",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.Auditing.Endpoints/Dtos/AuditEntryDetailResponse.cs
+++ b/src/Granit.Auditing.Endpoints/Dtos/AuditEntryDetailResponse.cs
@@ -9,6 +9,7 @@ namespace Granit.Auditing.Endpoints.Dtos;
 /// <param name="UserName">Actor display name.</param>
 /// <param name="Category">Audit log category.</param>
 /// <param name="IpAddress">Source IP address.</param>
+/// <param name="UserAgent">Client user-agent string captured at the time of the operation.</param>
 /// <param name="TenantId">Tenant identifier.</param>
 /// <param name="CorrelationId">Distributed tracing correlation ID.</param>
 /// <param name="EntityChanges">Nested entity and property changes.</param>
@@ -19,6 +20,7 @@ public sealed record AuditEntryDetailResponse(
     string? UserName,
     string Category,
     string? IpAddress,
+    string? UserAgent,
     Guid? TenantId,
     string? CorrelationId,
     IReadOnlyList<AuditEntityChangeResponse> EntityChanges);

--- a/src/Granit.Auditing.Endpoints/Internal/AuditingResponseMapper.cs
+++ b/src/Granit.Auditing.Endpoints/Internal/AuditingResponseMapper.cs
@@ -31,6 +31,7 @@ internal static class AuditingResponseMapper
             entry.UserName,
             entry.Category.ToString(),
             entry.IpAddress,
+            entry.UserAgent,
             entry.TenantId,
             entry.CorrelationId,
             entry.EntityChanges.Select(ToEntityChangeResponse).ToList());

--- a/src/Granit.DataExchange.Endpoints/Dtos/Export/ExportJobResponse.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Export/ExportJobResponse.cs
@@ -15,12 +15,14 @@ public sealed record ExportJobResponse(
     string? FileName,
     string? ErrorMessage,
     DateTimeOffset CreatedAt,
-    DateTimeOffset? CompletedAt)
+    DateTimeOffset? CompletedAt,
+    DateTimeOffset? ModifiedAt,
+    string? ModifiedBy)
 {
     /// <summary>
     /// Maps an <see cref="ExportJob"/> domain entity to a response DTO.
     /// </summary>
     internal static ExportJobResponse FromJob(ExportJob job) =>
         new(job.Id, job.DefinitionName, job.Format, job.Status, job.RowCount,
-            job.FileName, job.ErrorMessage, job.CreatedAt, job.CompletedAt);
+            job.FileName, job.ErrorMessage, job.CreatedAt, job.CompletedAt, job.ModifiedAt, job.ModifiedBy);
 }

--- a/src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs
@@ -7,28 +7,34 @@ namespace Granit.DataExchange.Endpoints.Dtos.Import;
 /// </summary>
 /// <param name="Id">Unique job identifier.</param>
 /// <param name="DefinitionName">Logical import definition name.</param>
+/// <param name="EntityTypeName">Name of the target entity type being imported (e.g. <c>Patient</c>).</param>
 /// <param name="OriginalFileName">Original uploaded file name.</param>
 /// <param name="MimeType">MIME type of the uploaded file.</param>
 /// <param name="FileSizeBytes">File size in bytes.</param>
 /// <param name="Status">Current job status.</param>
 /// <param name="CreatedAt">UTC timestamp of creation.</param>
 /// <param name="CompletedAt">UTC timestamp of completion; <c>null</c> while in progress.</param>
+/// <param name="ModifiedAt">UTC timestamp of the last state transition; <c>null</c> if never modified.</param>
+/// <param name="ModifiedBy">Identity that last modified the job; <c>null</c> if never modified.</param>
 /// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record ImportJobResponse(
     Guid Id,
     string DefinitionName,
+    string EntityTypeName,
     string OriginalFileName,
     string MimeType,
     long FileSizeBytes,
     ImportJobStatus Status,
     DateTimeOffset CreatedAt,
     DateTimeOffset? CompletedAt,
+    DateTimeOffset? ModifiedAt,
+    string? ModifiedBy,
     string ConcurrencyStamp)
 {
     /// <summary>
     /// Maps an <see cref="ImportJob"/> domain entity to a response DTO.
     /// </summary>
     internal static ImportJobResponse FromJob(ImportJob job) =>
-        new(job.Id, job.DefinitionName, job.OriginalFileName, job.MimeType,
-            job.FileSizeBytes, job.Status, job.CreatedAt, job.CompletedAt, job.ConcurrencyStamp);
+        new(job.Id, job.DefinitionName, job.EntityTypeName, job.OriginalFileName, job.MimeType,
+            job.FileSizeBytes, job.Status, job.CreatedAt, job.CompletedAt, job.ModifiedAt, job.ModifiedBy, job.ConcurrencyStamp);
 }

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportExecutionEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportExecutionEndpoints.cs
@@ -85,7 +85,7 @@ internal static class ExportExecutionEndpoints
         ExportJobResponse response = job is not null
             ? ExportJobResponse.FromJob(job)
             : new ExportJobResponse(result.JobId, request.DefinitionName, request.Format,
-                result.Status, null, null, null, clock.Now, null);
+                result.Status, null, null, null, clock.Now, null, null, null);
 
         return TypedResults.Created($"/jobs/{result.JobId}", response);
     }

--- a/src/Granit.Notifications.Endpoints/Dtos/NotificationPreferenceResponse.cs
+++ b/src/Granit.Notifications.Endpoints/Dtos/NotificationPreferenceResponse.cs
@@ -8,4 +8,6 @@ public sealed record NotificationPreferenceResponse(
     string UserId,
     string NotificationTypeName,
     string ChannelName,
-    bool IsEnabled);
+    bool IsEnabled,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ModifiedAt);

--- a/src/Granit.Notifications.Endpoints/Dtos/NotificationSubscriptionResponse.cs
+++ b/src/Granit.Notifications.Endpoints/Dtos/NotificationSubscriptionResponse.cs
@@ -8,4 +8,5 @@ public sealed record NotificationSubscriptionResponse(
     string UserId,
     string NotificationTypeName,
     string? EntityType,
-    string? EntityId);
+    string? EntityId,
+    DateTimeOffset CreatedAt);

--- a/src/Granit.Notifications.Endpoints/Endpoints/PreferenceEndpoints.cs
+++ b/src/Granit.Notifications.Endpoints/Endpoints/PreferenceEndpoints.cs
@@ -58,7 +58,7 @@ internal static class PreferenceEndpoints
         Guid? tenantId = tenant.IsAvailable ? tenant.Id : null;
         IReadOnlyList<NotificationPreference> preferences = await reader.GetListAsync(userId, tenantId).ConfigureAwait(false);
         var result = preferences
-            .Select(p => new NotificationPreferenceResponse(p.Id, p.UserId, p.NotificationTypeName, p.ChannelName, p.IsEnabled))
+            .Select(p => new NotificationPreferenceResponse(p.Id, p.UserId, p.NotificationTypeName, p.ChannelName, p.IsEnabled, p.CreatedAt, p.ModifiedAt))
             .ToList();
         return TypedResults.Ok(result);
     }

--- a/src/Granit.Notifications.Endpoints/Internal/NotificationsResponseMapper.cs
+++ b/src/Granit.Notifications.Endpoints/Internal/NotificationsResponseMapper.cs
@@ -21,7 +21,7 @@ internal static class NotificationsResponseMapper
     public static List<NotificationSubscriptionResponse> ToSubscriptionResponses(
         IReadOnlyList<NotificationSubscription> subscriptions) =>
         subscriptions.Select(s => new NotificationSubscriptionResponse(
-            s.Id, s.UserId, s.NotificationTypeName, s.EntityType, s.EntityId)).ToList();
+            s.Id, s.UserId, s.NotificationTypeName, s.EntityType, s.EntityId, s.CreatedAt)).ToList();
 
     /// <summary>Extracts the user identifier from the current <see cref="ClaimsPrincipal"/>.</summary>
     /// <exception cref="UnauthorizedAccessException">Thrown when no user identifier claim is found.</exception>

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportStatusResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportStatusResponse.cs
@@ -6,6 +6,8 @@ namespace Granit.Privacy.Endpoints.Dtos;
 /// Status of a personal data export request (GDPR Art. 15/20).
 /// </summary>
 /// <param name="RequestId">Correlation ID of the export saga.</param>
+/// <param name="SubjectUserId">User whose personal data was exported (the data subject).</param>
+/// <param name="CallerUserId">User who requested the export — differs from <paramref name="SubjectUserId"/> in on-behalf-of flows.</param>
 /// <param name="State">Current state: Pending, Completed, PartiallyCompleted, or TimedOut.</param>
 /// <param name="RequestedAt">Timestamp when the export was requested (UTC).</param>
 /// <param name="CompletedAt">Timestamp when the export completed (UTC), or <c>null</c> if still pending.</param>
@@ -16,6 +18,8 @@ namespace Granit.Privacy.Endpoints.Dtos;
 /// <param name="MissingProviders">Data providers that did not respond before timeout (empty if fully completed).</param>
 public sealed record PrivacyExportStatusResponse(
     Guid RequestId,
+    Guid SubjectUserId,
+    Guid CallerUserId,
     string State,
     DateTimeOffset RequestedAt,
     DateTimeOffset? CompletedAt,

--- a/src/Granit.Privacy.Endpoints/Internal/PrivacyResponseMapper.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/PrivacyResponseMapper.cs
@@ -52,6 +52,8 @@ internal static class PrivacyResponseMapper
     internal static PrivacyExportStatusResponse MapExportStatus(ExportRequestStatus status) =>
         new(
             status.RequestId,
+            status.SubjectUserId,
+            status.CallerUserId,
             status.State.ToString(),
             status.RequestedAt,
             status.CompletedAt,

--- a/src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs
@@ -6,6 +6,7 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <param name="Content">Raw template source content.</param>
 /// <param name="MimeType">MIME type of the content (e.g. <c>text/html</c>).</param>
 /// <param name="Status">Lifecycle status (<c>Draft</c>, <c>Published</c>, or <c>Archived</c>).</param>
+/// <param name="Version">Monotonically increasing version number within the same template key.</param>
 /// <param name="CreatedAt">UTC timestamp of creation.</param>
 /// <param name="CreatedBy">Identity of the user who created this revision.</param>
 /// <param name="PublishedAt">UTC timestamp of publication; <c>null</c> for drafts.</param>
@@ -17,6 +18,7 @@ public sealed record TemplateRevisionResponse(
     string Content,
     string MimeType,
     WorkflowLifecycleStatus Status,
+    int Version,
     DateTimeOffset CreatedAt,
     string CreatedBy,
     DateTimeOffset? PublishedAt,

--- a/src/Granit.Templating.Endpoints/Internal/TemplatingResponseMapper.cs
+++ b/src/Granit.Templating.Endpoints/Internal/TemplatingResponseMapper.cs
@@ -24,6 +24,7 @@ internal static class TemplatingResponseMapper
             revision.Content,
             revision.MimeType,
             revision.Status,
+            revision.Version,
             revision.CreatedAt,
             revision.CreatedBy,
             revision.PublishedAt,

--- a/tests/Granit.Auditing.Endpoints.Tests/Dtos/AuditEntryDetailResponseTests.cs
+++ b/tests/Granit.Auditing.Endpoints.Tests/Dtos/AuditEntryDetailResponseTests.cs
@@ -27,6 +27,7 @@ public sealed class AuditEntryDetailResponseTests
             "Jane Doe",
             "ConfigurationChange",
             "10.0.0.1",
+            "Mozilla/5.0",
             null,
             "trace-1",
             changes);
@@ -36,6 +37,8 @@ public sealed class AuditEntryDetailResponseTests
         response.UserId.ShouldBe("user-1");
         response.UserName.ShouldBe("Jane Doe");
         response.Category.ShouldBe("ConfigurationChange");
+        response.IpAddress.ShouldBe("10.0.0.1");
+        response.UserAgent.ShouldBe("Mozilla/5.0");
         response.EntityChanges.ShouldHaveSingleItem();
         response.EntityChanges[0].EntityType.ShouldBe("Patient");
         response.EntityChanges[0].PropertyChanges.ShouldHaveSingleItem();
@@ -50,6 +53,7 @@ public sealed class AuditEntryDetailResponseTests
             "user-1",
             null,
             "DataMutation",
+            null,
             null,
             null,
             null,

--- a/tests/Granit.Notifications.Endpoints.Tests/NotificationPreferenceResponseTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/NotificationPreferenceResponseTests.cs
@@ -17,9 +17,11 @@ public sealed class NotificationPreferenceResponseTests
     {
         // Arrange
         var id = Guid.NewGuid();
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+        DateTimeOffset modifiedAt = createdAt.AddMinutes(5);
 
         // Act
-        NotificationPreferenceResponse response = new(id, "user-1", "NewMessage", "Email", true);
+        NotificationPreferenceResponse response = new(id, "user-1", "NewMessage", "Email", true, createdAt, modifiedAt);
 
         // Assert
         response.Id.ShouldBe(id);
@@ -27,13 +29,16 @@ public sealed class NotificationPreferenceResponseTests
         response.NotificationTypeName.ShouldBe("NewMessage");
         response.ChannelName.ShouldBe("Email");
         response.IsEnabled.ShouldBeTrue();
+        response.CreatedAt.ShouldBe(createdAt);
+        response.ModifiedAt.ShouldBe(modifiedAt);
     }
 
     [Fact]
     public void Record_Equality_SameValues_AreEqual()
     {
         var id = Guid.NewGuid();
-        new NotificationPreferenceResponse(id, "u", "T", "C", true)
-            .ShouldBe(new NotificationPreferenceResponse(id, "u", "T", "C", true));
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+        new NotificationPreferenceResponse(id, "u", "T", "C", true, createdAt, null)
+            .ShouldBe(new NotificationPreferenceResponse(id, "u", "T", "C", true, createdAt, null));
     }
 }

--- a/tests/Granit.Notifications.Endpoints.Tests/NotificationSubscriptionResponseTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/NotificationSubscriptionResponseTests.cs
@@ -17,9 +17,10 @@ public sealed class NotificationSubscriptionResponseTests
     {
         // Arrange
         var id = Guid.NewGuid();
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow;
 
         // Act
-        NotificationSubscriptionResponse response = new(id, "user-1", "NewMessage", "Acme.Patients", "p-42");
+        NotificationSubscriptionResponse response = new(id, "user-1", "NewMessage", "Acme.Patients", "p-42", createdAt);
 
         // Assert
         response.Id.ShouldBe(id);
@@ -27,13 +28,14 @@ public sealed class NotificationSubscriptionResponseTests
         response.NotificationTypeName.ShouldBe("NewMessage");
         response.EntityType.ShouldBe("Acme.Patients");
         response.EntityId.ShouldBe("p-42");
+        response.CreatedAt.ShouldBe(createdAt);
     }
 
     [Fact]
     public void Constructor_NullOptionalFields()
     {
         var id = Guid.NewGuid();
-        NotificationSubscriptionResponse response = new(id, "user-1", "TopicSub", null, null);
+        NotificationSubscriptionResponse response = new(id, "user-1", "TopicSub", null, null, DateTimeOffset.UtcNow);
 
         response.EntityType.ShouldBeNull();
         response.EntityId.ShouldBeNull();

--- a/tests/Granit.Privacy.Endpoints.Tests/Dtos/PrivacyDtoTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Dtos/PrivacyDtoTests.cs
@@ -22,14 +22,18 @@ public sealed class PrivacyDtoTests
     public void PrivacyExportStatusResponse_HoldsAllProperties()
     {
         var requestId = Guid.NewGuid();
+        var subjectUserId = Guid.NewGuid();
+        var callerUserId = Guid.NewGuid();
         DateTimeOffset requested = DateTimeOffset.UtcNow;
         DateTimeOffset completed = requested.AddMinutes(3);
         List<string> missing = ["provider-a"];
 
         PrivacyExportStatusResponse response = new(
-            requestId, "Completed", requested, completed, "gdpr-export/123", missing);
+            requestId, subjectUserId, callerUserId, "Completed", requested, completed, "gdpr-export/123", missing);
 
         response.RequestId.ShouldBe(requestId);
+        response.SubjectUserId.ShouldBe(subjectUserId);
+        response.CallerUserId.ShouldBe(callerUserId);
         response.State.ShouldBe("Completed");
         response.RequestedAt.ShouldBe(requested);
         response.CompletedAt.ShouldBe(completed);


### PR DESCRIPTION
## Why

Follow-up to the Timeline federation-fields fix (#2776). An audit of every `*.Endpoints` response mapper surfaced the same smell elsewhere: `*Response` records dropping display-meaningful fields their source domain entity / projection already carries. This PR fixes the genuine gaps (one commit per module) and leaves deliberate omissions alone.

## Changes (one commit each)

| Module | Response | Added | Source |
|---|---|---|---|
| **Templating** | `TemplateRevisionResponse` | `Version` | `TemplateRevision.Version` — revision tracking / concurrency |
| **DataExchange** | `ImportJobResponse` | `EntityTypeName`, `ModifiedAt`, `ModifiedBy` | `ImportJob` (AuditedAggregateRoot) — what's imported + state-transition audit |
| **DataExchange** | `ExportJobResponse` | `ModifiedAt`, `ModifiedBy` | `ExportJob` (AuditedAggregateRoot) |
| **Auditing** | `AuditEntryDetailResponse` | `UserAgent` | `AuditEntry.UserAgent` — parity with the already-exposed `IpAddress` |
| **Privacy** | `PrivacyExportStatusResponse` | `SubjectUserId`, `CallerUserId` | `ExportRequestStatus` — disambiguates the on-behalf-of flow |
| **Notifications** | `NotificationSubscriptionResponse` / `NotificationPreferenceResponse` | `CreatedAt` / `CreatedAt`+`ModifiedAt` | audit timestamps, consistent with Role/Webhook/Hostname responses |

## Deliberately NOT changed (verified intentional)

- **Privacy** `PrivacyDeletionStatusResponse.UserId` — the deletion-status route is strictly self-scoped (`status.UserId != userId` → 404), so it's always the caller → redundant.
- **ApiKeys** `LastExpirationNotifiedAt` — internal notification bookkeeping.
- **Notifications** `MobilePushTokenResponse.Id` — tokens are addressed by `deviceToken`.
- **Identity** `UserSessionResponse.UserId` — `/me/sessions` is self-scoped.
- Everywhere: `CreatedBy`/`ModifiedBy` actor ids on non-audit-display responses, `TenantId`, soft-delete internals, `DeviceTokenHash`, `IsOrphaned`/`OrphanedAt`.

## Contract

OpenAPI regenerated and verified for all 7 schemas across 6 module specs — every new field lands in `required` with correct nullability (value-nullable fields are required keys per the DTO convention; enum/uuid/int types as expected). Generated specs are git-ignored; consumers re-sync from CI artifacts.

## Tests

All five affected suites green (Templating 114, DataExchange 120, Auditing 39, Privacy 145, Notifications 88). `dotnet format --verify-no-changes` clean on all 10 touched projects.