### PR TITLE
test(ai): fix AIUsageRecordQueryDefinition column/group-by counts after ConversationId

### DIFF
--- a/tests/Granit.AI.Tests/Queries/AIUsageRecordQueryDefinitionTests.cs
+++ b/tests/Granit.AI.Tests/Queries/AIUsageRecordQueryDefinitionTests.cs
@@ -15,7 +15,7 @@ public sealed class AIUsageRecordQueryDefinitionTests
     public void Declares_expected_columns()
     {
         System.Collections.Generic.IReadOnlyList<Granit.QueryEngine.ColumnDescriptor> columns = _definition.GetColumns();
-        columns.Count.ShouldBe(9);
+        columns.Count.ShouldBe(10);
         columns.Select(c => c.PropertyName).ShouldContain("WorkspaceName");
         columns.Select(c => c.PropertyName).ShouldContain("Provider");
         columns.Select(c => c.PropertyName).ShouldContain("Model");
@@ -25,16 +25,18 @@ public sealed class AIUsageRecordQueryDefinitionTests
         columns.Select(c => c.PropertyName).ShouldContain("CostCurrency");
         columns.Select(c => c.PropertyName).ShouldContain("Timestamp");
         columns.Select(c => c.PropertyName).ShouldContain("Duration");
+        columns.Select(c => c.PropertyName).ShouldContain("ConversationId");
     }
 
     [Fact]
     public void Declares_groupby_fields()
     {
         System.Collections.Generic.IReadOnlyList<Granit.QueryEngine.Filtering.GroupByDescriptor> groupByFields = _definition.GetGroupByFields();
-        groupByFields.Count.ShouldBe(3);
+        groupByFields.Count.ShouldBe(4);
         groupByFields.Select(g => g.PropertyName).ShouldContain("WorkspaceName");
         groupByFields.Select(g => g.PropertyName).ShouldContain("Provider");
         groupByFields.Select(g => g.PropertyName).ShouldContain("Model");
+        groupByFields.Select(g => g.PropertyName).ShouldContain("ConversationId");
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #2810 (#2808). That PR added `ConversationId` as a column + group-by
on `AIUsageRecordQueryDefinition` but the exact-count assertions in
`Granit.AI.Tests/Queries/AIUsageRecordQueryDefinitionTests` were not updated in
the same commit (the count fix lived in a later, unmerged commit). #2810 merged
without it, so the `ai` shard is currently red on develop.

Bumps the expected counts: columns 9 → 10, group-by 3 → 4, and asserts
`ConversationId` is present in both.

## Verification
- `dotnet test tests/Granit.AI.Tests --filter AIUsageRecordQueryDefinition` — green (6/6).