### PR TITLE
fix(query-engine): always apply deterministic order before Skip/Take

### DIFF
--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableSortExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableSortExtensions.cs
@@ -14,6 +14,14 @@ internal static class QueryableSortExtensions
     /// Format: <c>"-createdAt,lastName"</c> (prefix <c>-</c> for descending).
     /// Only whitelisted sortable columns are applied.
     /// </summary>
+    /// <remarks>
+    /// A deterministic ordering is <b>always</b> applied: when the request supplies no sort,
+    /// the definition declares no <c>DefaultSort</c>, or none of the requested fields are
+    /// whitelisted, a stable fallback key is used (the cursor key, then a conventional
+    /// <c>Id</c>, then the first sortable column). Without it the downstream row-limiting
+    /// operators (<c>Skip</c>/<c>Take</c>) run unordered, producing both EF Core's
+    /// <c>RowLimitingOperationWithoutOrderByWarning</c> and non-deterministic pages.
+    /// </remarks>
     public static IQueryable<TEntity> ApplySort<TEntity>(
         this IQueryable<TEntity> source,
         string? sort,
@@ -24,56 +32,87 @@ internal static class QueryableSortExtensions
             ? builder.DefaultSortValue ?? string.Empty
             : sort;
 
-        if (string.IsNullOrWhiteSpace(effectiveSort))
-        {
-            return source;
-        }
-
-        var sortableFields = builder.Columns
-            .Where(c => c.IsSortable)
-            .Select(c => c.PropertyName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        string[] parts = effectiveSort.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         bool isFirst = true;
 
-        foreach (string part in parts)
+        if (!string.IsNullOrWhiteSpace(effectiveSort))
         {
-            bool descending = part.StartsWith('-');
-            string fieldName = descending ? part[1..] : part;
+            var sortableFields = builder.Columns
+                .Where(c => c.IsSortable)
+                .Select(c => c.PropertyName)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-            if (!sortableFields.Contains(fieldName))
+            string[] parts = effectiveSort.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            foreach (string part in parts)
             {
-                continue;
-            }
+                bool descending = part.StartsWith('-');
+                string fieldName = descending ? part[1..] : part;
 
-            // Check for shadow property first
-            ColumnDescriptor? shadowCol = builder.Columns
-                .FirstOrDefault(c => c.IsShadowProperty
-                    && string.Equals(c.PropertyName, fieldName, StringComparison.OrdinalIgnoreCase));
+                if (!sortableFields.Contains(fieldName))
+                {
+                    continue;
+                }
 
-            if (shadowCol is not null)
-            {
-                source = ApplyOrderByShadow(source, fieldName, shadowCol.ClrType, descending, isFirst);
+                // Check for shadow property first
+                ColumnDescriptor? shadowCol = builder.Columns
+                    .FirstOrDefault(c => c.IsShadowProperty
+                        && string.Equals(c.PropertyName, fieldName, StringComparison.OrdinalIgnoreCase));
+
+                if (shadowCol is not null)
+                {
+                    source = ApplyOrderByShadow(source, fieldName, shadowCol.ClrType, descending, isFirst);
+                    isFirst = false;
+                    continue;
+                }
+
+                PropertyInfo? property = typeof(TEntity).GetProperty(
+                    fieldName,
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+                if (property is null)
+                {
+                    continue;
+                }
+
+                source = ApplyOrderBy(source, property, descending, isFirst);
                 isFirst = false;
-                continue;
             }
-
-            PropertyInfo? property = typeof(TEntity).GetProperty(
-                fieldName,
-                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-            if (property is null)
-            {
-                continue;
-            }
-
-            source = ApplyOrderBy(source, property, descending, isFirst);
-            isFirst = false;
         }
 
-        return source;
+        // No explicit ordering resolved — guarantee a deterministic order so that
+        // Skip/Take downstream is stable and EF Core does not warn.
+        return isFirst ? ApplyFallbackOrder(source, builder) : source;
     }
+
+    /// <summary>
+    /// Applies a deterministic fallback ordering when no explicit sort resolved.
+    /// Prefers the cursor key (unique and orderable — typically the primary key), then a
+    /// conventional <c>Id</c>, then the first sortable column. Returns the source unchanged
+    /// only when none of these can be resolved to a CLR property.
+    /// </summary>
+    private static IQueryable<TEntity> ApplyFallbackOrder<TEntity>(
+        IQueryable<TEntity> source,
+        QueryDefinitionBuilder<TEntity> builder)
+        where TEntity : class
+    {
+        PropertyInfo? property = ResolveProperty<TEntity>(builder.CursorPropertyName)
+            ?? ResolveProperty<TEntity>("Id")
+            ?? builder.Columns
+                .Where(c => c.IsSortable && !c.IsShadowProperty)
+                .Select(c => ResolveProperty<TEntity>(c.PropertyName))
+                .FirstOrDefault(p => p is not null);
+
+        return property is null
+            ? source
+            : ApplyOrderBy(source, property, descending: false, isFirst: true);
+    }
+
+    private static PropertyInfo? ResolveProperty<TEntity>(string? name) =>
+        string.IsNullOrEmpty(name)
+            ? null
+            : typeof(TEntity).GetProperty(
+                name,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
 
     private static IQueryable<TEntity> ApplyOrderByShadow<TEntity>(
         IQueryable<TEntity> source,

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableSortExtensionsTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableSortExtensionsTests.cs
@@ -122,15 +122,48 @@ public sealed class QueryableSortExtensionsTests
     }
 
     [Fact]
-    public void Empty_sort_and_no_default_returns_unsorted()
+    public void Empty_sort_and_no_default_falls_back_to_id()
     {
+        // No request sort, no DefaultSort → must still order deterministically (by Id)
+        // so downstream Skip/Take is stable and EF Core does not warn.
         QueryDefinitionBuilder<TestProduct> builder = new();
-        List<TestProduct> source = [new() { Name = "B" }, new() { Name = "A" }];
+        var first = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var second = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        List<TestProduct> source =
+        [
+            new() { Id = second, Name = "B" },
+            new() { Id = first, Name = "A" },
+        ];
 
         var result = source.AsQueryable()
             .ApplySort("", builder)
             .ToList();
 
         result.Count.ShouldBe(2);
+        result[0].Id.ShouldBe(first);
+        result[1].Id.ShouldBe(second);
+    }
+
+    [Fact]
+    public void Non_whitelisted_only_sort_falls_back_to_cursor_key()
+    {
+        // Requested field is not sortable → nothing resolves → fall back to the cursor key.
+        QueryDefinitionBuilder<TestProduct> builder = new();
+        builder.SupportsCursorPagination(p => p.Price);
+
+        List<TestProduct> source =
+        [
+            new() { Name = "B", Price = 30 },
+            new() { Name = "A", Price = 10 },
+            new() { Name = "C", Price = 20 },
+        ];
+
+        var result = source.AsQueryable()
+            .ApplySort("Name", builder)
+            .ToList();
+
+        result[0].Price.ShouldBe(10);
+        result[1].Price.ShouldBe(20);
+        result[2].Price.ShouldBe(30);
     }
 }


### PR DESCRIPTION
## Problem

EF Core was emitting `RowLimitingOperationWithoutOrderByWarning`:

> The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator. This may lead to unpredictable results.

The warning originates in the **QueryEngine**, not in any individual `*QueryDefinition`. Every execution path — offset, cursor, projection, grouped, stream — funnels its `Skip`/`Take` through `ApplySort`. That method returned the queryable **unordered** in two cases:

1. The request supplied no `sort` **and** the definition declared no `DefaultSort`.
2. Every requested sort field was non-whitelisted / non-existent (loop `continue`d on each).

In both cases the downstream `Skip`/`Take` ran with no `OrderBy` → the warning, plus genuinely non-deterministic pages. On the cursor path it was also a keyset correctness bug: the query filtered by the cursor key but never ordered by it.

## Fix

`ApplySort` now **always** applies a deterministic ordering. When nothing explicit resolves, it falls back to a stable key in priority order:

1. `CursorPropertyName` — documented unique + orderable (typically the PK); also fixes keyset correctness
2. a conventional `Id` (`Granit.Domain.Entity` guarantees `Guid Id`)
3. the first sortable column

Only if none resolve does it return the source unchanged (pathological — no `Id`, no cursor, no CLR-backed sortable column). One-point fix covers all six pagination paths.

## Tests

- Renamed the stale `Empty_sort_and_no_default_returns_unsorted` test to assert the `Id` fallback
- Added a cursor-key fallback test (requested field non-whitelisted → orders by cursor key)
- `Granit.QueryEngine.EntityFrameworkCore.Tests`: **204 passed**
- `Granit.QueryEngine.AspNetCore.Tests.Integration` (real EF Core): **14 passed**
- `dotnet format --verify-no-changes` clean

## Follow-up (out of scope)

On the cursor path with a configured `DefaultSort` that does not itself include the cursor key, the `ORDER BY` still won't append the cursor key as a tiebreaker — a latent keyset edge case independent of this warning.