### PR TITLE
fix(mentions): break DI cycle by resolving ILookupRegistry lazily

### DIFF
--- a/src/Granit.Mentions/Internal/MentionLookupSource.cs
+++ b/src/Granit.Mentions/Internal/MentionLookupSource.cs
@@ -2,6 +2,7 @@ using Granit.Authorization;
 using Granit.DataLookup.Descriptors;
 using Granit.DataLookup.Registry;
 using Granit.DataLookup.Sources;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Mentions.Internal;
@@ -20,11 +21,17 @@ namespace Granit.Mentions.Internal;
 /// </remarks>
 internal sealed partial class MentionLookupSource(
     IEnumerable<MentionSource> mentionSources,
-    ILookupRegistry lookupRegistry,
+    IServiceProvider serviceProvider,
     IPermissionChecker permissionChecker,
     ILogger<MentionLookupSource> logger) : ILookupSource
 {
     private const char Separator = ':';
+
+    // Resolved lazily, not constructor-injected: LookupRegistry consumes IEnumerable<ILookupSource>,
+    // which includes this source, so a constructor dependency on ILookupRegistry forms a DI cycle.
+    // Both this source and the registry are scoped, so by the time SearchAsync runs this instance is
+    // already cached in the scope — resolving the registry here reuses it, no recursion. (#2833)
+    private ILookupRegistry Registry => serviceProvider.GetRequiredService<ILookupRegistry>();
 
     public string Name => MentionLookup.SourceName;
 
@@ -54,7 +61,7 @@ internal sealed partial class MentionLookupSource(
         List<LookupItem> items = [];
         foreach (string name in SelectNames(type))
         {
-            ILookupSource? source = lookupRegistry.Resolve(name);
+            ILookupSource? source = Registry.Resolve(name);
             if (source is null || !await IsAuthorizedAsync(source, cancellationToken).ConfigureAwait(false))
             {
                 LogSourceSkipped(name);
@@ -86,7 +93,7 @@ internal sealed partial class MentionLookupSource(
             return null;
         }
 
-        ILookupSource? source = lookupRegistry.Resolve(type);
+        ILookupSource? source = Registry.Resolve(type);
         if (source is null || !await IsAuthorizedAsync(source, cancellationToken).ConfigureAwait(false))
         {
             return null;

--- a/tests/Granit.Mentions.Tests/MentionLookupSourceTests.cs
+++ b/tests/Granit.Mentions.Tests/MentionLookupSourceTests.cs
@@ -3,6 +3,7 @@ using Granit.DataLookup.Descriptors;
 using Granit.DataLookup.Registry;
 using Granit.DataLookup.Sources;
 using Granit.Mentions.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
@@ -44,9 +45,16 @@ public sealed class MentionLookupSourceTests
 
     private readonly IPermissionChecker _checker = Substitute.For<IPermissionChecker>();
 
-    private MentionLookupSource Build(ILookupSource[] sources, params string[] mentionable) =>
-        new([.. mentionable.Select(n => new MentionSource(n))], new FakeLookupRegistry(sources), _checker,
+    private MentionLookupSource Build(ILookupSource[] sources, params string[] mentionable)
+    {
+        // MentionLookupSource resolves ILookupRegistry lazily off IServiceProvider (breaks the DI cycle);
+        // hand it a provider carrying the fake registry.
+        ServiceProvider provider = new ServiceCollection()
+            .AddSingleton<ILookupRegistry>(new FakeLookupRegistry(sources))
+            .BuildServiceProvider();
+        return new([.. mentionable.Select(n => new MentionSource(n))], provider, _checker,
             NullLogger<MentionLookupSource>.Instance);
+    }
 
     private static LookupQuery Query(string? search = "a", int pageSize = 8, string? type = null) =>
         new(Search: search, PageSize: pageSize,

--- a/tests/Granit.Mentions.Tests/MentionsRegistrationTests.cs
+++ b/tests/Granit.Mentions.Tests/MentionsRegistrationTests.cs
@@ -1,7 +1,12 @@
+using Granit.Authorization;
+using Granit.DataLookup.Descriptors;
+using Granit.DataLookup.Extensions;
+using Granit.DataLookup.Registry;
 using Granit.DataLookup.Sources;
 using Granit.Mentions.Extensions;
 using Granit.Mentions.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using Shouldly;
 
 namespace Granit.Mentions.Tests;
@@ -43,5 +48,47 @@ public sealed class MentionsRegistrationTests
         // A non-idempotent registration would register MentionLookupSource twice; LookupRegistry
         // throws on a duplicate source name, so exactly one descriptor proves TryAddEnumerable holds.
         MentionFacadeCount(services).ShouldBe(1);
+    }
+
+    /// <summary>A minimal registered lookup source, so the mention facade has a real sibling to fan out to.</summary>
+    private sealed class StubLookupSource(string name) : ILookupSource
+    {
+        public string Name => name;
+        public string? RequiredPermission => null;
+        public IReadOnlyList<string> ScopeKeys => [];
+
+        public ValueTask<LookupResult> SearchAsync(LookupQuery query, CancellationToken cancellationToken) =>
+            ValueTask.FromResult(new LookupResult([new LookupItem($"{name}-1", $"{name} 1")]));
+
+        public ValueTask<LookupItem?> ResolveByValueAsync(object value, CancellationToken cancellationToken) =>
+            ValueTask.FromResult<LookupItem?>(null);
+    }
+
+    /// <summary>
+    /// Regression for the DI cycle (#2833). <c>LookupRegistry</c> consumes <see cref="IEnumerable{T}"/> of
+    /// <see cref="ILookupSource"/> — which includes the mention facade — and the facade used to
+    /// constructor-inject <see cref="ILookupRegistry"/>, closing a structural cycle. The container threw
+    /// <c>"A circular dependency was detected for the service of type 'ILookupRegistry'"</c> at startup.
+    /// <c>ValidateOnBuild</c> reproduces that detection; resolving the registry and facade proves the
+    /// lazy <see cref="IServiceProvider"/> resolution broke the cycle without breaking the fan-out.
+    /// </summary>
+    [Fact]
+    public void Container_validates_and_resolves_with_the_mention_facade_in_the_lookup_graph()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMetrics();
+        services.AddSingleton(Substitute.For<IPermissionChecker>());
+        services.AddGranitDataLookup();
+        services.AddScoped<ILookupSource>(_ => new StubLookupSource("user"));
+        services.AddMentionSource("user");
+
+        ServiceProvider provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+
+        using IServiceScope scope = provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<ILookupRegistry>().ShouldNotBeNull();
+        scope.ServiceProvider.GetServices<ILookupSource>()
+            .ShouldContain(source => source is MentionLookupSource);
     }
 }


### PR DESCRIPTION
## Problem

Wiring the mention picker crashed any host at startup:

```
A circular dependency was detected for the service of type 'Granit.DataLookup.Registry.ILookupRegistry'.
  IAIMentionContextResolver(AIMentionContextResolver)
    -> ILookupRegistry(LookupRegistry)
    -> IEnumerable<ILookupSource>
    -> ILookupSource(Granit.Mentions.Internal.MentionLookupSource)
    -> ILookupRegistry
```

`MentionLookupSource` is registered as an `ILookupSource`, which `LookupRegistry` aggregates via `IEnumerable<ILookupSource>`. The facade constructor-injected `ILookupRegistry` to fan the picker out across the tagged sources — closing a structural, constructor-time cycle the container rejects.

## Fix

Resolve `ILookupRegistry` lazily off `IServiceProvider` instead of by constructor injection. Both the facade and the registry are **scoped**, so by the time `SearchAsync`/`ResolveByValueAsync` runs, the facade instance is already cached in the scope — resolving the registry at that point reuses the existing instance, no recursion.

## Tests

- `dotnet build` + `dotnet test` on `Granit.Mentions` green.
- New `ValidateOnBuild` DI regression test (`MentionsRegistrationTests`) wires `AddGranitDataLookup` + a mention source + the facade and resolves both `ILookupRegistry` and `MentionLookupSource` without throwing — this exact graph threw the circular-dependency error before the fix.
- Updated the existing `MentionLookupSource` unit tests for the new constructor signature (lazy `IServiceProvider`).