### PR TITLE
feat(ai-chat): report-message endpoint with feedback persistence

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3410,6 +3410,24 @@
       "members": []
     },
     {
+      "name": "MessageReport",
+      "fqn": "Granit.AI.Chat.Domain.MessageReport",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Domain/MessageReport.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "MessageReportCategory",
+      "fqn": "Granit.AI.Chat.Domain.MessageReportCategory",
+      "kind": "enum",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Domain/MessageReportCategory.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "MessageRole",
       "fqn": "Granit.AI.Chat.Domain.MessageRole",
       "kind": "enum",
@@ -3551,6 +3569,15 @@
           "returnType": "ConversationSummaryResponse"
         }
       ]
+    },
+    {
+      "name": "ReportMessageRequest",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.ReportMessageRequest",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/ReportMessageRequest.cs",
+      "line": 8,
+      "members": []
     },
     {
       "name": "SendMessageRequest",
@@ -3706,6 +3733,15 @@
       "project": "Granit.AI.Chat.EntityFrameworkCore",
       "file": "src/Granit.AI.Chat.EntityFrameworkCore/GranitAIChatEntityFrameworkCoreModule.cs",
       "line": 14,
+      "members": []
+    },
+    {
+      "name": "ChatMessageReportedEvent",
+      "fqn": "Granit.AI.Chat.Events.ChatMessageReportedEvent",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Events/ChatMessageReportedEvent.cs",
+      "line": 18,
       "members": []
     },
     {
@@ -3881,6 +3917,12 @@
           "name": "AppendMessagesAsync",
           "kind": "method",
           "signature": "AppendMessagesAsync(Guid id, Guid ownerId, IReadOnlyList<Message> messages, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "ReportMessageAsync",
+          "kind": "method",
+          "signature": "ReportMessageAsync(Guid reportId, Guid messageId, Guid ownerId, string reason, MessageReportCategory? category, CancellationToken cancellationToken = default)",
           "returnType": "Task<bool>"
         },
         {

--- a/src/Granit.AI.Chat.Endpoints/Dtos/ReportMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/ReportMessageRequest.cs
@@ -1,0 +1,8 @@
+using Granit.AI.Chat.Domain;
+
+namespace Granit.AI.Chat.Endpoints.Dtos;
+
+/// <summary>Request to report (flag) a message for review.</summary>
+/// <param name="Reason">The free-text reason the user supplies. Required, bounded length.</param>
+/// <param name="Category">The optional category the user selects from a closed set.</param>
+public sealed record ReportMessageRequest(string Reason, MessageReportCategory? Category = null);

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -32,6 +32,7 @@ internal static class ChatSendEndpoints
                 + "'clarification' when applicable). Rejects a non-chat-capable workspace before streaming.")
             .Produces<ChatStreamEvent>(StatusCodes.Status200OK, "text/event-stream")
             .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status429TooManyRequests)

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ConversationEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ConversationEndpoints.cs
@@ -21,6 +21,7 @@ internal static class ConversationEndpoints
             .WithSummary("Lists the current user's conversations.")
             .WithDescription("Returns the caller's own conversations, newest first, without their messages.")
             .Produces<IReadOnlyList<ConversationSummaryResponse>>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIChatPermissions.Conversations.Read);
 
         group.MapGet("/{id:guid}", GetByIdAsync)
@@ -28,6 +29,7 @@ internal static class ConversationEndpoints
             .WithSummary("Returns one of the current user's conversations by ID.")
             .WithDescription("Returns the conversation and its messages. Scoped to the caller: another user's conversation is reported as not found.")
             .Produces<ConversationResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Read);
 
@@ -37,6 +39,7 @@ internal static class ConversationEndpoints
             .WithDescription("Creates an empty conversation with the given title, owned by the caller.")
             .Produces<ConversationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIChatPermissions.Conversations.Manage);
 
         group.MapPut("/{id:guid}/title", RenameAsync)
