### PR TITLE
test(ai-chat,mentions): guard AI chat seam DI registration (attachments, suggestions, mentions)

### DIFF
--- a/tests/Granit.AI.Chat.BlobStorage.Tests/AIChatBlobStorageRegistrationTests.cs
+++ b/tests/Granit.AI.Chat.BlobStorage.Tests/AIChatBlobStorageRegistrationTests.cs
@@ -1,0 +1,58 @@
+using Granit.AI.Chat.Attachments;
+using Granit.AI.Chat.BlobStorage.Extensions;
+using Granit.BlobStorage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.AI.Chat.BlobStorage.Tests;
+
+/// <summary>
+/// Guards the DI wiring, not just the declaration: an architecture test confirms the module is
+/// well-formed, but only resolving the container proves <see cref="IAIAttachmentSource"/> binds to
+/// <see cref="BlobStorageAIAttachmentSource"/> rather than silently falling back to the Null default.
+/// </summary>
+public sealed class AIChatBlobStorageRegistrationTests
+{
+    private static ServiceProvider BuildProvider(Action<IServiceCollection>? arrange = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IBlobContentReader>());
+        arrange?.Invoke(services);
+        services.AddBlobStorageChatAttachments();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AddBlobStorageChatAttachments_ResolvesBlobStorageSource()
+    {
+        using ServiceProvider provider = BuildProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        IAIAttachmentSource source = scope.ServiceProvider.GetRequiredService<IAIAttachmentSource>();
+
+        source.ShouldBeOfType<BlobStorageAIAttachmentSource>();
+    }
+
+    [Fact]
+    public void AddBlobStorageChatAttachments_OverridesPreRegisteredDefault()
+    {
+        // Mirrors the real module graph: GranitAIChatModule runs first and TryAdds a default source,
+        // then GranitAIChatBlobStorageModule registers BlobStorage. The override must win — a
+        // regression to TryAddScoped (or a module-ordering flip) would silently drop attachments.
+        using ServiceProvider provider = BuildProvider(services =>
+            services.TryAddScoped<IAIAttachmentSource, StubDefaultAttachmentSource>());
+        using IServiceScope scope = provider.CreateScope();
+
+        IAIAttachmentSource source = scope.ServiceProvider.GetRequiredService<IAIAttachmentSource>();
+
+        source.ShouldBeOfType<BlobStorageAIAttachmentSource>();
+    }
+
+    private sealed class StubDefaultAttachmentSource : IAIAttachmentSource
+    {
+        public Task<AIAttachmentData?> GetAsync(string reference, CancellationToken cancellationToken = default) =>
+            Task.FromResult<AIAttachmentData?>(null);
+    }
+}

