### PR TITLE
fix(blob-storage): accept ZIP-based container formats in MagicBytesValidator

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -14413,7 +14413,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage",
       "file": "src/Granit.BlobStorage/Validators/MagicBytesValidator.cs",
-      "line": 21,
+      "line": 26,
       "members": [
         {
           "name": "Order",

--- a/src/Granit.BlobStorage/Validators/MagicBytesValidator.cs
+++ b/src/Granit.BlobStorage/Validators/MagicBytesValidator.cs
@@ -17,9 +17,37 @@ namespace Granit.BlobStorage.Validators;
 /// passes through and sets <see cref="BlobValidationResult.VerifiedContentType"/> to the
 /// declared type (conservative behaviour: do not reject what cannot be inspected).
 /// </para>
+/// <para>
+/// ZIP-based container formats (OOXML, ODF, EPUB, JAR) share the PK magic signature with
+/// plain ZIP archives. When magic bytes indicate <c>application/zip</c> and the declared
+/// type is a known ZIP-based container, validation passes using the declared type.
+/// </para>
 /// </remarks>
 public sealed class MagicBytesValidator(IOptions<BlobStorageOptions> options) : IBlobValidator
 {
+    // ZIP-based container formats whose first bytes are identical to a plain .zip archive.
+    // Magic-byte detection returns "application/zip" for all of them, so a declared-vs-detected
+    // mismatch would incorrectly reject valid files. Accept these when zip is detected.
+    private static readonly HashSet<string> ZipCompatibleTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Office Open XML (.docx / .xlsx / .pptx and their template variants)
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.presentationml.template",
+        "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+        // OpenDocument (.odt / .ods / .odp)
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "application/vnd.oasis.opendocument.presentation",
+        "application/vnd.oasis.opendocument.graphics",
+        // Other common ZIP containers
+        "application/epub+zip",
+        "application/java-archive",
+    };
+
     /// <inheritdoc/>
     public int Order => 10;
 
@@ -52,6 +80,14 @@ public sealed class MagicBytesValidator(IOptions<BlobStorageOptions> options) : 
                     "from magic bytes. Unverified content types are rejected by policy.");
             }
 
+            return BlobValidationResult.Success(context.Descriptor.DeclaredContentType);
+        }
+
+        // ZIP-based container formats (OOXML, ODF, EPUB, JAR…) share the PK magic signature
+        // with plain ZIP; return the declared type rather than the generic "application/zip".
+        if (string.Equals(detectedType, "application/zip", StringComparison.OrdinalIgnoreCase)
+            && ZipCompatibleTypes.Contains(context.Descriptor.DeclaredContentType))
+        {
             return BlobValidationResult.Success(context.Descriptor.DeclaredContentType);
         }
 


### PR DESCRIPTION
## Summary

As a Développeur, when I upload an Office document (`.docx`, `.xlsx`, `.pptx`) or any ZIP-based container format, I expect the file to be accepted rather than rejected with a content-type mismatch.

**Root cause:** `MagicByteDetector` returns `"application/zip"` for all ZIP-based formats (OOXML, ODF, EPUB, JAR) because they all start with the `PK\x03\x04` magic bytes. `MagicBytesValidator` compared this against the declared Office MIME type (e.g. `application/vnd.openxmlformats-officedocument.wordprocessingml.document`) — always a mismatch → blob marked `Rejected`.

**Fix:** Add a `ZipCompatibleTypes` allowlist in `MagicBytesValidator`. When magic bytes indicate `application/zip` and the declared type is a known ZIP-based container format, accept the blob using the declared content type rather than rejecting the mismatch.

**Formats covered:**
- Office Open XML: `.docx`, `.dotx`, `.xlsx`, `.xltx`, `.pptx`, `.potx`, `.ppsx`
- OpenDocument: `.odt`, `.ods`, `.odp`, `.odg`
- Other: `.epub`, `.jar`

## Related

Found while diagnosing `POST /documents/finalize 400` errors in granit-showcase-dotnet.
Companion fix in `granit-business`: map `BlobNotValidException` → `InvalidOperationException` (defense-in-depth).
Companion fix in `granit-front`: `retry: 0` on `useFinalizeUpload` / `useAppendDocumentVersion`.

## Test plan

- [ ] Upload a `.docx` file via Documents UploadButton → should succeed (was: 422 content-type mismatch)
- [ ] Upload a `.xlsx` file → should succeed
- [ ] Upload a `.pptx` file → should succeed
- [ ] Upload a `.pdf` file → still succeeds (regression)
- [ ] Upload a `.png` file declared as `application/pdf` → still rejected (magic bytes mismatch)
- [ ] Upload a genuine `.zip` declared as `application/zip` → still accepted