### PR TITLE
test(validation): isolate ValidationMetrics recorder to its own meter

### DIFF
--- a/tests/Granit.Validation.Endpoints.Tests/ValidationMetricsTests.cs
+++ b/tests/Granit.Validation.Endpoints.Tests/ValidationMetricsTests.cs
@@ -59,6 +59,7 @@ public sealed class ValidationMetricsTests
 
     private sealed class Recorder : IDisposable
     {
+        private readonly ServiceProvider _provider;
         private readonly MeterListener _listener;
         private readonly List<Measurement> _measurements = [];
 
@@ -66,15 +67,21 @@ public sealed class ValidationMetricsTests
 
         private Recorder()
         {
-            IMeterFactory factory = new ServiceCollection().AddMetrics()
-                .BuildServiceProvider().GetRequiredService<IMeterFactory>();
+            _provider = new ServiceCollection().AddMetrics().BuildServiceProvider();
+            IMeterFactory factory = _provider.GetRequiredService<IMeterFactory>();
             Metrics = new ValidationMetrics(factory);
 
             _listener = new MeterListener
             {
                 InstrumentPublished = (instrument, listener) =>
                 {
-                    if (instrument.Meter.Name == ValidationMetrics.MeterName)
+                    // The listener is process-global: filtering by meter name alone would also
+                    // capture measurements emitted by parallel test classes that hit the live
+                    // endpoints (ValidationEndpointsHttpTests) under the same meter name. Scope
+                    // to THIS factory's meter — the default IMeterFactory stamps Meter.Scope
+                    // with the factory instance.
+                    if (instrument.Meter.Name == ValidationMetrics.MeterName
+                        && ReferenceEquals(instrument.Meter.Scope, factory))
                     {
                         listener.EnableMeasurementEvents(instrument);
                     }
@@ -90,6 +97,10 @@ public sealed class ValidationMetricsTests
         // Measurements are delivered synchronously on Add, so the list is already populated.
         public Measurement Single() => _measurements.ShouldHaveSingleItem();
 
-        public void Dispose() => _listener.Dispose();
+        public void Dispose()
+        {
+            _listener.Dispose();
+            _provider.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Problem

Flaky CI failure in `ValidationMetricsTests.RecordFieldValidated_UnknownCode_IsCappedToSentinel`:

```
System.InvalidOperationException : Sequence contains more than one element
   at Shouldly.ShouldBeEnumerableTestExtensions.ShouldHaveSingleItem
   at ValidationMetricsTests.Recorder.Single()
```

The test's `Recorder` uses a `MeterListener` that enabled measurement events for **any** instrument whose `Meter.Name == "Granit.Validation.Endpoints"`. `MeterListener` is process-global, and `ValidationEndpointsHttpTests` (a sibling class in the same assembly) spins up a live host and POSTs to `/validation/validate`, which emits `RecordFieldValidated` via DI under the **same meter name**. xUnit parallelizes across test classes, so a stray measurement from the HTTP test intermittently bled into the recorder → `ShouldHaveSingleItem` saw two. Timing-dependent, hence flaky.

## Fix

Scope the listener to **this** factory's meter using `Meter.Scope` reference equality — the default `IMeterFactory` (from `AddMetrics()`) stamps `Meter.Scope` with the factory instance, so each recorder's meter is uniquely identifiable. Also dispose the `ServiceProvider` to avoid leaking meters across tests.

## Verification

- `Granit.Validation.Endpoints.Tests`: **60 passed**, run 4× consecutively with no flake (full assembly, so the parallel HTTP tests run alongside)
- `dotnet format --verify-no-changes` clean

Pre-existing flake, independent of #2848.