@@ -45,6 +48,7 @@ internal static class ConversationEndpoints
             .WithDescription("Updates the conversation title. Scoped to the caller: another user's conversation is reported as not found.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Manage);
 
@@ -53,6 +57,7 @@ internal static class ConversationEndpoints
             .WithSummary("Deletes one of the current user's conversations.")
             .WithDescription("Soft-deletes the conversation. Scoped to the caller: another user's conversation is reported as not found.")
             .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Delete);
 

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/MessageReportEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/MessageReportEndpoints.cs
@@ -1,0 +1,58 @@
+using Granit.AI.Chat.Endpoints.Dtos;
+using Granit.AI.Chat.Endpoints.Permissions;
+using Granit.Guids;
+using Granit.Users;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.AI.Chat.Endpoints.Endpoints;
+
+/// <summary>The owner-scoped endpoint for reporting (flagging) a message for review.</summary>
+internal static class MessageReportEndpoints
+{
+    internal static RouteGroupBuilder MapMessageReportEndpoint(this RouteGroupBuilder group)
+    {
+        group.MapPost("/messages/{messageId:guid}/report", ReportAsync)
+            .WithName("ReportChatMessage")
+            .WithSummary("Reports a message in one of the current user's conversations.")
+            .WithDescription(
+                "Records a user report flagging the message for review and raises a domain event the "
+                + "application can route. Scoped to the caller: a message outside the caller's own "
+                + "conversations is reported as not found. The report stores identifiers plus the "
+                + "user-entered reason — never the message content (ADR-071).")
+            .Produces(StatusCodes.Status202Accepted)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(AIChatPermissions.Conversations.Report);
+
+        return group;
+    }
+
+    private static async Task<Results<Accepted, ProblemHttpResult>> ReportAsync(
+        Guid messageId,
+        ReportMessageRequest request,
+        [FromServices] IConversationStore store,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IGuidGenerator guidGenerator,
+        CancellationToken cancellationToken)
+    {
+        if (currentUser.UserGuid is not { } ownerId)
+        {
+            return TypedResults.Problem(
+                detail: "The current identity has no user context.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        bool reported = await store.ReportMessageAsync(
+            guidGenerator.Create(), messageId, ownerId, request.Reason, request.Category, cancellationToken)
+            .ConfigureAwait(false);
+
+        return reported
+            ? TypedResults.Accepted((string?)null)
+            : TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+    }
+}

--- a/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class AIChatEndpointRouteBuilderExtensions
 
         group.MapConversationEndpoints();
         group.MapChatSendEndpoint();
+        group.MapMessageReportEndpoint();
         group.MapChatWorkspaceEndpoint();
         return group;
     }

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/cs.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/cs.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Odesílání zpráv ve vašich konverzacích",
     "Permission:AIChat.Conversations.Manage": "Vytváření a přejmenování vašich konverzací",
     "Permission:AIChat.Conversations.Delete": "Mazání vašich konverzací",
+    "Permission:AIChat.Conversations.Report": "Nahlásit zprávy ve svých konverzacích",
     "AIChat:Validation:TooManyMentions": "Zpráva může odkazovat nejvýše na 25 položek.",
     "AIChat:Validation:TooManyAttachments": "Příliš mnoho příloh v jedné zprávě.",
     "AIChat:Validation:UnsupportedAttachmentType": "Tento typ souboru není podporován.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/de.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/de.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Nachrichten in Ihren Konversationen senden",
     "Permission:AIChat.Conversations.Manage": "Ihre Konversationen erstellen und umbenennen",
     "Permission:AIChat.Conversations.Delete": "Ihre Konversationen löschen",
+    "Permission:AIChat.Conversations.Report": "Nachrichten in Ihren Konversationen melden",
     "AIChat:Validation:TooManyMentions": "Eine Nachricht kann höchstens 25 Elemente referenzieren.",
     "AIChat:Validation:TooManyAttachments": "Zu viele Anhänge in einer einzelnen Nachricht.",
     "AIChat:Validation:UnsupportedAttachmentType": "Dieser Dateityp wird nicht unterstützt.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/en.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/en.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Send messages in your conversations",
     "Permission:AIChat.Conversations.Manage": "Create and rename your conversations",
     "Permission:AIChat.Conversations.Delete": "Delete your conversations",
+    "Permission:AIChat.Conversations.Report": "Report messages in your conversations",
     "AIChat:Validation:TooManyMentions": "A message can reference at most 25 items.",
     "AIChat:Validation:TooManyAttachments": "Too many attachments on a single message.",
     "AIChat:Validation:UnsupportedAttachmentType": "This file type is not supported.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/es.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/es.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Enviar mensajes en tus conversaciones",
     "Permission:AIChat.Conversations.Manage": "Crear y renombrar tus conversaciones",
     "Permission:AIChat.Conversations.Delete": "Eliminar tus conversaciones",
+    "Permission:AIChat.Conversations.Report": "Denunciar mensajes en tus conversaciones",
     "AIChat:Validation:TooManyMentions": "Un mensaje puede referenciar como máximo 25 elementos.",
     "AIChat:Validation:TooManyAttachments": "Demasiados archivos adjuntos en un solo mensaje.",
     "AIChat:Validation:UnsupportedAttachmentType": "Este tipo de archivo no es compatible.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/fr.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/fr.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Envoyer des messages dans vos conversations",
     "Permission:AIChat.Conversations.Manage": "Créer et renommer vos conversations",
     "Permission:AIChat.Conversations.Delete": "Supprimer vos conversations",
+    "Permission:AIChat.Conversations.Report": "Signaler des messages dans vos conversations",
     "AIChat:Validation:TooManyMentions": "Un message peut référencer au maximum 25 éléments.",
     "AIChat:Validation:TooManyAttachments": "Trop de pièces jointes sur un même message.",
     "AIChat:Validation:UnsupportedAttachmentType": "Ce type de fichier n'est pas pris en charge.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/hi.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/hi.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "अपनी बातचीत में संदेश भेजें",
     "Permission:AIChat.Conversations.Manage": "अपनी बातचीत बनाएँ और नाम बदलें",
     "Permission:AIChat.Conversations.Delete": "अपनी बातचीत हटाएँ",
