### PR TITLE
fix(imaging-ai): update test to AIWorkspace.Key rename

### DIFF
--- a/tests/Granit.Imaging.AI.Tests/LlmImageTextExtractorTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/LlmImageTextExtractorTests.cs
@@ -21,8 +21,8 @@ public sealed class LlmImageTextExtractorTests
     private readonly IAIUsageRecordFactory _usageRecordFactory = Substitute.For<IAIUsageRecordFactory>();
     private readonly IAIUsageTracker _usageTracker = Substitute.For<IAIUsageTracker>();
 
-    private static AIWorkspace Workspace(string name, string provider = "OpenAI", string model = "gpt-4o") =>
-        new() { Name = name, Provider = provider, Model = model };
+    private static AIWorkspace Workspace(string key, string provider = "OpenAI", string model = "gpt-4o") =>
+        new() { Key = key, Provider = provider, Model = model };
 
     private void SetupResponse(string text, int? input = 10, int? output = 4)
     {


### PR DESCRIPTION
## Summary

Fixes the CI build break in `Granit.Imaging.AI.Tests` introduced by commit `3255c0d40` (`refactor(ai-workspace): rename Name→Key`). The `AIWorkspace` test helper still set the removed `Name` member:

- `CS0117`: `AIWorkspace` does not contain a definition for `Name`
- `CS9035`: required member `AIWorkspace.Key` must be set

The helper now sets `Key`, and its parameter is renamed `name → key` for homogeneity.

## Verification

- `dotnet build tests/Granit.Imaging.AI.Tests` → 0 warnings, 0 errors