### PR TITLE
feat(openapi-generator): publish a query-engine contract document

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2035,7 +2035,8 @@
       "name": "Granit.OpenApi.Generator",
       "deps": [
         "Granit.OpenApi.Generation",
-        "Granit.*.Endpoints"
+        "Granit.*.Endpoints",
+        "Granit.QueryEngine.AspNetCore"
       ],
       "framework": "net10.0"
     },
@@ -40310,7 +40311,7 @@
       "kind": "class",
       "project": "Granit.OpenApi.Generator",
       "file": "src/Granit.OpenApi.Generator/GeneratorModule.cs",
-      "line": 47,
+      "line": 50,
       "members": []
     },
     {

--- a/src/Granit.OpenApi.Generator/GeneratorEndpoints.cs
+++ b/src/Granit.OpenApi.Generator/GeneratorEndpoints.cs
@@ -24,6 +24,7 @@ using Granit.OpenIddict.Endpoints.Extensions;
 using Granit.Presence.Endpoints.Extensions;
 using Granit.Privacy.Endpoints.Discovery;
 using Granit.Privacy.Endpoints.Extensions;
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Scheduling.Endpoints.Extensions;
 using Granit.Settings.Endpoints.Extensions;
 using Granit.Templating.Endpoints.Extensions;
@@ -87,6 +88,8 @@ internal static class GeneratorEndpoints
             e.MapGranitPrivacy();
             e.MapGranitPrivacyGpcDiscovery();
         }),
