### PR TITLE
refactor(ai-chat): metadata-only GET-by-id + framework audit cleanups

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3502,7 +3502,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 51,
+      "line": 55,
       "members": [
         {
           "name": "FromAggregate",
@@ -3945,6 +3945,12 @@
           "returnType": "Task<Conversation?>"
         },
         {
+          "name": "GetMetadataAsync",
+          "kind": "method",
+          "signature": "GetMetadataAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Conversation?>"
+        },
+        {
           "name": "GetMessagesPageAsync",
           "kind": "method",
           "signature": "GetMessagesPageAsync(Guid conversationId, Guid ownerId, string? cursor, int? pageSize, CancellationToken cancellationToken = default)",
@@ -4126,7 +4132,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat.Privacy",
       "file": "src/Granit.AI.Chat.Privacy/DataDeletion/ConversationPersonalDataDeletionHandler.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "Handle",
@@ -4145,9 +4151,9 @@
       "line": 11,
       "members": [
         {
-          "name": "HandleAsync",
+          "name": "Handle",
           "kind": "method",
-          "signature": "HandleAsync(PersonalDataRequestedEto request, ConversationPrivacyDataProvider provider, PrivacyFragmentUploader uploader, CancellationToken cancellationToken)",
+          "signature": "Handle(PersonalDataRequestedEto request, ConversationPrivacyDataProvider provider, PrivacyFragmentUploader uploader, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]

--- a/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
@@ -33,7 +33,7 @@ public sealed record ConversationSummaryResponse(
 /// The author, lower-cased ("user"/"assistant"/"system"/"tool") to match the AI-SDK wire
 /// convention the <c>@granit/ai-chat</c> client contract expects. The default
 /// <see cref="System.Text.Json.Serialization.JsonStringEnumConverter"/> would emit PascalCase, so
-/// the role is mapped explicitly here — see <see cref="ConversationResponse.FromAggregate"/>.
+/// the role is mapped explicitly here — see <see cref="MessageResponse.FromEntity"/>.
 /// </param>
 /// <param name="Content">The message text.</param>
 /// <param name="CreatedAt">When the message was created.</param>
@@ -47,17 +47,20 @@ public sealed record MessageResponse(Guid Id, string Role, string Content, DateT
     }
 }
 
-/// <summary>A conversation with its messages.</summary>
+/// <summary>
+/// A conversation's metadata (title, favorite, timestamps), without its messages. The thread is
+/// paged separately via <c>GET /conversations/{id}/messages</c>, so detail reads never materialise
+/// an entire history just to render the header.
+/// </summary>
 public sealed record ConversationResponse(
     Guid Id,
     string Title,
     Guid OwnerId,
     bool IsFavorite,
     DateTimeOffset CreatedAt,
-    DateTimeOffset? ModifiedAt,
-    IReadOnlyList<MessageResponse> Messages)
+    DateTimeOffset? ModifiedAt)
 {
-    /// <summary>Projects a <see cref="Conversation"/> (with messages) to a response.</summary>
+    /// <summary>Projects a <see cref="Conversation"/> to its metadata response.</summary>
     public static ConversationResponse FromAggregate(Conversation conversation) =>
         new(
             conversation.Id,
@@ -65,6 +68,5 @@ public sealed record ConversationResponse(
             conversation.OwnerId,
             conversation.IsFavorite,
             conversation.CreatedAt,
-            conversation.ModifiedAt,
-            [.. conversation.Messages.Select(MessageResponse.FromEntity)]);
+            conversation.ModifiedAt);
 }

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatMessagesEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatMessagesEndpoints.cs
@@ -28,7 +28,6 @@ internal static class ChatMessagesEndpoints
                 "nextCursor to load the page of older messages; nextCursor is null at the start of " +
                 "history. Scoped to the caller: another user's conversation is reported as not found.")
             .Produces<PagedResult<MessageResponse>>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Read);
 

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -40,9 +40,7 @@ internal static partial class ChatSendEndpoints
                 + "200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.")
             .Produces<ChatStreamEvent>(StatusCodes.Status200OK, "text/event-stream")
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status429TooManyRequests)
             .RequireAuthorization(AIChatPermissions.Conversations.Send)
             // The agentic loop costs real provider spend per call; bound per-user volume to prevent

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ConversationEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ConversationEndpoints.cs
@@ -21,15 +21,13 @@ internal static class ConversationEndpoints
             .WithSummary("Lists the current user's conversations.")
             .WithDescription("Returns the caller's own conversations, newest first, without their messages.")
             .Produces<IReadOnlyList<ConversationSummaryResponse>>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIChatPermissions.Conversations.Read);
 
         group.MapGet("/{id:guid}", GetByIdAsync)
             .WithName("GetConversation")
             .WithSummary("Returns one of the current user's conversations by ID.")
