### PR TITLE
feat(query-engine): localize query catalog labels via Query:{Name} key

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -47260,7 +47260,7 @@
       "kind": "record",
       "project": "Granit.QueryEngine.AspNetCore",
       "file": "src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs",
-      "line": 22,
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
@@ -15,4 +15,12 @@ public interface IQueryDefinitionDescriptor
     /// The entity type this definition applies to.
     /// </summary>
     Type EntityType { get; }
+
+    /// <summary>
+    /// The localization resource used to resolve this query's display label. The localizer is
+    /// queried with the key <c>"Query:{Name}"</c>, falling back to <see cref="Name"/> when the
+    /// key is absent. <c>null</c> means no localization is attempted. This is the same resource
+    /// that resolves the query's column labels.
+    /// </summary>
+    Type? LocalizationResourceType { get; }
 }

--- a/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
@@ -16,8 +16,9 @@ namespace Granit.QueryEngine.AspNetCore.Dtos;
 /// frontend surfaces a query without a base path as not-yet-routable.
 /// </param>
 /// <param name="Label">
-/// Human-facing label for the dropdown. The descriptor carries no display metadata, so this
-/// degrades gracefully to <see cref="Name"/>.
+/// Human-facing label for the dropdown, resolved from the query's localization resource via the
+/// key <c>"Query:{Name}"</c> in the request culture. Degrades gracefully to <see cref="Name"/>
+/// when the module has not declared that key (localization is opt-in per module).
 /// </param>
 public sealed record QueryCatalogEntryResponse(
     string Name,

--- a/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
 
 namespace Granit.QueryEngine.AspNetCore.Endpoints;
 
@@ -14,6 +15,13 @@ namespace Granit.QueryEngine.AspNetCore.Endpoints;
 /// </summary>
 internal static class QueryCatalogEndpoints
 {
+    /// <summary>
+    /// Localization-key prefix for a query's display label. The localizer (resolved from the
+    /// definition's <see cref="IQueryDefinitionDescriptor.LocalizationResourceType"/>) is queried
+    /// with <c>"Query:{Name}"</c>; a module opts in by adding that key to its own resource.
+    /// </summary>
+    private const string LabelKeyPrefix = "Query:";
+
     /// <summary>
     /// Maps <c>GET /catalog</c> on the supplied route group. Returns every registered
     /// <see cref="QueryDefinition{TEntity}"/> projected through
@@ -40,13 +48,26 @@ internal static class QueryCatalogEndpoints
         [FromServices] IQueryDefinitionRegistry registry,
         [FromServices] EndpointDataSource endpointDataSource,
         [FromServices] LinkGenerator linkGenerator,
-        HttpContext httpContext)
+        HttpContext httpContext,
+        // Optional — a host without Granit.Localization wired still serves the catalogue,
+        // with labels falling back to the raw query name.
+        [FromServices] IStringLocalizerFactory? localizerFactory = null)
     {
         // Resolve each List-tagged endpoint's URL via LinkGenerator so route parameters
-        // (e.g. /api/v{version:apiVersion}/patients) are substituted using the current
-        // request's ambient route values. Reading RoutePattern.RawText directly would
-        // expose the unsubstituted template and the frontend would 404. Same mechanism
-        // as Granit.Entities' entity-discovery surface.
+        // (e.g. /api/v{version:apiVersion}/patients) are substituted into the path.
+        // The request's API version is passed EXPLICITLY: ambient-value reuse does not
+        // reliably substitute {version:apiVersion} when linking to a *different* endpoint
+        // than the current one, so it leaks as a `?version=1` query string
+        // (e.g. /api/cms/pages?version=1 instead of /api/v1/cms/pages). An explicit route
+        // value is always bound into the matching path segment. Reading RoutePattern.RawText
+        // directly would expose the unsubstituted template and the frontend would 404.
+        // Same mechanism as Granit.Entities' entity-discovery surface.
+        RouteValueDictionary routeValues = new();
+        if (httpContext.Request.RouteValues.TryGetValue("version", out object? version) && version is not null)
+        {
+            routeValues["version"] = version;
+        }
+
         var routeIndex = endpointDataSource.Endpoints
             .OfType<RouteEndpoint>()
             .Select(e => new
@@ -55,19 +76,54 @@ internal static class QueryCatalogEndpoints
                 Name = e.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName,
             })
             .Where(x => x.Meta is { Kind: EntityEndpointKind.List } && x.Name is not null)
