### PR TITLE
feat(endpoints): expose missing audit/concurrency fields on response DTOs

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -68,7 +68,7 @@ FLAGS
     naming        Permissions, events, jobs, DTOs, module homogeneity, SectionName hierarchy
     http          HTTP conventions, status codes, pagination, caching
     openapi       Endpoint metadata (5 mandatory elements)
-    persistence   DbContext, EF Core, interceptors, concurrency
+    persistence   DbContext, EF Core, interceptors, concurrency, DTO stamp/audit gaps
     ddd           Aggregate roots, value objects, factory methods
     validation    FluentValidation, localization, MapGranitGroup
     events        Domain events (*Event) and integration events (*Eto)
@@ -309,6 +309,22 @@ After auditing individual modules, perform cross-cutting checks:
    in-memory caches used as source of truth, migrations applied at boot, and
    liveness probes coupled to external dependencies. These patterns tend to repeat
    module-to-module, so call them out as a cross-cutting cluster, not one-offs.
+14. **DTO enrichment completeness** (`--scope persistence` / `--scope ddd`,
+   checklist §6d–§6f) — scan every module that has a `.Endpoints` satellite for two
+   systemic gaps. Cluster findings as "DTO enrichment gaps" and propose exact DTO
+   parameter additions following the `ImportJobResponse` pattern.
+
+   **Missing `ConcurrencyStamp`**: entity implements `IConcurrencyAware` AND a
+   mutation endpoint (PUT/PATCH/state-change POST) exists, but the `*Response` DTO
+   does not include `ConcurrencyStamp`. The client cannot build a conflict-safe
+   round-trip without it. Severity: `IMPROVEMENT` (bumps to `CONVENTION` when a
+   `409` path is already declared on the endpoint).
+
+   **Missing `ModifiedAt`**: entity inherits `AuditedAggregateRoot`,
+   `FullAuditedAggregateRoot`, `AuditedEntity`, or `FullAuditedEntity`, but the
+   `*Response` DTO omits `modifiedAt` (`DateTimeOffset?`, nullable). `CreationAudited*`
+   entities that correctly expose only `createdAt` are NOT a finding. Severity:
+   `IMPROVEMENT` (bumps to `CONVENTION` when a mutation endpoint exists).
 
 ### Context window discipline
 

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -855,7 +855,75 @@ Ref: `docs-site/…/data/interceptors.mdx`
 - [ ] Tests use SQLite or Testcontainers — never `UseInMemoryDatabase()` for
   concurrency (ignores tokens → false positive)
 
+**Detection strategy — `ConcurrencyStamp` gap in response DTOs:**
+
+1. Find all `IConcurrencyAware` entities in the module:
+
+   ```bash
+   grep -rl "IConcurrencyAware" src/Granit.{Module}/ --include="*.cs"
+   ```
+
+2. For each entity, confirm at least one **mutation** endpoint exists (PUT, PATCH,
+   or a POST that updates state) in the matching `.Endpoints` project.
+3. Locate the corresponding `*Response` DTO (usually `{EntityName}Response.cs` in
+   `src/Granit.{Module}.Endpoints/Dtos/`).
+4. Check whether `ConcurrencyStamp` (type `string`, non-null) is among the record
+   parameters. If absent while the entity implements `IConcurrencyAware` AND a
+   mutation endpoint exists → **IMPROVEMENT** finding.
+   - Severity bumps to **CONVENTION** when a round-trip conflict path (409) is
+     already declared on the endpoint but the stamp is not exposed — the client
+     cannot build the ETag without it.
+5. Also check the matching `*Request` DTO for the mutation endpoint: it should accept
+   the stamp back via `IConcurrencyStampRequest` (separate story — flag as
+   **IMPROVEMENT** if missing but do not block on it).
+
+Reference implementation: `ImportJobResponse` / `ExportJobResponse` in
+`Granit.DataExchange.Endpoints`.
+
 Ref: `docs-site/…/data/concurrency.mdx`
