### PR TITLE
fix(entities): auto-emit enum options for select/multiselect form fields

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20517,7 +20517,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -20527,6 +20527,15 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs",
       "line": 10,
+      "members": []
+    },
+    {
+      "name": "FieldSelectOption",
+      "fqn": "Granit.Entities.Forms.FieldSelectOption",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Forms/FieldSelectOption.cs",
+      "line": 17,
       "members": []
     },
     {

--- a/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using Granit.DataLookup.Descriptors;
@@ -153,7 +154,7 @@ public sealed class FieldBuilder<TEntity, TProperty>
             PropertyName = _propertyName,
             ClrType = _clrType,
             Component = _component,
-            Config = _config,
+            Config = ResolveConfig(),
             LabelKey = _labelKey,
             HelpKey = _helpKey,
             RequiresPermission = _requiresPermission,
@@ -162,6 +163,59 @@ public sealed class FieldBuilder<TEntity, TProperty>
             VisibleIf = _visibleIf,
             Lookup = _lookup,
         };
+
+    /// <summary>
+    /// Auto-populates <c>config["options"]</c> for an enum-backed choice component so the
+    /// renderer never receives a <c>select</c>/<c>multiselect</c> with no options (ADR-041 —
+    /// both require an <c>options[]</c> config). Skipped when the field declares a data lookup
+    /// (the picker supplies its own values) or the caller already provided <c>options</c>.
+    /// </summary>
+    private Dictionary<string, object?>? ResolveConfig()
+    {
+        Type unwrapped = Nullable.GetUnderlyingType(_clrType) ?? _clrType;
+        bool autoOptions = unwrapped.IsEnum
+            && _lookup is null
+            && _component is "select" or "multiselect" or "status"
+            && (_config is null || !_config.ContainsKey("options"));
+
+        if (!autoOptions)
+        {
+            return _config;
+        }
+
+        Dictionary<string, object?> config = _config is null
+            ? new Dictionary<string, object?>(StringComparer.Ordinal)
+            : new Dictionary<string, object?>(_config, StringComparer.Ordinal);
+        config["options"] = BuildEnumOptions(unwrapped);
+        return config;
+    }
+
+    /// <summary>
+    /// Materializes an enum's members as <see cref="FieldSelectOption"/>s — value = the member's
+    /// PascalCase name (symmetric with the wire enum format), label = the
+    /// <c>Enum:{TypeName}.{Value}</c> i18n key (ADR-023, shared with <c>EnumLookupSource</c>).
+    /// For <c>[Flags]</c> enums the zero member (the empty set) is dropped — selecting nothing
+    /// already represents it in a multiselect.
+    /// </summary>
+    private static List<FieldSelectOption> BuildEnumOptions(Type enumType)
+    {
+        bool isFlags = enumType.IsDefined(typeof(FlagsAttribute), inherit: false);
+        string[] names = Enum.GetNames(enumType);
+        List<FieldSelectOption> options = new(names.Length);
+
+        foreach (string name in names)
+        {
+            if (isFlags
+                && Convert.ToInt64(Enum.Parse(enumType, name), CultureInfo.InvariantCulture) == 0)
+            {
+                continue;
+            }
+
+            options.Add(new FieldSelectOption(name, $"Enum:{enumType.Name}.{name}"));
+        }
+
+        return options;
+    }
 
     /// <summary>
     /// Picks a sensible default component from the standard catalog (per ADR-041) based on the
@@ -203,7 +257,8 @@ public sealed class FieldBuilder<TEntity, TProperty>
 
         if (unwrapped.IsEnum)
         {
-            return "select";
+            // [Flags] enums are a set, not a single choice → multiselect (ADR-041).
+            return unwrapped.IsDefined(typeof(FlagsAttribute), inherit: false) ? "multiselect" : "select";
         }
 
         return "text";

--- a/src/Granit.Entities.Abstractions/Forms/FieldSelectOption.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldSelectOption.cs
@@ -1,0 +1,17 @@
+namespace Granit.Entities.Forms;
+
+/// <summary>
+/// One choice for a <c>select</c> / <c>multiselect</c> / <c>status</c> field component
+/// (ADR-041). Emitted in the field's opaque <c>config["options"]</c> array and consumed
+/// verbatim by the React renderer.
+/// </summary>
+/// <param name="Value">
+/// Wire value sent back to the server. For enum-backed fields this is the member's
+/// PascalCase name (symmetric with <c>JsonStringEnumConverter</c>).
+/// </param>
+/// <param name="LabelKey">
+/// i18n key for the human label (resolved client-side), or <see langword="null"/> to fall
+/// back to the raw <see cref="Value"/>. Enum-backed fields use the <c>Enum:{TypeName}.{Value}</c>
+/// convention (ADR-023), shared with <c>EnumLookupSource</c>.
+/// </param>
+public sealed record FieldSelectOption(object? Value, string? LabelKey);

--- a/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
@@ -112,6 +112,32 @@ public sealed class EntityDefinitionTests
     }
 
     [Fact]