-            .Select(x => new { x.Meta, Path = linkGenerator.GetPathByName(httpContext, x.Name!) })
+            .Select(x => new { x.Meta, Path = linkGenerator.GetPathByName(httpContext, x.Name!, routeValues) })
             .Where(x => x.Path is not null)
             .GroupBy(x => x.Meta!.EntityType)
             .ToDictionary(g => g.Key, g => NormalizeRoutePath(g.First().Path!));
 
-        return TypedResults.Ok(QueryCatalogProjection.Project(registry.GetAll(), routeIndex));
+        return TypedResults.Ok(QueryCatalogProjection.Project(
+            registry.GetAll(),
+            routeIndex,
+            descriptor => ResolveLabel(descriptor, localizerFactory)));
     }
 
     /// <summary>
-    /// Strips the trailing slash from a resolved path unless it IS the root. The frontend
-    /// appends <c>/meta</c>, <c>/{id}</c>, etc. on top of the base, so a trailing slash would
-    /// yield <c>/path//meta</c> on the wire. Mirrors Granit.Entities' normalization.
+    /// Resolves a query's display label by querying its localization resource with
+    /// <c>"Query:{Name}"</c>, mirroring how the query engine resolves column labels. Falls back to
+    /// the raw <see cref="IQueryDefinitionDescriptor.Name"/> when no factory, no resource, or no
+    /// matching key is found — so the label is always present and localization stays opt-in.
     /// </summary>
-    private static string NormalizeRoutePath(string path) =>
-        path.Length > 1 ? path.TrimEnd('/') : path;
+    private static string ResolveLabel(
+        IQueryDefinitionDescriptor descriptor,
+        IStringLocalizerFactory? localizerFactory)
+    {
+        if (localizerFactory is not null && descriptor.LocalizationResourceType is { } resourceType)
+        {
+            IStringLocalizer localizer = localizerFactory.Create(resourceType);
+            LocalizedString localized = localizer[LabelKeyPrefix + descriptor.Name];
+            if (!localized.ResourceNotFound)
+            {
+                return localized.Value;
+            }
+        }
+
+        return descriptor.Name;
+    }
+
+    /// <summary>
+    /// Normalises a resolved list-endpoint path for use as a base path. Drops any query
+    /// string (a base path must never carry one — the frontend appends <c>/meta</c>,
+    /// <c>/{id}</c>, etc., so <c>/path?x=1/meta</c> would be malformed) and strips the
+    /// trailing slash unless the path IS the root. Mirrors Granit.Entities' normalization.
+    /// </summary>
+    private static string NormalizeRoutePath(string path)
+    {
+        int query = path.IndexOf('?');
+        if (query >= 0)
+        {
+            path = path[..query];
+        }
+
+        return path.Length > 1 ? path.TrimEnd('/') : path;
+    }
 }

--- a/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
@@ -14,28 +14,31 @@ internal static class QueryCatalogProjection
     /// Projects <paramref name="descriptors"/> (already ordered by the registry) into catalog
     /// entries. <paramref name="basePathByEntityType"/> maps an entity CLR type to the resolved
     /// base path of its <c>List</c> endpoint; a descriptor whose entity type is absent gets a
