### PR TITLE
fix(hostnames): order ListByOwner by value-converted Host, not Host.Value

### DIFF
--- a/src/Granit.Hostnames.EntityFrameworkCore/Internal/EfManagedHostnameStore.cs
+++ b/src/Granit.Hostnames.EntityFrameworkCore/Internal/EfManagedHostnameStore.cs
@@ -70,7 +70,11 @@ internal sealed class EfManagedHostnameStore(
         ListAsync(
             Spec.For<ManagedHostname>()
                 .Where(h => h.OwnerType == ownerType && h.OwnerId == ownerId)
-                .OrderBy(h => (object)h.Host.Value)
+                // Order by the whole Host value object — its ValueConverter round-trips the whole
+                // value to a single column, so EF can translate ORDER BY over `h.Host`. Reaching
+                // into `h.Host.Value` is NOT translatable (the converter has no member mapping for
+                // `.Value`) and throws "could not be translated" at query time.
+                .OrderBy(h => (object)h.Host)
                 .Limit(Math.Min(maxResults, MaxListByOwnerResults)),
             cancellationToken);
 

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreRelationalTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreRelationalTests.cs
@@ -1,0 +1,137 @@
+using System.Diagnostics.Metrics;
+using Granit.Hostnames.Diagnostics;
+using Granit.Hostnames.Domain;
+using Granit.Hostnames.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Hostnames.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Relational (SQLite) coverage for queries that must translate to SQL. The companion
+/// <see cref="EfManagedHostnameStoreTests"/> uses the in-memory provider, which client-evaluates
+/// every expression and therefore cannot catch LINQ-translation failures — exactly the class of
+/// bug this suite guards against (e.g. ordering through a value-converted property's member).
+/// </summary>
+public sealed class EfManagedHostnameStoreRelationalTests
+{
+    private static readonly Guid Tenant = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid OwnerId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task ListByOwnerAsync_orders_by_host_and_filters_owner()
+    {
+        // The Host value object is persisted via a ValueConverter (whole-value round-trip).
+        // Ordering must target the converted property itself; reaching into Host.Value is not
+        // translatable and throws against a relational provider. Regression for the CMS
+        // GET /sites/{id}/hostnames 500 (InvalidOperationException: could not be translated).
+        using var factory = SqliteHostnamesContextFactory.Create(Tenant);
+        EfManagedHostnameStore store = CreateStore(factory);
+        var otherOwner = Guid.NewGuid();
+
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await store.AddAsync(MakeHostname("zeta.example.com"), ct);
+        await store.AddAsync(MakeHostname("alpha.example.com"), ct);
+        await store.AddAsync(MakeHostname("mid.example.com"), ct);
+        await store.AddAsync(MakeHostname("other.example.com", otherOwner), ct);
+
+        IReadOnlyList<ManagedHostname> result =
+            await store.ListByOwnerAsync("cms.site", OwnerId, cancellationToken: ct);
+
+        // Only the queried owner's rows, ascending by host.
+        result.Select(h => h.Host.Value)
+            .ShouldBe(["alpha.example.com", "mid.example.com", "zeta.example.com"]);
+    }
+
+    private static EfManagedHostnameStore CreateStore(SqliteHostnamesContextFactory factory)
+    {
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(Tenant);
+
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>()).Returns(new Meter("test"));
+
+        return new EfManagedHostnameStore(factory, tenant, new HostnamesMetrics(meterFactory));
+    }
+
+    private static ManagedHostname MakeHostname(string host, Guid? ownerId = null) =>
+        ManagedHostname.Create(Guid.NewGuid(), host, "cms.site", ownerId ?? OwnerId, Tenant, isPrimary: false);
+
+    private sealed class SqliteHostnamesContextFactory(
+        SqliteConnection connection,
+        DbContextOptions<HostnamesDbContext> options,
+        ICurrentTenant tenant)
+        : IDbContextFactory<HostnamesDbContext>, IDisposable
+    {
+        public static SqliteHostnamesContextFactory Create(Guid tenantId)
+        {
+            ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+            tenant.IsAvailable.Returns(true);
+            tenant.Id.Returns(tenantId);
+
+            SqliteConnection connection = new("DataSource=:memory:");
+            connection.Open();
+
+            DbContextOptionsBuilder<HostnamesDbContext> optionsBuilder = new();
+            optionsBuilder.UseSqlite(connection);
+            optionsBuilder.ReplaceService<IModelCustomizer, SqliteCompatibleModelCustomizer>();
+            DbContextOptions<HostnamesDbContext> options = optionsBuilder.Options;
+
+            using (HostnamesDbContext db = new(options, tenant))
+            {
+                db.Database.EnsureCreated();
+            }
+
+            return new SqliteHostnamesContextFactory(connection, options, tenant);
+        }
+
+        public HostnamesDbContext CreateDbContext() => new(options, tenant);
+
+        public Task<HostnamesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+
+        public void Dispose() => connection.Dispose();
+    }
+
+    /// <summary>Remaps PostgreSQL-specific CLR types to SQLite-compatible ones — same shape as
+    /// the companion <c>*.EntityFrameworkCore.Tests</c> factories.</summary>
+    private sealed class SqliteCompatibleModelCustomizer(ModelCustomizerDependencies dependencies)
+        : RelationalModelCustomizer(dependencies)
+    {
+        private static readonly ValueConverter<DateTimeOffset, long> DateTimeOffsetConverter = new(
+            v => v.ToUnixTimeMilliseconds(),
+            v => DateTimeOffset.FromUnixTimeMilliseconds(v));
+
+        private static readonly ValueConverter<DateTimeOffset?, long?> NullableDateTimeOffsetConverter = new(
+            v => v.HasValue ? v.Value.ToUnixTimeMilliseconds() : null,
+            v => v.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds(v.Value) : null);
+
+        public override void Customize(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.Customize(modelBuilder, context);
+
+            foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                foreach (IMutableProperty property in entityType.GetProperties())
+                {
+                    if (property.ClrType == typeof(DateTimeOffset))
+                    {
+                        property.SetValueConverter(DateTimeOffsetConverter);
+                    }
+                    else if (property.ClrType == typeof(DateTimeOffset?))
+                    {
+                        property.SetValueConverter(NullableDateTimeOffsetConverter);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreTests.cs
@@ -153,23 +153,10 @@ public sealed class EfManagedHostnameStoreTests
         result.ShouldBeEmpty();
     }
 
-    [Fact]
-    public async Task ListByOwnerAsync_returns_only_matching_owner()
-    {
-        string db = nameof(ListByOwnerAsync_returns_only_matching_owner);
-        EfManagedHostnameStore store = CreateStore(db);
-        var otherOwner = Guid.NewGuid();
-
-        await store.AddAsync(MakeHostname("a.com", ownerId: OwnerId), TestContext.Current.CancellationToken);
-        await store.AddAsync(MakeHostname("b.com", ownerId: OwnerId), TestContext.Current.CancellationToken);
-        await store.AddAsync(MakeHostname("c.com", ownerId: otherOwner), TestContext.Current.CancellationToken);
-
-        IReadOnlyList<ManagedHostname> result = await store.ListByOwnerAsync(
-            "cms.site", OwnerId, cancellationToken: TestContext.Current.CancellationToken);
-
-        result.Count.ShouldBe(2);
-        result.ShouldAllBe(h => h.OwnerId == OwnerId);
-    }
+    // ListByOwnerAsync orders by the value-converted Host column. The in-memory provider sorts
+    // client-side and the Hostname value object is not IComparable, so a non-empty ordered result
+    // can only be exercised against a relational provider — see
+    // EfManagedHostnameStoreRelationalTests.ListByOwnerAsync_orders_by_host_and_filters_owner.
 
     // ── UpdateAsync ───────────────────────────────────────────────────────────
 

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/Granit.Hostnames.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/Granit.Hostnames.EntityFrameworkCore.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/packages.lock.json
@@ -31,6 +31,21 @@
           "Microsoft.Extensions.Logging": "10.0.9"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -112,6 +127,14 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -121,6 +144,20 @@
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
@@ -137,6 +174,11 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -228,6 +270,33 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",


### PR DESCRIPTION
## Problem

`EfManagedHostnameStore.ListByOwnerAsync` ordered by `h.Host.Value`, reaching into the `Host` value object's member. `Host` round-trips through a `ValueConverter` to a single column with no member mapping for `.Value`, so EF Core cannot translate the `ORDER BY` and throws `InvalidOperationException: ... could not be translated` at query time — surfacing as a **500 on CMS `GET /sites/{id}/hostnames`**.

## Fix

Order by the whole `Host` value object (`(object)h.Host`), which the converter translates to the backing column.

## Tests

- Removed the in-memory `ListByOwnerAsync` test that could never catch this — the in-memory provider client-evaluates every expression.
- Added `EfManagedHostnameStoreRelationalTests` (SQLite) exercising the real SQL translation path: asserts owner filtering **and** ascending host ordering. This is the class of bug the in-memory provider structurally cannot detect.

All 23 tests pass; `dotnet format` clean.