### PR TITLE
fix(timeline,mentions): framework audit convention + correctness fixes

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -52150,6 +52150,12 @@
           "kind": "method",
           "signature": "GetStreamAsync(string entityType, string entityId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
           "returnType": "Task<TimelineStreamResult>"
+        },
+        {
+          "name": "GetEntryAsync",
+          "kind": "method",
+          "signature": "GetEntryAsync(string entityType, string entityId, Guid entryId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TimelineStreamEntry?>"
         }
       ]
     },
@@ -52754,7 +52760,7 @@
       "kind": "class",
       "project": "Granit.Timeline",
       "file": "src/Granit.Timeline/GranitTimelineModule.cs",
-      "line": 21,
+      "line": 23,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Mentions/Extensions/MentionsServiceCollectionExtensions.cs
+++ b/src/Granit.Mentions/Extensions/MentionsServiceCollectionExtensions.cs
@@ -29,7 +29,8 @@ public static class MentionsServiceCollectionExtensions
     /// <summary>
     /// Tags an existing lookup source (by name) as mentionable, so the <c>@</c> picker includes it.
     /// The source must be registered separately (e.g. <c>AddQueryDefinitionLookup</c>,
-    /// <c>AddQueryableLookup</c>). Also ensures the facade is registered.
+    /// <c>AddQueryableLookup</c>). Also ensures the facade is registered. Calling this twice with the
+    /// same name registers a duplicate tag; duplicates are collapsed case-insensitively at query time.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="lookupSourceName">The lookup source name to expose, e.g. <c>user</c>, <c>invoice</c>.</param>