-    /// <c>null</c> base path — never a forged URL.
+    /// <c>null</c> base path — never a forged URL. <paramref name="resolveLabel"/> produces the
+    /// human-facing dropdown label for a descriptor (the localized <c>"Query:{Name}"</c> string,
+    /// or the raw <c>Name</c> as fallback).
     /// </summary>
     public static IReadOnlyList<QueryCatalogEntryResponse> Project(
         IEnumerable<IQueryDefinitionDescriptor> descriptors,
-        IReadOnlyDictionary<Type, string> basePathByEntityType)
+        IReadOnlyDictionary<Type, string> basePathByEntityType,
+        Func<IQueryDefinitionDescriptor, string> resolveLabel)
     {
         ArgumentNullException.ThrowIfNull(descriptors);
         ArgumentNullException.ThrowIfNull(basePathByEntityType);
+        ArgumentNullException.ThrowIfNull(resolveLabel);
 
-        return [.. descriptors.Select(d => ToResponse(d, basePathByEntityType))];
+        return [.. descriptors.Select(d => ToResponse(d, basePathByEntityType, resolveLabel))];
     }
 
     private static QueryCatalogEntryResponse ToResponse(
         IQueryDefinitionDescriptor descriptor,
-        IReadOnlyDictionary<Type, string> basePathByEntityType)
+        IReadOnlyDictionary<Type, string> basePathByEntityType,
+        Func<IQueryDefinitionDescriptor, string> resolveLabel)
     {
         string? basePath = basePathByEntityType.TryGetValue(descriptor.EntityType, out string? path)
             ? path
             : null;
 
-        // The descriptor exposes no display label, so the dropdown label degrades to the
-        // wire identifier. A richer label can be layered on later without a wire break.
-        return new QueryCatalogEntryResponse(descriptor.Name, basePath, descriptor.Name);
+        return new QueryCatalogEntryResponse(descriptor.Name, basePath, resolveLabel(descriptor));
     }
 }

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
@@ -71,7 +71,8 @@ public sealed class QueryDefinitionRegistryTests
         registry.GetAll().ShouldHaveSingleItem().Name.ShouldBe("Acme.Patients");
     }
 