-            .WithDescription("Returns the conversation and its messages. Scoped to the caller: another user's conversation is reported as not found.")
+            .WithDescription("Returns the conversation's metadata (title, favorite, timestamps); its messages are paged separately via GET /{id}/messages. Scoped to the caller: another user's conversation is reported as not found.")
             .Produces<ConversationResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Read);
 
@@ -39,7 +37,6 @@ internal static class ConversationEndpoints
             .WithDescription("Creates an empty conversation with the given title, owned by the caller.")
             .Produces<ConversationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIChatPermissions.Conversations.Manage);
 
         group.MapPut("/{id:guid}/title", RenameAsync)
@@ -48,7 +45,6 @@ internal static class ConversationEndpoints
             .WithDescription("Updates the conversation title. Scoped to the caller: another user's conversation is reported as not found.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Manage);
 
@@ -58,7 +54,6 @@ internal static class ConversationEndpoints
             .WithDescription("Sets the conversation's favorite flag to the requested state (idempotent, not a toggle). Scoped to the caller: another user's conversation is reported as not found.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Manage);
 
@@ -67,7 +62,6 @@ internal static class ConversationEndpoints
             .WithSummary("Deletes one of the current user's conversations.")
             .WithDescription("Soft-deletes the conversation. Scoped to the caller: another user's conversation is reported as not found.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Delete);
 
@@ -101,7 +95,7 @@ internal static class ConversationEndpoints
             return Unauthorized();
         }
 
-        Conversation? conversation = await store.GetAsync(id, ownerId, cancellationToken).ConfigureAwait(false);
+        Conversation? conversation = await store.GetMetadataAsync(id, ownerId, cancellationToken).ConfigureAwait(false);
         return conversation is null
             ? TypedResults.Problem(statusCode: StatusCodes.Status404NotFound)
             : TypedResults.Ok(ConversationResponse.FromAggregate(conversation));

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/MessageReportEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/MessageReportEndpoints.cs
@@ -25,7 +25,6 @@ internal static class MessageReportEndpoints
                 + "user-entered reason — never the message content (ADR-071).")
             .Produces(StatusCodes.Status202Accepted)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(AIChatPermissions.Conversations.Report);
 

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/AIChatDbContext.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/AIChatDbContext.cs
@@ -11,6 +11,12 @@ namespace Granit.AI.Chat.EntityFrameworkCore.Internal;
 /// Isolated, tenant-aware DbContext for chat conversations. Inherits <see cref="GranitDbContext"/>
 /// so the multi-tenant query filter is parameterised per request.
 /// </summary>
+/// <remarks>
+/// <paramref name="currentTenant"/> is non-nullable by design: the base <see cref="GranitDbContext"/>
+/// owns the tenant context and rejects null. The "optional <c>ICurrentTenant?</c>" convention applies
+/// only to contexts that do not inherit <see cref="GranitDbContext"/> and pass the tenant to
+/// <c>ApplyGranitConventions</c> themselves.
+/// </remarks>
 internal sealed class AIChatDbContext(
     DbContextOptions<AIChatDbContext> options,
     ICurrentTenant currentTenant,

--- a/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/Internal/EfConversationStore.cs
@@ -32,6 +32,18 @@ internal sealed class EfConversationStore(
             .ConfigureAwait(false);
     }
 
+    public async Task<Conversation?> GetMetadataAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default)
+    {
+        // No message include: the GET-by-id endpoint only needs metadata, and clients page the
+        // thread via GetMessagesPageAsync. Loading the whole history here would scale with thread
+        // length on every header read.
+        await using AIChatDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.Conversations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id && c.OwnerId == ownerId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<PagedResult<Message>?> GetMessagesPageAsync(
         Guid conversationId,
         Guid ownerId,

--- a/src/Granit.AI.Chat.Privacy/DataDeletion/ConversationPersonalDataDeletionHandler.cs
+++ b/src/Granit.AI.Chat.Privacy/DataDeletion/ConversationPersonalDataDeletionHandler.cs
@@ -5,7 +5,8 @@ using Granit.Privacy.DataDeletion.Events;
 namespace Granit.AI.Chat.Privacy.DataDeletion;
 
 /// <summary>
-/// Wolverine handler that erases a data subject's conversations (and their messages) on a
+/// Wolverine handler that erases a data subject's conversations — including their messages and any
+/// message reports (the user-entered report reason is free-text personal data) — on a
 /// <see cref="PersonalDataDeletionRequestedEto"/> (GDPR Art. 17). Hard deletes via
 /// <see cref="IConversationDataManager.EraseOwnerAsync"/> — soft delete would leave the message
 /// content recoverable, which the right to erasure forbids.

--- a/src/Granit.AI.Chat.Privacy/DataExport/AIChatPersonalDataExportHandler.cs
+++ b/src/Granit.AI.Chat.Privacy/DataExport/AIChatPersonalDataExportHandler.cs
@@ -10,7 +10,7 @@ namespace Granit.AI.Chat.Privacy.DataExport;
 /// </summary>
 public class AIChatPersonalDataExportHandler
 {
-    public static Task HandleAsync(
+    public static Task Handle(
         PersonalDataRequestedEto request,
         ConversationPrivacyDataProvider provider,
         PrivacyFragmentUploader uploader,

--- a/src/Granit.AI.Chat.Privacy/README.md
+++ b/src/Granit.AI.Chat.Privacy/README.md
@@ -5,7 +5,8 @@ personal data, so this package makes them participate in the `Granit.Privacy` fl
 
 - **Take-out (Art. 15/20)** — `ConversationPrivacyDataProvider` exports the user's conversations
   (with messages) as a staged JSON fragment in the scatter-gather export saga.
-- **Erasure (Art. 17)** — a personal-data deletion handler hard-deletes the subject's conversations
+- **Erasure (Art. 17)** — a personal-data deletion handler hard-deletes the subject's conversations,
+  their messages, and any message reports (the user-entered report reason is free-text personal data)
   on account deletion (soft delete would leave message content recoverable).
 
 Attachment *content* is transient and owned by the application's blob store, which contributes its

--- a/src/Granit.AI.Chat/IConversationStore.cs
+++ b/src/Granit.AI.Chat/IConversationStore.cs
@@ -14,7 +14,20 @@ public interface IConversationStore
     Task<Conversation> CreateAsync(Conversation conversation, CancellationToken cancellationToken = default);
 
     /// <summary>Returns the owner's conversation including its messages, or <see langword="null"/>.</summary>
+    /// <remarks>
+    /// Materialises the full message history; this is the variant the chat turn needs to send the
+    /// thread to the model. For metadata-only reads (the GET-by-id endpoint) use
+    /// <see cref="GetMetadataAsync"/>, which skips the message include.
+    /// </remarks>
     Task<Conversation?> GetAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the owner's conversation <b>without</b> its messages, or <see langword="null"/>.
+    /// Backs the GET-by-id endpoint, whose clients page the thread separately via
+    /// <see cref="GetMessagesPageAsync"/>; skipping the message include avoids loading an entire
+    /// history just to read the conversation's metadata (title, favorite flag, timestamps).
+    /// </summary>
+    Task<Conversation?> GetMetadataAsync(Guid id, Guid ownerId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns one backwards-paginated page of the owner's conversation messages (newest first),

--- a/src/Granit.AI.Prompts.Endpoints/Endpoints/PromptCatalogueEndpoints.cs
+++ b/src/Granit.AI.Prompts.Endpoints/Endpoints/PromptCatalogueEndpoints.cs
@@ -24,7 +24,6 @@ internal static class PromptCatalogueEndpoints
             .WithSummary("Lists the caller's prompt catalogue.")
             .WithDescription("Returns the framework-seeded system prompts plus the caller's own prompts, system prompts first then by name, without their instruction text.")
             .Produces<IReadOnlyList<PromptSummaryResponse>>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIPromptsPermissions.Templates.Read);
 
         group.MapGet("/picker", PickerAsync)
@@ -32,7 +31,6 @@ internal static class PromptCatalogueEndpoints
             .WithSummary("Returns the catalogue grouped by category for the chat picker.")
             .WithDescription("Returns the caller's catalogue grouped by category, each prompt carrying its icon, colour, and short description. Uncategorised prompts fall under the \"General\" group.")
             .Produces<PromptPickerResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIPromptsPermissions.Templates.Read);
 
         group.MapGet("/{id:guid}", GetByIdAsync)
@@ -41,7 +39,6 @@ internal static class PromptCatalogueEndpoints
             .WithDescription("Returns the prompt with its instruction text. Scoped to the caller: another user's private prompt is reported as not found.")
             .Produces<PromptResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIPromptsPermissions.Templates.Read);
 
         group.MapPost("/", CreateAsync)
@@ -50,7 +47,6 @@ internal static class PromptCatalogueEndpoints
             .WithDescription("Creates a private prompt with the given content, decoration, and categories, owned by the caller. Returns 422 when a referenced category does not exist.")
             .Produces<PromptResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(AIPromptsPermissions.Templates.Manage);
 
@@ -61,7 +57,6 @@ internal static class PromptCatalogueEndpoints
             .Produces<PromptResponse>()
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(AIPromptsPermissions.Templates.Manage);
 
@@ -72,7 +67,6 @@ internal static class PromptCatalogueEndpoints
             .Produces<PromptResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIPromptsPermissions.Templates.Manage);
 
         group.MapDelete("/{id:guid}", DeleteAsync)
@@ -81,7 +75,6 @@ internal static class PromptCatalogueEndpoints
             .WithDescription("Deletes the prompt. System prompts cannot be deleted; another user's prompt is reported as not found.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AIPromptsPermissions.Templates.Delete);
 
         return group;

--- a/src/Granit.Hostnames.Endpoints/Endpoints/HostnamesWriteEndpoints.cs
+++ b/src/Granit.Hostnames.Endpoints/Endpoints/HostnamesWriteEndpoints.cs
@@ -65,7 +65,6 @@ internal static class HostnamesWriteEndpoints
             .WithSummary("Reports the SSL/TLS certificate status from the edge provider.")
             .WithDescription("Webhook endpoint called by the edge provider (e.g. Cloudflare, AWS) when the certificate state changes. The request must carry a valid HMAC-SHA-256 signature in the configured header when Hostnames:CertificateWebhookSecret is set. Stores the new CertificateStatus and expiry date, and dispatches the appropriate integration event (HostnameCertificateSecuredEto or HostnameCertificateFailedEto). Idempotent: repeated delivery of the same status does not re-raise events. Returns 204 on success, 404 when not found. Requires the Hostnames.Certificates.Report permission.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;

--- a/src/Granit.Http.SecurityHeaders.Endpoints/Endpoints/CspAuditEndpoints.cs
+++ b/src/Granit.Http.SecurityHeaders.Endpoints/Endpoints/CspAuditEndpoints.cs
@@ -29,9 +29,7 @@ internal static class CspAuditEndpoints
                 "implementations. Contributors that branch on request-scoped state beyond " +
                 "endpoint metadata (e.g. authenticated user, tenant) will under-report — the " +
                 "audit synthesises requests carrying only the matched endpoint.")
-            .Produces<CspAuditResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
-            .ProducesProblem(StatusCodes.Status403Forbidden);
+            .Produces<CspAuditResponse>();
     }
 
     internal static Ok<CspAuditResponse> HandleGetCspAudit(

--- a/src/Granit.Identity.Endpoints/Endpoints/MyUserDeviceEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/MyUserDeviceEndpoints.cs
@@ -24,8 +24,7 @@ internal static class MyUserDeviceEndpoints
             .WithDescription(
                 "Returns the devices the authenticated user has signed in from — device type, OS, browser, "
                 + "last activity and approximate location — aggregated across the configured session backend.")
-            .Produces<IReadOnlyList<UserDeviceResponse>>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces<IReadOnlyList<UserDeviceResponse>>();
 
         group.MapPost("/trust", TrustAsync)
             .WithName("TrustMyDevice")
@@ -34,8 +33,7 @@ internal static class MyUserDeviceEndpoints
                 "Binds the current browser to a stable device identity (signed cookie) and records a trust "
                 + "verdict for the configured duration. A trusted device may, when the deployment opts in, skip "
                 + "the two-factor step-up on subsequent logins.")
-            .Produces<DeviceTrustedResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces<DeviceTrustedResponse>();
 
         group.MapDelete("/{deviceId}/trust", RevokeTrustAsync)
             .WithName("RevokeMyDeviceTrust")
@@ -43,8 +41,7 @@ internal static class MyUserDeviceEndpoints
             .WithDescription(
                 "Removes the trust verdict for the given device id. When it is the current device, the signed "
                 + "device-trust cookie is also cleared so the device is no longer recognised.")
-            .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status204NoContent);
 
         return group;
     }

--- a/src/Granit.Identity.Endpoints/Endpoints/MyUserSessionEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/MyUserSessionEndpoints.cs
@@ -28,23 +28,20 @@ internal static class MyUserSessionEndpoints
                 "Returns the authenticated user's active sessions across the configured backend "
                 + "(BFF, OpenIddict or Keycloak), each enriched with its approximate location and persisted "
                 + "risk level. The current session is flagged. Raw IP addresses are never returned.")
