### PR TITLE
fix(query-engine): add Granit.Testing to AspNetCore.Tests lock file (NU1004)

### DIFF
--- a/tests/Granit.QueryEngine.AspNetCore.Tests/packages.lock.json
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/packages.lock.json
@@ -557,6 +557,14 @@
           "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.http.apidocumentation": {
         "type": "Project",
         "dependencies": {
@@ -619,6 +627,16 @@
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
@@ -660,6 +678,12 @@
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0"
         }
+      },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
       },
       "FluentValidation": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Why

#2850 added a `Granit.Testing` `<ProjectReference>` to `Granit.QueryEngine.AspNetCore.Tests` (for the `GET /catalog` HTTP test driven through `GranitEndpointTestHost`), but its `packages.lock.json` was not updated. CI restores in **locked mode**, so it fails:

```
error NU1004: A new project reference to Granit.Testing was found ... The packages lock file
is inconsistent with the project dependencies so restore can't be run in locked mode.
```

My mistake on #2850: I reverted the lock file to avoid unrelated floating-version churn and wrongly assumed project references don't appear in the lock file — under locked mode they do.

## Fix

Adds exactly the three missing entries to the test project's lock file:

- `granit.testing` (Project)
- `granit.guids` (Project — pulled in transitively by Granit.Testing)
- `Bogus` (CentralTransitive — Granit.Testing's fake-data dependency)

**No version bumps**: every existing pinned version (Scalar, the test SDK, …) is left exactly as on `develop`. The only `resolved`/`contentHash` line in the diff is the new `Bogus` entry. Verified with `dotnet restore --locked-mode` (green) + build + 59 tests passing.