### PR TITLE
fix(validation): enforce ConcurrencyStamp.NotEmpty() on concurrency-aware request validators

### DIFF
--- a/src/Granit.DataExchange.Endpoints/Validators/ConfirmMappingsRequestValidator.cs
+++ b/src/Granit.DataExchange.Endpoints/Validators/ConfirmMappingsRequestValidator.cs
@@ -12,6 +12,9 @@ internal sealed class ConfirmMappingsRequestValidator : GranitValidator<ConfirmM
 {
     public ConfirmMappingsRequestValidator()
     {
+        RuleFor(x => x.ConcurrencyStamp)
+            .NotEmpty();
+
         RuleFor(x => x.Mappings)
             .NotEmpty()
             .Must(m => m.Any(mapping => mapping.TargetProperty is not null))

--- a/src/Granit.MultiTenancy.Endpoints/Validators/UpdateTenantRequestValidator.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Validators/UpdateTenantRequestValidator.cs
@@ -15,6 +15,9 @@ internal sealed class UpdateTenantRequestValidator : GranitValidator<UpdateTenan
 
     public UpdateTenantRequestValidator()
     {
+        RuleFor(x => x.ConcurrencyStamp)
+            .NotEmpty();
+
         RuleFor(x => x.Name)
             .NotEmpty()
             .MaximumLength(MaxNameLength);

--- a/src/Granit.Privacy.Endpoints/Validators/LegalDocumentUpdateRequestValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Validators/LegalDocumentUpdateRequestValidator.cs
@@ -10,6 +10,9 @@ internal sealed class LegalDocumentUpdateRequestValidator : AbstractValidator<Le
 {
     public LegalDocumentUpdateRequestValidator()
     {
+        RuleFor(x => x.ConcurrencyStamp)
+            .NotEmpty();
+
         RuleFor(x => x.DisplayName)
             .NotEmpty()
             .MaximumLength(500);

--- a/src/Granit.Templating.Endpoints/Validators/SaveTemplateRequestValidator.cs
+++ b/src/Granit.Templating.Endpoints/Validators/SaveTemplateRequestValidator.cs
@@ -41,5 +41,9 @@ internal sealed class SaveTemplateRequestValidator : GranitValidator<SaveTemplat
             .Matches(TemplatingPatterns.Bcp47Pattern())
             .WithErrorCodeAndMessage("Validation:InvalidBcp47LanguageTag")
             .When(x => x.Culture is not null);
+
+        RuleFor(x => x.ConcurrencyStamp)
+            .NotEmpty()
+            .When(x => x.ConcurrencyStamp is not null);
     }
 }

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/InMemoryRoleMetadataStore.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/InMemoryRoleMetadataStore.cs
@@ -36,7 +36,7 @@ internal sealed class InMemoryRoleMetadataStore : IRoleMetadataStore
         return Task.CompletedTask;
     }
 
-    public Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+    public Task UpdateAsync(RoleMetadata role, string? concurrencyStamp = null, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
     public Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default)

--- a/tests/Granit.Identity.Federated.Cognito.Tests/Sync/CognitoClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/Sync/CognitoClientRoleSyncServiceTests.cs
@@ -80,7 +80,7 @@ public sealed class CognitoClientRoleSyncServiceTests
                 && r.MultiTenancySides == MultiTenancySides.Host
                 && !r.IsSystem && r.TenantId == null),
             Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public sealed class CognitoClientRoleSyncServiceTests
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public sealed class CognitoClientRoleSyncServiceTests
 
         await _store.Received(1).UpdateAsync(
             Arg.Is<RoleMetadata>(r => r.Description == "NEW description"),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
     }
 
@@ -152,7 +152,7 @@ public sealed class CognitoClientRoleSyncServiceTests
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         orphan.IsOrphaned.ShouldBeFalse();
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().RemoveAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
     }
 
@@ -172,7 +172,7 @@ public sealed class CognitoClientRoleSyncServiceTests
         orphan.IsOrphaned.ShouldBeTrue();
         orphan.OrphanedAt.ShouldBe(_clock.Now);
         await _store.Received(1).UpdateAsync(
-            Arg.Is<RoleMetadata>(r => r.IsOrphaned), Arg.Any<CancellationToken>());
+            Arg.Is<RoleMetadata>(r => r.IsOrphaned), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -189,7 +189,7 @@ public sealed class CognitoClientRoleSyncServiceTests
 
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -229,6 +229,6 @@ public sealed class CognitoClientRoleSyncServiceTests
         previouslyOrphaned.OrphanedAt.ShouldBeNull();
         await _store.Received(1).UpdateAsync(
             Arg.Is<RoleMetadata>(r => !r.IsOrphaned && r.Name == "editor"),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/InMemoryRoleMetadataStore.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/InMemoryRoleMetadataStore.cs
@@ -39,7 +39,7 @@ internal sealed class InMemoryRoleMetadataStore : IRoleMetadataStore
         return Task.CompletedTask;
     }
 
-    public Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+    public Task UpdateAsync(RoleMetadata role, string? concurrencyStamp = null, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
     public Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default)

--- a/tests/Granit.Identity.Federated.EntraId.Tests/Sync/EntraIdClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/Sync/EntraIdClientRoleSyncServiceTests.cs
@@ -81,7 +81,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
             Arg.Is<RoleMetadata>(r => r.ClientId == appId && r.MultiTenancySides == MultiTenancySides.Host
                 && !r.IsSystem && r.TenantId == null),
             Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
 
         await _store.Received(1).UpdateAsync(
             Arg.Is<RoleMetadata>(r => r.Description == "NEW description"),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
     }
 
@@ -158,7 +158,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         orphan.IsOrphaned.ShouldBeFalse();
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().RemoveAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
     }
 
