### PR TITLE
test(arch): cable the QueryDefinition data-lookup coverage rule

### DIFF
--- a/tests/Granit.ArchitectureTests.Abstractions.Tests/QueryDefinitionLookupRulesTests.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions.Tests/QueryDefinitionLookupRulesTests.cs
@@ -1,0 +1,91 @@
+using Granit.ArchitectureTests.Abstractions.Rules;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests.Abstractions.Tests;
+
+/// <summary>
+/// Behavioural tests for <see cref="QueryDefinitionLookupRules"/>: a filterable <c>*Id</c> column
+/// without a lookup fails, while a wired column, an exempt column, and non-foreign-key columns pass.
+/// Uses synthetic definitions so the rule is validated without a dependency on
+/// <c>Granit.QueryEngine</c>.
+/// </summary>
+public sealed class QueryDefinitionLookupRulesTests
+{
+    private static readonly Type OpenBase = typeof(FakeQueryDefinition<>);
+
+    [Fact]
+    public void Filterable_foreign_key_without_lookup_fails()
+    {
+        Should.Throw<ShouldAssertException>(() =>
+            QueryDefinitionLookupRules.EveryFilterableForeignKeyColumnShouldDeclareLookup(
+                [typeof(UnwiredDefinition)], OpenBase));
+    }
+
+    [Fact]
+    public void Filterable_foreign_key_with_lookup_passes()
+    {
+        Should.NotThrow(() =>
+            QueryDefinitionLookupRules.EveryFilterableForeignKeyColumnShouldDeclareLookup(
+                [typeof(WiredDefinition)], OpenBase));
+    }
+
+    [Fact]
+    public void Unwired_foreign_key_passes_when_exempted()
+    {
+        HashSet<string> exemptions = new(StringComparer.Ordinal)
+        {
+            $"{typeof(UnwiredEntity).FullName}.PartyId",
+        };
+
+        Should.NotThrow(() =>
+            QueryDefinitionLookupRules.EveryFilterableForeignKeyColumnShouldDeclareLookup(
+                [typeof(UnwiredDefinition)], OpenBase, exemptions));
+    }
+
+    [Fact]
+    public void Non_foreign_key_and_non_filterable_columns_are_ignored()
+    {
+        // Name (not an Id), Id (the primary key), and a non-filterable PlanId must all pass.
+        Should.NotThrow(() =>
+            QueryDefinitionLookupRules.EveryFilterableForeignKeyColumnShouldDeclareLookup(
+                [typeof(EdgeCaseDefinition)], OpenBase));
+    }
+
+    // ── Synthetic fixtures ───────────────────────────────────────────────────────────────────────
+
+    private sealed class UnwiredEntity;
+
+    private sealed class WiredEntity;
+
+    private sealed class EdgeEntity;
+
+    private sealed record FakeColumn(string PropertyName, bool IsFilterable, object? Lookup);
+
+    private abstract class FakeQueryDefinition<TEntity>
+    {
+        public abstract IReadOnlyList<FakeColumn> GetColumns();
+    }
+
+    private sealed class UnwiredDefinition : FakeQueryDefinition<UnwiredEntity>
+    {
+        public override IReadOnlyList<FakeColumn> GetColumns() =>
+            [new FakeColumn("PartyId", IsFilterable: true, Lookup: null)];
+    }
+
+    private sealed class WiredDefinition : FakeQueryDefinition<WiredEntity>
+    {
+        public override IReadOnlyList<FakeColumn> GetColumns() =>
+            [new FakeColumn("PartyId", IsFilterable: true, Lookup: new object())];
+    }
+
+    private sealed class EdgeCaseDefinition : FakeQueryDefinition<EdgeEntity>
+    {
+        public override IReadOnlyList<FakeColumn> GetColumns() =>
+        [
+            new FakeColumn("Name", IsFilterable: true, Lookup: null),
+            new FakeColumn("Id", IsFilterable: true, Lookup: null),
+            new FakeColumn("PlanId", IsFilterable: false, Lookup: null),
+        ];
+    }
+}

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/QueryDefinitionLookupRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/QueryDefinitionLookupRules.cs
@@ -1,0 +1,243 @@
+using System.Collections;
+using System.Reflection;
+using Shouldly;
+
+namespace Granit.ArchitectureTests.Abstractions.Rules;
+
+/// <summary>
+/// Reusable data-lookup coverage rule: every <b>filterable foreign-key column</b> declared on a
+/// <c>QueryDefinition&lt;T&gt;</c> must attach a data-lookup source (<c>.Lookup("name")</c>) so the
+/// admin-grid filter renders a typeahead picker instead of forcing the operator to type a raw
+/// identifier (and so a stored value rehydrates into a human-readable label).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A "foreign-key column" is detected heuristically by name: any column whose property name ends in
+/// <c>"Id"</c> (other than the primary key <c>"Id"</c> itself) — e.g. <c>TenantId</c>, <c>PartyId</c>,
+/// <c>PlanId</c>. This catches the overwhelming majority of links in the Granit codebases, where
+/// foreign keys are consistently <c>{Entity}Id</c>.
+/// </para>
+/// <para>
+/// Columns that legitimately have no lookup — polymorphic references (<c>EntityId</c> +
+/// <c>EntityType</c>), opaque external identifiers (<c>ProviderTransactionId</c>), or plain
+/// string identifiers that merely end in "Id" (<c>TaxId</c>) — are declared in the exemption set,
+/// keyed as <c>"{EntityFullName}.{PropertyName}"</c>, each with an inline justification.
+/// </para>
+/// <para>
+/// The open generic base type is passed as a parameter (pass <c>typeof(QueryDefinition&lt;&gt;)</c>)
+/// to avoid a hard dependency on <c>Granit.QueryEngine</c> in this package; columns are read by
+/// reflection over the public <c>GetColumns()</c> shape (<c>PropertyName</c>, <c>IsFilterable</c>,
+/// <c>Lookup</c>).
+/// </para>
+/// </remarks>
+public static class QueryDefinitionLookupRules
+{
+    /// <summary>
+    /// Discovers every concrete <c>QueryDefinition&lt;T&gt;</c> in the assemblies matched by
+    /// <paramref name="assemblyGlob"/> next to <paramref name="callerAssembly"/> and asserts that
+    /// each filterable foreign-key column declares a lookup or is exempt.
+    /// </summary>
+    /// <param name="callerAssembly">Test assembly — used to locate DLLs in the output directory.</param>
+    /// <param name="assemblyGlob">Glob to select assemblies (e.g. <c>"Granit.*.dll"</c>).</param>
+    /// <param name="queryDefinitionOpenType">Open generic base. Pass <c>typeof(QueryDefinition&lt;&gt;)</c>.</param>
+    /// <param name="exemptColumns">
+    /// Columns intentionally exempt, keyed <c>"{EntityFullName}.{PropertyName}"</c>. Each should
+    /// carry an inline justification.
+    /// </param>
+    public static void EveryFilterableForeignKeyColumnShouldDeclareLookup(
+        Assembly callerAssembly,
+        string assemblyGlob,
+        Type queryDefinitionOpenType,
+        IReadOnlySet<string>? exemptColumns = null)
+    {
+        ArgumentNullException.ThrowIfNull(callerAssembly);
+        ArgumentNullException.ThrowIfNull(queryDefinitionOpenType);
+
+        string outputDir = Path.GetDirectoryName(callerAssembly.Location)!;
+
+        List<Type> definitions =
+        [
+            .. Directory.GetFiles(outputDir, assemblyGlob)
+                .Where(path =>
+                {
+                    string name = Path.GetFileNameWithoutExtension(path);
+                    return !name.Contains("Tests", StringComparison.Ordinal)
+                        && !name.EndsWith(".resources", StringComparison.Ordinal);
+                })
+                .Select(TryLoad)
+                .Where(a => a is not null)
+                .SelectMany(GetLoadableTypes!)
+                .Where(t => IsConcreteDefinition(t, queryDefinitionOpenType)),
+        ];
+
+        // Discovery tripwire: a glob typo, a renamed base type, or a signature drift would otherwise
+        // leave the rule silently green over zero definitions. Fail loudly instead. The codebase
+        // always ships concrete QueryDefinition<T> types, so an empty set means the rule is broken,
+        // not that coverage is complete.
+        definitions.ShouldNotBeEmpty(
+            $"Data-lookup coverage rule discovered no concrete {queryDefinitionOpenType.Name} types " +
+            $"under '{assemblyGlob}' next to {callerAssembly.GetName().Name}. The rule is mis-wired " +
+            "(wrong glob, wrong open generic, or definitions that no longer derive from it) — fix the " +
+            "wiring rather than assuming there is nothing to check.");
+
+        EveryFilterableForeignKeyColumnShouldDeclareLookup(definitions, queryDefinitionOpenType, exemptColumns);
+    }
+
+    /// <summary>
+    /// Pure overload over an explicit candidate type set — instantiates each
+    /// <c>QueryDefinition&lt;T&gt;</c>, reads its columns, and asserts lookup coverage. Useful in
+    /// unit tests with synthetic definitions.
+    /// </summary>
+    public static void EveryFilterableForeignKeyColumnShouldDeclareLookup(
+        IEnumerable<Type> candidateTypes,
+        Type queryDefinitionOpenType,
+        IReadOnlySet<string>? exemptColumns = null)
+    {
+        ArgumentNullException.ThrowIfNull(candidateTypes);
+        ArgumentNullException.ThrowIfNull(queryDefinitionOpenType);
+        exemptColumns ??= new HashSet<string>(StringComparer.Ordinal);
+
+        List<string> violations = [];
+
+        foreach (Type type in candidateTypes)
+        {
+            if (!IsConcreteDefinition(type, queryDefinitionOpenType))
+            {
+                continue;
+            }
+
+            Type? entity = ExtractGenericArgument(type, queryDefinitionOpenType);
+            if (entity?.FullName is null)
+            {
+                continue;
+            }
+
+            object? instance = TryInstantiate(type);
+            if (instance is null)
+            {
+                // Definitions without a parameterless constructor (e.g. dynamically parameterised
+                // reference-data definitions) cannot be introspected statically — skip them.
+                continue;
+            }
+
+            IEnumerable? columns = TryGetColumns(instance);
+            if (columns is null)
+            {
+                continue;
+            }
+
+            foreach (object? column in columns)
+            {
+                if (column is null)
+                {
+                    continue;
+                }
+
+                string? propertyName = GetProperty(column, "PropertyName") as string;
+                if (propertyName is null || !IsForeignKeyColumn(propertyName))
+                {
+                    continue;
+                }
+
+                if (GetProperty(column, "IsFilterable") is not true)
+                {
+                    continue;
+                }
+
+                if (GetProperty(column, "Lookup") is not null)
+                {
+                    continue;
+                }
+
+                string key = $"{entity.FullName}.{propertyName}";
+                if (!exemptColumns.Contains(key))
+                {
+                    violations.Add(key);
+                }
+            }
+        }
+
+        violations.Sort(StringComparer.Ordinal);
+
+        violations.ShouldBeEmpty(
+            "Data-lookup coverage rule: every filterable foreign-key column (a '*Id' column) must declare " +
+            ".Lookup(\"<source>\") so the admin-grid filter renders a typeahead picker instead of a raw " +
+            "identifier. Wire the column to a registered lookup source, or add it to the exemption list " +
+            "with a justification (polymorphic / opaque / external identifiers). " +
+            $"Unwired: {string.Join("; ", violations)}");
+    }
+
+    private static bool IsConcreteDefinition(Type type, Type queryDefinitionOpenType) =>
+        type is { IsAbstract: false, IsClass: true }
+        && !type.IsGenericTypeDefinition
+        && ExtractGenericArgument(type, queryDefinitionOpenType) is not null;
+
+    private static bool IsForeignKeyColumn(string propertyName) =>
+        propertyName.Length > "Id".Length
+        && propertyName.EndsWith("Id", StringComparison.Ordinal);
+
+    private static Type? ExtractGenericArgument(Type candidate, Type openGenericBase)
+    {
+        for (Type? cursor = candidate.BaseType; cursor is not null; cursor = cursor.BaseType)
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == openGenericBase)
+            {
+                return cursor.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    private static object? TryInstantiate(Type type)
+    {
+        try
+        {
+            return Activator.CreateInstance(type, nonPublic: true);
+        }
+        catch (Exception ex) when (ex is MissingMethodException or TargetInvocationException or MemberAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static IEnumerable? TryGetColumns(object instance)
+    {
+        try
+        {
+            MethodInfo? method = instance.GetType().GetMethod("GetColumns", Type.EmptyTypes);
+            return method?.Invoke(instance, null) as IEnumerable;
+        }
+        catch (TargetInvocationException)
+        {
+            return null;
+        }
+    }
+
+    private static object? GetProperty(object obj, string name) =>
+        obj.GetType().GetProperty(name)?.GetValue(obj);
+
+    private static Type[] GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return [.. ex.Types.Where(t => t is not null)!];
+        }
+    }
+
+    private static Assembly? TryLoad(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileLoadException)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Granit.ArchitectureTests/LookupExemptions.cs
+++ b/tests/Granit.ArchitectureTests/LookupExemptions.cs
@@ -1,0 +1,79 @@
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Columns exempt from the data-lookup coverage rule (<c>QueryDefinitionLookupRules</c>): a
+/// filterable <c>*Id</c> column that does not (yet) declare a typeahead picker. Keyed
+/// <c>"{EntityFullName}.{PropertyName}"</c>, each with an inline justification.
+/// </summary>
+/// <remarks>
+/// Two kinds of entry:
+/// <list type="bullet">
+/// <item><b>[PERMANENT]</b> — legitimately no lookup: polymorphic references (<c>EntityId</c> paired
+/// with <c>EntityType</c>), opaque/external identifiers (correlation ids, OAuth client ids, external
+/// IdP ids), or audit/infra logs that are never an interactive admin grid.</item>
+/// <item><b>[BACKLOG]</b> — a real foreign key to an entity that <i>should</i> render a picker; wire
+/// <c>.Lookup("&lt;source&gt;")</c> once that lookup source is registered, then remove the entry.</item>
+/// </list>
+/// <c>TenantId</c> is exempted as a category: it is a cross-cutting multi-tenancy scoping column and
+/// the framework ships no tenant lookup source; a host running multi-tenant admin may wire one.
+/// <para>
+/// Blind spot: definitions without a parameterless constructor (DI-injected) are skipped by the rule
+/// and never surface as violations — do not assume such a definition's columns are covered here.
+/// </para>
+/// </remarks>
+internal static class LookupExemptions
+{
+    public static readonly HashSet<string> Columns = new(StringComparer.Ordinal)
+    {
+        // ── [PERMANENT] polymorphic references (carry a companion *Type discriminator) ──
+        "Granit.Auditing.Domain.AuditEntityChange.EntityId",                     // [PERMANENT] polymorphic (EntityType)
+        "Granit.Timeline.Domain.TimelineEntry.EntityId",                         // [PERMANENT] polymorphic (EntityType)
+        "Granit.Workflow.Domain.WorkflowTransitionRecord.EntityId",             // [PERMANENT] polymorphic (EntityType)
+
+        // ── [PERMANENT] opaque / external / correlation identifiers ──
+        "Granit.Auditing.Domain.AuditEntry.CorrelationId",                       // [PERMANENT] opaque correlation id
+        "Granit.Scheduling.Domain.ScheduledAction.CorrelationId",               // [PERMANENT] opaque correlation id
+        "Granit.Identity.Federated.Domain.FederatedIdentity.ExternalUserId",     // [PERMANENT] external IdP subject (opaque)
+        "Granit.Authorization.Domain.RoleMetadata.ClientId",                     // [PERMANENT] external OAuth client id
+        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication.ClientId", // [PERMANENT] external OAuth client id
+
+        // ── [PERMANENT] audit / infra logs — not interactive admin grids ──
+        "Granit.AI.AIUsageRecord.ConversationId",                                // [PERMANENT] AI cost/audit log; owner-private chat ref
+        "Granit.Auditing.Domain.AuditEntityChange.AuditEntryId",                 // [PERMANENT] internal audit-log FK
+        "Granit.Auditing.Domain.AuditEntry.UserId",                              // [PERMANENT] actor on the audit log (ISO 27001 A.12.4); not a picker
+        "Granit.Webhooks.Domain.WebhookDeliveryAttempt.SubscriptionId",          // [PERMANENT] delivery-log FK (infra)
+
+        // ── [BACKLOG] user foreign keys → wire .Lookup("user") once AddUserDirectoryLookup is standard ──
+        "Granit.AI.Prompts.Domain.PromptTemplate.OwnerId",                       // [BACKLOG] → .Lookup("user")
+        "Granit.Hostnames.Domain.ManagedHostname.OwnerId",                       // [BACKLOG] → .Lookup("user")
+        "Granit.Notifications.Domain.NotificationPreference.UserId",             // [BACKLOG] → .Lookup("user")
+        "Granit.Notifications.Domain.UserNotification.RecipientUserId",          // [BACKLOG] → .Lookup("user")
+        "Granit.Timeline.Domain.TimelineEntry.AuthorId",                         // [BACKLOG] → .Lookup("user")
+
+        // ── [BACKLOG] other entity foreign keys → wire a lookup once the source exists ──
+        "Granit.Templating.Store.TemplateSummary.CategoryId",                    // [BACKLOG] → .Lookup("template-category")
+
+        // ── [PERMANENT] TenantId — cross-cutting tenant scoping; no framework tenant lookup shipped ──
+        "Granit.AI.Prompts.Domain.PromptCategory.TenantId",                      // [PERMANENT] tenant scope
+        "Granit.AI.Prompts.Domain.PromptTemplate.TenantId",                      // [PERMANENT] tenant scope
+        "Granit.Authentication.ApiKeys.Domain.ApiKeyEntry.TenantId",            // [PERMANENT] tenant scope
+        "Granit.Authorization.Domain.PermissionGrant.TenantId",                 // [PERMANENT] tenant scope
+        "Granit.Authorization.Domain.RoleMetadata.TenantId",                    // [PERMANENT] tenant scope
+        "Granit.BlobStorage.Domain.BlobDescriptor.TenantId",                    // [PERMANENT] tenant scope
+        "Granit.DataExchange.Export.Domain.ExportJob.TenantId",                 // [PERMANENT] tenant scope
+        "Granit.DataExchange.Import.Domain.ImportJob.TenantId",                 // [PERMANENT] tenant scope
+        "Granit.Identity.Domain.User.TenantId",                                  // [PERMANENT] tenant scope
+        "Granit.Identity.Federated.Domain.FederatedIdentity.TenantId",          // [PERMANENT] tenant scope
+        "Granit.Identity.Local.Domain.GranitUserGroup.TenantId",               // [PERMANENT] tenant scope
+        "Granit.Localization.Domain.LocalizationOverride.TenantId",            // [PERMANENT] tenant scope
+        "Granit.Notifications.Domain.NotificationPreference.TenantId",          // [PERMANENT] tenant scope
+        "Granit.Notifications.Domain.UserNotification.TenantId",                // [PERMANENT] tenant scope
+        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication.TenantId", // [PERMANENT] tenant scope
+        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictScope.TenantId", // [PERMANENT] tenant scope
+        "Granit.Scheduling.Domain.ScheduledAction.TenantId",                   // [PERMANENT] tenant scope
+        "Granit.Timeline.Domain.TimelineEntry.TenantId",                       // [PERMANENT] tenant scope
+        "Granit.Webhooks.Domain.WebhookDeliveryAttempt.TenantId",             // [PERMANENT] tenant scope
+        "Granit.Webhooks.Domain.WebhookSubscription.TenantId",                 // [PERMANENT] tenant scope
+        "Granit.Workflow.Domain.WorkflowTransitionRecord.TenantId",            // [PERMANENT] tenant scope
+    };
+}

--- a/tests/Granit.ArchitectureTests/QueryDefinitionLookupTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryDefinitionLookupTests.cs
@@ -1,0 +1,22 @@
+using Granit.ArchitectureTests.Abstractions.Rules;
+using Granit.QueryEngine;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces data-lookup coverage: every filterable foreign-key (<c>*Id</c>) column on a
+/// <c>QueryDefinition&lt;T&gt;</c> must declare <c>.Lookup("&lt;source&gt;")</c> so the admin grid
+/// renders a typeahead picker (and the same lookup powers the <c>@</c> mention picker). Logic lives
+/// in <c>Granit.ArchitectureTests.Abstractions</c> so downstream repos reuse it.
+/// </summary>
+public sealed class QueryDefinitionLookupTests
+{
+    [Fact]
+    public void Every_filterable_foreign_key_column_should_declare_a_lookup() =>
+        QueryDefinitionLookupRules.EveryFilterableForeignKeyColumnShouldDeclareLookup(
+            typeof(QueryDefinitionLookupTests).Assembly,
+            "Granit.*.dll",
+            typeof(QueryDefinition<>),
+            LookupExemptions.Columns);
+}


### PR DESCRIPTION
Wires `QueryDefinitionLookupRules` (in `Granit.ArchitectureTests.Abstractions`) into the architecture suite. The rule asserts that **every filterable foreign-key (`*Id`) column** on a `QueryDefinition<T>` declares `.Lookup("<source>")`, so the admin grid renders a typeahead picker instead of a raw identifier — the same lookup that now powers the `@` mention picker (#2826, mentions are tagged DataLookup sources).

## Changes
- **`QueryDefinitionLookupTests`** — runs the rule over `Granit.*.dll` with `typeof(QueryDefinition<>)`.
- **`LookupExemptions`** — the current **39** filterable `*Id` columns, each categorised:
  - **[PERMANENT]** — legitimately no picker: polymorphic refs (`EntityId`+`EntityType`), opaque/external ids (correlation, OAuth client, external IdP), audit/infra logs, and the cross-cutting `TenantId` scope (no framework tenant lookup ships).
  - **[BACKLOG]** — real FKs that should get a picker (`OwnerId`/`AuthorId`/`UserId`/`RecipientUserId` → `.Lookup("user")`, `CategoryId` → a category lookup) once the source is standard; remove the entry when wired.
- Includes the rule + its unit test in `Granit.ArchitectureTests.Abstractions(.Tests)`.

This is a **ratchet**: existing columns are tracked, and any *new* filterable FK column must declare a lookup or be explicitly exempted with a justification.

## Tests
Rule unit test (`Abstractions.Tests`): 4. Architecture suite: **228** (was 227). Format clean.

## Note
Wiring the [BACKLOG] columns to real lookups (e.g. `.Lookup("user")`) is follow-up feature work per module — it touches each `QueryDefinition` (and its exact-count tests) and needs the lookup sources registered. Tracked via the exemption comments.