### PR TITLE
feat(ai-chat): export message reports + reduce chat orchestration complexity

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3874,6 +3874,12 @@
           "returnType": "Task<IReadOnlyList<Conversation>>"
         },
         {
+          "name": "GetReportsForOwnerAsync",
+          "kind": "method",
+          "signature": "GetReportsForOwnerAsync(Guid ownerId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<MessageReport>>"
+        },
+        {
           "name": "EraseOwnerAsync",
           "kind": "method",
           "signature": "EraseOwnerAsync(Guid? tenantId, Guid ownerId, CancellationToken cancellationToken = default)",

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationDataManager.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationDataManager.cs
@@ -23,6 +23,17 @@ internal sealed class EfConversationDataManager(IDbContextFactory<AIChatDbContex
             .ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<MessageReport>> GetReportsForOwnerAsync(Guid ownerId, CancellationToken cancellationToken = default)
+    {
+        await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.MessageReports
+            .AsNoTracking()
+            .Where(r => r.OwnerId == ownerId)
+            .OrderBy(r => r.CreatedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<int> EraseOwnerAsync(Guid? tenantId, Guid ownerId, CancellationToken cancellationToken = default)
     {
         await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Granit.AI.Chat.Privacy/DataExport/ConversationPrivacyDataProvider.cs
+++ b/src/Granit.AI.Chat.Privacy/DataExport/ConversationPrivacyDataProvider.cs
@@ -8,9 +8,9 @@ namespace Granit.AI.Chat.Privacy.DataExport;
 
 /// <summary>
 /// Privacy data provider for Granit.AI.Chat. Emits the user's conversations (with their messages)
-/// as a single staged JSON fragment during the scatter-gather export saga (GDPR Art. 15/20).
-/// Attachment <em>content</em> is not held by the chat module — it is transient and owned by the
-/// application's blob store, which contributes its own provider.
+/// and the message reports they raised as a single staged JSON fragment during the scatter-gather
+/// export saga (GDPR Art. 15/20). Attachment <em>content</em> is not held by the chat module — it is
+/// transient and owned by the application's blob store, which contributes its own provider.
 /// </summary>
 public sealed class ConversationPrivacyDataProvider(
     IConversationStore store,
@@ -33,7 +33,15 @@ public sealed class ConversationPrivacyDataProvider(
         // Cheap presence check — the summary list omits messages.
         IReadOnlyList<Conversation> summaries = await store
             .ListAsync(context.SubjectUserId, cancellationToken).ConfigureAwait(false);
-        return summaries.Count > 0;
+        if (summaries.Count > 0)
+        {
+            return true;
+        }
+
+        // A report can outlive its conversation (soft-deleted), so check reports independently.
+        IReadOnlyList<MessageReport> reports = await dataManager
+            .GetReportsForOwnerAsync(context.SubjectUserId, cancellationToken).ConfigureAwait(false);
+        return reports.Count > 0;
     }
 
     /// <inheritdoc />
@@ -49,7 +57,9 @@ public sealed class ConversationPrivacyDataProvider(
     {
         IReadOnlyList<Conversation> conversations = await dataManager
             .GetAllForOwnerAsync(context.SubjectUserId, cancellationToken).ConfigureAwait(false);
-        if (conversations.Count == 0)
+        IReadOnlyList<MessageReport> reports = await dataManager
+            .GetReportsForOwnerAsync(context.SubjectUserId, cancellationToken).ConfigureAwait(false);
+        if (conversations.Count == 0 && reports.Count == 0)
         {
             yield break;
         }
@@ -57,7 +67,9 @@ public sealed class ConversationPrivacyDataProvider(
         var export = new ConversationsExport(
             UserId: context.SubjectUserId,
             ConversationCount: conversations.Count,
-            Conversations: [.. conversations.Select(Map)]);
+            Conversations: [.. conversations.Select(Map)],
+            ReportCount: reports.Count,
+            Reports: [.. reports.Select(Map)]);
 
         yield return await fragmentBuilder
             .BuildJsonAsync(context, ProviderName, "ai-chat-conversations.json", export, cancellationToken)
@@ -70,12 +82,23 @@ public sealed class ConversationPrivacyDataProvider(
             conversation.Title,
             conversation.CreatedAt,
             [.. conversation.Messages.Select(m => new MessageExport(m.Role.ToString().ToLowerInvariant(), m.Content, m.CreatedAt))]);
+
+    private static ReportExport Map(MessageReport report) =>
+        new(
+            report.Id,
+            report.MessageId,
+            report.ConversationId,
+            report.Reason,
+            report.Category?.ToString(),
+            report.CreatedAt);
 }
 
 internal sealed record ConversationsExport(
     Guid UserId,
     int ConversationCount,
-    IReadOnlyList<ConversationExport> Conversations);
+    IReadOnlyList<ConversationExport> Conversations,
+    int ReportCount,
+    IReadOnlyList<ReportExport> Reports);
 
 internal sealed record ConversationExport(
     Guid Id,
@@ -86,4 +109,12 @@ internal sealed record ConversationExport(
 internal sealed record MessageExport(
     string Role,
     string Content,
+    DateTimeOffset CreatedAt);
+
+internal sealed record ReportExport(
+    Guid Id,
+    Guid MessageId,
+    Guid ConversationId,
+    string Reason,
+    string? Category,
     DateTimeOffset CreatedAt);

--- a/src/Granit.AI.Chat/IConversationDataManager.cs
+++ b/src/Granit.AI.Chat/IConversationDataManager.cs
@@ -17,6 +17,12 @@ public interface IConversationDataManager
     Task<IReadOnlyList<Conversation>> GetAllForOwnerAsync(Guid ownerId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns every message report raised by <paramref name="ownerId"/>, for a data take-out.
+    /// Respects the ambient tenant scope.
+    /// </summary>
+    Task<IReadOnlyList<MessageReport>> GetReportsForOwnerAsync(Guid ownerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Permanently erases (hard delete, bypassing soft-delete) every conversation and message owned
     /// by <paramref name="ownerId"/>, optionally constrained to <paramref name="tenantId"/>. Returns
     /// the number of conversations removed. Idempotent.

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -112,12 +112,18 @@ internal sealed class ChatService(
         };
     }
 
-    public async IAsyncEnumerable<ChatTurnUpdate> StreamAsync(
+    public IAsyncEnumerable<ChatTurnUpdate> StreamAsync(
         ChatSendHandle handle,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(handle);
+        return StreamCoreAsync(handle, cancellationToken);
+    }
 
+    private async IAsyncEnumerable<ChatTurnUpdate> StreamCoreAsync(
+        ChatSendHandle handle,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
         // Persist the user turn before the loop runs: the message and conversation then survive a
         // crash mid-stream (only the regenerable assistant turn can be lost — see ADR-068).
         await PersistUserTurnAsync(handle, cancellationToken).ConfigureAwait(false);

--- a/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
+++ b/src/Granit.AI.Tools/Internal/AIToolOrchestrator.cs
@@ -62,12 +62,18 @@ internal sealed partial class AIToolOrchestrator(
         return result!;
     }
 
-    public async IAsyncEnumerable<AIOrchestrationUpdate> RunStreamingAsync(
+    public IAsyncEnumerable<AIOrchestrationUpdate> RunStreamingAsync(
         AIOrchestrationRequest request,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        return RunStreamingCoreAsync(request, cancellationToken);
+    }
 
+    private async IAsyncEnumerable<AIOrchestrationUpdate> RunStreamingCoreAsync(
+        AIOrchestrationRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
         GranitAIToolsOrchestrationOptions options = orchestrationOptions.Value;
         int maxIterations = Math.Max(1, options.MaxIterations);
 
@@ -120,8 +126,8 @@ internal sealed partial class AIToolOrchestrator(
         using FunctionInvokingChatClient agentClient = new(loopClient)
         {
             MaximumIterationsPerRequest = maxIterations,
-            // An unknown call yields an error result and the loop continues (the model self-corrects);
-            // it never halts the loop.
+            // An unknown call yields an error result and the loop keeps going so the model can
+            // self-correct, rather than halting the run.
             TerminateOnUnknownCalls = false,
             FunctionInvoker = (ctx, ct) => InvokeToolAsync(state, options, ctx, ct),
         };
@@ -175,68 +181,109 @@ internal sealed partial class AIToolOrchestrator(
             }
         }
 
-        var finalResponse = allUpdates.ToChatResponse();
+        yield return AIOrchestrationUpdate.Completed(await FinalizeAsync(
+            new RunTelemetry(allUpdates, loopClient, state, maxIterations, startTimestamp, anyUsage, totalInput, totalOutput, tenantId),
+            workspaceName,
+            workspace,
+            systemPrompt,
+            request).ConfigureAwait(false));
+    }
+
+    // Assembles the settled result once the stream ends: reconstructs the final response, derives the
+    // iteration / max-reached signals, records iteration + usage metrics, and logs the run outcome.
+    private async Task<AIOrchestrationResult> FinalizeAsync(
+        RunTelemetry telemetry,
+        string workspaceName,
+        AIWorkspace workspace,
+        AISystemPrompt systemPrompt,
+        AIOrchestrationRequest request)
+    {
+        var finalResponse = telemetry.Updates.ToChatResponse();
         string finalText = finalResponse.Text ?? string.Empty;
 
         // One iteration per model round-trip.
-        int iterations = Math.Max(1, loopClient.Calls);
+        int iterations = Math.Max(1, telemetry.LoopClient.Calls);
 
         // The loop hit the cap iff it ran the maximum number of round-trips and the last one still
         // wanted tools (so the model intended to continue) — as opposed to settling on a final answer
         // or being halted by a tool interrupt.
-        bool maxReached = loopClient.Calls >= maxIterations
-            && loopClient.LastResponseHadToolCalls
-            && state.Interrupt is null;
+        bool maxReached = telemetry.LoopClient.Calls >= telemetry.MaxIterations
+            && telemetry.LoopClient.LastResponseHadToolCalls
+            && telemetry.State.Interrupt is null;
 
-        TimeSpan duration = timeProvider.GetElapsedTime(startTimestamp);
-        metrics.RecordIterations(tenantId, iterations);
+        TimeSpan duration = timeProvider.GetElapsedTime(telemetry.StartTimestamp);
+        metrics.RecordIterations(telemetry.TenantId, iterations);
 
         if (maxReached)
         {
-            LogMaxIterationsReached(maxIterations);
+            LogMaxIterationsReached(telemetry.MaxIterations);
         }
 
-        if (state.Interrupt is not null)
+        if (telemetry.State.Interrupt is not null)
         {
-            LogInterrupted(state.Interrupt.Kind);
+            LogInterrupted(telemetry.State.Interrupt.Kind);
         }
 
-        if (anyUsage)
+        if (telemetry.AnyUsage)
         {
-            AIUsageRecord record = usageRecordFactory.Create(
-                workspaceName,
-                workspace.Provider,
-                workspace.Model,
-                (int)totalInput,
-                (int)totalOutput,
-                duration) with
-            {
-                PromptVersion = systemPrompt.Guardrails.Version,
-                PromptTemplateName = request.InvokedPromptName,
-                PromptTemplateVersion = request.InvokedPromptVersion,
-            };
-
-            // Stamp usage even if the caller's request was aborted mid-stream, but cap the write so a
-            // stuck sink can't leak an orphaned task.
-            using CancellationTokenSource usageCts = new(TimeSpan.FromSeconds(5));
-            await usageTracker.RecordAsync(record, usageCts.Token).ConfigureAwait(false);
+            await RecordUsageAsync(telemetry, workspaceName, workspace, systemPrompt, request, duration)
+                .ConfigureAwait(false);
         }
 
-        LogRunCompleted(workspaceName, iterations, state.Outcomes.Count, maxReached);
+        LogRunCompleted(workspaceName, iterations, telemetry.State.Outcomes.Count, maxReached);
 
-        yield return AIOrchestrationUpdate.Completed(new AIOrchestrationResult
+        return new AIOrchestrationResult
         {
             Content = finalText,
             Messages = [.. finalResponse.Messages],
             Iterations = iterations,
             MaxIterationsReached = maxReached,
-            ToolInvocations = state.Outcomes,
-            InputTokens = anyUsage ? (int)totalInput : null,
-            OutputTokens = anyUsage ? (int)totalOutput : null,
+            ToolInvocations = telemetry.State.Outcomes,
+            InputTokens = telemetry.AnyUsage ? (int)telemetry.TotalInput : null,
+            OutputTokens = telemetry.AnyUsage ? (int)telemetry.TotalOutput : null,
             Duration = duration,
-            Interrupt = state.Interrupt,
-        });
+            Interrupt = telemetry.State.Interrupt,
+        };
     }
+
+    private async Task RecordUsageAsync(
+        RunTelemetry telemetry,
+        string workspaceName,
+        AIWorkspace workspace,
+        AISystemPrompt systemPrompt,
+        AIOrchestrationRequest request,
+        TimeSpan duration)
+    {
+        AIUsageRecord record = usageRecordFactory.Create(
+            workspaceName,
+            workspace.Provider,
+            workspace.Model,
+            (int)telemetry.TotalInput,
+            (int)telemetry.TotalOutput,
+            duration) with
+        {
+            PromptVersion = systemPrompt.Guardrails.Version,
+            PromptTemplateName = request.InvokedPromptName,
+            PromptTemplateVersion = request.InvokedPromptVersion,
+        };
+
+        // Stamp usage even if the caller's request was aborted mid-stream, but cap the write so a
+        // stuck sink can't leak an orphaned task.
+        using CancellationTokenSource usageCts = new(TimeSpan.FromSeconds(5));
+        await usageTracker.RecordAsync(record, usageCts.Token).ConfigureAwait(false);
+    }
+
+    // The accumulated signals the loop hands to FinalizeAsync once the stream ends.
+    private sealed record RunTelemetry(
+        List<ChatResponseUpdate> Updates,
+        ModelLoopChatClient LoopClient,
+        RunState State,
+        int MaxIterations,
+        long StartTimestamp,
+        bool AnyUsage,
+        long TotalInput,
+        long TotalOutput,
+        string? TenantId);
 
     // The FunctionInvokingChatClient invocation hook: runs the resolved tool under the caller's gate,
     // guards the result size, records metrics and the audit outcome, and turns a tool-raised interrupt

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationDataManagerTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationDataManagerTests.cs
@@ -67,6 +67,19 @@ public sealed class EfConversationDataManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task GetReportsForOwner_returns_only_that_owners_reports_oldest_first()
+    {
+        Conversation a = await SeedAsync(UserA, When(2024), "a1");
+        Conversation b = await SeedAsync(UserB, When(2024), "b1");
+        await ReportAsync(a.Messages[0].Id, a.Id, UserA);
+        await ReportAsync(b.Messages[0].Id, b.Id, UserB);
+
+        IReadOnlyList<MessageReport> reports = await _sut.GetReportsForOwnerAsync(UserA, TestContext.Current.CancellationToken);
+
+        reports.ShouldHaveSingleItem().OwnerId.ShouldBe(UserA);
+    }
+
+    [Fact]
     public async Task EraseOwner_also_hard_deletes_the_owners_message_reports()
     {
         Conversation a = await SeedAsync(UserA, When(2024), "a1");

--- a/tests/Granit.AI.Chat.Privacy.Tests/ConversationPrivacyDataProviderTests.cs
+++ b/tests/Granit.AI.Chat.Privacy.Tests/ConversationPrivacyDataProviderTests.cs
@@ -39,9 +39,20 @@ public sealed class ConversationPrivacyDataProviderTests
     }
 
     [Fact]
-    public async Task HasData_is_false_when_the_subject_has_no_conversations()
+    public async Task HasData_is_true_when_the_subject_has_reports_but_no_conversations()
     {
         _store.ListAsync(Subject, Arg.Any<CancellationToken>()).Returns([]);
+        _dataManager.GetReportsForOwnerAsync(Subject, Arg.Any<CancellationToken>())
+            .Returns([MessageReport.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Subject, "wrong", MessageReportCategory.Inaccurate)]);
+
+        (await CreateProvider().HasDataAsync(Context(), TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task HasData_is_false_when_the_subject_has_no_conversations_or_reports()
+    {
+        _store.ListAsync(Subject, Arg.Any<CancellationToken>()).Returns([]);
+        _dataManager.GetReportsForOwnerAsync(Subject, Arg.Any<CancellationToken>()).Returns([]);
 
         (await CreateProvider().HasDataAsync(Context(), TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
@@ -79,6 +90,29 @@ public sealed class ConversationPrivacyDataProviderTests
             "ai-chat",
             "ai-chat-conversations.json",
             Arg.Is<ConversationsExport>(d => d.ConversationCount == 1 && d.Conversations[0].Messages.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Export_includes_the_subjects_message_reports()
+    {
+        var report = MessageReport.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Subject, "This is wrong.", MessageReportCategory.Inaccurate);
+        _dataManager.GetReportsForOwnerAsync(Subject, Arg.Any<CancellationToken>()).Returns([report]);
+
+        await foreach (ExportFragment _ in CreateProvider().ExportAsync(Context(), TestContext.Current.CancellationToken))
+        {
+            // drain
+        }
+
+        await _fragmentBuilder.Received(1).BuildJsonAsync(
+            Arg.Any<PrivacyExportContext>(),
+            "ai-chat",
+            "ai-chat-conversations.json",
+            Arg.Is<ConversationsExport>(d =>
+                d.ReportCount == 1
+                && d.Reports[0].Reason == "This is wrong."
+                && d.Reports[0].Category == "Inaccurate"),
             Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the report-message endpoint ([#2802](https://github.com/granit-fx/granit-dotnet/pull/2802)). Two things:

1. **GDPR take-out (Art. 15/20):** message reports are now included in the user's data export.
2. **Sonar cleanup** of the chat orchestration code flagged on the module.

## Privacy / data export

- New `IConversationDataManager.GetReportsForOwnerAsync` (tenant-scoped read).
- `ConversationPrivacyDataProvider` now surfaces the user's `MessageReport`s in the staged `ai-chat-conversations.json` fragment (id, messageId, conversationId, reason, category, timestamp).
- A report can outlive a soft-deleted conversation, so both `HasDataAsync` and `ExportAsync` check reports **independently** of conversations.

This complements the erasure side already shipped in #2802 (`EraseOwnerAsync` / `PurgeOlderThanAsync` remove reports), closing the Art. 17 ↔ Art. 15/20 loop.

## Sonar issues (module Chat)

- **`ChatService.StreamAsync`** (`yield` smell): split the eager argument check from the async iterator into `StreamCoreAsync`, so the `ArgumentNullException` guard runs at call time rather than on first `MoveNext`.
- **`AIToolOrchestrator.RunStreamingAsync`** (`yield` smell + `brain-overload`): same guard/iterator split (`RunStreamingCoreAsync`), and extracted the post-loop finalization — result assembly, iteration/usage metrics, logging — into `FinalizeAsync` / `RecordUsageAsync`. Cognitive complexity **16 → 11** (verified via roslyn-lens).
- **Commented-out-code false positive** on the `TerminateOnUnknownCalls` comment: reworded so it no longer ends like a statement and trips the heuristic (the explanation is preserved).

## Tests

Report take-out (HasData with reports only / no data; export includes reports; `GetReportsForOwner` owner-scoping). Existing orchestrator and chat suites unchanged and green: AI.Tools 45, AI.Chat 67, EFCore 17, Privacy 9, Endpoints 31, + 226 architecture tests. `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)