### PR TITLE
fix(mentions): lookup naming + wire user & category FK lookups (empty the backlog)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2463,6 +2463,7 @@
       "name": "Granit.Templating",
       "deps": [
         "Granit.DataExchange.Abstractions",
+        "Granit.DataLookup.Abstractions",
         "Granit.QueryEngine.Abstractions",
         "Granit.Timing",
         "Granit.Workflow"
@@ -50060,7 +50061,7 @@
       "kind": "class",
       "project": "Granit.Templating",
       "file": "src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "AddGranitTemplating",

--- a/src/Granit.AI.Prompts/Queries/PromptTemplateQueryDefinition.cs
+++ b/src/Granit.AI.Prompts/Queries/PromptTemplateQueryDefinition.cs
@@ -22,7 +22,7 @@ public sealed class PromptTemplateQueryDefinition : QueryDefinition<PromptTempla
             .Column(p => p.Name, c => c.Label("Name").LabelKey("AIPrompts.Columns.Name").Filterable().Sortable())
             .Column(p => p.ShortDescription, c => c.Label("Description").LabelKey("AIPrompts.Columns.Description").Filterable())
             .Column(p => p.IsSystem, c => c.Label("System").LabelKey("AIPrompts.Columns.IsSystem").Filterable().Sortable())
-            .Column(p => p.OwnerId, c => c.Label("Owner").LabelKey("AIPrompts.Columns.Owner").Filterable())
+            .Column(p => p.OwnerId, c => c.Label("Owner").LabelKey("AIPrompts.Columns.Owner").Filterable().Lookup("users", requiredPermission: "Identity.Users.Read"))
             .Column(p => p.Version, c => c.Label("Version").LabelKey("AIPrompts.Columns.Version").Sortable())
             .Column(p => p.TenantId, c => c.Label("Tenant").LabelKey("AIPrompts.Columns.Tenant").Filterable())
             .Column(p => p.CreatedAt, c => c.Label("Created At").LabelKey("AIPrompts.Columns.CreatedAt").Sortable())

--- a/src/Granit.Auditing.Notifications/packages.lock.json
+++ b/src/Granit.Auditing.Notifications/packages.lock.json
@@ -74,6 +74,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Authentication.ApiKeys.Notifications/packages.lock.json
+++ b/src/Granit.Authentication.ApiKeys.Notifications/packages.lock.json
@@ -79,6 +79,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.BackgroundJobs.Notifications/packages.lock.json
+++ b/src/Granit.BackgroundJobs.Notifications/packages.lock.json
@@ -102,6 +102,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.DocumentGeneration.Excel/packages.lock.json
+++ b/src/Granit.DocumentGeneration.Excel/packages.lock.json
@@ -91,6 +91,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.DocumentGeneration.Pdf/packages.lock.json
+++ b/src/Granit.DocumentGeneration.Pdf/packages.lock.json
@@ -226,6 +226,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.DocumentGeneration/packages.lock.json
+++ b/src/Granit.DocumentGeneration/packages.lock.json
@@ -39,6 +39,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Hostnames.Notifications/packages.lock.json
+++ b/src/Granit.Hostnames.Notifications/packages.lock.json
@@ -64,6 +64,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
+++ b/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
@@ -20,7 +20,7 @@ public sealed class ManagedHostnameQueryDefinition : QueryDefinition<ManagedHost
             // `e => e.Host.Value` to dodge that throws at definition build. See issue #2767.
             .Column(e => e.Host, c => c.Label("Host").LabelKey("Hostnames.Columns.Host").Filterable().Sortable())
             .Column(e => e.OwnerType, c => c.Label("Owner Type").LabelKey("Hostnames.Columns.OwnerType").Filterable().Sortable())
-            .Column(e => e.OwnerId, c => c.Label("Owner Id").LabelKey("Hostnames.Columns.OwnerId").Filterable())
+            .Column(e => e.OwnerId, c => c.Label("Owner Id").LabelKey("Hostnames.Columns.OwnerId").Filterable().Lookup("users", requiredPermission: "Identity.Users.Read"))
             .Column(e => e.IsPrimary, c => c.Label("Primary").LabelKey("Hostnames.Columns.IsPrimary").Filterable().Sortable())
             .Column(e => e.Status, c => c.Label("Status").LabelKey("Hostnames.Columns.Status").Filterable().Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("Hostnames.Columns.CreatedAt").Sortable())

--- a/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -64,15 +64,20 @@ public static class IdentityEntityFrameworkCoreServiceCollectionExtensions
         services.AddScoped<IGranitAutoInterceptor>(sp =>
             sp.GetRequiredService<UserLookupHashInterceptor>());
 
+        // The canonical user directory is exposed as the "users" lookup so any column declaring
+        // .Lookup("users") (and the @ mention picker) resolves wherever identity-EF is wired.
+        services.AddUserDirectoryLookup();
+
         return services;
     }
 
     /// <summary>
