### PR TITLE
feat(ai-chat): backwards keyset-paginated conversation messages endpoint

### DIFF
--- a/.github/shard-filters/ai.slnf
+++ b/.github/shard-filters/ai.slnf
@@ -55,6 +55,7 @@
       "src/Granit.Privacy/Granit.Privacy.csproj",
       "src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj",
       "src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj",
+      "src/Granit.QueryEngine.EntityFrameworkCore/Granit.QueryEngine.EntityFrameworkCore.csproj",
       "src/Granit.QueryEngine/Granit.QueryEngine.csproj",
       "src/Granit.RateLimiting/Granit.RateLimiting.csproj",
       "src/Granit.Settings/Granit.Settings.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40,6 +40,7 @@
         "Granit.AI.Prompts",
         "Granit.AI.Tools",
         "Granit.Guids",
+        "Granit.QueryEngine.Abstractions",
         "Granit.Settings",
         "Granit.TextExtraction"
       ],
@@ -61,6 +62,7 @@
         "Granit.Guids",
         "Granit.Http.ApiDocumentation",
         "Granit.Http.RateLimiting",
+        "Granit.QueryEngine.Abstractions",
         "Granit.Validation"
       ],
       "framework": "net10.0"
@@ -69,7 +71,8 @@
       "name": "Granit.AI.Chat.EntityFrameworkCore",
       "deps": [
         "Granit.AI.Chat",
-        "Granit.Persistence.EntityFrameworkCore"
+        "Granit.Persistence.EntityFrameworkCore",
+        "Granit.QueryEngine.EntityFrameworkCore"
       ],
       "framework": "net10.0"
     },
@@ -3499,7 +3502,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 43,
+      "line": 51,
       "members": [
         {
           "name": "FromAggregate",
@@ -3559,10 +3562,10 @@
       "line": 40,
       "members": [
         {
-          "name": "FromAggregate",
+          "name": "FromEntity",
           "kind": "method",
-          "signature": "FromAggregate(Conversation conversation)",
-          "returnType": "ConversationResponse"
+          "signature": "FromEntity(Message message)",
+          "returnType": "MessageResponse"
         }
       ]
     },
@@ -3760,7 +3763,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat.EntityFrameworkCore",
       "file": "src/Granit.AI.Chat.EntityFrameworkCore/GranitAIChatEntityFrameworkCoreModule.cs",
-      "line": 14,
+      "line": 17,
       "members": []
     },
     {
@@ -3855,7 +3858,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/GranitAIChatModule.cs",
-      "line": 29,
+      "line": 34,
       "members": [
         {
           "name": "ConfigureServices",
@@ -3927,7 +3930,7 @@
       "kind": "interface",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IConversationStore.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "CreateAsync",
@@ -3940,6 +3943,12 @@
           "kind": "method",
           "signature": "GetAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default)",
           "returnType": "Task<Conversation?>"
+        },
+        {
+          "name": "GetMessagesPageAsync",
+          "kind": "method",
+          "signature": "GetMessagesPageAsync(Guid conversationId, Guid ownerId, string? cursor, int? pageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<Message>?>"
         },
         {
           "name": "ListAsync",
@@ -4206,6 +4215,22 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ChatMessageQueryDefinition",
+      "fqn": "Granit.AI.Chat.Queries.ChatMessageQueryDefinition",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Queries/ChatMessageQueryDefinition.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
         }
       ]
     },

--- a/.slnf/ai.slnf
+++ b/.slnf/ai.slnf
@@ -56,6 +56,7 @@
       "src/Granit.Privacy/Granit.Privacy.csproj",
       "src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj",
       "src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj",
+      "src/Granit.QueryEngine.EntityFrameworkCore/Granit.QueryEngine.EntityFrameworkCore.csproj",
       "src/Granit.QueryEngine/Granit.QueryEngine.csproj",
       "src/Granit.RateLimiting/Granit.RateLimiting.csproj",
       "src/Granit.Settings/Granit.Settings.csproj",

--- a/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
+++ b/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
@@ -83,6 +83,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }

