### PR TITLE
refactor(text-extraction): audit cleanup — tracing span, dead-member prune, options validation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -51064,7 +51064,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction",
       "file": "src/Granit.TextExtraction/Extensions/ServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitTextExtraction",
@@ -51451,7 +51451,7 @@
       "kind": "class",
       "project": "Granit.TextExtraction",
       "file": "src/Granit.TextExtraction/Options/GranitTextExtractionOptions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "MaxConcurrentExtractions",
@@ -51562,12 +51562,6 @@
       "file": "src/Granit.TextExtraction.Pdf.Ocr/IPdfRasterizer.cs",
       "line": 10,
       "members": [
-        {
-          "name": "GetPageCount",
-          "kind": "method",
-          "signature": "GetPageCount(ReadOnlyMemory<byte> pdfBytes, CancellationToken cancellationToken)",
-          "returnType": "int"
-        },
         {
           "name": "RasterisePageAsync",
           "kind": "method",

--- a/src/Granit.TextExtraction.Pdf.Ocr/IPdfRasterizer.cs
+++ b/src/Granit.TextExtraction.Pdf.Ocr/IPdfRasterizer.cs
@@ -10,12 +10,6 @@ namespace Granit.TextExtraction.Pdf.Ocr;
 public interface IPdfRasterizer
 {
     /// <summary>
-    /// Returns the total page count for the document. Called once per extraction so the
-    /// extractor can clamp against <c>MaxPagesToRasterise</c> before any rendering.
-    /// </summary>
-    int GetPageCount(ReadOnlyMemory<byte> pdfBytes, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Renders a single page (zero-based index) at <paramref name="dpi"/> and returns
     /// the encoded PNG bytes. Throws on PDF-level errors (corrupt page, missing page);
     /// the calling extractor catches and soft-skips so a single bad page never sinks

--- a/src/Granit.TextExtraction.Pdf.Ocr/Internal/DefaultPdfRasterizer.cs
+++ b/src/Granit.TextExtraction.Pdf.Ocr/Internal/DefaultPdfRasterizer.cs
@@ -28,19 +28,6 @@ internal sealed class DefaultPdfRasterizer : IPdfRasterizer
 {
     private readonly Lock _gate = new();
 
-    public int GetPageCount(ReadOnlyMemory<byte> pdfBytes, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        lock (_gate)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            // PDFtoImage's byte[] overload reads everything synchronously; allocating
-            // the array is unavoidable because Conversion.GetPageCount has no Memory<>
-            // overload.
-            return Conversion.GetPageCount(pdfBytes.ToArray());
-        }
-    }
-
     public Task<byte[]> RasterisePageAsync(
         ReadOnlyMemory<byte> pdfBytes,
         int pageIndex,

--- a/src/Granit.TextExtraction/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.TextExtraction/Extensions/ServiceCollectionExtensions.cs
@@ -5,7 +5,6 @@ using Granit.TextExtraction.Internal;
 using Granit.TextExtraction.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 
 namespace Granit.TextExtraction.Extensions;
 
@@ -26,10 +25,9 @@ public static class ServiceCollectionExtensions
         GranitActivitySourceRegistry.Register(TextExtractionActivitySource.Name);
 
         services.AddOptions<GranitTextExtractionOptions>()
-            .BindConfiguration(GranitTextExtractionOptions.SectionName);
-
-        services.TryAddSingleton(sp =>
-            sp.GetRequiredService<IOptions<GranitTextExtractionOptions>>().Value);
+            .BindConfiguration(GranitTextExtractionOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
         services.TryAddSingleton<TextExtractionMetrics>();
         services.TryAddSingleton<PlainTextExtractor>();

--- a/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
+++ b/src/Granit.TextExtraction/Internal/TextExtractionPipeline.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Granit.MultiTenancy;
 using Granit.TextExtraction.Diagnostics;
 using Granit.TextExtraction.Exceptions;
@@ -67,6 +68,17 @@ internal sealed class TextExtractionPipeline : ITextExtractionPipeline, IDisposa
         ITextExtractor selected = SelectExtractor(contentType);
         string? tenantId = ResolveTenantId();
 
+        // One span per extraction so the queue-wait + parse latency (Tika HTTP hop, OCR
+        // render) is visible per extractor/MIME and propagates W3C trace context downstream.
+        using Activity? activity = TextExtractionActivitySource.Source.StartActivity(
+            TextExtractionActivitySource.Extract);
+        if (activity is not null)
+        {
+            activity.SetTag("extractor", selected.Name);
+            activity.SetTag("content_type", TextExtractionMetrics.NormalizeContentType(contentType));
+            activity.SetTag("tenant_id", tenantId ?? TextExtractionMetrics.GlobalTenant);
+        }
+
         // Bound the number of in-flight extractions across the host process.
         // Done OUTSIDE the timeout link so queue time doesn't eat the per-extraction budget.
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -92,6 +104,12 @@ internal sealed class TextExtractionPipeline : ITextExtractionPipeline, IDisposa
                     .ExtractAsync(source, contentType, _options.MaxExtractedCharLength, effectiveToken)
                     .ConfigureAwait(false);
 
+                if (activity is not null)
+                {
+                    activity.SetTag("char_count", result.CharCount);
+                    activity.SetTag("truncated", result.IsTruncated);
+                }
+
                 _metrics.RecordSuccess(tenantId, result.ExtractorName, contentType);
                 if (result.IsTruncated)
                 {
@@ -107,11 +125,13 @@ internal sealed class TextExtractionPipeline : ITextExtractionPipeline, IDisposa
             {
                 // Our timeout fired (not the caller's token) — re-surface as a structured
                 // pipeline failure so consumers can branch on `reason == "extraction_timeout"`.
+                activity?.SetStatus(ActivityStatusCode.Error, "extraction_timeout");
                 _metrics.RecordFailed(tenantId, selected.Name, contentType, "extraction_timeout");
                 throw new TextExtractionException("extraction_timeout");
             }
             catch (TextExtractionException tex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, tex.Reason);
                 _metrics.RecordFailed(tenantId, selected.Name, contentType, tex.Reason);
                 throw;
             }
@@ -121,6 +141,7 @@ internal sealed class TextExtractionPipeline : ITextExtractionPipeline, IDisposa
             }
             catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
                 _metrics.RecordFailed(tenantId, selected.Name, contentType, ex.GetType().Name);
                 throw;
             }

--- a/src/Granit.TextExtraction/Options/GranitTextExtractionOptions.cs
+++ b/src/Granit.TextExtraction/Options/GranitTextExtractionOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Granit.TextExtraction.Options;
 
 /// <summary>
@@ -19,6 +21,7 @@ public sealed class GranitTextExtractionOptions
     /// Maximum number of extractions allowed to run concurrently across the host process.
     /// Defaults to <see cref="Environment.ProcessorCount"/>.
     /// </summary>
+    [Range(1, int.MaxValue)]
     public int MaxConcurrentExtractions { get; set; } = Environment.ProcessorCount;
 
     /// <summary>Per-extraction timeout. Defaults to 30 seconds.</summary>
@@ -29,18 +32,21 @@ public sealed class GranitTextExtractionOptions
     /// Defaults to 100 MB. Breaching it raises
     /// <see cref="Granit.TextExtraction.Exceptions.TextExtractionException"/> with reason <c>input_too_large</c>.
     /// </summary>
+    [Range(1, long.MaxValue)]
     public long MaxBodySizeBytes { get; set; } = 100L * 1024 * 1024;
 
     /// <summary>
     /// Zip-bomb ceiling for archive-shaped extractors (Office, ZIP). Defaults to 500 MB.
     /// Enforced by extractors that walk decompressed entries.
     /// </summary>
+    [Range(1, long.MaxValue)]
     public long MaxDecompressedBytes { get; set; } = 500L * 1024 * 1024;
 
     /// <summary>
     /// Maximum number of entries an archive (e.g. an Office .docx) is allowed to contain.
     /// Defaults to 10 000. Protects against archive-entry DoS.
     /// </summary>
+    [Range(1, int.MaxValue)]
     public int MaxZipEntries { get; set; } = 10_000;
 
     /// <summary>
@@ -49,11 +55,13 @@ public sealed class GranitTextExtractionOptions
     /// Producing more characters MUST result in
     /// <see cref="Granit.TextExtraction.TextExtractionResult.IsTruncated"/> set to <c>true</c>.
     /// </summary>
+    [Range(1, int.MaxValue)]
     public int MaxExtractedCharLength { get; set; } = 500_000;
 
     /// <summary>
     /// Maximum total pixels for image rasterisation (PDF page rendering, OCR pre-processing).
     /// Defaults to 100 000 000 (≈ 10 000 × 10 000). Guard against pixel-flood attacks.
     /// </summary>
+    [Range(1, long.MaxValue)]
     public long MaxImagePixels { get; set; } = 100_000_000;
 }

--- a/src/Granit.TextExtraction/PlainTextExtractor.cs
+++ b/src/Granit.TextExtraction/PlainTextExtractor.cs
@@ -11,8 +11,6 @@ namespace Granit.TextExtraction;
 /// </summary>
 public sealed class PlainTextExtractor(IOptions<GranitTextExtractionOptions> options) : ITextExtractor
 {
-    private const string PlainText = "text/plain";
-
     /// <summary>The stable extractor identifier surfaced on metrics and spans.</summary>
     public const string ExtractorName = "granit.text-extraction.plain-text";
 
@@ -94,10 +92,4 @@ public sealed class PlainTextExtractor(IOptions<GranitTextExtractionOptions> opt
             ExtractorName: ExtractorName,
             Confidence: ExtractionConfidence.Deterministic);
     }
-
-    /// <summary>
-    /// Stable singleton MIME used when callers don't know the source content type and want
-    /// to force the plain-text path. Kept as a constant so consumers don't allocate strings.
-    /// </summary>
-    internal const string FallbackContentType = PlainText;
 }


### PR DESCRIPTION
## Context

Follow-up to a `/audit Granit.TextExtraction*` pass. The family audited **COMPLIANT** (0 blocking findings); this PR clears the 5 non-blocking polish items it surfaced. Pure framework hygiene — no behavioural change to a correctly-configured host.

## Changes

| Finding | Fix |
| --- | --- |
| ActivitySource registered but never emitted a span | `TextExtractionPipeline` now starts one span per extraction (`extractor` / `content_type` / `tenant_id` / `char_count` / `truncated` tags + `Error` status on timeout/failure), so latency (Tika HTTP hop, OCR render) is traceable and W3C context propagates downstream. |
| `IPdfRasterizer.GetPageCount` was dead | Removed. Verified it was speculative (added in #2329, never called, never stubbed in tests): the `MaxPagesToRasterise` clamp it was meant for already uses PdfPig's `NumberOfPages`. Wiring it would re-parse the PDF through PDFium for a count we already hold. |
| Dead DI registration of the unwrapped options value | Removed (no consumer injects the bare `GranitTextExtractionOptions`; all use `IOptions<T>`). |
| Options had no startup validation | Added `ValidateDataAnnotations().ValidateOnStart()` + `[Range]` on the numeric DoS caps so misconfiguration fails fast at startup instead of per-extraction at runtime. `ExtractionTimeout` left unconstrained — `0`/negative legitimately means "disabled". |
| Unused `FallbackContentType` / `PlainText` consts | Removed. |

## Verification

- Build: all 9 `Granit.TextExtraction*` projects — 0 warnings, 0 errors
- Tests: `Granit.TextExtraction.Tests` 46/46, `Granit.TextExtraction.Pdf.Ocr.Tests` 17/17
- `dotnet format --verify-no-changes` clean on touched projects

No docs change required (the cleanup touches no documented public API; doc PRs ship separately against `granit-docs` anyway).