### PR TITLE
feat(timeline): diagnostics — meter + activity source for the activity stream

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -52286,6 +52286,40 @@
       ]
     },
     {
+      "name": "TimelineMetrics",
+      "fqn": "Granit.Timeline.Diagnostics.TimelineMetrics",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Diagnostics/TimelineMetrics.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "RecordEntryPosted",
+          "kind": "method",
+          "signature": "RecordEntryPosted(string? tenantId, string entityType, string entryType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordEntryEdited",
+          "kind": "method",
+          "signature": "RecordEntryEdited(string? tenantId, string entityType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordEntryDeleted",
+          "kind": "method",
+          "signature": "RecordEntryDeleted(string? tenantId, string entityType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordAnchorCreated",
+          "kind": "method",
+          "signature": "RecordAnchorCreated(string? tenantId, string entityType, string sourceKey)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "EmojiValidator",
       "fqn": "Granit.Timeline.Domain.EmojiValidator",
       "kind": "class",
@@ -52744,7 +52778,7 @@
       "kind": "class",
       "project": "Granit.Timeline",
       "file": "src/Granit.Timeline/Extensions/TimelineServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitTimeline",

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineStore.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineStore.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timeline.Abstractions;
+using Granit.Timeline.Diagnostics;
 using Granit.Timeline.Domain;
 using Granit.Timeline.Internal;
 using Granit.Timeline.Options;
@@ -28,15 +30,19 @@ internal sealed class EfCoreTimelineStore(
     IGuidGenerator guidGenerator,
     ICurrentTenant currentTenant,
     IOptions<TimelineOptions> options,
-    IEnumerable<ITimelineSource>? sources = null)
+    IEnumerable<ITimelineSource>? sources = null,
+    TimelineMetrics? metrics = null)
     : EfStoreBase<TimelineEntry, TimelineDbContext>(dbContextFactory, currentTenant), ITimelineWriter
 {
     private readonly AuditContext _audit = new(guidGenerator, clock, currentUser, currentTenant);
     private readonly TimelineOptions _options = options.Value;
     private readonly IEnumerable<ITimelineSource> _sources = sources ?? [];
+    private readonly TimelineMetrics? _metrics = metrics;
+
+    private string? TenantTag() => _audit.CurrentTenant.IsAvailable ? _audit.CurrentTenant.Id.ToString() : null;
 
     /// <inheritdoc/>
-    public Task<TimelineEntry> PostEntryAsync(
+    public async Task<TimelineEntry> PostEntryAsync(
         string entityType,
         string entityId,
         TimelineEntryType entryType,
@@ -44,22 +50,28 @@ internal sealed class EfCoreTimelineStore(
         Guid? parentEntryId = null,
         CancellationToken cancellationToken = default)
     {
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.PostEntry");
         TimelineEntry entry = TimelineEntityFactory.CreateEntry(
             entityType, entityId, entryType, body, parentEntryId, _audit);
         entry.RaisePostedEvent();
 
-        return WriteAsync(
+        await WriteAsync(
             async db =>
             {
                 db.TimelineEntries.Add(entry);
                 return entry;
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
+
+        _metrics?.RecordEntryPosted(TenantTag(), entry.EntityType, entry.EntryType.ToString());
+        return entry;
     }
 
     /// <inheritdoc/>
-    public Task DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default) =>
-        WriteAsync(
+    public async Task DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default)
+    {
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.DeleteEntry");
+        string entityType = await WriteAsync(
             async db =>
             {
                 TimelineEntry entry = await db.TimelineEntries
@@ -68,15 +80,20 @@ internal sealed class EfCoreTimelineStore(
                     ?? throw new KeyNotFoundException($"Timeline entry '{entryId}' not found.");
 
                 entry.SoftDelete(clock.Now, currentUser.UserId);
+                return entry.EntityType;
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
+
+        _metrics?.RecordEntryDeleted(TenantTag(), entityType);
+    }
 
     /// <inheritdoc/>
-    public Task UpdateEntryBodyAsync(Guid entryId, string newBody, CancellationToken cancellationToken = default)
+    public async Task UpdateEntryBodyAsync(Guid entryId, string newBody, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(newBody);
 
-        return WriteAsync(
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.UpdateEntryBody");
+        string entityType = await WriteAsync(
             async db =>
             {
                 TimelineEntry entry = await db.TimelineEntries
@@ -85,8 +102,11 @@ internal sealed class EfCoreTimelineStore(
 
                 TimelineEditGate.EnsureEditable(entry, currentUser.UserId, clock.Now, _options.EditWindow);
                 entry.UpdateBody(newBody, clock.Now);
+                return entry.EntityType;
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
+
+        _metrics?.RecordEntryEdited(TenantTag(), entityType);
     }
 
     /// <inheritdoc/>
@@ -97,6 +117,7 @@ internal sealed class EfCoreTimelineStore(
         string sourceId,
         CancellationToken cancellationToken = default)
     {
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.AnchorExternal");
         ITimelineSource source = TimelineAnchor.ResolveSource(_sources, sourceKey);
 
         Guid? tenantId = _audit.CurrentTenant.IsAvailable ? _audit.CurrentTenant.Id : null;
@@ -127,6 +148,8 @@ internal sealed class EfCoreTimelineStore(
                     return shadow.Id;
                 },
                 cancellationToken).ConfigureAwait(false);
+
+            _metrics?.RecordAnchorCreated(TenantTag(), entityType, sourceKey);
         }
         catch (DbUpdateException)
         {

--- a/src/Granit.Timeline/Diagnostics/TimelineActivitySource.cs
+++ b/src/Granit.Timeline/Diagnostics/TimelineActivitySource.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace Granit.Timeline.Diagnostics;
+
+/// <summary>OpenTelemetry activity source for the timeline activity-stream engine.</summary>
+internal static class TimelineActivitySource
+{
+    /// <summary>Activity source name.</summary>
+    public const string Name = "Granit.Timeline";
+
+    /// <summary>Shared activity source instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+}

--- a/src/Granit.Timeline/Diagnostics/TimelineMetrics.cs
+++ b/src/Granit.Timeline/Diagnostics/TimelineMetrics.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.Timeline.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the timeline activity-stream engine.
+/// Meter: <c>Granit.Timeline</c>.
+/// </summary>
+/// <remarks>
+/// All metrics follow the <c>granit.timeline.{entity}.{action}</c> naming convention and include
+/// <c>tenant_id</c> (coalesced to <c>"global"</c>) plus a sanitised <c>entity_type</c> via
+/// <see cref="TagList"/>. Instruments are created lazily so a host that never resolves the meter
+/// pays nothing.
+/// </remarks>
+public sealed class TimelineMetrics(IMeterFactory meterFactory)
+{
+    /// <summary>The meter name for this module.</summary>
+    public const string MeterName = "Granit.Timeline";
+
+    private const string TagTenantId = "tenant_id";
+    private const string TagEntityType = "entity_type";
+    private const string TagEntryType = "entry_type";
+    private const string TagSourceKey = "source_key";
+    private const string DefaultTenant = "global";
+    private const string Unknown = "_unknown_";
+    private const int MaxTagLength = 64;
+
+    private readonly Meter _meter = meterFactory.Create(MeterName);
+
+    private Counter<long>? _entriesPosted;
+    private Counter<long>? _entriesEdited;
+    private Counter<long>? _entriesDeleted;
+    private Counter<long>? _anchorsCreated;
+
+    private Counter<long> EntriesPosted => _entriesPosted ??= _meter.CreateCounter<long>(
+        "granit.timeline.entry.posted",
+        description: "Number of timeline entries posted (comments, internal notes, system logs).");
+
+    private Counter<long> EntriesEdited => _entriesEdited ??= _meter.CreateCounter<long>(
+        "granit.timeline.entry.edited",
+        description: "Number of timeline entry bodies edited within the edit window.");
+
+    private Counter<long> EntriesDeleted => _entriesDeleted ??= _meter.CreateCounter<long>(
+        "granit.timeline.entry.deleted",
+        description: "Number of timeline entries soft-deleted.");
+
+    private Counter<long> AnchorsCreated => _anchorsCreated ??= _meter.CreateCounter<long>(
+        "granit.timeline.anchor.created",
+        description: "Number of shadow rows materialised when anchoring an external timeline source entry.");
+
+    /// <summary>Records a posted timeline entry.</summary>
+    public void RecordEntryPosted(string? tenantId, string entityType, string entryType) =>
+        EntriesPosted.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagEntityType, Sanitize(entityType) },
+            { TagEntryType, Sanitize(entryType) },
+        });
+
+    /// <summary>Records an edited timeline entry body.</summary>
+    public void RecordEntryEdited(string? tenantId, string entityType) =>
+        EntriesEdited.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagEntityType, Sanitize(entityType) },
+        });
+
+    /// <summary>Records a soft-deleted timeline entry.</summary>
+    public void RecordEntryDeleted(string? tenantId, string entityType) =>
+        EntriesDeleted.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagEntityType, Sanitize(entityType) },
+        });
+
+    /// <summary>Records a newly materialised external-source anchor (shadow row).</summary>
+    public void RecordAnchorCreated(string? tenantId, string entityType, string sourceKey) =>
+        AnchorsCreated.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagEntityType, Sanitize(entityType) },
+            { TagSourceKey, Sanitize(sourceKey) },
+        });
+
+    /// <summary>
+    /// Caps tag cardinality: rejects values that are empty, over-long, or carry characters outside
+    /// the bounded set, so a hostile or polymorphic value cannot explode the time-series count.
+    /// </summary>
+    private static string Sanitize(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > MaxTagLength)
+        {
+            return Unknown;
+        }
+
+        return value.All(c => char.IsLetterOrDigit(c) || c is '.' or '_' or '-')
+            ? value
+            : Unknown;
+    }
+}

