### PR TITLE
fix(ai-chat): only offer 'Auto' workspace when the host default is chat-capable

### DIFF
--- a/src/Granit.AI.Chat/Internal/ChatWorkspaceCatalog.cs
+++ b/src/Granit.AI.Chat/Internal/ChatWorkspaceCatalog.cs
@@ -1,22 +1,26 @@
 using Granit.AI.Chat.Settings;
+using Granit.AI.Options;
 using Granit.AI.Workspaces;
+using Microsoft.Extensions.Options;
 
 namespace Granit.AI.Chat.Internal;
 
 /// <summary>
 /// Default <see cref="IChatWorkspaceCatalog"/>. Filters the tenant's workspaces to the
 /// chat-capable ones via <see cref="IAIWorkspaceCapabilityResolver"/> and prepends the reserved
-/// <c>Auto</c> option.
+/// <c>Auto</c> option — but only when the host's default workspace is itself chat-capable, so a
+/// user can never pick an option that would 404 at send time.
 /// </summary>
 internal sealed class ChatWorkspaceCatalog(
     IAIWorkspaceProvider workspaceProvider,
-    IAIWorkspaceCapabilityResolver capabilityResolver) : IChatWorkspaceCatalog
+    IAIWorkspaceCapabilityResolver capabilityResolver,
+    IOptions<GranitAIOptions> aiOptions) : IChatWorkspaceCatalog
 {
     public async ValueTask<IReadOnlyList<string>> GetSelectableWorkspacesAsync(CancellationToken cancellationToken = default)
     {
         IReadOnlyList<AIWorkspace> workspaces = await workspaceProvider.GetAllAsync(cancellationToken).ConfigureAwait(false);
 
-        List<string> selectable = [AIChatSettingNames.ReservedAutoWorkspace];
+        List<string> chatCapable = [];
         foreach (AIWorkspace workspace in workspaces)
         {
             AIModelCapabilities? capabilities = await capabilityResolver
@@ -27,10 +31,20 @@ internal sealed class ChatWorkspaceCatalog(
             // capability set (null) is treated as chat-capable, mirroring the send-time guard.
             if (capabilities is not { Chat: false })
             {
-                selectable.Add(workspace.Name);
+                chatCapable.Add(workspace.Name);
             }
         }
 
-        return selectable;
+        // 'Auto' delegates to the host's configured default workspace (see
+        // ChatService.ResolveWorkspaceNameAsync). Offer it only when that default actually resolves
+        // to a chat-capable workspace; otherwise selecting it would throw at send time. This also
+        // suppresses 'Auto' for the framework's placeholder default ("default"), which no host seeds.
+        string defaultWorkspace = aiOptions.Value.DefaultWorkspace;
+        bool autoIsResolvable = !string.IsNullOrWhiteSpace(defaultWorkspace)
+            && chatCapable.Contains(defaultWorkspace, StringComparer.OrdinalIgnoreCase);
+
+        return autoIsResolvable
+            ? [AIChatSettingNames.ReservedAutoWorkspace, .. chatCapable]
+            : chatCapable;
     }
 }

--- a/tests/Granit.AI.Chat.Tests/ChatWorkspaceCatalogTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatWorkspaceCatalogTests.cs
@@ -1,5 +1,6 @@
 using Granit.AI.Chat.Internal;
 using Granit.AI.Chat.Settings;
+using Granit.AI.Options;
 using Granit.AI.Workspaces;
 using NSubstitute;
 using Shouldly;
@@ -13,6 +14,10 @@ public sealed class ChatWorkspaceCatalogTests
 
     private static AIWorkspace Workspace(string name, string model) =>
         new() { Name = name, Provider = "OpenAI", Model = model };
+
+    private ChatWorkspaceCatalog Catalog(string defaultWorkspace) =>
+        new(_workspaceProvider, _capabilityResolver,
+            Microsoft.Extensions.Options.Options.Create(new GranitAIOptions { DefaultWorkspace = defaultWorkspace }));
 
     [Fact]
     public async Task Lists_auto_first_then_chat_capable_workspaces_excluding_non_chat()
@@ -30,8 +35,9 @@ public sealed class ChatWorkspaceCatalogTests
         _capabilityResolver.ResolveAsync("OpenAI", "mystery", Arg.Any<CancellationToken>())
             .Returns((AIModelCapabilities?)null);
 
-        var catalog = new ChatWorkspaceCatalog(_workspaceProvider, _capabilityResolver);
-        IReadOnlyList<string> result = await catalog.GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
+        // The host default is a chat-capable workspace, so 'Auto' is resolvable and offered first.
+        IReadOnlyList<string> result = await Catalog("chat")
+            .GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
 
         result[0].ShouldBe(AIChatSettingNames.ReservedAutoWorkspace);
         result.ShouldContain("chat");
@@ -40,13 +46,49 @@ public sealed class ChatWorkspaceCatalogTests
     }
 
     [Fact]
-    public async Task Returns_only_auto_when_no_workspaces()
+    public async Task Omits_auto_when_default_workspace_is_not_chat_capable()
+    {
+        _workspaceProvider.GetAllAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            Workspace("chat", "gpt-4o"),
+        ]);
+        _capabilityResolver.ResolveAsync("OpenAI", "gpt-4o", Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Chat = true });
+
+        // Framework placeholder default ("default") matches no workspace => 'Auto' would 404, so omit it.
+        IReadOnlyList<string> result = await Catalog("default")
+            .GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldNotContain(AIChatSettingNames.ReservedAutoWorkspace);
+        result.ShouldHaveSingleItem().ShouldBe("chat");
+    }
+
+    [Fact]
+    public async Task Omits_auto_when_default_workspace_is_blank()
+    {
+        _workspaceProvider.GetAllAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            Workspace("chat", "gpt-4o"),
+        ]);
+        _capabilityResolver.ResolveAsync("OpenAI", "gpt-4o", Arg.Any<CancellationToken>())
+            .Returns(new AIModelCapabilities { Chat = true });
+
+        IReadOnlyList<string> result = await Catalog("  ")
+            .GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldNotContain(AIChatSettingNames.ReservedAutoWorkspace);
+        result.ShouldHaveSingleItem().ShouldBe("chat");
+    }
+
+    [Fact]
+    public async Task Returns_empty_when_no_workspaces()
     {
         _workspaceProvider.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
-        var catalog = new ChatWorkspaceCatalog(_workspaceProvider, _capabilityResolver);
 
-        IReadOnlyList<string> result = await catalog.GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
+        // No workspaces => nothing chat-capable => 'Auto' cannot resolve => empty list.
+        IReadOnlyList<string> result = await Catalog("general-chat")
+            .GetSelectableWorkspacesAsync(TestContext.Current.CancellationToken);
 
-        result.ShouldHaveSingleItem().ShouldBe(AIChatSettingNames.ReservedAutoWorkspace);
+        result.ShouldBeEmpty();
     }
 }


### PR DESCRIPTION
## Problem

`ChatWorkspaceCatalog` always prepended the reserved `Auto` option. `Auto` delegates to the
host's configured default workspace (`GranitAIOptions.DefaultWorkspace`). When that default is
not chat-capable — or is the framework placeholder `"default"` that no host seeds — selecting
`Auto` threw at send time (a 404 the user couldn't have anticipated from the selector).

## Fix

Offer `Auto` only when `DefaultWorkspace` resolves to a chat-capable workspace; otherwise return
just the chat-capable list. Mirrors the existing send-time guard.

## Tests

`tests/Granit.AI.Chat.Tests` — 63 passing (includes new Auto-resolvability cases). `dotnet format` clean.