--- a/tests/Granit.AI.Chat.Tests/AIChatSuggestionsRegistrationTests.cs
+++ b/tests/Granit.AI.Chat.Tests/AIChatSuggestionsRegistrationTests.cs
@@ -1,0 +1,49 @@
+using Granit.AI.Chat.Extensions;
+using Granit.AI.Chat.Internal;
+using Granit.AI.Chat.Suggestions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Granit.AI.Chat.Tests;
+
+/// <summary>
+/// Guards the DI wiring of the suggestion seam, not just its declaration. The resolver fans out over
+/// an injected <see cref="IEnumerable{T}"/> of <see cref="IAISuggestionProvider"/>; the builder must
+/// keep registering each provider additively (<c>AddScoped</c>). A regression to a single-registration
+/// <c>TryAdd</c> would silently keep only one provider — every other module's suggestions would vanish
+/// with all behavioural tests still green.
+/// </summary>
+public sealed class AIChatSuggestionsRegistrationTests
+{
+    private sealed class StubProviderA : IAISuggestionProvider
+    {
+        public ValueTask<IReadOnlyList<AISuggestedAction>> GetSuggestionsAsync(
+            AISuggestionContext context, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IReadOnlyList<AISuggestedAction>>([]);
+    }
+
+    private sealed class StubProviderB : IAISuggestionProvider
+    {
+        public ValueTask<IReadOnlyList<AISuggestedAction>> GetSuggestionsAsync(
+            AISuggestionContext context, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IReadOnlyList<AISuggestedAction>>([]);
+    }
+
+    [Fact]
+    public void AddGranitChatSuggestions_RegistersResolverAndAllProviders()
+    {
+        var services = new ServiceCollection();
+
+        services.AddGranitChatSuggestions(builder => builder.Add<StubProviderA>().Add<StubProviderB>());
+
+        // The single resolver default must be wired...
+        services.Count(d => d.ServiceType == typeof(IAISuggestionResolver) &&
+                            d.ImplementationType == typeof(AISuggestionResolver)).ShouldBe(1);
+
+        // ...and every contributed provider must register additively (collection-consumed).
+        Type[] providers = [.. services
+            .Where(d => d.ServiceType == typeof(IAISuggestionProvider))
+            .Select(d => d.ImplementationType!)];
+        providers.ShouldBe([typeof(StubProviderA), typeof(StubProviderB)], ignoreOrder: true);
+    }
+}

--- a/tests/Granit.Mentions.Tests/MentionsRegistrationTests.cs
+++ b/tests/Granit.Mentions.Tests/MentionsRegistrationTests.cs
@@ -1,0 +1,47 @@
+using Granit.DataLookup.Sources;
+using Granit.Mentions.Extensions;
+using Granit.Mentions.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Granit.Mentions.Tests;
+
+/// <summary>
+/// Guards the DI wiring of the mention facade, not just its declaration. <c>LookupRegistry</c> builds
+/// its name→source map from the injected <see cref="IEnumerable{T}"/> of <see cref="ILookupSource"/>;
+/// the <c>mentions</c> facade only resolves if <see cref="MentionLookupSource"/> is actually in that
+/// collection. A regression of the <c>TryAddEnumerable</c> registration to a single <c>TryAddScoped</c>
+/// (or dropping it) would make the picker silently resolve nothing — or, registered twice via a plain
+/// <c>AddScoped</c>, would crash the registry on a duplicate source name.
+/// </summary>
+public sealed class MentionsRegistrationTests
+{
+    private static int MentionFacadeCount(IServiceCollection services) =>
+        services.Count(d =>
+            d.ServiceType == typeof(ILookupSource) &&
+            d.ImplementationType == typeof(MentionLookupSource));
+
+    [Fact]
+    public void AddGranitMentions_RegistersMentionFacadeAsLookupSource()
+    {
+        var services = new ServiceCollection();
+
+        services.AddGranitMentions();
+
+        MentionFacadeCount(services).ShouldBe(1);
+        MentionLookup.SourceName.ShouldBe("mentions");
+    }
+
+    [Fact]
+    public void AddGranitMentions_IsIdempotent()
+    {
+        var services = new ServiceCollection();
+
+        services.AddGranitMentions();
+        services.AddGranitMentions();
+
+        // A non-idempotent registration would register MentionLookupSource twice; LookupRegistry
+        // throws on a duplicate source name, so exactly one descriptor proves TryAddEnumerable holds.
+        MentionFacadeCount(services).ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2821 / #2822. Architecture tests confirm the AI-chat seam modules are *well-formed* (declaration), but nothing proved their DI *registration* actually works. Each seam can pass every behavioural + architecture test and still silently no-op if its wiring regresses — the same class of bug as the sessions-provider silent no-op.

This PR adds resolution/registration guards across the **three** seams the base `GranitAIChatModule` wires:

### 1. Attachments (`Granit.AI.Chat.BlobStorage.Tests`)
`AddGranitChatAttachments<T>()` relies on `AddScoped` (last-wins) to override the `NullAIAttachmentSource` the base module `TryAdd`s. A regression to `TryAddScoped`, or a module-ordering flip, would resolve `IAIAttachmentSource` to the Null default and drop every attachment.
- `IAIAttachmentSource` binds to `BlobStorageAIAttachmentSource`
- it overrides a pre-registered default (mirrors the real module graph)

### 2. Suggestions (`Granit.AI.Chat.Tests`)
`AISuggestionResolver` fans out over `IEnumerable<IAISuggestionProvider>`; the builder must register providers additively (`AddScoped`). A regression to `TryAddScoped` keeps only one provider — every other module's suggestions vanish.
- resolver wired + all contributed providers register additively

### 3. Mentions (`Granit.Mentions.Tests`)
`LookupRegistry` builds its name→source map from `IEnumerable<ILookupSource>`; the `mentions` facade resolves only if `MentionLookupSource` is in it. The registration must stay `TryAddEnumerable` (idempotent) — a plain `AddScoped` double-registers and crashes the registry on a duplicate source name.
- facade registered as an `ILookupSource`
- registration is idempotent

## Teeth

Every guard was verified to **fail** against the exact regression it protects (attachment `Add`→`TryAdd` → resolves `NullAIAttachmentSource`; suggestion `Add`→`TryAdd` → one provider survives; mention `TryAddEnumerable`→`AddScoped` → idempotency breaks), then pass once reverted.

## Test plan

- [x] All new tests pass (attachments 6/6, suggestions 1/1, mentions 2/2)
- [x] `dotnet format --verify-no-changes` clean on all three test projects
- [x] Regression-proven (teeth verified for each seam)