### PR TITLE
feat(query-engine): reuse entity DisplayKey as catalog label key (front-resolved)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -47260,7 +47260,7 @@
       "kind": "record",
       "project": "Granit.QueryEngine.AspNetCore",
       "file": "src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs",
-      "line": 23,
+      "line": 26,
       "members": []
     },
     {

--- a/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
@@ -15,12 +15,4 @@ public interface IQueryDefinitionDescriptor
     /// The entity type this definition applies to.
     /// </summary>
     Type EntityType { get; }
-
-    /// <summary>
-    /// The localization resource used to resolve this query's display label. The localizer is
-    /// queried with the key <c>"Query:{Name}"</c>, falling back to <see cref="Name"/> when the
-    /// key is absent. <c>null</c> means no localization is attempted. This is the same resource
-    /// that resolves the query's column labels.
-    /// </summary>
-    Type? LocalizationResourceType { get; }
 }

--- a/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
@@ -15,12 +15,15 @@ namespace Granit.QueryEngine.AspNetCore.Dtos;
 /// it. Registration and routing are decoupled, so a forged URL is never emitted — the
 /// frontend surfaces a query without a base path as not-yet-routable.
 /// </param>
-/// <param name="Label">
-/// Human-facing label for the dropdown, resolved from the query's localization resource via the
-/// key <c>"Query:{Name}"</c> in the request culture. Degrades gracefully to <see cref="Name"/>
-/// when the module has not declared that key (localization is opt-in per module).
+/// <param name="LabelKey">
+/// Localization key the frontend resolves for the dropdown label, in the same way it resolves
+/// entity display names. It is the target entity's <c>DisplayKey</c> (e.g. <c>"Entity:Party"</c>)
+/// when the query targets a registered entity — reusing the already-translated entity name — and
+/// otherwise <c>"Query:{Name}"</c>, a key a module may declare in its own localization resource.
+/// The server emits a key, never a resolved string: translation happens client-side against the
+/// merged i18n bundle, consistent with entity discovery, permissions and validation.
 /// </param>
 public sealed record QueryCatalogEntryResponse(
     string Name,
     string? BasePath,
-    string Label);
+    string LabelKey);

--- a/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Localization;
 
 namespace Granit.QueryEngine.AspNetCore.Endpoints;
 
@@ -16,9 +15,10 @@ namespace Granit.QueryEngine.AspNetCore.Endpoints;
 internal static class QueryCatalogEndpoints
 {
     /// <summary>
-    /// Localization-key prefix for a query's display label. The localizer (resolved from the
-    /// definition's <see cref="IQueryDefinitionDescriptor.LocalizationResourceType"/>) is queried
-    /// with <c>"Query:{Name}"</c>; a module opts in by adding that key to its own resource.
+    /// Localization-key prefix used as the fallback label key when a query's target entity is not
+    /// registered (so its already-translated <c>DisplayKey</c> cannot be reused). A module opts in
+    /// by adding <c>"Query:{Name}"</c> to its own localization resource; the frontend resolves the
+    /// key against the merged i18n bundle, exactly as it resolves entity display names.
     /// </summary>
     private const string LabelKeyPrefix = "Query:";
 
@@ -35,10 +35,11 @@ internal static class QueryCatalogEndpoints
             .WithDescription(
                 "Returns the full query catalogue surfaced by IQueryDefinitionRegistry so a "
                 + "dashboard editor can offer a dropdown of queries instead of a free-text "
-                + "queryName. Each entry carries the wire identifier and, when a MapGranitQuery "
-                + "route exposes it, the resolved base path of its list endpoint. Registration "
-                + "and routing are decoupled: a query registered without a mapped route is "
-                + "returned with a null base path rather than a forged URL.")
+                + "queryName. Each entry carries the wire identifier, a localization key for the "
+                + "label (the target entity's display key when registered, else Query:{Name}), and "
+                + "— when a MapGranitQuery route exposes it — the resolved base path of its list "
+                + "endpoint. Registration and routing are decoupled: a query registered without a "
+                + "mapped route is returned with a null base path rather than a forged URL.")
             .Produces<IReadOnlyList<QueryCatalogEntryResponse>>();
 
         return group;
