### PR TITLE
feat(query-engine): add GET /catalog listing registered query definitions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -47254,6 +47254,31 @@
       ]
     },
     {
+      "name": "QueryCatalogEntryResponse",
+      "fqn": "Granit.QueryEngine.AspNetCore.Dtos.QueryCatalogEntryResponse",
+      "kind": "record",
+      "project": "Granit.QueryEngine.AspNetCore",
+      "file": "src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "QueryCatalogEndpointRouteBuilderExtensions",
+      "fqn": "Granit.QueryEngine.AspNetCore.Extensions.QueryCatalogEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.QueryEngine.AspNetCore",
+      "file": "src/Granit.QueryEngine.AspNetCore/Extensions/QueryCatalogEndpointRouteBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "MapGranitQueryCatalog",
+          "kind": "method",
+          "signature": "MapGranitQueryCatalog(this IEndpointRouteBuilder endpoints, string prefix = \"\")",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
       "name": "QueryEndpointRouteBuilderExtensions",
       "fqn": "Granit.QueryEngine.AspNetCore.Extensions.QueryEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -47268,7 +47293,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.AspNetCore",
       "file": "src/Granit.QueryEngine.AspNetCore/GranitQueryEngineAspNetCoreModule.cs",
-      "line": 24,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -47564,6 +47589,28 @@
       "file": "src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs",
       "line": 7,
       "members": []
+    },
+    {
+      "name": "IQueryDefinitionRegistry",
+      "fqn": "Granit.QueryEngine.IQueryDefinitionRegistry",
+      "kind": "interface",
+      "project": "Granit.QueryEngine.Abstractions",
+      "file": "src/Granit.QueryEngine.Abstractions/IQueryDefinitionRegistry.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<IQueryDefinitionDescriptor>"
+        },
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string name)",
+          "returnType": "IQueryDefinitionDescriptor?"
+        }
+      ]
     },
     {
       "name": "IQueryEngine",

--- a/src/Granit.QueryEngine.Abstractions/IQueryDefinitionRegistry.cs
+++ b/src/Granit.QueryEngine.Abstractions/IQueryDefinitionRegistry.cs
@@ -1,0 +1,22 @@
+namespace Granit.QueryEngine;
+
+/// <summary>
+/// Read-only registry of every <see cref="QueryDefinition{TEntity}"/> registered across
+/// all loaded modules. Surfaces the query catalogue to the <c>GET /catalog</c> endpoint
+/// so a dashboard editor can offer a dropdown of queries instead of a free-text
+/// <c>queryName</c>.
+/// </summary>
+public interface IQueryDefinitionRegistry
+{
+    /// <summary>
+    /// Returns every registered descriptor, ordered by <see cref="IQueryDefinitionDescriptor.Name"/>
+    /// (ordinal). Stable across processes — useful for tests and snapshot fixtures.
+    /// </summary>
+    IReadOnlyList<IQueryDefinitionDescriptor> GetAll();
+
+    /// <summary>
+    /// Looks up a descriptor by its wire identifier. Returns <c>null</c> when the name is
+    /// not registered (callers translate to a 404 at the HTTP layer).
+    /// </summary>
+    IQueryDefinitionDescriptor? Find(string name);
+}

--- a/src/Granit.QueryEngine.Abstractions/Internal/QueryDefinitionRegistry.cs
+++ b/src/Granit.QueryEngine.Abstractions/Internal/QueryDefinitionRegistry.cs
@@ -1,0 +1,33 @@
+namespace Granit.QueryEngine.Internal;
+
+/// <summary>
+/// Default <see cref="IQueryDefinitionRegistry"/> backed by the <see cref="IQueryDefinitionDescriptor"/>
+/// instances registered in DI by <c>AddQueryDefinition</c>. Mirrors
+/// <c>DashboardDefinitionRegistry</c>: a stable-ordered snapshot plus a by-name index.
+/// </summary>
+internal sealed class QueryDefinitionRegistry : IQueryDefinitionRegistry
+{
+    private readonly IReadOnlyList<IQueryDefinitionDescriptor> _ordered;
+    private readonly Dictionary<string, IQueryDefinitionDescriptor> _byName;
+
+    public QueryDefinitionRegistry(IEnumerable<IQueryDefinitionDescriptor> descriptors)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+
+        IQueryDefinitionDescriptor[] snapshot = descriptors.ToArray();
+
+        // Stable ordering by name. Ordinal comparison keeps test fixtures deterministic
+        // and matches the wire identifier's culture-invariant nature.
+        _ordered = [.. snapshot.OrderBy(d => d.Name, StringComparer.Ordinal)];
+
+        _byName = snapshot.ToDictionary(d => d.Name, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<IQueryDefinitionDescriptor> GetAll() => _ordered;
+
+    public IQueryDefinitionDescriptor? Find(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        return _byName.TryGetValue(name, out IQueryDefinitionDescriptor? d) ? d : null;
+    }
+}

--- a/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
@@ -1,0 +1,25 @@
+namespace Granit.QueryEngine.AspNetCore.Dtos;
+
+/// <summary>
+/// Response payload for a single entry in <c>GET /catalog</c>. Mirrors the wire-relevant
+/// subset of <see cref="IQueryDefinitionDescriptor"/>, letting a dashboard editor offer a
+/// dropdown of registered queries instead of a free-text <c>queryName</c>.
+/// </summary>
+/// <param name="Name">
+/// Wire identifier of the query definition — e.g. <c>"Acme.Patients"</c>. Stable across
+/// processes; safe to persist as the selected query in a dashboard widget.
+/// </param>
+/// <param name="BasePath">
+/// Resolved HTTP base path of the query's list endpoint (e.g. <c>"/api/patients"</c>), or
+/// <c>null</c> when the definition is registered but no <c>MapGranitQuery</c> route exposes
+/// it. Registration and routing are decoupled, so a forged URL is never emitted — the
+/// frontend surfaces a query without a base path as not-yet-routable.
+/// </param>
+/// <param name="Label">
+/// Human-facing label for the dropdown. The descriptor carries no display metadata, so this
+/// degrades gracefully to <see cref="Name"/>.
+/// </param>
+public sealed record QueryCatalogEntryResponse(
+    string Name,
+    string? BasePath,
+    string Label);

--- a/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
@@ -1,0 +1,73 @@
+using Granit.Entities;
+using Granit.QueryEngine.AspNetCore.Dtos;
+using Granit.QueryEngine.AspNetCore.Internal;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.QueryEngine.AspNetCore.Endpoints;
+
+/// <summary>
+/// HTTP handler for the query-engine catalogue read surface.
+/// </summary>
+internal static class QueryCatalogEndpoints
+{
+    /// <summary>
+    /// Maps <c>GET /catalog</c> on the supplied route group. Returns every registered
+    /// <see cref="QueryDefinition{TEntity}"/> projected through
+    /// <see cref="QueryCatalogEntryResponse"/>, in the registry's stable (name-ordinal) order.
+    /// </summary>
+    public static RouteGroupBuilder MapQueryCatalogEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/catalog", ListCatalogAsync)
+            .WithName("ListQueryCatalog")
+            .WithSummary("Lists every registered QueryDefinition.")
+            .WithDescription(
+                "Returns the full query catalogue surfaced by IQueryDefinitionRegistry so a "
+                + "dashboard editor can offer a dropdown of queries instead of a free-text "
+                + "queryName. Each entry carries the wire identifier and, when a MapGranitQuery "
+                + "route exposes it, the resolved base path of its list endpoint. Registration "
+                + "and routing are decoupled: a query registered without a mapped route is "
+                + "returned with a null base path rather than a forged URL.")
+            .Produces<IReadOnlyList<QueryCatalogEntryResponse>>();
+
+        return group;
+    }
+
+    private static Ok<IReadOnlyList<QueryCatalogEntryResponse>> ListCatalogAsync(
+        [FromServices] IQueryDefinitionRegistry registry,
+        [FromServices] EndpointDataSource endpointDataSource,
+        [FromServices] LinkGenerator linkGenerator,
+        HttpContext httpContext)
+    {
+        // Resolve each List-tagged endpoint's URL via LinkGenerator so route parameters
+        // (e.g. /api/v{version:apiVersion}/patients) are substituted using the current
+        // request's ambient route values. Reading RoutePattern.RawText directly would
+        // expose the unsubstituted template and the frontend would 404. Same mechanism
+        // as Granit.Entities' entity-discovery surface.
+        var routeIndex = endpointDataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .Select(e => new
+            {
+                Meta = e.Metadata.GetMetadata<EntityEndpointMetadata>(),
+                Name = e.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName,
+            })
+            .Where(x => x.Meta is { Kind: EntityEndpointKind.List } && x.Name is not null)
+            .Select(x => new { x.Meta, Path = linkGenerator.GetPathByName(httpContext, x.Name!) })
+            .Where(x => x.Path is not null)
+            .GroupBy(x => x.Meta!.EntityType)
+            .ToDictionary(g => g.Key, g => NormalizeRoutePath(g.First().Path!));
+
+        return TypedResults.Ok(QueryCatalogProjection.Project(registry.GetAll(), routeIndex));
+    }
+
+    /// <summary>
+    /// Strips the trailing slash from a resolved path unless it IS the root. The frontend
+    /// appends <c>/meta</c>, <c>/{id}</c>, etc. on top of the base, so a trailing slash would
+    /// yield <c>/path//meta</c> on the wire. Mirrors Granit.Entities' normalization.
+    /// </summary>
+    private static string NormalizeRoutePath(string path) =>
+        path.Length > 1 ? path.TrimEnd('/') : path;
+}

--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryCatalogEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryCatalogEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,43 @@
+using Granit.QueryEngine.AspNetCore.Endpoints;
+using Granit.Validation.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.QueryEngine.AspNetCore.Extensions;
+
+/// <summary>
+/// Extension methods for registering the query-engine catalogue endpoint.
+/// </summary>
+public static class QueryCatalogEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps <c>GET {prefix}/catalog</c>, exposing every registered
+    /// <see cref="QueryDefinition{TEntity}"/> so a dashboard editor can offer a dropdown of
+    /// queries instead of a free-text <c>queryName</c>. Independent of
+    /// <see cref="QueryEndpointRouteBuilderExtensions.MapGranitQuery{TEntity}(IEndpointRouteBuilder, string, System.Action{Options.QueryEndpointOptions})"/>:
+    /// a query registered via <c>AddQueryDefinition</c> appears in the catalogue even when no
+    /// route exposes it (with a <c>null</c> base path).
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="prefix">Optional route prefix for the catalogue group. Defaults to empty.</param>
+    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
+    public static RouteGroupBuilder MapGranitQueryCatalog(
+        this IEndpointRouteBuilder endpoints,
+        string prefix = "")
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        RouteGroupBuilder group = endpoints.MapGranitGroup(prefix)
+            .WithTags("Query Engine");
+
+        // Authenticated-only gate: the catalogue exposes query identifiers and base paths
+        // (metadata, not row data), mirroring the per-query list endpoints' default. The
+        // descriptors carry no PermissionGroup, so there is nothing to filter per-item on.
+        group.RequireAuthorization();
+
+        group.MapQueryCatalogEndpoints();
+
+        return group;
+    }
+}

