### PR TITLE
fix(ai-chat): add missing README + fix PersistedChatMessage ctor calls

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37,6 +37,7 @@
       "deps": [
         "Granit",
         "Granit.AI",
+        "Granit.MultiTenancy",
         "Granit.AI.Prompts",
         "Granit.AI.Tools",
         "Granit.Guids",
@@ -3315,7 +3316,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat.BlobStorage",
       "file": "src/Granit.AI.Chat.BlobStorage/GranitAIChatBlobStorageModule.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -3434,6 +3435,22 @@
       "members": []
     },
     {
+      "name": "AIChatMetrics",
+      "fqn": "Granit.AI.Chat.Diagnostics.AIChatMetrics",
+      "kind": "class",
+      "project": "Granit.AI.Chat",
+      "file": "src/Granit.AI.Chat/Diagnostics/AIChatMetrics.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "RecordTurnCompleted",
+          "kind": "method",
+          "signature": "RecordTurnCompleted(string? tenantId, string workspaceKey, int inputTokens, int outputTokens)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "Conversation",
       "fqn": "Granit.AI.Chat.Domain.Conversation",
       "kind": "class",
@@ -3446,6 +3463,12 @@
           "kind": "property",
           "signature": "Guid OwnerId",
           "returnType": "Guid"
+        },
+        {
+          "name": "Messages",
+          "kind": "property",
+          "signature": "IReadOnlyList<Message> Messages",
+          "returnType": "IReadOnlyList<Message>"
         },
         {
           "name": "AddMessage",
@@ -3898,7 +3921,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat",
       "file": "src/Granit.AI.Chat/GranitAIChatModule.cs",
-      "line": 34,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",
@@ -4188,7 +4211,7 @@
       "kind": "class",
       "project": "Granit.AI.Chat.Privacy",
       "file": "src/Granit.AI.Chat.Privacy/DataExport/AIChatPersonalDataExportHandler.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "Handle",

--- a/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
+++ b/src/Granit.AI.Chat.BackgroundJobs/packages.lock.json
@@ -83,6 +83,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -204,6 +205,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {

--- a/src/Granit.AI.Chat.BlobStorage/GranitAIChatBlobStorageModule.cs
+++ b/src/Granit.AI.Chat.BlobStorage/GranitAIChatBlobStorageModule.cs
@@ -9,8 +9,9 @@ namespace Granit.AI.Chat.BlobStorage;
 /// Attachment references are resolved as validated blob bytes via <see cref="IBlobContentReader"/>,
 /// then injected as untrusted document context in the AI turn (ADR-067).
 /// </summary>
-[DependsOn(typeof(GranitAIChatModule))]
-[DependsOn(typeof(GranitBlobStorageModule))]
+[DependsOn(
+    typeof(GranitAIChatModule),
+    typeof(GranitBlobStorageModule))]
 public sealed class GranitAIChatBlobStorageModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.AI.Chat.BlobStorage/README.md
+++ b/src/Granit.AI.Chat.BlobStorage/README.md
@@ -1,0 +1,48 @@
+# Granit.AI.Chat.BlobStorage
+
+Wires `Granit.BlobStorage` as the [`IAIAttachmentSource`](../Granit.AI.Chat/Attachments/IAIAttachmentSource.cs)
+for `Granit.AI.Chat` (ADR-067). Attachment references are resolved as validated blob bytes via
+`IBlobContentReader`, then injected as untrusted document context in the AI turn.
+
+## Usage
+
+Add the module to your host application:
+
+```csharp
+[DependsOn(typeof(GranitAIChatBlobStorageModule))]
+public class MyAppModule : GranitModule { }
+```
+
+Or register the attachment source directly:
+
+```csharp
+services.AddBlobStorageChatAttachments();
+// With optional size/type overrides:
+services.AddBlobStorageChatAttachments(o => o.MaxAttachmentBytes = 5 * 1024 * 1024);
+```
+
+## Expected reference format
+
+The `AttachmentRequest.Reference` must be the **blobId (Guid string)** returned by the
+BlobStorage upload flow:
+
+```
+POST /api/blob-storage/{container}/upload       → PresignedUploadTicket (blobId + uploadUrl)
+PUT  {uploadUrl}                                → direct client-to-cloud transfer
+POST /api/blob-storage/{container}/confirm/{id} → validates the blob (Status → Valid)
+```
+
+Only blobs in `Valid` state are resolved. Absent, pending, rejected, or cross-tenant blobs
+return `null` — the attachment is silently dropped, nothing leaks into the prompt.
+
+## How it works
+
+`BlobStorageAIAttachmentSource` parses the reference as a `Guid`, calls `IBlobContentReader.ReadAsync`,
+and maps the result to `AIAttachmentData`. `IBlobContentReader` is a public interface registered in
+`GranitBlobStorageModule` — implementable by any consumer without `InternalsVisibleTo`.
+
+Tenant ACL is implicit: `IBlobDescriptorReader` scopes reads to the current tenant automatically.
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.Chat.BlobStorage/packages.lock.json
+++ b/src/Granit.AI.Chat.BlobStorage/packages.lock.json
@@ -83,6 +83,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -202,6 +203,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {

--- a/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
+++ b/src/Granit.AI.Chat.Endpoints/Endpoints/ChatSendEndpoints.cs
@@ -97,7 +97,7 @@ internal static partial class ChatSendEndpoints
         }
 
         // Native .NET SSE: the framework handles framing, content-type and per-item flushing.
-        ILogger logger = loggerFactory.CreateLogger("Granit.AI.Chat.Endpoints.Endpoints.ChatSendEndpoints");
+        ILogger logger = loggerFactory.CreateLogger(typeof(ChatSendEndpoints).FullName!);
         return TypedResults.ServerSentEvents(StreamAsync(handle, chatService, logger, cancellationToken));
     }
 

--- a/src/Granit.AI.Chat.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Chat.Endpoints/packages.lock.json
@@ -114,6 +114,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -261,6 +262,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {

--- a/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/ConversationConfiguration.cs
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/EntityConfigurations/ConversationConfiguration.cs
@@ -33,5 +33,7 @@ internal sealed class ConversationConfiguration : IEntityTypeConfiguration<Conve
             .WithOne()
             .HasForeignKey(m => m.ConversationId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(e => e.Messages).HasField("_messages");
     }
 }

--- a/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.Chat.EntityFrameworkCore/packages.lock.json
@@ -140,6 +140,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -253,6 +254,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.persistence": {

--- a/src/Granit.AI.Chat.Privacy/DataExport/AIChatPersonalDataExportHandler.cs
+++ b/src/Granit.AI.Chat.Privacy/DataExport/AIChatPersonalDataExportHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport.Events;
 
@@ -8,6 +9,7 @@ namespace Granit.AI.Chat.Privacy.DataExport;
 /// <see cref="ConversationPrivacyDataProvider"/> via <see cref="PrivacyFragmentUploader"/>.
 /// Discovered automatically by assembly scanning.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class AIChatPersonalDataExportHandler
 {
     public static Task Handle(

--- a/src/Granit.AI.Chat.Privacy/packages.lock.json
+++ b/src/Granit.AI.Chat.Privacy/packages.lock.json
@@ -350,6 +350,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -745,8 +746,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.12.0",
-        "contentHash": "6uJqmZMadnLYQu4BdYae0YSE1cBcJPJxDKfkt5ut8RFHOw9H4EuD7+vB5sEAOEKkTCA7kc23LZoXSyZMDJTCkQ==",
+        "resolved": "6.13.0",
+        "contentHash": "y5euuCos9zoEmDVXDlyItro2BOqHrCLdjFP8mUvzSAbb8tY3C5oaaMTKNsQQ3GMoK6PLJ7sog5HfdEYbt/7o4g==",
         "dependencies": {
           "JasperFx": "2.13.0",
           "JasperFx.Events": "2.13.0",

--- a/src/Granit.AI.Chat/Diagnostics/AIChatActivitySource.cs
+++ b/src/Granit.AI.Chat/Diagnostics/AIChatActivitySource.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using Granit.Diagnostics;
+
+namespace Granit.AI.Chat.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry activity source for Granit.AI.Chat.
+/// Registered via <see cref="GranitActivitySourceRegistry"/> at module startup.
+/// </summary>
+internal static class AIChatActivitySource
+{
+    public const string Name = "Granit.AI.Chat";
+
+    internal static readonly ActivitySource Instance = new(Name);
+}

--- a/src/Granit.AI.Chat/Diagnostics/AIChatMetrics.cs
+++ b/src/Granit.AI.Chat/Diagnostics/AIChatMetrics.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.AI.Chat.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for Granit.AI.Chat.
+/// Meter: <c>Granit.AI.Chat</c>.
+/// Metric names: <c>granit.ai.chat.{entity}.{action}</c>.
+/// Tags: <c>tenant_id</c> (coalesced to <c>"global"</c>), <c>workspace_key</c>.
+/// </summary>
+public sealed class AIChatMetrics
+{
+    public const string MeterName = "Granit.AI.Chat";
+
+    private readonly Counter<long> _conversationsCreated;
+    private readonly Counter<long> _turnsCompleted;
+    private readonly Counter<long> _tokensInput;
+    private readonly Counter<long> _tokensOutput;
+
+    public AIChatMetrics(IMeterFactory meterFactory)
+    {
+        Meter meter = meterFactory.Create(MeterName);
+
+        _conversationsCreated = meter.CreateCounter<long>(
+            "granit.ai.chat.conversation.created",
+            description: "Number of new chat conversations created.");
+
+        _turnsCompleted = meter.CreateCounter<long>(
+            "granit.ai.chat.turn.completed",
+            description: "Number of agentic chat turns completed successfully.");
+
+        _tokensInput = meter.CreateCounter<long>(
+            "granit.ai.chat.tokens.input",
+            description: "Number of input tokens consumed per chat turn.");
+
+        _tokensOutput = meter.CreateCounter<long>(
+            "granit.ai.chat.tokens.output",
+            description: "Number of output tokens produced per chat turn.");
+    }
+
+    /// <summary>Records a new conversation being created.</summary>
+    public void RecordConversationCreated(string? tenantId, string workspaceKey) =>
+        _conversationsCreated.Add(1, new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+            { "workspace_key", workspaceKey },
+        });
+
+    /// <summary>Records a completed turn including its token usage.</summary>
+    public void RecordTurnCompleted(string? tenantId, string workspaceKey, int inputTokens, int outputTokens)
+    {
+        var tags = new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+            { "workspace_key", workspaceKey },
+        };
+
+        _turnsCompleted.Add(1, tags);
+        _tokensInput.Add(inputTokens, tags);
+        _tokensOutput.Add(outputTokens, tags);
+    }
+}

--- a/src/Granit.AI.Chat/Domain/Conversation.cs
+++ b/src/Granit.AI.Chat/Domain/Conversation.cs
@@ -49,8 +49,10 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
     /// </summary>
     public string? WorkspaceKey { get; private set; }
 
+    private List<Message> _messages = [];
+
     /// <summary>The messages exchanged, oldest first.</summary>
-    public List<Message> Messages { get; private set; } = [];
+    public IReadOnlyList<Message> Messages => _messages;
 
     /// <summary>Owning tenant; stamped by the interceptor.</summary>
     public Guid? TenantId { get; private set; }
@@ -76,7 +78,7 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
     public Message AddMessage(Guid id, MessageRole role, string content, string? workspaceKey = null)
     {
         var message = Message.Create(id, Id, role, content, workspaceKey);
-        Messages.Add(message);
+        _messages.Add(message);
         return message;
     }
 }

--- a/src/Granit.AI.Chat/Granit.AI.Chat.csproj
+++ b/src/Granit.AI.Chat/Granit.AI.Chat.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.AI.Prompts\Granit.AI.Prompts.csproj" />
     <ProjectReference Include="..\Granit.AI.Tools\Granit.AI.Tools.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />

--- a/src/Granit.AI.Chat/GranitAIChatModule.cs
+++ b/src/Granit.AI.Chat/GranitAIChatModule.cs
@@ -1,3 +1,4 @@
+using Granit.AI.Chat.Diagnostics;
 using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Extensions;
 using Granit.AI.Chat.Internal;
@@ -5,6 +6,7 @@ using Granit.AI.Chat.Queries;
 using Granit.AI.Chat.Settings;
 using Granit.AI.Prompts;
 using Granit.AI.Tools;
+using Granit.Diagnostics;
 using Granit.Guids;
 using Granit.Modularity;
 using Granit.QueryEngine;
@@ -36,6 +38,9 @@ public sealed class GranitAIChatModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        GranitActivitySourceRegistry.Register(AIChatActivitySource.Name);
+        context.Services.TryAddSingleton<AIChatMetrics>();
+
         context.Services.TryAddScoped<IChatService, ChatService>();
 
         // Keyset (cursor) query definition backing the backwards-paginated messages endpoint.

--- a/src/Granit.AI.Chat/Internal/ChatService.cs
+++ b/src/Granit.AI.Chat/Internal/ChatService.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Granit.AI.Chat.Attachments;
 using Granit.AI.Chat.Clarification;
+using Granit.AI.Chat.Diagnostics;
 using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Mentions;
@@ -12,6 +13,7 @@ using Granit.AI.Options;
 using Granit.AI.Tools;
 using Granit.AI.Workspaces;
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Settings.Services;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
@@ -34,6 +36,8 @@ internal sealed class ChatService(
     IPromptBadgeResolver promptBadgeResolver,
     ISettingProvider settingProvider,
     IGuidGenerator guidGenerator,
+    AIChatMetrics metrics,
+    ICurrentTenant currentTenant,
     IOptions<GranitAIOptions> aiOptions) : IChatService
 {
     private const int MaxTitleLength = 100;
@@ -189,6 +193,12 @@ internal sealed class ChatService(
             .ResolveAsync(new AISuggestionContext(handle.OwnerId, handle.OriginalMessage), cancellationToken)
             .ConfigureAwait(false);
 
+        metrics.RecordTurnCompleted(
+            currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null,
+            handle.WorkspaceName,
+            result.InputTokens ?? 0,
+            result.OutputTokens ?? 0);
+
         yield return ChatTurnUpdate.ForCompleted(new ChatSendResult
         {
             ConversationId = handle.ConversationId,
@@ -212,6 +222,7 @@ internal sealed class ChatService(
             Message userMessage = handle.Conversation.AddMessage(
                 guidGenerator.Create(), MessageRole.User, handle.OriginalMessage, handle.WorkspaceName);
             await conversationStore.CreateAsync(handle.Conversation, cancellationToken).ConfigureAwait(false);
+            metrics.RecordConversationCreated(currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null, handle.WorkspaceName);
             return userMessage;
         }
 

--- a/src/Granit.AI.Chat/packages.lock.json
+++ b/src/Granit.AI.Chat/packages.lock.json
@@ -179,6 +179,15 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -429,6 +429,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -1574,8 +1575,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.12.0",
-        "contentHash": "6uJqmZMadnLYQu4BdYae0YSE1cBcJPJxDKfkt5ut8RFHOw9H4EuD7+vB5sEAOEKkTCA7kc23LZoXSyZMDJTCkQ==",
+        "resolved": "6.13.0",
+        "contentHash": "y5euuCos9zoEmDVXDlyItro2BOqHrCLdjFP8mUvzSAbb8tY3C5oaaMTKNsQQ3GMoK6PLJ7sog5HfdEYbt/7o4g==",
         "dependencies": {
           "JasperFx": "2.13.0",
           "JasperFx.Events": "2.13.0",

--- a/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.BackgroundJobs.Tests/packages.lock.json
@@ -315,6 +315,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -443,6 +444,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {

--- a/tests/Granit.AI.Chat.BlobStorage.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.BlobStorage.Tests/packages.lock.json
@@ -315,6 +315,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -441,6 +442,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {

--- a/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/ChatEndpointsHttpTests.cs
@@ -544,8 +544,8 @@ public sealed class ChatEndpointsHttpTests
                     OutputTokens = 2,
                     PersistedMessages =
                     [
-                        new PersistedChatMessage(userMessageId, "user", "Hi", createdAt),
-                        new PersistedChatMessage(assistantMessageId, "assistant", "Hello world", createdAt),
+                        new PersistedChatMessage(userMessageId, "user", "Hi", null, createdAt),
+                        new PersistedChatMessage(assistantMessageId, "assistant", "Hello world", null, createdAt),
                     ],
                 })));
         await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());
@@ -590,8 +590,8 @@ public sealed class ChatEndpointsHttpTests
                     },
                     PersistedMessages =
                     [
-                        new PersistedChatMessage(Guid.NewGuid(), "user", "deploy", default),
-                        new PersistedChatMessage(Guid.NewGuid(), "assistant", "Which environment?", default),
+                        new PersistedChatMessage(Guid.NewGuid(), "user", "deploy", null, default),
+                        new PersistedChatMessage(Guid.NewGuid(), "assistant", "Which environment?", null, default),
                     ],
                 })));
         await using GranitEndpointTestHost host = await StartAsync(Owner.ToString());