-    /// Registers the canonical user directory as a <c>Granit.DataLookup</c> source named <c>user</c>
-    /// — a typeahead over <see cref="IUserDirectoryQueryableSource"/> (label = <c>DisplayName</c>,
-    /// gated on <c>Identity.Users.Read</c>), available for form-field pickers and, once tagged via
-    /// <c>AddMentionSource("user")</c>, the <c>@</c> mention picker. Works in every provider mode
-    /// (the canonical <c>User</c> table is synced for local and federated).
+    /// Registers the canonical user directory as a <c>Granit.DataLookup</c> source named
+    /// <c>users</c> — a typeahead over <see cref="IUserDirectoryQueryableSource"/> (label =
+    /// <c>DisplayName</c>, gated on <c>Identity.Users.Read</c>), available for form-field pickers and,
+    /// once tagged via <c>AddMentionSource("users")</c>, the <c>@</c> mention picker. Works in every
+    /// provider mode (the canonical <c>User</c> table is synced for local and federated). Idempotent —
+    /// <see cref="AddGranitIdentityEntityFrameworkCore"/> already calls it.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
@@ -80,11 +85,17 @@ public static class IdentityEntityFrameworkCoreServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        if (services.Any(d => d.ServiceType == typeof(UserDirectoryLookupMarker)))
+        {
+            return services;
+        }
+
+        services.AddSingleton<UserDirectoryLookupMarker>();
         services.AddScoped<ILookupSource>(sp =>
         {
             IUserDirectoryQueryableSource directory = sp.GetRequiredService<IUserDirectoryQueryableSource>();
             return new QueryableLookupSource<User>(
-                name: "user",
+                name: "users",
                 queryableFactory: directory.GetQueryable,
                 valueSelector: u => u.Id,
                 labelSelector: u => u.DisplayName,
@@ -94,4 +105,7 @@ public static class IdentityEntityFrameworkCoreServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>Sentinel ensuring the <c>users</c> lookup is registered at most once.</summary>
+    private sealed class UserDirectoryLookupMarker;
 }

--- a/src/Granit.Identity.Federated.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Federated.Notifications/packages.lock.json
@@ -170,6 +170,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Local.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Local.Notifications/packages.lock.json
@@ -211,6 +211,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Identity.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Notifications/packages.lock.json
@@ -108,6 +108,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Mentions/README.md
+++ b/src/Granit.Mentions/README.md
@@ -8,7 +8,8 @@ queryable) becomes mentionable with a single line and **zero new classes**.
 ## How it works
 
 - A single facade `ILookupSource` named `mentions` is registered (`AddGranitMentions`).
-- `AddMentionSource("user")` tags an existing lookup source as mentionable.
+- `AddMentionSource("users")` tags an existing lookup source as mentionable. Source names follow the
+  DataLookup convention: a plural, kebab-case collection noun (`users`, `tenants`, `ref-countries`).
 - The facade fans the picker out across the tagged sources (optionally narrowed by `scope.type`),
   applies **lenient** per-type authorization (an unauthorized type is skipped, never a 403 for the
   whole picker), merges and caps, and re-stamps each item's value as a composite `type:value` so one
@@ -22,8 +23,8 @@ endpoint. A host that wants the `@` picker:
 ```csharp
 // 1. Expose each entity as a lookup, then tag it mentionable.
 services.AddQueryDefinitionLookup<Invoice, MyDbContext>();   // Granit.DataLookup.EntityFrameworkCore
-services.AddMentionSource("invoice");
-services.AddUserDirectoryLookup().AddMentionSource("user");  // Granit.Identity.EntityFrameworkCore — @user
+services.AddMentionSource("invoices");
+services.AddMentionSource("users");   // the "users" lookup is auto-registered by AddGranitIdentityEntityFrameworkCore — @user
 
 // 2. Map the DataLookup endpoints (this is what serves the picker).
 app.MapGranitDataLookups();
@@ -37,7 +38,7 @@ app.MapGranitDataLookups();
 | Resolve a selection | `GET /lookups/mentions/resolve?value=<type>:<id>` |
 | List mentionable + other sources | `GET /lookups` |
 
-Each suggestion's `value` is the composite `type:id` (e.g. `user:3f2a…`) and `extra.type` carries
+Each suggestion's `value` is the composite `type:id` (e.g. `users:3f2a…`) and `extra.type` carries
 the type — the front sends `type:id` back, and an AI-chat turn carries it as a `MentionRequest`. AI
 chat resolves through the same facade and injects the result wrapped in the untrusted-document
 envelope.

--- a/src/Granit.Notifications.Brevo/packages.lock.json
+++ b/src/Granit.Notifications.Brevo/packages.lock.json
@@ -355,6 +355,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.14.7",
-        "contentHash": "341XBsfXxS5SsAvOmflJDdQwDCHl7G5Uw51IPStxWyZijS4nYIypOqIDfv2pdUFsh3QfHeI/h7o36wj6+FOt+w==",
+        "resolved": "4.0.14.8",
+        "contentHash": "AoFdd2AH0Bq4inK6rNgYnoUJcUU60o8jYkKy/hUs9kAgQtesKzAqG+GcRWPoy2nFgj3KXru+D6Vw1uto3tVikQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.9.4, 5.0.0)"
+          "AWSSDK.Core": "[4.0.9.6, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -69,8 +69,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.9.4",
-        "contentHash": "bpxzv4e0WjOVmKiYkjkNWeKvwyzoIVFS+u5zYnsryM2qTyhkfeLGQ4LPqDo+m/7OIJlGWr6V9zkc3V9bb0QmYg=="
+        "resolved": "4.0.9.6",
+        "contentHash": "Lzi5hMHNB+ApeMbQxNDCUNa+Lta00ozr1okKUGqUyNXUC/OG136k8M6jXgNrbwsRxDmVdHHY6UdD4aoUaGVzkQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -176,6 +176,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/packages.lock.json
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/packages.lock.json
@@ -242,6 +242,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Notifications.Email.Scaleway/packages.lock.json
+++ b/src/Granit.Notifications.Email.Scaleway/packages.lock.json
@@ -337,6 +337,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Notifications.Email.SendGrid/packages.lock.json
+++ b/src/Granit.Notifications.Email.SendGrid/packages.lock.json
@@ -337,6 +337,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Notifications.Email.Smtp/packages.lock.json
+++ b/src/Granit.Notifications.Email.Smtp/packages.lock.json
@@ -191,6 +191,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Notifications.Email/packages.lock.json
+++ b/src/Granit.Notifications.Email/packages.lock.json
@@ -108,6 +108,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Notifications/Queries/NotificationPreferenceQueryDefinition.cs
+++ b/src/Granit.Notifications/Queries/NotificationPreferenceQueryDefinition.cs
@@ -17,7 +17,7 @@ public sealed class NotificationPreferenceQueryDefinition : QueryDefinition<Noti
     {
         builder
             .Column(e => e.TenantId, c => c.Label("Tenant").LabelKey("Notifications.Columns.Tenant").Filterable().Sortable())
-            .Column(e => e.UserId, c => c.Label("User").LabelKey("Notifications.Columns.UserId").Filterable().Sortable())
+            .Column(e => e.UserId, c => c.Label("User").LabelKey("Notifications.Columns.UserId").Filterable().Sortable().Lookup("users", requiredPermission: "Identity.Users.Read"))
             .Column(e => e.NotificationTypeName, c => c.Label("Notification Type").LabelKey("Notifications.Columns.NotificationTypeName").Filterable().Sortable())
             .Column(e => e.ChannelName, c => c.Label("Channel").LabelKey("Notifications.Columns.ChannelName").Filterable().Sortable())
             .Column(e => e.IsEnabled, c => c.Label("Enabled").LabelKey("Notifications.Columns.IsEnabled").Filterable().Sortable())

--- a/src/Granit.Notifications/Queries/UserNotificationQueryDefinition.cs
+++ b/src/Granit.Notifications/Queries/UserNotificationQueryDefinition.cs
@@ -17,7 +17,7 @@ public sealed class UserNotificationQueryDefinition : QueryDefinition<UserNotifi
     {
         builder
             .Column(e => e.TenantId, c => c.Label("Tenant").LabelKey("Notifications.Columns.Tenant").Filterable().Sortable())
-            .Column(e => e.RecipientUserId, c => c.Label("Recipient").LabelKey("Notifications.Columns.RecipientUserId").Filterable().Sortable())
+            .Column(e => e.RecipientUserId, c => c.Label("Recipient").LabelKey("Notifications.Columns.RecipientUserId").Filterable().Sortable().Lookup("users", requiredPermission: "Identity.Users.Read"))
             .Column(e => e.NotificationTypeName, c => c.Label("Notification Type").LabelKey("Notifications.Columns.NotificationTypeName").Filterable().Sortable())
             .Column(e => e.Severity, c => c.Label("Severity").LabelKey("Notifications.Columns.Severity").Filterable().Sortable())
             .Column(e => e.State, c => c.Label("State").LabelKey("Notifications.Columns.State").Filterable().Sortable())

--- a/src/Granit.Privacy.Notifications/packages.lock.json
+++ b/src/Granit.Privacy.Notifications/packages.lock.json
@@ -402,6 +402,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -529,8 +530,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.12.0",
-        "contentHash": "6uJqmZMadnLYQu4BdYae0YSE1cBcJPJxDKfkt5ut8RFHOw9H4EuD7+vB5sEAOEKkTCA7kc23LZoXSyZMDJTCkQ==",
+        "resolved": "6.13.1",
+        "contentHash": "HQvtFTZaoegRXMQk3CYvkaPcbzD/njHOeAFIWf/eoSZ7edQClKaLrjMmOvvt0OUviHTY4+5wXLARmGkRrTKtpA==",
         "dependencies": {
           "JasperFx": "2.13.0",
           "JasperFx.Events": "2.13.0",

--- a/src/Granit.Scheduling.Notifications/packages.lock.json
+++ b/src/Granit.Scheduling.Notifications/packages.lock.json
@@ -134,6 +134,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Templating.AI/packages.lock.json
+++ b/src/Granit.Templating.AI/packages.lock.json
@@ -182,6 +182,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Templating.Endpoints/packages.lock.json
+++ b/src/Granit.Templating.Endpoints/packages.lock.json
@@ -140,6 +140,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Templating.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Templating.EntityFrameworkCore/packages.lock.json
@@ -169,6 +169,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Templating.Mjml/packages.lock.json
+++ b/src/Granit.Templating.Mjml/packages.lock.json
@@ -59,6 +59,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Templating.Scriban/packages.lock.json
+++ b/src/Granit.Templating.Scriban/packages.lock.json
@@ -75,6 +75,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Templating.Workflow/packages.lock.json
+++ b/src/Granit.Templating.Workflow/packages.lock.json
@@ -39,6 +39,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Granit.DataExchange.Extensions;
+using Granit.DataLookup.Sources;
 using Granit.Diagnostics;
 using Granit.QueryEngine.Extensions;
 using Granit.Templating.Diagnostics;
@@ -59,6 +60,10 @@ public static class ServiceCollectionExtensions
         // Query + Export definitions (ADR-020: owned by the base module).
         services.AddQueryDefinition<TemplateSummary, TemplateSummaryQueryDefinition>();
         services.AddExportDefinition<TemplateSummary, TemplateSummaryExportDefinition>();
+
+        // 'template-categories' lookup backing the CategoryId column picker (and the @ mention path
+        // when tagged). Registered once; coexists with other ILookupSource registrations.
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<ILookupSource, TemplateCategoryLookupSource>());
 
         return services;
     }

--- a/src/Granit.Templating/Granit.Templating.csproj
+++ b/src/Granit.Templating/Granit.Templating.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.DataLookup.Abstractions\Granit.DataLookup.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
     <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />

--- a/src/Granit.Templating/Internal/TemplateCategoryLookupSource.cs
+++ b/src/Granit.Templating/Internal/TemplateCategoryLookupSource.cs
@@ -1,0 +1,53 @@
+using Granit.DataLookup.Descriptors;
+using Granit.DataLookup.Sources;
+using Granit.Templating.Store;
+
+namespace Granit.Templating.Internal;
+
+/// <summary>
+/// Exposes template categories as the <c>template-categories</c> <see cref="ILookupSource"/> so a
+/// <c>CategoryId</c> column renders a typeahead picker (and rehydrates a stored id into the category
+/// name). Backed by <see cref="ITemplateCategoryStoreReader"/> with in-memory filtering — categories
+/// are a small, bounded set — and gated on <c>Templating.Categories.Read</c>.
+/// </summary>
+internal sealed class TemplateCategoryLookupSource(ITemplateCategoryStoreReader reader) : ILookupSource
+{
+    public string Name => "template-categories";
+
+    public string? RequiredPermission => "Templating.Categories.Read";
+
+    public IReadOnlyList<string> ScopeKeys => [];
+
+    public async ValueTask<LookupResult> SearchAsync(LookupQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (query.PageSize <= 0)
+        {
+            return new LookupResult([]);
+        }
+
+        // Already ordered by SortOrder then Name by the reader.
+        IReadOnlyList<TemplateCategory> categories = await reader.ListCategoriesAsync(cancellationToken).ConfigureAwait(false);
+
+        IEnumerable<TemplateCategory> matches = string.IsNullOrWhiteSpace(query.Search)
+            ? categories
+            : categories.Where(c => c.Name.Contains(query.Search, StringComparison.OrdinalIgnoreCase));
+
+        List<LookupItem> items = [.. matches.Take(query.PageSize).Select(ToItem)];
+        return new LookupResult(items);
+    }
+
+    public async ValueTask<LookupItem?> ResolveByValueAsync(object value, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (!Guid.TryParse(value.ToString(), out Guid id))
+        {
+            return null;
+        }
+
+        TemplateCategory? category = await reader.GetCategoryAsync(id, cancellationToken).ConfigureAwait(false);
+        return category is null ? null : ToItem(category);
+    }
+
+    private static LookupItem ToItem(TemplateCategory category) => new(category.Id, category.Name);
+}

--- a/src/Granit.Templating/Queries/TemplateSummaryQueryDefinition.cs
+++ b/src/Granit.Templating/Queries/TemplateSummaryQueryDefinition.cs
@@ -25,7 +25,7 @@ public sealed class TemplateSummaryQueryDefinition : QueryDefinition<TemplateSum
             .Column(s => s.CurrentStatus, c => c.Label("Status").LabelKey("Template.Columns.Status").Filterable().Sortable())
             .Column(s => s.HasPublishedVersion, c => c.Label("Has Published Version").LabelKey("Template.Columns.HasPublishedVersion").Filterable())
             .Column(s => s.LayoutName, c => c.Label("Layout").LabelKey("Template.Columns.LayoutName").Filterable())
-            .Column(s => s.CategoryId, c => c.Label("Category").LabelKey("Template.Columns.Category").Filterable())
+            .Column(s => s.CategoryId, c => c.Label("Category").LabelKey("Template.Columns.Category").Filterable().Lookup("template-categories", requiredPermission: "Templating.Categories.Read"))
             .Column(s => s.LastModifiedAt, c => c.Label("Last Modified").LabelKey("Template.Columns.LastModifiedAt").Sortable())
             .Column(s => s.LastModifiedBy, c => c.Label("Last Modified By").LabelKey("Template.Columns.LastModifiedBy").Filterable())
             .GlobalSearch(s => s.Name)

--- a/src/Granit.Timeline.Notifications/packages.lock.json
+++ b/src/Granit.Timeline.Notifications/packages.lock.json
@@ -54,6 +54,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Timeline/Queries/TimelineEntryQueryDefinition.cs
+++ b/src/Granit.Timeline/Queries/TimelineEntryQueryDefinition.cs
@@ -20,7 +20,7 @@ public sealed class TimelineEntryQueryDefinition : QueryDefinition<TimelineEntry
             .Column(e => e.EntityType, c => c.Label("Entity Type").LabelKey("Timeline.Columns.EntityType").Filterable().Sortable())
             .Column(e => e.EntityId, c => c.Label("Entity ID").LabelKey("Timeline.Columns.EntityId").Filterable().Sortable())
             .Column(e => e.EntryType, c => c.Label("Entry Type").LabelKey("Timeline.Columns.EntryType").Filterable().Sortable())
-            .Column(e => e.AuthorId, c => c.Label("Author").LabelKey("Timeline.Columns.AuthorId").Filterable().Sortable())
+            .Column(e => e.AuthorId, c => c.Label("Author").LabelKey("Timeline.Columns.AuthorId").Filterable().Sortable().Lookup("users", requiredPermission: "Identity.Users.Read"))
             .Column(e => e.IsDeleted, c => c.Label("Deleted").LabelKey("Timeline.Columns.IsDeleted").Filterable().Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("Timeline.Columns.CreatedAt").Sortable())
             .GlobalSearch(e => e.EntityType, e => e.EntityId, e => e.Body)

--- a/src/Granit.Webhooks.Notifications/packages.lock.json
+++ b/src/Granit.Webhooks.Notifications/packages.lock.json
@@ -316,6 +316,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Workflow.Notifications/packages.lock.json
+++ b/src/Granit.Workflow.Notifications/packages.lock.json
@@ -181,6 +181,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/tests/Granit.ArchitectureTests/LookupExemptions.cs
+++ b/tests/Granit.ArchitectureTests/LookupExemptions.cs
@@ -43,9 +43,6 @@ internal static class LookupExemptions
         "Granit.Auditing.Domain.AuditEntry.UserId",                              // [PERMANENT] actor on the audit log (ISO 27001 A.12.4); not a picker
         "Granit.Webhooks.Domain.WebhookDeliveryAttempt.SubscriptionId",          // [PERMANENT] delivery-log FK (infra)
 
-        // ── [BACKLOG] other entity foreign keys → wire a lookup once the source exists ──
-        "Granit.Templating.Store.TemplateSummary.CategoryId",                    // [BACKLOG] → .Lookup("template-category") — no category lookup source yet
-
         // ── [PERMANENT] TenantId — cross-cutting tenant scoping; no framework tenant lookup shipped ──
         "Granit.AI.Prompts.Domain.PromptCategory.TenantId",                      // [PERMANENT] tenant scope
         "Granit.AI.Prompts.Domain.PromptTemplate.TenantId",                      // [PERMANENT] tenant scope

--- a/tests/Granit.ArchitectureTests/LookupExemptions.cs
+++ b/tests/Granit.ArchitectureTests/LookupExemptions.cs
@@ -43,15 +43,8 @@ internal static class LookupExemptions
         "Granit.Auditing.Domain.AuditEntry.UserId",                              // [PERMANENT] actor on the audit log (ISO 27001 A.12.4); not a picker
         "Granit.Webhooks.Domain.WebhookDeliveryAttempt.SubscriptionId",          // [PERMANENT] delivery-log FK (infra)
 
-        // ── [BACKLOG] user foreign keys → wire .Lookup("user") once AddUserDirectoryLookup is standard ──
-        "Granit.AI.Prompts.Domain.PromptTemplate.OwnerId",                       // [BACKLOG] → .Lookup("user")
-        "Granit.Hostnames.Domain.ManagedHostname.OwnerId",                       // [BACKLOG] → .Lookup("user")
-        "Granit.Notifications.Domain.NotificationPreference.UserId",             // [BACKLOG] → .Lookup("user")
-        "Granit.Notifications.Domain.UserNotification.RecipientUserId",          // [BACKLOG] → .Lookup("user")
-        "Granit.Timeline.Domain.TimelineEntry.AuthorId",                         // [BACKLOG] → .Lookup("user")
-
         // ── [BACKLOG] other entity foreign keys → wire a lookup once the source exists ──
-        "Granit.Templating.Store.TemplateSummary.CategoryId",                    // [BACKLOG] → .Lookup("template-category")
+        "Granit.Templating.Store.TemplateSummary.CategoryId",                    // [BACKLOG] → .Lookup("template-category") — no category lookup source yet
 
         // ── [PERMANENT] TenantId — cross-cutting tenant scoping; no framework tenant lookup shipped ──
         "Granit.AI.Prompts.Domain.PromptCategory.TenantId",                      // [PERMANENT] tenant scope

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3843,6 +3843,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/UserDirectoryLookupRegistrationTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/UserDirectoryLookupRegistrationTests.cs
@@ -15,7 +15,7 @@ public sealed class UserDirectoryLookupRegistrationTests
     }
 
     [Fact]
-    public void AddUserDirectoryLookup_registers_a_user_lookup_source_gated_on_users_read()
+    public void AddUserDirectoryLookup_registers_a_users_lookup_source_gated_on_users_read()
     {
         var services = new ServiceCollection();
         services.AddSingleton<IUserDirectoryQueryableSource>(new StubDirectory());
@@ -26,9 +26,26 @@ public sealed class UserDirectoryLookupRegistrationTests
         using IServiceScope scope = provider.CreateScope();
 
         ILookupSource? source = scope.ServiceProvider.GetServices<ILookupSource>()
-            .SingleOrDefault(s => s.Name == "user");
+            .SingleOrDefault(s => s.Name == "users");
 
         source.ShouldNotBeNull();
         source.RequiredPermission.ShouldBe("Identity.Users.Read");
+    }
+
+    [Fact]
+    public void AddUserDirectoryLookup_is_idempotent()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IUserDirectoryQueryableSource>(new StubDirectory());
+
+        services.AddUserDirectoryLookup();
+        services.AddUserDirectoryLookup();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        scope.ServiceProvider.GetServices<ILookupSource>()
+            .Count(s => s.Name == "users")
+            .ShouldBe(1);
     }
 }

--- a/tests/Granit.Templating.Tests/TemplateCategoryLookupSourceTests.cs
+++ b/tests/Granit.Templating.Tests/TemplateCategoryLookupSourceTests.cs
@@ -1,0 +1,89 @@
+using Granit.DataLookup.Descriptors;
+using Granit.Templating.Internal;
+using Granit.Templating.Store;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Templating.Tests;
+
+public sealed class TemplateCategoryLookupSourceTests
+{
+    private static readonly Guid Marketing = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Billing = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private sealed class StubReader(params TemplateCategory[] categories) : ITemplateCategoryStoreReader
+    {
+        public Task<IReadOnlyList<TemplateCategory>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<TemplateCategory>>(categories);
+
+        public Task<TemplateCategory?> GetCategoryAsync(Guid id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Array.Find(categories, c => c.Id == id));
+    }
+
+    private static TemplateCategory Category(Guid id, string name, int sortOrder = 0) =>
+        new() { Id = id, Name = name, SortOrder = sortOrder, TemplateCount = 0 };
+
+    private static TemplateCategoryLookupSource Build(params TemplateCategory[] categories) =>
+        new(new StubReader(categories));
+
+    [Fact]
+    public void Name_and_permission()
+    {
+        TemplateCategoryLookupSource source = Build();
+        source.Name.ShouldBe("template-categories");
+        source.RequiredPermission.ShouldBe("Templating.Categories.Read");
+    }
+
+    [Fact]
+    public async Task Search_returns_all_categories_mapped_to_id_and_name()
+    {
+        TemplateCategoryLookupSource source = Build(Category(Marketing, "Marketing"), Category(Billing, "Billing"));
+
+        LookupResult result = await source.SearchAsync(new LookupQuery(PageSize: 8), TestContext.Current.CancellationToken);
+
+        result.Items.Select(i => i.Value).ShouldBe([Marketing, Billing]);
+        result.Items.Select(i => i.Label).ShouldBe(["Marketing", "Billing"]);
+    }
+
+    [Fact]
+    public async Task Search_filters_by_name_case_insensitively()
+    {
+        TemplateCategoryLookupSource source = Build(Category(Marketing, "Marketing"), Category(Billing, "Billing"));
+
+        LookupResult result = await source.SearchAsync(new LookupQuery(Search: "bill", PageSize: 8), TestContext.Current.CancellationToken);
+
+        result.Items.ShouldHaveSingleItem();
+        result.Items[0].Value.ShouldBe(Billing);
+    }
+
+    [Fact]
+    public async Task Search_caps_at_page_size()
+    {
+        TemplateCategoryLookupSource source = Build(Category(Marketing, "Marketing"), Category(Billing, "Billing"));
+
+        LookupResult result = await source.SearchAsync(new LookupQuery(PageSize: 1), TestContext.Current.CancellationToken);
+
+        result.Items.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Resolve_returns_the_category_by_id()
+    {
+        TemplateCategoryLookupSource source = Build(Category(Marketing, "Marketing"));
+
+        LookupItem? item = await source.ResolveByValueAsync(Marketing.ToString(), TestContext.Current.CancellationToken);
+
+        item.ShouldNotBeNull();
+        item.Value.ShouldBe(Marketing);
+        item.Label.ShouldBe("Marketing");
+    }
+
+    [Fact]
+    public async Task Resolve_returns_null_for_unknown_or_malformed_value()
+    {
+        TemplateCategoryLookupSource source = Build(Category(Marketing, "Marketing"));
+
+        (await source.ResolveByValueAsync(Billing.ToString(), TestContext.Current.CancellationToken)).ShouldBeNull();
+        (await source.ResolveByValueAsync("not-a-guid", TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+}

--- a/tests/Granit.Templating.Tests/packages.lock.json
+++ b/tests/Granit.Templating.Tests/packages.lock.json
@@ -271,6 +271,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"


### PR DESCRIPTION
Follow-up to the mention/lookup work. Two fixes from review:

## 1. Naming convention — plural, kebab-case
Lookup source names are a **plural, kebab-case collection noun** matching the permission resource. The existing precedent is `.Lookup("tenants", requiredPermission: "MultiTenancy.Tenants.Read")` (in `AuditEntryQueryDefinition`), and the DataLookup docs use `"tenants"`, `"ref-countries"`. The user directory was wrongly **singular** (`"user"`) — carried over from the `@user` mention type of the earlier resolver design. Renamed to **`"users"`** (matching `Identity.Users.Read`).

## 2. The source is now actually wired
`.Lookup("users")` referenced a source that was **opt-in** (`AddUserDirectoryLookup`, host had to call it) — a dangling contract. The `users` lookup is now **auto-registered by `AddGranitIdentityEntityFrameworkCore`** (idempotent), so it resolves wherever identity-EF is present. The mention *tag* (`AddMentionSource("users")`) stays opt-in.

## 3. FK columns wired (not exempted)
The 5 user foreign keys were a cop-out `[BACKLOG]` exemption. They are now properly wired to `.Lookup("users", requiredPermission: "Identity.Users.Read")` and removed from `LookupExemptions`:
`PromptTemplate.OwnerId`, `ManagedHostname.OwnerId`, `TimelineEntry.AuthorId`, `NotificationPreference.UserId`, `UserNotification.RecipientUserId`.

## Tests
The 4 modules' query tests, `Granit.Identity.EntityFrameworkCore` (28, incl. a new idempotency test), and the architecture coverage rule — all green. Format + markdownlint clean.