### PR TITLE
fix(analytics): return empty queryable instead of crashing when no active tenant (SchemaPerTenant)

### DIFF
--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobQueryableSource.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobQueryableSource.cs
@@ -21,7 +21,21 @@ internal sealed class EfBlobQueryableSource(
 
     public IQueryable<BlobDescriptor> GetQueryable()
     {
-        _context ??= contextFactory.CreateDbContext();
+        if (_context is null)
+        {
+            try
+            {
+                _context = contextFactory.CreateDbContext();
+            }
+            catch (InvalidOperationException) when (_bypassTenantFilter)
+            {
+                // Per-tenant factory (SchemaPerTenant / DatabasePerTenant) requires a resolved
+                // tenant; none is active in the host context. Return empty so analytics runners
+                // report "no data" rather than crashing the metric endpoint.
+                return Enumerable.Empty<BlobDescriptor>().AsQueryable();
+            }
+        }
+
         IQueryable<BlobDescriptor> query = _context.Blobs.AsNoTracking();
         return _bypassTenantFilter
             ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])


### PR DESCRIPTION
## Summary

- **Root cause**: `EfDocumentQueryableSource`, `EfFolderQueryableSource`, `EfTenantStorageQuotaQueryableSource`, and `EfActivityQueryableSource` (in granit-business) called `contextFactory.CreateDbContext()` in primary-constructor field initializers **before** the `currentTenant.IsAvailable` check. `EfBlobQueryableSource` (this repo) shared the same gap at execution time.
- When the app uses SchemaPerTenant isolation, `IsolatedDbContextFactory` dispatches to `TenantPerSchemaDbContextFactory`, which deliberately throws `InvalidOperationException` with no active tenant (ISO 27001 guard). All `IMetricRunner` instances are constructed together when `MetricEndpointService` is built, so one failing construction crashes **every** host-router analytics request — including unrelated metrics like `Granit.Invoicing.UnpaidInvoiceCountMetric`.

## Changes

- **`EfBlobQueryableSource`** (this PR): adds `catch (InvalidOperationException) when (_bypassTenantFilter)` in `GetQueryable()` — returns `Enumerable.Empty<BlobDescriptor>().AsQueryable()` when the per-tenant factory throws with no active tenant. SharedDatabase factories and the tenant path are unaffected.
- Companion fix for Documents / Activity sources in granit-business MR !xxx.

## Behaviour after fix

| Isolation strategy | No active tenant (host router) | Active tenant (normal request) |
|---|---|---|
| SharedDatabase | Cross-tenant data (unchanged) | Tenant-filtered data (unchanged) |
| SchemaPerTenant / DatabasePerTenant | Empty sequence — metric shows "no data" | Tenant-filtered data (unchanged) |

## Test plan

- [x] `Granit.BlobStorage.EntityFrameworkCore.Tests` — 15/15 pass
- [ ] Run `GET /host/api/v1/analytics/metrics/Granit.Invoicing.UnpaidInvoiceCountMetric` in the showcase (after removing the MSW mock) — should return a valid response with `noData: true` instead of 500
- [ ] Run the same endpoint in a tenant context — should return the real count