--- a/src/Granit.QueryEngine.AspNetCore/GranitQueryEngineAspNetCoreModule.cs
+++ b/src/Granit.QueryEngine.AspNetCore/GranitQueryEngineAspNetCoreModule.cs
@@ -3,7 +3,9 @@ using Granit.Http.ApiDocumentation;
 using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore.Internal;
+using Granit.QueryEngine.Internal;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.QueryEngine.AspNetCore;
 
@@ -28,5 +30,8 @@ public sealed class GranitQueryEngineAspNetCoreModule : GranitModule
     {
         ArgumentNullException.ThrowIfNull(context);
         context.Services.AddLocalizationResource<QueryEngineAspNetCoreLocalizationResource>();
+
+        // Surfaces every registered IQueryDefinitionDescriptor to the GET /catalog endpoint.
+        context.Services.TryAddSingleton<IQueryDefinitionRegistry, QueryDefinitionRegistry>();
     }
 }

--- a/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
@@ -1,0 +1,41 @@
+using Granit.QueryEngine.AspNetCore.Dtos;
+
+namespace Granit.QueryEngine.AspNetCore.Internal;
+
+/// <summary>
+/// Maps <see cref="IQueryDefinitionDescriptor"/> instances to the wire shape
+/// (<see cref="QueryCatalogEntryResponse"/>), resolving each entry's base path from a
+/// pre-built entity-type → route-path index. Extracted to its own class so the projection
+/// logic is unit-testable without the full WebApplication harness.
+/// </summary>
+internal static class QueryCatalogProjection
+{
+    /// <summary>
+    /// Projects <paramref name="descriptors"/> (already ordered by the registry) into catalog
+    /// entries. <paramref name="basePathByEntityType"/> maps an entity CLR type to the resolved
+    /// base path of its <c>List</c> endpoint; a descriptor whose entity type is absent gets a
+    /// <c>null</c> base path — never a forged URL.
+    /// </summary>
+    public static IReadOnlyList<QueryCatalogEntryResponse> Project(
+        IEnumerable<IQueryDefinitionDescriptor> descriptors,
+        IReadOnlyDictionary<Type, string> basePathByEntityType)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+        ArgumentNullException.ThrowIfNull(basePathByEntityType);
+
+        return [.. descriptors.Select(d => ToResponse(d, basePathByEntityType))];
+    }
+
+    private static QueryCatalogEntryResponse ToResponse(
+        IQueryDefinitionDescriptor descriptor,
+        IReadOnlyDictionary<Type, string> basePathByEntityType)
+    {
+        string? basePath = basePathByEntityType.TryGetValue(descriptor.EntityType, out string? path)
+            ? path
+            : null;
+
+        // The descriptor exposes no display label, so the dropdown label degrades to the
+        // wire identifier. A richer label can be layered on later without a wire break.
+        return new QueryCatalogEntryResponse(descriptor.Name, basePath, descriptor.Name);
+    }
+}

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
@@ -1,0 +1,92 @@
+using Granit.QueryEngine.Extensions;
+using Granit.QueryEngine.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.Abstractions.Tests;
+
+public sealed class QueryDefinitionRegistryTests
+{
+    [Fact]
+    public void GetAll_orders_by_name_ordinal()
+    {
+        QueryDefinitionRegistry registry = new(
+        [
+            new FakeDescriptor("Acme.Patients", typeof(Patient)),
+            new FakeDescriptor("Acme.Doctors", typeof(Doctor)),
+            new FakeDescriptor("Acme.Appointments", typeof(Appointment)),
+        ]);
+
+        registry.GetAll().Select(d => d.Name).ShouldBe([
+            "Acme.Appointments",
+            "Acme.Doctors",
+            "Acme.Patients",
+        ]);
+    }
+
+    [Fact]
+    public void Find_returns_descriptor_when_registered()
+    {
+        QueryDefinitionRegistry registry = new(
+            [new FakeDescriptor("Acme.Patients", typeof(Patient))]);
+
+        IQueryDefinitionDescriptor? found = registry.Find("Acme.Patients");
+
+        found.ShouldNotBeNull();
+        found.EntityType.ShouldBe(typeof(Patient));
+    }
+
+    [Fact]
+    public void Find_returns_null_when_not_registered()
+    {
+        QueryDefinitionRegistry registry = new(
+            [new FakeDescriptor("Acme.Patients", typeof(Patient))]);
+
+        registry.Find("Acme.Missing").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Find_throws_on_null_or_empty_name()
+    {
+        QueryDefinitionRegistry registry = new([]);
+
+        Should.Throw<ArgumentException>(() => registry.Find(string.Empty));
+        Should.Throw<ArgumentException>(() => registry.Find(null!));
+    }
+
+    [Fact]
+    public void Idempotent_registration_yields_a_single_catalogue_entry()
+    {
+        // AddQueryDefinition is a no-op on the second call, so the same definition registered
+        // twice must surface exactly one descriptor in the catalogue — never a duplicate that
+        // would trip the by-name ToDictionary or show twice in a dropdown.
+        ServiceCollection services = new();
+        services.AddQueryDefinition<Patient, PatientQueryDefinition>();
+        services.AddQueryDefinition<Patient, PatientQueryDefinition>();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        QueryDefinitionRegistry registry = new(sp.GetServices<IQueryDefinitionDescriptor>());
+
+        registry.GetAll().ShouldHaveSingleItem().Name.ShouldBe("Acme.Patients");
+    }
+
+    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
+
+    private sealed class Patient
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class Doctor;
+
+    private sealed class Appointment;
+
+    private sealed class PatientQueryDefinition : QueryDefinition<Patient>
+    {
+        public override string Name => "Acme.Patients";
+
+        protected override void Configure(QueryDefinitionBuilder<Patient> builder) =>
+            builder.Column(e => e.Name);
+    }
+}

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.QueryEngine.AspNetCore.Dtos;
+using Granit.QueryEngine.AspNetCore.Extensions;
+using Granit.QueryEngine.Extensions;
+using Granit.QueryEngine.Internal;
+using Granit.Testing.Endpoints;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.AspNetCore.Tests.Endpoints;
+
+/// <summary>
+/// HTTP-level tests for <c>GET /catalog</c> driven through <see cref="GranitEndpointTestHost"/>.
+/// Exercises the live EndpointDataSource / LinkGenerator route resolution the projection unit
+/// tests cannot reach: a mapped query resolves its base path, a registered-but-unmapped query
+/// surfaces a null base path, and the authenticated-only gate holds.
+/// </summary>
+public sealed class QueryCatalogEndpointsHttpTests
+{
+    private static Task<GranitEndpointTestHost> StartAsync() =>
+        GranitEndpointTestHost.StartAsync(
+            configureServices: services =>
+            {
+                services.AddAuthorizationBuilder();
+
+                // Two definitions registered; only the routed one is mapped below.
+                services.AddQueryDefinition<RoutedEntity, RoutedQueryDefinition>();
+                services.AddQueryDefinition<UnroutedEntity, UnroutedQueryDefinition>();
+                services.TryAddSingleton<IQueryDefinitionRegistry, QueryDefinitionRegistry>();
+            },
+            configureEndpoints: app =>
+            {
+                app.MapGranitQuery<RoutedEntity>(
+                    _ => Enumerable.Empty<RoutedEntity>().AsQueryable(),
+                    prefix: "routed-things");
+                app.MapGranitQueryCatalog();
+            });
+
+    [Fact]
+    public async Task Catalog_lists_every_registered_query_ordered_by_name()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        body.ShouldNotBeNull();
+        body.Select(e => e.Name).ShouldBe(["Test.Routed", "Test.Unrouted"]);
+        body.ShouldAllBe(e => e.Label == e.Name);
+    }
+
+    [Fact]
+    public async Task Catalog_resolves_the_base_path_of_a_mapped_query()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        QueryCatalogEntryResponse routed = body!.Single(e => e.Name == "Test.Routed");
+        routed.BasePath.ShouldBe("/routed-things");
+    }
+
+    [Fact]
+    public async Task Catalog_emits_null_base_path_for_a_registered_but_unmapped_query()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        QueryCatalogEntryResponse unrouted = body!.Single(e => e.Name == "Test.Unrouted");
+        unrouted.BasePath.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Catalog_is_unauthorized_for_an_anonymous_caller()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+
+        HttpResponseMessage response = await host.CreateAnonymousClient()
+            .GetAsync("/catalog", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private sealed class RoutedEntity
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class UnroutedEntity
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class RoutedQueryDefinition : QueryDefinition<RoutedEntity>
+    {
+        public override string Name => "Test.Routed";
+
+        protected override void Configure(QueryDefinitionBuilder<RoutedEntity> builder) =>
+            builder.Column(e => e.Name);
+    }
+
+    private sealed class UnroutedQueryDefinition : QueryDefinition<UnroutedEntity>
+    {
+        public override string Name => "Test.Unrouted";
+
+        protected override void Configure(QueryDefinitionBuilder<UnroutedEntity> builder) =>
+            builder.Column(e => e.Name);
+    }
+}

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Granit.QueryEngine.AspNetCore.Tests.csproj
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Granit.QueryEngine.AspNetCore.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
@@ -1,0 +1,64 @@
+using Granit.QueryEngine.AspNetCore.Dtos;
+using Granit.QueryEngine.AspNetCore.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.AspNetCore.Tests.Internal;
+
+public sealed class QueryCatalogProjectionTests
+{
+    [Fact]
+    public void Project_resolves_base_path_when_the_entity_type_is_routed()
+    {
+        IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
+            [new FakeDescriptor("Acme.Patients", typeof(Patient))],
+            new Dictionary<Type, string> { [typeof(Patient)] = "/api/patients" });
+
+        QueryCatalogEntryResponse entry = entries.ShouldHaveSingleItem();
+        entry.Name.ShouldBe("Acme.Patients");
+        entry.BasePath.ShouldBe("/api/patients");
+    }
+
+    [Fact]
+    public void Project_emits_null_base_path_when_the_entity_type_is_not_routed()
+    {
+        // Registration and routing are decoupled: a definition can be registered without any
+        // MapGranitQuery route. The projection must surface a null base path, never a forged URL.
+        IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
+            [new FakeDescriptor("Acme.Patients", typeof(Patient))],
+            new Dictionary<Type, string>());
+
+        entries.ShouldHaveSingleItem().BasePath.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Project_uses_the_name_as_the_label()
+    {
+        IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
+            [new FakeDescriptor("Acme.Patients", typeof(Patient))],
+            new Dictionary<Type, string>());
+
+        entries.ShouldHaveSingleItem().Label.ShouldBe("Acme.Patients");
+    }
+
+    [Fact]
+    public void Project_preserves_the_input_order()
+    {
+        IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
+            [
+                new FakeDescriptor("Acme.Appointments", typeof(Appointment)),
+                new FakeDescriptor("Acme.Doctors", typeof(Doctor)),
+            ],
+            new Dictionary<Type, string>());
+
+        entries.Select(e => e.Name).ShouldBe(["Acme.Appointments", "Acme.Doctors"]);
+    }
+
+    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
+
+    private sealed class Patient;
+
+    private sealed class Doctor;
+
+    private sealed class Appointment;
+}