--- a/src/Granit.Timeline/Extensions/TimelineServiceCollectionExtensions.cs
+++ b/src/Granit.Timeline/Extensions/TimelineServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Granit.DataExchange.Extensions;
+using Granit.Diagnostics;
 using Granit.QueryEngine.Extensions;
 using Granit.Timeline.Abstractions;
+using Granit.Timeline.Diagnostics;
 using Granit.Timeline.Domain;
 using Granit.Timeline.Exports;
 using Granit.Timeline.Internal;
@@ -24,6 +26,11 @@ public static class TimelineServiceCollectionExtensions
     public static IServiceCollection AddGranitTimeline(this IServiceCollection services)
     {
         services.AddOptions<TimelineOptions>();
+
+        // Diagnostics: meter resolved from IMeterFactory (host adds it via AddMetrics);
+        // ActivitySource exported for the host's OpenTelemetry tracer pipeline.
+        GranitActivitySourceRegistry.Register(TimelineActivitySource.Name);
+        services.TryAddSingleton<TimelineMetrics>();
 
         // Core stores (default: in-memory, replaced by EF Core package).
         // Scoped: depends on ICurrentUserService (scoped per-request).

--- a/src/Granit.Timeline/Internal/InMemoryTimelineStore.cs
+++ b/src/Granit.Timeline/Internal/InMemoryTimelineStore.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Timeline.Abstractions;
+using Granit.Timeline.Diagnostics;
 using Granit.Timeline.Domain;
 using Granit.Timeline.Options;
 using Granit.Timing;
@@ -19,14 +21,18 @@ internal sealed class InMemoryTimelineStore(
     IGuidGenerator guidGenerator,
     ICurrentTenant currentTenant,
     IOptions<TimelineOptions> options,
-    IEnumerable<ITimelineSource>? sources = null) : ITimelineWriter
+    IEnumerable<ITimelineSource>? sources = null,
+    TimelineMetrics? metrics = null) : ITimelineWriter
 {
     private readonly AuditContext _audit = new(guidGenerator, clock, currentUser, currentTenant);
     private readonly TimelineOptions _options = options.Value;
     private readonly IEnumerable<ITimelineSource> _sources = sources ?? [];
+    private readonly TimelineMetrics? _metrics = metrics;
 
     internal readonly ConcurrentDictionary<Guid, TimelineEntry> Entries = new();
     internal readonly ConcurrentDictionary<Guid, TimelineAttachment> Attachments = new();
+
+    private string? TenantTag() => currentTenant.IsAvailable ? currentTenant.Id.ToString() : null;
 
     /// <inheritdoc/>
     public Task<TimelineEntry> PostEntryAsync(
@@ -37,23 +43,27 @@ internal sealed class InMemoryTimelineStore(
         Guid? parentEntryId = null,
         CancellationToken cancellationToken = default)
     {
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.PostEntry");
         TimelineEntry entry = TimelineEntityFactory.CreateEntry(
             entityType, entityId, entryType, body, parentEntryId, _audit);
         entry.RaisePostedEvent();
 
         Entries[entry.Id] = entry;
+        _metrics?.RecordEntryPosted(TenantTag(), entry.EntityType, entry.EntryType.ToString());
         return Task.FromResult(entry);
     }
 
     /// <inheritdoc/>
     public Task DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default)
     {
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.DeleteEntry");
         if (!Entries.TryGetValue(entryId, out TimelineEntry? entry))
         {
             throw new KeyNotFoundException($"Timeline entry '{entryId}' not found.");
         }
 
         entry.SoftDelete(clock.Now, currentUser.UserId);
+        _metrics?.RecordEntryDeleted(TenantTag(), entry.EntityType);
         return Task.CompletedTask;
     }
 
@@ -62,6 +72,7 @@ internal sealed class InMemoryTimelineStore(
     {
         ArgumentException.ThrowIfNullOrEmpty(newBody);
 
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.UpdateEntryBody");
         if (!Entries.TryGetValue(entryId, out TimelineEntry? entry))
         {
             throw new KeyNotFoundException($"Timeline entry '{entryId}' not found.");
@@ -69,6 +80,7 @@ internal sealed class InMemoryTimelineStore(
 
         TimelineEditGate.EnsureEditable(entry, currentUser.UserId, clock.Now, _options.EditWindow);
         entry.UpdateBody(newBody, clock.Now);
+        _metrics?.RecordEntryEdited(TenantTag(), entry.EntityType);
         return Task.CompletedTask;
     }
 
@@ -80,6 +92,7 @@ internal sealed class InMemoryTimelineStore(
         string sourceId,
         CancellationToken cancellationToken = default)
     {
+        using Activity? activity = TimelineActivitySource.Source.StartActivity("Timeline.AnchorExternal");
         ITimelineSource source = TimelineAnchor.ResolveSource(_sources, sourceKey);
 
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
@@ -100,7 +113,11 @@ internal sealed class InMemoryTimelineStore(
             entityType, entityId, sourceKey, sourceId, projection, _audit);
 
         // TryAdd is the equivalent of INSERT ... ON CONFLICT DO NOTHING.
-        Entries.TryAdd(shadow.Id, shadow);
+        if (Entries.TryAdd(shadow.Id, shadow))
+        {
+            _metrics?.RecordAnchorCreated(TenantTag(), entityType, sourceKey);
+        }
+
         return shadow.Id;
     }
 

--- a/tests/Granit.Timeline.Tests/TimelineMetricsTests.cs
+++ b/tests/Granit.Timeline.Tests/TimelineMetricsTests.cs
@@ -1,0 +1,118 @@
+// =============================================================================
+// Tests — TimelineMetrics
+// =============================================================================
+// Proves the meter actually emits: a real IMeterFactory + MeterListener capture
+// each counter and its tags, so the registration seam has teeth rather than just
+// resolving an object that never records.
+// =============================================================================
+
+using System.Diagnostics.Metrics;
+using Granit.Timeline.Diagnostics;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.Tests;
+
+public sealed class TimelineMetricsTests
+{
+    [Fact]
+    public void RecordEntryPosted_emits_counter_with_tenant_entity_and_entry_type()
+    {
+        using TestMeterFactory factory = new();
+        TimelineMetrics metrics = new(factory);
+        using var capture = Capture.For("granit.timeline.entry.posted");
+
+        metrics.RecordEntryPosted("tenant-1", "Patient", "Comment");
+
+        capture.Total.ShouldBe(1);
+        capture.Tags["tenant_id"].ShouldBe("tenant-1");
+        capture.Tags["entity_type"].ShouldBe("Patient");
+        capture.Tags["entry_type"].ShouldBe("Comment");
+    }
+
+    [Fact]
+    public void RecordEntryDeleted_coalesces_null_tenant_to_global()
+    {
+        using TestMeterFactory factory = new();
+        TimelineMetrics metrics = new(factory);
+        using var capture = Capture.For("granit.timeline.entry.deleted");
+
+        metrics.RecordEntryDeleted(tenantId: null, "Patient");
+
+        capture.Total.ShouldBe(1);
+        capture.Tags["tenant_id"].ShouldBe("global");
+    }
+
+    [Fact]
+    public void RecordAnchorCreated_caps_cardinality_on_hostile_entity_type()
+    {
+        using TestMeterFactory factory = new();
+        TimelineMetrics metrics = new(factory);
+        using var capture = Capture.For("granit.timeline.anchor.created");
+
+        metrics.RecordAnchorCreated("t", entityType: "DROP TABLE; --", sourceKey: "auditing");
+
+        capture.Total.ShouldBe(1);
+        capture.Tags["entity_type"].ShouldBe("_unknown_");
+        capture.Tags["source_key"].ShouldBe("auditing");
+    }
+
+    // A real IMeterFactory (the NSubstitute one returns a null Meter, which would
+    // never publish instruments to a listener).
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        private readonly List<Meter> _meters = [];
+
+        public Meter Create(MeterOptions options)
+        {
+            Meter meter = new(options);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (Meter meter in _meters)
+            {
+                meter.Dispose();
+            }
+        }
+    }
+
+    private sealed class Capture : IDisposable
+    {
+        private readonly MeterListener _listener;
+
+        public long Total { get; private set; }
+
+        public Dictionary<string, object?> Tags { get; } = new(StringComparer.Ordinal);
+
+        private Capture(string instrumentName)
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == TimelineMetrics.MeterName
+                        && instrument.Name == instrumentName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            _listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+            {
+                Total += measurement;
+                foreach (KeyValuePair<string, object?> tag in tags)
+                {
+                    Tags[tag.Key] = tag.Value;
+                }
+            });
+            _listener.Start();
+        }
+
+        public static Capture For(string instrumentName) => new(instrumentName);
+
+        public void Dispose() => _listener.Dispose();
+    }
+}

--- a/tests/Granit.Timeline.Tests/TimelineServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Timeline.Tests/TimelineServiceCollectionExtensionsTests.cs
@@ -4,9 +4,12 @@
 // Verifies that AddGranitTimeline registers all expected services.
 // =============================================================================
 
+using System.Diagnostics.Metrics;
+using Granit.Diagnostics;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Timeline.Abstractions;
+using Granit.Timeline.Diagnostics;
 using Granit.Timeline.Extensions;
 using Granit.Timing;
 using Granit.Users;
@@ -71,11 +74,39 @@ public sealed class TimelineServiceCollectionExtensionsTests
         notifier.ShouldNotBeNull();
     }
 
