### PR TITLE
feat(ai-chat): favorite flag on conversations + PUT /conversations/{id}/favorite

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3397,6 +3397,12 @@
           "kind": "property",
           "signature": "Guid OwnerId",
           "returnType": "Guid"
+        },
+        {
+          "name": "AddMessage",
+          "kind": "method",
+          "signature": "AddMessage(Guid id, MessageRole role, string content)",
+          "returnType": "Message"
         }
       ]
     },
@@ -3487,7 +3493,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 38,
+      "line": 43,
       "members": [
         {
           "name": "FromAggregate",
@@ -3503,7 +3509,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 14,
+      "line": 18,
       "members": [
         {
           "name": "FromAggregate",
@@ -3544,7 +3550,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 35,
+      "line": 40,
       "members": [
         {
           "name": "FromAggregate",
@@ -3587,6 +3593,22 @@
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
       "line": 10,
       "members": []
+    },
+    {
+      "name": "SetConversationFavoriteRequest",
+      "fqn": "Granit.AI.Chat.Endpoints.Dtos.SetConversationFavoriteRequest",
+      "kind": "record",
+      "project": "Granit.AI.Chat.Endpoints",
+      "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "FromAggregate",
+          "kind": "method",
+          "signature": "FromAggregate(Conversation conversation)",
+          "returnType": "ConversationSummaryResponse"
+        }
+      ]
     },
     {
       "name": "SuggestedActionResponse",
@@ -3935,6 +3957,12 @@
           "name": "RenameAsync",
           "kind": "method",
           "signature": "RenameAsync(Guid id, Guid ownerId, string title, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "SetFavoriteAsync",
+          "kind": "method",
+          "signature": "SetFavoriteAsync(Guid id, Guid ownerId, bool isFavorite, CancellationToken cancellationToken = default)",
           "returnType": "Task<bool>"
         },
         {

--- a/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
@@ -10,16 +10,21 @@ public sealed record CreateConversationRequest(string Title);
 /// <param name="Title">The new title.</param>
 public sealed record RenameConversationRequest(string Title);
 
+/// <summary>Request to set a conversation's favorite flag to an explicit state (not a toggle).</summary>
+/// <param name="IsFavorite">The desired favorite state.</param>
+public sealed record SetConversationFavoriteRequest(bool IsFavorite);
+
 /// <summary>A conversation in a list (without messages).</summary>
 public sealed record ConversationSummaryResponse(
     Guid Id,
     string Title,
+    bool IsFavorite,
     DateTimeOffset CreatedAt,
     DateTimeOffset? ModifiedAt)
 {
     /// <summary>Projects a <see cref="Conversation"/> to a summary.</summary>
     public static ConversationSummaryResponse FromAggregate(Conversation conversation) =>
-        new(conversation.Id, conversation.Title, conversation.CreatedAt, conversation.ModifiedAt);
+        new(conversation.Id, conversation.Title, conversation.IsFavorite, conversation.CreatedAt, conversation.ModifiedAt);
 }
 
 /// <summary>A message in a conversation.</summary>
@@ -39,6 +44,7 @@ public sealed record ConversationResponse(
     Guid Id,
     string Title,
     Guid OwnerId,
+    bool IsFavorite,
     DateTimeOffset CreatedAt,
     DateTimeOffset? ModifiedAt,
     IReadOnlyList<MessageResponse> Messages)
@@ -49,6 +55,7 @@ public sealed record ConversationResponse(
             conversation.Id,
             conversation.Title,
             conversation.OwnerId,
+            conversation.IsFavorite,
             conversation.CreatedAt,
             conversation.ModifiedAt,
             [.. conversation.Messages.Select(m =>

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ConversationEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ConversationEndpoints.cs
@@ -52,6 +52,16 @@ internal static class ConversationEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Manage);
 
+        group.MapPut("/{id:guid}/favorite", SetFavoriteAsync)
+            .WithName("SetConversationFavorite")
+            .WithSummary("Sets the favorite flag on one of the current user's conversations.")
+            .WithDescription("Sets the conversation's favorite flag to the requested state (idempotent, not a toggle). Scoped to the caller: another user's conversation is reported as not found.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(AIChatPermissions.Conversations.Manage);
+
         group.MapDelete("/{id:guid}", DeleteAsync)
             .WithName("DeleteConversation")
             .WithSummary("Deletes one of the current user's conversations.")
@@ -130,6 +140,24 @@ internal static class ConversationEndpoints
 
         bool renamed = await store.RenameAsync(id, ownerId, request.Title, cancellationToken).ConfigureAwait(false);
         return renamed
+            ? TypedResults.NoContent()
+            : TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> SetFavoriteAsync(
+        Guid id,
+        SetConversationFavoriteRequest request,
+        [FromServices] IConversationStore store,
+        [FromServices] ICurrentUserService currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (currentUser.UserGuid is not { } ownerId)
+        {
+            return Unauthorized();
+        }
+
+        bool updated = await store.SetFavoriteAsync(id, ownerId, request.IsFavorite, cancellationToken).ConfigureAwait(false);
+        return updated
             ? TypedResults.NoContent()
             : TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
     }

--- a/src/Granit.AI.Chat.Endpoints/Validators/SetConversationFavoriteRequestValidator.cs
+++ b/src/Granit.AI.Chat.Endpoints/Validators/SetConversationFavoriteRequestValidator.cs
@@ -1,0 +1,13 @@
+using Granit.AI.Chat.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.AI.Chat.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="SetConversationFavoriteRequest"/>. The single <c>bool</c> field is
+/// unconstrained (both states are valid), so the validator carries no rules; it exists to satisfy
+/// the framework's "every <c>*Request</c> has a <see cref="GranitValidator{T}"/>" convention.
+/// </summary>
+internal sealed class SetConversationFavoriteRequestValidator : GranitValidator<SetConversationFavoriteRequest>
+{
+}

--- a/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/ConversationConfiguration.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/ConversationConfiguration.cs
@@ -19,6 +19,7 @@ internal sealed class ConversationConfiguration : IEntityTypeConfiguration<Conve
 
         builder.Property(e => e.Title).HasMaxLength(500).IsRequired();
         builder.Property(e => e.OwnerId).IsRequired();
+        builder.Property(e => e.IsFavorite).HasDefaultValue(false);
         builder.Property(e => e.CreatedBy).HasMaxLength(256);
         builder.Property(e => e.ModifiedBy).HasMaxLength(256);
         builder.Property(e => e.DeletedBy).HasMaxLength(256);

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
@@ -105,6 +105,22 @@ internal sealed class EfConversationStore(IDbContextFactory<AIChatDbContext> con
         return true;
     }
 
+    public async Task<bool> SetFavoriteAsync(Guid id, Guid ownerId, bool isFavorite, CancellationToken cancellationToken = default)
+    {
+        await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        Conversation? conversation = await context.Conversations
+            .FirstOrDefaultAsync(c => c.Id == id && c.OwnerId == ownerId, cancellationToken)
+            .ConfigureAwait(false);
+        if (conversation is null)
+        {
+            return false;
+        }
+
+        conversation.SetFavorite(isFavorite);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
     public async Task<bool> DeleteAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default)
     {
         await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Granit.AI.Chat/Domain/Conversation.cs
+++ b/src/Granit.AI.Chat/Domain/Conversation.cs
@@ -34,6 +34,9 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
     /// <summary>The user who owns this conversation.</summary>
     public Guid OwnerId { get; private set; }
 
+    /// <summary>Whether the owner has marked this conversation as a favorite.</summary>
+    public bool IsFavorite { get; private set; }
+
     /// <summary>The messages exchanged, oldest first.</summary>
     public List<Message> Messages { get; private set; } = [];
 
@@ -53,6 +56,9 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
         ArgumentException.ThrowIfNullOrWhiteSpace(title);
         Title = title;
     }
+
+    /// <summary>Sets the favorite flag to the given state (idempotent — not a toggle).</summary>
+    public void SetFavorite(bool isFavorite) => IsFavorite = isFavorite;
 
     /// <summary>Appends a message and returns it.</summary>
     public Message AddMessage(Guid id, MessageRole role, string content)

--- a/src/Granit.AI.Chat/IConversationStore.cs
+++ b/src/Granit.AI.Chat/IConversationStore.cs
@@ -43,6 +43,12 @@ public interface IConversationStore
     /// <summary>Renames the owner's conversation; <see langword="false"/> if it is not theirs.</summary>
     Task<bool> RenameAsync(Guid id, Guid ownerId, string title, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sets the favorite flag on the owner's conversation to <paramref name="isFavorite"/>
+    /// (idempotent, not a toggle); <see langword="false"/> if the conversation is not theirs.
+    /// </summary>
+    Task<bool> SetFavoriteAsync(Guid id, Guid ownerId, bool isFavorite, CancellationToken cancellationToken = default);
+
     /// <summary>Deletes the owner's conversation; <see langword="false"/> if it is not theirs.</summary>
     Task<bool> DeleteAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
@@ -167,6 +167,70 @@ public sealed class ChatEndpointsHttpTests
     }
 
     [Fact]
+    public async Task SetFavorite_returns_204_when_updated()
+    {
+        var id = Guid.NewGuid();
+        _store.SetFavoriteAsync(id, Owner, true, Arg.Any<CancellationToken>()).Returns(true);
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PutAsJsonAsync(
+            $"/conversations/{id}/favorite", new SetConversationFavoriteRequest(true), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        await _store.Received(1).SetFavoriteAsync(id, Owner, true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetFavorite_passes_the_explicit_false_state_through()
+    {
+        var id = Guid.NewGuid();
+        _store.SetFavoriteAsync(id, Owner, false, Arg.Any<CancellationToken>()).Returns(true);
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PutAsJsonAsync(
+            $"/conversations/{id}/favorite", new SetConversationFavoriteRequest(false), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        await _store.Received(1).SetFavoriteAsync(id, Owner, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetFavorite_returns_404_when_absent()
+    {
+        var id = Guid.NewGuid();
+        _store.SetFavoriteAsync(id, Owner, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(false);
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PutAsJsonAsync(
+            $"/conversations/{id}/favorite", new SetConversationFavoriteRequest(true), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task SetFavorite_without_the_manage_permission_is_forbidden()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpClient client = host.CreateClientWithPermissions(AIChatPermissions.Conversations.Read);
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            $"/conversations/{Guid.NewGuid()}/favorite", new SetConversationFavoriteRequest(true), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task SetFavorite_without_a_user_context_is_unauthorized()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(userId: null);
+
+        HttpResponseMessage response = await FullAccess(host).PutAsJsonAsync(
+            $"/conversations/{Guid.NewGuid()}/favorite", new SetConversationFavoriteRequest(true), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task Delete_returns_204_when_deleted()
     {
         var id = Guid.NewGuid();

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
@@ -149,13 +149,27 @@ public sealed class ConversationEndpointsUnitTests
     {
         var conversation = Conversation.Create(Guid.NewGuid(), Guid.NewGuid(), "Chat");
         conversation.AddMessage(Guid.NewGuid(), MessageRole.Assistant, "Hi");
+        conversation.SetFavorite(true);
 
         var response = ConversationResponse.FromAggregate(conversation);
 
         response.Title.ShouldBe("Chat");
         response.OwnerId.ShouldBe(conversation.OwnerId);
+        response.IsFavorite.ShouldBeTrue();
         MessageResponse message = response.Messages.ShouldHaveSingleItem();
         message.Role.ShouldBe("assistant");
         message.Content.ShouldBe("Hi");
+    }
+
+    [Fact]
+    public void Summary_projects_the_favorite_flag()
+    {
+        var conversation = Conversation.Create(Guid.NewGuid(), Guid.NewGuid(), "Chat");
+        conversation.SetFavorite(true);
+
+        var summary = ConversationSummaryResponse.FromAggregate(conversation);
+
+        summary.Title.ShouldBe("Chat");
+        summary.IsFavorite.ShouldBeTrue();
     }
 }

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
@@ -75,6 +75,41 @@ public sealed class EfConversationStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task Conversations_are_not_favorite_by_default()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Plain");
+
+        Conversation? loaded = await _sut.GetAsync(seeded.Id, UserA, TestContext.Current.CancellationToken);
+
+        loaded!.IsFavorite.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SetFavorite_persists_the_explicit_state_for_the_owner_and_is_idempotent()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Pinned");
+
+        (await _sut.SetFavoriteAsync(seeded.Id, UserA, true, TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await _sut.GetAsync(seeded.Id, UserA, TestContext.Current.CancellationToken))!.IsFavorite.ShouldBeTrue();
+
+        // Setting the same state again is a no-op success (set semantics, not a toggle).
+        (await _sut.SetFavoriteAsync(seeded.Id, UserA, true, TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await _sut.GetAsync(seeded.Id, UserA, TestContext.Current.CancellationToken))!.IsFavorite.ShouldBeTrue();
+
+        (await _sut.SetFavoriteAsync(seeded.Id, UserA, false, TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await _sut.GetAsync(seeded.Id, UserA, TestContext.Current.CancellationToken))!.IsFavorite.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SetFavorite_fails_for_another_user()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Private");
+
+        (await _sut.SetFavoriteAsync(seeded.Id, UserB, true, TestContext.Current.CancellationToken)).ShouldBeFalse();
+        (await _sut.GetAsync(seeded.Id, UserA, TestContext.Current.CancellationToken))!.IsFavorite.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task AppendMessages_adds_to_the_owner_conversation_and_rejects_others()
     {
         Conversation seeded = await SeedAsync(UserA, "Chat", "first");

--- a/tests/Granit.AI.Chat.Tests/ConversationTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ConversationTests.cs
@@ -42,6 +42,29 @@ public sealed class ConversationTests
     }
 
     [Fact]
+    public void Create_defaults_to_not_favorite()
+    {
+        var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Chat");
+
+        conversation.IsFavorite.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetFavorite_sets_the_explicit_state_and_is_idempotent()
+    {
+        var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Chat");
+
+        conversation.SetFavorite(true);
+        conversation.IsFavorite.ShouldBeTrue();
+
+        conversation.SetFavorite(true);
+        conversation.IsFavorite.ShouldBeTrue();
+
+        conversation.SetFavorite(false);
+        conversation.IsFavorite.ShouldBeFalse();
+    }
+
+    [Fact]
     public void AddMessage_appends_a_message_bound_to_the_conversation()
     {
         var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Chat");


### PR DESCRIPTION
## What

Adds a per-user **favorite** flag to agentic-chat conversations so the front (`@granit/ai-chat`) can let users pin their own conversations.

## Changes

- **Domain** — `Conversation` gains `IsFavorite` with a `SetFavorite(bool)` behavior method. Explicit *set* semantics (idempotent), **not** a toggle.
- **Persistence** — `ConversationConfiguration` maps the column with a DB default of `false` (NOT NULL, non-nullable bool). Following the framework convention, **no migration ships here** — consuming apps own migrations; the EF config carries the column + default. Round-trip is covered by the SQLite store tests (`EnsureCreated`).
- **Store** — `IConversationStore.SetFavoriteAsync(id, ownerId, isFavorite, ct)` sets the flag owner-scoped; returns `false` (→ 404) for another user's / unknown conversation.
- **DTOs** — `isFavorite` exposed on both `ConversationResponse` (detail) and `ConversationSummaryResponse` (list). Serialized `isFavorite`, `required` in OpenAPI (always-present non-null bool).
- **Endpoint** — `PUT /conversations/{id}/favorite` with `SetConversationFavoriteRequest { bool IsFavorite }`. Returns **204**; **404** when not the caller's. Gated by `AIChat.Conversations.Manage` (same permission as rename) plus owner scoping. Empty `GranitValidator` added to satisfy the validator-per-request convention (the bool is unconstrained).

List sort is left as-is (newest first); the front filters by `isFavorite`.

## Tests

- Domain: `SetFavorite` explicit-state + idempotency, default `false`.
- Store (SQLite): set true/false + idempotent, default not-favorite, owner-scoped rejection.
- HTTP: 204 on update, explicit-`false` passthrough, 404 when absent, 401 no-user, 403 without `Manage`.
- Projection: `isFavorite` on detail + summary responses.

## Verification

- `dotnet build` + targeted `dotnet test` green (AI.Chat, EntityFrameworkCore, Endpoints).
- `dotnet format --verify-no-changes` clean; `ValidationConventionTests` + OpenAPI arch tests pass.
- OpenAPI contract regenerated (git-ignored; CI publishes): `PUT /conversations/{id}/favorite` + `isFavorite` required on both responses verified.