+
+### 6f. Response DTO completeness — audit fields
+
+Every `*Response` DTO must expose the audit fields that its domain entity inherits
+from the base class, so that clients can display provenance and sort/filter
+without a second request.
+
+**Rules by base class:**
+
+| Entity base | Required in `*Response` | Optional |
+| ----------- | ----------------------- | -------- |
+| `AuditedEntity` / `AuditedAggregateRoot` | `createdAt` (non-null), `modifiedAt` (nullable) | `createdBy`, `modifiedBy` |
+| `FullAuditedEntity` / `FullAuditedAggregateRoot` | `createdAt`, `modifiedAt` (nullable) | `createdBy`, `modifiedBy`, `deletedAt`, `deletedBy` |
+| `CreationAuditedEntity` / `CreationAuditedAggregateRoot` | `createdAt` (non-null) | `createdBy` — **do NOT add `modifiedAt`** (not provided by base) |
+| `Entity` | — | nothing |
+
+`modifiedAt` is always **nullable** (`DateTimeOffset?`) — `null` until the first
+mutation occurs. Never use `updatedAt` (convention: `modifiedAt`).
+
+**Detection strategy:**
+
+1. For each domain entity in `src/Granit.{Module}/`, inspect its base class:
+
+   ```bash
+   grep -rn "AuditedAggregateRoot\|FullAuditedAggregateRoot\|AuditedEntity\|FullAuditedEntity" \
+     src/Granit.{Module}/ --include="*.cs"
+   ```
+
+2. Locate the corresponding `*Response` DTO in `src/Granit.{Module}.Endpoints/Dtos/`.
+
+3. Check whether `ModifiedAt` (or `modifiedAt`) appears in the record parameter list.
+   Absence on an `Audited*` entity → **IMPROVEMENT** finding (bumps to **CONVENTION**
+   if the entity has a mutation endpoint, because the client cannot know the
+   last-update time without polling).
+
+4. `CreationAudited*` entities that correctly expose only `CreatedAt` are **NOT** a
+   finding — do not flag the absence of `ModifiedAt` on these.
+
+Reference implementations: `RoleResponse` (with `ModifiedAt`),
+`NotificationSubscriptionResponse` (correctly `CreatedAt`-only,
+`CreationAuditedEntity`), `ImportJobResponse` (full set).
+
+Ref: `CLAUDE.md §DTOs`, `docs-site/…/data/persistence.mdx`
 
 ### 6e. Migrations
 

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -8697,7 +8697,7 @@
       "kind": "record",
       "project": "Granit.Authentication.ApiKeys.Endpoints",
       "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyResponse.cs",
-      "line": 21,
+      "line": 22,
       "members": []
     },
     {
@@ -15801,7 +15801,7 @@
       "kind": "record",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportJobResponse.cs",
-      "line": 9,
+      "line": 10,
       "members": []
     },
     {
@@ -29404,7 +29404,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -47980,7 +47980,7 @@
       "kind": "record",
       "project": "Granit.Scheduling.Endpoints",
       "file": "src/Granit.Scheduling.Endpoints/Dtos/ScheduledActionResponse.cs",
-      "line": 17,
+      "line": 18,
       "members": []
     },
     {

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyResponse.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyResponse.cs
@@ -18,6 +18,7 @@ namespace Granit.Authentication.ApiKeys.Endpoints.Dtos;
 /// <param name="RevokedAt">Revocation timestamp, if revoked.</param>
 /// <param name="CacheBehavior">Cache behavior.</param>
 /// <param name="CreatedAt">Creation timestamp.</param>
+/// <param name="ModifiedAt">Last modification timestamp; <c>null</c> until the key is first modified (e.g. scope update).</param>
 public sealed record ApiKeyResponse(
     Guid Id,
     string Name,
@@ -31,7 +32,8 @@ public sealed record ApiKeyResponse(
     DateTimeOffset? LastUsedAt,
     DateTimeOffset? RevokedAt,
     CacheBehavior CacheBehavior,
-    DateTimeOffset CreatedAt)
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ModifiedAt)
 {
     /// <summary>Maps an <see cref="ApiKeyEntry"/> to a response DTO.</summary>
     internal static ApiKeyResponse FromEntry(ApiKeyEntry entry) =>
@@ -47,5 +49,6 @@ public sealed record ApiKeyResponse(
             entry.LastUsedAt,
             entry.RevokedAt,
             entry.CacheBehavior,
-            entry.CreatedAt);
+            entry.CreatedAt,
+            entry.ModifiedAt);
 }

--- a/src/Granit.DataExchange.Endpoints/Dtos/Export/ExportJobResponse.cs
+++ b/src/Granit.DataExchange.Endpoints/Dtos/Export/ExportJobResponse.cs
@@ -5,6 +5,7 @@ namespace Granit.DataExchange.Endpoints.Dtos.Export;
 
 /// <summary>
 /// Response DTO for an export job summary.
+/// <para><c>ConcurrencyStamp</c>: opaque optimistic-concurrency token; pass back in update requests to detect concurrent modifications (HTTP 409).</para>
 /// </summary>
 public sealed record ExportJobResponse(
     Guid Id,
@@ -17,12 +18,14 @@ public sealed record ExportJobResponse(
     DateTimeOffset CreatedAt,
     DateTimeOffset? CompletedAt,
     DateTimeOffset? ModifiedAt,
-    string? ModifiedBy)
+    string? ModifiedBy,
+    string ConcurrencyStamp)
 {
     /// <summary>
     /// Maps an <see cref="ExportJob"/> domain entity to a response DTO.
     /// </summary>
     internal static ExportJobResponse FromJob(ExportJob job) =>
         new(job.Id, job.DefinitionName, job.Format, job.Status, job.RowCount,
-            job.FileName, job.ErrorMessage, job.CreatedAt, job.CompletedAt, job.ModifiedAt, job.ModifiedBy);
+            job.FileName, job.ErrorMessage, job.CreatedAt, job.CompletedAt, job.ModifiedAt, job.ModifiedBy,
+            job.ConcurrencyStamp);
 }

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportExecutionEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportExecutionEndpoints.cs
@@ -85,7 +85,7 @@ internal static class ExportExecutionEndpoints
         ExportJobResponse response = job is not null
             ? ExportJobResponse.FromJob(job)
             : new ExportJobResponse(result.JobId, request.DefinitionName, request.Format,
-                result.Status, null, null, null, clock.Now, null, null, null);
+                result.Status, null, null, null, clock.Now, null, null, null, string.Empty);
 
         return TypedResults.Created($"/jobs/{result.JobId}", response);
     }

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
@@ -12,6 +12,7 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <param name="IsSystem"><c>true</c> for platform-seeded roles (cannot be renamed or deleted).</param>
 /// <param name="CreatedAt">Creation timestamp.</param>
 /// <param name="ModifiedAt">Last modification timestamp.</param>
