### PR TITLE
test(openiddict-endpoints): expand coverage for Granit.OpenIddict.Endpoints

### DIFF
--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -1060,6 +1060,45 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
     }
 
     // -------------------------------------------------------------------------
+    // ConsentOidcEndpoints — GET /oidc/applications/{clientId}
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetApplicationInfo_ExistingApp_ReturnsClientIdAndDisplayName()
+    {
+        object app = new();
+
+        _server.ApplicationManager.FindByClientIdAsync("consent-client", Arg.Any<CancellationToken>())
+            .Returns(app);
+        _server.ApplicationManager.GetDisplayNameAsync(app, Arg.Any<CancellationToken>())
+            .Returns("Consent App");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/oidc/applications/consent-client", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        OidcApplicationInfoResponse? result = await response.Content
+            .ReadFromJsonAsync<OidcApplicationInfoResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ClientId.ShouldBe("consent-client");
+        result.DisplayName.ShouldBe("Consent App");
+    }
+
+    [Fact]
+    public async Task GetApplicationInfo_NotFound_Returns404()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("unknown-client", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/oidc/applications/unknown-client", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/ConnectVerifyEndpointsTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/ConnectVerifyEndpointsTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Granit.OpenIddict.Endpoints.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Endpoints.Tests.Integration;
+
+/// <summary>
+/// Tests for <c>ConnectVerifyEndpoints</c> (/connect/verify) that do not require a running
+/// OpenIddict server pipeline. When no <c>user_code</c> is present (or the OpenIddict
+/// middleware has not processed the request), <c>GetOpenIddictServerRequest()</c> returns
+/// <c>null</c> and the endpoint redirects to the configured device verification path.
+/// </summary>
+public sealed class ConnectVerifyEndpointsTests : IAsyncLifetime
+{
+    private WebApplication _app = null!;
+    private HttpClient _client = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        _app = builder.Build();
+        _app.MapGranitOpenIddictServer();
+        await _app.StartAsync(TestContext.Current.CancellationToken);
+
+        _client = _app.GetTestServer().CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        await _app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Verify_NoUserCode_Get_RedirectsToDefaultDevicePath()
+    {
+        // GET /connect/verify without a user_code: GetOpenIddictServerRequest() returns null
+        // → the endpoint falls into the "no user_code" branch and redirects to /device.
+        HttpResponseMessage response = await _client.GetAsync(
+            "/connect/verify", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location?.ToString().ShouldBe("/device");
+    }
+
+    [Fact]
+    public async Task Verify_NoUserCode_Post_RedirectsToDefaultDevicePath()
+    {
+        HttpResponseMessage response = await _client.PostAsync(
+            "/connect/verify", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location?.ToString().ShouldBe("/device");
+    }
+
+    [Fact]
+    public async Task Verify_NoUserCode_CustomDevicePath_RedirectsToCustomPath()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        await using WebApplication app = builder.Build();
+        app.MapGranitOpenIddictServer(o => o.DeviceVerificationPath = "/custom-device");
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using HttpClient client = app.GetTestServer().CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/connect/verify", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location?.ToString().ShouldBe("/custom-device");
+    }
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
@@ -94,6 +94,23 @@ public sealed class OidcPrincipalFactoryTests
     }
 
     [Fact]
+    public async Task CreateUserPrincipal_OnlyLastName_SetsNameAndFamilyNameWithoutGivenName()
+    {
+        LocalIdentity user = CreateTestUser();
+        user.FirstName = null;
+        user.LastName = "Doe";
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Name)?.Value.ShouldBe("Doe");
+        identity.FindFirst(OpenIddictConstants.Claims.FamilyName)?.Value.ShouldBe("Doe");
+        identity.FindFirst(OpenIddictConstants.Claims.GivenName).ShouldBeNull();
+    }
+
+    [Fact]
     public async Task CreateUserPrincipal_NullNames_NoNameClaim()
     {
         LocalIdentity user = CreateTestUser();

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Validators/AdminOidcValidatorTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Validators/AdminOidcValidatorTests.cs
@@ -80,6 +80,102 @@ public sealed class AdminOidcCreateApplicationRequestValidatorTests
         TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
         result.ShouldNotHaveValidationErrorFor(x => x.DisplayName);
     }
+
+    [Fact]
+    public void ConsentType_exceeding_max_length_fails()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", ConsentType: new string('a', 65));
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ConsentType);
+    }
+
+    [Fact]
+    public void ConsentType_at_max_length_passes()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", ConsentType: new string('a', 64));
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.ConsentType);
+    }
+
+    [Fact]
+    public void SigningKeyJwk_exceeding_max_length_fails()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", SigningKeyJwk: new string('a', 65537));
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.SigningKeyJwk);
+    }
+
+    [Fact]
+    public void SigningKeyJwk_at_max_length_passes()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", SigningKeyJwk: new string('a', 65536));
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.SigningKeyJwk);
+    }
+
+    [Fact]
+    public void Permission_empty_string_in_array_fails()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", Permissions: ["ept:token", ""]);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("Permissions[1]");
+    }
+
+    [Fact]
+    public void Permission_exceeding_max_length_fails()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", Permissions: [new string('a', 513)]);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("Permissions[0]");
+    }
+
+    [Fact]
+    public void Null_permissions_skips_element_validation()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", Permissions: null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void RedirectUri_relative_uri_fails()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", RedirectUris: ["not-absolute"]);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("RedirectUris[0]");
+    }
+
+    [Fact]
+    public void RedirectUri_absolute_uri_passes()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", RedirectUris: ["https://example.com/callback"]);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor("RedirectUris[0]");
+    }
+
+    [Fact]
+    public void Null_redirect_uris_skips_element_validation()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", RedirectUris: null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void PostLogoutRedirectUri_relative_uri_fails()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", PostLogoutRedirectUris: ["not-absolute"]);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor("PostLogoutRedirectUris[0]");
+    }
+
+    [Fact]
+    public void Null_post_logout_redirect_uris_skips_element_validation()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", PostLogoutRedirectUris: null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
 }
 
 public sealed class AdminOidcCreateScopeRequestValidatorTests


