### PR TITLE
chore(hooks): auto-configure core.hooksPath via Directory.Build.targets

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,18 @@
+<Project>
+  <!--
+    Activate Husky git hooks once per developer environment.
+    Skipped in CI (CI env var is set by all major CI/CD platforms).
+    The sentinel file (.git/.husky-configured) prevents the race condition
+    that occurs when MSBuild evaluates this target in parallel across all
+    projects on the first restore — subsequent builds are a no-op.
+  -->
+  <PropertyGroup>
+    <_HuskySentinel>$(MSBuildThisFileDirectory).git/.husky-configured</_HuskySentinel>
+  </PropertyGroup>
+
+  <Target Name="SetupGitHooks" BeforeTargets="Build"
+          Condition="'$(CI)' != 'true' AND !Exists('$(_HuskySentinel)')">
+    <Exec Command="git config core.hooksPath .husky" ContinueOnError="true" />
+    <Touch Files="$(_HuskySentinel)" AlwaysCreate="true" />
+  </Target>
+</Project>


### PR DESCRIPTION
## Summary

- Adds `Directory.Build.targets` with a `SetupGitHooks` MSBuild target that runs `git config core.hooksPath .husky` automatically on the first `dotnet build` after a fresh clone
- Skipped in CI (`CI` env var)
- A sentinel file (`.git/.husky-configured`) prevents the race condition from parallel per-project evaluation and makes subsequent builds a no-op

## Test plan

- [ ] Clone the repo on a clean machine (no `core.hooksPath` set)
- [ ] Run `dotnet build` — verify `core.hooksPath` is now `.husky`
- [ ] Run `dotnet build` again — verify no git output (sentinel active)
- [ ] Verify hooks fire on next commit (Conventional Commits validation, gitleaks, code index regen)