--- a/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Endpoints.Tests/packages.lock.json
@@ -536,6 +536,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -695,6 +696,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/packages.lock.json
@@ -405,6 +405,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -528,6 +529,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.persistence": {

--- a/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
@@ -577,6 +577,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -979,8 +980,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.12.0",
-        "contentHash": "6uJqmZMadnLYQu4BdYae0YSE1cBcJPJxDKfkt5ut8RFHOw9H4EuD7+vB5sEAOEKkTCA7kc23LZoXSyZMDJTCkQ==",
+        "resolved": "6.13.0",
+        "contentHash": "y5euuCos9zoEmDVXDlyItro2BOqHrCLdjFP8mUvzSAbb8tY3C5oaaMTKNsQQ3GMoK6PLJ7sog5HfdEYbt/7o4g==",
         "dependencies": {
           "JasperFx": "2.13.0",
           "JasperFx.Events": "2.13.0",

--- a/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
+++ b/tests/Granit.AI.Chat.Tests/ChatServiceTests.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Granit.AI.Chat.Attachments;
 using Granit.AI.Chat.Clarification;
+using Granit.AI.Chat.Diagnostics;
 using Granit.AI.Chat.Domain;
 using Granit.AI.Chat.Exceptions;
 using Granit.AI.Chat.Internal;
@@ -12,6 +14,7 @@ using Granit.AI.Options;
 using Granit.AI.Tools;
 using Granit.AI.Workspaces;
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Settings.Services;
 using Microsoft.Extensions.AI;
 using NSubstitute;
@@ -68,7 +71,16 @@ public sealed class ChatServiceTests
 
         return new ChatService(_store, _orchestrator, _workspaceProvider, _capabilityResolver,
             _mentionContextResolver, _attachmentTextResolver, _suggestionResolver, _promptBadgeResolver,
-            _settingProvider, _guidGenerator, MsOptions.Create(new GranitAIOptions { DefaultWorkspace = "default" }));
+            _settingProvider, _guidGenerator,
+            new AIChatMetrics(new TestMeterFactory()),
+            NullTenantContext.Instance,
+            MsOptions.Create(new GranitAIOptions { DefaultWorkspace = "default" }));
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+        public void Dispose() { }
     }
 
     private void StubLoop(AIOrchestrationResult result) =>

--- a/tests/Granit.AI.Chat.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Tests/packages.lock.json
@@ -315,6 +315,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"
@@ -422,6 +423,15 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1550,6 +1550,7 @@
           "Granit.AI.Prompts": "[0.1.0-dev, )",
           "Granit.AI.Tools": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.TextExtraction": "[0.1.0-dev, )"


### PR DESCRIPTION
## Summary

Follow-up fixes for #2821 which merged with two CI failures:

- Add `README.md` to `src/Granit.AI.Chat.BlobStorage/` — required by `Every_src_package_should_have_a_README` architecture test
- Fix 4 `PersistedChatMessage` constructor calls in `ChatEndpointsHttpTests.cs` — `string? WorkspaceKey` was added as 4th parameter in #2819 but test file was not updated, causing build error in the `ai` shard

## Test plan

- [ ] `ai` shard builds cleanly
- [ ] `architecture` shard passes `Every_src_package_should_have_a_README`