### PR TITLE
fix(dpop): skip OIDC /connect endpoints in resource-side validation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -9496,6 +9496,12 @@
           "kind": "property",
           "signature": "bool RequireNonce",
           "returnType": "bool"
+        },
+        {
+          "name": "ExcludedPathPrefixes",
+          "kind": "property",
+          "signature": "string[] ExcludedPathPrefixes",
+          "returnType": "string[]"
         }
       ]
     },

--- a/src/Granit.Authentication.DPoP/Middleware/DPoPValidationMiddleware.cs
+++ b/src/Granit.Authentication.DPoP/Middleware/DPoPValidationMiddleware.cs
@@ -23,6 +23,20 @@ internal sealed partial class DPoPValidationMiddleware(
     {
         DPoPValidationOptions opts = options.Value;
 
+        // Skip the OIDC authorization-server endpoints when co-located (monolith): the proof
+        // presented at /connect/token is validated server-side, which records its jti for
+        // replay protection. Validating the same proof here first would make the server handler
+        // see a duplicate jti → "proof replay detected" → token exchange fails. See
+        // DPoPValidationOptions.ExcludedPathPrefixes.
+        foreach (string prefix in opts.ExcludedPathPrefixes)
+        {
+            if (context.Request.Path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                await next(context).ConfigureAwait(false);
+                return;
+            }
+        }
+
         // Only process authenticated requests with DPoP header or when DPoP is required
         bool hasDPoPHeader = context.Request.Headers.ContainsKey("DPoP");
         bool hasDPoPScheme = context.Request.Headers.Authorization

--- a/src/Granit.Authentication.DPoP/Options/DPoPValidationOptions.cs
+++ b/src/Granit.Authentication.DPoP/Options/DPoPValidationOptions.cs
@@ -64,4 +64,22 @@ public sealed class DPoPValidationOptions
     /// Default: 2048 (NIST SP 800-57 recommendation).
     /// </summary>
     public int MinimumRsaKeySize { get; set; } = 2048;
+
+    /// <summary>
+    /// Gets or sets request path prefixes the resource-side validation middleware skips
+    /// entirely (case-insensitive segment match). Requests under these prefixes pass
+    /// straight through without proof validation.
+    /// <para>
+    /// This matters when the OpenID Connect authorization server is co-located with the
+    /// resource server (a monolith). The DPoP proof presented at the token endpoint
+    /// (<c>/connect/token</c>) is validated server-side by the OIDC pipeline, which records
+    /// the proof's <c>jti</c> for replay protection. If this middleware also validated the
+    /// same proof, it would record the <c>jti</c> first, so the server handler would then
+    /// see a duplicate <c>jti</c> → "proof replay detected" → the token exchange fails.
+    /// Excluding the OIDC endpoints avoids the double validation. On a standalone resource
+    /// server these paths do not exist, so the default is harmless.
+    /// </para>
+    /// Default: <c>["/connect"]</c> (the Granit OpenIddict server endpoint prefix).
+    /// </summary>
+    public string[] ExcludedPathPrefixes { get; set; } = ["/connect"];
 }

--- a/tests/Granit.Authentication.DPoP.Tests/Middleware/DPoPValidationMiddlewareTests.cs
+++ b/tests/Granit.Authentication.DPoP.Tests/Middleware/DPoPValidationMiddlewareTests.cs
@@ -168,6 +168,33 @@ public sealed class DPoPValidationMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_ExcludedPathPrefix_SkipsValidationAndCallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Method = "POST";
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.example.com");
+        // Default ExcludedPathPrefixes includes "/connect" — the co-located OIDC token endpoint.
+        context.Request.Path = "/connect/token";
+        context.Request.Headers.Append("DPoP", "proof.jwt");
+
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions(), _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(200);
+        // The proof must NOT be validated here — that is the AS pipeline's job.
+        await _validator.DidNotReceive().ValidateAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task InvokeAsync_ValidProof_ServerNonceSet_AddsResponseHeader()
     {
         DefaultHttpContext context = new();


### PR DESCRIPTION
## Problem

In a monolith where the OpenIddict authorization server is co-located with the resource server,
the DPoP proof presented at `/connect/token` is validated **server-side** by the OIDC pipeline,
which records the proof's `jti` for replay protection. The resource-side `DPoPValidationMiddleware`
was validating the *same* proof first and recording the `jti`, so the server handler then saw a
duplicate `jti` → "proof replay detected" → the token exchange failed.

## Fix

Add `DPoPValidationOptions.ExcludedPathPrefixes` (default `["/connect"]`); the middleware passes
requests under those prefixes straight through without proof validation. On a standalone resource
server those paths don't exist, so the default is harmless.

## Tests

`tests/Granit.Authentication.DPoP.Tests` — 73 passing (includes new middleware exclusion cases).
`dotnet format` clean.