### PR TITLE
docs(openiddict): reframe DPoP validation extraction as permanent integration

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40972,7 +40972,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs",
-      "line": 19,
+      "line": 22,
       "members": [
         {
           "name": "Descriptor",

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -227,9 +227,11 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
             options.UseLocalServer();
             options.UseAspNetCore();
 
-            // OpenIddict 7.x's built-in extraction handler only accepts "Bearer" scheme.
-            // This handler picks up "Authorization: DPoP <token>" so BFF sessions with
-            // UseDPoP=true authenticate correctly against the local server (monolith).
+            // OpenIddict has no DPoP support; its built-in extractor only accepts "Bearer".
+            // Granit owns the whole DPoP chain, so this handler picks up
+            // "Authorization: DPoP <token>" (RFC 9449 §7.1) for every DPoP client — BFF
+            // sessions as well as no-BFF consumers (SPA, mobile, native) where mTLS is
+            // impractical. It is a permanent part of the integration, not a stopgap.
             options.AddEventHandler(DPoPValidationTokenExtractionHandler.Descriptor);
         });
 

--- a/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
@@ -11,10 +11,13 @@ namespace Granit.OpenIddict.Server.Handlers;
 /// <c>Authorization: DPoP &lt;token&gt;</c> scheme (RFC 9449 §7.1).
 /// </summary>
 /// <remarks>
-/// OpenIddict 7.x's built-in <c>ExtractAccessTokenFromAuthorizationHeader</c> only accepts
-/// the <c>Bearer</c> scheme. This handler runs immediately after it and picks up
-/// DPoP-schemed tokens, enabling the local-server validation pipeline (monolith) to
-/// authenticate requests sent by the Granit BFF when <c>UseDPoP</c> is enabled.
+/// OpenIddict has no DPoP support of its own — its built-in
+/// <c>ExtractAccessTokenFromAuthorizationHeader</c> only handles the <c>Bearer</c> scheme.
+/// DPoP is implemented entirely by Granit on top of OpenIddict's pipeline, so extracting
+/// DPoP-schemed tokens in the validation stack is an intrinsic, permanent part of that
+/// integration — not a workaround for an upstream defect. This handler runs as a fallback
+/// after the Bearer extractor and populates the access token for any DPoP client: a BFF, or
+/// a no-BFF consumer (SPA, mobile, native) where mTLS token binding is impractical.
 /// </remarks>
 public sealed class DPoPValidationTokenExtractionHandler
     : IOpenIddictValidationHandler<OpenIddictValidationEvents.ProcessAuthenticationContext>


### PR DESCRIPTION
Follow-up to #2788 (merged).

## Why

The DPoP validation extraction handler was framed in comments as a *workaround for
an OpenIddict limitation*. That framing is wrong: OpenIddict has **no DPoP support
at all** (by design — it covers `Bearer` and mTLS). Granit implements the entire
DPoP chain itself on top of OpenIddict's pipeline, so extracting DPoP-schemed tokens
in the validation stack is an **intrinsic, permanent part of that integration**, not
a stopgap awaiting an upstream fix.

## Changes (comments only)

- `DPoPValidationTokenExtractionHandler` XML doc: clarify OpenIddict has no DPoP
  support, this is a permanent component, and broaden the rationale beyond the BFF to
  cover **no-BFF consumers** (SPA, mobile, native) where mTLS token binding is
  impractical — the scenario where DPoP is the only realistic sender-constraining
  option (FAPI 2.0 accepts both mTLS and DPoP).
- Registration comment in `AddGranitOpenIddictServer` updated to match.

No behavioral change. Tracking context in #2789.