@@ -48,10 +49,8 @@ internal static class QueryCatalogEndpoints
         [FromServices] IQueryDefinitionRegistry registry,
         [FromServices] EndpointDataSource endpointDataSource,
         [FromServices] LinkGenerator linkGenerator,
-        HttpContext httpContext,
-        // Optional — a host without Granit.Localization wired still serves the catalogue,
-        // with labels falling back to the raw query name.
-        [FromServices] IStringLocalizerFactory? localizerFactory = null)
+        [FromServices] IEnumerable<IEntityDefinitionDescriptor> entityDescriptors,
+        HttpContext httpContext)
     {
         // Resolve each List-tagged endpoint's URL via LinkGenerator so route parameters
         // (e.g. /api/v{version:apiVersion}/patients) are substituted into the path.
@@ -81,34 +80,37 @@ internal static class QueryCatalogEndpoints
             .GroupBy(x => x.Meta!.EntityType)
             .ToDictionary(g => g.Key, g => NormalizeRoutePath(g.First().Path!));
 
+        Dictionary<Type, string> entityDisplayKeys = BuildEntityDisplayKeyIndex(entityDescriptors);
+
         return TypedResults.Ok(QueryCatalogProjection.Project(
             registry.GetAll(),
             routeIndex,
-            descriptor => ResolveLabel(descriptor, localizerFactory)));
+            descriptor => ResolveLabelKey(descriptor, entityDisplayKeys)));
     }
 
     /// <summary>
-    /// Resolves a query's display label by querying its localization resource with
-    /// <c>"Query:{Name}"</c>, mirroring how the query engine resolves column labels. Falls back to
-    /// the raw <see cref="IQueryDefinitionDescriptor.Name"/> when no factory, no resource, or no
-    /// matching key is found — so the label is always present and localization stays opt-in.
+    /// Returns the localization key the frontend resolves for a query's dropdown label: the target
+    /// entity's <c>DisplayKey</c> when that entity is registered — reusing its already-translated
+    /// name — otherwise the <c>"Query:{Name}"</c> convention key. The server emits a key, never a
+    /// resolved string; translation happens client-side, consistent with entity discovery.
     /// </summary>
-    private static string ResolveLabel(
+    private static string ResolveLabelKey(
         IQueryDefinitionDescriptor descriptor,
-        IStringLocalizerFactory? localizerFactory)
-    {
-        if (localizerFactory is not null && descriptor.LocalizationResourceType is { } resourceType)
-        {
-            IStringLocalizer localizer = localizerFactory.Create(resourceType);
-            LocalizedString localized = localizer[LabelKeyPrefix + descriptor.Name];
-            if (!localized.ResourceNotFound)
-            {
-                return localized.Value;
-            }
-        }
+        Dictionary<Type, string> entityDisplayKeys) =>
+        entityDisplayKeys.TryGetValue(descriptor.EntityType, out string? displayKey)
+            ? displayKey
+            : LabelKeyPrefix + descriptor.Name;
 
-        return descriptor.Name;
-    }
+    /// <summary>
+    /// Indexes registered entity definitions by CLR type → <c>DisplayKey</c>, skipping entities
+    /// that declare no display key. A query whose entity is absent falls back to its own label key.
+    /// </summary>
+    private static Dictionary<Type, string> BuildEntityDisplayKeyIndex(
+        IEnumerable<IEntityDefinitionDescriptor> entityDescriptors) =>
+        entityDescriptors
+            .Where(d => d.Descriptor.DisplayKey is not null)
+            .GroupBy(d => d.EntityType)
+            .ToDictionary(g => g.Key, g => g.First().Descriptor.DisplayKey!);
 
     /// <summary>
     /// Normalises a resolved list-endpoint path for use as a base path. Drops any query
