### PR TITLE
feat(ai-chat): store WorkspaceKey on Message for per-turn workspace tracking

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3291,7 +3291,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 105,
+      "line": 109,
       "members": [
         {
           "name": "ConversationId",
@@ -3316,7 +3316,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 59,
+      "line": 63,
       "members": [
         {
           "name": "ConversationId",
@@ -3338,7 +3338,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 156,
+      "line": 160,
       "members": [
         {
           "name": "ForDelta",
@@ -3372,7 +3372,7 @@
       "kind": "enum",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 136,
+      "line": 140,
       "members": []
     },
     {
@@ -3410,7 +3410,7 @@
         {
           "name": "AddMessage",
           "kind": "method",
-          "signature": "AddMessage(Guid id, MessageRole role, string content)",
+          "signature": "AddMessage(Guid id, MessageRole role, string content, string? workspaceKey = null)",
           "returnType": "Message"
         }
       ]
@@ -3502,7 +3502,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 56,
+      "line": 65,
       "members": [
         {
           "name": "FromAggregate",
@@ -3559,7 +3559,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat.Endpoints",
       "file": "src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs",
-      "line": 41,
+      "line": 45,
       "members": [
         {
           "name": "FromEntity",
@@ -3874,7 +3874,7 @@
       "kind": "interface",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 204,
+      "line": 208,
       "members": [
         {
           "name": "PrepareAsync",
@@ -4110,7 +4110,7 @@
       "kind": "record",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/IChatService.cs",
-      "line": 56,
+      "line": 60,
       "members": [
         {
           "name": "ConversationId",

--- a/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
+++ b/src/Granit.AI.Chat.Endpoints/Dtos/ConversationDtos.cs
@@ -37,14 +37,23 @@ public sealed record ConversationSummaryResponse(
 /// the role is mapped explicitly here — see <see cref="MessageResponse.FromEntity"/>.
 /// </param>
 /// <param name="Content">The message text.</param>
+/// <param name="WorkspaceKey">
+/// Machine key of the workspace that produced this message, or <see langword="null"/> for messages
+/// predating this field. Lets the UI show which AI was used per turn.
+/// </param>
 /// <param name="CreatedAt">When the message was created.</param>
-public sealed record MessageResponse(Guid Id, string Role, string Content, DateTimeOffset CreatedAt)
+public sealed record MessageResponse(Guid Id, string Role, string Content, string? WorkspaceKey, DateTimeOffset CreatedAt)
 {
     /// <summary>Projects a <see cref="Message"/> to a response, lower-casing the role for the wire.</summary>
     public static MessageResponse FromEntity(Message message)
     {
         ArgumentNullException.ThrowIfNull(message);
-        return new MessageResponse(message.Id, message.Role.ToString().ToLowerInvariant(), message.Content, message.CreatedAt);
+        return new MessageResponse(
+            message.Id,
+            message.Role.ToString().ToLowerInvariant(),
+            message.Content,
+            message.WorkspaceKey,
+            message.CreatedAt);
     }
 }
 

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -258,7 +258,7 @@ internal static partial class ChatSendEndpoints
             yield return new ChatStreamEvent(
                 "persisted",
                 Messages: [.. result.PersistedMessages.Select(m =>
-                    new MessageResponse(m.Id, m.Role, m.Content, m.CreatedAt))]);
+                    new MessageResponse(m.Id, m.Role, m.Content, m.WorkspaceKey, m.CreatedAt))]);
         }
 
         yield return new ChatStreamEvent("usage", InputTokens: result.InputTokens, OutputTokens: result.OutputTokens);

--- a/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/MessageConfiguration.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/MessageConfiguration.cs
@@ -18,6 +18,7 @@ internal sealed class MessageConfiguration : IEntityTypeConfiguration<Message>
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.Content).IsRequired();
+        builder.Property(e => e.WorkspaceKey).HasMaxLength(256);
         builder.Property(e => e.CreatedBy).HasMaxLength(256);
 
         // Role persists as its PascalCase string name via ApplyGranitConventions.

--- a/src/Granit.AI.Chat/Domain/Conversation.cs
+++ b/src/Granit.AI.Chat/Domain/Conversation.cs
@@ -73,9 +73,9 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
     public void SetFavorite(bool isFavorite) => IsFavorite = isFavorite;
 
     /// <summary>Appends a message and returns it.</summary>
-    public Message AddMessage(Guid id, MessageRole role, string content)
+    public Message AddMessage(Guid id, MessageRole role, string content, string? workspaceKey = null)
     {
-        var message = Message.Create(id, Id, role, content);
+        var message = Message.Create(id, Id, role, content, workspaceKey);
         Messages.Add(message);
         return message;
     }

--- a/src/Granit.AI.Chat/Domain/Message.cs
+++ b/src/Granit.AI.Chat/Domain/Message.cs
@@ -13,7 +13,12 @@ public sealed class Message : CreationAuditedEntity
     }
 
     /// <summary>Creates a message belonging to <paramref name="conversationId"/>.</summary>
-    public static Message Create(Guid id, Guid conversationId, MessageRole role, string content)
+    public static Message Create(
+        Guid id,
+        Guid conversationId,
+        MessageRole role,
+        string content,
+        string? workspaceKey = null)
     {
         ArgumentNullException.ThrowIfNull(content);
 
@@ -23,6 +28,7 @@ public sealed class Message : CreationAuditedEntity
             ConversationId = conversationId,
             Role = role,
             Content = content,
+            WorkspaceKey = workspaceKey,
         };
     }
 
@@ -34,4 +40,11 @@ public sealed class Message : CreationAuditedEntity
 
     /// <summary>The message text.</summary>
     public string Content { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Machine key of the workspace that produced this message (e.g. <c>support-chat</c>),
+    /// or <see langword="null"/> for messages predating this field. Allows the UI to show
+    /// which AI was used per turn and to restore the workspace selector.
+    /// </summary>
+    public string? WorkspaceKey { get; private set; }
 }

--- a/src/Granit.AI.Chat/IChatService.cs
+++ b/src/Granit.AI.Chat/IChatService.cs
@@ -52,8 +52,12 @@ public sealed record ChatSendRequest
 /// <param name="Id">The server-assigned message identifier.</param>
 /// <param name="Role">The author, lower-cased ("user"/"assistant") to match the client wire convention.</param>
 /// <param name="Content">The message text, as persisted.</param>
+/// <param name="WorkspaceKey">
+/// Machine key of the workspace that produced this message, or <see langword="null"/> for messages
+/// predating this field. Mirrors <c>MessageResponse.WorkspaceKey</c>.
+/// </param>
 /// <param name="CreatedAt">The server creation timestamp.</param>
-public sealed record PersistedChatMessage(Guid Id, string Role, string Content, DateTimeOffset CreatedAt);
+public sealed record PersistedChatMessage(Guid Id, string Role, string Content, string? WorkspaceKey, DateTimeOffset CreatedAt);
 
 /// <summary>The outcome of a send: the (possibly new) conversation and the assistant's answer.</summary>
 public sealed record ChatSendResult

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -209,12 +209,14 @@ internal sealed class ChatService(
     {
         if (handle.IsNew)
         {
-            Message userMessage = handle.Conversation.AddMessage(guidGenerator.Create(), MessageRole.User, handle.OriginalMessage);
+            Message userMessage = handle.Conversation.AddMessage(
+                guidGenerator.Create(), MessageRole.User, handle.OriginalMessage, handle.WorkspaceName);
             await conversationStore.CreateAsync(handle.Conversation, cancellationToken).ConfigureAwait(false);
             return userMessage;
         }
 
-        var message = Message.Create(guidGenerator.Create(), handle.ConversationId, MessageRole.User, handle.OriginalMessage);
+        var message = Message.Create(
+            guidGenerator.Create(), handle.ConversationId, MessageRole.User, handle.OriginalMessage, handle.WorkspaceName);
         await conversationStore.AppendMessagesAsync(
             handle.ConversationId,
             handle.OwnerId,
@@ -225,7 +227,8 @@ internal sealed class ChatService(
 
     private async Task<Message> PersistAssistantTurnAsync(ChatSendHandle handle, string assistantContent, CancellationToken cancellationToken)
     {
-        var message = Message.Create(guidGenerator.Create(), handle.ConversationId, MessageRole.Assistant, assistantContent);
+        var message = Message.Create(
+            guidGenerator.Create(), handle.ConversationId, MessageRole.Assistant, assistantContent, handle.WorkspaceName);
         await conversationStore.AppendMessagesAsync(
             handle.ConversationId,
             handle.OwnerId,
@@ -239,7 +242,7 @@ internal sealed class ChatService(
     /// The role is lower-cased to match the client wire convention (as in the conversation read model).
     /// </summary>
     private static PersistedChatMessage ToPersisted(Message message) =>
-        new(message.Id, message.Role.ToString().ToLowerInvariant(), message.Content, message.CreatedAt);
+        new(message.Id, message.Role.ToString().ToLowerInvariant(), message.Content, message.WorkspaceKey, message.CreatedAt);
 
     /// <summary>
     /// Parses a clarification from a loop interrupt, or <see langword="null"/> when the interrupt is

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -540,6 +540,21 @@ public sealed class ChatServiceTests
     }
 
     [Fact]
+    public async Task Persisted_messages_carry_the_resolved_workspace_key()
+    {
+        ChatService service = CreateService();
+        _workspaceProvider.GetAsync("analytics", Arg.Any<CancellationToken>())
+            .Returns(new AIWorkspace { Name = "analytics", Provider = "OpenAI", Model = "gpt-4o" });
+
+        ChatSendResult result = await SendAsync(
+            service, Request() with { WorkspaceName = "analytics" }, TestContext.Current.CancellationToken);
+
+        result.PersistedMessages.Count.ShouldBe(2);
+        result.PersistedMessages[0].WorkspaceKey.ShouldBe("analytics");
+        result.PersistedMessages[1].WorkspaceKey.ShouldBe("analytics");
+    }
+
+    [Fact]
     public async Task A_loop_failure_mid_stream_persists_the_user_turn_but_no_assistant_turn()
     {
         ChatService service = CreateService();

--- a/tests/Granit.AI.Chat.Tests/ConversationTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ConversationTests.cs
@@ -92,4 +92,24 @@ public sealed class ConversationTests
 
         conversation.WorkspaceKey.ShouldBeNull();
     }
+
+    [Fact]
+    public void AddMessage_records_the_workspace_key_on_the_message()
+    {
+        var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Chat");
+
+        Message message = conversation.AddMessage(Guid.NewGuid(), MessageRole.User, "Hello", "analytics");
+
+        message.WorkspaceKey.ShouldBe("analytics");
+    }
+
+    [Fact]
+    public void AddMessage_leaves_workspace_key_null_when_omitted()
+    {
+        var conversation = Conversation.Create(Guid.NewGuid(), Owner, "Chat");
+
+        Message message = conversation.AddMessage(Guid.NewGuid(), MessageRole.User, "Hello");
+
+        message.WorkspaceKey.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
## Summary

Closes #2817 (follow-up to #2818).

Users can change workspace mid-conversation. Each message now records the resolved workspace key used for that specific turn so the UI can:
- Show which AI model was used per turn in the thread
- Restore the correct workspace selector when scrolling back through history

**Changes:**
- `Message.Create` / `Conversation.AddMessage` accept `string? workspaceKey`
- `MessageConfiguration` maps `WorkspaceKey` column (`varchar(256)`, nullable)
- `MessageResponse` exposes `string? WorkspaceKey` (always-present-but-may-be-null — no default, per §DTOs)
- `PersistedChatMessage` (SSE `persisted` frame) exposes `string? WorkspaceKey`
- `ChatService.PersistUserTurnAsync` / `PersistAssistantTurnAsync` pass `handle.WorkspaceName` to every message creation site
- `ToPersisted` threads `message.WorkspaceKey` into the settled result
- `ChatSendEndpoints` passes `m.WorkspaceKey` when projecting the `persisted` SSE frame

## Test plan

- [x] `ConversationTests`: `AddMessage_records_the_workspace_key_on_the_message` + `AddMessage_leaves_workspace_key_null_when_omitted`
- [x] `ChatServiceTests`: `Persisted_messages_carry_the_resolved_workspace_key`
- [x] All 79 `Granit.AI.Chat.Tests` pass
- [x] Full `ai` shard (311 tests) passes