+    "Permission:AIChat.Conversations.Report": "अपनी बातचीत में संदेशों की रिपोर्ट करें",
     "AIChat:Validation:TooManyMentions": "एक संदेश अधिकतम 25 आइटम का संदर्भ दे सकता है।",
     "AIChat:Validation:TooManyAttachments": "एक ही संदेश में बहुत अधिक अनुलग्नक हैं।",
     "AIChat:Validation:UnsupportedAttachmentType": "यह फ़ाइल प्रकार समर्थित नहीं है।",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/it.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/it.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Inviare messaggi nelle tue conversazioni",
     "Permission:AIChat.Conversations.Manage": "Creare e rinominare le tue conversazioni",
     "Permission:AIChat.Conversations.Delete": "Eliminare le tue conversazioni",
+    "Permission:AIChat.Conversations.Report": "Segnalare messaggi nelle tue conversazioni",
     "AIChat:Validation:TooManyMentions": "Un messaggio può fare riferimento ad al massimo 25 elementi.",
     "AIChat:Validation:TooManyAttachments": "Troppi allegati in un singolo messaggio.",
     "AIChat:Validation:UnsupportedAttachmentType": "Questo tipo di file non è supportato.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ja.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ja.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "自分の会話でメッセージを送信する",
     "Permission:AIChat.Conversations.Manage": "自分の会話を作成・名前変更する",
     "Permission:AIChat.Conversations.Delete": "自分の会話を削除する",
+    "Permission:AIChat.Conversations.Report": "会話内のメッセージを報告する",
     "AIChat:Validation:TooManyMentions": "1 つのメッセージで参照できる項目は最大 25 件です。",
     "AIChat:Validation:TooManyAttachments": "1 つのメッセージに添付ファイルが多すぎます。",
     "AIChat:Validation:UnsupportedAttachmentType": "このファイル形式はサポートされていません。",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ko.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/ko.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "내 대화에서 메시지 보내기",
     "Permission:AIChat.Conversations.Manage": "내 대화 만들기 및 이름 변경",
     "Permission:AIChat.Conversations.Delete": "내 대화 삭제",
+    "Permission:AIChat.Conversations.Report": "대화의 메시지 신고",
     "AIChat:Validation:TooManyMentions": "메시지는 최대 25개 항목을 참조할 수 있습니다.",
     "AIChat:Validation:TooManyAttachments": "한 메시지에 첨부 파일이 너무 많습니다.",
     "AIChat:Validation:UnsupportedAttachmentType": "이 파일 형식은 지원되지 않습니다.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/nl.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/nl.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Berichten in uw gesprekken verzenden",
     "Permission:AIChat.Conversations.Manage": "Uw gesprekken aanmaken en hernoemen",
     "Permission:AIChat.Conversations.Delete": "Uw gesprekken verwijderen",
+    "Permission:AIChat.Conversations.Report": "Berichten in uw gesprekken rapporteren",
     "AIChat:Validation:TooManyMentions": "Een bericht kan maximaal 25 items vermelden.",
     "AIChat:Validation:TooManyAttachments": "Te veel bijlagen in één bericht.",
     "AIChat:Validation:UnsupportedAttachmentType": "Dit bestandstype wordt niet ondersteund.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pl.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pl.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Wysyłanie wiadomości w swoich rozmowach",
     "Permission:AIChat.Conversations.Manage": "Tworzenie i zmiana nazw swoich rozmów",
     "Permission:AIChat.Conversations.Delete": "Usuwanie swoich rozmów",
+    "Permission:AIChat.Conversations.Report": "Zgłaszanie wiadomości w swoich rozmowach",
     "AIChat:Validation:TooManyMentions": "Wiadomość może odwoływać się do maksymalnie 25 elementów.",
     "AIChat:Validation:TooManyAttachments": "Zbyt wiele załączników w jednej wiadomości.",
     "AIChat:Validation:UnsupportedAttachmentType": "Ten typ pliku nie jest obsługiwany.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pt.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/pt.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Enviar mensagens nas suas conversas",
     "Permission:AIChat.Conversations.Manage": "Criar e renomear as suas conversas",
     "Permission:AIChat.Conversations.Delete": "Eliminar as suas conversas",
+    "Permission:AIChat.Conversations.Report": "Denunciar mensagens nas suas conversas",
     "AIChat:Validation:TooManyMentions": "Uma mensagem pode referenciar no máximo 25 itens.",
     "AIChat:Validation:TooManyAttachments": "Demasiados anexos numa única mensagem.",
     "AIChat:Validation:UnsupportedAttachmentType": "Este tipo de ficheiro não é suportado.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/sv.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/sv.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Skicka meddelanden i dina konversationer",
     "Permission:AIChat.Conversations.Manage": "Skapa och byt namn på dina konversationer",
     "Permission:AIChat.Conversations.Delete": "Ta bort dina konversationer",
+    "Permission:AIChat.Conversations.Report": "Rapportera meddelanden i dina konversationer",
     "AIChat:Validation:TooManyMentions": "Ett meddelande kan referera till högst 25 objekt.",
     "AIChat:Validation:TooManyAttachments": "För många bilagor i ett enskilt meddelande.",
     "AIChat:Validation:UnsupportedAttachmentType": "Den här filtypen stöds inte.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/tr.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/tr.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "Sohbetlerinizde mesaj gönderin",
     "Permission:AIChat.Conversations.Manage": "Sohbetlerinizi oluşturun ve yeniden adlandırın",
     "Permission:AIChat.Conversations.Delete": "Sohbetlerinizi silin",
