### PR TITLE
fix(ai-workspace): cap WorkspaceModelName to 64 chars

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -55,6 +55,14 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.AI.Chat.BlobStorage",
+      "deps": [
+        "Granit.AI.Chat",
+        "Granit.BlobStorage"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.AI.Chat.Endpoints",
       "deps": [
         "Granit.AI.Chat",
@@ -3282,6 +3290,38 @@
           "kind": "property",
           "signature": "int RetentionDays",
           "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "AIChatBlobStorageServiceCollectionExtensions",
+      "fqn": "Granit.AI.Chat.BlobStorage.Extensions.AIChatBlobStorageServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Chat.BlobStorage",
+      "file": "src/Granit.AI.Chat.BlobStorage/Extensions/AIChatBlobStorageServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddBlobStorageChatAttachments",
+          "kind": "method",
+          "signature": "AddBlobStorageChatAttachments(this IServiceCollection services, Action<GranitAIChatAttachmentOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIChatBlobStorageModule",
+      "fqn": "Granit.AI.Chat.BlobStorage.GranitAIChatBlobStorageModule",
+      "kind": "class",
+      "project": "Granit.AI.Chat.BlobStorage",
+      "file": "src/Granit.AI.Chat.BlobStorage/GranitAIChatBlobStorageModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
         }
       ]
     },
@@ -13196,6 +13236,15 @@
       "members": []
     },
     {
+      "name": "BlobContent",
+      "fqn": "Granit.BlobStorage.BlobContent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobContent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "BlobStorageLocalizationResource",
       "fqn": "Granit.BlobStorage.BlobStorageLocalizationResource",
       "kind": "class",
@@ -13880,13 +13929,29 @@
       "kind": "class",
       "project": "Granit.BlobStorage",
       "file": "src/Granit.BlobStorage/GranitBlobStorageModule.cs",
-      "line": 31,
+      "line": 32,
       "members": [
         {
           "name": "ConfigureServices",
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IBlobContentReader",
+      "fqn": "Granit.BlobStorage.IBlobContentReader",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobContentReader.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ReadAsync",
+          "kind": "method",
+          "signature": "ReadAsync(Guid blobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobContent?>"
         }
       ]
     },

--- a/src/Granit.AI.Endpoints/Validators/AIWorkspaceMutableFieldsValidator.cs
+++ b/src/Granit.AI.Endpoints/Validators/AIWorkspaceMutableFieldsValidator.cs
@@ -22,6 +22,10 @@ internal sealed class AIWorkspaceMutableFieldsValidator<T> : GranitValidator<T>
             .NotEmpty()
             .MaximumLength(128);
 
+        RuleFor(x => x.WorkspaceModelName)
+            .MaximumLength(64)
+            .When(x => x.WorkspaceModelName is not null);
+
         RuleFor(x => x.SystemPrompt)
             .MaximumLength(32_000)
             .When(x => x.SystemPrompt is not null);

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
@@ -34,7 +34,7 @@ internal sealed class AIWorkspaceEntityConfiguration : IEntityTypeConfiguration<
             .IsRequired();
 
         builder.Property(e => e.WorkspaceModelName)
-            .HasMaxLength(256);
+            .HasMaxLength(64);
 
         builder.Property(e => e.SystemPrompt)
             .HasMaxLength(10000);

--- a/tests/Granit.AI.Endpoints.Tests/Validators/AIWorkspaceCreateRequestValidatorTests.cs
+++ b/tests/Granit.AI.Endpoints.Tests/Validators/AIWorkspaceCreateRequestValidatorTests.cs
@@ -79,4 +79,20 @@ public sealed class AIWorkspaceCreateRequestValidatorTests
         TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.MaxOutputTokens);
     }
+
+    [Fact]
+    public void WorkspaceModelName_too_long_fails()
+    {
+        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", new string('x', 65), null, null, null);
+        TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.WorkspaceModelName);
+    }
+
+    [Fact]
+    public void WorkspaceModelName_null_passes()
+    {
+        AIWorkspaceCreateRequest request = new("test", "OpenAI", "gpt-4o", null, null, null, null);
+        TestValidationResult<AIWorkspaceCreateRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.WorkspaceModelName);
+    }
 }


### PR DESCRIPTION
## Summary

- `HasMaxLength(256)` → `HasMaxLength(64)` on `AIWorkspaceEntity.WorkspaceModelName`
- `MaximumLength(64)` added to `AIWorkspaceMutableFieldsValidator` (with `When(not null)` guard)
- 2 new validator tests: too-long fails, null passes