### PR TITLE
feat(ai-chat): emit a persisted-messages SSE frame so the client gets real ids

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3288,7 +3288,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 84,
+      "line": 105,
       "members": [
         {
           "name": "ConversationId",
@@ -3313,13 +3313,19 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 47,
+      "line": 59,
       "members": [
         {
           "name": "ConversationId",
           "kind": "property",
           "signature": "required Guid ConversationId",
           "returnType": "required Guid"
+        },
+        {
+          "name": "Clarification",
+          "kind": "property",
+          "signature": "AIClarificationRequest? Clarification",
+          "returnType": "AIClarificationRequest?"
         }
       ]
     },
@@ -3329,7 +3335,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 135,
+      "line": 156,
       "members": [
         {
           "name": "ForDelta",
@@ -3363,7 +3369,7 @@
       "kind": "enum",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 115,
+      "line": 136,
       "members": []
     },
     {
@@ -3457,7 +3463,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 60,
+      "line": 69,
       "members": []
     },
     {
@@ -3475,7 +3481,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 82,
+      "line": 92,
       "members": []
     },
     {
@@ -3484,7 +3490,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 77,
+      "line": 87,
       "members": []
     },
     {
@@ -3616,7 +3622,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs",
-      "line": 89,
+      "line": 99,
       "members": []
     },
     {
@@ -3865,7 +3871,7 @@
       "kind": "interface",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 183,
+      "line": 204,
       "members": [
         {
           "name": "PrepareAsync",
@@ -4080,6 +4086,28 @@
           "kind": "method",
           "signature": "new(StringComparer.OrdinalIgnoreCase)",
           "returnType": "HashSet<string> AllowedContentTypes { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "PersistedChatMessage",
+      "fqn": "Granit.AI.Chat.PersistedChatMessage",
+      "kind": "record",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/IChatService.cs",
+      "line": 56,
+      "members": [
+        {
+          "name": "ConversationId",
+          "kind": "property",
+          "signature": "required Guid ConversationId",
+          "returnType": "required Guid"
+        },
+        {
+          "name": "Clarification",
+          "kind": "property",
+          "signature": "AIClarificationRequest? Clarification",
+          "returnType": "AIClarificationRequest?"
         }
       ]
     },

--- a/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/SendMessageRequest.cs
@@ -32,11 +32,20 @@ public sealed record AttachmentRequest(string Reference, string FileName, string
 /// <c>conversation</c> (carries <see cref="ConversationId"/>), <c>delta</c> (carries a
 /// <see cref="Content"/> chunk), <c>tool_call</c> (a tool started — carries <see cref="ToolName"/> +
 /// <see cref="ToolCallId"/>), <c>tool_result</c> (a tool finished — adds <see cref="Succeeded"/>),
-/// <c>usage</c> (carries the token counts), <c>suggestions</c> (carries the typed
-/// <see cref="SuggestedActions"/>), <c>clarification</c>, or <c>error</c> (a mid-stream failure —
-/// carries <see cref="Code"/>).
+/// <c>persisted</c> (the turn's saved messages — carries <see cref="Messages"/>), <c>usage</c>
+/// (carries the token counts), <c>suggestions</c> (carries the typed <see cref="SuggestedActions"/>),
+/// <c>clarification</c>, or <c>error</c> (a mid-stream failure — carries <see cref="Code"/>).
 /// </summary>
 /// <remarks>
+/// <para>
+/// The <c>persisted</c> frame carries the turn's newly-saved message rows (<see cref="Messages"/>,
+/// the user message then the assistant message, oldest-first) with their real ids and server
+/// timestamps, emitted once on a successful turn just before <c>usage</c>. It lets the client render
+/// the actual rows — and report the just-streamed assistant message — instead of synthesising ids. It
+/// is <em>not</em> emitted on a clarification turn (there is no answer to append) nor on the
+/// <c>error</c> frame; when it is absent the client falls back to its optimistic, client-id append.
+/// Older clients ignore the unknown frame, so it is backward compatible.
+/// </para>
 /// <para>
 /// Tool frames carry only the tool's name and call id — never its arguments or raw result (privacy);
 /// the front maps the name to a localized label. A "thinking" indicator is derived front-side from a
@@ -68,7 +77,8 @@ public sealed record ChatStreamEvent(
     string? ToolName = null,
     string? ToolCallId = null,
     bool? Succeeded = null,
-    string? Code = null);
+    string? Code = null,
+    IReadOnlyList<MessageResponse>? Messages = null);
 
 /// <summary>A typed clarification the front renders as clickable choices; the turn blocks until answered.</summary>
 /// <param name="Question">The disambiguating question.</param>

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -30,8 +30,10 @@ internal static partial class ChatSendEndpoints
                 + "assistant messages, and streams the answer as Server-Sent Events: a 'conversation' "
                 + "frame with the (possibly new) conversation id (flushed immediately), then live "
                 + "'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' "
-                + "content frames as the model writes, then a 'usage' frame (and 'suggestions' / "
-                + "'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. "
+                + "content frames as the model writes, then (on a successful turn) a 'persisted' frame "
+                + "carrying the turn's saved user and assistant messages with their real ids and server "
+                + "timestamps, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). "
+                + "Rejects a non-chat-capable workspace before streaming. "
                 + "If the agent fails after the stream is committed (provider quota exhausted, a provider "
                 + "5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying "
                 + "a machine 'code' (rate_limit / provider_unavailable / server_error) — a frame within the "
@@ -244,9 +246,23 @@ internal static partial class ChatSendEndpoints
         Message = "Chat send stream failed mid-stream for conversation {ConversationId}; emitting an '{Code}' error frame.")]
     private static partial void LogStreamFailed(ILogger logger, Exception exception, Guid conversationId, string code);
 
-    /// <summary>The terminal frames derived from the settled result: usage, then any suggestions and clarification.</summary>
+    /// <summary>
+    /// The terminal frames derived from the settled result: the turn's persisted identities, then
+    /// usage, then any suggestions and clarification.
+    /// </summary>
     private static IEnumerable<ChatStreamEvent> CompletionFrames(ChatSendResult result)
     {
+        // Surface the turn's persisted rows (real ids + server timestamps) so the client renders the
+        // actual messages and can report the just-streamed answer. Suppressed on a clarification (no
+        // answer to append) and when no ids are available — the client then keeps its optimistic append.
+        if (result.Clarification is null && result.PersistedMessages.Count > 0)
+        {
+            yield return new ChatStreamEvent(
+                "persisted",
+                Messages: [.. result.PersistedMessages.Select(m =>
+                    new MessageResponse(m.Id, m.Role, m.Content, m.CreatedAt))]);
+        }
+
         yield return new ChatStreamEvent("usage", InputTokens: result.InputTokens, OutputTokens: result.OutputTokens);
 
         if (result.SuggestedActions.Count > 0)

--- a/src/Granit.AI.Chat/IChatService.cs
+++ b/src/Granit.AI.Chat/IChatService.cs
@@ -43,6 +43,18 @@ public sealed record ChatSendRequest
     public IReadOnlyList<Guid>? PromptRefs { get; init; }
 }
 
+/// <summary>
+/// A message persisted during a turn, projected so the streaming endpoint can surface the turn's real
+/// identities (server-assigned id + timestamp) to the client without re-loading the conversation.
+/// Mirrors the fields of the conversation read model's message projection (id, role, content,
+/// created-at); <see cref="Role"/> is lower-cased ("user"/"assistant") to match the client wire convention.
+/// </summary>
+/// <param name="Id">The server-assigned message identifier.</param>
+/// <param name="Role">The author, lower-cased ("user"/"assistant") to match the client wire convention.</param>
+/// <param name="Content">The message text, as persisted.</param>
+/// <param name="CreatedAt">The server creation timestamp.</param>
+public sealed record PersistedChatMessage(Guid Id, string Role, string Content, DateTimeOffset CreatedAt);
+
 /// <summary>The outcome of a send: the (possibly new) conversation and the assistant's answer.</summary>
 public sealed record ChatSendResult
 {
@@ -72,6 +84,15 @@ public sealed record ChatSendResult
     /// until the user picks an option). <see cref="Content"/> then carries the question text.
     /// </summary>
     public AIClarificationRequest? Clarification { get; init; }
+
+    /// <summary>
+    /// The turn's newly-persisted messages — the user message (saved before the loop) then the
+    /// assistant message (saved after it), oldest-first — carrying their real ids and server
+    /// timestamps. The streaming endpoint emits these as a <c>persisted</c> frame so the client can
+    /// render the actual rows (and report the just-streamed message) instead of synthesising ids.
+    /// Empty when no turn was persisted.
+    /// </summary>
+    public IReadOnlyList<PersistedChatMessage> PersistedMessages { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -125,8 +125,10 @@ internal sealed class ChatService(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Persist the user turn before the loop runs: the message and conversation then survive a
-        // crash mid-stream (only the regenerable assistant turn can be lost — see ADR-068).
-        await PersistUserTurnAsync(handle, cancellationToken).ConfigureAwait(false);
+        // crash mid-stream (only the regenerable assistant turn can be lost — see ADR-068). The
+        // persisted entity (real id + server timestamp) is carried into the settled result so the
+        // endpoint can stream the turn's identities back to the client.
+        Message userMessage = await PersistUserTurnAsync(handle, cancellationToken).ConfigureAwait(false);
 
         var orchestrationRequest = new AIOrchestrationRequest
         {
@@ -179,7 +181,7 @@ internal sealed class ChatService(
             yield return ChatTurnUpdate.ForDelta(assistantContent);
         }
 
-        await PersistAssistantTurnAsync(handle, assistantContent, cancellationToken).ConfigureAwait(false);
+        Message assistantMessage = await PersistAssistantTurnAsync(handle, assistantContent, cancellationToken).ConfigureAwait(false);
 
         // Gather typed, non-executing suggested actions from registered providers under the caller's
         // ACLs. Ephemeral — surfaced with the answer, never persisted.
@@ -196,32 +198,48 @@ internal sealed class ChatService(
             OutputTokens = result.OutputTokens,
             SuggestedActions = suggestedActions,
             Clarification = clarification,
+            // Both turns are saved by now (CreatedAt stamped by the audit interceptor) — carry their
+            // identities oldest-first so the endpoint can emit them. The endpoint suppresses the frame
+            // on a clarification (no answer to append).
+            PersistedMessages = [ToPersisted(userMessage), ToPersisted(assistantMessage)],
         });
     }
 
-    private async Task PersistUserTurnAsync(ChatSendHandle handle, CancellationToken cancellationToken)
+    private async Task<Message> PersistUserTurnAsync(ChatSendHandle handle, CancellationToken cancellationToken)
     {
         if (handle.IsNew)
         {
-            handle.Conversation.AddMessage(guidGenerator.Create(), MessageRole.User, handle.OriginalMessage);
+            Message userMessage = handle.Conversation.AddMessage(guidGenerator.Create(), MessageRole.User, handle.OriginalMessage);
             await conversationStore.CreateAsync(handle.Conversation, cancellationToken).ConfigureAwait(false);
+            return userMessage;
         }
-        else
-        {
-            await conversationStore.AppendMessagesAsync(
-                handle.ConversationId,
-                handle.OwnerId,
-                [Message.Create(guidGenerator.Create(), handle.ConversationId, MessageRole.User, handle.OriginalMessage)],
-                cancellationToken).ConfigureAwait(false);
-        }
-    }
 
-    private Task<bool> PersistAssistantTurnAsync(ChatSendHandle handle, string assistantContent, CancellationToken cancellationToken) =>
-        conversationStore.AppendMessagesAsync(
+        var message = Message.Create(guidGenerator.Create(), handle.ConversationId, MessageRole.User, handle.OriginalMessage);
+        await conversationStore.AppendMessagesAsync(
             handle.ConversationId,
             handle.OwnerId,
-            [Message.Create(guidGenerator.Create(), handle.ConversationId, MessageRole.Assistant, assistantContent)],
-            cancellationToken);
+            [message],
+            cancellationToken).ConfigureAwait(false);
+        return message;
+    }
+
+    private async Task<Message> PersistAssistantTurnAsync(ChatSendHandle handle, string assistantContent, CancellationToken cancellationToken)
+    {
+        var message = Message.Create(guidGenerator.Create(), handle.ConversationId, MessageRole.Assistant, assistantContent);
+        await conversationStore.AppendMessagesAsync(
+            handle.ConversationId,
+            handle.OwnerId,
+            [message],
+            cancellationToken).ConfigureAwait(false);
+        return message;
+    }
+
+    /// <summary>
+    /// Projects a persisted <see cref="Message"/> to the wire identity carried in the settled result.
+    /// The role is lower-cased to match the client wire convention (as in the conversation read model).
+    /// </summary>
+    private static PersistedChatMessage ToPersisted(Message message) =>
+        new(message.Id, message.Role.ToString().ToLowerInvariant(), message.Content, message.CreatedAt);
 
     /// <summary>
     /// Parses a clarification from a loop interrupt, or <see langword="null"/> when the interrupt is

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
+using Granit.AI.Chat.Clarification;
 using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Endpoints.Dtos;
 using Granit.AI.Chat.Endpoints.Extensions;
@@ -446,6 +447,87 @@ public sealed class ChatEndpointsHttpTests
     }
 
     [Fact]
+    public async Task Send_emits_one_persisted_frame_with_the_turns_real_messages_before_usage()
+    {
+        var conversationId = Guid.NewGuid();
+        var userMessageId = Guid.NewGuid();
+        var assistantMessageId = Guid.NewGuid();
+        var createdAt = new DateTimeOffset(2026, 6, 18, 9, 30, 0, TimeSpan.Zero);
+        _chatService.PrepareAsync(Arg.Any<ChatSendRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ChatSendHandle { ConversationId = conversationId });
+        _chatService.StreamAsync(Arg.Any<ChatSendHandle>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Stream(
+                ChatTurnUpdate.ForDelta("Hello world"),
+                ChatTurnUpdate.ForCompleted(new ChatSendResult
+                {
+                    ConversationId = conversationId,
+                    Content = "Hello world",
+                    InputTokens = 3,
+                    OutputTokens = 2,
+                    PersistedMessages =
+                    [
+                        new PersistedChatMessage(userMessageId, "user", "Hi", createdAt),
+                        new PersistedChatMessage(assistantMessageId, "assistant", "Hello world", createdAt),
+                    ],
+                })));
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            "/conversations/messages", new SendMessageRequest("Hi"), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        // Exactly one persisted frame, carrying both real message ids, ordered before usage.
+        int persistedAt = body.IndexOf("\"type\":\"persisted\"", StringComparison.Ordinal);
+        persistedAt.ShouldBeGreaterThanOrEqualTo(0);
+        body.IndexOf("\"type\":\"persisted\"", persistedAt + 1, StringComparison.Ordinal).ShouldBe(-1);
+        persistedAt.ShouldBeLessThan(body.IndexOf("\"type\":\"usage\"", StringComparison.Ordinal));
+        body.ShouldContain(userMessageId.ToString());
+        body.ShouldContain(assistantMessageId.ToString());
+        // The camelCase MessageResponse shape the GET endpoint already uses is reused verbatim.
+        body.ShouldContain("\"role\":\"assistant\"");
+        body.ShouldContain("\"createdAt\":");
+    }
+
+    [Fact]
+    public async Task Send_emits_no_persisted_frame_on_a_clarification_turn()
+    {
+        var conversationId = Guid.NewGuid();
+        _chatService.PrepareAsync(Arg.Any<ChatSendRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ChatSendHandle { ConversationId = conversationId });
+        // The service persists the question as an assistant row, so the identities ride along — but the
+        // endpoint must suppress the frame: there is no answer bubble to append, only clickable options.
+        _chatService.StreamAsync(Arg.Any<ChatSendHandle>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Stream(
+                ChatTurnUpdate.ForCompleted(new ChatSendResult
+                {
+                    ConversationId = conversationId,
+                    Content = "Which environment?",
+                    Clarification = new AIClarificationRequest
+                    {
+                        Question = "Which environment?",
+                        Options = [new AIClarificationOption { Label = "Prod" }, new AIClarificationOption { Label = "Test" }],
+                        AllowOther = false,
+                    },
+                    PersistedMessages =
+                    [
+                        new PersistedChatMessage(Guid.NewGuid(), "user", "deploy", default),
+                        new PersistedChatMessage(Guid.NewGuid(), "assistant", "Which environment?", default),
+                    ],
+                })));
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host).PostAsJsonAsync(
+            "/conversations/messages", new SendMessageRequest("deploy"), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("clarification");
+        body.ShouldNotContain("\"type\":\"persisted\"");
+    }
+
+    [Fact]
     public async Task Send_flushes_the_conversation_frame_before_the_agent_settles()
     {
         var conversationId = Guid.NewGuid();
@@ -538,6 +620,8 @@ public sealed class ChatEndpointsHttpTests
         string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         body.ShouldContain("\"type\":\"error\"");
         body.ShouldContain("server_error");
+        // A failed turn settles no result, so no persisted identities are emitted.
+        body.ShouldNotContain("\"type\":\"persisted\"");
     }
 
     [Fact]

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -130,6 +130,17 @@ public sealed class ChatServiceTests
         result.Content.ShouldBe("the answer");
         result.InputTokens.ShouldBe(10);
 
+        // The turn's persisted identities ride along, user then assistant (oldest-first), carrying the
+        // real ids the endpoint streams back as the 'persisted' frame.
+        result.PersistedMessages.Count.ShouldBe(2);
+        result.PersistedMessages[0].Role.ShouldBe("user");
+        result.PersistedMessages[0].Content.ShouldBe("What changed?");
+        result.PersistedMessages[0].Id.ShouldNotBe(Guid.Empty);
+        result.PersistedMessages[1].Role.ShouldBe("assistant");
+        result.PersistedMessages[1].Content.ShouldBe("the answer");
+        result.PersistedMessages[1].Id.ShouldNotBe(Guid.Empty);
+        result.PersistedMessages[0].Id.ShouldNotBe(result.PersistedMessages[1].Id);
+
         // The user turn is persisted up front (conversation created with just the user message)...
         await _store.Received(1).CreateAsync(
             Arg.Is<Conversation>(c =>
@@ -144,6 +155,32 @@ public sealed class ChatServiceTests
             Arg.Is<IReadOnlyList<Message>>(m =>
                 m.Count == 1 && m[0].Role == MessageRole.Assistant && m[0].Content == "the answer"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Persisted_message_identities_match_the_entities_written_to_the_store()
+    {
+        ChatService service = CreateService();
+        Conversation? created = null;
+        Message? appendedAssistant = null;
+        // Configured after CreateService so these capturing stubs win over its defaults.
+        _store.CreateAsync(Arg.Any<Conversation>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(created = ci.Arg<Conversation>()));
+        _store.AppendMessagesAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                appendedAssistant = ci.Arg<IReadOnlyList<Message>>()[0];
+                return Task.FromResult(true);
+            });
+
+        ChatSendResult result = await SendAsync(service, Request(message: "What changed?"), TestContext.Current.CancellationToken);
+
+        // The user identity is the row stored on the new conversation; the assistant identity is the
+        // row appended afterwards — so the front can render/report exactly what GET returns.
+        created.ShouldNotBeNull();
+        appendedAssistant.ShouldNotBeNull();
+        result.PersistedMessages[0].Id.ShouldBe(created.Messages[0].Id);
+        result.PersistedMessages[1].Id.ShouldBe(appendedAssistant.Id);
     }
 
     [Fact]


### PR DESCRIPTION
## What

The agentic chat send stream (`POST {basePath}/conversations/messages`, ADR-067/071) never surfaced the turn's persisted message ids. The front (`@granit/react-ai-chat` `useChatStream`) could therefore only optimistically append the finished turn with **client-synthesised** ids/timestamps — so the just-streamed assistant message was **not reportable** (`POST .../messages/{messageId}/report` 404s on the synthetic id) and React keys stayed unstable until a full reload.

This adds an additive, backward-compatible `persisted` SSE frame carrying the turn's real persisted rows.

## How

- **`Granit.AI.Chat`** — new `PersistedChatMessage` projection (id/role/content/createdAt) and `ChatSendResult.PersistedMessages`. `ChatService` now returns the persisted `Message` entities from both persist steps (real id + interceptor-stamped `CreatedAt`) and carries them oldest-first (user then assistant).
- **`Granit.AI.Chat.Endpoints`** — `ChatStreamEvent` gains an optional `messages` field reusing the existing `MessageResponse` shape (verbatim, same as `GET /conversations/{id}`). `CompletionFrames` emits one `persisted` frame **just before `usage`**.

## Contract

```
data: {"type":"persisted","messages":[
  {"id":"…","role":"user","content":"…","createdAt":"…"},
  {"id":"…","role":"assistant","content":"…","createdAt":"…"}
]}
```

- Emitted **once on a successful turn**, before `usage`.
- **Omitted** on a clarification turn (no answer to append), on the `error` frame, and on client cancellation — the client then keeps its optimistic, client-id append.
- Older clients ignore the unknown frame → non-breaking.

## Tests

- **Service**: persisted identities ride along oldest-first; their ids equal the entities actually written to the store (i.e. what `GET` returns and `/report` accepts).
- **Endpoint**: exactly one `persisted` frame with both real ids before `usage`; none on a clarification turn; none on an errored turn.

## Verification

`ai` test projects green (71 + 43), `architecture` shard green (226), `dotnet format --verify-no-changes` clean, gitleaks clean.

## Follow-ups (separate PRs)

- **Docs**: ADR-071 SSE section updated locally (ships as its own `granit-docs` PR per repo policy).
- **Front**: `@granit/ai-chat` `CHAT_STREAM_EVENT_TYPES.PERSISTED` + `messages?` on `ChatStreamEvent`; `useChatStream` appends `event.messages` verbatim, synthetic fallback retained.