### PR TITLE
fix(query-engine): safe async wrappers for non-EF IQueryable sources

### DIFF
--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/AsyncQuerySafeExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/AsyncQuerySafeExtensions.cs
@@ -1,0 +1,44 @@
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Safe async wrappers that fall back to synchronous operations for non-EF Core queryables.
+/// Required for in-memory <see cref="IQueryableSource{TEntity}"/> implementations (e.g.,
+/// config-backed sources like <c>TaxRateEntryQueryableSource</c>) that return an
+/// in-memory IQueryable and therefore don't implement <see cref="IAsyncQueryProvider"/>.
+/// </summary>
+internal static class AsyncQuerySafeExtensions
+{
+    internal static Task<int> CountSafeAsync<T>(
+        this IQueryable<T> source,
+        CancellationToken cancellationToken = default) =>
+        source.Provider is IAsyncQueryProvider
+            ? source.CountAsync(cancellationToken)
+            : Task.FromResult(source.Count());
+
+    internal static Task<List<T>> ToListSafeAsync<T>(
+        this IQueryable<T> source,
+        CancellationToken cancellationToken = default) =>
+        source.Provider is IAsyncQueryProvider
+            ? source.ToListAsync(cancellationToken)
+            : Task.FromResult(source.ToList());
+
+    internal static IAsyncEnumerable<T> AsAsyncEnumerableSafe<T>(this IQueryable<T> source) =>
+        source.Provider is IAsyncQueryProvider
+            ? source.AsAsyncEnumerable()
+            : IterateSync(source);
+
+    private static async IAsyncEnumerable<T> IterateSync<T>(
+        IEnumerable<T> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (T item in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+}

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -86,7 +86,7 @@ internal sealed class QueryEngine<TEntity>(
 
             int? precomputedCount = request.SkipTotalCount
                 ? null
-                : await filtered.CountAsync(cancellationToken).ConfigureAwait(false);
+                : await filtered.CountSafeAsync(cancellationToken).ConfigureAwait(false);
 
             IQueryable<TEntity> query = filtered.ApplySort(request.Sort, _builder);
 
@@ -129,7 +129,7 @@ internal sealed class QueryEngine<TEntity>(
 
         int? precomputedCount = request.SkipTotalCount
             ? null
-            : await filtered.CountAsync(cancellationToken).ConfigureAwait(false);
+            : await filtered.CountSafeAsync(cancellationToken).ConfigureAwait(false);
 
         IQueryable<TEntity> sorted2 = filtered.ApplySort(request.Sort, _builder);
         int skip = (page - 1) * pageSize;
@@ -141,7 +141,7 @@ internal sealed class QueryEngine<TEntity>(
                 .Skip(skip)
                 .Take(pageSize + 1)
                 .Select(projection)
-                .ToListAsync(cancellationToken)
+                .ToListSafeAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             bool hasMore = items.Count > pageSize;
@@ -157,7 +157,7 @@ internal sealed class QueryEngine<TEntity>(
             .Skip(skip)
             .Take(pageSize)
             .Select(projection)
-            .ToListAsync(cancellationToken)
+            .ToListSafeAsync(cancellationToken)
             .ConfigureAwait(false);
 
         bool hasMorePages = skip + pagedItems.Count < precomputedCount.Value;
@@ -217,7 +217,7 @@ internal sealed class QueryEngine<TEntity>(
             IQueryable<TEntity> sorted = query.ApplySort(request.Sort, _builder);
             List<TEntity> allItems = await sorted
                 .Take(_builder.MaxPageSizeValue * entityResult.Groups.Count)
-                .ToListAsync(cancellationToken)
+                .ToListSafeAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             PropertyInfo? groupProp = typeof(TEntity).GetProperty(
@@ -268,7 +268,7 @@ internal sealed class QueryEngine<TEntity>(
         int limit = _builder.MaxStreamSizeValue;
         int count = 0;
 
-        await foreach (TEntity entity in query.Take(limit).AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false))
+        await foreach (TEntity entity in query.Take(limit).AsAsyncEnumerableSafe().WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             count++;
             yield return entity;
@@ -420,7 +420,7 @@ internal sealed class QueryEngine<TEntity>(
         List<TProjection> items = await query
             .Take(pageSize + 1)
             .Select(projection)
-            .ToListAsync(cancellationToken)
+            .ToListSafeAsync(cancellationToken)
             .ConfigureAwait(false);
 
         bool hasMore = items.Count > pageSize;

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableGroupByExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableGroupByExtensions.cs
@@ -55,10 +55,12 @@ internal static class QueryableGroupByExtensions
 
         object groupedQuery = groupByMethod.Invoke(null, [source, keySelector])!;
 
+        bool isAsyncProvider = source.Provider is Microsoft.EntityFrameworkCore.Query.IAsyncQueryProvider;
+
         // Materialize groups with count
         // We need to project to a known type
         List<GroupEntry<T>> groups = await MaterializeGroupsAsync<T>(
-            groupedQuery, keyType, groupByField, maxGroupCount, cancellationToken).ConfigureAwait(false);
+            groupedQuery, keyType, groupByField, maxGroupCount, isAsyncProvider, cancellationToken).ConfigureAwait(false);
 
         int totalCount = groups.Sum(g => g.Count);
 
@@ -70,6 +72,7 @@ internal static class QueryableGroupByExtensions
         Type keyType,
         string fieldName,
         int maxGroupCount,
+        bool isAsyncProvider,
         CancellationToken cancellationToken)
         where T : class
     {
@@ -109,15 +112,28 @@ internal static class QueryableGroupByExtensions
 
         projected = takeMethod.Invoke(null, [projected, maxGroupCount])!;
 
-        // Materialize via ToListAsync
-        MethodInfo toListAsync = typeof(EntityFrameworkQueryableExtensions)
-            .GetMethods()
-            .First(m => m.Name == nameof(EntityFrameworkQueryableExtensions.ToListAsync)
-                && m.GetParameters().Length == 2)
-            .MakeGenericMethod(resultType);
+        // Materialize — use async EF Core path for real DbContext sources, sync fallback for in-memory.
+        System.Collections.IList materialized;
+        if (isAsyncProvider)
+        {
+            MethodInfo toListAsync = typeof(EntityFrameworkQueryableExtensions)
+                .GetMethods()
+                .First(m => m.Name == nameof(EntityFrameworkQueryableExtensions.ToListAsync)
+                    && m.GetParameters().Length == 2)
+                .MakeGenericMethod(resultType);
 
-        dynamic task = toListAsync.Invoke(null, [projected, cancellationToken])!;
-        var materialized = (System.Collections.IList)await task.ConfigureAwait(false);
+            dynamic task = toListAsync.Invoke(null, [projected, cancellationToken])!;
+            materialized = (System.Collections.IList)await task.ConfigureAwait(false);
+        }
+        else
+        {
+            MethodInfo toList = typeof(Enumerable)
+                .GetMethods()
+                .First(m => m.Name == nameof(Enumerable.ToList) && m.GetParameters().Length == 1)
+                .MakeGenericMethod(resultType);
+
+            materialized = (System.Collections.IList)toList.Invoke(null, [projected])!;
+        }
 
         List<GroupEntry<T>> entries = [];
         PropertyInfo keyProp = resultType.GetProperty("Key")!;

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryablePaginationExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryablePaginationExtensions.cs
@@ -1,6 +1,5 @@
 using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
@@ -30,7 +29,7 @@ internal static class QueryablePaginationExtensions
             List<T> items = await source
                 .Skip(skip)
                 .Take(pageSize + 1)
-                .ToListAsync(cancellationToken)
+                .ToListSafeAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             bool hasMore = items.Count > pageSize;
@@ -47,7 +46,7 @@ internal static class QueryablePaginationExtensions
         List<T> pagedItems = await source
             .Skip(skip)
             .Take(pageSize)
-            .ToListAsync(cancellationToken)
+            .ToListSafeAsync(cancellationToken)
             .ConfigureAwait(false);
 
         bool hasMorePages = skip + pagedItems.Count < totalCount;
@@ -78,7 +77,7 @@ internal static class QueryablePaginationExtensions
 
         if (cursorProperty is null)
         {
-            List<T> fallback = await source.Take(pageSize).ToListAsync(cancellationToken).ConfigureAwait(false);
+            List<T> fallback = await source.Take(pageSize).ToListSafeAsync(cancellationToken).ConfigureAwait(false);
             return new PagedResult<T>(fallback, TotalCount: null, HasMore: false);
         }
 
@@ -105,7 +104,7 @@ internal static class QueryablePaginationExtensions
         // Take pageSize + 1 to determine if there are more pages
         List<T> items = await query
             .Take(pageSize + 1)
-            .ToListAsync(cancellationToken)
+            .ToListSafeAsync(cancellationToken)
             .ConfigureAwait(false);
 
         string? nextCursor = null;


### PR DESCRIPTION
## Summary

- Adds `AsyncQuerySafeExtensions` with `CountSafeAsync`, `ToListSafeAsync`, and `AsAsyncEnumerableSafe` — each checks for `IAsyncQueryProvider` and falls back to the synchronous equivalent for in-memory `IQueryableSource` implementations.
- Replaces all bare `CountAsync` / `ToListAsync` / `AsAsyncEnumerable` calls across `QueryEngine`, `QueryablePaginationExtensions`, and `QueryableGroupByExtensions` with these safe wrappers.
- `QueryableGroupByExtensions` uses a slightly different path (reflection-based `ToList` fallback) since group materialisation goes through untyped `object` queryables; the `isAsyncProvider` flag is captured before the reflection chain and threaded into `MaterializeGroupsAsync`.

## Context

Follows #2841 which fixed the empty-queryable case for per-tenant factories. This PR fixes the complementary crash: config-backed `IQueryableSource` implementations (e.g. `TaxRateEntryQueryableSource`) return a plain in-memory `IQueryable` that doesn't implement `IAsyncQueryProvider`, causing `InvalidOperationException: The source 'IQueryable' doesn't implement 'IAsyncEnumerable<T>'` on any query engine operation.

## Test plan

- [ ] Build `Granit.QueryEngine.EntityFrameworkCore` — no EF reference leak in `QueryablePaginationExtensions` (removed `using Microsoft.EntityFrameworkCore`)
- [ ] Run `Granit.QueryEngine.Tests` shard — offset, cursor, group-by, stream paths all exercised
- [ ] Smoke-test a config-backed `IQueryableSource` (e.g. tax rates) through the query engine — no `InvalidOperationException`