--- a/src/Granit.Mentions/Internal/MentionLookupSource.cs
+++ b/src/Granit.Mentions/Internal/MentionLookupSource.cs
@@ -30,7 +30,7 @@ internal sealed partial class MentionLookupSource(
     // Resolved lazily, not constructor-injected: LookupRegistry consumes IEnumerable<ILookupSource>,
     // which includes this source, so a constructor dependency on ILookupRegistry forms a DI cycle.
     // Both this source and the registry are scoped, so by the time SearchAsync runs this instance is
-    // already cached in the scope — resolving the registry here reuses it, no recursion. (#2833)
+    // already cached in the scope — resolving the registry here reuses it, no recursion. (#2834)
     private ILookupRegistry Registry => serviceProvider.GetRequiredService<ILookupRegistry>();
 
     public string Name => MentionLookup.SourceName;

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
@@ -54,6 +54,7 @@ internal static class TimelineEntryEndpoints
             .WithSummary("Soft-deletes a comment or internal note (GDPR right to erasure).")
             .WithDescription("Performs a soft-delete on the timeline entry. Only the author or users with Timeline.Entries.Manage permission can delete. SystemLog entries are immutable (ISO 27001). Returns 404 if the entry does not exist.")
             .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;
@@ -66,6 +67,7 @@ internal static class TimelineEntryEndpoints
         [FromServices] ITimelineWriter writer,
         [FromServices] ITimelineFollowerService followerService,
         [FromServices] ITimelineNotifier notifier,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         TimelineEntry entry = await writer.PostEntryAsync(
@@ -104,7 +106,10 @@ internal static class TimelineEntryEndpoints
             SourceId: null,
             EditedAt: null);
 
-        return TypedResults.Created($"/api/timeline/{entityType}/{entityId}/entries/{entry.Id}", result);
+        // Location is built from the actual request path so it honours the host's configured
+        // route prefix (TimelineEndpointsOptions.RoutePrefix) and mount point.
+        string location = $"{httpContext.Request.Path}/{entry.Id}";
+        return TypedResults.Created(location, result);
     }
 
     private static async Task<Results<Ok<AnchorTimelineEntryResponse>, ProblemHttpResult>> AnchorExternalAsync(
@@ -176,8 +181,7 @@ internal static class TimelineEntryEndpoints
 
         if (!isAdmin)
         {
-            TimelineStreamResult stream = await reader.GetStreamAsync(entityType, entityId, 1, 1000, cancellationToken).ConfigureAwait(false);
-            TimelineStreamEntry? target = stream.Page.Items.FirstOrDefault(e => e.Id == entryId);
+            TimelineStreamEntry? target = await reader.GetEntryAsync(entityType, entityId, entryId, cancellationToken).ConfigureAwait(false);
 
             if (target is null)
             {

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
@@ -1,7 +1,8 @@
 {
   "culture": "cs",
   "texts": {
-    "Validation:TooManyAttachments": "Nelze připojit více než 20 souborů.",
+    "Timeline:Validation:TooManyAttachments": "Nelze připojit více než 20 souborů.",
+    "Timeline:Validation:InvalidSourceKey": "Neplatný formát klíče zdroje.",
     "Permission:Timeline.Entries.Create": "Přidávat komentáře a sledovat/přestat sledovat entity",
     "Permission:Timeline.Entries.Manage": "Spravovat (mazat) libovolnou položku časové osy bez ohledu na vlastníka",
     "Permission:Timeline.Entries.Read": "Zobrazit aktivity a historii auditu",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
@@ -1,7 +1,8 @@
 {
   "culture": "de",
   "texts": {
-    "Validation:TooManyAttachments": "Es können nicht mehr als 20 Dateien angehängt werden.",
+    "Timeline:Validation:TooManyAttachments": "Es können nicht mehr als 20 Dateien angehängt werden.",
+    "Timeline:Validation:InvalidSourceKey": "Ungültiges Format des Quellschlüssels.",
     "Permission:Timeline.Entries.Create": "Kommentare veröffentlichen und Entitäten folgen/entfolgen",
     "Permission:Timeline.Entries.Manage": "Beliebige Zeitachseneinträge verwalten (löschen), unabhängig vom Eigentümer",
     "Permission:Timeline.Entries.Read": "Aktivitätsfeeds und Prüfverlauf anzeigen",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en-GB.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
-    "Validation:TooManyAttachments": "Cannot attach more than 20 files.",
+    "Timeline:Validation:TooManyAttachments": "Cannot attach more than 20 files.",
     "Permission:Timeline.Entries.Manage": "Manage (delete) any timeline entry regardless of ownership",
     "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds",
     "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
@@ -1,7 +1,8 @@
 {
   "culture": "en",
   "texts": {
-    "Validation:TooManyAttachments": "Cannot attach more than 20 files.",
+    "Timeline:Validation:TooManyAttachments": "Cannot attach more than 20 files.",
+    "Timeline:Validation:InvalidSourceKey": "Invalid source key format.",
     "Permission:Timeline.Entries.Create": "Post comments and follow/unfollow entities",
     "Permission:Timeline.Entries.Manage": "Manage (delete) any timeline entry regardless of ownership",
     "Permission:Timeline.Entries.Read": "View activity feeds and audit history",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
@@ -1,7 +1,8 @@
 {
   "culture": "es",
   "texts": {
-    "Validation:TooManyAttachments": "No se pueden adjuntar más de 20 archivos.",
+    "Timeline:Validation:TooManyAttachments": "No se pueden adjuntar más de 20 archivos.",
+    "Timeline:Validation:InvalidSourceKey": "Formato de clave de origen no válido.",
     "Permission:Timeline.Entries.Create": "Publicar comentarios y seguir/dejar de seguir entidades",
     "Permission:Timeline.Entries.Manage": "Gestionar (eliminar) cualquier entrada de línea de tiempo sin importar el propietario",
     "Permission:Timeline.Entries.Read": "Ver flujos de actividad e historial de auditoría",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr-CA.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
-    "Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
+    "Timeline:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
     "Permission:Timeline.Entries.Manage": "Gérer (supprimer) toute entrée de fil d'activité quel que soit le propriétaire",
     "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité",
     "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
@@ -1,7 +1,8 @@
 {
   "culture": "fr",
   "texts": {
-    "Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
+    "Timeline:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
+    "Timeline:Validation:InvalidSourceKey": "Format de clé de source non valide.",
     "Permission:Timeline.Entries.Create": "Poster des commentaires et suivre/ne plus suivre des entités",
     "Permission:Timeline.Entries.Manage": "Gérer (supprimer) toute entrée de fil d'activité quel que soit le propriétaire",
     "Permission:Timeline.Entries.Read": "Consulter les flux d'activité et l'historique d'audit",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/hi.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/hi.json
@@ -1,7 +1,8 @@
 {
   "culture": "hi",
   "texts": {
-    "Validation:TooManyAttachments": "20 से अधिक फ़ाइलें संलग्न नहीं की जा सकतीं।",
+    "Timeline:Validation:TooManyAttachments": "20 से अधिक फ़ाइलें संलग्न नहीं की जा सकतीं।",
+    "Timeline:Validation:InvalidSourceKey": "स्रोत कुंजी प्रारूप अमान्य है।",
     "Permission:Timeline.Entries.Create": "टिप्पणियाँ पोस्ट करें और इकाइयों को फ़ॉलो/अनफ़ॉलो करें",
     "Permission:Timeline.Entries.Manage": "स्वामित्व की परवाह किए बिना किसी भी टाइमलाइन प्रविष्टि को प्रबंधित (हटाएँ) करें",
     "Permission:Timeline.Entries.Read": "गतिविधि फ़ीड और ऑडिट इतिहास देखें",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
@@ -1,7 +1,8 @@
 {
   "culture": "it",
   "texts": {
-    "Validation:TooManyAttachments": "Non è possibile allegare più di 20 file.",
+    "Timeline:Validation:TooManyAttachments": "Non è possibile allegare più di 20 file.",
+    "Timeline:Validation:InvalidSourceKey": "Formato della chiave di origine non valido.",
     "Permission:Timeline.Entries.Create": "Pubblicare commenti e seguire/smettere di seguire entità",
     "Permission:Timeline.Entries.Manage": "Gestire (eliminare) qualsiasi voce della timeline indipendentemente dal proprietario",
     "Permission:Timeline.Entries.Read": "Visualizzare i flussi di attività e la cronologia di audit",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
@@ -1,7 +1,8 @@
 {
   "culture": "ja",
   "texts": {
-    "Validation:TooManyAttachments": "添付ファイルは20個までです。",
+    "Timeline:Validation:TooManyAttachments": "添付ファイルは20個までです。",
+    "Timeline:Validation:InvalidSourceKey": "ソースキーの形式が無効です。",
     "Permission:Timeline.Entries.Create": "コメントの投稿とエンティティのフォロー/フォロー解除",
     "Permission:Timeline.Entries.Manage": "所有者に関係なくタイムラインエントリを管理（削除）",
     "Permission:Timeline.Entries.Read": "アクティビティフィードと監査履歴を表示",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
@@ -1,7 +1,8 @@
 {
   "culture": "ko",
   "texts": {
-    "Validation:TooManyAttachments": "20개 이상의 파일을 첨부할 수 없습니다.",
+    "Timeline:Validation:TooManyAttachments": "20개 이상의 파일을 첨부할 수 없습니다.",
+    "Timeline:Validation:InvalidSourceKey": "소스 키 형식이 잘못되었습니다.",
     "Permission:Timeline.Entries.Create": "댓글 작성 및 엔티티 팔로우/언팔로우",
     "Permission:Timeline.Entries.Manage": "소유자에 관계없이 타임라인 항목 관리(삭제)",
     "Permission:Timeline.Entries.Read": "활동 피드 및 감사 이력 보기",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
@@ -1,7 +1,8 @@
 {
   "culture": "nl",
   "texts": {
-    "Validation:TooManyAttachments": "U kunt niet meer dan 20 bestanden bijvoegen.",
+    "Timeline:Validation:TooManyAttachments": "U kunt niet meer dan 20 bestanden bijvoegen.",
+    "Timeline:Validation:InvalidSourceKey": "Ongeldige indeling van bronsleutel.",
     "Permission:Timeline.Entries.Create": "Reacties plaatsen en entiteiten volgen/ontvolgen",
     "Permission:Timeline.Entries.Manage": "Alle tijdlijnvermeldingen beheren (verwijderen) ongeacht eigenaar",
     "Permission:Timeline.Entries.Read": "Activiteitsfeeds en auditgeschiedenis bekijken",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
@@ -1,7 +1,8 @@
 {
   "culture": "pl",
   "texts": {
-    "Validation:TooManyAttachments": "Nie można dołączyć więcej niż 20 plików.",
+    "Timeline:Validation:TooManyAttachments": "Nie można dołączyć więcej niż 20 plików.",
+    "Timeline:Validation:InvalidSourceKey": "Nieprawidłowy format klucza źródła.",
     "Permission:Timeline.Entries.Create": "Dodawanie komentarzy i śledzenie/zaprzestanie śledzenia encji",
     "Permission:Timeline.Entries.Manage": "Zarządzanie (usuwanie) wpisów osi czasu niezależnie od właściciela",
     "Permission:Timeline.Entries.Read": "Wyświetlanie kanałów aktywności i historii audytu",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt-BR.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "Validation:TooManyAttachments": "Não é possível anexar mais de 20 arquivos.",
+    "Timeline:Validation:TooManyAttachments": "Não é possível anexar mais de 20 arquivos.",
     "Permission:Timeline.Entries.Manage": "Gerenciar (excluir) qualquer entrada de linha do tempo independentemente do proprietário",
     "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade",
     "Permission:Timeline.InternalNotes.Read": "Ver notas internas somente para funcionários nos feeds de atividade",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
@@ -1,7 +1,8 @@
 {
   "culture": "pt",
   "texts": {
-    "Validation:TooManyAttachments": "Não é possível anexar mais de 20 ficheiros.",
+    "Timeline:Validation:TooManyAttachments": "Não é possível anexar mais de 20 ficheiros.",
+    "Timeline:Validation:InvalidSourceKey": "Formato da chave de origem inválido.",
     "Permission:Timeline.Entries.Create": "Publicar comentários e seguir/deixar de seguir entidades",
     "Permission:Timeline.Entries.Manage": "Gerir (eliminar) qualquer entrada de cronologia independentemente do proprietário",
     "Permission:Timeline.Entries.Read": "Ver fluxos de atividade e histórico de auditoria",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
@@ -1,7 +1,8 @@
 {
   "culture": "sv",
   "texts": {
-    "Validation:TooManyAttachments": "Det går inte att bifoga fler än 20 filer.",
+    "Timeline:Validation:TooManyAttachments": "Det går inte att bifoga fler än 20 filer.",
+    "Timeline:Validation:InvalidSourceKey": "Ogiltigt format för källnyckel.",
     "Permission:Timeline.Entries.Create": "Publicera kommentarer och följa/sluta följa entiteter",
     "Permission:Timeline.Entries.Manage": "Hantera (ta bort) tidslinjepost oavsett ägare",
     "Permission:Timeline.Entries.Read": "Visa aktivitetsflöden och revisionshistorik",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
@@ -1,7 +1,8 @@
 {
   "culture": "tr",
   "texts": {
-    "Validation:TooManyAttachments": "20'den fazla dosya eklenemez.",
+    "Timeline:Validation:TooManyAttachments": "20'den fazla dosya eklenemez.",
+    "Timeline:Validation:InvalidSourceKey": "Kaynak anahtarı biçimi geçersiz.",
     "Permission:Timeline.Entries.Create": "Yorum yap ve varlıkları takip et/takipten çık",
     "Permission:Timeline.Entries.Manage": "Sahibinden bağımsız olarak herhangi bir zaman çizelgesi girişini yönetin (silin)",
     "Permission:Timeline.Entries.Read": "Etkinlik akışlarını ve denetim geçmişini görüntüle",

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
@@ -1,7 +1,8 @@
 {
   "culture": "zh",
   "texts": {
-    "Validation:TooManyAttachments": "不能附加超过20个文件。",
+    "Timeline:Validation:TooManyAttachments": "不能附加超过20个文件。",
+    "Timeline:Validation:InvalidSourceKey": "源键格式无效。",
     "Permission:Timeline.Entries.Create": "发表评论和关注/取消关注实体",
     "Permission:Timeline.Entries.Manage": "管理（删除）任何时间轴条目，无论所有者",
     "Permission:Timeline.Entries.Read": "查看活动流和审计历史",

--- a/src/Granit.Timeline.Endpoints/Validators/AnchorTimelineEntryRequestValidator.cs
+++ b/src/Granit.Timeline.Endpoints/Validators/AnchorTimelineEntryRequestValidator.cs
@@ -16,7 +16,7 @@ internal sealed class AnchorTimelineEntryRequestValidator : AbstractValidator<An
         RuleFor(x => x.SourceKey)
             .NotEmpty()
             .Must(TimelineSourceKeys.IsValid)
-            .WithErrorCodeAndMessage("Validation:InvalidSourceKey");
+            .WithErrorCodeAndMessage("Timeline:Validation:InvalidSourceKey");
         RuleFor(x => x.SourceId).NotEmpty().MaximumLength(128);
     }
 }

--- a/src/Granit.Timeline.Endpoints/Validators/PostTimelineEntryRequestValidator.cs
+++ b/src/Granit.Timeline.Endpoints/Validators/PostTimelineEntryRequestValidator.cs
@@ -19,6 +19,6 @@ internal sealed class PostTimelineEntryRequestValidator : AbstractValidator<Post
             .NotEqual(TimelineEntryType.SystemLog);
         RuleFor(x => x.AttachmentBlobIds)
             .Must(ids => ids is null || ids.Count <= 20)
-            .WithErrorCodeAndMessage("Validation:TooManyAttachments");
+            .WithErrorCodeAndMessage("Timeline:Validation:TooManyAttachments");
     }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineQuery.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineQuery.cs
@@ -74,25 +74,55 @@ internal sealed class EfCoreTimelineQuery(
 
         ILookup<Guid, TimelineAttachment> attachmentLookup = attachments.ToLookup(a => a.EntryId);
 
-        return [..
-            entries.Select(e => new TimelineStreamEntry
-            {
-                Id = e.Id,
-                OccurredAt = e.CreatedAt,
-                EntryType = (TimelineStreamEntryType)e.EntryType,
-                AuthorId = e.AuthorId,
-                AuthorName = e.AuthorName,
-                Body = e.Body,
-                ParentEntryId = e.ParentEntryId,
-                Origin = e.SourceKey is null ? TimelineEntryOrigin.Native : TimelineEntryOrigin.External,
-                SourceKey = e.SourceKey ?? TimelineSourceKeys.Native,
-                SourceId = e.SourceId,
-                EditedAt = e.EditedAt,
-                Attachments = [..
-                    attachmentLookup[e.Id]
-                        .Select(a => new TimelineAttachmentInfo(a.Id, a.BlobId, a.FileName, a.ContentType, a.SizeBytes))],
-            })];
+        return [.. entries.Select(e => MapToStreamEntry(e, attachmentLookup[e.Id]))];
     }
+
+    /// <inheritdoc/>
+    public async Task<TimelineStreamEntry?> GetEntryAsync(
+        string entityType,
+        string entityId,
+        Guid entryId,
+        CancellationToken cancellationToken = default)
+    {
+        await using TimelineDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        TimelineEntry? entry = await db.TimelineEntries
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                e => e.Id == entryId && e.EntityType == entityType && e.EntityId == entityId,
+                cancellationToken).ConfigureAwait(false);
+
+        if (entry is null)
+        {
+            return null;
+        }
+
+        List<TimelineAttachment> attachments = await db.TimelineAttachments
+            .AsNoTracking()
+            .Where(a => a.EntryId == entryId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return MapToStreamEntry(entry, attachments);
+    }
+
+    private static TimelineStreamEntry MapToStreamEntry(
+        TimelineEntry entry, IEnumerable<TimelineAttachment> attachments) =>
+        new()
+        {
+            Id = entry.Id,
+            OccurredAt = entry.CreatedAt,
+            EntryType = (TimelineStreamEntryType)entry.EntryType,
+            AuthorId = entry.AuthorId,
+            AuthorName = entry.AuthorName,
+            Body = entry.Body,
+            ParentEntryId = entry.ParentEntryId,
+            Origin = entry.SourceKey is null ? TimelineEntryOrigin.Native : TimelineEntryOrigin.External,
+            SourceKey = entry.SourceKey ?? TimelineSourceKeys.Native,
+            SourceId = entry.SourceId,
+            EditedAt = entry.EditedAt,
+            Attachments = [..
+                attachments.Select(a => new TimelineAttachmentInfo(a.Id, a.BlobId, a.FileName, a.ContentType, a.SizeBytes))],
+        };
 
     private async Task<int> CountNativeAsync(string entityType, string entityId, CancellationToken cancellationToken)
     {

--- a/src/Granit.Timeline/Abstractions/ITimelineReader.cs
+++ b/src/Granit.Timeline/Abstractions/ITimelineReader.cs
@@ -25,4 +25,17 @@ public interface ITimelineReader
         int page = 1,
         int pageSize = QueryEngineDefaults.DefaultPageSize,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a single native timeline entry projected as a <see cref="TimelineStreamEntry"/>,
+    /// or <see langword="null"/> when no matching entry exists (wrong entity, soft-deleted, or
+    /// unknown id). Scoped to the current tenant by the same query filter as
+    /// <see cref="GetStreamAsync"/>. Used for targeted lookups such as ownership checks, where
+    /// scanning a page would be both wasteful and incorrect beyond the page bound.
+    /// </summary>
+    Task<TimelineStreamEntry?> GetEntryAsync(
+        string entityType,
+        string entityId,
+        Guid entryId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Timeline/GranitTimelineModule.cs
+++ b/src/Granit.Timeline/GranitTimelineModule.cs
@@ -1,3 +1,4 @@
+using Granit.DataExchange;
 using Granit.Guids;
 using Granit.Modularity;
 using Granit.QueryEngine;
@@ -15,6 +16,7 @@ namespace Granit.Timeline;
 /// to enable durable persistence.
 /// </remarks>
 [DependsOn(
+    typeof(GranitDataExchangeAbstractionsModule),
     typeof(GranitGuidsModule),
     typeof(GranitQueryEngineAbstractionsModule),
     typeof(GranitTimingModule))]

--- a/src/Granit.Timeline/Internal/InMemoryTimelineQuery.cs
+++ b/src/Granit.Timeline/Internal/InMemoryTimelineQuery.cs
@@ -44,6 +44,21 @@ internal sealed class InMemoryTimelineQuery(
             _logger,
             cancellationToken);
 
+    /// <inheritdoc/>
+    public Task<TimelineStreamEntry?> GetEntryAsync(
+        string entityType,
+        string entityId,
+        Guid entryId,
+        CancellationToken cancellationToken = default)
+    {
+        TimelineStreamEntry? entry =
+            store.Entries.TryGetValue(entryId, out TimelineEntry? e)
+                && e.EntityType == entityType && e.EntityId == entityId && !e.IsDeleted
+                ? MapToStreamEntry(e)
+                : null;
+        return Task.FromResult(entry);
+    }
+
     private TimelineStreamEntry MapToStreamEntry(TimelineEntry entry) =>
         new()
         {

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using Granit.Authorization;
 using Granit.Domain;
-using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
 using Granit.Timeline.Domain;
 using Granit.Timeline.Domain.ValueObjects;
@@ -319,8 +318,8 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
             Body = "my comment",
         };
 
-        _reader.GetStreamAsync("Patient", "42", 1, 1000, Arg.Any<CancellationToken>())
-            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>([streamEntry], 1, HasMore: false), []));
+        _reader.GetEntryAsync("Patient", "42", entryId, Arg.Any<CancellationToken>())
+            .Returns(streamEntry);
 
         // Act
         HttpResponseMessage response = await _authClient.DeleteAsync(
@@ -349,8 +348,8 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
             Body = "their comment",
         };
 
-        _reader.GetStreamAsync("Patient", "42", 1, 1000, Arg.Any<CancellationToken>())
-            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>([streamEntry], 1, HasMore: false), []));
+        _reader.GetEntryAsync("Patient", "42", entryId, Arg.Any<CancellationToken>())
+            .Returns(streamEntry);
 
         // Act
         HttpResponseMessage response = await _authClient.DeleteAsync(
@@ -368,8 +367,8 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
         _permissionChecker.IsGrantedAsync(TimelinePermissions.Entries.Manage, Arg.Any<CancellationToken>())
             .Returns(false);
 
-        _reader.GetStreamAsync("Patient", "42", 1, 1000, Arg.Any<CancellationToken>())
-            .Returns(new TimelineStreamResult(new PagedResult<TimelineStreamEntry>([], 0, HasMore: false), []));
+        _reader.GetEntryAsync("Patient", "42", entryId, Arg.Any<CancellationToken>())
+            .Returns((TimelineStreamEntry?)null);
 
         // Act
         HttpResponseMessage response = await _authClient.DeleteAsync(


### PR DESCRIPTION
## Context

`/audit Granit.Mentions et Granit.Timeline*` — framework convention audit. Verdict was **COMPLIANT** (no blocking findings); this PR lands the concrete convention + correctness fixes. Mentions was essentially clean.

## Findings fixed

| # | Sev | Fix |
|---|-----|-----|
| 1 | CONVENTION | `Timeline:Validation:InvalidSourceKey` resolved to **nothing** in all 18 cultures — the anchor source-key 422 returned the raw key. Added the message to all 15 base cultures (regionals inherit). |
| 2 | CONVENTION | Module-owned validation keys moved off the framework `Validation:` namespace to `Timeline:Validation:*` (ADR-066), matching the `AIChat:Validation:*` precedent. |
| 3 | CONVENTION | `GranitTimelineModule` now declares `GranitDataExchangeAbstractionsModule` in `[DependsOn]` (direct project ref consumed via `AddExportDefinition`, previously undeclared; not arch-test-enforced). |
| 4 | CONVENTION | `DeleteTimelineEntry` now declares `403` in its OpenAPI metadata (the handler already returns it). |
| 5 | IMPROVEMENT | Delete ownership check no longer page-scans 1000 entries (which gave a **false 404** for the real author beyond the page bound). New `ITimelineReader.GetEntryAsync` does a single-entry lookup; in-memory + EF Core impls added. |
| 7 | IMPROVEMENT | POST `Created` Location header is derived from the request path instead of a hardcoded `/api/timeline` prefix, honouring `TimelineEndpointsOptions.RoutePrefix`. |
| 9/10 | CLEANUP | Mentions: corrected the DI-cycle comment ref (#2834) and clarified `AddMentionSource` idempotency doc. |

## Deferred (feature-scope, not landed here)

- **#6 — base `Granit.Timeline` has no `Diagnostics/` (metrics + ActivitySource).** An additive observability feature that would touch the in-memory + EF store constructors (and ~5 direct-construction test sites). Worth a dedicated PR. `Granit.Timeline.AI` already has exemplary diagnostics.
- **#8 — optimistic concurrency on `TimelineEntry` body edits.** Genuinely optional: edits are author-gated + within a 15-min window. `IConcurrencyAware` needs a host-owned migration (framework ships none), so it's a cross-cutting change, not a convention fix.

## Verification

- Build: `Granit.Mentions`, `Granit.Timeline`, `.EntityFrameworkCore`, `.Endpoints` — succeeded
- Tests: Mentions 13 · Timeline 164 · Timeline.EFCore 30 · Timeline.Endpoints 66 · **ArchitectureTests 228** — 0 failures
- `dotnet format --verify-no-changes` clean on all touched projects
- `.mcp-code-index.json` regenerated (freshness gate)