+    [Fact]
+    public void AddGranitTimeline_RegistersTimelineMetrics()
+    {
+        ServiceCollection services = new();
+        AddRequiredDependencies(services);
+
+        services.AddGranitTimeline();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        TimelineMetrics? metrics = sp.GetService<TimelineMetrics>();
+        metrics.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddGranitTimeline_RegistersActivitySource()
+    {
+        ServiceCollection services = new();
+        AddRequiredDependencies(services);
+
+        services.AddGranitTimeline();
+
+        GranitActivitySourceRegistry.GetRegisteredSources()
+            .ShouldContain(TimelineActivitySource.Name);
+    }
+
     private static void AddRequiredDependencies(ServiceCollection services)
     {
         services.AddSingleton(Substitute.For<IClock>());
         services.AddSingleton(Substitute.For<IGuidGenerator>());
         services.AddSingleton(Substitute.For<ICurrentUserService>());
         services.AddSingleton(Substitute.For<ICurrentTenant>());
+        // The stores depend on TimelineMetrics, which the host supplies an IMeterFactory for
+        // (AddMetrics / OpenTelemetry). Mirror that here so the writer/reader resolve.
+        services.AddSingleton(Substitute.For<IMeterFactory>());
     }
 }


### PR DESCRIPTION
## Context