-    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
+    private sealed record FakeDescriptor(string Name, Type EntityType, Type? LocalizationResourceType = null)
+        : IQueryDefinitionDescriptor;
 
     private sealed class Patient
     {

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
@@ -7,6 +7,7 @@ using Granit.QueryEngine.Internal;
 using Granit.Testing.Endpoints;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Localization;
 using Shouldly;
 using Xunit;
 
@@ -14,9 +15,10 @@ namespace Granit.QueryEngine.AspNetCore.Tests.Endpoints;
 
 /// <summary>
 /// HTTP-level tests for <c>GET /catalog</c> driven through <see cref="GranitEndpointTestHost"/>.
-/// Exercises the live EndpointDataSource / LinkGenerator route resolution the projection unit
-/// tests cannot reach: a mapped query resolves its base path, a registered-but-unmapped query
-/// surfaces a null base path, and the authenticated-only gate holds.
+/// Exercises the live EndpointDataSource / LinkGenerator route resolution and the localized-label
+/// resolution the projection unit tests cannot reach: a mapped query resolves its base path, a
+/// registered-but-unmapped query surfaces a null base path, the <c>Query:{Name}</c> localization
+/// key drives the label (falling back to the raw name), and the authenticated-only gate holds.
 /// </summary>
 public sealed class QueryCatalogEndpointsHttpTests
 {
@@ -25,8 +27,11 @@ public sealed class QueryCatalogEndpointsHttpTests
             configureServices: services =>
             {
                 services.AddAuthorizationBuilder();
+                services.AddSingleton<IStringLocalizerFactory>(new StubLocalizerFactory());
 
-                // Two definitions registered; only the routed one is mapped below.
+                // Two definitions registered; only the routed one is mapped below. The routed
+                // definition declares a localization resource carrying a "Query:Test.Routed" label;
+                // the unrouted one declares none (label falls back to its name).
                 services.AddQueryDefinition<RoutedEntity, RoutedQueryDefinition>();
                 services.AddQueryDefinition<UnroutedEntity, UnroutedQueryDefinition>();
                 services.TryAddSingleton<IQueryDefinitionRegistry, QueryDefinitionRegistry>();
@@ -49,7 +54,6 @@ public sealed class QueryCatalogEndpointsHttpTests
 
         body.ShouldNotBeNull();
         body.Select(e => e.Name).ShouldBe(["Test.Routed", "Test.Unrouted"]);
-        body.ShouldAllBe(e => e.Label == e.Name);
     }
 
     [Fact]
@@ -77,6 +81,30 @@ public sealed class QueryCatalogEndpointsHttpTests
     }
 
     [Fact]
+    public async Task Catalog_resolves_the_label_from_the_Query_prefixed_localization_key()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        QueryCatalogEntryResponse routed = body!.Single(e => e.Name == "Test.Routed");
+        routed.Label.ShouldBe("Routed Things");
+    }
+
+    [Fact]
+    public async Task Catalog_falls_back_to_the_name_when_no_localization_key_exists()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        QueryCatalogEntryResponse unrouted = body!.Single(e => e.Name == "Test.Unrouted");
+        unrouted.Label.ShouldBe("Test.Unrouted");
+    }
+
+    [Fact]
     public async Task Catalog_is_unauthorized_for_an_anonymous_caller()
     {
         await using GranitEndpointTestHost host = await StartAsync();
@@ -101,6 +129,8 @@ public sealed class QueryCatalogEndpointsHttpTests
     {
         public override string Name => "Test.Routed";
 
+        public override Type LocalizationResourceType => typeof(TestQueryLabelsResource);
+
         protected override void Configure(QueryDefinitionBuilder<RoutedEntity> builder) =>
             builder.Column(e => e.Name);
     }
@@ -111,5 +141,32 @@ public sealed class QueryCatalogEndpointsHttpTests
 
         protected override void Configure(QueryDefinitionBuilder<UnroutedEntity> builder) =>
             builder.Column(e => e.Name);
+    }
+
+    private sealed class TestQueryLabelsResource;
+
+    private sealed class StubLocalizerFactory : IStringLocalizerFactory
+    {
+        private static readonly Dictionary<string, string> RoutedLabels =
+            new() { ["Query:Test.Routed"] = "Routed Things" };
+
+        public IStringLocalizer Create(Type resourceSource) =>
+            resourceSource == typeof(TestQueryLabelsResource)
+                ? new StubLocalizer(RoutedLabels)
+                : new StubLocalizer(new Dictionary<string, string>());
+
+        public IStringLocalizer Create(string baseName, string location) => new StubLocalizer(new Dictionary<string, string>());
+    }
+
+    private sealed class StubLocalizer(IReadOnlyDictionary<string, string> map) : IStringLocalizer
+    {
+        public LocalizedString this[string name] =>
+            map.TryGetValue(name, out string? value)
+                ? new LocalizedString(name, value, resourceNotFound: false)
+                : new LocalizedString(name, name, resourceNotFound: true);
+
+        public LocalizedString this[string name, params object[] arguments] => this[name];
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
     }
 }

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
@@ -7,12 +7,15 @@ namespace Granit.QueryEngine.AspNetCore.Tests.Internal;
 
 public sealed class QueryCatalogProjectionTests
 {
+    private static string ByName(IQueryDefinitionDescriptor d) => d.Name;
+
     [Fact]
     public void Project_resolves_base_path_when_the_entity_type_is_routed()
     {
         IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
             [new FakeDescriptor("Acme.Patients", typeof(Patient))],
-            new Dictionary<Type, string> { [typeof(Patient)] = "/api/patients" });
+            new Dictionary<Type, string> { [typeof(Patient)] = "/api/patients" },
+            ByName);
 
         QueryCatalogEntryResponse entry = entries.ShouldHaveSingleItem();
         entry.Name.ShouldBe("Acme.Patients");
@@ -26,19 +29,21 @@ public sealed class QueryCatalogProjectionTests
         // MapGranitQuery route. The projection must surface a null base path, never a forged URL.
         IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
             [new FakeDescriptor("Acme.Patients", typeof(Patient))],