-            .Produces<IReadOnlyList<UserSessionResponse>>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces<IReadOnlyList<UserSessionResponse>>();
 
         group.MapDelete("/{sessionId}", RevokeAsync)
             .WithName("RevokeMyUserSession")
             .WithSummary("Revokes one of the caller's sessions by ID.")
             .WithDescription("Revokes the specified session of the authenticated user. Returns 404 when no such session exists.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapDelete("/", RevokeOthersAsync)
             .WithName("RevokeMyOtherUserSessions")
             .WithSummary("Revokes all of the caller's sessions except the current one.")
             .WithDescription("Revokes every session of the authenticated user except the one making the request, and returns how many were revoked.")
-            .Produces<UserSessionsRevokedResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces<UserSessionsRevokedResponse>();
 
         return group;
     }

--- a/src/Granit.Presence.Endpoints/Endpoints/PresenceRoomEndpoints.cs
+++ b/src/Granit.Presence.Endpoints/Endpoints/PresenceRoomEndpoints.cs
@@ -31,7 +31,6 @@ internal static class PresenceRoomEndpoints
             .RequireAuthorization(PresencePermissions.Rooms.Join)
             .Produces<ResourceRoomResponse>()
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
@@ -43,7 +42,6 @@ internal static class PresenceRoomEndpoints
             .RequireAuthorization(PresencePermissions.Rooms.Read)
             .Produces<ResourceRoomResponse>()
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
@@ -55,7 +53,6 @@ internal static class PresenceRoomEndpoints
             .RequireAuthorization(PresencePermissions.Rooms.Join)
             .Produces(StatusCodes.Status204NoContent)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;