--- a/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
@@ -37,7 +37,15 @@ public sealed record ConversationSummaryResponse(
 /// </param>
 /// <param name="Content">The message text.</param>
 /// <param name="CreatedAt">When the message was created.</param>
-public sealed record MessageResponse(Guid Id, string Role, string Content, DateTimeOffset CreatedAt);
+public sealed record MessageResponse(Guid Id, string Role, string Content, DateTimeOffset CreatedAt)
+{
+    /// <summary>Projects a <see cref="Message"/> to a response, lower-casing the role for the wire.</summary>
+    public static MessageResponse FromEntity(Message message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        return new MessageResponse(message.Id, message.Role.ToString().ToLowerInvariant(), message.Content, message.CreatedAt);
+    }
+}
 
 /// <summary>A conversation with its messages.</summary>
 public sealed record ConversationResponse(
@@ -58,6 +66,5 @@ public sealed record ConversationResponse(
             conversation.IsFavorite,
             conversation.CreatedAt,
             conversation.ModifiedAt,
-            [.. conversation.Messages.Select(m =>
-                new MessageResponse(m.Id, m.Role.ToString().ToLowerInvariant(), m.Content, m.CreatedAt))]);
+            [.. conversation.Messages.Select(MessageResponse.FromEntity)]);
 }

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatMessagesEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatMessagesEndpoints.cs
@@ -1,0 +1,70 @@
+using Granit.AI.Chat.Domain;
+using Granit.AI.Chat.Endpoints.Dtos;
+using Granit.AI.Chat.Endpoints.Permissions;
+using Granit.QueryEngine;
+using Granit.Users;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.AI.Chat.Endpoints.Endpoints;
+
+/// <summary>
+/// Owner-scoped, backwards-paginated read endpoint for a conversation's message thread. Pages the
+/// newest messages first and walks toward older history via an opaque keyset cursor, so the client
+/// loads the latest page on open and earlier pages on scroll-up.
+/// </summary>
+internal static class ChatMessagesEndpoints
+{
+    internal static RouteGroupBuilder MapChatMessagesEndpoint(this RouteGroupBuilder group)
+    {
+        group.MapGet("/{id:guid}/messages", GetMessagesAsync)
+            .WithName("GetConversationMessages")
+            .WithSummary("Returns a backwards-paginated page of a conversation's messages.")
+            .WithDescription(
+                "Returns the newest page of messages first, sorted newest-first. Pass the returned " +
+                "nextCursor to load the page of older messages; nextCursor is null at the start of " +
+                "history. Scoped to the caller: another user's conversation is reported as not found.")
+            .Produces<PagedResult<MessageResponse>>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(AIChatPermissions.Conversations.Read);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<PagedResult<MessageResponse>>, ProblemHttpResult>> GetMessagesAsync(
+        Guid id,
+        [FromQuery] string? cursor,
+        [FromQuery] int? pageSize,
+        [FromServices] IConversationStore store,
+        [FromServices] ICurrentUserService currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (currentUser.UserGuid is not { } ownerId)
+        {
+            return Unauthorized();
+        }
+
+        PagedResult<Message>? page = await store
+            .GetMessagesPageAsync(id, ownerId, cursor, pageSize, cancellationToken)
+            .ConfigureAwait(false);
+        if (page is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        // Project the entities to the wire DTO; TotalCount stays null (keyset pagination), the cursor
+        // and HasMore flow straight through from the query engine.
+        IReadOnlyList<MessageResponse> items = [.. page.Items.Select(MessageResponse.FromEntity)];
+        PagedResult<MessageResponse> response = new(items, TotalCount: null, page.HasMore, page.NextCursor);
+        return TypedResults.Ok(response);
+    }
+
+    private static ProblemHttpResult Unauthorized() =>
+        TypedResults.Problem(
+            detail: "The current identity has no user context.",
+            statusCode: StatusCodes.Status401Unauthorized);
+}

--- a/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.AI.Chat.Endpoints/Extensions/AIChatEndpointRouteBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class AIChatEndpointRouteBuilderExtensions
             .WithTags(options.TagName);
 
         group.MapConversationEndpoints();
+        group.MapChatMessagesEndpoint();
         group.MapChatSendEndpoint();
         group.MapMessageReportEndpoint();
         group.MapChatWorkspaceEndpoint();

--- a/src/Granit.AI.Chat.Endpoints/Granit.AI.Chat.Endpoints.csproj
+++ b/src/Granit.AI.Chat.Endpoints/Granit.AI.Chat.Endpoints.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Http.RateLimiting\Granit.Http.RateLimiting.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>
 

--- a/src/Granit.AI.Chat.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Chat.Endpoints/packages.lock.json
@@ -114,6 +114,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Granit.AI.Chat.EntityFrameworkCore.csproj
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Granit.AI.Chat.EntityFrameworkCore.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.AI.Chat\Granit.AI.Chat.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.EntityFrameworkCore\Granit.QueryEngine.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.AI.Chat.EntityFrameworkCore/GranitAIChatEntityFrameworkCoreModule.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/GranitAIChatEntityFrameworkCoreModule.cs
@@ -1,14 +1,17 @@
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine.EntityFrameworkCore;
 
 namespace Granit.AI.Chat.EntityFrameworkCore;
 
 /// <summary>
 /// Granit module registering EF Core persistence for AI Chat. The host configures the
 /// <see cref="Internal.AIChatDbContext"/> (connection string); this module registers the
-/// owner-scoped <see cref="IConversationStore"/>.
+/// owner-scoped <see cref="IConversationStore"/> and the <c>IQueryEngine&lt;Message&gt;</c> runtime
+/// backing the backwards-paginated messages endpoint.
 /// </summary>
 [DependsOn(
     typeof(GranitAIChatModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitQueryEngineEntityFrameworkCoreModule))]
 public sealed class GranitAIChatEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
@@ -1,4 +1,5 @@
 using Granit.AI.Chat.Domain;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.AI.Chat.EntityFrameworkCore.Internal;
@@ -7,7 +8,9 @@ namespace Granit.AI.Chat.EntityFrameworkCore.Internal;
 /// EF Core <see cref="IConversationStore"/>. Every query is scoped to the owner (and the tenant,
 /// via the DbContext filter), so a caller can only reach their own conversations.
 /// </summary>
-internal sealed class EfConversationStore(IDbContextFactory<AIChatDbContext> contextFactory) : IConversationStore
+internal sealed class EfConversationStore(
+    IDbContextFactory<AIChatDbContext> contextFactory,
+    IQueryEngine<Message> messageQueryEngine) : IConversationStore
 {
     public async Task<Conversation> CreateAsync(Conversation conversation, CancellationToken cancellationToken = default)
     {
@@ -27,6 +30,37 @@ internal sealed class EfConversationStore(IDbContextFactory<AIChatDbContext> con
             .Include(c => c.Messages.OrderBy(m => m.CreatedAt))
             .FirstOrDefaultAsync(c => c.Id == id && c.OwnerId == ownerId, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    public async Task<PagedResult<Message>?> GetMessagesPageAsync(
+        Guid conversationId,
+        Guid ownerId,
+        string? cursor,
+        int? pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // Ownership gate first: a foreign or absent conversation is "not found", so a caller can
+        // never page another user's thread. Message rows carry no tenant/owner filter of their own.
+        bool owned = await context.Conversations
+            .AsNoTracking()
+            .AnyAsync(c => c.Id == conversationId && c.OwnerId == ownerId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!owned)
+        {
+            return null;
+        }
+
+        IQueryable<Message> source = context.Set<Message>()
+            .AsNoTracking()
+            .Where(m => m.ConversationId == conversationId);
+
+        // An empty (non-null) cursor selects keyset mode for the first page: a null cursor would fall
+        // to offset pagination (no NextCursor), whereas an empty one returns the newest page AND a
+        // NextCursor to walk older. PageSize defaults/clamps via the query definition.
+        QueryRequest request = new() { Cursor = cursor ?? string.Empty, PageSize = pageSize };
+        return await messageQueryEngine.ExecuteAsync(source, request, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Conversation>> ListAsync(Guid ownerId, CancellationToken cancellationToken = default)

--- a/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
@@ -140,6 +140,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
@@ -275,11 +276,27 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Localization.Abstractions": "[10.*, )"
         }
       },
       "granit.settings": {

--- a/src/Granit.AI.Chat.Privacy/packages.lock.json
+++ b/src/Granit.AI.Chat.Privacy/packages.lock.json
@@ -350,6 +350,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }

--- a/src/Granit.AI.Chat/Granit.AI.Chat.csproj
+++ b/src/Granit.AI.Chat/Granit.AI.Chat.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Granit.AI.Prompts\Granit.AI.Prompts.csproj" />
     <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />
     <ProjectReference Include="..\Granit.TextExtraction\Granit.TextExtraction.csproj" />
   </ItemGroup>

--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -1,10 +1,14 @@
+using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Extensions;
 using Granit.AI.Chat.Internal;
+using Granit.AI.Chat.Queries;
 using Granit.AI.Chat.Settings;
 using Granit.AI.Prompts;
 using Granit.AI.Tools;
 using Granit.Guids;
 using Granit.Modularity;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Extensions;
 using Granit.Settings;
 using Granit.TextExtraction;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +28,7 @@ namespace Granit.AI.Chat;
     typeof(GranitAIPromptsModule),
     typeof(GranitAIToolsModule),
     typeof(GranitGuidsModule),
+    typeof(GranitQueryEngineAbstractionsModule),
     typeof(GranitSettingsModule),
     typeof(GranitTextExtractionModule))]
 public sealed class GranitAIChatModule : GranitModule
@@ -32,6 +37,10 @@ public sealed class GranitAIChatModule : GranitModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.TryAddScoped<IChatService, ChatService>();
+
+        // Keyset (cursor) query definition backing the backwards-paginated messages endpoint.
+        // The endpoint drives IQueryEngine<Message> directly over an owner-scoped source.
+        context.Services.AddQueryDefinition<Message, ChatMessageQueryDefinition>();
 
         // Badge resolution expands the turn's '/' prompt-catalogue references into the instruction
         // (owner-scoped via IPromptTemplateStore). Always present; resolves to nothing when no refs.

--- a/src/Granit.AI.Chat/IConversationStore.cs
+++ b/src/Granit.AI.Chat/IConversationStore.cs
@@ -1,4 +1,5 @@
 using Granit.AI.Chat.Domain;
+using Granit.QueryEngine;
 
 namespace Granit.AI.Chat;
 
@@ -14,6 +15,25 @@ public interface IConversationStore
 
     /// <summary>Returns the owner's conversation including its messages, or <see langword="null"/>.</summary>
     Task<Conversation?> GetAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns one backwards-paginated page of the owner's conversation messages (newest first),
+    /// or <see langword="null"/> when the conversation is absent or not the owner's (reported as
+    /// "not found", so a caller can never page another user's thread).
+    /// </summary>
+    /// <remarks>
+    /// Pass <paramref name="cursor"/> <see langword="null"/> for the newest page, then the returned
+    /// <see cref="PagedResult{T}.NextCursor"/> for each older page; the cursor is <see langword="null"/>
+    /// at the start of history. <paramref name="pageSize"/> is clamped to the query definition's
+    /// bounds (default 30, max 100). The result's <c>TotalCount</c> is always <see langword="null"/>
+    /// (keyset pagination does not count).
+    /// </remarks>
+    Task<PagedResult<Message>?> GetMessagesPageAsync(
+        Guid conversationId,
+        Guid ownerId,
+        string? cursor,
+        int? pageSize,
+        CancellationToken cancellationToken = default);
 
     /// <summary>Returns the owner's conversations (without messages), newest first.</summary>
     Task<IReadOnlyList<Conversation>> ListAsync(Guid ownerId, CancellationToken cancellationToken = default);

--- a/src/Granit.AI.Chat/Queries/ChatMessageQueryDefinition.cs
+++ b/src/Granit.AI.Chat/Queries/ChatMessageQueryDefinition.cs
@@ -1,0 +1,40 @@
+using Granit.AI.Chat.Domain;
+using Granit.QueryEngine;
+
+namespace Granit.AI.Chat.Queries;
+
+/// <summary>
+/// Query definition for a conversation's <see cref="Message"/> thread, used by the
+/// <c>GET /conversations/{id}/messages</c> endpoint to page <strong>backwards</strong> through
+/// history: newest messages first, then older pages on scroll-up.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Keyset (cursor) pagination over the composite <c>createdAt</c> + <c>id</c> key gives stable
+/// pages even as new messages arrive at the head — there is no offset to drift. The default sort
+/// is <c>-createdAt</c> (newest first); the unique message <c>Id</c> is the tiebreaker, so
+/// the cursor walks strictly toward older messages and dries up (<c>NextCursor == null</c>) at the
+/// start of history.
+/// </para>
+/// <para>
+/// This definition is driven directly via <see cref="IQueryEngine{TEntity}"/> by the bespoke,
+/// owner-scoped messages endpoint (the source is pre-scoped to one conversation), not exposed
+/// through <c>MapGranitQuery</c>; the columns exist only to whitelist the sort/cursor keys, so they
+/// carry no localization metadata.
+/// </para>
+/// </remarks>
+public sealed class ChatMessageQueryDefinition : QueryDefinition<Message>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.AI.Chat.ChatMessageQuery";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<Message> builder) =>
+        builder
+            .Column(m => m.CreatedAt, c => c.Label("Created At").Sortable())
+            .Column(m => m.Id, c => c.Label("Id").Sortable())
+            .SupportsCursorPagination(m => m.Id)
+            .DefaultSort("-createdAt")
+            .DefaultPageSize(30)
+            .MaxPageSize(100);
+}

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -429,6 +429,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
@@ -441,6 +442,7 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.RateLimiting": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
@@ -315,6 +315,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
@@ -11,6 +11,7 @@ using Granit.AI.Chat.Settings;
 using Granit.AI.Exceptions;
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.QueryEngine;
 using Granit.RateLimiting.Extensions;
 using Granit.Testing.Endpoints;
 using Granit.Users;
@@ -127,6 +128,83 @@ public sealed class ChatEndpointsHttpTests
         HttpResponseMessage response = await FullAccess(host).GetAsync($"/conversations/{conversation.Id}", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    // ── Messages (backwards keyset pagination) ───────────────────────────────────
+
+    [Fact]
+    public async Task Messages_without_a_user_context_is_unauthorized()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(userId: null);
+
+        HttpResponseMessage response = await FullAccess(host)
+            .GetAsync($"/conversations/{Guid.NewGuid()}/messages", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Messages_returns_404_for_a_conversation_that_is_not_the_callers()
+    {
+        var id = Guid.NewGuid();
+        _store.GetMessagesPageAsync(id, Owner, Arg.Any<string?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns((PagedResult<Message>?)null);
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host)
+            .GetAsync($"/conversations/{id}/messages", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Messages_returns_the_newest_page_first_with_a_cursor()
+    {
+        var id = Guid.NewGuid();
+        var newer = Message.Create(Guid.NewGuid(), id, MessageRole.Assistant, "newer");
+        var older = Message.Create(Guid.NewGuid(), id, MessageRole.User, "older");
+        _store.GetMessagesPageAsync(id, Owner, null, Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<Message>([newer, older], TotalCount: null, HasMore: true, NextCursor: "older-cursor"));
+
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        PagedResult<MessageResponse>? body = await FullAccess(host)
+            .GetFromJsonAsync<PagedResult<MessageResponse>>($"/conversations/{id}/messages", TestContext.Current.CancellationToken);
+
+        body.ShouldNotBeNull();
+        body.Items.Select(m => m.Content).ShouldBe(["newer", "older"]);
+        body.Items[0].Role.ShouldBe("assistant");
+        body.TotalCount.ShouldBeNull();
+        body.NextCursor.ShouldBe("older-cursor");
+    }
+
+    [Fact]
+    public async Task Messages_passes_the_cursor_and_pageSize_through_for_older_pages()
+    {
+        var id = Guid.NewGuid();
+        _store.GetMessagesPageAsync(id, Owner, "older-cursor", 10, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<Message>([], TotalCount: null, HasMore: false, NextCursor: null));
+
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpResponseMessage response = await FullAccess(host)
+            .GetAsync($"/conversations/{id}/messages?cursor=older-cursor&pageSize=10", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        // The cursor and page size flow straight through to the owner-scoped store query.
+        await _store.Received(1).GetMessagesPageAsync(id, Owner, "older-cursor", 10, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Messages_without_the_read_permission_is_forbidden()
+    {
+        await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
+
+        HttpClient client = host.CreateClientWithPermissions("AIChat.Conversations.Other");
+        HttpResponseMessage response = await client.GetAsync(
+            $"/conversations/{Guid.NewGuid()}/messages", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }
 
     [Fact]

--- a/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
@@ -536,6 +536,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
@@ -548,6 +549,7 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.RateLimiting": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
@@ -12,7 +12,7 @@ public sealed class EfConversationStoreTests : IDisposable
     private readonly TestDbContextFactory _factory = TestDbContextFactory.Create();
     private readonly EfConversationStore _sut;
 
-    public EfConversationStoreTests() => _sut = new EfConversationStore(_factory);
+    public EfConversationStoreTests() => _sut = new EfConversationStore(_factory, TestQueryEngine.ForMessages());
 
     public void Dispose() => _factory.Dispose();
 

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/MessageKeysetPaginationTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/MessageKeysetPaginationTests.cs
@@ -1,0 +1,104 @@
+using Granit.AI.Chat.Domain;
+using Granit.AI.Chat.EntityFrameworkCore.Internal;
+using Granit.QueryEngine;
+using Shouldly;
+
+namespace Granit.AI.Chat.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Exercises <see cref="EfConversationStore.GetMessagesPageAsync"/> against the real EF Core query
+/// engine (SQLite) to prove the backwards keyset behaviour the messages endpoint depends on: newest
+/// page first, a cursor that walks strictly toward older messages, a null cursor at the start of
+/// history, owner scoping, and conversation scoping.
+/// </summary>
+public sealed class MessageKeysetPaginationTests : IAsyncLifetime
+{
+    private readonly Guid _conversationId = Guid.NewGuid();
+    private readonly Guid _otherConversationId = Guid.NewGuid();
+    private readonly Guid _ownerId = Guid.NewGuid();
+    private TestDbContextFactory _factory = null!;
+    private EfConversationStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _factory = TestDbContextFactory.Create();
+
+        var baseTime = new DateTimeOffset(2026, 6, 18, 8, 0, 0, TimeSpan.Zero);
+        await using (AIChatDbContext seed = _factory.CreateDbContext())
+        {
+            // Parent conversations must exist to satisfy the message → conversation foreign key.
+            seed.Conversations.Add(Conversation.Create(_conversationId, _ownerId, "target"));
+            seed.Conversations.Add(Conversation.Create(_otherConversationId, _ownerId, "other"));
+
+            // Five messages in the target conversation, oldest (m0) → newest (m4).
+            for (int i = 0; i < 5; i++)
+            {
+                var message = Message.Create(Guid.NewGuid(), _conversationId, MessageRole.User, $"m{i}");
+                message.CreatedAt = baseTime.AddMinutes(i);
+                seed.Set<Message>().Add(message);
+            }
+
+            // A message in another conversation that must never leak into the scoped page.
+            var foreign = Message.Create(Guid.NewGuid(), _otherConversationId, MessageRole.User, "foreign");
+            foreign.CreatedAt = baseTime.AddMinutes(2);
+            seed.Set<Message>().Add(foreign);
+
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        _store = new EfConversationStore(_factory, TestQueryEngine.ForMessages());
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _factory.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private Task<PagedResult<Message>?> PageAsync(string? cursor, int pageSize) =>
+        _store.GetMessagesPageAsync(_conversationId, _ownerId, cursor, pageSize, TestContext.Current.CancellationToken);
+
+    [Fact]
+    public async Task First_page_returns_the_newest_messages_with_a_next_cursor()
+    {
+        PagedResult<Message>? page = await PageAsync(cursor: null, pageSize: 2);
+
+        page.ShouldNotBeNull();
+        page.Items.Select(m => m.Content).ShouldBe(["m4", "m3"]);
+        page.TotalCount.ShouldBeNull();
+        page.HasMore.ShouldBeTrue();
+        page.NextCursor.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Cursor_walks_toward_older_messages_then_dries_up_at_history_start()
+    {
+        List<string> seen = [];
+        string? cursor = null;
+        PagedResult<Message>? page;
+
+        do
+        {
+            page = await PageAsync(cursor, pageSize: 2);
+            page.ShouldNotBeNull();
+            seen.AddRange(page.Items.Select(m => m.Content));
+            cursor = page.NextCursor;
+        }
+        while (cursor is not null);
+
+        // Strictly newest → oldest, every message exactly once, scoped to the conversation.
+        seen.ShouldBe(["m4", "m3", "m2", "m1", "m0"]);
+        seen.ShouldNotContain("foreign");
+        page.HasMore.ShouldBeFalse();
+        page.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Returns_null_for_a_conversation_that_is_not_the_owners()
+    {
+        PagedResult<Message>? page = await _store.GetMessagesPageAsync(
+            _conversationId, ownerId: Guid.NewGuid(), cursor: null, pageSize: 2, TestContext.Current.CancellationToken);
+
+        page.ShouldBeNull();
+    }
+}

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/TestQueryEngine.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/TestQueryEngine.cs
@@ -1,0 +1,35 @@
+using Granit.AI.Chat.Domain;
+using Granit.AI.Chat.Queries;
+using Granit.QueryEngine;
+using Granit.QueryEngine.EntityFrameworkCore;
+using Granit.QueryEngine.Extensions;
+using Granit.QueryEngine.Options;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.AI.Chat.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Builds the real <see cref="IQueryEngine{TEntity}"/> for tests. The implementation is internal to
+/// its assembly, so the open generic the EF Core module would register is wired by reflection — this
+/// keeps the test-only dependency without a contrived <c>InternalsVisibleTo</c>.
+/// </summary>
+internal static class TestQueryEngine
+{
+    private static readonly ServiceProvider Provider = Build();
+
+    public static IQueryEngine<Message> ForMessages() => Provider.GetRequiredService<IQueryEngine<Message>>();
+
+    private static ServiceProvider Build()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddOptions<QueryEngineOptions>();
+        services.AddQueryDefinition<Message, ChatMessageQueryDefinition>();
+
+        Type engineOpenGeneric = typeof(GranitQueryEngineEntityFrameworkCoreModule).Assembly
+            .GetType("Granit.QueryEngine.EntityFrameworkCore.Internal.QueryEngine`1", throwOnError: true)!;
+        services.AddSingleton(typeof(IQueryEngine<>), engineOpenGeneric);
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
@@ -405,6 +405,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
@@ -414,6 +415,7 @@
         "dependencies": {
           "Granit.AI.Chat": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
@@ -549,11 +551,27 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Localization.Abstractions": "[10.*, )"
         }
       },
       "granit.settings": {

--- a/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
@@ -577,6 +577,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }

--- a/tests/Granit.AI.Chat.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Tests/packages.lock.json
@@ -315,6 +315,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }

--- a/tests/Granit.ArchitectureTests/PairingExemptions.cs
+++ b/tests/Granit.ArchitectureTests/PairingExemptions.cs
@@ -21,6 +21,7 @@ internal static class PairingExemptions
     public static readonly HashSet<string> Infrastructure = new(StringComparer.Ordinal)
     {
         "Granit.AI.AIUsageRecord",                                                        // [INFRA] AI cost / audit log
+        "Granit.AI.Chat.Domain.Message",                                                  // [INFRA] owner-private chat content; cursor-paginated thread view only, never an admin grid/export (GDPR export via Granit.AI.Chat.Privacy)
         "Granit.Auditing.Domain.AuditEntityChange",                                       // [INFRA] audit log
         "Granit.Auditing.Domain.AuditEntry",                                              // [INFRA] audit log
         "Granit.Authorization.Domain.PermissionGrant",                                    // [INFRA] RBAC config

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1550,6 +1550,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
         }
@@ -1569,6 +1570,7 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.RateLimiting": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
@@ -1577,6 +1579,7 @@
         "dependencies": {
           "Granit.AI.Chat": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
@@ -4589,8 +4592,8 @@
       "Markdig": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.3.1",
-        "contentHash": "nAa41a9X0sSWHeLQbc3vzn5wKKlA0hKR6i1sXjl0hCSfywwR21R0hwB1m+XObKofbZVRhbe7c8mdgZUv3/NRWQ=="
+        "resolved": "1.3.2",
+        "contentHash": "fZgOC/3CswUrndjDTac70aQpYdtxbW5+5bRumR7vzvI2HJbkmgKisB1c9oT+GA6v0jB/JDR9BLa9FiPzQmaK6A=="
       },
       "MaxMind.GeoIP2": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## What

Exposes a conversation thread as a **backwards-paginated** endpoint so the front loads the newest page first, then older messages on scroll-up — using the framework's **generic query-engine keyset pagination** (`PagedResult` + opaque cursor), not a bespoke shape.

```
GET {basePath}/conversations/{id}/messages?cursor={opaque}&pageSize={N}
```

- no cursor → newest `pageSize` messages; cursor → the `pageSize` messages **older** than it
- `pageSize` default 30, max 100
- `200 → PagedResult<MessageResponse>` { items newest-first (`-createdAt`), `totalCount: null`, `nextCursor: string|null` }
- owner-only: a conversation outside the caller's own returns **404**
- `MessageResponse` reused unchanged

## How

- **`ChatMessageQueryDefinition : QueryDefinition<Message>`** (base module) — `SupportsCursorPagination(m => m.Id)`, `DefaultSort("-createdAt")`, page 30 / max 100.
- **`IConversationStore.GetMessagesPageAsync`** (impl in `EfConversationStore`) owns the `IQueryEngine<Message>` call plus the owner + `ConversationId` scoping. A foreign/absent conversation returns `null` → 404, so a caller can never page another user's thread.
- The **endpoint stays HTTP-only**: maps `PagedResult<Message>` → `PagedResult<MessageResponse>`.

### Two non-obvious points
1. **`IQueryable` stays in the persistence layer.** The archi rule `IQueryableShouldNotEscapePersistenceLayer` forbids `IQueryable` in `.Endpoints`, so the query engine is invoked from the EF Core store, not the handler (same generic-engine mechanics, correct layering).
2. **First page sends an empty (not null) cursor.** The engine only enters the keyset branch when `Cursor is not null`; a null cursor falls to offset pagination and emits no `nextCursor`. An empty cursor returns the newest page *and* a `nextCursor`. The entity overload is used because the projection overload never computes `nextCursor`.

`Message` added to the Query/Export pairing exemptions (owner-private content, no admin export surface; GDPR export handled by `Granit.AI.Chat.Privacy`).

## Tests
- **Endpoint** (`ChatEndpointsHttpTests`): 404 foreign conversation, 401 no user, forbidden without `Read`, newest-page mapping + `nextCursor`, cursor/pageSize passthrough.
- **EF Core SQLite** (`MessageKeysetPaginationTests`, real query engine): newest page first, cursor walks older, `nextCursor` null at history start, owner + conversation scoping.
- ai + architecture shards green; `dotnet format --verify-no-changes` clean.

## Docs
ADR-067/071 update ships as a separate `granit-docs` PR (docs decoupled per repo convention).