### PR TITLE
feat(query-engine): group query catalog by owning module

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -47260,7 +47260,7 @@
       "kind": "record",
       "project": "Granit.QueryEngine.AspNetCore",
       "file": "src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs",
-      "line": 26,
+      "line": 31,
       "members": []
     },
     {
@@ -47589,7 +47589,14 @@
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs",
       "line": 7,
-      "members": []
+      "members": [
+        {
+          "name": "ModuleOf",
+          "kind": "method",
+          "signature": "ModuleOf(Type entityType)",
+          "returnType": "string Name { get; } Type EntityType { get; } string ModuleName { get; } string"
+        }
+      ]
     },
     {
       "name": "IQueryDefinitionRegistry",
@@ -47831,6 +47838,12 @@
           "kind": "method",
           "signature": "typeof(TEntity)",
           "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "ModuleOf",
+          "kind": "method",
+          "signature": "ModuleOf(typeof(TEntity)",
+          "returnType": "string ModuleName => IQueryDefinitionDescriptor."
         },
         {
           "name": "LocalizationResourceType",

--- a/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
@@ -15,4 +15,27 @@ public interface IQueryDefinitionDescriptor
     /// The entity type this definition applies to.
     /// </summary>
     Type EntityType { get; }
+
+    /// <summary>
+    /// Owning module of this query (e.g. <c>"Auditing"</c> for both <c>AuditEntryQuery</c> and
+    /// <c>AuditEntityChangeQuery</c>). Used to group and sort the query catalogue — entries are
+    /// ordered by module, then by name. Defaults to <see cref="ModuleOf"/> of
+    /// <see cref="EntityType"/>; override to customise.
+    /// </summary>
+    string ModuleName { get; }
+
+    /// <summary>
+    /// Derives the owning module name from an entity type: its assembly's simple name with the
+    /// framework <c>Granit.</c> prefix stripped (so <c>Granit.Auditing</c> → <c>Auditing</c> and
+    /// <c>Granit.Identity.Local</c> → <c>Identity.Local</c>). A non-framework assembly name is
+    /// returned unchanged, so a consumer's queries group under their own assembly name.
+    /// </summary>
+    static string ModuleOf(Type entityType)
+    {
+        ArgumentNullException.ThrowIfNull(entityType);
+
+        string assembly = entityType.Assembly.GetName().Name ?? entityType.Namespace ?? "Unknown";
+        const string prefix = "Granit.";
+        return assembly.StartsWith(prefix, StringComparison.Ordinal) ? assembly[prefix.Length..] : assembly;
+    }
 }

--- a/src/Granit.QueryEngine.Abstractions/Internal/QueryDefinitionRegistry.cs
+++ b/src/Granit.QueryEngine.Abstractions/Internal/QueryDefinitionRegistry.cs
@@ -16,9 +16,14 @@ internal sealed class QueryDefinitionRegistry : IQueryDefinitionRegistry
 
         IQueryDefinitionDescriptor[] snapshot = descriptors.ToArray();
 
-        // Stable ordering by name. Ordinal comparison keeps test fixtures deterministic
-        // and matches the wire identifier's culture-invariant nature.
-        _ordered = [.. snapshot.OrderBy(d => d.Name, StringComparer.Ordinal)];
+        // Stable ordering by module, then by name. Ordinal comparison keeps test fixtures
+        // deterministic and matches the wire identifier's culture-invariant nature.
+        _ordered =
+        [
+            .. snapshot
+                .OrderBy(d => d.ModuleName, StringComparer.Ordinal)
+                .ThenBy(d => d.Name, StringComparer.Ordinal),
+        ];
 
         _byName = snapshot.ToDictionary(d => d.Name, StringComparer.Ordinal);
     }

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinition.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinition.cs
@@ -48,6 +48,13 @@ public abstract class QueryDefinition<TEntity> : IQueryDefinitionDescriptor wher
     public Type EntityType => typeof(TEntity);
 
     /// <summary>
+    /// Owning module of this query, used to group and sort the query catalogue. Defaults to the
+    /// target entity's owning assembly with the framework <c>Granit.</c> prefix stripped (e.g.
+    /// <c>"Auditing"</c>). Override only when the entity does not live in its module's assembly.
+    /// </summary>
+    public virtual string ModuleName => IQueryDefinitionDescriptor.ModuleOf(typeof(TEntity));
+
+    /// <summary>
     /// The localization resource type used to resolve <see cref="ColumnDescriptor.LabelKey"/> values.
     /// Override in derived classes to point to the module's localization resource marker class.
     /// When <c>null</c>, no localization is attempted and <see cref="ColumnDescriptor.Label"/>