--- a/src/Granit.Presence.Endpoints/Endpoints/PresenceSelfEndpoints.cs
+++ b/src/Granit.Presence.Endpoints/Endpoints/PresenceSelfEndpoints.cs
@@ -23,8 +23,7 @@ internal static class PresenceSelfEndpoints
             .WithName("GetMyPresence")
             .WithSummary("Returns the caller's current presence snapshot.")
             .WithDescription("Computes the effective presence status for the authenticated user by blending their manual override (if any) with their last reported heartbeat.")
-            .Produces<PresenceResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces<PresenceResponse>();
 
         group.MapPut("/my", SetMyPresenceAsync)
             .WithName("SetMyPresence")
@@ -33,7 +32,6 @@ internal static class PresenceSelfEndpoints
             .RequireGranitRateLimiting(PresenceRateLimitPolicies.Mutate)
             .Produces<PresenceResponse>()
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapDelete("/my/override", ClearMyPresenceAsync)
@@ -42,7 +40,6 @@ internal static class PresenceSelfEndpoints
             .WithDescription("Removes any active manual override so the effective status is derived from the heartbeat alone.")
             .RequireGranitRateLimiting(PresenceRateLimitPolicies.Mutate)
             .Produces<PresenceResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/my/poll", PollMyPresenceAsync)
