### PR TITLE
fix(query-engine): make Add{Query,Export}Definition idempotent

### DIFF
--- a/src/Granit.DataExchange.Abstractions/Extensions/ExportDefinitionServiceCollectionExtensions.cs
+++ b/src/Granit.DataExchange.Abstractions/Extensions/ExportDefinitionServiceCollectionExtensions.cs
@@ -20,11 +20,23 @@ public static class ExportDefinitionServiceCollectionExtensions
     /// <typeparam name="TDefinition">The export definition implementation.</typeparam>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// Idempotent for a given (<typeparamref name="TEntity"/>, <typeparamref name="TDefinition"/>)
+    /// pair: registering the same definition more than once is a no-op. Modules sharing a base
+    /// module (e.g. the Scriban and MJML templating engines both calling <c>AddGranitTemplating</c>)
+    /// would otherwise register duplicate <see cref="IExportDefinitionDescriptor"/> entries.
+    /// </remarks>
     public static IServiceCollection AddExportDefinition<TEntity, TDefinition>(
         this IServiceCollection services)
         where TEntity : class
         where TDefinition : ExportDefinition<TEntity>
     {
+        if (services.Any(d => d.ServiceType == typeof(ExportDefinition<TEntity>)
+            && d.ImplementationType == typeof(TDefinition)))
+        {
+            return services;
+        }
+
         services.AddSingleton<ExportDefinition<TEntity>, TDefinition>();
         services.AddSingleton<IExportDefinitionDescriptor>(sp =>
             sp.GetRequiredService<ExportDefinition<TEntity>>());

--- a/src/Granit.QueryEngine.Abstractions/Extensions/QueryDefinitionServiceCollectionExtensions.cs
+++ b/src/Granit.QueryEngine.Abstractions/Extensions/QueryDefinitionServiceCollectionExtensions.cs
@@ -21,17 +21,32 @@ public static class QueryDefinitionServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
+    /// <para>
     /// The concrete <typeparamref name="TDefinition"/> is registered as a resolvable
     /// singleton so callers (and the <c>Granit.Entities</c> integrity check) can locate
     /// it through DI — both the base <see cref="QueryDefinition{TEntity}"/> service and
     /// the non-generic <see cref="IQueryDefinitionDescriptor"/> resolve to the same
     /// instance.
+    /// </para>
+    /// <para>
+    /// Idempotent: registering the same <typeparamref name="TDefinition"/> more than once
+    /// is a no-op. Several modules that share a base module (e.g. the Scriban and MJML
+    /// templating engines both calling <c>AddGranitTemplating</c>) would otherwise register
+    /// duplicate <see cref="IQueryDefinitionDescriptor"/> entries, producing two aggregate
+    /// runners with the same name and crashing the analytics runner registry on a
+    /// duplicate-key <c>ToDictionary</c>.
+    /// </para>
     /// </remarks>
     public static IServiceCollection AddQueryDefinition<TEntity, TDefinition>(
         this IServiceCollection services)
         where TEntity : class
         where TDefinition : QueryDefinition<TEntity>, new()
     {
+        if (services.Any(d => d.ServiceType == typeof(TDefinition)))
+        {
+            return services;
+        }
+
         services.AddSingleton<TDefinition>(sp =>
         {
             TDefinition definition = new();


### PR DESCRIPTION
## Problem

A host that registers both `AddGranitTemplatingWithScriban()` and `AddGranitTemplatingWithMjml()` (supported usage — Scriban engine + MJML transformer) crashes at the first analytics-backed request:

```
System.ArgumentException: An item with the same key has already been added. Key: Granit.Templating.TemplateSummaryQuery
   at System.Linq.Enumerable.ToDictionary[...]
   at Granit.Analytics.Internal.QueryAggregateService..ctor(IEnumerable`1 runners)
```

### Root cause

Both `With*` extensions call `AddGranitTemplating()`, which is idempotent (`TryAdd*`) **except** for its query/export definition registrations:

```csharp
services.AddQueryDefinition<TemplateSummary, TemplateSummaryQueryDefinition>();
services.AddExportDefinition<TemplateSummary, TemplateSummaryExportDefinition>();
```

`AddQueryDefinition` / `AddExportDefinition` used plain `AddSingleton`, so calling them twice registered **two** `IQueryDefinitionDescriptor` entries for the same definition. The analytics widget-renderer registration then minted one `IQueryAggregateRunner` per descriptor → two runners with the same `Name` → duplicate-key `ToDictionary` crash in `QueryAggregateService`.

This was latent until analytics runners became a consumer of the descriptor enumeration.

## Fix

Make both registrars idempotent:

- `AddQueryDefinition` — no-ops when `TDefinition` is already registered.
- `AddExportDefinition` — no-ops on a duplicate `(TEntity, TDefinition)` pair (precise enough that genuinely distinct definitions still register).

Registering the exact same definition twice was never intentional, so this is safe and benefits every module that shares a base module.

## Verification

- `Granit.QueryEngine.Abstractions` and `Granit.DataExchange.Abstractions` build clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)