+    public void FieldBuilder_EnumField_DefaultsToSelect_WithAutoOptions()
+    {
+        EntityDefinitionDescriptor d = new SampleEntityDefinition().Descriptor;
+        FieldDescriptor kind = d.Forms[0].Sections.SelectMany(s => s.Fields).First(f => f.PropertyName == "Kind");
+
+        kind.Component.ShouldBe("select");
+        kind.Config.ShouldNotBeNull();
+        IReadOnlyList<FieldSelectOption> options = kind.Config!["options"].ShouldBeAssignableTo<IReadOnlyList<FieldSelectOption>>()!;
+        options.Select(o => o.Value).ShouldBe(["Individual", "Company"]);
+        options.Select(o => o.LabelKey).ShouldBe(["Enum:SampleKind.Individual", "Enum:SampleKind.Company"]);
+    }
+
+    [Fact]
+    public void FieldBuilder_FlagsEnumField_DefaultsToMultiselect_DroppingZeroMember()
+    {
+        EntityDefinitionDescriptor d = new SampleEntityDefinition().Descriptor;
+        FieldDescriptor roles = d.Forms[0].Sections.SelectMany(s => s.Fields).First(f => f.PropertyName == "Roles");
+
+        roles.Component.ShouldBe("multiselect");
+        roles.Config.ShouldNotBeNull();
+        IReadOnlyList<FieldSelectOption> options = roles.Config!["options"].ShouldBeAssignableTo<IReadOnlyList<FieldSelectOption>>()!;
+        // None (0) is dropped — the empty selection already represents it.
+        options.Select(o => o.Value).ShouldBe(["Customer", "Supplier"]);
+    }
+
+    [Fact]
     public void FieldBuilder_OverridesComponent_AndConfig()
     {
         EntityDefinitionDescriptor d = new SampleEntityDefinition().Descriptor;
@@ -187,6 +213,22 @@ public sealed class EntityDefinitionTests
         public DateTimeOffset IssuedAt { get; set; }
         public string Status { get; set; } = "";
         public string? Notes { get; set; }
+        public SampleKind Kind { get; set; }
+        public SampleRoles Roles { get; set; }
+    }
+
+    private enum SampleKind
+    {
+        Individual = 0,
+        Company = 1,
+    }
+
+    [Flags]
+    private enum SampleRoles
+    {
+        None = 0,
+        Customer = 1 << 0,
+        Supplier = 1 << 1,
     }
 
     private sealed class SampleQueryDefinition;
@@ -223,6 +265,8 @@ public sealed class EntityDefinitionTests
                         .RequiresPermission("Sample.SampleEntities.Manage"))
                     .Field(x => x.Active)
                     .Field(x => x.IssuedAt)
+                    .Field(x => x.Kind)
+                    .Field(x => x.Roles)
                     .Field(x => x.Notes, fld => fld.VisibleIf("Status", FieldOp.Eq, "Draft")))
                 .Customizable());
 


### PR DESCRIPTION
## Problem

Entity edit forms render enum fields broken. On the showcase Party form (`/w/Showcase.Crm/Granit.Parties.Party/new`) the renderer shows:

> Select component on Kind requires config.options with the documented shape.
> Select component on Roles requires config.options with the documented shape.
> Select component on Status requires config.options with the documented shape.

## Root cause

`FieldBuilder.ChooseDefaultComponent` mapped **every** enum to the `"select"` component but never populated `config.options`. Per **ADR-041**, `select`/`multiselect` must carry an `options[]` config, so the React `SelectComponent` correctly rejects enum fields. `[Flags]` enums were also wrongly mapped to single `select` instead of `multiselect`.

## Fix

- `[Flags]` enums now default to `"multiselect"`; plain enums to `"select"`.
- `Build()` auto-emits `config["options"]` for enum-backed `select`/`multiselect`/`status` fields:
  - `value` = enum member's PascalCase name (symmetric with `JsonStringEnumConverter`)
  - `labelKey` = `Enum:{TypeName}.{Value}` — the same convention `EnumLookupSource`/**ADR-023** already own (resolved client-side)
  - `[Flags]` zero members (`None`) dropped — the empty selection represents them
  - Skipped when a lookup is declared or the caller already supplied `options`
- New `FieldSelectOption` record for the option shape.

Fixes the three Party fields plus owned-collection enum fields (`PhoneKind`, `AddressKind`) uniformly — the composer already passes `Config` through verbatim.

## Tests

`Granit.Entities.Abstractions.Tests` — 2 new tests (plain enum → `select` + auto-options; `[Flags]` → `multiselect` dropping the zero member). 107 total green, `dotnet format` clean.

## Follow-up (not in this PR)

- After publish, the showcase restores the new `Granit.Entities.Abstractions 0.1.0-dev.*` → fixes **Kind**/**Status** (front `select` already exists).
- **Roles** additionally needs a `multiselect` component in `@granit/react-entities` `STANDARD_FORM_COMPONENTS` (separate granit-front PR) — until then it renders the graceful `MissingComponent` placeholder rather than erroring.