### PR TITLE
fix(openiddict): accept DPoP scheme in validation token extraction

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40967,6 +40967,28 @@
       ]
     },
     {
+      "name": "DPoPValidationTokenExtractionHandler",
+      "fqn": "Granit.OpenIddict.Server.Handlers.DPoPValidationTokenExtractionHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Server",
+      "file": "src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "Descriptor",
+          "kind": "property",
+          "signature": "OpenIddictValidationHandlerDescriptor Descriptor",
+          "returnType": "OpenIddictValidationHandlerDescriptor"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OpenIddictValidationEvents.ProcessAuthenticationContext context)",
+          "returnType": "ValueTask"
+        }
+      ]
+    },
+    {
       "name": "OpenIddictUserSessionCreatedHandler",
       "fqn": "Granit.OpenIddict.Server.Handlers.OpenIddictUserSessionCreatedHandler",
       "kind": "class",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40972,7 +40972,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "Descriptor",

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -226,6 +226,11 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
         {
             options.UseLocalServer();
             options.UseAspNetCore();
+
+            // OpenIddict 7.x's built-in extraction handler only accepts "Bearer" scheme.
+            // This handler picks up "Authorization: DPoP <token>" so BFF sessions with
+            // UseDPoP=true authenticate correctly against the local server (monolith).
+            options.AddEventHandler(DPoPValidationTokenExtractionHandler.Descriptor);
         });
 
         // Normalize OIDC short-name "role" claims emitted by OpenIddict.Validation into