+/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
 public sealed record RoleResponse(
     Guid Id,
     string Name,
@@ -21,4 +22,5 @@ public sealed record RoleResponse(
     string? Description,
     bool IsSystem,
     DateTimeOffset CreatedAt,
-    DateTimeOffset? ModifiedAt);
+    DateTimeOffset? ModifiedAt,
+    string ConcurrencyStamp);

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -313,5 +313,6 @@ internal static class GranitRoleEndpoints
             role.Description,
             role.IsSystem,
             role.CreatedAt,
-            role.ModifiedAt);
+            role.ModifiedAt,
+            role.ConcurrencyStamp);
 }

--- a/src/Granit.Scheduling.Endpoints/Dtos/ScheduledActionResponse.cs
+++ b/src/Granit.Scheduling.Endpoints/Dtos/ScheduledActionResponse.cs
@@ -14,6 +14,7 @@ namespace Granit.Scheduling.Endpoints.Dtos;
 /// <param name="CancelledBy">The user who cancelled the action (null if not cancelled).</param>
 /// <param name="FailureReason">Error message if the action failed.</param>
 /// <param name="CreatedAt">The UTC timestamp when the action was created.</param>
+/// <param name="ModifiedAt">The UTC timestamp of the last state change (reschedule, cancellation, execution); <c>null</c> if the action was never modified.</param>
 public sealed record ScheduledActionResponse(
     Guid Id,
     string PayloadType,
@@ -23,4 +24,5 @@ public sealed record ScheduledActionResponse(
     DateTimeOffset? ExecutedAt,
     string? CancelledBy,
     string? FailureReason,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ModifiedAt);

--- a/src/Granit.Scheduling.Endpoints/Endpoints/SchedulingReadEndpoints.cs
+++ b/src/Granit.Scheduling.Endpoints/Endpoints/SchedulingReadEndpoints.cs
@@ -55,5 +55,6 @@ internal static class SchedulingReadEndpoints
             action.ExecutedAt,
             action.CancelledBy,
             action.FailureReason,
-            action.CreatedAt);
+            action.CreatedAt,
+            action.ModifiedAt);
 }


### PR DESCRIPTION
## Summary

Four response DTOs were missing fields that their source entities already carry, requiring clients to make extra requests or work around stale data.

| Module | DTO | Field added | Reason |
|---|---|---|---|
| Authentication.ApiKeys | `ApiKeyResponse` | `modifiedAt` (nullable) | `FullAuditedAggregateRoot` — set on scope update via `PUT /{id}/scopes` |
| Identity.Local | `RoleResponse` | `concurrencyStamp` | `IConcurrencyAware` — needed for conflict-safe `PUT /{id}` rename |
| Scheduling | `ScheduledActionResponse` | `modifiedAt` (nullable) | `AuditedAggregateRoot` — set on reschedule/cancel/execute |
| DataExchange | `ExportJobResponse` | `concurrencyStamp` | `IConcurrencyAware` — already exposed `modifiedAt`/`modifiedBy` |

Reference implementation: `ImportJobResponse` (exposes the full set: `createdAt`, `modifiedAt`, `modifiedBy`, `concurrencyStamp`).

All additions are **non-breaking** (new fields in existing JSON records; front-end ignores unknown fields until it adds them).

Also updates the `/audit` skill (`SKILL.md` + `checklist.md`) with:
- **§6d**: detection strategy for `IConcurrencyAware` entities whose `*Response` omits `ConcurrencyStamp`
- **§6f** (new): detection strategy for `AuditedAggregateRoot`/`AuditedEntity` response DTOs missing `ModifiedAt`, with base-class table and false-positive guard for `CreationAudited*` entities
- **Step 5 item 14**: cross-module DTO enrichment completeness scan

## Test plan

- [x] `dotnet build` on all 4 touched `.Endpoints` projects — 0 errors, 0 warnings
- [x] All 4 affected CI shards (`security`, `identity`, `infrastructure`, `application`) — all tests pass
- [x] `dotnet format --verify-no-changes` on all 4 projects — clean
- [x] `npx markdownlint-cli2` on `SKILL.md` and `checklist.md` — 0 errors
- [ ] Front-end follow-up: see `granit-front/HANDOVER_DTO_ENRICHMENT.md` (created in the sibling repo)