Follow-up to the [Timeline audit](https://github.com/granit-fx/granit-dotnet/pull/2838) — closes **deferred finding #6**: base `Granit.Timeline` shipped no observability while its smaller `Granit.Timeline.AI` satellite had both metrics and an activity source. This mirrors that module's pattern.

## What's added

- **`TimelineMetrics`** (meter `Granit.Timeline`) — counters:
  - `granit.timeline.entry.posted` (tags: `tenant_id`, `entity_type`, `entry_type`)
  - `granit.timeline.entry.edited` / `.deleted` (tags: `tenant_id`, `entity_type`)
  - `granit.timeline.anchor.created` (tags: `tenant_id`, `entity_type`, `source_key`)
  - `tenant_id` coalesced to `"global"`; `entity_type` / `entry_type` / `source_key` cardinality-sanitised (copied from `TimelineAIMetrics`).
- **`TimelineActivitySource`** (`Granit.Timeline`), registered via `GranitActivitySourceRegistry`; a span per write operation (`Timeline.PostEntry`, `.UpdateEntryBody`, `.DeleteEntry`, `.AnchorExternal`).
- Emitted from **both** `ITimelineWriter` impls — `InMemoryTimelineStore` + `EfCoreTimelineStore`.
- `AddGranitTimeline`: `TryAddSingleton<TimelineMetrics>()` + register the activity source.

## Design notes

- `TimelineMetrics` is an **optional trailing ctor param** (`TimelineMetrics? metrics = null`) on the stores, so the ~5 direct store constructions in tests compile unchanged. In production the host supplies `IMeterFactory` (via `AddMetrics` / OpenTelemetry) — the same requirement `Granit.BlobStorage` and `Granit.Timeline.AI` already impose. The DI-registration tests now register an `IMeterFactory` to mirror a real host.
- Readers are untouched (no metrics on the query path) to keep this PR scoped to the write path.

## Verification

- Build: `Granit.Timeline`, `.EntityFrameworkCore`, `.Endpoints` — succeeded
- Tests: **Timeline 169** (+5: 3 `MeterListener` "teeth" tests + 2 DI-resolution), EFCore 30, Endpoints 66 — 0 failures
- `dotnet format --verify-no-changes` clean
- `.mcp-code-index.json` regenerated (freshness gate)
- Metrics/ActivitySource PII + file-organization arch tests verified (tags are non-PII; `Diagnostics/` namespace aligns); full architecture shard running.