### PR TITLE
feat(domain): add Address postal value object

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19498,6 +19498,40 @@
       ]
     },
     {
+      "name": "Address",
+      "fqn": "Granit.Domain.ValueObjects.Address",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/Address.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string street1, string city, string postalCode, string country, string? street2 = null, string? state = null)",
+          "returnType": "Address"
+        },
+        {
+          "name": "Street2",
+          "kind": "property",
+          "signature": "string? Street2",
+          "returnType": "string?"
+        },
+        {
+          "name": "PostalCode",
+          "kind": "property",
+          "signature": "string PostalCode",
+          "returnType": "string"
+        },
+        {
+          "name": "State",
+          "kind": "property",
+          "signature": "string? State",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
       "name": "BlobReference",
       "fqn": "Granit.Domain.ValueObjects.BlobReference",
       "kind": "class",

--- a/src/Granit/Domain/ValueObjects/Address.cs
+++ b/src/Granit/Domain/ValueObjects/Address.cs
@@ -1,0 +1,87 @@
+using System.Text.Json.Serialization;
+using Granit.DataProtection;
+
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>Postal address value object.</summary>
+/// <remarks>
+/// Owned value object — equality is structural over all components. Sensitive components
+/// (street lines, postal code) are flagged for the data-protection registry so the
+/// Privacy export/erasure handlers honour them automatically.
+/// </remarks>
+public sealed class Address : ValueObject
+{
+    // [JsonConstructor] enables STJ deserialization via the framework's RemoveValueObjectEntityTypes
+    // convention, which stores multi-field ValueObject types as JSON columns.
+    [JsonConstructor]
+    private Address() { }
+
+    /// <summary>Creates a new address.</summary>
+    /// <param name="street1">Street address line 1 (required).</param>
+    /// <param name="city">City (required).</param>
+    /// <param name="postalCode">Postal / ZIP code (required).</param>
+    /// <param name="country">ISO 3166-1 alpha-2 country code (required, exactly 2 chars).</param>
+    /// <param name="street2">Optional second street line.</param>
+    /// <param name="state">Optional administrative subdivision.</param>
+    public static Address Create(
+        string street1,
+        string city,
+        string postalCode,
+        string country,
+        string? street2 = null,
+        string? state = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(street1);
+        ArgumentException.ThrowIfNullOrWhiteSpace(city);
+        ArgumentException.ThrowIfNullOrWhiteSpace(postalCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(country);
+
+        if (country.Length != 2)
+        {
+            throw new ArgumentException(
+                "Country must be a 2-letter ISO 3166-1 alpha-2 code.", nameof(country));
+        }
+
+        return new Address
+        {
+            Street1 = street1,
+            Street2 = street2,
+            City = city,
+            PostalCode = postalCode,
+            State = state,
+            Country = country.ToUpperInvariant(),
+        };
+    }
+
+    /// <summary>Street address line 1 (required).</summary>
+    [SensitiveData]
+    public string Street1 { get; init; } = string.Empty;
+
+    /// <summary>Optional second street line.</summary>
+    [SensitiveData]
+    public string? Street2 { get; init; }
+
+    /// <summary>City (required).</summary>
+    public string City { get; init; } = string.Empty;
+
+    /// <summary>Postal / ZIP code (required).</summary>
+    [SensitiveData]
+    public string PostalCode { get; init; } = string.Empty;
+
+    /// <summary>Optional administrative subdivision (e.g., a US state).</summary>
+    public string? State { get; init; }
+
+    /// <summary>ISO 3166-1 alpha-2 country code (always upper-case after construction).</summary>
+    public string Country { get; init; } = string.Empty;
+
+    /// <inheritdoc />
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Street1;
+        yield return Street2;
+        yield return City;
+        yield return PostalCode;
+        yield return State;
+        yield return Country;
+    }
+}

--- a/tests/Granit.Tests/Domain/ValueObjects/AddressTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/AddressTests.cs
@@ -1,0 +1,80 @@
+using Granit.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Domain.ValueObjects;
+
+public sealed class AddressTests
+{
+    [Fact]
+    public void Create_MinimalArgs_NormalisesCountryToUpperCase()
+    {
+        var addr = Address.Create(
+            street1: "rue 1", city: "Brussels", postalCode: "1000", country: "be");
+
+        addr.Country.ShouldBe("BE");
+        addr.Street1.ShouldBe("rue 1");
+        addr.City.ShouldBe("Brussels");
+        addr.PostalCode.ShouldBe("1000");
+        addr.Street2.ShouldBeNull();
+        addr.State.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_AllArgs_PopulatesEveryField()
+    {
+        var addr = Address.Create(
+            street1: "L1", city: "C", postalCode: "1000", country: "BE",
+            street2: "L2", state: "BR");
+
+        addr.Street2.ShouldBe("L2");
+        addr.State.ShouldBe("BR");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_BlankStreet1_Throws(string street1) =>
+        Should.Throw<ArgumentException>(() =>
+            Address.Create(street1, "City", "1000", "BE"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_BlankCity_Throws(string city) =>
+        Should.Throw<ArgumentException>(() =>
+            Address.Create("L1", city, "1000", "BE"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_BlankPostalCode_Throws(string postalCode) =>
+        Should.Throw<ArgumentException>(() =>
+            Address.Create("L1", "City", postalCode, "BE"));
+
+    [Theory]
+    [InlineData("BEL")]
+    [InlineData("B")]
+    [InlineData("BELGIUM")]
+    public void Create_InvalidCountryLength_Throws(string country) =>
+        Should.Throw<ArgumentException>(() =>
+            Address.Create("L1", "City", "1000", country));
+
+    [Fact]
+    public void Equality_IsStructural()
+    {
+        var a = Address.Create("L1", "C", "1000", "BE", "L2", "St");
+        var b = Address.Create("L1", "C", "1000", "BE", "L2", "St");
+
+        a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void Equality_DiffersOnState()
+    {
+        var a = Address.Create("L1", "C", "1000", "BE", state: "BR");
+        var b = Address.Create("L1", "C", "1000", "BE", state: "WL");
+
+        a.ShouldNotBe(b);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Granit.Domain.ValueObjects.Address`, a structural-equality value object for postal addresses.

- Required: `street1`, `city`, `postalCode`, `country` (ISO 3166-1 alpha-2, validated to 2 chars and upper-cased on construction)
- Optional: `street2`, `state`
- Sensitive components (`Street1`, `Street2`, `PostalCode`) flagged with `[SensitiveData]` so Privacy export/erasure and audit/log redaction honour them automatically
- `[JsonConstructor]` private ctor supports STJ deserialization for JSON-column storage of multi-field value objects

## Tests

`AddressTests` (13 cases): country normalisation, full-field population, blank-required validation, country-length validation, and structural equality. All passing; build and `dotnet format` clean.