### PR TITLE
feat(ai-chat): emit an `error` SSE frame on mid-stream send failures

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3457,7 +3457,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 43,
+      "line": 60,
       "members": []
     },
     {
@@ -3475,7 +3475,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 64,
+      "line": 82,
       "members": []
     },
     {
@@ -3484,7 +3484,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 59,
+      "line": 77,
       "members": []
     },
     {
@@ -3616,7 +3616,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 71,
+      "line": 89,
       "members": []
     },
     {

--- a/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
@@ -33,12 +33,29 @@ public sealed record AttachmentRequest(string Reference, string FileName, string
 /// <see cref="Content"/> chunk), <c>tool_call</c> (a tool started — carries <see cref="ToolName"/> +
 /// <see cref="ToolCallId"/>), <c>tool_result</c> (a tool finished — adds <see cref="Succeeded"/>),
 /// <c>usage</c> (carries the token counts), <c>suggestions</c> (carries the typed
-/// <see cref="SuggestedActions"/>), or <c>clarification</c>.
+/// <see cref="SuggestedActions"/>), <c>clarification</c>, or <c>error</c> (a mid-stream failure —
+/// carries <see cref="Code"/>).
 /// </summary>
 /// <remarks>
+/// <para>
 /// Tool frames carry only the tool's name and call id — never its arguments or raw result (privacy);
 /// the front maps the name to a localized label. A "thinking" indicator is derived front-side from a
 /// <c>tool_result</c> not yet followed by a <c>delta</c>, so there is no thinking frame on the wire.
+/// </para>
+/// <para>
+/// An <c>error</c> frame is the terminal frame when the agentic loop fails <em>after</em> the stream
+/// has been committed (a HTTP problem is no longer possible at that point — see the send endpoint,
+/// which validates and returns 401/404/422/429 <em>before</em> opening the stream). It carries only
+/// <see cref="Code"/>; <see cref="Content"/> stays <see langword="null"/> so no raw provider detail
+/// leaks. The front maps the machine code to a localized message and never trusts backend text. A
+/// client-initiated cancellation is <em>not</em> an error and produces no <c>error</c> frame.
+/// </para>
+/// <para>
+/// <see cref="Code"/> is a stable, machine-readable code (<c>snake_case</c>) present only on the
+/// <c>error</c> frame. The closed set is: <c>rate_limit</c> (provider quota exhausted / 429 mid-stream
+/// — "denial of wallet"), <c>provider_unavailable</c> (provider 5xx, timeout, or connection failure),
+/// and <c>server_error</c> (any other, unclassified failure — the default).
+/// </para>
 /// </remarks>
 public sealed record ChatStreamEvent(
     string Type,
@@ -50,7 +67,8 @@ public sealed record ChatStreamEvent(
     ClarificationResponse? Clarification = null,
     string? ToolName = null,
     string? ToolCallId = null,
-    bool? Succeeded = null);
+    bool? Succeeded = null,
+    string? Code = null);
 
 /// <summary>A typed clarification the front renders as clickable choices; the turn blocks until answered.</summary>
 /// <param name="Question">The disambiguating question.</param>

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using Granit.AI.Chat.Attachments;
 using Granit.AI.Chat.Endpoints.Dtos;
@@ -12,11 +13,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 
 namespace Granit.AI.Chat.Endpoints.Endpoints;
 
 /// <summary>The send-message endpoint: runs the agentic loop and streams the answer over SSE.</summary>
-internal static class ChatSendEndpoints
+internal static partial class ChatSendEndpoints
 {
     internal static RouteGroupBuilder MapChatSendEndpoint(this RouteGroupBuilder group)
     {
@@ -29,7 +31,11 @@ internal static class ChatSendEndpoints
                 + "frame with the (possibly new) conversation id (flushed immediately), then live "
                 + "'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' "
                 + "content frames as the model writes, then a 'usage' frame (and 'suggestions' / "
-                + "'clarification' when applicable). Rejects a non-chat-capable workspace before streaming.")
+                + "'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. "
+                + "If the agent fails after the stream is committed (provider quota exhausted, a provider "
+                + "5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying "
+                + "a machine 'code' (rate_limit / provider_unavailable / server_error) — a frame within the "
+                + "200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.")
             .Produces<ChatStreamEvent>(StatusCodes.Status200OK, "text/event-stream")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -48,6 +54,7 @@ internal static class ChatSendEndpoints
         SendMessageRequest request,
         [FromServices] IChatService chatService,
         [FromServices] ICurrentUserService currentUser,
+        [FromServices] ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
         if (currentUser.UserGuid is not { } ownerId)
@@ -90,20 +97,61 @@ internal static class ChatSendEndpoints
         }
 
         // Native .NET SSE: the framework handles framing, content-type and per-item flushing.
-        return TypedResults.ServerSentEvents(StreamAsync(handle, chatService, cancellationToken));
+        ILogger logger = loggerFactory.CreateLogger("Granit.AI.Chat.Endpoints.Endpoints.ChatSendEndpoints");
+        return TypedResults.ServerSentEvents(StreamAsync(handle, chatService, logger, cancellationToken));
     }
 
     private static async IAsyncEnumerable<ChatStreamEvent> StreamAsync(
         ChatSendHandle handle,
         IChatService chatService,
+        ILogger logger,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Flush the conversation id first — its frame commits the SSE headers in milliseconds, long
         // before the agent settles, so the client never times out waiting for the first byte.
         yield return new ChatStreamEvent("conversation", ConversationId: handle.ConversationId);
 
-        await foreach (ChatTurnUpdate update in chatService.StreamAsync(handle, cancellationToken).ConfigureAwait(false))
+        // A failure mid-stream can no longer become an HTTP problem (the 200 is committed). Drive the
+        // turn through a manual enumerator so a thrown frame can be converted to a terminal 'error'
+        // frame: C# forbids 'yield' inside a catch, so the catch only captures the error code and the
+        // frame is yielded just outside it.
+        await using IAsyncEnumerator<ChatTurnUpdate> updates =
+            chatService.StreamAsync(handle, cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+        while (true)
         {
+            ChatTurnUpdate update;
+            string? errorCode = null;
+            try
+            {
+                if (!await updates.MoveNextAsync().ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                update = updates.Current;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // An expected client abort, not a failure: emit no 'error' frame, let it propagate.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                errorCode = MapErrorCode(ex);
+                LogStreamFailed(logger, ex, handle.ConversationId, errorCode);
+                update = null!; // unread: the error-frame branch below short-circuits before the switch.
+            }
+
+            if (errorCode is not null)
+            {
+                // Terminal frame. Content stays null so no raw provider detail leaks; the front maps
+                // the code to a localized message. No partial assistant turn was persisted — the chat
+                // service writes the assistant turn only after the loop settles (ADR-068).
+                yield return new ChatStreamEvent("error", Code: errorCode);
+                yield break;
+            }
+
             switch (update.Kind)
             {
                 case ChatTurnUpdateKind.Delta:
@@ -129,6 +177,72 @@ internal static class ChatSendEndpoints
             }
         }
     }
+
+    /// <summary>
+    /// Classifies a mid-stream failure into one of the closed wire codes the front maps to a localized
+    /// message. Provider SDK exceptions are not referenced as types here (this layer takes no provider
+    /// dependency); the HTTP status is read structurally so any provider's exception is still classified.
+    /// </summary>
+    private static string MapErrorCode(Exception exception)
+    {
+        if (TryGetHttpStatus(exception) is { } status)
+        {
+            return status switch
+            {
+                StatusCodes.Status429TooManyRequests => "rate_limit",
+                StatusCodes.Status408RequestTimeout or (>= 500 and < 600) => "provider_unavailable",
+                _ => "server_error", // other 4xx mid-stream is a server-side fault, not unavailability.
+            };
+        }
+
+        // No HTTP status: a transport-level failure (no connection, reset, timeout) means the provider
+        // is unreachable. A non-client OperationCanceledException reaches here only as a provider-side
+        // timeout — a client abort was already re-thrown above.
+        return IsTransportFailure(exception) ? "provider_unavailable" : "server_error";
+    }
+
+    /// <summary>
+    /// Reads an upstream HTTP status from the exception chain: <see cref="HttpRequestException.StatusCode"/>
+    /// when typed, else a public <c>int Status</c> property (the shape provider SDK exceptions such as
+    /// <c>System.ClientModel.ClientResultException</c> expose), read structurally to avoid a hard
+    /// dependency on every provider's SDK. <see langword="null"/> when no status is carried.
+    /// </summary>
+    private static int? TryGetHttpStatus(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is HttpRequestException { StatusCode: { } statusCode })
+            {
+                return (int)statusCode;
+            }
+
+            if (current.GetType().GetProperty("Status")?.GetValue(current) is int status and > 0)
+            {
+                return status;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Whether the failure (or any inner one) is a transport-level fault — provider unreachable.</summary>
+    private static bool IsTransportFailure(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is HttpRequestException or IOException or SocketException or TimeoutException or OperationCanceledException)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Chat send stream failed mid-stream for conversation {ConversationId}; emitting an '{Code}' error frame.")]
+    private static partial void LogStreamFailed(ILogger logger, Exception exception, Guid conversationId, string code);
 
     /// <summary>The terminal frames derived from the settled result: usage, then any suggestions and clarification.</summary>
     private static IEnumerable<ChatStreamEvent> CompletionFrames(ChatSendResult result)

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
@@ -479,6 +479,114 @@ public sealed class ChatEndpointsHttpTests
         }
     }
 
+    [Fact]
+    public async Task Send_ends_with_a_rate_limit_error_frame_when_the_provider_is_throttled_mid_stream()
+    {
+        var conversationId = Guid.NewGuid();
+        _chatService.PrepareAsync(Arg.Any<ChatSendRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ChatSendHandle { ConversationId = conversationId });
+        // The provider returns 429 part-way through the stream — a "denial of wallet" mid-flight.
+        _chatService.StreamAsync(Arg.Any<ChatSendHandle>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ThrowingStream(
+                new HttpRequestException("secret-provider-detail", null, HttpStatusCode.TooManyRequests)));
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            "/conversations/messages", new SendMessageRequest("Hi"), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("\"type\":\"error\"");
+        body.ShouldContain("rate_limit");
+        // The raw provider detail never reaches the wire — only the machine code does.
+        body.ShouldNotContain("secret-provider-detail");
+    }
+
+    [Fact]
+    public async Task Send_ends_with_a_provider_unavailable_error_frame_on_a_provider_5xx()
+    {
+        var conversationId = Guid.NewGuid();
+        _chatService.PrepareAsync(Arg.Any<ChatSendRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ChatSendHandle { ConversationId = conversationId });
+        _chatService.StreamAsync(Arg.Any<ChatSendHandle>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ThrowingStream(
+                new HttpRequestException("upstream down", null, HttpStatusCode.ServiceUnavailable)));
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            "/conversations/messages", new SendMessageRequest("Hi"), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("provider_unavailable");
+    }
+
+    [Fact]
+    public async Task Send_ends_with_a_server_error_frame_for_an_unclassified_failure()
+    {
+        var conversationId = Guid.NewGuid();
+        _chatService.PrepareAsync(Arg.Any<ChatSendRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ChatSendHandle { ConversationId = conversationId });
+        _chatService.StreamAsync(Arg.Any<ChatSendHandle>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ThrowingStream(new InvalidOperationException("boom")));
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            "/conversations/messages", new SendMessageRequest("Hi"), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("\"type\":\"error\"");
+        body.ShouldContain("server_error");
+    }
+
+    [Fact]
+    public async Task Send_does_not_convert_a_client_cancellation_into_an_error_frame()
+    {
+        var conversationId = Guid.NewGuid();
+        _chatService.PrepareAsync(Arg.Any<ChatSendRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ChatSendHandle { ConversationId = conversationId });
+        // The stream blocks until the request is cancelled, then surfaces an OperationCanceledException
+        // with the request token set — the client-abort case the endpoint must not turn into an error.
+        _chatService.StreamAsync(Arg.Any<ChatSendHandle>(), Arg.Any<CancellationToken>())
+            .Returns(ci => BlockingStream(ci.Arg<CancellationToken>()));
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        using var cts = new CancellationTokenSource();
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/conversations/messages")
+        {
+            Content = JsonContent.Create(new SendMessageRequest("Hi")),
+        };
+        using HttpResponseMessage response = await FullAccess(host).SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var seen = new System.Text.StringBuilder();
+        try
+        {
+            await using Stream stream = await response.Content.ReadAsStreamAsync(cts.Token);
+            using var reader = new StreamReader(stream);
+            char[] buffer = new char[64];
+            int read;
+            while ((read = await reader.ReadAsync(buffer, cts.Token)) > 0)
+            {
+                seen.Append(buffer, 0, read);
+                // The conversation frame proves the stream committed; now cancel like a closing client.
+                if (seen.ToString().Contains("conversation"))
+                {
+                    await cts.CancelAsync();
+                }
+            }
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException)
+        {
+            // Expected: the cancellation aborts the stream rather than producing an error frame.
+        }
+
+        seen.ToString().ShouldContain("conversation");
+        seen.ToString().ShouldNotContain("error");
+    }
+
     private static async IAsyncEnumerable<ChatTurnUpdate> Stream(params ChatTurnUpdate[] updates)
     {
         foreach (ChatTurnUpdate update in updates)
@@ -486,6 +594,22 @@ public sealed class ChatEndpointsHttpTests
             await Task.Yield();
             yield return update;
         }
+    }
+
+    private static async IAsyncEnumerable<ChatTurnUpdate> ThrowingStream(Exception error)
+    {
+        await Task.Yield();
+        yield return ChatTurnUpdate.ForDelta("partial");
+        throw error;
+    }
+
+    private static async IAsyncEnumerable<ChatTurnUpdate> BlockingStream(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // The endpoint emits the conversation frame itself; this never yields and blocks until the
+        // request is cancelled, at which point Task.Delay throws with the token set.
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+        yield break;
     }
 
     private static async IAsyncEnumerable<ChatTurnUpdate> GatedStream(

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -456,4 +456,40 @@ public sealed class ChatServiceTests
                 r.UserCustomContext!.Length == AIChatSettingNames.MaxCustomContextLength),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task A_loop_failure_mid_stream_persists_the_user_turn_but_no_assistant_turn()
