### PR TITLE
fix(wolverine): codegen-clean service registrations + feat(privacy): legal document list-all via query engine

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2200,6 +2200,7 @@
       "name": "Granit.Privacy",
       "deps": [
         "Granit",
+        "Granit.QueryEngine.Abstractions",
         "Granit.Settings",
         "Granit.Workflow"
       ],
@@ -2259,6 +2260,7 @@
         "Granit.Http.RateLimiting",
         "Granit.Privacy",
         "Granit.Privacy.Regulations",
+        "Granit.QueryEngine.AspNetCore",
         "Granit.Validation",
         "Granit.Workspaces.Abstractions"
       ],
@@ -2269,8 +2271,9 @@
       "deps": [
         "Granit.Encryption.EntityFrameworkCore",
         "Granit.Guids",
+        "Granit.Persistence.EntityFrameworkCore",
         "Granit.Privacy",
-        "Granit.Persistence.EntityFrameworkCore"
+        "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -45097,6 +45100,15 @@
       ]
     },
     {
+      "name": "LegalDocumentDetailResponse",
+      "fqn": "Granit.Privacy.Dtos.LegalDocumentDetailResponse",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Dtos/LegalDocumentDetailResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "GpcDiscoveryEndpointRouteBuilderExtensions",
       "fqn": "Granit.Privacy.Endpoints.Discovery.GpcDiscoveryEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -45135,15 +45147,6 @@
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/Dtos/LegalDocumentCreateRequest.cs",
       "line": 8,
-      "members": []
-    },
-    {
-      "name": "LegalDocumentDetailResponse",
-      "fqn": "Granit.Privacy.Endpoints.Dtos.LegalDocumentDetailResponse",
-      "kind": "record",
-      "project": "Granit.Privacy.Endpoints",
-      "file": "src/Granit.Privacy.Endpoints/Dtos/LegalDocumentDetailResponse.cs",
-      "line": 15,
       "members": []
     },
     {
@@ -45529,7 +45532,7 @@
       "kind": "class",
       "project": "Granit.Privacy.EntityFrameworkCore",
       "file": "src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitPrivacyEntityFrameworkCore",
@@ -45595,7 +45598,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs",
-      "line": 19,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitPrivacy",
@@ -46527,6 +46530,22 @@
       "file": "src/Granit.Privacy/ProcessingPurposes/ProcessingPurposeDefinition.cs",
       "line": 14,
       "members": []
+    },
+    {
+      "name": "LegalDocumentQueryDefinition",
+      "fqn": "Granit.Privacy.Queries.LegalDocumentQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Queries/LegalDocumentQueryDefinition.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "ConsentModel",

--- a/src/Granit.Notifications.Wolverine/Granit.Notifications.Wolverine.csproj
+++ b/src/Granit.Notifications.Wolverine/Granit.Notifications.Wolverine.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Notifications.Wolverine.Tests" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Granit.Notifications/Granit.Notifications.csproj
+++ b/src/Granit.Notifications/Granit.Notifications.csproj
@@ -9,6 +9,7 @@
     <InternalsVisibleTo Include="Granit.Notifications.Wolverine" />
     <InternalsVisibleTo Include="Granit.Notifications.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Granit.Notifications.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentDetailResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/LegalDocumentDetailResponse.cs
@@ -1,26 +1,2 @@
-namespace Granit.Privacy.Endpoints.Dtos;
-
-/// <summary>Detailed view of a legal document version.</summary>
-/// <param name="Id">Unique identifier of this document version.</param>
-/// <param name="DocumentId">Logical document identifier shared across all versions.</param>
-/// <param name="Version">Monotonically increasing version number.</param>
-/// <param name="LifecycleStatus">Current lifecycle status (<c>Draft</c>, <c>Published</c>, or <c>Archived</c>).</param>
-/// <param name="DisplayName">Human-readable document title.</param>
-/// <param name="Description">Optional admin-only changelog note.</param>
-/// <param name="TemplateName">Optional Granit.Templating template name for rendered content.</param>
-/// <param name="DocumentBlobId">Optional blob ID for a downloadable document.</param>
-/// <param name="CreatedAt">UTC timestamp of creation.</param>
-/// <param name="LastModifiedAt">UTC timestamp of last modification.</param>
-/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
-public sealed record LegalDocumentDetailResponse(
-    Guid Id,
-    string DocumentId,
-    int Version,
-    string LifecycleStatus,
-    string DisplayName,
-    string? Description,
-    string? TemplateName,
-    Guid? DocumentBlobId,
-    DateTimeOffset CreatedAt,
-    DateTimeOffset LastModifiedAt,
-    string ConcurrencyStamp);
+// Moved to Granit.Privacy.Dtos. Re-exported for backward compatibility.
+global using LegalDocumentDetailResponse = Granit.Privacy.Dtos.LegalDocumentDetailResponse;

--- a/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Privacy.Endpoints.Dtos;
 using Granit.Privacy.Endpoints.Permissions;
 using Granit.Privacy.LegalAgreements;
 using Granit.Privacy.LegalAgreements.Domain;
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -36,14 +37,13 @@ internal static class LegalDocumentAdminEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(PrivacyPermissions.LegalDocuments.Read);
 
-        group.MapGet("/", ListAsync)
-            .WithName("ListLegalDocumentVersions")
-            .WithSummary("Lists all versions of a legal document.")
-            .WithDescription(
-                "Returns the version history for the specified document ID, ordered by version descending. "
-                + "Includes drafts, published, and archived versions.")
-            .Produces<IReadOnlyList<LegalDocumentDetailResponse>>()
-            .RequireAuthorization(PrivacyPermissions.LegalDocuments.Read);
+        // GET / and GET /meta — served by the query engine (filtering, sorting, search, pagination).
+        // GET /        → PagedResult<LegalDocumentDetailResponse>
+        // GET /meta    → query metadata (columns, filters, sorts, presets)
+        // The "published" quick filter is the default; pass ?quickFilters=draft to see drafts.
+        // Filter by document ID via ?filter[documentId.eq]=privacy-policy to view version history.
+        group.MapGranitQuery<LegalDocument>(configure: opts =>
+            opts.AuthorizationPolicy = PrivacyPermissions.LegalDocuments.Read);
 
         group.MapPut("/{id:guid}", UpdateAsync)
             .WithName("UpdateLegalDocument")
@@ -105,21 +105,6 @@ internal static class LegalDocumentAdminEndpoints
         return document is null
             ? TypedResults.Problem(statusCode: StatusCodes.Status404NotFound)
             : TypedResults.Ok(ToResponse(document));
-    }
-
-    private static async Task<Ok<IReadOnlyList<LegalDocumentDetailResponse>>> ListAsync(
-        [FromQuery] string documentId,
-        [FromServices] ILegalDocumentReader reader,
-        CancellationToken cancellationToken)
-    {
-        IReadOnlyList<LegalDocument> documents = await reader
-            .GetVersionHistoryAsync(documentId, cancellationToken)
-            .ConfigureAwait(false);
-
-        IReadOnlyList<LegalDocumentDetailResponse> response = documents
-            .Select(ToResponse).ToList();
-
-        return TypedResults.Ok(response);
     }
 
     private static async Task<Results<Ok<LegalDocumentDetailResponse>, ProblemHttpResult>> UpdateAsync(

--- a/src/Granit.Privacy.Endpoints/Granit.Privacy.Endpoints.csproj
+++ b/src/Granit.Privacy.Endpoints/Granit.Privacy.Endpoints.csproj
@@ -24,8 +24,9 @@
     <ProjectReference Include="..\Granit.Http.RateLimiting\Granit.Http.RateLimiting.csproj" />
     <ProjectReference Include="..\Granit.Privacy\Granit.Privacy.csproj" />
     <ProjectReference Include="..\Granit.Privacy.Regulations\Granit.Privacy.Regulations.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
-      <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Privacy.Endpoints/packages.lock.json
+++ b/src/Granit.Privacy.Endpoints/packages.lock.json
@@ -230,6 +230,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",
           "WolverineFx": "[6.*, )"
@@ -241,11 +242,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.ratelimiting": {
@@ -354,8 +372,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.16.4",
-        "contentHash": "ZDD3CHXn1OR4yHQ55NcXsU+aRzSIc1kwkpgPVM9LaK0XKuEzRqZWZ/4WS9tLI3dur6OMlcpXjGIDk/Pe3fniXQ=="
+        "resolved": "2.16.5",
+        "contentHash": "194DwaZqe9Cd4nJPdY0c7/3ldLhxtgiMMAlWsgGdKuDLvGgKh7Poozd12nowxFS3ytKYzMcyMPjCIWww5n0hDA=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",
@@ -379,8 +397,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.12.0",
-        "contentHash": "6uJqmZMadnLYQu4BdYae0YSE1cBcJPJxDKfkt5ut8RFHOw9H4EuD7+vB5sEAOEKkTCA7kc23LZoXSyZMDJTCkQ==",
+        "resolved": "6.14.0",
+        "contentHash": "2AqBUVfjBDDQ6d8nwVDj/rQ5Ife/m8mcsWbuyqBL9ov6HCZ9pZaEKTbmwiO7IpsW16xPR6wqW4ugO2lvS0fSWQ==",
         "dependencies": {
           "JasperFx": "2.13.0",
           "JasperFx.Events": "2.13.0",

--- a/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Extensions/PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Privacy.DataExport;
 using Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
 using Granit.Privacy.EntityFrameworkCore.Internal;
 using Granit.Privacy.LegalAgreements;
+using Granit.Privacy.LegalAgreements.Domain;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -56,6 +58,7 @@ public static class PrivacyEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.AddScoped<EfLegalDocumentStore>();
         builder.Services.TryAddScoped<ILegalDocumentReader>(sp => sp.GetRequiredService<EfLegalDocumentStore>());
         builder.Services.TryAddScoped<ILegalDocumentWriter>(sp => sp.GetRequiredService<EfLegalDocumentStore>());
+        builder.Services.TryAddScoped<IQueryableSource<LegalDocument>, EfLegalDocumentQueryableSource>();
 
         builder.Services.TryAddScoped<ILegalDocumentPublicationService, LegalDocumentPublicationService>();
 

--- a/src/Granit.Privacy.EntityFrameworkCore/Granit.Privacy.EntityFrameworkCore.csproj
+++ b/src/Granit.Privacy.EntityFrameworkCore/Granit.Privacy.EntityFrameworkCore.csproj
@@ -19,8 +19,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Encryption.EntityFrameworkCore\Granit.Encryption.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
-    <ProjectReference Include="..\Granit.Privacy\Granit.Privacy.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.Privacy\Granit.Privacy.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/EfLegalDocumentQueryableSource.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/EfLegalDocumentQueryableSource.cs
@@ -1,0 +1,48 @@
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Privacy.LegalAgreements.Domain;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Privacy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="LegalDocument"/>,
+/// backing <c>MapGranitQuery&lt;LegalDocument&gt;</c> on the admin endpoints.
+/// </summary>
+/// <remarks>
+/// The <c>Publishable</c> global query filter is always bypassed so drafts and archived
+/// versions are visible alongside published ones. The multi-tenant filter is also bypassed
+/// when no tenant context is active (host-level admin), returning documents across all tenants.
+/// </remarks>
+internal sealed class EfLegalDocumentQueryableSource(
+    IDbContextFactory<PrivacyDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : IQueryableSource<LegalDocument>, IAsyncDisposable, IDisposable
+{
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+    private PrivacyDbContext? _context;
+
+    public IQueryable<LegalDocument> GetQueryable()
+    {
+        _context ??= contextFactory.CreateDbContext();
+        IQueryable<LegalDocument> query = _context.LegalDocuments.AsNoTracking();
+
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant, GranitFilterNames.Publishable])
+            : query.IgnoreQueryFilters([GranitFilterNames.Publishable]);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        PrivacyDbContext? context = _context;
+        _context = null;
+        return context?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/src/Granit.Privacy.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Privacy.EntityFrameworkCore/packages.lock.json
@@ -442,6 +442,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",
           "WolverineFx": "[6.*, )"
@@ -608,8 +609,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.12.0",
-        "contentHash": "6uJqmZMadnLYQu4BdYae0YSE1cBcJPJxDKfkt5ut8RFHOw9H4EuD7+vB5sEAOEKkTCA7kc23LZoXSyZMDJTCkQ==",
+        "resolved": "6.14.0",
+        "contentHash": "2AqBUVfjBDDQ6d8nwVDj/rQ5Ife/m8mcsWbuyqBL9ov6HCZ9pZaEKTbmwiO7IpsW16xPR6wqW4ugO2lvS0fSWQ==",
         "dependencies": {
           "JasperFx": "2.13.0",
           "JasperFx.Events": "2.13.0",

--- a/src/Granit.Privacy/Dtos/LegalDocumentDetailResponse.cs
+++ b/src/Granit.Privacy/Dtos/LegalDocumentDetailResponse.cs
@@ -1,0 +1,26 @@
+namespace Granit.Privacy.Dtos;
+
+/// <summary>Detailed view of a legal document version.</summary>
+/// <param name="Id">Unique identifier of this document version.</param>
+/// <param name="DocumentId">Logical document identifier shared across all versions.</param>
+/// <param name="Version">Monotonically increasing version number.</param>
+/// <param name="LifecycleStatus">Current lifecycle status (<c>Draft</c>, <c>Published</c>, or <c>Archived</c>).</param>
+/// <param name="DisplayName">Human-readable document title.</param>
+/// <param name="Description">Optional admin-only changelog note.</param>
+/// <param name="TemplateName">Optional Granit.Templating template name for rendered content.</param>
+/// <param name="DocumentBlobId">Optional blob ID for a downloadable document.</param>
+/// <param name="CreatedAt">UTC timestamp of creation.</param>
+/// <param name="LastModifiedAt">UTC timestamp of last modification.</param>
+/// <param name="ConcurrencyStamp">Opaque optimistic-concurrency token. Pass back in update requests to detect concurrent modifications (HTTP 409).</param>
+public sealed record LegalDocumentDetailResponse(
+    Guid Id,
+    string DocumentId,
+    int Version,
+    string LifecycleStatus,
+    string DisplayName,
+    string? Description,
+    string? TemplateName,
+    Guid? DocumentBlobId,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset LastModifiedAt,
+    string ConcurrencyStamp);

--- a/src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs
@@ -4,10 +4,13 @@ using Granit.Privacy.DataExport.Audit;
 using Granit.Privacy.DataExport.Internal;
 using Granit.Privacy.Diagnostics;
 using Granit.Privacy.LegalAgreements;
+using Granit.Privacy.LegalAgreements.Domain;
 using Granit.Privacy.LegalAgreements.Internal;
 using Granit.Privacy.Options;
 using Granit.Privacy.ProcessingPurposes;
 using Granit.Privacy.ProcessingPurposes.Internal;
+using Granit.Privacy.Queries;
+using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -31,6 +34,7 @@ public static class PrivacyServiceCollectionExtensions
 
         GranitActivitySourceRegistry.Register(PrivacyActivitySource.Name);
         services.TryAddSingleton<PrivacyMetrics>();
+        services.AddQueryDefinition<LegalDocument, LegalDocumentQueryDefinition>();
 
         services.AddOptions<GranitPrivacyOptions>()
             .BindConfiguration(GranitPrivacyOptions.SectionName)

--- a/src/Granit.Privacy/Granit.Privacy.csproj
+++ b/src/Granit.Privacy/Granit.Privacy.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />
     <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />
   </ItemGroup>

--- a/src/Granit.Privacy/Queries/LegalDocumentQueryDefinition.cs
+++ b/src/Granit.Privacy/Queries/LegalDocumentQueryDefinition.cs
@@ -1,0 +1,81 @@
+using Granit.Privacy.Dtos;
+using Granit.Privacy.LegalAgreements.Domain;
+using Granit.QueryEngine;
+using Granit.Workflow.Domain;
+
+namespace Granit.Privacy.Queries;
+
+/// <summary>
+/// Query definition for legal document admin management — declares columns, filters,
+/// sorting, quick filters, and the list-view projection. Powers
+/// <c>MapGranitQuery&lt;LegalDocument&gt;</c> on the admin endpoints.
+/// </summary>
+/// <remarks>
+/// The <c>published</c> quick filter is the default so the list shows the active
+/// version of each document on first load; opt in to <c>draft</c> or remove the
+/// filter entirely to see all lifecycle statuses.
+/// </remarks>
+public sealed class LegalDocumentQueryDefinition : QueryDefinition<LegalDocument>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Privacy.LegalDocumentQuery";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<LegalDocument> builder)
+    {
+        builder
+            .Column(e => e.DocumentId, c => c
+                .Label("Document")
+                .LabelKey("Privacy.LegalDocuments.Columns.DocumentId")
+                .Filterable()
+                .Sortable())
+            .Column(e => e.DisplayName, c => c
+                .Label("Display Name")
+                .LabelKey("Privacy.LegalDocuments.Columns.DisplayName")
+                .Filterable()
+                .Sortable())
+            .Column(e => e.Version, c => c
+                .Label("Version")
+                .LabelKey("Privacy.LegalDocuments.Columns.Version")
+                .Filterable()
+                .Sortable())
+            .Column(e => e.LifecycleStatus, c => c
+                .Label("Status")
+                .LabelKey("Privacy.LegalDocuments.Columns.LifecycleStatus")
+                .Filterable()
+                .Sortable())
+            .Column(e => e.CreatedAt, c => c
+                .Label("Created At")
+                .LabelKey("Privacy.LegalDocuments.Columns.CreatedAt")
+                .Sortable())
+            .Column(e => e.ModifiedAt, c => c
+                .Label("Modified At")
+                .LabelKey("Privacy.LegalDocuments.Columns.LastModifiedAt")
+                .Sortable())
+            .QuickFilter(
+                "draft",
+                "Drafts",
+                e => e.LifecycleStatus == WorkflowLifecycleStatus.Draft)
+            .QuickFilter(
+                "published",
+                "Published",
+                e => e.LifecycleStatus == WorkflowLifecycleStatus.Published,
+                isDefault: true)
+            .GlobalSearch(e => e.DocumentId)
+            .DefaultSort("-modifiedAt")
+            .DefaultPageSize(25)
+            .MaxPageSize(100)
+            .ProjectTo(e => new LegalDocumentDetailResponse(
+                e.Id,
+                e.DocumentId,
+                e.Version,
+                e.LifecycleStatus.ToString(),
+                e.DisplayName,
+                e.Description,
+                e.TemplateName,
+                e.DocumentBlobId,
+                e.CreatedAt,
+                e.ModifiedAt ?? e.CreatedAt,
+                e.ConcurrencyStamp));
+    }
+}

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -96,12 +96,13 @@ public static class WolverineHostApplicationBuilderExtensions
         // WolverineCurrentUserService: AsyncLocal override + IHttpContextAccessor fallback.
         // Registered as the ICurrentUserService for Wolverine — restores user identity in
         // background handlers so EF Core audit interceptors record the correct ModifiedBy.
+        // Two separate scoped instances per scope is intentional: all AsyncLocal fields are
+        // static, so setter.Change() and currentUser.UserId share state regardless of instance.
+        // Direct AddScoped<IFoo, TConcrete>() (not a lambda factory) keeps both registrations
+        // codegen-clean for Wolverine static mode.
         builder.Services.AddHttpContextAccessor();
-        builder.Services.AddScoped<WolverineCurrentUserService>();
-        builder.Services.AddScoped<ICurrentUserService>(
-            sp => sp.GetRequiredService<WolverineCurrentUserService>());
-        builder.Services.AddScoped<IWolverineUserContextSetter>(
-            sp => sp.GetRequiredService<WolverineCurrentUserService>());
+        builder.Services.AddScoped<ICurrentUserService, WolverineCurrentUserService>();
+        builder.Services.AddScoped<IWolverineUserContextSetter, WolverineCurrentUserService>();
 
         // FluentValidation — auto-discover validators from [WolverineHandlerModule] assemblies.
         // Modules without Wolverine handlers must still register manually.
@@ -156,17 +157,12 @@ public static class WolverineHostApplicationBuilderExtensions
             // forces fail-fast.
             opts.CodeGeneration.TypeLoadMode = messagingOptions.CodeGenerationMode;
 
-            // Service-location policy for code generation. Wolverine 6 defaults to NotAllowed,
-            // which ABORTS `codegen write` (Static) when a chain dependency can't be inlined —
-            // true for three framework registrations reached via the context-propagation
-            // middleware on every chain: ICurrentUserService + IWolverineUserContextSetter
-            // (scoped forwarding factories onto the shared WolverineCurrentUserService) and the
-            // internal INotificationPublisher impl. AllowedButWarn lets codegen fall back to
-            // runtime service location for those (everything else still inlines), so Static works
-            // without each consumer setting it. The cleaner long-term fix is to make those
-            // registrations inline-able (direct interface→concrete + InternalsVisibleTo
-            // "WolverineHandlers") so NotAllowed can be restored — tracked as a follow-up.
-            opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn;
+            // Service-location policy: NotAllowed aborts `codegen write` when a dependency
+            // can't be inlined. All three previously-problematic registrations are now clean:
+            // ICurrentUserService + IWolverineUserContextSetter use direct AddScoped<IFoo, TConcrete>
+            // (no lambda); INotificationPublisher impls are internal but InternalsVisibleTo
+            // "WolverineHandlers" is declared in Granit.Notifications and Granit.Notifications.Wolverine.
+            opts.ServiceLocationPolicy = ServiceLocationPolicy.NotAllowed;
 
             // IDomainEvent — force local routing, never forward to external transports.
             // IIntegrationEvent routing is configured by the provider package.

--- a/src/Granit.Wolverine/Granit.Wolverine.csproj
+++ b/src/Granit.Wolverine/Granit.Wolverine.csproj
@@ -16,6 +16,7 @@
     <InternalsVisibleTo Include="Granit.Wolverine.Postgresql" />
     <InternalsVisibleTo Include="Granit.Wolverine.SqlServer" />
     <InternalsVisibleTo Include="Granit.Wolverine.Tests" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     <ProjectReference Include="..\..\src\Granit\Granit.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- **fix(wolverine):** `ICurrentUserService`, `IWolverineUserContextSetter`, and `INotificationPublisher` were opaque to Wolverine codegen, causing `[WRN] Utilizing service location` on every handler chain. Fixed by replacing lambda forwarding factories with direct `AddScoped<IFoo, TConcrete>()` registrations and adding `InternalsVisibleTo("WolverineHandlers")` to `Granit.Wolverine`, `Granit.Notifications`, and `Granit.Notifications.Wolverine`. `ServiceLocationPolicy` promoted from `AllowedButWarn` → `NotAllowed`.
- **feat(privacy) [WIP]:** Replaces the bespoke `GET /legal-documents/{documentId}/versions` list handler with `MapGranitQuery<LegalDocument>` — filtering, sorting, pagination and metadata endpoint come for free. Wires `EfLegalDocumentQueryableSource` and registers `LegalDocumentQueryDefinition`. `LegalDocumentDetailResponse` moved to `Granit.Privacy.Dtos` (re-exported via `global using` in `.Endpoints` for backward compat).

## Test plan

- [ ] Wolverine fix: build a host with `CodeGenerationMode = Static`, run `dotnet run -- codegen write` — no `[WRN] Utilizing service location` in output
- [ ] Privacy WIP: `GET /admin/legal-documents` returns paginated results with default `published` quick-filter
- [ ] Privacy WIP: `GET /admin/legal-documents/meta` returns query metadata (columns, filters, presets)
- [ ] Privacy WIP: `?filter[documentId.eq]=privacy-policy` scopes results to a single document's version history
- [ ] Privacy WIP: existing unit and architecture tests pass for the `privacy` shard