### PR TITLE
feat(identity): wire RoleMetadata concurrency stamp end-to-end

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -11315,7 +11315,7 @@
         {
           "name": "UpdateAsync",
           "kind": "method",
-          "signature": "UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default)",
+          "signature": "UpdateAsync(RoleMetadata role, string? concurrencyStamp = null, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {
@@ -29413,7 +29413,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs",
-      "line": 6,
+      "line": 9,
       "members": []
     },
     {
@@ -30631,7 +30631,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs",
-      "line": 60,
+      "line": 66,
       "members": []
     },
     {
@@ -30875,7 +30875,7 @@
         {
           "name": "RenameAsync",
           "kind": "method",
-          "signature": "RenameAsync(Guid roleId, string newName, string? newDescription, CancellationToken cancellationToken = default)",
+          "signature": "RenameAsync(Guid roleId, string newName, string? newDescription, string concurrencyStamp, CancellationToken cancellationToken = default)",
           "returnType": "Task<RoleMetadata>"
         },
         {

--- a/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCoreRoleMetadataStore.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCoreRoleMetadataStore.cs
@@ -1,5 +1,6 @@
 using Granit.Authorization.Domain;
 using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Authorization.EntityFrameworkCore.Stores;
@@ -56,10 +57,14 @@ internal sealed class EfCoreRoleMetadataStore<TContext>(TContext context)
     }
 
     /// <inheritdoc />
-    public async Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default)
+    public async Task UpdateAsync(RoleMetadata role, string? concurrencyStamp = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(role);
         context.RoleMetadata.Update(role);
+        if (concurrencyStamp is not null)
+        {
+            context.SetConcurrencyStampOriginalValue(role, concurrencyStamp);
+        }
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Granit.Authorization/IRoleMetadataStore.cs
+++ b/src/Granit.Authorization/IRoleMetadataStore.cs
@@ -62,7 +62,10 @@ public interface IRoleMetadataStore
     Task AddAsync(RoleMetadata role, CancellationToken cancellationToken = default);
 
     /// <summary>Persists modifications applied to a tracked <see cref="RoleMetadata"/>.</summary>
-    Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default);
+    /// <param name="role">Modified aggregate.</param>
+    /// <param name="concurrencyStamp">When provided, overrides the EF Core original-value for the concurrency token so a mismatch throws a concurrency exception (→ HTTP 409).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateAsync(RoleMetadata role, string? concurrencyStamp = null, CancellationToken cancellationToken = default);
 
     /// <summary>Removes a role metadata row.</summary>
     Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default);

--- a/src/Granit.Authorization/Services/NullRoleMetadataStore.cs
+++ b/src/Granit.Authorization/Services/NullRoleMetadataStore.cs
@@ -37,7 +37,7 @@ internal sealed class NullRoleMetadataStore : IRoleMetadataStore
             "Add Granit.Authorization.EntityFrameworkCore (or an equivalent provider) and wire the store.");
 
     /// <inheritdoc />
-    public Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+    public Task UpdateAsync(RoleMetadata role, string? concurrencyStamp = null, CancellationToken cancellationToken = default) =>
         throw new InvalidOperationException(
             "No IRoleMetadataStore implementation is registered.");
 

--- a/src/Granit.Identity.Federated.Cognito/Sync/CognitoClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.Cognito/Sync/CognitoClientRoleSyncService.cs
@@ -127,13 +127,13 @@ public sealed partial class CognitoClientRoleSyncService(
                 {
                     existing.Rename(existing.Name, role.Description);
                 }
-                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken: cancellationToken).ConfigureAwait(false);
                 restored++;
             }
             else if (!string.Equals(existing.Description, role.Description, StringComparison.Ordinal))
             {
                 existing.Rename(existing.Name, role.Description);
-                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken: cancellationToken).ConfigureAwait(false);
                 updated++;
             }
             else
@@ -180,7 +180,7 @@ public sealed partial class CognitoClientRoleSyncService(
                     if (!row.IsOrphaned)
                     {
                         row.MarkAsOrphaned(clock.Now);
-                        await roleMetadataStore.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
+                        await roleMetadataStore.UpdateAsync(row, cancellationToken: cancellationToken).ConfigureAwait(false);
                         LogOrphanSoftDeleted(logger, row.Name, clientId);
                         softDeleted++;
                     }

--- a/src/Granit.Identity.Federated.EntraId/Sync/EntraIdClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.EntraId/Sync/EntraIdClientRoleSyncService.cs
@@ -109,13 +109,13 @@ public sealed partial class EntraIdClientRoleSyncService(
                 {
                     existing.Rename(existing.Name, role.Description);
                 }
-                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken: cancellationToken).ConfigureAwait(false);
                 restored++;
             }
             else if (!string.Equals(existing.Description, role.Description, StringComparison.Ordinal))
             {
                 existing.Rename(existing.Name, role.Description);
-                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken: cancellationToken).ConfigureAwait(false);
                 updated++;
             }
             else
