### PR TITLE
feat(ai-chat): expose workspaceKey on conversation responses + workspaceModelName on workspace DTOs

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3502,7 +3502,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 55,
+      "line": 56,
       "members": [
         {
           "name": "FromAggregate",
@@ -3559,7 +3559,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 40,
+      "line": 41,
       "members": [
         {
           "name": "FromEntity",
@@ -4486,7 +4486,7 @@
       "kind": "record",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceCreateRequest.cs",
-      "line": 12,
+      "line": 16,
       "members": []
     },
     {
@@ -4504,7 +4504,7 @@
       "kind": "record",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceResponse.cs",
-      "line": 17,
+      "line": 20,
       "members": []
     },
     {
@@ -4513,7 +4513,7 @@
       "kind": "record",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs",
-      "line": 12,
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
@@ -19,12 +19,13 @@ public sealed record ConversationSummaryResponse(
     Guid Id,
     string Title,
     bool IsFavorite,
+    string? WorkspaceKey,
     DateTimeOffset CreatedAt,
     DateTimeOffset? ModifiedAt)
 {
     /// <summary>Projects a <see cref="Conversation"/> to a summary.</summary>
     public static ConversationSummaryResponse FromAggregate(Conversation conversation) =>
-        new(conversation.Id, conversation.Title, conversation.IsFavorite, conversation.CreatedAt, conversation.ModifiedAt);
+        new(conversation.Id, conversation.Title, conversation.IsFavorite, conversation.WorkspaceKey, conversation.CreatedAt, conversation.ModifiedAt);
 }
 
 /// <summary>A message in a conversation.</summary>
@@ -57,6 +58,7 @@ public sealed record ConversationResponse(
     string Title,
     Guid OwnerId,
     bool IsFavorite,
+    string? WorkspaceKey,
     DateTimeOffset CreatedAt,
     DateTimeOffset? ModifiedAt)
 {
@@ -67,6 +69,7 @@ public sealed record ConversationResponse(
             conversation.Title,
             conversation.OwnerId,
             conversation.IsFavorite,
+            conversation.WorkspaceKey,
             conversation.CreatedAt,
             conversation.ModifiedAt);
 }

--- a/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/ConversationConfiguration.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/ConversationConfiguration.cs
@@ -20,6 +20,7 @@ internal sealed class ConversationConfiguration : IEntityTypeConfiguration<Conve
         builder.Property(e => e.Title).HasMaxLength(500).IsRequired();
         builder.Property(e => e.OwnerId).IsRequired();
         builder.Property(e => e.IsFavorite).HasDefaultValue(false);
+        builder.Property(e => e.WorkspaceKey).HasMaxLength(256);
         builder.Property(e => e.CreatedBy).HasMaxLength(256);
         builder.Property(e => e.ModifiedBy).HasMaxLength(256);
         builder.Property(e => e.DeletedBy).HasMaxLength(256);

--- a/src/Granit.AI.Chat/Domain/Conversation.cs
+++ b/src/Granit.AI.Chat/Domain/Conversation.cs
@@ -16,7 +16,11 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
     /// Creates a conversation owned by <paramref name="ownerId"/>. The tenant is stamped by the
     /// persistence interceptor on save.
     /// </summary>
-    public static Conversation Create(Guid id, Guid ownerId, string title)
+    public static Conversation Create(
+        Guid id,
+        Guid ownerId,
+        string title,
+        string? workspaceKey = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(title);
 
@@ -25,6 +29,7 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
             Id = id,
             OwnerId = ownerId,
             Title = title,
+            WorkspaceKey = workspaceKey,
         };
     }
 
@@ -36,6 +41,13 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
 
     /// <summary>Whether the owner has marked this conversation as a favorite.</summary>
     public bool IsFavorite { get; private set; }
+
+    /// <summary>
+    /// Machine key of the workspace used when the conversation was created (e.g.
+    /// <c>support-chat</c>), or <see langword="null"/> for conversations predating this field.
+    /// Frozen at creation — subsequent turns do not overwrite it.
+    /// </summary>
+    public string? WorkspaceKey { get; private set; }
 
     /// <summary>The messages exchanged, oldest first.</summary>
     public List<Message> Messages { get; private set; } = [];

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -59,7 +59,7 @@ internal sealed class ChatService(
 
         bool isNew = request.ConversationId is null;
         Conversation conversation = isNew
-            ? Conversation.Create(guidGenerator.Create(), request.OwnerId, DeriveTitle(request.Message))
+            ? Conversation.Create(guidGenerator.Create(), request.OwnerId, DeriveTitle(request.Message), workspaceName)
             : await conversationStore.GetAsync(request.ConversationId!.Value, request.OwnerId, cancellationToken).ConfigureAwait(false)
                 ?? throw new ConversationNotFoundException(request.ConversationId.Value);
 

--- a/src/Granit.AI.Endpoints/Dtos/AIWorkspaceCreateRequest.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIWorkspaceCreateRequest.cs
@@ -6,6 +6,10 @@ namespace Granit.AI.Endpoints.Dtos;
 /// <param name="Name">Unique workspace name (lowercase alphanumeric with hyphens).</param>
 /// <param name="Provider">Provider identifier (e.g. <c>OpenAI</c>, <c>AzureOpenAI</c>).</param>
 /// <param name="Model">Model identifier (e.g. <c>gpt-4o</c>).</param>
+/// <param name="WorkspaceModelName">
+/// Optional human-readable display label (e.g. <c>GPT-4o</c>, <c>Support AI</c>).
+/// When omitted, the model identifier is used as the display fallback.
+/// </param>
 /// <param name="SystemPrompt">Optional system prompt.</param>
 /// <param name="Temperature">Optional sampling temperature (0.0–2.0).</param>
 /// <param name="MaxOutputTokens">Optional maximum output tokens.</param>
@@ -13,6 +17,7 @@ public sealed record AIWorkspaceCreateRequest(
     string Name,
     string Provider,
     string Model,
+    string? WorkspaceModelName = null,
     string? SystemPrompt = null,
     float? Temperature = null,
     int? MaxOutputTokens = null) : IAIWorkspaceMutableFields;

--- a/src/Granit.AI.Endpoints/Dtos/AIWorkspaceResponse.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIWorkspaceResponse.cs
@@ -8,6 +8,9 @@ namespace Granit.AI.Endpoints.Dtos;
 /// <param name="Name">Unique workspace name.</param>
 /// <param name="Provider">Provider identifier (e.g. <c>OpenAI</c>, <c>AzureOpenAI</c>).</param>
 /// <param name="Model">Model identifier (e.g. <c>gpt-4o</c>).</param>
+/// <param name="WorkspaceModelName">
+/// Human-readable display label, or <c>null</c> when unset (fall back to <paramref name="Model"/>).
+/// </param>
 /// <param name="SystemPrompt">Optional system prompt.</param>
 /// <param name="Temperature">Sampling temperature (0.0–2.0).</param>
 /// <param name="MaxOutputTokens">Maximum tokens to generate.</param>
@@ -18,6 +21,7 @@ public sealed record AIWorkspaceResponse(
     string Name,
     string Provider,
     string Model,
+    string? WorkspaceModelName,
     string? SystemPrompt,
     float? Temperature,
     int? MaxOutputTokens,

--- a/src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs
@@ -5,6 +5,10 @@ namespace Granit.AI.Endpoints.Dtos;
 /// </summary>
 /// <param name="Provider">Provider identifier.</param>
 /// <param name="Model">Model identifier.</param>
+/// <param name="WorkspaceModelName">
+/// Optional human-readable display label (e.g. <c>GPT-4o</c>, <c>Support AI</c>).
+/// Pass <see langword="null"/> to clear the label and fall back to the model identifier.
+/// </param>
 /// <param name="SystemPrompt">Optional system prompt.</param>
 /// <param name="Temperature">Optional sampling temperature (0.0–2.0).</param>
 /// <param name="MaxOutputTokens">Optional maximum output tokens.</param>
@@ -12,6 +16,7 @@ namespace Granit.AI.Endpoints.Dtos;
 public sealed record AIWorkspaceUpdateRequest(
     string Provider,
     string Model,
+    string? WorkspaceModelName = null,
     string? SystemPrompt = null,
     float? Temperature = null,
     int? MaxOutputTokens = null,

--- a/src/Granit.AI.Endpoints/Dtos/IAIWorkspaceMutableFields.cs
+++ b/src/Granit.AI.Endpoints/Dtos/IAIWorkspaceMutableFields.cs
@@ -12,6 +12,12 @@ public interface IAIWorkspaceMutableFields
     /// <summary>Model identifier (e.g. <c>gpt-4o</c>).</summary>
     string Model { get; }
 
+    /// <summary>
+    /// Human-readable display label (e.g. <c>GPT-4o</c>, <c>Support AI</c>).
+    /// When <see langword="null"/>, the model identifier is used as the display fallback.
+    /// </summary>
+    string? WorkspaceModelName { get; }
+
     /// <summary>Optional system prompt.</summary>
     string? SystemPrompt { get; }
 

--- a/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
@@ -128,6 +128,7 @@ internal static class AIWorkspaceEndpoints
             Name = request.Name,
             Provider = request.Provider,
             Model = request.Model,
+            WorkspaceModelName = request.WorkspaceModelName,
             SystemPrompt = request.SystemPrompt,
             Temperature = request.Temperature,
             MaxOutputTokens = request.MaxOutputTokens,
@@ -180,6 +181,7 @@ internal static class AIWorkspaceEndpoints
         {
             Provider = request.Provider,
             Model = request.Model,
+            WorkspaceModelName = request.WorkspaceModelName,
             SystemPrompt = request.SystemPrompt,
             Temperature = request.Temperature,
             MaxOutputTokens = request.MaxOutputTokens,
@@ -225,6 +227,7 @@ internal static class AIWorkspaceEndpoints
         workspace.Name,
         workspace.Provider,
         workspace.Model,
+        workspace.WorkspaceModelName,
         workspace.SystemPrompt,
         workspace.Temperature,
         workspace.MaxOutputTokens,

--- a/src/Granit.AI.Endpoints/Internal/AISchemaExampleProvider.cs
+++ b/src/Granit.AI.Endpoints/Internal/AISchemaExampleProvider.cs
@@ -52,6 +52,7 @@ internal sealed class AISchemaExampleProvider : ISchemaExampleProvider
                 ["name"] = "support-triage",
                 ["provider"] = "OpenAI",
                 ["model"] = "gpt-4o",
+                ["workspaceModelName"] = "GPT-4o Support",
                 ["systemPrompt"] = "You classify incoming support tickets into one of: billing, bug, feature-request, other.",
                 ["temperature"] = 0.2f,
                 ["maxOutputTokens"] = 512,
@@ -60,6 +61,7 @@ internal sealed class AISchemaExampleProvider : ISchemaExampleProvider
             {
                 ["provider"] = "OpenAI",
                 ["model"] = "gpt-4o-mini",
+                ["workspaceModelName"] = "GPT-4o mini",
                 ["systemPrompt"] = "You classify incoming support tickets into one of: billing, bug, feature-request, other.",
                 ["temperature"] = 0.2f,
                 ["maxOutputTokens"] = 512,

--- a/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
@@ -16,6 +16,8 @@ internal sealed class AIWorkspaceEntity : AuditedEntity, IActive, IMultiTenant, 
 
     public string Model { get; set; } = string.Empty;
 
+    public string? WorkspaceModelName { get; set; }
+
     public string? SystemPrompt { get; set; }
 
     public float? Temperature { get; set; }
@@ -54,6 +56,7 @@ internal sealed class AIWorkspaceEntity : AuditedEntity, IActive, IMultiTenant, 
         Name = Name,
         Provider = Provider,
         Model = Model,
+        WorkspaceModelName = WorkspaceModelName,
         SystemPrompt = SystemPrompt,
         Temperature = Temperature,
         MaxOutputTokens = MaxOutputTokens,
@@ -69,6 +72,7 @@ internal sealed class AIWorkspaceEntity : AuditedEntity, IActive, IMultiTenant, 
         Name = workspace.Name,
         Provider = workspace.Provider,
         Model = workspace.Model,
+        WorkspaceModelName = workspace.WorkspaceModelName,
         SystemPrompt = workspace.SystemPrompt,
         Temperature = workspace.Temperature,
         MaxOutputTokens = workspace.MaxOutputTokens,

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
@@ -33,6 +33,9 @@ internal sealed class AIWorkspaceEntityConfiguration : IEntityTypeConfiguration<
             .HasMaxLength(100)
             .IsRequired();
 
+        builder.Property(e => e.WorkspaceModelName)
+            .HasMaxLength(256);
+
         builder.Property(e => e.SystemPrompt)
             .HasMaxLength(10000);
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
@@ -93,6 +93,7 @@ internal sealed class EfAIWorkspaceStore(
 
                 entity.Provider = workspace.Provider;
                 entity.Model = workspace.Model;
+                entity.WorkspaceModelName = workspace.WorkspaceModelName;
                 entity.SystemPrompt = workspace.SystemPrompt;
                 entity.Temperature = workspace.Temperature;
                 entity.MaxOutputTokens = workspace.MaxOutputTokens;

--- a/src/Granit.AI/Workspaces/AIWorkspace.cs
+++ b/src/Granit.AI/Workspaces/AIWorkspace.cs
@@ -28,6 +28,12 @@ public sealed record AIWorkspace
     public required string Model { get; init; }
 
     /// <summary>
+    /// Human-readable display label for this workspace (e.g. <c>GPT-4o</c>, <c>Support AI</c>).
+    /// When <see langword="null"/>, consumers should fall back to <see cref="Model"/>.
+    /// </summary>
+    public string? WorkspaceModelName { get; init; }
+
+    /// <summary>
     /// Optional system prompt prepended to all conversations in this workspace.
     /// </summary>
     public string? SystemPrompt { get; init; }

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -496,6 +496,50 @@ public sealed class ChatServiceTests
     }
 
     [Fact]
+    public async Task New_conversation_is_created_with_the_resolved_workspace_key()
+    {
+        ChatService service = CreateService();
+        Conversation? created = null;
+        _store.CreateAsync(Arg.Any<Conversation>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(created = ci.Arg<Conversation>()));
+
+        await SendAsync(service, Request() with { WorkspaceName = "support" }, TestContext.Current.CancellationToken);
+
+        created.ShouldNotBeNull();
+        created.WorkspaceKey.ShouldBe("support");
+    }
+
+    [Fact]
+    public async Task New_conversation_stores_the_resolved_workspace_key_even_when_defaulted()
+    {
+        ChatService service = CreateService();
+        Conversation? created = null;
+        _store.CreateAsync(Arg.Any<Conversation>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(created = ci.Arg<Conversation>()));
+
+        // No explicit workspace — resolved to the configured default "default".
+        await SendAsync(service, Request(), TestContext.Current.CancellationToken);
+
+        created.ShouldNotBeNull();
+        created.WorkspaceKey.ShouldBe("default");
+    }
+
+    [Fact]
+    public async Task Existing_conversation_workspace_key_is_not_overwritten_on_subsequent_turns()
+    {
+        var conversationId = Guid.NewGuid();
+        var existing = Conversation.Create(conversationId, Owner, "Existing", "original");
+        _store.GetAsync(conversationId, Owner, Arg.Any<CancellationToken>()).Returns(existing);
+        ChatService service = CreateService();
+
+        // Send with a different workspace — must not mutate the stored aggregate.
+        await SendAsync(service, Request(conversationId) with { WorkspaceName = "other" }, TestContext.Current.CancellationToken);
+
+        existing.WorkspaceKey.ShouldBe("original");
+        await _store.DidNotReceive().CreateAsync(Arg.Any<Conversation>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task A_loop_failure_mid_stream_persists_the_user_turn_but_no_assistant_turn()
     {
         ChatService service = CreateService();

--- a/tests/Granit.AI.Chat.Tests/ConversationTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ConversationTests.cs
@@ -76,4 +76,20 @@ public sealed class ConversationTests
         message.Role.ShouldBe(MessageRole.User);
         message.Content.ShouldBe("Hello");
     }
+
+    [Fact]
+    public void Create_stores_the_workspace_key()
+    {
+        var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Chat", "support-chat");
+
+        conversation.WorkspaceKey.ShouldBe("support-chat");
+    }
+
+    [Fact]
+    public void Create_leaves_workspace_key_null_when_omitted()
+    {
+        var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Chat");
+
+        conversation.WorkspaceKey.ShouldBeNull();
+    }
 }

--- a/tests/Granit.AI.Endpoints.Tests/Validators/AIWorkspaceCreateRequestValidatorTests.cs
+++ b/tests/Granit.AI.Endpoints.Tests/Validators/AIWorkspaceCreateRequestValidatorTests.cs
@@ -12,7 +12,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [Fact]
     public void Valid_request_passes()
     {
-        AIWorkspaceCreateRequest request = new("my-workspace", "OpenAI", "gpt-4o", null, 0.7f, 4096);
+        AIWorkspaceCreateRequest request = new("my-workspace", "OpenAI", "gpt-4o", null, null, 0.7f, 4096);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldNotHaveAnyValidationErrors();
     }
@@ -22,7 +22,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [InlineData(null)]
     public void Name_empty_fails(string? name)
     {
-        AIWorkspaceCreateRequest request = new(name!, "OpenAI", "gpt-4o", null, null, null);
+        AIWorkspaceCreateRequest request = new(name!, "OpenAI", "gpt-4o", null, null, null, null);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.Name);
     }
@@ -33,7 +33,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [InlineData("-starts-with-dash")]
     public void Name_invalid_format_fails(string name)
     {
-        AIWorkspaceCreateRequest request = new(name, "OpenAI", "gpt-4o", null, null, null);
+        AIWorkspaceCreateRequest request = new(name, "OpenAI", "gpt-4o", null, null, null, null);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.Name);
     }
@@ -41,7 +41,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [Fact]
     public void Provider_empty_fails()
     {
-        AIWorkspaceCreateRequest request = new("test", "", "gpt-4o", null, null, null);
+        AIWorkspaceCreateRequest request = new("test", "", "gpt-4o", null, null, null, null);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.Provider);
     }
@@ -49,7 +49,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [Fact]
     public void Model_empty_fails()
     {
-        AIWorkspaceCreateRequest request = new("test", "OpenAI", "", null, null, null);
+        AIWorkspaceCreateRequest request = new("test", "OpenAI", "", null, null, null, null);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.Model);
     }
@@ -59,7 +59,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [InlineData(2.1f)]
     public void Temperature_out_of_range_fails(float temperature)
     {
-        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", null, temperature, null);
+        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", null, null, temperature, null);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.Temperature);
     }
@@ -67,7 +67,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [Fact]
     public void Temperature_null_passes()
     {
-        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", null, null, null);
+        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", null, null, null, null);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldNotHaveValidationErrorFor(x => x.Temperature);
     }
@@ -75,7 +75,7 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
     [Fact]
     public void MaxOutputTokens_zero_fails()
     {
-        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", null, null, 0);
+        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", null, null, null, 0);
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.MaxOutputTokens);
     }


### PR DESCRIPTION
Closes #2817

## Summary

- **`Conversation.WorkspaceKey`** — new nullable string property frozen at conversation creation time from the resolved workspace name of the first message. Subsequent turns in the same conversation do not overwrite it.
- **`ConversationResponse.workspaceKey`** + **`ConversationSummaryResponse.workspaceKey`** — exposed on both read endpoints so the `@granit/react-ai-chat` UI can restore the workspace selector after a URL change / component remount.
- **`AIWorkspace.WorkspaceModelName`** — optional human-readable display label (e.g. `"GPT-4o"`, `"Support AI"`) added to the workspace record, entity, EF config, `IAIWorkspaceMutableFields`, and create/update/response DTOs. Admins can now name workspaces for display without abusing the machine key.

## Scope note

`workspaceModelName` in **workspace** DTOs is intentionally separate from `workspaceKey` in **conversation** DTOs: the conversation stores the key that identifies which workspace was used; the workspace itself carries the display label. The UI can resolve the label by fetching `GET /workspaces/{workspaceKey}`.

Per-message workspace tracking (changing the AI mid-conversation) is explicitly **out of scope** — see the story's last acceptance criterion.

## Test plan

- [ ] `ConversationTests` — `Create_stores_the_workspace_key`, `Create_leaves_workspace_key_null_when_omitted`
- [ ] `ChatServiceTests` — `New_conversation_is_created_with_the_resolved_workspace_key`, `New_conversation_stores_the_resolved_workspace_key_even_when_defaulted`, `Existing_conversation_workspace_key_is_not_overwritten_on_subsequent_turns`
- [ ] AI shard: all 0 failures (verified locally)
- [ ] Architecture shard: 227 passed (verified locally)