### PR TITLE
docs(audit): expand concurrency-stamp check to full 7-link round-trip

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -314,11 +314,35 @@ After auditing individual modules, perform cross-cutting checks:
    systemic gaps. Cluster findings as "DTO enrichment gaps" and propose exact DTO
    parameter additions following the `ImportJobResponse` pattern.
 
-   **Missing `ConcurrencyStamp`**: entity implements `IConcurrencyAware` AND a
-   mutation endpoint (PUT/PATCH/state-change POST) exists, but the `*Response` DTO
-   does not include `ConcurrencyStamp`. The client cannot build a conflict-safe
-   round-trip without it. Severity: `IMPROVEMENT` (bumps to `CONVENTION` when a
-   `409` path is already declared on the endpoint).
+   **`ConcurrencyStamp` — two-stage check (checklist §6d, 7-link chain):**
+
+   Stage 1 — **Exposure gap** (`*Response` DTO): entity implements `IConcurrencyAware`
+   AND a mutation endpoint exists, but the `*Response` DTO does not include
+   `string ConcurrencyStamp`. The client cannot build a conflict-safe round-trip without
+   it. Severity: `IMPROVEMENT` (→ `CONVENTION` when a `409` path is already declared
+   on the endpoint).
+
+   Stage 2 — **Wiring gap** (links 3–7): the stamp is present in the `*Response` DTO
+   but the round-trip is incomplete. Check each link in order and report the first
+   broken one. **Link 3** (`CONVENTION`): `*Request` DTO does not implement
+   `IConcurrencyStampRequest` / missing `string ConcurrencyStamp` parameter.
+   **Link 4** (`CONVENTION`): `*RequestValidator` missing
+   `RuleFor(x => x.ConcurrencyStamp).NotEmpty()`. **Link 5** (`CONVENTION`): service
+   / orchestrator interface mutation method does not accept `string concurrencyStamp`.
+   **Link 6** (`CONVENTION`): store interface `UpdateAsync` does not accept
+   `string? concurrencyStamp`. **Link 7** (`BREAKING`): store implementation does not
+   call `SetConcurrencyStampOriginalValue` after `Update()`/attach and before
+   `SaveChangesAsync` — silent overwrite; the interceptor always regenerates the stamp
+   on save, so EF's token always matches and `409` never fires.
+
+   When flagging link 6, also grep for positional callers that may have broken silently:
+
+   ```bash
+   grep -rn "\.UpdateAsync([^)]*,\s*cancellationToken)" src/ --include="*.cs"
+   ```
+
+   Reference implementation: `RoleMetadata` / `RoleUpdateRequest` /
+   `GranitRoleOrchestrator` / `EfCoreRoleMetadataStore` (PR #2781).
 
    **Missing `ModifiedAt`**: entity inherits `AuditedAggregateRoot`,
    `FullAuditedAggregateRoot`, `AuditedEntity`, or `FullAuditedEntity`, but the

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -847,38 +847,67 @@ Ref: `docs-site/…/data/interceptors.mdx`
 
 ### 6d. Concurrency
 
+Checklist items cover the full 7-link round-trip from entity to HTTP response and
+back to the database conflict check.
+
 - [ ] `IConcurrencyAware` entities have `ConcurrencyStamp` property
-- [ ] Response DTOs include `ConcurrencyStamp`
-- [ ] Request DTOs accept stamp back (implement `IConcurrencyStampRequest`)
-- [ ] `DbUpdateConcurrencyException` mapped to HTTP 409 via
-  `EfCoreExceptionStatusCodeMapper`
-- [ ] Tests use SQLite or Testcontainers — never `UseInMemoryDatabase()` for
-  concurrency (ignores tokens → false positive)
+- [ ] `*Response` DTO includes `string ConcurrencyStamp` (non-null, no default)
+- [ ] `*Request` DTO for the mutation endpoint implements `IConcurrencyStampRequest`
+  with a `string ConcurrencyStamp` parameter
+- [ ] `*RequestValidator` enforces `RuleFor(x => x.ConcurrencyStamp).NotEmpty()`
+- [ ] Service / orchestrator interface mutation method accepts `string concurrencyStamp`
+  as a **required** (non-optional) parameter before `CancellationToken`
+- [ ] Store interface `UpdateAsync` (or equivalent) accepts
+  `string? concurrencyStamp = null` — optional so internal callers that never hold a
+  client stamp compile without change
+- [ ] Store implementation calls
+  `context.SetConcurrencyStampOriginalValue(entity, concurrencyStamp)` **after**
+  `context.Update(entity)` / attach, **before** `SaveChangesAsync` — the order is
+  critical; calling it before `Update()` loses the override because `Update()` resets
+  entry state
+- [ ] `DbUpdateConcurrencyException` mapped to HTTP 409 via `EfCoreExceptionStatusCodeMapper`
+- [ ] Tests use SQLite or Testcontainers — never `UseInMemoryDatabase()` for concurrency
+  (in-memory provider ignores concurrency tokens → false positive)
 
-**Detection strategy — `ConcurrencyStamp` gap in response DTOs:**
+**Detection strategy — full concurrency round-trip:**
 
-1. Find all `IConcurrencyAware` entities in the module:
+For each `IConcurrencyAware` entity that has a mutation endpoint (PUT/PATCH/state-change
+POST) in the matching `.Endpoints` project, verify the **7-link chain** in order:
 
-   ```bash
-   grep -rl "IConcurrencyAware" src/Granit.{Module}/ --include="*.cs"
-   ```
+| # | Link | What to check |
+| --- | --- | --- |
+| 1 | Entity | Implements `IConcurrencyAware` (has `ConcurrencyStamp`) |
+| 2 | `*Response` DTO | `string ConcurrencyStamp` record param (non-null, no default) |
+| 3 | `*Request` DTO | Implements `IConcurrencyStampRequest`; has `string ConcurrencyStamp` |
+| 4 | `*RequestValidator` | `RuleFor(x => x.ConcurrencyStamp).NotEmpty()` |
+| 5 | Service interface | Mutation signature includes `string concurrencyStamp` (required) |
+| 6 | Store interface | `UpdateAsync(entity, string? concurrencyStamp = null, CancellationToken ct = default)` |
+| 7 | Store implementation | `SetConcurrencyStampOriginalValue` after attach, before `SaveChangesAsync` |
 
-2. For each entity, confirm at least one **mutation** endpoint exists (PUT, PATCH,
-   or a POST that updates state) in the matching `.Endpoints` project.
-3. Locate the corresponding `*Response` DTO (usually `{EntityName}Response.cs` in
-   `src/Granit.{Module}.Endpoints/Dtos/`).
-4. Check whether `ConcurrencyStamp` (type `string`, non-null) is among the record
-   parameters. If absent while the entity implements `IConcurrencyAware` AND a
-   mutation endpoint exists → **IMPROVEMENT** finding.
-   - Severity bumps to **CONVENTION** when a round-trip conflict path (409) is
-     already declared on the endpoint but the stamp is not exposed — the client
-     cannot build the ETag without it.
-5. Also check the matching `*Request` DTO for the mutation endpoint: it should accept
-   the stamp back via `IConcurrencyStampRequest` (separate story — flag as
-   **IMPROVEMENT** if missing but do not block on it).
+Severity by broken link:
 
-Reference implementation: `ImportJobResponse` / `ExportJobResponse` in
-`Granit.DataExchange.Endpoints`.
+| Missing link | Severity |
+| --- | --- |
+| Link 2 absent | IMPROVEMENT (→ CONVENTION when 409 path is declared on endpoint) |
+| Links 3–5 absent while link 2 is present | CONVENTION (stamp is exposed but client cannot use it for conflict detection) |
+| Link 6 absent (store ignores the stamp parameter) | CONVENTION |
+| Link 7 absent (stamp accepted but never set as original value) | BREAKING — silent overwrite; the interceptor regenerates the stamp on save, so the EF token always matches; 409 never fires |
+
+**Caller fixup risk when adding link 6.** Inserting `string? concurrencyStamp = null`
+before `CancellationToken` in an existing store interface shifts `CancellationToken`
+from position 2 to position 3. Existing positional callers `UpdateAsync(entity, ct)`
+pass the token as `concurrencyStamp`. When the types differ (`CancellationToken` vs
+`string?`) the compiler catches it; when they are accidentally compatible it is a
+silent bug. Fix: add named `cancellationToken: ct` to every non-stamp caller. Grep:
+
+```bash
+grep -rn "\.UpdateAsync([^)]*,\s*cancellationToken)" src/ --include="*.cs"
+```
+
+**Reference implementation:** `RoleMetadata` → `RoleUpdateRequest : IConcurrencyStampRequest`
+→ `RoleUpdateRequestValidator` → `IGranitRoleOrchestrator.RenameAsync(…, string concurrencyStamp, …)`
+→ `IRoleMetadataStore.UpdateAsync(…, string? concurrencyStamp = null, …)`
+→ `EfCoreRoleMetadataStore.UpdateAsync` calls `context.SetConcurrencyStampOriginalValue`.
 
 Ref: `docs-site/…/data/concurrency.mdx`
 


### PR DESCRIPTION
## Summary

Extends the `/audit` skill to detect incomplete concurrency-stamp wiring end-to-end, not just the `*Response` DTO gap.

- `checklist.md §6d` restructured into a **7-link chain** (entity → response DTO → request DTO → validator → service interface → store interface → store implementation), each with a distinct severity. Link 7 (missing `SetConcurrencyStampOriginalValue`) is `BREAKING` because the EF interceptor always regenerates the stamp on save, so `409` silently never fires. Adds a "caller fixup risk" grep to detect positional callers that break when a new optional param is inserted before `CancellationToken`.
- `SKILL.md` step 5 item 14 splits the `ConcurrencyStamp` check into **Stage 1** (exposure gap in `*Response`, `IMPROVEMENT`/`CONVENTION`) and **Stage 2** (wiring gap, per-link severity). References PR #2781 as the canonical implementation.

## Context

Discovered while implementing the full concurrency-stamp round-trip for `RoleMetadata` (PR #2781). The previous audit check only caught the response-DTO gap; the remaining 6 links had no detection rule.

## Test plan

- [ ] `npx markdownlint-cli2 ".claude/skills/audit/SKILL.md" ".claude/skills/audit/checklist.md"` → 0 errors ✅
- [ ] `/audit Identity.Local --scope persistence` on a module with a partial chain → correct severity emitted for each broken link