### PR TITLE
fix(identity): repair RenameAsync CI failures introduced by concurrency-stamp guard

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -295,6 +295,11 @@ internal static class GranitRoleEndpoints
     /// </summary>
     private static bool CanMutate(RoleMetadata role, ICurrentTenant currentTenant)
     {
+        if (role.IsSystem)
+        {
+            return false;
+        }
+
         if (!currentTenant.IsAvailable)
         {
             return true;

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
@@ -200,12 +200,12 @@ public sealed class GranitRoleEndpointsTests
     {
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
-        Guid roleId = await CreateViaEndpointAsync(
+        RoleResponseLite created = await CreateViaEndpointAsync(
             "Manager", MultiTenancySides.Tenant, tenantId: _tenantA);
 
         HttpResponseMessage response = await _app.HttpClient.PutAsJsonAsync(
-            $"/admin/roles/{roleId:D}",
-            new { name = "SeniorManager", description = "Renamed" },
+            $"/admin/roles/{created.Id:D}",
+            new { name = "SeniorManager", description = "Renamed", concurrencyStamp = created.ConcurrencyStamp },
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -221,16 +221,16 @@ public sealed class GranitRoleEndpointsTests
     {
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
-        Guid roleId = await CreateViaEndpointAsync(
+        RoleResponseLite created = await CreateViaEndpointAsync(
             "Manager", MultiTenancySides.Tenant, tenantId: _tenantA);
 
         HttpResponseMessage response = await _app.HttpClient.DeleteAsync(
-            $"/admin/roles/{roleId:D}", TestContext.Current.CancellationToken);
+            $"/admin/roles/{created.Id:D}", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
 
         HttpResponseMessage getAfter = await _app.HttpClient.GetAsync(
-            $"/admin/roles/{roleId:D}", TestContext.Current.CancellationToken);
+            $"/admin/roles/{created.Id:D}", TestContext.Current.CancellationToken);
         getAfter.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
 
@@ -317,7 +317,7 @@ public sealed class GranitRoleEndpointsTests
     // helpers
     // ─────────────────────────────────────────────────────────────────────
 
-    private async Task<Guid> CreateViaEndpointAsync(
+    private async Task<RoleResponseLite> CreateViaEndpointAsync(
         string name, MultiTenancySides side, Guid? tenantId)
     {
         HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
@@ -333,7 +333,7 @@ public sealed class GranitRoleEndpointsTests
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
         RoleResponseLite? created = await response.Content
             .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
-        return created!.Id;
+        return created!;
     }
 
     private async Task<RoleMetadata> SeedMetadataAsync(
@@ -362,5 +362,6 @@ public sealed class GranitRoleEndpointsTests
         Guid? TenantId,
         string? ClientId,
         string? Description,
-        bool IsSystem);
+        bool IsSystem,
+        string ConcurrencyStamp);
 }

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Extensions;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.Testing.Fakes;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -71,7 +72,10 @@ public sealed class RoleEndpointsTestApplication : IAsyncLifetime
         builder.Services.AddDbContext<TestIdentityDbContext>(opts =>
             opts.UseNpgsql(_postgres.ConnectionString));
         builder.Services.AddDbContext<TestHostDbContext>(opts =>
-            opts.UseNpgsql(_postgres.ConnectionString));
+        {
+            opts.UseNpgsql(_postgres.ConnectionString);
+            opts.AddInterceptors(new ConcurrencyStampInterceptor());
+        });
 
         builder.Services.AddIdentityCore<LocalIdentity>()
             .AddRoles<GranitRole>()

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTestApplication.cs
@@ -3,6 +3,7 @@ using Granit.Guids.Extensions;
 using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.Persistence.EntityFrameworkCore.SharedConnection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -49,7 +50,10 @@ public sealed class RoleOrchestratorAtomicTestApplication : IAsyncLifetime
         // Host DbContext registered via factory — the atomic path's IAuthorizationHostDbContextAccessor
         // requires IDbContextFactory<THost> to create a fresh context for SetDbConnection.
         services.AddDbContextFactory<TestHostDbContext>(opts =>
-            opts.UseNpgsql(_postgres.ConnectionString));
+        {
+            opts.UseNpgsql(_postgres.ConnectionString);
+            opts.AddInterceptors(new ConcurrencyStampInterceptor());
+        });
 
         services.AddIdentityCore<LocalIdentity>()
             .AddRoles<GranitRole>()

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTestApplication.cs
@@ -3,6 +3,7 @@ using Granit.Guids.Extensions;
 using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -45,7 +46,10 @@ public sealed class RoleOrchestratorTestApplication : IAsyncLifetime
         services.AddDbContext<TestIdentityDbContext>(opts =>
             opts.UseNpgsql(_postgres.ConnectionString));
         services.AddDbContext<TestHostDbContext>(opts =>
-            opts.UseNpgsql(_postgres.ConnectionString));
+        {
+            opts.UseNpgsql(_postgres.ConnectionString);
+            opts.AddInterceptors(new ConcurrencyStampInterceptor());
+        });
 
         // ASP.NET Core Identity — lightweight IdentityCore pipeline is enough for the
         // orchestrator; no cookies / token providers / email services required.


### PR DESCRIPTION
## Summary

- **`CanMutate` missing `IsSystem` check** — `Rename_SystemRole_Returns403` expected a 403 but the orchestrator's `ArgumentException` (null stamp from body) escaped before the system-role guard. Added `if (role.IsSystem) return false;` at the top of `CanMutate` so the endpoint returns 403 before the orchestrator runs.
- **`ConcurrencyStampInterceptor` not wired in test applications** — All three integration-test hosts registered `TestHostDbContext` with a bare `UseNpgsql`, leaving `ConcurrencyStamp == ""` after every save. Added `opts.AddInterceptors(new ConcurrencyStampInterceptor())` to each registration.
- **`Rename_AsTenantAdmin_OwnTenantRole_Returns200` discarded the stamp** — `CreateViaEndpointAsync` returned only the `Guid`; the PUT body omitted `concurrencyStamp`. Changed the helper to return the full `RoleResponseLite` (now includes `ConcurrencyStamp`) and included the stamp in the PUT body.

## Test plan

- [ ] `RoleOrchestratorTests.RenameAsync_SystemRole_Refused` — expects `InvalidOperationException` (system role); `CanMutate` now returns false first at endpoint level, but orchestrator-level guard still works for direct callers
- [ ] `RoleOrchestratorAtomicTests.RenameAsync_HappyPath_UpdatesBothRowsAtomically` — `ConcurrencyStampInterceptor` now sets a real stamp after create, so stamp passed to rename is non-empty
- [ ] `RoleOrchestratorTests.RenameAsync_MetadataNameCollision_RevertsIdentityRole` — same interceptor fix
- [ ] `GranitRoleEndpointsTests.Rename_AsTenantAdmin_OwnTenantRole_Returns200` — PUT now includes the stamp from the POST response
- [ ] `GranitRoleEndpointsTests.Rename_SystemRole_Returns403` — `CanMutate` returns false → 403 before orchestrator