+    {
+        ChatService service = CreateService();
+        // The loop emits a delta, then the provider faults mid-stream. Only the regenerable assistant
+        // turn may be lost — the user turn, persisted up front, survives (ADR-068).
+        _orchestrator.RunStreamingAsync(Arg.Any<AIOrchestrationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ => FaultingStream());
+        ChatSendHandle handle = await service.PrepareAsync(Request(message: "boom"), TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (ChatTurnUpdate _ in service.StreamAsync(handle, TestContext.Current.CancellationToken))
+            {
+            }
+        });
+
+        // The user turn is persisted before the loop runs...
+        await _store.Received(1).CreateAsync(
+            Arg.Is<Conversation>(c =>
+                c.Messages.Count == 1 && c.Messages[0].Role == MessageRole.User && c.Messages[0].Content == "boom"),
+            Arg.Any<CancellationToken>());
+        // ...but the failed turn appends no assistant message.
+        await _store.DidNotReceive().AppendMessagesAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Is<IReadOnlyList<Message>>(m => m.Any(x => x.Role == MessageRole.Assistant)),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static async IAsyncEnumerable<AIOrchestrationUpdate> FaultingStream()
+    {
+        yield return AIOrchestrationUpdate.Delta("partial");
+        await Task.Yield();
+        throw new InvalidOperationException("provider exploded mid-stream");
+    }
 }