@@ -118,7 +120,7 @@ internal static class QueryCatalogEndpoints
     /// </summary>
     private static string NormalizeRoutePath(string path)
     {
-        int query = path.IndexOf('?');
+        int query = path.IndexOf('?', StringComparison.Ordinal);
         if (query >= 0)
         {
             path = path[..query];

--- a/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
@@ -5,8 +5,8 @@ namespace Granit.QueryEngine.AspNetCore.Internal;
 /// <summary>
 /// Maps <see cref="IQueryDefinitionDescriptor"/> instances to the wire shape
 /// (<see cref="QueryCatalogEntryResponse"/>), resolving each entry's base path from a
-/// pre-built entity-type → route-path index. Extracted to its own class so the projection
-/// logic is unit-testable without the full WebApplication harness.
+/// pre-built entity-type → route-path index and its label key from a resolver. Extracted to its
+/// own class so the projection logic is unit-testable without the full WebApplication harness.
 /// </summary>
 internal static class QueryCatalogProjection
 {
@@ -14,31 +14,31 @@ internal static class QueryCatalogProjection
     /// Projects <paramref name="descriptors"/> (already ordered by the registry) into catalog
     /// entries. <paramref name="basePathByEntityType"/> maps an entity CLR type to the resolved
     /// base path of its <c>List</c> endpoint; a descriptor whose entity type is absent gets a
-    /// <c>null</c> base path — never a forged URL. <paramref name="resolveLabel"/> produces the
-    /// human-facing dropdown label for a descriptor (the localized <c>"Query:{Name}"</c> string,
-    /// or the raw <c>Name</c> as fallback).
+    /// <c>null</c> base path — never a forged URL. <paramref name="resolveLabelKey"/> produces the
+    /// localization key the frontend resolves for the dropdown label (the target entity's
+    /// display key, or <c>"Query:{Name}"</c> as fallback).
     /// </summary>
     public static IReadOnlyList<QueryCatalogEntryResponse> Project(
         IEnumerable<IQueryDefinitionDescriptor> descriptors,
         IReadOnlyDictionary<Type, string> basePathByEntityType,
-        Func<IQueryDefinitionDescriptor, string> resolveLabel)
+        Func<IQueryDefinitionDescriptor, string> resolveLabelKey)
     {
         ArgumentNullException.ThrowIfNull(descriptors);
         ArgumentNullException.ThrowIfNull(basePathByEntityType);
-        ArgumentNullException.ThrowIfNull(resolveLabel);
+        ArgumentNullException.ThrowIfNull(resolveLabelKey);
 
-        return [.. descriptors.Select(d => ToResponse(d, basePathByEntityType, resolveLabel))];
+        return [.. descriptors.Select(d => ToResponse(d, basePathByEntityType, resolveLabelKey))];
     }
 
     private static QueryCatalogEntryResponse ToResponse(
         IQueryDefinitionDescriptor descriptor,
         IReadOnlyDictionary<Type, string> basePathByEntityType,
-        Func<IQueryDefinitionDescriptor, string> resolveLabel)
+        Func<IQueryDefinitionDescriptor, string> resolveLabelKey)
     {
         string? basePath = basePathByEntityType.TryGetValue(descriptor.EntityType, out string? path)
             ? path
             : null;
 
-        return new QueryCatalogEntryResponse(descriptor.Name, basePath, resolveLabel(descriptor));
+        return new QueryCatalogEntryResponse(descriptor.Name, basePath, resolveLabelKey(descriptor));
     }
 }

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
@@ -71,8 +71,7 @@ public sealed class QueryDefinitionRegistryTests
         registry.GetAll().ShouldHaveSingleItem().Name.ShouldBe("Acme.Patients");
     }
 