+        // Non-".Endpoints" surface: the query catalogue ships from Granit.QueryEngine.AspNetCore.
+        new("query-engine", e => e.MapGranitQueryCatalog()),
         new("scheduling", e => e.MapGranitScheduling()),
         new("settings", e =>
         {

--- a/src/Granit.OpenApi.Generator/GeneratorModule.cs
+++ b/src/Granit.OpenApi.Generator/GeneratorModule.cs
@@ -10,7 +10,9 @@ namespace Granit.OpenApi.Generator;
 /// <remarks>
 /// Keep this list and <see cref="GeneratorEndpoints.All"/> in lockstep with the set of
 /// <c>src/Granit.*.Endpoints</c> packages — <c>OpenApiGeneratorCompletenessTests</c> fails the
-/// build if a module is added without being wired here.
+/// build if a module is added without being wired here. A small number of HTTP surfaces ship
+/// from a non-<c>.Endpoints</c> package (e.g. the query catalogue in
+/// <c>Granit.QueryEngine.AspNetCore</c>); those are wired explicitly and tracked by the same test.
 /// </remarks>
 [DependsOn(
     typeof(Granit.AI.Chat.Endpoints.GranitAIChatEndpointsModule),
@@ -37,6 +39,7 @@ namespace Granit.OpenApi.Generator;
     typeof(Granit.OpenIddict.Endpoints.GranitOpenIddictEndpointsModule),
     typeof(Granit.Presence.Endpoints.GranitPresenceEndpointsModule),
     typeof(Granit.Privacy.Endpoints.GranitPrivacyEndpointsModule),
+    typeof(Granit.QueryEngine.AspNetCore.GranitQueryEngineAspNetCoreModule),
     typeof(Granit.Scheduling.Endpoints.GranitSchedulingEndpointsModule),
     typeof(Granit.Settings.Endpoints.GranitSettingsEndpointsModule),
     typeof(Granit.Templating.Endpoints.GranitTemplatingEndpointsModule),

--- a/src/Granit.OpenApi.Generator/Granit.OpenApi.Generator.csproj
+++ b/src/Granit.OpenApi.Generator/Granit.OpenApi.Generator.csproj
@@ -27,6 +27,10 @@
          reference. The module still MUST be added to GeneratorModule's [DependsOn] (service config)
          AND GeneratorEndpoints.All (slug + route mapping) — those drive generation, not the glob. -->
     <ProjectReference Include="..\Granit.*.Endpoints\Granit.*.Endpoints.csproj" />
+    <!-- The query-engine exposes its HTTP surface (the GET /catalog query catalogue) from
+         Granit.QueryEngine.AspNetCore, not a *.Endpoints package, so the wildcard above does
+         not cover it. Reference it explicitly to publish a 'query-engine' contract document. -->
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.ArchitectureTests/OpenApiGeneratorCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/OpenApiGeneratorCompletenessTests.cs
@@ -32,6 +32,16 @@ public sealed partial class OpenApiGeneratorCompletenessTests
             .Where(name => File.Exists(Path.Join(RepoRoot, "src", name, $"{name}.csproj")))
             .OrderBy(name => name, StringComparer.Ordinal)];
 
+    /// <summary>
+    /// Slugs for HTTP surfaces that ship from a package whose name does NOT end in
+    /// <c>.Endpoints</c>, so the <c>Granit.*.Endpoints</c> glob cannot discover them. Each must be
+    /// wired into the generator explicitly (csproj <c>ProjectReference</c>, <c>GeneratorModule</c>
+    /// <c>[DependsOn]</c>, and a <c>GeneratorEndpoints.All</c> entry) — they are counted here so the
+    /// registry-completeness assertion stays exact. The query-engine exposes its query catalogue
+    /// (<c>GET /catalog</c>) from <c>Granit.QueryEngine.AspNetCore</c>.
+    /// </summary>
+    private static readonly IReadOnlyList<string> NonEndpointsDocumentSlugs = ["query-engine"];
+
     [Fact]
     public void Generator_csproj_references_exactly_the_endpoints_projects()
     {
@@ -76,10 +86,19 @@ public sealed partial class OpenApiGeneratorCompletenessTests
         string registrySource = File.ReadAllText(Path.Join(GeneratorDir, "GeneratorEndpoints.cs"));
 
         int entries = RegistryEntryRegex().Count(registrySource);
+        int expected = EndpointsProjectNames.Count + NonEndpointsDocumentSlugs.Count;
 
-        entries.ShouldBe(EndpointsProjectNames.Count,
-            $"GeneratorEndpoints.All must declare one document per endpoints module " +
-            $"({EndpointsProjectNames.Count} expected, found {entries}). Every module's routes must be mounted.");
+        entries.ShouldBe(expected,
+            $"GeneratorEndpoints.All must declare one document per endpoints module plus the " +
+            $"{NonEndpointsDocumentSlugs.Count} non-.Endpoints surface(s) [{string.Join(", ", NonEndpointsDocumentSlugs)}] " +
+            $"({expected} expected, found {entries}). Every module's routes must be mounted.");
+
+        // Each explicitly-wired non-.Endpoints surface must carry its declared slug.
+        List<string> missing =
+            [.. NonEndpointsDocumentSlugs.Where(slug => !registrySource.Contains($"new(\"{slug}\"", StringComparison.Ordinal))];
+
+        missing.ShouldBeEmpty(
+            "GeneratorEndpoints.All is missing a registry entry for non-.Endpoints surface(s): " + string.Join(", ", missing));
     }
 
     [GeneratedRegex("""<ProjectReference\s+Include="[^"]*\\(?<name>[^"\\]+)\.csproj""")]


### PR DESCRIPTION
## Why

`Granit.OpenApi.Generator` exists so `granit-front` gets generated types for **every HTTP
surface the framework exposes** — its completeness test even says an un-wired endpoint
*"silently drops its contract from the artifacts (and from the granit-front type feed)"*.

The query catalogue (`GET /catalog`, #2850) is built precisely to be consumed by the
front (the dashboard-editor query dropdown), but it ships from
**`Granit.QueryEngine.AspNetCore`** — a non-`.Endpoints` package the `Granit.*.Endpoints`
glob can't discover. So it was silently absent from the generated contract. This wires it in.

## Changes

- **csproj**: explicit `<ProjectReference>` to `Granit.QueryEngine.AspNetCore` (the wildcard
  only covers `*.Endpoints`). No lock-file change — the project was already in the generator's
  transitive closure; `dotnet restore --locked-mode` stays green.
- **`GeneratorModule`**: `[DependsOn(typeof(GranitQueryEngineAspNetCoreModule))]` so the module
  system configures its services (registry, localization).
- **`GeneratorEndpoints.All`**: `new("query-engine", e => e.MapGranitQueryCatalog())`.
- **`OpenApiGeneratorCompletenessTests`**: fact 3 evolved from "one entry per `.Endpoints`
  package" to "`.Endpoints` packages **+** an explicit `NonEndpointsDocumentSlugs` list", and now
  also asserts each such slug is actually wired. The count stays **exact**, and a future
  non-`.Endpoints` surface can't drift unnoticed.

## Verification

Building the generator emits `Granit.OpenApi.Generator_query-engine.json` containing:

```
GET /catalog   operationId: ListQueryCatalog   tags: ["Query Engine"]
components.schemas.QueryCatalogEntryResponse  ✓
```

- All 3 `OpenApiGeneratorCompletenessTests` facts pass.
- `dotnet build` of the generator green (0 warnings); `dotnet format --verify-no-changes` clean
  on both changed projects.

## Depends on

#2850 (merged) — provides `MapGranitQueryCatalog`. Branched off `develop` after that merge, so
this is **not** stacked.
