### PR TITLE
fix(mcp): guard assembly scan against ReflectionTypeLoadException from InternalsVisibleTo

### DIFF
--- a/src/Granit.Mcp/Extensions/McpServiceCollectionExtensions.cs
+++ b/src/Granit.Mcp/Extensions/McpServiceCollectionExtensions.cs
@@ -101,13 +101,32 @@ public static class McpServiceCollectionExtensions
 
         foreach (Assembly assembly in moduleAssemblies)
         {
-            mcpBuilder.WithToolsFromAssembly(assembly);
-            mcpBuilder.WithPromptsFromAssembly(assembly);
+            try
+            {
+                mcpBuilder.WithToolsFromAssembly(assembly);
+                mcpBuilder.WithPromptsFromAssembly(assembly);
+            }
+            catch (ReflectionTypeLoadException)
+            {
+                // Assembly references internal types from another assembly via InternalsVisibleTo
+                // (e.g. EFC modules consuming an internal DbContext). No MCP tools live in those
+                // assemblies, so skipping is safe.
+            }
         }
 
         foreach (Assembly assembly in moduleAssemblies)
         {
-            IEnumerable<Type> contributorTypes = assembly.GetTypes()
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t is not null).ToArray()!;
+            }
+
+            IEnumerable<Type> contributorTypes = types
                 .Where(t => t is { IsAbstract: false, IsInterface: false }
                     && typeof(IMcpToolContributor).IsAssignableFrom(t));
 


### PR DESCRIPTION
## Problem

`GranitMcpModule.ConfigureServices` crashed at startup with a `ReflectionTypeLoadException` when an EFC module referenced an `internal` type from another assembly via `InternalsVisibleTo`.

Concrete case: `Granit.Parties.Deduplication.EntityFrameworkCore` accesses `PartiesDbContext` (internal to `Granit.Parties.EntityFrameworkCore`). When the MCP scanner calls `GetTypes()` on that assembly, the runtime cannot materialise compiler-generated async generic types (`ConfiguredTaskAwaitable<PartiesDbContext>`) from a third-party context — even though `InternalsVisibleTo` is granted at compile time.

## Fix

`DiscoverFromAssemblies` now applies the standard .NET pattern for scanning mixed-visibility assemblies:

- **`WithToolsFromAssembly` / `WithPromptsFromAssembly`**: try/catch on `ReflectionTypeLoadException` — no MCP tools live in EFC assemblies, so skipping is safe.
- **`assembly.GetTypes()`**: catch + fallback on `ex.Types` (partially-loaded set) to continue registering `IMcpToolContributor` implementations from healthy assemblies.

## Impact

No regression on normal assemblies (the catch only fires on failure). Unblocks wiring of any EFC module that consumes an internal `DbContext` via `InternalsVisibleTo`.