### PR TITLE
fix(sonar): resolve code-smell and architecture issues across 6 modules

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -34105,8 +34105,15 @@
       "kind": "class",
       "project": "Granit.Localization.AI",
       "file": "src/Granit.Localization.AI/GranitLocalizationAIModule.cs",
-      "line": 16,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "ITranslationSuggestionService",

--- a/src/Granit.Authentication.DPoP/Middleware/DPoPValidationMiddleware.cs
+++ b/src/Granit.Authentication.DPoP/Middleware/DPoPValidationMiddleware.cs
@@ -28,13 +28,11 @@ internal sealed partial class DPoPValidationMiddleware(
         // replay protection. Validating the same proof here first would make the server handler
         // see a duplicate jti → "proof replay detected" → token exchange fails. See
         // DPoPValidationOptions.ExcludedPathPrefixes.
-        foreach (string prefix in opts.ExcludedPathPrefixes)
+        if (opts.ExcludedPathPrefixes.Any(p =>
+                context.Request.Path.StartsWithSegments(p, StringComparison.OrdinalIgnoreCase)))
         {
-            if (context.Request.Path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase))
-            {
-                await next(context).ConfigureAwait(false);
-                return;
-            }
+            await next(context).ConfigureAwait(false);
+            return;
         }
 
         // Only process authenticated requests with DPoP header or when DPoP is required

--- a/src/Granit.Localization.AI/Granit.Localization.AI.csproj
+++ b/src/Granit.Localization.AI/Granit.Localization.AI.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
     <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />

--- a/src/Granit.Localization.AI/GranitLocalizationAIModule.cs
+++ b/src/Granit.Localization.AI/GranitLocalizationAIModule.cs
@@ -1,5 +1,7 @@
 using Granit.AI;
 using Granit.AI.Tools;
+using Granit.Localization.AI.Internal;
+using Granit.Localization.Extensions;
 using Granit.Modularity;
 
 namespace Granit.Localization.AI;
@@ -13,4 +15,9 @@ namespace Granit.Localization.AI;
 /// (e.g. <c>Granit.AI.OpenAI</c>) to function.
 /// </remarks>
 [DependsOn(typeof(GranitAIModule), typeof(GranitAIToolsModule), typeof(GranitLocalizationModule))]
-public sealed class GranitLocalizationAIModule : GranitModule;
+public sealed class GranitLocalizationAIModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddLocalizationResource<LocalizationAILocalizationResource>();
+}