@@ -179,7 +179,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         orphan.IsOrphaned.ShouldBeTrue();
         orphan.OrphanedAt.ShouldBe(_clock.Now);
         await _store.Received(1).UpdateAsync(
-            Arg.Is<RoleMetadata>(r => r.IsOrphaned), Arg.Any<CancellationToken>());
+            Arg.Is<RoleMetadata>(r => r.IsOrphaned), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
 
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -239,6 +239,6 @@ public sealed class EntraIdClientRoleSyncServiceTests
         previouslyOrphaned.OrphanedAt.ShouldBeNull();
         await _store.Received(1).UpdateAsync(
             Arg.Is<RoleMetadata>(r => !r.IsOrphaned && r.Name == "Editor"),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/InMemoryRoleMetadataStore.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/InMemoryRoleMetadataStore.cs
@@ -42,7 +42,7 @@ internal sealed class InMemoryRoleMetadataStore : IRoleMetadataStore
 
     // The role is already tracked by reference — the sync calls Rename() on the
     // existing instance before UpdateAsync(). Nothing else to do in the in-memory store.
-    public Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+    public Task UpdateAsync(RoleMetadata role, string? concurrencyStamp = null, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
     public Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default)

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/Sync/KeycloakClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/Sync/KeycloakClientRoleSyncServiceTests.cs
@@ -80,7 +80,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
             Arg.Is<RoleMetadata>(r => r.ClientId == "app-a" && r.MultiTenancySides == MultiTenancySides.Host
                 && !r.IsSystem && r.TenantId == null),
             Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
 
         await _store.Received(1).UpdateAsync(
             Arg.Is<RoleMetadata>(r => r.Description == "NEW description"),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
     }
 
@@ -155,7 +155,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
 
         // KeepAndLog: no mutation on the row; it stays with IsOrphaned = false.
         orphan.IsOrphaned.ShouldBeFalse();
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().RemoveAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
     }
 
@@ -177,7 +177,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
         orphan.IsOrphaned.ShouldBeTrue();
         orphan.OrphanedAt.ShouldBe(_clock.Now);
         await _store.Received(1).UpdateAsync(
-            Arg.Is<RoleMetadata>(r => r.IsOrphaned), Arg.Any<CancellationToken>());
+            Arg.Is<RoleMetadata>(r => r.IsOrphaned), Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().RemoveAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
     }
 
@@ -197,7 +197,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
 
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
-        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -240,6 +240,6 @@ public sealed class KeycloakClientRoleSyncServiceTests
         previouslyOrphaned.OrphanedAt.ShouldBeNull();
         await _store.Received(1).UpdateAsync(
             Arg.Is<RoleMetadata>(r => !r.IsOrphaned && r.Name == "editor"),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTests.cs
@@ -111,6 +111,7 @@ public sealed class RoleOrchestratorAtomicTests
 
         await renameOrchestrator.RenameAsync(
             created.Id, newName: "AlphaPrime", newDescription: "renamed",
+            concurrencyStamp: created.ConcurrencyStamp,
             TestContext.Current.CancellationToken);
 
         GranitRole? identityRole = await roleManager.FindByIdAsync(created.Id.ToString("D"));

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTests.cs
@@ -109,6 +109,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
             created.Id,
             newName: "AlphaPrime",
             newDescription: "Renamed.",
+            concurrencyStamp: created.ConcurrencyStamp,
             TestContext.Current.CancellationToken);
 
         GranitRole? identityRole = await roleManager.FindByIdAsync(created.Id.ToString("D"));
@@ -145,6 +146,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
                 alpha.Id,
                 newName: "Beta",
                 newDescription: null,
+                concurrencyStamp: alpha.ConcurrencyStamp,
                 TestContext.Current.CancellationToken));
 
         // Invariant: the Identity-side GranitRole kept its original name.
@@ -168,6 +170,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
             await orchestrator.RenameAsync(
                 system.Id, newName: "NotSuperAdmin", newDescription: null,
+                concurrencyStamp: system.ConcurrencyStamp,
                 TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("system role");


### PR DESCRIPTION
## Summary

- `ConfirmMappingsRequestValidator`, `LegalDocumentUpdateRequestValidator`, and `UpdateTenantRequestValidator` were missing `RuleFor(x => x.ConcurrencyStamp).NotEmpty()`. All three implement `IConcurrencyStampRequest` (7-link chain Links 3, 5, 6, 7 already wired) but Link 4 was absent.
- `SaveTemplateRequestValidator` gains the same guard with `.When(x => x.ConcurrencyStamp is not null)`, matching `SaveTemplateRequest`'s nullable dual create/update stamp design.
- Adapt federated-provider `InMemoryRoleMetadataStore` test doubles and NSubstitute assertions to the `IRoleMetadataStore.UpdateAsync(role, string? concurrencyStamp, ct)` signature added in #2781.

**Root cause:** an empty string `""` passed as a stamp is not `null`, so `SetConcurrencyStampOriginalValue` sets EF's `OriginalValue` to `""`, which never matches the stored GUID — causing a spurious 409 on every mutation. The `NotEmpty()` rule catches this at 422 before the store layer is hit.

Identified by `/audit all --scope concurrency`.

## Test plan

- [ ] `dotnet build src/Granit.DataExchange.Endpoints` — clean
- [ ] `dotnet build src/Granit.Privacy.Endpoints` — clean
- [ ] `dotnet build src/Granit.MultiTenancy.Endpoints` — clean
- [ ] `dotnet build src/Granit.Templating.Endpoints` — clean
- [ ] Identity shard tests pass (federated Cognito / EntraId / Keycloak sync + orchestrator)