--- a/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Dtos/QueryCatalogEntryResponse.cs
@@ -5,6 +5,11 @@ namespace Granit.QueryEngine.AspNetCore.Dtos;
 /// subset of <see cref="IQueryDefinitionDescriptor"/>, letting a dashboard editor offer a
 /// dropdown of registered queries instead of a free-text <c>queryName</c>.
 /// </summary>
+/// <param name="ModuleName">
+/// Owning module of the query — e.g. <c>"Auditing"</c> for both <c>AuditEntryQuery</c> and
+/// <c>AuditEntityChangeQuery</c>. The catalogue is ordered by module, then by name, so a
+/// dashboard editor can present queries grouped under their module heading.
+/// </param>
 /// <param name="Name">
 /// Wire identifier of the query definition — e.g. <c>"Acme.Patients"</c>. Stable across
 /// processes; safe to persist as the selected query in a dashboard widget.
@@ -24,6 +29,7 @@ namespace Granit.QueryEngine.AspNetCore.Dtos;
 /// merged i18n bundle, consistent with entity discovery, permissions and validation.
 /// </param>
 public sealed record QueryCatalogEntryResponse(
+    string ModuleName,
     string Name,
     string? BasePath,
     string LabelKey);

--- a/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
@@ -25,7 +25,7 @@ internal static class QueryCatalogEndpoints
     /// <summary>
     /// Maps <c>GET /catalog</c> on the supplied route group. Returns every registered
     /// <see cref="QueryDefinition{TEntity}"/> projected through
-    /// <see cref="QueryCatalogEntryResponse"/>, in the registry's stable (name-ordinal) order.
+    /// <see cref="QueryCatalogEntryResponse"/>, in the registry's stable order (module, then name).
     /// </summary>
     public static RouteGroupBuilder MapQueryCatalogEndpoints(this RouteGroupBuilder group)
     {
@@ -35,8 +35,10 @@ internal static class QueryCatalogEndpoints
             .WithDescription(
                 "Returns the full query catalogue surfaced by IQueryDefinitionRegistry so a "
                 + "dashboard editor can offer a dropdown of queries instead of a free-text "
-                + "queryName. Each entry carries the wire identifier, a localization key for the "
-                + "label (the target entity's display key when registered, else Query:{Name}), and "
+                + "queryName. Entries are ordered by owning module, then by name, so the editor "
+                + "can group them under module headings. Each entry carries the wire identifier, "
+                + "its owning module, a localization key for the label (the target entity's "
+                + "display key when registered, else Query:{Name}), and "
                 + "— when a MapGranitQuery route exposes it — the resolved base path of its list "
                 + "endpoint. Registration and routing are decoupled: a query registered without a "
                 + "mapped route is returned with a null base path rather than a forged URL.")

--- a/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Internal/QueryCatalogProjection.cs
@@ -39,6 +39,7 @@ internal static class QueryCatalogProjection
             ? path
             : null;
 
-        return new QueryCatalogEntryResponse(descriptor.Name, basePath, resolveLabelKey(descriptor));
+        return new QueryCatalogEntryResponse(
+            descriptor.ModuleName, descriptor.Name, basePath, resolveLabelKey(descriptor));
     }
 }

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionRegistryTests.cs
@@ -9,7 +9,7 @@ namespace Granit.QueryEngine.Abstractions.Tests;
 public sealed class QueryDefinitionRegistryTests
 {
     [Fact]
-    public void GetAll_orders_by_name_ordinal()
+    public void GetAll_orders_by_name_ordinal_within_a_module()
     {
         QueryDefinitionRegistry registry = new(
         [
@@ -22,6 +22,25 @@ public sealed class QueryDefinitionRegistryTests
             "Acme.Appointments",
             "Acme.Doctors",
             "Acme.Patients",
+        ]);
+    }
+
+    [Fact]
+    public void GetAll_orders_by_module_then_name()
+    {
+        // Two modules, names interleaved alphabetically across them: the catalogue must group by
+        // module first (so a dashboard editor can render module headings), then sort by name.
+        QueryDefinitionRegistry registry = new(
+        [
+            new FakeDescriptor("Identity.UsersQuery", typeof(Patient), ModuleName: "Identity"),
+            new FakeDescriptor("Auditing.AuditEntryQuery", typeof(Doctor), ModuleName: "Auditing"),
+            new FakeDescriptor("Auditing.AuditEntityChangeQuery", typeof(Appointment), ModuleName: "Auditing"),
+        ]);
+
+        registry.GetAll().Select(d => (d.ModuleName, d.Name)).ShouldBe([
+            ("Auditing", "Auditing.AuditEntityChangeQuery"),
+            ("Auditing", "Auditing.AuditEntryQuery"),
+            ("Identity", "Identity.UsersQuery"),
         ]);
     }
 
@@ -71,7 +90,8 @@ public sealed class QueryDefinitionRegistryTests
         registry.GetAll().ShouldHaveSingleItem().Name.ShouldBe("Acme.Patients");
     }
 