### PR DESCRIPTION
## Summary

- **`AdminOidcCreateApplicationRequestValidator`**: 12 new tests covering `ConsentType`, `SigningKeyJwk`, `Permissions[]`, `RedirectUris[]`, and `PostLogoutRedirectUris[]` rules — previously only `ClientId` + `DisplayName` were exercised.
- **`OidcPrincipalFactory.CreateUserPrincipalAsync`**: last-name-only case (`FirstName = null`, `LastName` set) — `Name` + `FamilyName` emitted, `GivenName` absent.
- **`ConsentOidcEndpoints.GetApplicationInfoAsync`**: found (200) and not-found (404) cases via the existing `OidcEndpointsTestServer` (endpoint was already mapped, just never tested).
- **`ConnectVerifyEndpoints`**: GET + POST `/connect/verify` with no `user_code` redirect to the configured `DeviceVerificationPath`; custom path override variant. Uses a minimal `WebApplication` without the OpenIddict pipeline — the `null`-request redirect branch fires before any auth or OpenIddict interaction.

## Context

Part of the global coverage improvement effort (currently 75.8 %). This package was at 47 % coverage (538 uncovered lines). The connect/* endpoints beyond the null-request redirect (`ConnectToken`, `ConnectAuthorization`, `ConnectLogout`, `ConnectUserInfo`) depend on the full OpenIddict server pipeline and cannot be tested without `OpenIddict.InMemory` or real Postgres — tracked separately.

## Test plan

- [ ] `dotnet test tests/Granit.OpenIddict.Endpoints.Tests --no-build` → 140 passed, 0 failed
- [ ] CI shard containing `tests/Granit.OpenIddict.Endpoints.Tests` passes