@@ -52,7 +49,6 @@ internal static class PresenceSelfEndpoints
             .RequireGranitRateLimiting(PresenceRateLimitPolicies.Poll)
             .Produces<PresenceResponse>()
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportDownloadEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportDownloadEndpoints.cs
@@ -45,7 +45,6 @@ internal static class PrivacyExportDownloadEndpoints
                 + "GET /exports/{requestId}/download/manifest to discover the shard count. "
                 + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
             .Produces(StatusCodes.Status200OK, contentType: "application/octet-stream")
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
@@ -58,7 +57,6 @@ internal static class PrivacyExportDownloadEndpoints
                 + "the shard count and per-shard sha256/integrity tag before pulling each ZIP. "
                 + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
             .Produces(StatusCodes.Status200OK, contentType: "application/json")
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
@@ -71,7 +69,6 @@ internal static class PrivacyExportDownloadEndpoints
                 + "Shard indices outside the manifest's bounds return 404. "
                 + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
             .Produces(StatusCodes.Status200OK, contentType: "application/zip")
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 

--- a/src/Granit.Timeline.Endpoints/Endpoints/ReactionEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/ReactionEndpoints.cs
@@ -32,8 +32,7 @@ internal static class ReactionEndpoints
             .WithSummary("Toggles a reaction on a timeline entry by the calling user.")
             .WithDescription("Idempotent toggle — adds the reaction if absent, removes if present. Accepts any well-formed Unicode emoji sequence (see EmojiValidator); rejects malformed input with 400 and Granit:Timeline:InvalidEmoji. Emits ReactionToggledEvent on the local bus on success. Concurrent double-POST is collapsed by the unique (EntryId, UserId, Emoji) DB index.")
             .Produces<ReactionToggleResponse>()