-    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
+    private sealed record FakeDescriptor(string Name, Type EntityType, string ModuleName = "Acme")
+        : IQueryDefinitionDescriptor;
 
     private sealed class Patient
     {

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
@@ -59,6 +59,20 @@ public sealed class QueryCatalogEndpointsHttpTests
     }
 
     [Fact]
+    public async Task Catalog_carries_the_module_derived_from_the_entity_assembly()
+    {
+        await using GranitEndpointTestHost host = await StartAsync();
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        // Both test entities live in this test assembly (Granit.QueryEngine.AspNetCore.Tests), so
+        // the default derivation strips the "Granit." prefix to "QueryEngine.AspNetCore.Tests".
+        QueryCatalogEntryResponse routed = body!.Single(e => e.Name == "Test.Routed");
+        routed.ModuleName.ShouldBe("QueryEngine.AspNetCore.Tests");
+    }
+
+    [Fact]
     public async Task Catalog_resolves_the_base_path_of_a_mapped_query()
     {
         await using GranitEndpointTestHost host = await StartAsync();

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/Internal/QueryCatalogProjectionTests.cs
@@ -60,7 +60,19 @@ public sealed class QueryCatalogProjectionTests
         entries.Select(e => e.Name).ShouldBe(["Acme.Appointments", "Acme.Doctors"]);
     }
 
-    private sealed record FakeDescriptor(string Name, Type EntityType) : IQueryDefinitionDescriptor;
+    [Fact]
+    public void Project_carries_the_owning_module()
+    {
+        IReadOnlyList<QueryCatalogEntryResponse> entries = QueryCatalogProjection.Project(
+            [new FakeDescriptor("Acme.Patients", typeof(Patient), ModuleName: "Acme")],
+            new Dictionary<Type, string>(),
+            ByName);
+
+        entries.ShouldHaveSingleItem().ModuleName.ShouldBe("Acme");
+    }
+
+    private sealed record FakeDescriptor(string Name, Type EntityType, string ModuleName = "Acme")
+        : IQueryDefinitionDescriptor;
 
     private sealed class Patient;
 


### PR DESCRIPTION
## What

Adds a **module** notion to the query catalog (`GET /catalog`) so a dashboard editor can present queries grouped under their owning module instead of one flat list. The catalog is now ordered **by module, then by name (asc)**.

Example: `AuditEntryQuery` and `AuditEntityChangeQuery` both surface under `"Auditing"`.

## How

- `IQueryDefinitionDescriptor` gains `ModuleName` + a static `ModuleOf(Type)` helper.
- `QueryDefinition<T>` provides `ModuleName` by default, derived from the target entity's owning assembly with the framework `Granit.` prefix stripped (`Granit.Auditing` → `"Auditing"`, `Granit.Identity.Local` → `"Identity.Local"`). Overridable per definition; a non-framework assembly name is returned unchanged so consumer queries group under their own name.
- `QueryDefinitionRegistry` orders `OrderBy(ModuleName).ThenBy(Name)`, both ordinal.
- `QueryCatalogEntryResponse` exposes the wire field `moduleName`; the projection and endpoint description are updated.

### Naming note
Named `ModuleName` rather than `Module` because `Module` is a VB reserved keyword and trips analyzer **CA1716** on virtual/interface members and public record parameters. Wire field is therefore `moduleName`.

## Tests
- `Granit.QueryEngine.Abstractions.Tests` — 28/28 (new: orders by module then name)
- `Granit.QueryEngine.AspNetCore.Tests` — 63/63 (new: projection carries module; HTTP catalog derives module from entity assembly)
- `dotnet format --verify-no-changes` clean on all 4 changed projects
- OpenAPI `query-engine` contract regenerated → `moduleName` present (gitignored build artifact; consumed downstream by granit-front)

## Follow-up (not in this PR)
`moduleName` is a raw identifier, not an i18n key (consistent with module names elsewhere in the framework not being localized). If the front wants a localizable `Module:{Name}` key for the group heading, that's a small additive change.