### PR TITLE
fix(reflection): extract TryScan helper and guard all assembly scanners

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -34626,7 +34626,7 @@
       "kind": "class",
       "project": "Granit.Mcp",
       "file": "src/Granit.Mcp/Extensions/McpServiceCollectionExtensions.cs",
-      "line": 22,
+      "line": 23,
       "members": []
     },
     {
@@ -47831,6 +47831,12 @@
           "kind": "method",
           "signature": "GetLoadableExportedTypes(this Assembly assembly)",
           "returnType": "IReadOnlyList<Type>"
+        },
+        {
+          "name": "TryScan",
+          "kind": "method",
+          "signature": "TryScan(this Assembly assembly, Action<Assembly> scan)",
+          "returnType": "void"
         }
       ]
     },
@@ -56198,7 +56204,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Extensions/WolverineValidationServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitValidatorsFromWolverineHandlerModules",

--- a/src/Granit.Mcp/Extensions/McpServiceCollectionExtensions.cs
+++ b/src/Granit.Mcp/Extensions/McpServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Granit.Mcp.Diagnostics;
 using Granit.Mcp.Options;
 using Granit.Mcp.Sanitization;
 using Granit.MultiTenancy;
+using Granit.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -101,32 +102,16 @@ public static class McpServiceCollectionExtensions
 
         foreach (Assembly assembly in moduleAssemblies)
         {
-            try
+            assembly.TryScan(a =>
             {
-                mcpBuilder.WithToolsFromAssembly(assembly);
-                mcpBuilder.WithPromptsFromAssembly(assembly);
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                // Assembly references internal types from another assembly via InternalsVisibleTo
-                // (e.g. EFC modules consuming an internal DbContext). No MCP tools live in those
-                // assemblies, so skipping is safe.
-            }
+                mcpBuilder.WithToolsFromAssembly(a);
+                mcpBuilder.WithPromptsFromAssembly(a);
+            });
         }
 
         foreach (Assembly assembly in moduleAssemblies)
         {
-            Type[] types;
-            try
-            {
-                types = assembly.GetTypes();
-            }
-            catch (ReflectionTypeLoadException ex)
-            {
-                types = ex.Types.Where(t => t is not null).ToArray()!;
-            }
-
-            IEnumerable<Type> contributorTypes = types
+            IEnumerable<Type> contributorTypes = assembly.GetLoadableTypes()
                 .Where(t => t is { IsAbstract: false, IsInterface: false }
                     && typeof(IMcpToolContributor).IsAssignableFrom(t));
 

--- a/src/Granit.Validation/GranitValidationModule.cs
+++ b/src/Granit.Validation/GranitValidationModule.cs
@@ -56,8 +56,8 @@ public sealed class GranitValidationModule : GranitModule
         // Auto-discover validators from all loaded module assemblies.
         foreach (Assembly assembly in context.ModuleAssemblies)
         {
-            context.Services.AddValidatorsFromAssembly(
-                assembly, ServiceLifetime.Scoped, includeInternalTypes: true);
+            assembly.TryScan(a => context.Services.AddValidatorsFromAssembly(
+                a, ServiceLifetime.Scoped, includeInternalTypes: true));
         }
 
         // Auto-discover IServerValidatorContributor from all loaded module assemblies.

--- a/src/Granit.Wolverine/Extensions/WolverineValidationServiceCollectionExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineValidationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using FluentValidation;
+using Granit.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Attributes;
 
@@ -38,8 +39,8 @@ public static class WolverineValidationServiceCollectionExtensions
         foreach (Assembly? assembly in AppDomain.CurrentDomain.GetAssemblies()
             .Where(a => a.GetCustomAttribute<WolverineHandlerModuleAttribute>() is not null))
         {
-            services.AddValidatorsFromAssembly(
-                assembly, ServiceLifetime.Scoped, includeInternalTypes: true);
+            assembly.TryScan(a => services.AddValidatorsFromAssembly(
+                a, ServiceLifetime.Scoped, includeInternalTypes: true));
         }
 
         return services;

--- a/src/Granit/Reflection/SafeTypeLoader.cs
+++ b/src/Granit/Reflection/SafeTypeLoader.cs
@@ -28,6 +28,37 @@ public static class SafeTypeLoader
         Load(assembly, static a => a.GetExportedTypes());
 
     /// <summary>
+    /// Invokes <paramref name="scan"/> against <paramref name="assembly"/>, swallowing
+    /// <see cref="ReflectionTypeLoadException"/> and missing-dependency load failures.
+    /// Use this when a third-party scanner (FluentValidation, MCP SDK, …) calls
+    /// <see cref="Assembly.GetTypes"/> internally and cannot be given a pre-filtered type list.
+    /// </summary>
+    public static void TryScan(this Assembly assembly, Action<Assembly> scan)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentNullException.ThrowIfNull(scan);
+
+        if (assembly.IsDynamic)
+        {
+            return;
+        }
+
+        try
+        {
+            scan(assembly);
+        }
+        catch (ReflectionTypeLoadException)
+        {
+            // Assembly references internal types from another assembly via InternalsVisibleTo.
+            // No discoverable registrations live in those assemblies — skip safely.
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or TypeLoadException)
+        {
+            // Assembly's public surface references an unloaded dependency — skip safely.
+        }
+    }
+
+    /// <summary>
     /// Shared resilience core. On <see cref="ReflectionTypeLoadException"/> returns the partial set that
     /// did load; on a missing-dependency load failure returns empty; any other exception propagates.
     /// </summary>


### PR DESCRIPTION
## Problem

Any third-party assembly scanner that calls `GetTypes()` internally crashes at startup with a `ReflectionTypeLoadException` when it encounters an EFC module that exposes an `internal` type (e.g. `DbContext`) via `InternalsVisibleTo`. The runtime cannot materialise compiler-generated async generic types (`ConfiguredTaskAwaitable<InternalT>`) from a third-party context — even though `InternalsVisibleTo` is granted at compile time.

Affected scanners found in the codebase:
- `McpServiceCollectionExtensions.DiscoverFromAssemblies` (`WithToolsFromAssembly` / `WithPromptsFromAssembly`)
- `GranitValidationModule` (`AddValidatorsFromAssembly`)
- `WolverineValidationServiceCollectionExtensions` (`AddValidatorsFromAssembly`)

## Fix

Adds `SafeTypeLoader.TryScan(this Assembly, Action<Assembly>)` — a reusable extension that wraps any third-party scanner and swallows `ReflectionTypeLoadException`, `FileNotFoundException`, `FileLoadException`, and `TypeLoadException`. Replaces all ad-hoc try/catch blocks and bare scanner calls with this helper.

The existing `GetLoadableTypes` / `GetLoadableExportedTypes` extensions already protect direct `GetTypes()` calls; `TryScan` covers the remaining gap where we pass the whole `Assembly` to an external scanner.

## Already protected (no change needed)

`ScheduledPayloadTypeRegistry`, `ApiDocumentationServiceCollectionExtensions`, `DbContextAutoExportDefinitionSource`, `DbContextResolver` — all use `GetLoadableTypes` / `GetLoadableExportedTypes` already.

## Supersedes

Closes #2786 (inline approach, same root cause, narrower fix).