--- a/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using OpenIddict.Validation;
+
+namespace Granit.OpenIddict.Server.Handlers;
+
+/// <summary>
+/// OpenIddict validation handler that extracts access tokens presented with the
+/// <c>Authorization: DPoP &lt;token&gt;</c> scheme (RFC 9449 §7.1).
+/// </summary>
+/// <remarks>
+/// OpenIddict 7.x's built-in <c>ExtractAccessTokenFromAuthorizationHeader</c> only accepts
+/// the <c>Bearer</c> scheme. This handler runs immediately after it and picks up
+/// DPoP-schemed tokens, enabling the local-server validation pipeline (monolith) to
+/// authenticate requests sent by the Granit BFF when <c>UseDPoP</c> is enabled.
+/// </remarks>
+public sealed class DPoPValidationTokenExtractionHandler
+    : IOpenIddictValidationHandler<OpenIddictValidationEvents.ProcessAuthenticationContext>
+{
+    // OpenIddict internals (from reflection on 7.5.0):
+    //   EvaluateValidatedTokens.Order     = -2_147_383_648
+    //   ExtractAccessTokenFromAuth.Order  = EvaluateValidatedTokens.Order + 500  = -2_147_383_148
+    // This handler runs one slot later as a fallback.
+    private const int HandlerOrder = -2_147_383_148 + 1;
+
+    /// <summary>Handler descriptor registered with the OpenIddict validation pipeline.</summary>
+    public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
+        = OpenIddictValidationHandlerDescriptor
+            .CreateBuilder<OpenIddictValidationEvents.ProcessAuthenticationContext>()
+            .UseSingletonHandler<DPoPValidationTokenExtractionHandler>()
+            .SetOrder(HandlerOrder)
+            .SetType(OpenIddictValidationHandlerType.Custom)
+            .Build();
+
+    /// <inheritdoc/>
+    public ValueTask HandleAsync(OpenIddictValidationEvents.ProcessAuthenticationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Skip if the Bearer extraction handler already found a token.
+        if (!string.IsNullOrEmpty(context.AccessToken))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        HttpRequest? request = context.Transaction.GetHttpRequest();
+        if (request is null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        string? authorization = request.Headers[HeaderNames.Authorization];
+        if (!string.IsNullOrEmpty(authorization)
+            && authorization.StartsWith("DPoP ", StringComparison.OrdinalIgnoreCase))
+        {
+            context.AccessToken = authorization["DPoP ".Length..];
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using OpenIddict.Validation;
+using OpenIddict.Validation.AspNetCore;
 
 namespace Granit.OpenIddict.Server.Handlers;
 
@@ -18,16 +19,18 @@ namespace Granit.OpenIddict.Server.Handlers;
 public sealed class DPoPValidationTokenExtractionHandler
     : IOpenIddictValidationHandler<OpenIddictValidationEvents.ProcessAuthenticationContext>
 {
-    // OpenIddict internals (from reflection on 7.5.0):
-    //   EvaluateValidatedTokens.Order     = -2_147_383_648
-    //   ExtractAccessTokenFromAuth.Order  = EvaluateValidatedTokens.Order + 500  = -2_147_383_148
-    // This handler runs one slot later as a fallback.
-    private const int HandlerOrder = -2_147_383_148 + 1;
+    // Run one slot after the built-in Bearer extractor so this acts as a fallback.
+    // Reference its public Descriptor.Order rather than a hardcoded constant: the
+    // order then tracks the built-in automatically across OpenIddict version bumps.
+    private static readonly int HandlerOrder = checked((int)(
+        OpenIddictValidationAspNetCoreHandlers.ExtractAccessTokenFromAuthorizationHeader
+            .Descriptor.Order + 1));
 
     /// <summary>Handler descriptor registered with the OpenIddict validation pipeline.</summary>
     public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
         = OpenIddictValidationHandlerDescriptor
             .CreateBuilder<OpenIddictValidationEvents.ProcessAuthenticationContext>()
+            .AddFilter<OpenIddictValidationAspNetCoreHandlerFilters.RequireHttpRequest>()
             .UseSingletonHandler<DPoPValidationTokenExtractionHandler>()
             .SetOrder(HandlerOrder)
             .SetType(OpenIddictValidationHandlerType.Custom)

--- a/tests/Granit.OpenIddict.Server.Tests/Handlers/DPoPValidationTokenExtractionHandlerTests.cs
+++ b/tests/Granit.OpenIddict.Server.Tests/Handlers/DPoPValidationTokenExtractionHandlerTests.cs
@@ -1,0 +1,111 @@
+using Granit.OpenIddict.Server.Handlers;
+using Microsoft.AspNetCore.Http;
+using OpenIddict.Abstractions;
+using OpenIddict.Validation;
+using Shouldly;
+using Xunit;
+using static OpenIddict.Validation.OpenIddictValidationEvents;
+
+namespace Granit.OpenIddict.Server.Tests.Handlers;
+
+public sealed class DPoPValidationTokenExtractionHandlerTests
+{
+    private const string Token = "header.payload.signature";
+
+    [Fact]
+    public async Task DPoPScheme_PopulatesAccessToken()
+    {
+        DPoPValidationTokenExtractionHandler handler = new();
+        ProcessAuthenticationContext context = BuildContext(authorization: $"DPoP {Token}");
+
+        await handler.HandleAsync(context);
+
+        context.AccessToken.ShouldBe(Token);
+    }
+
+    [Fact]
+    public async Task DPoPScheme_CaseInsensitivePrefix_PopulatesAccessToken()
+    {
+        DPoPValidationTokenExtractionHandler handler = new();
+        ProcessAuthenticationContext context = BuildContext(authorization: $"dpop {Token}");
+
+        await handler.HandleAsync(context);
+
+        context.AccessToken.ShouldBe(Token);
+    }
+
+    [Fact]
+    public async Task BearerAlreadyExtracted_LeavesAccessTokenUntouched()
+    {
+        DPoPValidationTokenExtractionHandler handler = new();
+        ProcessAuthenticationContext context = BuildContext(authorization: $"DPoP {Token}");
+        context.AccessToken = "already-extracted-by-bearer-handler";
+
+        await handler.HandleAsync(context);
+
+        context.AccessToken.ShouldBe("already-extracted-by-bearer-handler");
+    }
+
+    [Fact]
+    public async Task BearerScheme_IsIgnored()
+    {
+        DPoPValidationTokenExtractionHandler handler = new();
+        ProcessAuthenticationContext context = BuildContext(authorization: $"Bearer {Token}");
+
+        await handler.HandleAsync(context);
+
+        context.AccessToken.ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task NoAuthorizationHeader_LeavesAccessTokenNull()
+    {
+        DPoPValidationTokenExtractionHandler handler = new();
+        ProcessAuthenticationContext context = BuildContext(authorization: null);
+
+        await handler.HandleAsync(context);
+
+        context.AccessToken.ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task NoHttpRequest_LeavesAccessTokenNull()
+    {
+        DPoPValidationTokenExtractionHandler handler = new();
+        ProcessAuthenticationContext context = BuildContext(authorization: null, attachHttpRequest: false);
+
+        await handler.HandleAsync(context);
+
+        context.AccessToken.ShouldBeNullOrEmpty();
+    }
+
+    private static ProcessAuthenticationContext BuildContext(
+        string? authorization, bool attachHttpRequest = true)
+    {
+        OpenIddictValidationTransaction transaction = new()
+        {
+            Request = new OpenIddictRequest(),
+            Response = new OpenIddictResponse(),
+        };
+
+        if (attachHttpRequest)
+        {
+            DefaultHttpContext httpContext = new();
+            httpContext.Request.Method = "GET";
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("api.example.com");
+            httpContext.Request.Path = "/resource";
+            if (authorization is not null)
+            {
+                httpContext.Request.Headers["Authorization"] = authorization;
+            }
+
+            // OpenIddictValidationAspNetCoreHelpers.GetHttpRequest() reads a
+            // WeakReference<HttpRequest> keyed by the HttpRequest full type name.
+            transaction.Properties[typeof(HttpRequest).FullName!] =
+                new WeakReference<HttpRequest>(httpContext.Request);
+        }
+
+        return new ProcessAuthenticationContext(transaction);
+    }
+}


### PR DESCRIPTION
## Root cause

OpenIddict 7.x's built-in `ExtractAccessTokenFromAuthorizationHeader` handler hardcodes a `Bearer` scheme check:

```csharp
if (text.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
    context.AccessToken = text.Substring("Bearer ".Length);
// DPoP scheme → silently ignored → 401
```

The Granit BFF sends `Authorization: DPoP <token>` + `DPoP: <proof>` for sessions with `UseDPoP = true`. Because OpenIddict never extracts the token, every `[Authorize]` endpoint returns 401, and the BFF middleware interprets the failure as a session expiry — deleting the session cookie and redirecting to login.

## Fix

Add `DPoPValidationTokenExtractionHandler`, a custom `IOpenIddictValidationHandler<ProcessAuthenticationContext>` ordered one slot after the built-in Bearer extractor (`-2_147_383_147`). It runs as a fallback: if no token was found by the Bearer handler, it strips the `DPoP ` prefix and populates `context.AccessToken`.

The handler is registered in `AddGranitOpenIddictServer`'s `AddValidation` block, so all monolith/resource-server deployments pick it up automatically.

## Test plan

- [ ] Verify `UseDPoP: true` in showcase BFF config no longer causes 401 / session deletion
- [ ] Verify `UseDPoP: false` (Bearer fallback path) still authenticates correctly
- [ ] Verify token with `cnf.jkt` binding still validates (DPoP proof is checked by `UseGranitDPoPValidation()` middleware separately)