--- a/src/Granit.Localization.AI/Internal/LocalizationAILocalizationResource.cs
+++ b/src/Granit.Localization.AI/Internal/LocalizationAILocalizationResource.cs
@@ -1,0 +1,4 @@
+namespace Granit.Localization.AI.Internal;
+
+[LocalizationResourceName("LocalizationAI", DefaultCulture = "en")]
+internal sealed class LocalizationAILocalizationResource;

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/cs.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/cs.json
@@ -1,0 +1,6 @@
+{
+  "culture": "cs",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Použít nástroj překladu AI"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/de.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/de.json
@@ -1,0 +1,6 @@
+{
+  "culture": "de",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "KI-Übersetzungstool verwenden"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/en-GB.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/en.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/en.json
@@ -1,0 +1,6 @@
+{
+  "culture": "en",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Use the AI translation tool"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/es.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/es.json
@@ -1,0 +1,6 @@
+{
+  "culture": "es",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Usar la herramienta de traducción de IA"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/fr-CA.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/fr-CA.json
@@ -1,0 +1,4 @@
+{
+  "culture": "fr-CA",
+  "texts": {}
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/fr.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/fr.json
@@ -1,0 +1,6 @@
+{
+  "culture": "fr",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Utiliser l'outil de traduction IA"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/hi.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/hi.json
@@ -1,0 +1,6 @@
+{
+  "culture": "hi",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "एआई अनुवाद टूल का उपयोग करें"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/it.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/it.json
@@ -1,0 +1,6 @@
+{
+  "culture": "it",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Usare lo strumento di traduzione IA"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/ja.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/ja.json
@@ -1,0 +1,6 @@
+{
+  "culture": "ja",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "AI翻訳ツールを使用する"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/ko.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/ko.json
@@ -1,0 +1,6 @@
+{
+  "culture": "ko",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "AI 번역 도구 사용"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/nl.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/nl.json
@@ -1,0 +1,6 @@
+{
+  "culture": "nl",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "De AI-vertaaltool gebruiken"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/pl.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/pl.json
@@ -1,0 +1,6 @@
+{
+  "culture": "pl",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Korzystanie z narzędzia tłumaczenia AI"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/pt-BR.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "culture": "pt-BR",
+  "texts": {}
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/pt.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/pt.json
@@ -1,0 +1,6 @@
+{
+  "culture": "pt",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Usar a ferramenta de tradução de IA"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/sv.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/sv.json
@@ -1,0 +1,6 @@
+{
+  "culture": "sv",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Använd AI-översättningsverktyget"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/tr.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/tr.json
@@ -1,0 +1,6 @@
+{
+  "culture": "tr",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "Yapay zeka çeviri aracını kullan"
+  }
+}

--- a/src/Granit.Localization.AI/Localization/LocalizationAI/zh.json
+++ b/src/Granit.Localization.AI/Localization/LocalizationAI/zh.json
@@ -1,0 +1,6 @@
+{
+  "culture": "zh",
+  "texts": {
+    "Permission:AI.ChatTools.Translate": "使用 AI 翻译工具"
+  }
+}

--- a/src/Granit.Localization.AI/Permissions/LocalizationAIPermissionDefinitionProvider.cs
+++ b/src/Granit.Localization.AI/Permissions/LocalizationAIPermissionDefinitionProvider.cs
@@ -1,5 +1,5 @@
-using Granit.AI;
 using Granit.Authorization;
+using Granit.Localization.AI.Internal;
 
 namespace Granit.Localization.AI.Permissions;
 
@@ -10,22 +10,20 @@ namespace Granit.Localization.AI.Permissions;
 /// <remarks>
 /// Auto-discovered by <c>GranitAuthorizationModule</c>'s reflection scan over module assemblies.
 /// The <c>AI</c> group is also declared by <c>Granit.AI</c>; <see cref="IPermissionDefinitionContext.AddGroup"/>
-/// has GetOrAdd semantics, so both providers contribute to the one group and the group's display
-/// strings stay in the shared <see cref="AILocalizationResource"/> bundle.
+/// has GetOrAdd semantics, so the group's display string is already set by <c>Granit.AI</c>'s
+/// own provider and the <c>null</c> display here is intentionally ignored.
 /// </remarks>
 internal sealed class LocalizationAIPermissionDefinitionProvider : IPermissionDefinitionProvider
 {
     /// <inheritdoc />
     public void DefinePermissions(IPermissionDefinitionContext context)
     {
-        PermissionGroup group = context.AddGroup(
-            LocalizationAIPermissions.GroupName,
-            LocalizableString.Create<AILocalizationResource>("PermissionGroup:AI"));
+        PermissionGroup group = context.AddGroup(LocalizationAIPermissions.GroupName);
 
         // Per-tool gating for the translate chat tool (ADR-067). Off by default — an admin grants
         // the tool's permission to enable it for a user or role.
         group.AddPermission(
             LocalizationAIPermissions.ChatTools.Translate,
-            LocalizableString.Create<AILocalizationResource>("Permission:AI.ChatTools.Translate"));
+            LocalizableString.Create<LocalizationAILocalizationResource>("Permission:AI.ChatTools.Translate"));
     }
 }

--- a/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/DPoPValidationTokenExtractionHandler.cs
@@ -25,9 +25,9 @@ public sealed class DPoPValidationTokenExtractionHandler
     // Run one slot after the built-in Bearer extractor so this acts as a fallback.
     // Reference its public Descriptor.Order rather than a hardcoded constant: the
     // order then tracks the built-in automatically across OpenIddict version bumps.
-    private static readonly int HandlerOrder = checked((int)(
+    private static readonly int HandlerOrder = checked(
         OpenIddictValidationAspNetCoreHandlers.ExtractAccessTokenFromAuthorizationHeader
-            .Descriptor.Order + 1));
+            .Descriptor.Order + 1);
 
     /// <summary>Handler descriptor registered with the OpenIddict validation pipeline.</summary>
     public static OpenIddictValidationHandlerDescriptor Descriptor { get; }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
@@ -351,13 +351,16 @@ internal static class FilterExpressionBuilder
         }
         catch (Exception ex)
         {
-            if (logger is not null)
-            {
-                QueryEngineEfCoreLog.FilterValueConversionFailed(
-                    logger, field ?? "(unknown)", targetType.Name, ex);
-            }
-
+            LogConversionFailure(logger, field, targetType, ex);
             return null;
+        }
+    }
+
+    private static void LogConversionFailure(ILogger? logger, string? field, Type targetType, Exception ex)
+    {
+        if (logger is not null)
+        {
+            QueryEngineEfCoreLog.FilterValueConversionFailed(logger, field ?? "(unknown)", targetType.Name, ex);
         }
     }
 

--- a/tests/Granit.AI.Tools.Tests/ReasoningTextFilterTests.cs
+++ b/tests/Granit.AI.Tools.Tests/ReasoningTextFilterTests.cs
@@ -15,58 +15,40 @@ public sealed class ReasoningTextFilterTests
     }
 
     [Fact]
-    public void Passes_text_through_unchanged_when_there_is_no_think_block()
-    {
+    public void Passes_text_through_unchanged_when_there_is_no_think_block() =>
         Run("The answer is 42.").ShouldBe("The answer is 42.");
-    }
 
     [Fact]
-    public void Strips_a_leading_think_block_and_the_blank_gap_it_leaves()
-    {
+    public void Strips_a_leading_think_block_and_the_blank_gap_it_leaves() =>
         Run("<think>weighing options</think>\n\nThe answer is 42.").ShouldBe("The answer is 42.");
-    }
 
     [Fact]
-    public void Strips_a_think_block_split_across_several_deltas()
-    {
+    public void Strips_a_think_block_split_across_several_deltas() =>
         Run("<thi", "nk>secret reas", "oning</thi", "nk>visible").ShouldBe("visible");
-    }
 
     [Fact]
-    public void Strips_the_open_close_tags_when_each_straddles_a_delta_boundary()
-    {
+    public void Strips_the_open_close_tags_when_each_straddles_a_delta_boundary() =>
         Run("answer one <", "think>hidden</", "think> answer two")
             .ShouldBe("answer one  answer two");
-    }
 
     [Fact]
-    public void Keeps_text_that_only_looks_like_the_start_of_a_tag()
-    {
+    public void Keeps_text_that_only_looks_like_the_start_of_a_tag() =>
         // "<thx" can never become "<think>", so the held tail must be released as ordinary text.
         Run("a <thx b").ShouldBe("a <thx b");
-    }
 
     [Fact]
-    public void Drops_an_unterminated_think_block()
-    {
+    public void Drops_an_unterminated_think_block() =>
         Run("<think>reasoning that never closes").ShouldBe(string.Empty);
-    }
 
     [Fact]
-    public void Removes_multiple_think_blocks()
-    {
+    public void Removes_multiple_think_blocks() =>
         Run("<think>one</think>kept<think>two</think> end").ShouldBe("kept end");
-    }
 
     [Fact]
-    public void Matches_tags_case_insensitively()
-    {
+    public void Matches_tags_case_insensitively() =>
         Run("<THINK>x</Think>y").ShouldBe("y");
-    }
 
     [Fact]
-    public void Trims_only_the_leading_whitespace_not_internal_blank_lines()
-    {
+    public void Trims_only_the_leading_whitespace_not_internal_blank_lines() =>
         Run("<think>r</think>\n\nline one\n\nline two").ShouldBe("line one\n\nline two");
-    }
 }

--- a/tests/Granit.OpenIddict.Server.Tests/Handlers/DPoPValidationTokenExtractionHandlerTests.cs
+++ b/tests/Granit.OpenIddict.Server.Tests/Handlers/DPoPValidationTokenExtractionHandlerTests.cs
@@ -97,7 +97,7 @@ public sealed class DPoPValidationTokenExtractionHandlerTests
             httpContext.Request.Path = "/resource";
             if (authorization is not null)
             {
-                httpContext.Request.Headers["Authorization"] = authorization;
+                httpContext.Request.Headers.Authorization = authorization;
             }
 
             // OpenIddictValidationAspNetCoreHelpers.GetHttpRequest() reads a

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/ValueObjectColumnTranslationTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/ValueObjectColumnTranslationTests.cs
@@ -36,10 +36,8 @@ public sealed class ValueObjectColumnTranslationTests : IDisposable
     }
 
     [Fact]
-    public void Eq_filter_translates_and_matches_the_value()
-    {
+    public void Eq_filter_translates_and_matches_the_value() =>
         Query(new("Slug", FilterOperator.Eq, "beta")).ShouldBe(["beta"]);
-    }
 
     [Fact]
     public void In_filter_translates_to_sql_in()
@@ -54,11 +52,8 @@ public sealed class ValueObjectColumnTranslationTests : IDisposable
     [InlineData(FilterOperator.EndsWith)]
     [InlineData(FilterOperator.Gt)]
     [InlineData(FilterOperator.Lt)]
-    public void Unsupported_operators_are_dropped_not_thrown(FilterOperator op)
-    {
-        // The criterion produces no predicate (dropped) — never a mistranslation or a throw.
+    public void Unsupported_operators_are_dropped_not_thrown(FilterOperator op) =>
         FilterExpressionBuilder.Build<VoProbe>(new("Slug", op, "beta")).ShouldBeNull();
-    }
 
     [Fact]
     public void Sorting_by_a_value_object_column_translates()


### PR DESCRIPTION
## Summary

- **DPoPValidationMiddleware**: `foreach`+`if` → `Any()` (S3267)
- **DPoPValidationTokenExtractionHandler**: drop redundant `(int)` cast from `checked(...)` — `Order` is already `int`
- **FilterExpressionBuilder**: extract `LogConversionFailure` helper to bring cognitive complexity from 17 → 15 (S3776)
- **LocalizationAIPermissionDefinitionProvider** _(architecture fix)_: `Granit.Localization.AI` was referencing `AILocalizationResource` from `Granit.AI` in its permission provider — a disallowed cross-module relationship. Created `LocalizationAILocalizationResource` (internal marker + 18-culture JSON pack with `Permission:AI.ChatTools.Translate`) so the module uses its own resource. The group display string is intentionally `null` — `AddGroup` has GetOrAdd semantics and `Granit.AI`'s own provider sets it first.
- **Test files**: expression-body methods (Info nits) + `Headers.Authorization` typed property

## Test plan

- [ ] `dotnet build src/Granit.Authentication.DPoP` ✅
- [ ] `dotnet build src/Granit.OpenIddict.Server` ✅
- [ ] `dotnet build src/Granit.QueryEngine.EntityFrameworkCore` ✅
- [ ] `dotnet build src/Granit.Localization.AI` ✅
- [ ] `dotnet test tests/Granit.AI.Tools.Tests` — 58 passed ✅
- [ ] `dotnet test tests/Granit.OpenIddict.Server.Tests` — 32 passed ✅
- [ ] `dotnet test tests/Granit.QueryEngine.EntityFrameworkCore.Tests` — 203 passed ✅
- [ ] `dotnet test tests/Granit.ArchitectureTests` — 227 passed ✅