### PR DESCRIPTION
## What

Adds a **query catalog** to the query-engine: `GET /catalog` lists every registered
`QueryDefinition` so a front-end dashboard editor can offer a **dropdown of queries**
instead of a free-text `queryName`.

## How

- **`IQueryDefinitionRegistry`** (`Granit.QueryEngine.Abstractions`) + internal
  `QueryDefinitionRegistry` — a copy-conform of `DashboardDefinitionRegistry`: stable
  ordering by `Name` (ordinal) and a by-name index over
  `GetServices<IQueryDefinitionDescriptor>()`. Registered via `TryAddSingleton` in
  `GranitQueryEngineAspNetCoreModule`.
- **`QueryCatalogEntryResponse { Name, BasePath, Label }`** + `QueryCatalogProjection`
  (pure, unit-testable).
- **`MapGranitQueryCatalog`** maps `GET /catalog`. The base path is resolved from the live
  `EndpointDataSource` via `LinkGenerator.GetPathByName(...)` — never `RoutePattern.RawText`
  — keyed on the `List`-tagged `EntityEndpointMetadata`, exactly as
  `EntitiesEndpoints.BuildDiscoveryAsync` does.
- **Registration and routing are decoupled**: a query registered via `AddQueryDefinition`
  without a `MapGranitQuery` route is returned with `BasePath = null` — never a forged URL
  (same behaviour as entity discovery). `Label` degrades to `Name` (descriptor carries no
  display metadata).