### PR DESCRIPTION
## Problem

`POST /conversations/messages` validates the send and returns `401/404/422/429` as an RFC 7807 problem **before** the SSE stream opens. But once the stream is committed (200 `text/event-stream`, first `conversation` frame), there is **no error frame**. If the agentic loop fails mid-stream — provider quota exhausted ("denial of wallet"), a provider 5xx/timeout, or any other fault — the `IAsyncEnumerable` simply throws and the stream ends. The client sees a **truncated answer with no error signal**.

## Change

Convert a post-commit failure into a **terminal `error` frame** and close cleanly.

- New frame type `error` on `ChatStreamEvent`, carrying a new field **`Code`** — a stable, machine-readable code (`snake_case`), present only on the `error` frame.
- Closed code set (documented in XML doc):
  - `rate_limit` — provider quota / denial-of-wallet / 429 mid-stream
  - `provider_unavailable` — provider 5xx, timeout, connection failure
  - `server_error` — any other, unclassified failure (default)
- `Content` stays **null** on the `error` frame so no raw provider detail leaks. The front maps the code → localized message and never trusts backend text.
- **Client cancellation is not an error**: a `OperationCanceledException` raised once the request token is cancelled propagates and emits **no** `error` frame.

### Implementation notes

- C# forbids `yield` inside a `catch`, so `ChatSendEndpoints.StreamAsync` drives a **manual enumerator** — the `catch` only captures the code and the frame is yielded just outside it.
- `MapErrorCode` classifies dependency-free: it reads the upstream HTTP status from `HttpRequestException.StatusCode` (typed) or a structural `int Status` property (the shape provider SDK exceptions such as `System.ClientModel.ClientResultException` expose), so any provider's exception is classified without this layer taking a provider dependency. Transport faults (`IOException`/`SocketException`/`TimeoutException`/non-client `OperationCanceledException`) → `provider_unavailable`.
- The exception is logged at `Error` with the conversation id and the mapped code — no PII, no message content.
- **No partial assistant turn is persisted** on failure: the chat service appends the assistant turn only after the loop settles (ADR-068). Covered by a test.

## OpenAPI / front coordination

The OpenAPI generator emits the new `code` property on `ChatStreamEvent` automatically (verified in the regenerated `ai-chat` document; `code` is nullable and not `required`). **Merge order is backend-first** — `granit-front` then re-vendors the OpenAPI snapshot and adds the `errorKind` classification + `SystemMessage` component in a coordinated PR.

## Tests

- `rate_limit` / `provider_unavailable` / `server_error` mid-stream failures each end with the matching `error` frame; raw provider detail never reaches the wire.
- A client cancellation produces **no** `error` frame.
- Pre-stream paths (`401/404/422/429` as problems) unchanged.
- A mid-stream loop failure persists the **user** turn but **no assistant** turn (ADR-068).

`Granit.AI.Chat.Endpoints.Tests` (41) and `Granit.AI.Chat.Tests` (70) green; `dotnet format --verify-no-changes` clean.