-            .ProducesProblem(StatusCodes.Status400BadRequest)
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .ProducesProblem(StatusCodes.Status400BadRequest);
 
         return group;
     }

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
@@ -110,7 +110,7 @@ public sealed class ChatEndpointsHttpTests
     public async Task GetById_returns_404_when_absent()
     {
         var id = Guid.NewGuid();
-        _store.GetAsync(id, Owner, Arg.Any<CancellationToken>()).Returns((Conversation?)null);
+        _store.GetMetadataAsync(id, Owner, Arg.Any<CancellationToken>()).Returns((Conversation?)null);
         await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
 
         HttpResponseMessage response = await FullAccess(host).GetAsync($"/conversations/{id}", TestContext.Current.CancellationToken);
@@ -122,7 +122,7 @@ public sealed class ChatEndpointsHttpTests
     public async Task GetById_returns_the_conversation_when_found()
     {
         var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Found");
-        _store.GetAsync(conversation.Id, Owner, Arg.Any<CancellationToken>()).Returns(conversation);
+        _store.GetMetadataAsync(conversation.Id, Owner, Arg.Any<CancellationToken>()).Returns(conversation);
         await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
 
         HttpResponseMessage response = await FullAccess(host).GetAsync($"/conversations/{conversation.Id}", TestContext.Current.CancellationToken);

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ConversationEndpointsUnitTests.cs
@@ -145,7 +145,7 @@ public sealed class ConversationEndpointsUnitTests
     }
 
     [Fact]
-    public void Response_projects_the_aggregate_with_messages()
+    public void Response_projects_the_aggregate_metadata()
     {
         var conversation = Conversation.Create(Guid.NewGuid(), Guid.NewGuid(), "Chat");
         conversation.AddMessage(Guid.NewGuid(), MessageRole.Assistant, "Hi");
@@ -156,9 +156,6 @@ public sealed class ConversationEndpointsUnitTests
         response.Title.ShouldBe("Chat");
         response.OwnerId.ShouldBe(conversation.OwnerId);
         response.IsFavorite.ShouldBeTrue();
-        MessageResponse message = response.Messages.ShouldHaveSingleItem();
-        message.Role.ShouldBe("assistant");
-        message.Content.ShouldBe("Hi");
     }
 
     [Fact]

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationStoreTests.cs
@@ -50,6 +50,29 @@ public sealed class EfConversationStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetMetadata_returns_the_owner_conversation_without_loading_messages()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Brief", "hi", "there");
+
+        Conversation? loaded = await _sut.GetMetadataAsync(seeded.Id, UserA, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Title.ShouldBe("Brief");
+        // Metadata read: the message collection is not materialised even though the thread has rows.
+        loaded.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMetadata_does_not_return_another_users_conversation()
+    {
+        Conversation seeded = await SeedAsync(UserA, "Private");
+
+        Conversation? loaded = await _sut.GetMetadataAsync(seeded.Id, UserB, TestContext.Current.CancellationToken);
+
+        loaded.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task List_returns_only_the_owners_conversations()
     {
         await SeedAsync(UserA, "A1");


### PR DESCRIPTION
## Summary

Outcome of a `/audit Chat IA` pass over the `Granit.AI.Chat*` module family, plus the metadata-only GET-by-id refactor it surfaced and a repo-wide OpenAPI redundancy sweep.

### `refactor(ai-chat)` — commit 1
- **Metadata-only detail read.** `GET /conversations/{id}` returns metadata only (title, favorite, timestamps) via the new `IConversationStore.GetMetadataAsync`; the thread is paged separately via `GET /{id}/messages`. `ConversationResponse` drops its `Messages` field so detail reads never materialise an entire history.
- **Audit fixes:** removed redundant `.ProducesProblem(401/422)` on chat endpoints (auto-injected by `ProblemDetailsResponseOperationTransformer`); named message reports in the GDPR Art. 17 erasure surface (deletion handler doc + README — the report reason is free-text PII); normalised the export handler method to `Handle`; documented why `AIChatDbContext`'s `ICurrentTenant` is non-nullable.

### `chore(openapi)` — commit 2
- Dropped **29 redundant `ProducesProblem(401)`** (+1 generic 403) across Prompts, Hostnames, SecurityHeaders, Identity, Presence, Privacy and Timeline endpoints. **Kept** them on genuinely anonymous endpoints (login, passkey, CSRF, signed webhook, conditional OData) where the transformer does not inject and the contract entry would be lost.

## Audit verdict

`Granit.AI.Chat*` is **COMPLIANT** — 0 BREAKING / 0 ARCHITECTURE findings. DDD, layer purity, enum persistence, GDPR-symmetric privacy handlers, isolated tenant-aware DbContext, keyset pagination and 18-culture localization all verified correct. Chat metrics/tracing are deliberately owned by `Granit.AI` (`AIMetrics` / `AIChatTracingProfile`).

## Verification

- Builds: AI.Chat.Endpoints / Privacy / EFCore — 0 warnings, 0 errors.
- Tests (all green): AI.Chat.Endpoints 48, EFCore 25, Privacy 9, Prompts 21, Hostnames 33, SecurityHeaders 7, Presence 12, Timeline 66, Privacy.Endpoints 145, Identity.Endpoints 196.
- `dotnet format --verify-no-changes` clean on every touched project.