@@ -162,7 +162,7 @@ public sealed partial class EntraIdClientRoleSyncService(
                     if (!row.IsOrphaned)
                     {
                         row.MarkAsOrphaned(clock.Now);
-                        await roleMetadataStore.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
+                        await roleMetadataStore.UpdateAsync(row, cancellationToken: cancellationToken).ConfigureAwait(false);
                         LogOrphanSoftDeleted(logger, row.Name, appId);
                         softDeleted++;
                     }

--- a/src/Granit.Identity.Federated.Keycloak/Sync/KeycloakClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Sync/KeycloakClientRoleSyncService.cs
@@ -125,13 +125,13 @@ public sealed partial class KeycloakClientRoleSyncService(
                 {
                     existing.Rename(existing.Name, role.Description);
                 }
-                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken: cancellationToken).ConfigureAwait(false);
                 restored++;
             }
             else if (!string.Equals(existing.Description, role.Description, StringComparison.Ordinal))
             {
                 existing.Rename(existing.Name, role.Description);
-                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken: cancellationToken).ConfigureAwait(false);
                 updated++;
             }
             else
@@ -178,7 +178,7 @@ public sealed partial class KeycloakClientRoleSyncService(
                     if (!row.IsOrphaned)
                     {
                         row.MarkAsOrphaned(clock.Now);
-                        await roleMetadataStore.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
+                        await roleMetadataStore.UpdateAsync(row, cancellationToken: cancellationToken).ConfigureAwait(false);
                         LogOrphanSoftDeleted(logger, row.Name, clientId);
                         softDeleted++;
                     }

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
@@ -4,6 +4,7 @@ using Granit.Authorization.Domain;
 using Granit.Guids;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.SharedConnection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -75,9 +76,11 @@ internal sealed partial class GranitRoleOrchestrator(
         Guid roleId,
         string newName,
         string? newDescription,
+        string concurrencyStamp,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(newName);
+        ArgumentException.ThrowIfNullOrEmpty(concurrencyStamp);
 
         AtomicResolution atomic = await TryResolveAtomicContextsAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -87,12 +90,12 @@ internal sealed partial class GranitRoleOrchestrator(
             await using (atomic.HostContext)
             {
                 return await ExecuteAtomicRenameAsync(
-                    atomic.IdentityContext!, atomic.HostContext!, roleId, newName, newDescription, cancellationToken)
+                    atomic.IdentityContext!, atomic.HostContext!, roleId, newName, newDescription, concurrencyStamp, cancellationToken)
                     .ConfigureAwait(false);
             }
         }
 
-        return await ExecuteCompensatingRenameAsync(roleId, newName, newDescription, cancellationToken)
+        return await ExecuteCompensatingRenameAsync(roleId, newName, newDescription, concurrencyStamp, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -264,6 +267,7 @@ internal sealed partial class GranitRoleOrchestrator(
         Guid roleId,
         string newName,
         string? newDescription,
+        string concurrencyStamp,
         CancellationToken cancellationToken)
     {
         RoleMetadata? updated = null;
@@ -311,6 +315,7 @@ internal sealed partial class GranitRoleOrchestrator(
                             string.Join("; ", updateResult.Errors.Select(e => $"{e.Code}: {e.Description}")));
                     }
 
+                    hostCtx.SetConcurrencyStampOriginalValue(metadata, concurrencyStamp);
                     metadata.Rename(newName, newDescription);
                     await hostCtx.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -452,6 +457,7 @@ internal sealed partial class GranitRoleOrchestrator(
         Guid roleId,
         string newName,
         string? newDescription,
+        string concurrencyStamp,
         CancellationToken cancellationToken)
     {
         RoleMetadata? existingMetadata = await roleMetadataStore.FindByIdAsync(roleId, cancellationToken)
@@ -484,7 +490,7 @@ internal sealed partial class GranitRoleOrchestrator(
         try
         {
             existingMetadata.Rename(newName, newDescription);
-            await roleMetadataStore.UpdateAsync(existingMetadata, cancellationToken).ConfigureAwait(false);
+            await roleMetadataStore.UpdateAsync(existingMetadata, concurrencyStamp, cancellationToken).ConfigureAwait(false);
             return existingMetadata;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs
@@ -1,6 +1,12 @@
+using Granit.Domain;
+
 namespace Granit.Identity.Local.Endpoints.Dtos;
 
 /// <summary>Request to rename / update a local role's description. Side and tenant scope are immutable.</summary>
 /// <param name="Name">New display name (max 256 chars).</param>
+/// <param name="ConcurrencyStamp">Stamp from the last read; must match the stored value (prevents lost updates, HTTP 409).</param>
 /// <param name="Description">New description (max 2048 chars, nullable to clear).</param>
-public sealed record RoleUpdateRequest(string Name, string? Description = null);
+public sealed record RoleUpdateRequest(
+    string Name,
+    string ConcurrencyStamp,
+    string? Description = null) : IConcurrencyStampRequest;

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -215,7 +215,7 @@ internal static class GranitRoleEndpoints
         try
         {
             RoleMetadata updated = await orchestrator
-                .RenameAsync(id, request.Name, request.Description, cancellationToken)
+                .RenameAsync(id, request.Name, request.Description, request.ConcurrencyStamp, cancellationToken)
                 .ConfigureAwait(false);
             return TypedResults.Ok(Map(updated));
         }

--- a/src/Granit.Identity.Local.Endpoints/Validators/RoleUpdateRequestValidator.cs
+++ b/src/Granit.Identity.Local.Endpoints/Validators/RoleUpdateRequestValidator.cs
@@ -13,6 +13,9 @@ internal sealed class RoleUpdateRequestValidator : GranitValidator<RoleUpdateReq
             .NotEmpty()
             .MaximumLength(256);
 
+        RuleFor(x => x.ConcurrencyStamp)
+            .NotEmpty();
+
         RuleFor(x => x.Description)
             .MaximumLength(2048);
     }

--- a/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
@@ -37,10 +37,16 @@ public interface IGranitRoleOrchestrator
     /// Renames the role (both local and metadata side) and optionally updates its
     /// description. Side and tenant scope are immutable after creation.
     /// </summary>
+    /// <param name="roleId">Identifier of the role to rename.</param>
+    /// <param name="newName">New display name.</param>
+    /// <param name="newDescription">New description, or <see langword="null"/> to clear.</param>
+    /// <param name="concurrencyStamp">Stamp from the client's last read; must match the stored value — mismatch throws a concurrency exception (→ HTTP 409).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<RoleMetadata> RenameAsync(
         Guid roleId,
         string newName,
         string? newDescription,
+        string concurrencyStamp,
         CancellationToken cancellationToken = default);
 
     /// <summary>


### PR DESCRIPTION
## Summary

- `RoleUpdateRequest` now implements `IConcurrencyStampRequest` with a required `ConcurrencyStamp` field; the validator enforces `NotEmpty`
- `IGranitRoleOrchestrator.RenameAsync` and `IRoleMetadataStore.UpdateAsync` accept the stamp; `EfCoreRoleMetadataStore` calls `SetConcurrencyStampOriginalValue` before `SaveChangesAsync` — a stale stamp from the client yields HTTP 409
- Both execution paths in `GranitRoleOrchestrator` (`ExecuteAtomicRenameAsync` and `ExecuteCompensatingRenameAsync`) thread the stamp through; the atomic path sets the original value on the shared-connection `hostCtx` before `metadata.Rename()`
- 9 federated-provider callers (EntraId, Cognito, Keycloak sync services) updated to use `cancellationToken: cancellationToken` after the new optional `concurrencyStamp` parameter was inserted before `CancellationToken`
- `NullRoleMetadataStore` updated to match the interface signature

## Motivation

Without echoing the client stamp, a client reading at T=0 and writing at T+60 silently overwrites concurrent changes. EF Core change-tracking only protects concurrent server-side requests — not inter-session races.

## Test plan

- [ ] `dotnet test tests/Granit.Identity.Local.Endpoints.Tests` — 174 tests, all pass
- [ ] `PUT /roles/{id}` with a stale `concurrencyStamp` → HTTP 409
- [ ] `PUT /roles/{id}` with the correct stamp → HTTP 200 + updated `RoleResponse`
- [ ] Federated sync (EntraId/Cognito/Keycloak) still compiles and passes existing tests