-    private sealed record FakeDescriptor(string Name, Type EntityType, Type? LocalizationResourceType = null)
-        : IQueryDefinitionDescriptor;
+    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
 
     private sealed class Patient
     {

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Granit.Entities;
 using Granit.QueryEngine.AspNetCore.Dtos;
 using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.QueryEngine.Extensions;
@@ -7,7 +8,6 @@ using Granit.QueryEngine.Internal;
 using Granit.Testing.Endpoints;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Localization;
 using Shouldly;
 using Xunit;
 
@@ -15,10 +15,11 @@ namespace Granit.QueryEngine.AspNetCore.Tests.Endpoints;
 
 /// <summary>
 /// HTTP-level tests for <c>GET /catalog</c> driven through <see cref="GranitEndpointTestHost"/>.
-/// Exercises the live EndpointDataSource / LinkGenerator route resolution and the localized-label
+/// Exercises the live EndpointDataSource / LinkGenerator route resolution and the label-key
 /// resolution the projection unit tests cannot reach: a mapped query resolves its base path, a
-/// registered-but-unmapped query surfaces a null base path, the <c>Query:{Name}</c> localization
-/// key drives the label (falling back to the raw name), and the authenticated-only gate holds.
+/// registered-but-unmapped query surfaces a null base path, the label key reuses the target
+/// entity's DisplayKey when that entity is registered (falling back to <c>Query:{Name}</c>), and
+/// the authenticated-only gate holds.
 /// </summary>
 public sealed class QueryCatalogEndpointsHttpTests
 {
@@ -27,13 +28,14 @@ public sealed class QueryCatalogEndpointsHttpTests
             configureServices: services =>
             {
                 services.AddAuthorizationBuilder();
-                services.AddSingleton<IStringLocalizerFactory>(new StubLocalizerFactory());
 
-                // Two definitions registered; only the routed one is mapped below. The routed
-                // definition declares a localization resource carrying a "Query:Test.Routed" label;
-                // the unrouted one declares none (label falls back to its name).
+                // Two query definitions; only the routed one is mapped below. An entity definition
+                // is registered for RoutedEntity (carrying a DisplayKey) but NOT for UnroutedEntity,
+                // so the routed query reuses the entity's display key and the unrouted one falls
+                // back to "Query:{Name}".
                 services.AddQueryDefinition<RoutedEntity, RoutedQueryDefinition>();
                 services.AddQueryDefinition<UnroutedEntity, UnroutedQueryDefinition>();
+                services.AddSingleton<IEntityDefinitionDescriptor>(new RoutedEntityDefinition());
                 services.TryAddSingleton<IQueryDefinitionRegistry, QueryDefinitionRegistry>();
             },
             configureEndpoints: app =>
@@ -81,7 +83,7 @@ public sealed class QueryCatalogEndpointsHttpTests
     }
 
     [Fact]
-    public async Task Catalog_resolves_the_label_from_the_Query_prefixed_localization_key()
+    public async Task Catalog_reuses_the_entity_display_key_as_the_label_key()
     {
         await using GranitEndpointTestHost host = await StartAsync();
 
@@ -89,11 +91,11 @@ public sealed class QueryCatalogEndpointsHttpTests
             .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
 
         QueryCatalogEntryResponse routed = body!.Single(e => e.Name == "Test.Routed");
-        routed.Label.ShouldBe("Routed Things");
+        routed.LabelKey.ShouldBe("Entity:Test.Routed");
     }
 
     [Fact]
-    public async Task Catalog_falls_back_to_the_name_when_no_localization_key_exists()
+    public async Task Catalog_falls_back_to_the_query_label_key_when_no_entity_is_registered()
     {
         await using GranitEndpointTestHost host = await StartAsync();
 
@@ -101,7 +103,7 @@ public sealed class QueryCatalogEndpointsHttpTests
             .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
 
         QueryCatalogEntryResponse unrouted = body!.Single(e => e.Name == "Test.Unrouted");
-        unrouted.Label.ShouldBe("Test.Unrouted");
+        unrouted.LabelKey.ShouldBe("Query:Test.Unrouted");
     }
 
     [Fact]
@@ -129,8 +131,6 @@ public sealed class QueryCatalogEndpointsHttpTests
     {
         public override string Name => "Test.Routed";
 
-        public override Type LocalizationResourceType => typeof(TestQueryLabelsResource);
-
         protected override void Configure(QueryDefinitionBuilder<RoutedEntity> builder) =>
             builder.Column(e => e.Name);
     }
@@ -143,30 +143,11 @@ public sealed class QueryCatalogEndpointsHttpTests
             builder.Column(e => e.Name);
     }
 
