### PR TITLE
fix(identity): repair ManageGrant_Put CI failure in permission-tests

### DIFF
--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
@@ -153,7 +153,7 @@ public sealed class GranitRoleEndpointsPermissionTests
 
         HttpResponseMessage put = await client.PutAsJsonAsync(
             $"/admin/roles/{created!.Id:D}",
-            new { name = "SeniorAuditor" },
+            new { name = "SeniorAuditor", concurrencyStamp = created.ConcurrencyStamp },
             TestContext.Current.CancellationToken);
         put.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
@@ -282,5 +282,6 @@ public sealed class GranitRoleEndpointsPermissionTests
         Guid? TenantId,
         string? ClientId,
         string? Description,
-        bool IsSystem);
+        bool IsSystem,
+        string ConcurrencyStamp);
 }

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
@@ -7,6 +7,7 @@ using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Extensions;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.Testing.Fakes;
 using Granit.Users;
 using Microsoft.AspNetCore.Authentication;
@@ -65,7 +66,10 @@ public sealed class RoleEndpointsPermissionTestApplication : IAsyncLifetime
         builder.Services.AddDbContext<TestIdentityDbContext>(opts =>
             opts.UseNpgsql(_postgres.ConnectionString));
         builder.Services.AddDbContext<TestHostDbContext>(opts =>
-            opts.UseNpgsql(_postgres.ConnectionString));
+        {
+            opts.UseNpgsql(_postgres.ConnectionString);
+            opts.AddInterceptors(new ConcurrencyStampInterceptor());
+        });
 
         builder.Services.AddIdentityCore<LocalIdentity>()
             .AddRoles<GranitRole>()


### PR DESCRIPTION
## Summary

- **`ConcurrencyStampInterceptor` missing in `RoleEndpointsPermissionTestApplication`** — `TestHostDbContext` was registered without the interceptor, so `ConcurrencyStamp` stayed `""` after every save.
- **PUT body missing `concurrencyStamp`** — `ManageGrant_Put_Returns200` sent `new { name = "SeniorAuditor" }` without the stamp; `GranitRoleOrchestrator.RenameAsync` rejected it with `ArgumentNullException`.

Same root cause as #2784 but in the fourth (permission-test) fixture that was missed in that batch.

## Test plan

- [ ] `GranitRoleEndpointsPermissionTests.ManageGrant_Put_Returns200` — creates a role via POST, reads the stamp from the response, includes it in the PUT body → expects 200