+    "Permission:AIChat.Conversations.Report": "Sohbetlerinizdeki mesajları bildirme",
     "AIChat:Validation:TooManyMentions": "Bir mesaj en fazla 25 öğeye başvurabilir.",
     "AIChat:Validation:TooManyAttachments": "Tek bir mesajda çok fazla ek var.",
     "AIChat:Validation:UnsupportedAttachmentType": "Bu dosya türü desteklenmiyor.",

--- a/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/zh.json
+++ b/src/Granit.AI.Chat.Endpoints/Localization/AIChatEndpoints/zh.json
@@ -6,6 +6,7 @@
     "Permission:AIChat.Conversations.Send": "在您的对话中发送消息",
     "Permission:AIChat.Conversations.Manage": "创建和重命名您的对话",
     "Permission:AIChat.Conversations.Delete": "删除您的对话",
+    "Permission:AIChat.Conversations.Report": "举报对话中的消息",
     "AIChat:Validation:TooManyMentions": "一条消息最多可引用 25 个项目。",
     "AIChat:Validation:TooManyAttachments": "单条消息的附件过多。",
     "AIChat:Validation:UnsupportedAttachmentType": "不支持此文件类型。",

--- a/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissionDefinitionProvider.cs
+++ b/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissionDefinitionProvider.cs
@@ -31,5 +31,9 @@ internal sealed class AIChatPermissionDefinitionProvider : IPermissionDefinition
         group.AddPermission(
             AIChatPermissions.Conversations.Delete,
             LocalizableString.Create<AIChatEndpointsLocalizationResource>("Permission:AIChat.Conversations.Delete"));
+
+        group.AddPermission(
+            AIChatPermissions.Conversations.Report,
+            LocalizableString.Create<AIChatEndpointsLocalizationResource>("Permission:AIChat.Conversations.Report"));
     }
 }

--- a/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissions.cs
+++ b/src/Granit.AI.Chat.Endpoints/Permissions/AIChatPermissions.cs
@@ -23,5 +23,8 @@ public static class AIChatPermissions
 
         /// <summary>Delete one's own conversations.</summary>
         public const string Delete = "AIChat.Conversations.Delete";
+
+        /// <summary>Report (flag) a message in one's own conversations for review.</summary>
+        public const string Report = "AIChat.Conversations.Report";
     }
 }

--- a/src/Granit.AI.Chat.Endpoints/Validators/ReportMessageRequestValidator.cs
+++ b/src/Granit.AI.Chat.Endpoints/Validators/ReportMessageRequestValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+using Granit.AI.Chat.Domain;
+using Granit.AI.Chat.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.AI.Chat.Endpoints.Validators;
+
+/// <summary>Validates <see cref="ReportMessageRequest"/>.</summary>
+internal sealed class ReportMessageRequestValidator : GranitValidator<ReportMessageRequest>
+{
+    public ReportMessageRequestValidator()
+    {
+        RuleFor(x => x.Reason)
+            .NotEmpty()
+            .MaximumLength(MessageReport.MaxReasonLength);
+
+        RuleFor(x => x.Category)
+            .IsInEnum()
+            .When(x => x.Category is not null);
+    }
+}

--- a/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/MessageReportConfiguration.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/MessageReportConfiguration.cs
@@ -1,0 +1,32 @@
+using Granit.AI.Chat.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.AI.Chat.EntityFrameworkCore.EntityConfigurations;
+
+/// <summary>EF Core configuration for the <see cref="MessageReport"/> aggregate root.</summary>
+internal sealed class MessageReportConfiguration : IEntityTypeConfiguration<MessageReport>
+{
+    public void Configure(EntityTypeBuilder<MessageReport> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitAIChatDbProperties.DbTablePrefix + "message_reports",
+            GranitAIChatDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.MessageId).IsRequired();
+        builder.Property(e => e.ConversationId).IsRequired();
+        builder.Property(e => e.OwnerId).IsRequired();
+        builder.Property(e => e.Reason).HasMaxLength(MessageReport.MaxReasonLength).IsRequired();
+        builder.Property(e => e.CreatedBy).HasMaxLength(256);
+
+        // Category persists as its PascalCase string name via ApplyGranitConventions.
+
+        // "Reports for a message" — review/moderation lookups, scoped within the tenant.
+        builder.HasIndex(e => new { e.TenantId, e.MessageId })
+            .HasDatabaseName($"ix_{GranitAIChatDbProperties.DbTablePrefix}message_reports_tenant_message");
+    }
+}

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Extensions/AIChatModelBuilderExtensions.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Extensions/AIChatModelBuilderExtensions.cs
@@ -16,6 +16,7 @@ public static class AIChatModelBuilderExtensions
 
         modelBuilder.ApplyConfiguration(new ConversationConfiguration());
         modelBuilder.ApplyConfiguration(new MessageConfiguration());