-            new Dictionary<Type, string>());
+            new Dictionary<Type, string>(),
+            ByName);
 
         entries.ShouldHaveSingleItem().BasePath.ShouldBeNull();
     }
 
     [Fact]
-    public void Project_uses_the_name_as_the_label()
+    public void Project_uses_the_label_resolver_for_the_label()
     {
         IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
             [new FakeDescriptor("Acme.Patients", typeof(Patient))],
-            new Dictionary<Type, string>());
+            new Dictionary<Type, string>(),
+            d => $"Localized:{d.Name}");
 
-        entries.ShouldHaveSingleItem().Label.ShouldBe("Acme.Patients");
+        entries.ShouldHaveSingleItem().Label.ShouldBe("Localized:Acme.Patients");
     }
 
     [Fact]
@@ -49,12 +54,14 @@ public sealed class QueryCatalogProjectionTests
                 new FakeDescriptor("Acme.Appointments", typeof(Appointment)),
                 new FakeDescriptor("Acme.Doctors", typeof(Doctor)),
             ],
-            new Dictionary<Type, string>());
+            new Dictionary<Type, string>(),
+            ByName);
 
         entries.Select(e => e.Name).ShouldBe(["Acme.Appointments", "Acme.Doctors"]);
     }
 
-    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
+    private sealed record FakeDescriptor(string Name, Type EntityType, Type? LocalizationResourceType = null)
+        : IQueryDefinitionDescriptor;
 
     private sealed class Patient;
 


### PR DESCRIPTION
## Why

In #2850 the `/catalog` `Label` just duplicated the wire identifier (`Name`), so a dashboard
editor would render a dropdown of raw keys like `Granit.AI.Prompts.CategoriesQuery`. This makes
`Label` a **real, localized** name — **without adding a field**: the identifier *is* its own
localization key.

## How (`Query:{Name}` convention)

Mirrors exactly how the engine already localizes **column** labels (`QueryEngine.ResolveLabel`):
resolve `localizer["Query:" + Name]` against the query's localization resource, in the request
culture; fall back to the raw `Name` when the factory / resource / key is absent.

- **`IQueryDefinitionDescriptor`** now exposes `Type? LocalizationResourceType` — already
  implemented by `QueryDefinition<TEntity>` (it's the same resource used for column labels), so no
  behavioural change for existing definitions. Only direct implementer is `QueryDefinition<T>`
  (verified across granit-dotnet + granit-business).
- **`QueryCatalogEndpoints`** injects `IStringLocalizerFactory` (optional — a host without
  `Granit.Localization` still serves the catalogue with name-fallback labels) and resolves
  `"Query:{Name}"`.
- **`QueryCatalogProjection`** takes a label-resolver delegate (stays pure / unit-testable).

A module opts in by adding one entry to **its own** resource (no framework-resource changes):

```json
"Query:Granit.AI.Prompts.CategoriesQuery": "Prompt categories"
```

Absent → the front receives the key, exactly as today. **Wire shape `{ Name, BasePath, Label }`
is unchanged** — no breaking change to #2850.

## Also in this PR — route-resolution hardening

The list endpoint's base path is now linked with the request's **api-version passed as an explicit
route value**: ambient-value reuse did not reliably substitute `{version:apiVersion}` when linking
to a *different* endpoint than the current request, leaking it as a `?version=1` query string
(e.g. `/api/cms/pages?version=1` instead of `/api/v1/cms/pages`). `NormalizeRoutePath` now also
strips any query string before trimming the trailing slash.

## Tests

- Projection: label comes from the resolver delegate.
- HTTP (`GranitEndpointTestHost`): localized label via a `Query:Test.Routed` resource entry; raw-name
  fallback when no key is declared. Plus the existing base-path-resolved / null-when-unmapped / auth-gate
  coverage.
- 61 AspNetCore + 27 Abstractions tests green; `dotnet format --verify-no-changes` clean.

## Follow-up (not in this PR)

Per-module `Query:{Name}` translations (18 cultures) are opt-in and ship with each module — none added here.