-    private sealed class TestQueryLabelsResource;
-
-    private sealed class StubLocalizerFactory : IStringLocalizerFactory
+    private sealed class RoutedEntityDefinition : EntityDefinition<RoutedEntity>
     {
-        private static readonly Dictionary<string, string> RoutedLabels =
-            new() { ["Query:Test.Routed"] = "Routed Things" };
+        public override string Name => "Test.RoutedEntity";
 
-        public IStringLocalizer Create(Type resourceSource) =>
-            resourceSource == typeof(TestQueryLabelsResource)
-                ? new StubLocalizer(RoutedLabels)
-                : new StubLocalizer(new Dictionary<string, string>());
-
-        public IStringLocalizer Create(string baseName, string location) => new StubLocalizer(new Dictionary<string, string>());
-    }
-
-    private sealed class StubLocalizer(IReadOnlyDictionary<string, string> map) : IStringLocalizer
-    {
-        public LocalizedString this[string name] =>
-            map.TryGetValue(name, out string? value)
-                ? new LocalizedString(name, value, resourceNotFound: false)
-                : new LocalizedString(name, name, resourceNotFound: true);
-
-        public LocalizedString this[string name, params object[] arguments] => this[name];
-
-        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+        protected override void Configure(EntityDefinitionBuilder<RoutedEntity> builder) =>
+            builder.DisplayKey("Entity:Test.Routed");
     }
 }

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
@@ -36,14 +36,14 @@ public sealed class QueryCatalogProjectionTests
     }
 
     [Fact]
-    public void Project_uses_the_label_resolver_for_the_label()
+    public void Project_uses_the_label_key_resolver_for_the_label_key()
     {
         IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
             [new FakeDescriptor("Acme.Patients", typeof(Patient))],
             new Dictionary<Type, string>(),
-            d => $"Localized:{d.Name}");
+            d => $"Entity:{d.Name}");
 
-        entries.ShouldHaveSingleItem().Label.ShouldBe("Localized:Acme.Patients");
+        entries.ShouldHaveSingleItem().LabelKey.ShouldBe("Entity:Acme.Patients");
     }
 
     [Fact]
@@ -60,8 +60,7 @@ public sealed class QueryCatalogProjectionTests
         entries.Select(e => e.Name).ShouldBe(["Acme.Appointments", "Acme.Doctors"]);
     }
 
-    private sealed record FakeDescriptor(string Name, Type EntityType, Type? LocalizationResourceType = null)
-        : IQueryDefinitionDescriptor;
+    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
 
     private sealed class Patient;
 


### PR DESCRIPTION
## Why

#2853 resolved the `/catalog` label **server-side** and returned a string. That's inconsistent
with how the front gets every other display name in Granit: the **server emits an i18n key and the
front resolves it** against the merged bundle — entity discovery sends `DisplayKey`, permissions
and validation send keys. This PR aligns the catalogue with that pattern and, crucially, **reuses
the entity name that's already translated** instead of inventing per-query translations.

(Follows the maintainer's "c'est l'équivalent des tags OpenAPI" intuition: the server hands the
front a display source, the front renders it.)

## Changes

- **`QueryCatalogEntryResponse.Label` (server-resolved string) → `LabelKey` (client-resolved key).**
- **`LabelKey` = the target entity's `DisplayKey`** when that entity is registered — reusing its
  18-culture translation, exactly like entity discovery — **else `"Query:{Name}"`**, a key a module
  may declare in its own resource. The server never resolves; the front does `t(labelKey)`.
- Endpoint injects `IEnumerable<IEntityDefinitionDescriptor>`, indexes `EntityType → DisplayKey`,
  and **drops** the `IStringLocalizerFactory` server-side resolution from #2853.
- **Reverts** the `IQueryDefinitionDescriptor.LocalizationResourceType` member added in #2853 — no
  longer needed. `QueryDefinition<T>` keeps its own property for column labels (unchanged).

## Net effect on translations

**Near-zero new work.** Entity-backed queries inherit their entity's already-translated name
(`Entity:*`). Only a query *without* a registered entity needs an opt-in `Query:{Name}` key — and
even then it's one key, resolved (or humanized) by the front.

## Tests

- Projection: label-key comes from the resolver.
- HTTP (`GranitEndpointTestHost`): a registered `EntityDefinition` with `DisplayKey("Entity:Test.Routed")`
  → the routed query's `LabelKey` is `"Entity:Test.Routed"` (entity reuse); the unrouted query with no
  entity → `"Query:Test.Unrouted"` (fallback). Plus base-path-resolved / null-when-unmapped / auth-gate.
- 61 AspNetCore + 27 Abstractions tests green; `dotnet format --verify-no-changes` clean.

## Note

Supersedes the label mechanism shipped in #2853 (same wire entry, `Label` → `LabelKey`). Pre-1.0,
front not yet consuming → clean change, no `[Obsolete]`.