## Security

Gated **authenticated-only** (`RequireAuthorization()`). The catalogue exposes query
identifiers and base paths (metadata, not row data), and descriptors carry no
`PermissionGroup` to filter per-item on — so this mirrors the per-query list endpoints'
default rather than minting a new RBAC permission. (Decision confirmed with the maintainer.)

## Tests

- Registry: name-ordinal ordering, `Find` hit/miss, `Find` throws on null/empty,
  idempotent registration → single catalog entry.
- Projection: base path resolved when routed, `null` when unrouted, `Label == Name`,
  input order preserved.
- HTTP (`GranitEndpointTestHost`): live base-path resolution for a mapped query,
  `null` for a registered-but-unmapped query, ordered listing, and the auth gate (401).

`dotnet build` + `dotnet test` green on both affected projects; `dotnet format
--verify-no-changes` clean; `validate_granit_conventions` reports nothing on the new files.

## Follow-ups (decoupled, not in this PR)

- **OpenAPI/contract snapshot**: granit-dotnet commits no OpenAPI spec — `/catalog` surfaces
  only where a host mounts `MapGranitQueryCatalog`. Refreshing the showcase/BFF snapshot
  consumed by `@granit/contract-tests` is a cross-repo handoff.
- **Docs**: a `granit-docs` page for the catalog endpoint ships separately.