+        modelBuilder.ApplyConfiguration(new MessageReportConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/AIChatDbContext.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/AIChatDbContext.cs
@@ -20,6 +20,9 @@ internal sealed class AIChatDbContext(
     /// <summary>Conversations.</summary>
     public DbSet<Conversation> Conversations => Set<Conversation>();
 
+    /// <summary>User reports flagging a message for review.</summary>
+    public DbSet<MessageReport> MessageReports => Set<MessageReport>();
+
     /// <inheritdoc/>
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationDataManager.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationDataManager.cs
@@ -44,6 +44,13 @@ internal sealed class EfConversationDataManager(IDbContextFactory<AIChatDbContex
             .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // Reports carry the owner's id (personal data) — erase the owner's reports too (GDPR).
+        await context.MessageReports
+            .IgnoreQueryFilters([GranitFilterNames.SoftDelete, GranitFilterNames.MultiTenant])
+            .Where(r => r.OwnerId == ownerId && (tenantId == null || r.TenantId == tenantId))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         return await context.Conversations
             .IgnoreQueryFilters([GranitFilterNames.SoftDelete, GranitFilterNames.MultiTenant])
             .Where(c => ids.Contains(c.Id))
@@ -75,6 +82,13 @@ internal sealed class EfConversationDataManager(IDbContextFactory<AIChatDbContex
             await context.Set<Message>()
                 .IgnoreQueryFilters([GranitFilterNames.SoftDelete, GranitFilterNames.MultiTenant])
                 .Where(m => ids.Contains(m.ConversationId))
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            // Purge reports for the conversations being retired so no personal data outlives them.
+            await context.MessageReports
+                .IgnoreQueryFilters([GranitFilterNames.SoftDelete, GranitFilterNames.MultiTenant])
+                .Where(r => ids.Contains(r.ConversationId))
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
 

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
@@ -59,6 +59,36 @@ internal sealed class EfConversationStore(IDbContextFactory<AIChatDbContext> con
         return true;
     }
 
+    public async Task<bool> ReportMessageAsync(
+        Guid reportId,
+        Guid messageId,
+        Guid ownerId,
+        string reason,
+        MessageReportCategory? category,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // Resolve the conversation only through the owner's own conversations: a message in someone
+        // else's conversation (or a non-existent one) yields null, reported back as "not found".
+        Guid? conversationId = await context.Conversations
+            .Where(c => c.OwnerId == ownerId && c.Messages.Any(m => m.Id == messageId))
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (conversationId is not { } resolvedConversationId)
+        {
+            return false;
+        }
+
+        var report = MessageReport.Create(reportId, messageId, resolvedConversationId, ownerId, reason, category);
+        context.MessageReports.Add(report);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
     public async Task<bool> RenameAsync(Guid id, Guid ownerId, string title, CancellationToken cancellationToken = default)
     {
         await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Granit.AI.Chat/Domain/MessageReport.cs
+++ b/src/Granit.AI.Chat/Domain/MessageReport.cs
@@ -1,0 +1,75 @@
+using Granit.AI.Chat.Events;
+using Granit.Domain;
+
+namespace Granit.AI.Chat.Domain;
+
+/// <summary>
+/// A user's report (feedback) flagging a chat <see cref="Message"/> for review. Append-only and
+/// multi-tenant; owned by the reporter, who must own the message's <see cref="Conversation"/>
+/// (owner-only isolation, ADR-067). Privacy (ADR-071): stores identifiers plus the user-entered
+/// reason — never the reported message's content.
+/// </summary>
+public sealed class MessageReport : CreationAuditedAggregateRoot, IMultiTenant, IOwnable
+{
+    /// <summary>Maximum length of the free-text reason.</summary>
+    public const int MaxReasonLength = 2000;
+
+    private MessageReport()
+    {
+    }
+
+    /// <summary>
+    /// Creates a report flagging <paramref name="messageId"/> and raises
+    /// <see cref="ChatMessageReportedEvent"/>. The tenant is stamped by the persistence interceptor.
+    /// </summary>
+    public static MessageReport Create(
+        Guid id,
+        Guid messageId,
+        Guid conversationId,
+        Guid ownerId,
+        string reason,
+        MessageReportCategory? category)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        var report = new MessageReport
+        {
+            Id = id,
+            MessageId = messageId,
+            ConversationId = conversationId,
+            OwnerId = ownerId,
+            Reason = reason,
+            Category = category,
+        };
+
+        report.AddDomainEvent(
+            new ChatMessageReportedEvent(id, messageId, conversationId, ownerId, reason, category));
+
+        return report;
+    }
+
+    /// <summary>The flagged message.</summary>
+    public Guid MessageId { get; private set; }
+
+    /// <summary>The conversation the flagged message belongs to.</summary>
+    public Guid ConversationId { get; private set; }
+
+    /// <summary>The user who raised the report (the conversation owner).</summary>
+    public Guid OwnerId { get; private set; }
+
+    /// <summary>The free-text reason the user supplied.</summary>
+    public string Reason { get; private set; } = string.Empty;
+
+    /// <summary>The optional category the user selected.</summary>
+    public MessageReportCategory? Category { get; private set; }
+
+    /// <summary>Owning tenant; stamped by the interceptor.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc/>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+}

--- a/src/Granit.AI.Chat/Domain/MessageReportCategory.cs
+++ b/src/Granit.AI.Chat/Domain/MessageReportCategory.cs
@@ -1,0 +1,14 @@
+namespace Granit.AI.Chat.Domain;
+
+/// <summary>The reason a user flags a <see cref="Message"/>, chosen from a closed set.</summary>
+public enum MessageReportCategory
+{
+    /// <summary>The answer is factually wrong or misleading.</summary>
+    Inaccurate,
+
+    /// <summary>The content is harmful, unsafe, or offensive.</summary>
+    Harmful,
+
+    /// <summary>Any other reason; the free-text reason carries the detail.</summary>
+    Other,
+}

--- a/src/Granit.AI.Chat/Events/ChatMessageReportedEvent.cs
+++ b/src/Granit.AI.Chat/Events/ChatMessageReportedEvent.cs
@@ -1,0 +1,24 @@
+using Granit.AI.Chat.Domain;
+using Granit.Events;
+
+namespace Granit.AI.Chat.Events;
+
+/// <summary>
+/// Raised when a user flags a chat <see cref="Message"/> for review. In-process domain event so an
+/// application can route the signal (moderation queue, notification, metric) without coupling to the
+/// chat module. Privacy (ADR-071): carries only identifiers and the user-entered reason — never the
+/// reported message's content nor any tool arguments or results.
+/// </summary>
+/// <param name="ReportId">The persisted <see cref="MessageReport"/> identifier.</param>
+/// <param name="MessageId">The flagged message.</param>
+/// <param name="ConversationId">The conversation the message belongs to.</param>
+/// <param name="OwnerId">The user who raised the report (the conversation owner).</param>
+/// <param name="Reason">The free-text reason the user supplied.</param>
+/// <param name="Category">The optional category the user selected.</param>
+public sealed record ChatMessageReportedEvent(
+    Guid ReportId,
+    Guid MessageId,
+    Guid ConversationId,
+    Guid OwnerId,
+    string Reason,
+    MessageReportCategory? Category) : IDomainEvent;

--- a/src/Granit.AI.Chat/IConversationStore.cs
+++ b/src/Granit.AI.Chat/IConversationStore.cs
@@ -27,6 +27,19 @@ public interface IConversationStore
         IReadOnlyList<Message> messages,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Records a report flagging a message in one of the owner's conversations. Returns
+    /// <see langword="false"/> when the message does not exist or its conversation is not the
+    /// owner's, so a caller can never probe another user's messages.
+    /// </summary>
+    Task<bool> ReportMessageAsync(
+        Guid reportId,
+        Guid messageId,
+        Guid ownerId,
+        string reason,
+        MessageReportCategory? category,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Renames the owner's conversation; <see langword="false"/> if it is not theirs.</summary>
     Task<bool> RenameAsync(Guid id, Guid ownerId, string title, CancellationToken cancellationToken = default);
 

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
@@ -42,7 +42,8 @@ public sealed class ChatEndpointsHttpTests
                     .AddPolicy(AIChatPermissions.Conversations.Read, p => p.RequireClaim(TestAuthHandler.PermissionClaimType, AIChatPermissions.Conversations.Read))
                     .AddPolicy(AIChatPermissions.Conversations.Send, p => p.RequireClaim(TestAuthHandler.PermissionClaimType, AIChatPermissions.Conversations.Send))
                     .AddPolicy(AIChatPermissions.Conversations.Manage, p => p.RequireClaim(TestAuthHandler.PermissionClaimType, AIChatPermissions.Conversations.Manage))
-                    .AddPolicy(AIChatPermissions.Conversations.Delete, p => p.RequireClaim(TestAuthHandler.PermissionClaimType, AIChatPermissions.Conversations.Delete));
+                    .AddPolicy(AIChatPermissions.Conversations.Delete, p => p.RequireClaim(TestAuthHandler.PermissionClaimType, AIChatPermissions.Conversations.Delete))
+                    .AddPolicy(AIChatPermissions.Conversations.Report, p => p.RequireClaim(TestAuthHandler.PermissionClaimType, AIChatPermissions.Conversations.Report));
 
                 services.AddSingleton(_store);
                 services.AddSingleton(_chatService);
@@ -64,7 +65,8 @@ public sealed class ChatEndpointsHttpTests
         AIChatPermissions.Conversations.Read,
         AIChatPermissions.Conversations.Send,
         AIChatPermissions.Conversations.Manage,
-        AIChatPermissions.Conversations.Delete);
+        AIChatPermissions.Conversations.Delete,
+        AIChatPermissions.Conversations.Report);
 
     // ── Conversation CRUD ───────────────────────────────────────────────────────
 
@@ -186,6 +188,71 @@ public sealed class ChatEndpointsHttpTests
         HttpResponseMessage response = await FullAccess(host).DeleteAsync($"/conversations/{id}", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ── Report a message ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Report_returns_202_when_recorded()
+    {
+        var messageId = Guid.NewGuid();
+        _store.ReportMessageAsync(
+                Arg.Any<Guid>(), messageId, Owner, "Wrong answer", MessageReportCategory.Inaccurate, Arg.Any<CancellationToken>())
+            .Returns(true);
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            $"/conversations/messages/{messageId}/report",
+            new ReportMessageRequest("Wrong answer", MessageReportCategory.Inaccurate),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        await _store.Received(1).ReportMessageAsync(
+            Arg.Any<Guid>(), messageId, Owner, "Wrong answer", MessageReportCategory.Inaccurate, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Report_returns_404_when_the_message_is_not_the_callers()
+    {
+        var messageId = Guid.NewGuid();
+        _store.ReportMessageAsync(
+                Arg.Any<Guid>(), messageId, Owner, Arg.Any<string>(), Arg.Any<MessageReportCategory?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            $"/conversations/messages/{messageId}/report",
+            new ReportMessageRequest("Probing"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Report_without_a_user_context_is_unauthorized()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(userId: null);
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            $"/conversations/messages/{Guid.NewGuid()}/report",
+            new ReportMessageRequest("Wrong answer"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Report_without_the_report_permission_is_forbidden()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpClient client = host.CreateClientWithPermissions(AIChatPermissions.Conversations.Read);
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"/conversations/messages/{Guid.NewGuid()}/report",
+            new ReportMessageRequest("Wrong answer"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }
 
     // ── Workspaces ──────────────────────────────────────────────────────────────

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
@@ -28,7 +28,7 @@ public sealed class ConversationEndpointsUnitTests
     }
 
     [Fact]
-    public void Permission_provider_declares_read_manage_delete()
+    public void Permission_provider_declares_read_send_manage_delete_report()
     {
         CapturingPermissionContext context = new();
 
@@ -42,6 +42,7 @@ public sealed class ConversationEndpointsUnitTests
                 "AIChat.Conversations.Send",
                 "AIChat.Conversations.Manage",
                 "AIChat.Conversations.Delete",
+                "AIChat.Conversations.Report",
             ],
             ignoreOrder: true);
     }
@@ -130,6 +131,17 @@ public sealed class ConversationEndpointsUnitTests
 
         validator.Validate(new RenameConversationRequest("  ")).IsValid.ShouldBeFalse();
         validator.Validate(new RenameConversationRequest("Renamed")).IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Report_validator_rejects_blank_and_overlong_reasons()
+    {
+        ReportMessageRequestValidator validator = new();
+
+        validator.Validate(new ReportMessageRequest("  ")).IsValid.ShouldBeFalse();
+        validator.Validate(new ReportMessageRequest(new string('x', MessageReport.MaxReasonLength + 1))).IsValid.ShouldBeFalse();
+        validator.Validate(new ReportMessageRequest("This answer is wrong.")).IsValid.ShouldBeTrue();
+        validator.Validate(new ReportMessageRequest("Unsafe.", MessageReportCategory.Harmful)).IsValid.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationDataManagerTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationDataManagerTests.cs
@@ -67,6 +67,42 @@ public sealed class EfConversationDataManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task EraseOwner_also_hard_deletes_the_owners_message_reports()
+    {
+        Conversation a = await SeedAsync(UserA, When(2024), "a1");
+        Conversation b = await SeedAsync(UserB, When(2024), "b1");
+        await ReportAsync(a.Messages[0].Id, a.Id, UserA);
+        await ReportAsync(b.Messages[0].Id, b.Id, UserB);
+
+        await _sut.EraseOwnerAsync(tenantId: null, UserA, TestContext.Current.CancellationToken);
+
+        await using AIChatDbContext context = _factory.CreateDbContext();
+        IReadOnlyList<MessageReport> reports = await context.MessageReports.IgnoreQueryFilters()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        reports.ShouldHaveSingleItem().OwnerId.ShouldBe(UserB); // UserA's report erased, UserB's survives
+    }
+
+    [Fact]
+    public async Task PurgeOlderThan_also_removes_reports_for_purged_conversations()
+    {
+        Conversation old = await SeedAsync(UserA, When(2020), "old");
+        await ReportAsync(old.Messages[0].Id, old.Id, UserA);
+
+        await _sut.PurgeOlderThanAsync(When(2023), batchSize: 100, TestContext.Current.CancellationToken);
+
+        await using AIChatDbContext context = _factory.CreateDbContext();
+        (await context.MessageReports.IgnoreQueryFilters().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    private async Task ReportAsync(Guid messageId, Guid conversationId, Guid ownerId)
+    {
+        await using AIChatDbContext context = _factory.CreateDbContext();
+        context.MessageReports.Add(MessageReport.Create(
+            Guid.NewGuid(), messageId, conversationId, ownerId, "reason", MessageReportCategory.Other));
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task EraseOwner_is_idempotent()
     {
         await SeedAsync(UserA, When(2024), "a1");

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
@@ -93,6 +93,52 @@ public sealed class EfConversationStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ReportMessage_persists_a_report_for_the_owner()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Chat", "hello");
+        Guid messageId = seeded.Messages[0].Id;
+
+        bool reported = await _sut.ReportMessageAsync(
+            Guid.NewGuid(), messageId, UserA, "Wrong answer", MessageReportCategory.Inaccurate, TestContext.Current.CancellationToken);
+
+        reported.ShouldBeTrue();
+
+        await using AIChatDbContext context = _factory.CreateDbContext();
+        MessageReport stored = context.MessageReports.Single();
+        stored.MessageId.ShouldBe(messageId);
+        stored.ConversationId.ShouldBe(seeded.Id);
+        stored.OwnerId.ShouldBe(UserA);
+        stored.Reason.ShouldBe("Wrong answer");
+        stored.Category.ShouldBe(MessageReportCategory.Inaccurate);
+    }
+
+    [Fact]
+    public async Task ReportMessage_rejects_a_message_in_another_users_conversation()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Private", "secret");
+        Guid messageId = seeded.Messages[0].Id;
+
+        bool reported = await _sut.ReportMessageAsync(
+            Guid.NewGuid(), messageId, UserB, "Probing", MessageReportCategory.Other, TestContext.Current.CancellationToken);
+
+        reported.ShouldBeFalse();
+
+        await using AIChatDbContext context = _factory.CreateDbContext();
+        context.MessageReports.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReportMessage_returns_false_when_the_message_is_unknown()
+    {
+        await SeedAsync(UserA, "Chat", "hello");
+
+        bool reported = await _sut.ReportMessageAsync(
+            Guid.NewGuid(), Guid.NewGuid(), UserA, "No such message", category: null, TestContext.Current.CancellationToken);
+
+        reported.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task Delete_succeeds_for_the_owner_and_fails_for_others()
     {
         Conversation seeded = await SeedAsync(UserA, "Doomed");

--- a/tests/Granit.AI.Chat.Tests/MessageReportTests.cs
+++ b/tests/Granit.AI.Chat.Tests/MessageReportTests.cs
@@ -1,0 +1,53 @@
+using Granit.AI.Chat.Domain;
+using Granit.AI.Chat.Events;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+public sealed class MessageReportTests
+{
+    private static readonly Guid Owner = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Create_sets_the_fields_and_raises_the_reported_event()
+    {
+        var reportId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+
+        var report = MessageReport.Create(
+            reportId, messageId, conversationId, Owner, "This is wrong.", MessageReportCategory.Inaccurate);
+
+        report.Id.ShouldBe(reportId);
+        report.MessageId.ShouldBe(messageId);
+        report.ConversationId.ShouldBe(conversationId);
+        report.OwnerId.ShouldBe(Owner);
+        report.Reason.ShouldBe("This is wrong.");
+        report.Category.ShouldBe(MessageReportCategory.Inaccurate);
+
+        ChatMessageReportedEvent raised = report.DomainEvents.OfType<ChatMessageReportedEvent>().ShouldHaveSingleItem();
+        raised.ReportId.ShouldBe(reportId);
+        raised.MessageId.ShouldBe(messageId);
+        raised.ConversationId.ShouldBe(conversationId);
+        raised.OwnerId.ShouldBe(Owner);
+        raised.Reason.ShouldBe("This is wrong.");
+        raised.Category.ShouldBe(MessageReportCategory.Inaccurate);
+    }
+
+    [Fact]
+    public void Create_allows_a_null_category()
+    {
+        var report = MessageReport.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Owner, "No category.", category: null);
+
+        report.Category.ShouldBeNull();
+        report.DomainEvents.OfType<ChatMessageReportedEvent>().ShouldHaveSingleItem().Category.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_rejects_a_blank_reason(string reason) =>
+        Should.Throw<ArgumentException>(() => MessageReport.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Owner, reason, MessageReportCategory.Other));
+}


### PR DESCRIPTION
## Summary

Wires a real backend for the showcase **"report message"** action on agentic-chat messages (granit-showcase-react !115, slot `renderMessageActions` of #690), which today is only a demo toast. *Copy* (client-only) and *Regenerate* (reuses `POST /conversations/messages`) need no backend — only **reporting** does.

## What's included

- **`POST /conversations/messages/{messageId}/report`** — owner-scoped: a message outside the caller's own conversations is reported as **404**; **202 Accepted** on success, **422** on validation. Request: `ReportMessageRequest { string Reason; MessageReportCategory? Category }` (`Reason` required, ≤ 2000 chars; `Category` ∈ `Inaccurate | Harmful | Other`).
- **`MessageReport`** aggregate (`CreationAuditedAggregateRoot`, multi-tenant, `IOwnable`) persisted in the isolated `AIChatDbContext`. Stores `messageId`, `conversationId`, ownerId, reason, category, timestamp.
- **`ChatMessageReportedEvent`** domain event raised on create so an application can route the signal (moderation queue / notification / metric) without coupling to the chat module — dispatched by the persistence interceptor after commit.
- **`AIChat.Conversations.Report`** permission (least-privilege, ISO 27001 A.9.4), declared across the 15 base culture resources.
- **Privacy (ADR-071):** the report stores identifiers + the user-entered reason — **never** the reported message content nor any tool arguments/results.
- **GDPR:** `EraseOwnerAsync` and `PurgeOlderThanAsync` now also remove the matching reports so no personal data outlives the conversations it references.

## Contract

The endpoint carries the 5 mandatory OpenAPI metadata elements, so the build-time per-module contract picks the route up automatically — no committed spec to regenerate in this repo.

## Tests

Domain (factory + raised event), store (persist / 404 / cross-owner isolation), GDPR erase + purge, validator, and endpoint HTTP (202 / 404 / 401 / forbidden). All affected shards green, `dotnet format` clean, 226 architecture tests pass.

## Follow-up (separate repos, out of scope here)

1. **granit-front** — add `reportMessage` + hook to `@granit/react-ai-chat`.
2. **granit-showcase-react** — wire the `ChatMessageActions` dialog to it, replacing the demo toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)