### PR TITLE
refactor(geocoding): promote GeoPoint to shared GeoCoordinate value object

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19685,6 +19685,22 @@
       ]
     },
     {
+      "name": "GeoCoordinate",
+      "fqn": "Granit.Domain.ValueObjects.GeoCoordinate",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/GeoCoordinate.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "TryCreate",
+          "kind": "method",
+          "signature": "TryCreate(double latitude, double longitude)",
+          "returnType": "GeoCoordinate?"
+        }
+      ]
+    },
+    {
       "name": "HexColor",
       "fqn": "Granit.Domain.ValueObjects.HexColor",
       "kind": "class",
@@ -22554,15 +22570,6 @@
       ]
     },
     {
-      "name": "GeoPoint",
-      "fqn": "Granit.Geocoding.GeoPoint",
-      "kind": "record",
-      "project": "Granit.Geocoding.Abstractions",
-      "file": "src/Granit.Geocoding.Abstractions/GeoPoint.cs",
-      "line": 8,
-      "members": []
-    },
-    {
       "name": "GranitGeocodingModule",
       "fqn": "Granit.Geocoding.GranitGeocodingModule",
       "kind": "class",
@@ -22584,13 +22591,13 @@
       "kind": "interface",
       "project": "Granit.Geocoding.Abstractions",
       "file": "src/Granit.Geocoding.Abstractions/IGeocodingProvider.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "ResolveAsync",
           "kind": "method",
           "signature": "ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)",
-          "returnType": "string ProviderName { get; } Task<GeoPoint?>"
+          "returnType": "string ProviderName { get; } Task<GeoCoordinate?>"
         }
       ]
     },
@@ -22600,13 +22607,13 @@
       "kind": "interface",
       "project": "Granit.Geocoding.Abstractions",
       "file": "src/Granit.Geocoding.Abstractions/IGeocodingService.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "GeocodeAsync",
           "kind": "method",
           "signature": "GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default)",
-          "returnType": "Task<GeoPoint?>"
+          "returnType": "Task<GeoCoordinate?>"
         }
       ]
     },

--- a/src/Granit.Geocoding.Abstractions/GeoPoint.cs
+++ b/src/Granit.Geocoding.Abstractions/GeoPoint.cs
@@ -1,8 +1,0 @@
-namespace Granit.Geocoding;
-
-/// <summary>
-/// A geographic coordinate (WGS 84 decimal degrees) produced by geocoding a <see cref="PostalAddress"/>.
-/// </summary>
-/// <param name="Latitude">Latitude in decimal degrees, in the range [-90, 90].</param>
-/// <param name="Longitude">Longitude in decimal degrees, in the range [-180, 180].</param>
-public sealed record GeoPoint(double Latitude, double Longitude);

--- a/src/Granit.Geocoding.Abstractions/Granit.Geocoding.Abstractions.csproj
+++ b/src/Granit.Geocoding.Abstractions/Granit.Geocoding.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.Geocoding.Abstractions</PackageId>
-    <Description>Source-agnostic forward-geocoding contract for Granit: turn a PostalAddress into a GeoPoint (latitude/longitude). Holds the IGeocodingService / IGeocodingProvider interfaces and the PostalAddress / GeoPoint shapes so any module can depend on the contract without taking a runtime dependency on the Granit.Geocoding engine or a concrete provider.</Description>
+    <Description>Source-agnostic forward-geocoding contract for Granit: turn a PostalAddress into a GeoCoordinate (latitude/longitude). Holds the IGeocodingService / IGeocodingProvider interfaces and the PostalAddress shape (the coordinate is the shared Granit.Domain.ValueObjects.GeoCoordinate value object) so any module can depend on the contract without taking a runtime dependency on the Granit.Geocoding engine or a concrete provider.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.Geocoding.Abstractions/IGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Abstractions/IGeocodingProvider.cs
@@ -1,3 +1,5 @@
+using Granit.Domain.ValueObjects;
+
 namespace Granit.Geocoding;
 
 /// <summary>
@@ -20,5 +22,5 @@ public interface IGeocodingProvider
     /// <param name="address">The address to geocode.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The resolved coordinate, or <c>null</c> when this provider has no match for the address.</returns>
-    Task<GeoPoint?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default);
+    Task<GeoCoordinate?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Geocoding.Abstractions/IGeocodingService.cs
+++ b/src/Granit.Geocoding.Abstractions/IGeocodingService.cs
@@ -1,8 +1,10 @@
+using Granit.Domain.ValueObjects;
+
 namespace Granit.Geocoding;
 
 /// <summary>
-/// Forward-geocodes a <see cref="PostalAddress"/> to an approximate <see cref="GeoPoint"/>, applying the configured
-/// provider fallback order and result caching.
+/// Forward-geocodes a <see cref="PostalAddress"/> to an approximate <see cref="GeoCoordinate"/>, applying the
+/// configured provider fallback order and result caching.
 /// </summary>
 /// <remarks>
 /// This is the primary entry point consumers inject. It is a privacy-first no-op when no provider is registered or
@@ -19,5 +21,5 @@ public interface IGeocodingService
     /// The resolved coordinate, or <c>null</c> when the address is not geocodable, no provider is enabled, or every
     /// provider in the fallback chain failed or had no match. <strong>Never throws</strong> for these cases.
     /// </returns>
-    Task<GeoPoint?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default);
+    Task<GeoCoordinate?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Geocoding.Abstractions/README.md
+++ b/src/Granit.Geocoding.Abstractions/README.md
@@ -1,15 +1,15 @@
 # Granit.Geocoding.Abstractions
 
 Source-agnostic forward-geocoding contract for `granit`: turn a `PostalAddress`
-into a `GeoPoint` (latitude/longitude), **without** taking a runtime dependency on
-the `Granit.Geocoding` engine or any concrete provider.
+into a `GeoCoordinate` (latitude/longitude), **without** taking a runtime dependency
+on the `Granit.Geocoding` engine or any concrete provider.
 
 Part of the [granit](https://granit-fx.dev) framework.
 
 ## Why a separate package
 
 A consumer that only needs the *contract* — to inject `IGeocodingService`, accept a
-`PostalAddress`, store a `GeoPoint` — should not pull in the engine, its provider
+`PostalAddress`, store a `GeoCoordinate` — should not pull in the engine, its provider
 chain, or its caching stack. This package holds the contract alone, so the
 implementation stays an optional, swappable concern.
 
@@ -19,18 +19,21 @@ implementation stays an optional, swappable concern.
 public interface IGeocodingService
 {
     // Returns null when not geocodable — never throws.
-    Task<GeoPoint?> GeocodeAsync(PostalAddress address, CancellationToken ct = default);
+    Task<GeoCoordinate?> GeocodeAsync(PostalAddress address, CancellationToken ct = default);
 }
 
 public interface IGeocodingProvider          // low-level, one per provider package
 {
     string ProviderName { get; }
-    Task<GeoPoint?> ResolveAsync(PostalAddress address, CancellationToken ct = default);
+    Task<GeoCoordinate?> ResolveAsync(PostalAddress address, CancellationToken ct = default);
 }
 
 public sealed record PostalAddress(string? Street, string? PostalCode, string Locality, string Country);
-public sealed record GeoPoint(double Latitude, double Longitude);
 ```
+
+The coordinate is the shared `Granit.Domain.ValueObjects.GeoCoordinate` value object
+(WGS 84, range-validated) — not a geocoding-specific type — so a `GeoCoordinate`
+produced here is the same shape any other domain (e.g. IP geolocation) records.
 
 ## Why `PostalAddress` and not `Granit.Domain.ValueObjects.Address`
 
@@ -46,6 +49,6 @@ invariants, and the two concerns evolve independently.
 ## See also
 
 - [`Granit.Geocoding`](../Granit.Geocoding/README.md) — the engine that produces
-  `GeoPoint` through a pluggable, cached provider chain.
+  `GeoCoordinate` through a pluggable, cached provider chain.
 - [`Granit.Geocoding.Nominatim`](../Granit.Geocoding.Nominatim/README.md) — the
   OpenStreetMap Nominatim provider.

--- a/src/Granit.Geocoding.Nominatim/Internal/NominatimGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Nominatim/Internal/NominatimGeocodingProvider.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Granit.Domain.ValueObjects;
 using Granit.Geocoding.Nominatim.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -46,7 +47,7 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
 
     public void Dispose() => _throttleGate.Dispose();
 
-    public async Task<GeoPoint?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)
+    public async Task<GeoCoordinate?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(address);
 
@@ -70,7 +71,7 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
                 .ReadFromJsonAsync<List<NominatimPlace>>(cancellationToken)
                 .ConfigureAwait(false);
 
-            GeoPoint? point = Map(places);
+            GeoCoordinate? point = Map(places);
             if (point is null && places is { Count: > 0 })
             {
                 // A result was returned but its coordinate was unparseable or out of WGS 84 range — treat the
@@ -129,7 +130,7 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
         }
     }
 
-    private static GeoPoint? Map(List<NominatimPlace>? places)
+    private static GeoCoordinate? Map(List<NominatimPlace>? places)
     {
         if (places is not { Count: > 0 })
         {
@@ -137,15 +138,13 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
         }
 
         NominatimPlace first = places[0];
-        if (double.TryParse(first.Lat, NumberStyles.Float, CultureInfo.InvariantCulture, out double lat)
-            && double.TryParse(first.Lon, NumberStyles.Float, CultureInfo.InvariantCulture, out double lon)
-            && lat is >= -90 and <= 90
-            && lon is >= -180 and <= 180)
-        {
-            return new GeoPoint(lat, lon);
-        }
 
-        return null;
+        // Untrusted external input: TryCreate returns null for an unparseable or out-of-range coordinate, which
+        // ResolveAsync reports as a miss rather than surfacing a bogus point.
+        return double.TryParse(first.Lat, NumberStyles.Float, CultureInfo.InvariantCulture, out double lat)
+            && double.TryParse(first.Lon, NumberStyles.Float, CultureInfo.InvariantCulture, out double lon)
+            ? GeoCoordinate.TryCreate(lat, lon)
+            : null;
     }
 
     private async Task ThrottleAsync(CancellationToken cancellationToken)

--- a/src/Granit.Geocoding/Internal/DefaultGeocodingService.cs
+++ b/src/Granit.Geocoding/Internal/DefaultGeocodingService.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using Granit.Domain.ValueObjects;
 using Granit.Geocoding.Diagnostics;
 using Granit.Geocoding.Options;
 using Microsoft.Extensions.Logging;
@@ -46,7 +47,7 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
         _providers = OrderProviders(providers, _options.ProviderOrder);
     }
 
-    public async Task<GeoPoint?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default)
+    public async Task<GeoCoordinate?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(address);
 
@@ -70,13 +71,13 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
         // bounds cost, third-party rate limits, and duplicate GDPR transfers. Negative results are cached too —
         // with the shorter FailureCacheDuration applied adaptively inside the factory.
         bool resolvedFresh = false;
-        GeoPoint? resolved = await _cache.GetOrSetAsync<GeoPoint?>(
+        GeoCoordinate? resolved = await _cache.GetOrSetAsync<GeoCoordinate?>(
             cacheKey,
             async (ctx, ct) =>
             {
                 resolvedFresh = true;
                 long start = Stopwatch.GetTimestamp();
-                GeoPoint? r = await QueryProvidersAsync(address, ct).ConfigureAwait(false);
+                GeoCoordinate? r = await QueryProvidersAsync(address, ct).ConfigureAwait(false);
                 ctx.Options.Duration = r is null ? _options.FailureCacheDuration : _options.SuccessCacheDuration;
                 _metrics.RecordLookupDuration(r is null ? "not_found" : "found", Stopwatch.GetElapsedTime(start));
                 return r;
@@ -130,7 +131,7 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
             ? string.Empty
             : WhitespaceRegex().Replace(value.Trim(), " ").ToLower(CultureInfo.InvariantCulture);
 
-    private async Task<GeoPoint?> QueryProvidersAsync(PostalAddress address, CancellationToken cancellationToken)
+    private async Task<GeoCoordinate?> QueryProvidersAsync(PostalAddress address, CancellationToken cancellationToken)
     {
         foreach (IGeocodingProvider provider in _providers)
         {
@@ -138,7 +139,7 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
 
             try
             {
-                GeoPoint? result = await provider.ResolveAsync(address, cancellationToken).ConfigureAwait(false);
+                GeoCoordinate? result = await provider.ResolveAsync(address, cancellationToken).ConfigureAwait(false);
                 if (result is not null)
                 {
                     _metrics.RecordProviderAttempt(provider.ProviderName, "hit");

--- a/src/Granit.Geocoding/README.md
+++ b/src/Granit.Geocoding/README.md
@@ -1,6 +1,6 @@
 # Granit.Geocoding
 
-Forward-geocoding engine for `granit`: turn a `PostalAddress` into a `GeoPoint`
+Forward-geocoding engine for `granit`: turn a `PostalAddress` into a `GeoCoordinate`
 through a pluggable, cached provider chain.
 
 Part of the [granit](https://granit-fx.dev) framework.
@@ -18,7 +18,7 @@ With no provider package installed it is a privacy-first no-op: every address
 resolves to `null` without ever throwing or calling out.
 
 ```csharp
-GeoPoint? point = await geocoder.GeocodeAsync(
+GeoCoordinate? point = await geocoder.GeocodeAsync(
     new PostalAddress(Street: "Rue de la Loi 16", PostalCode: "1000",
                       Locality: "Brussels", Country: "BE"));
 ```

--- a/src/Granit/Domain/ValueObjects/GeoCoordinate.cs
+++ b/src/Granit/Domain/ValueObjects/GeoCoordinate.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// A geographic coordinate in WGS 84 decimal degrees — latitude and longitude. A reusable value object for any
+/// domain that records a point on Earth: address geocoding, IP geolocation, asset tracking, store locators.
+/// </summary>
+/// <remarks>
+/// Equality is structural over <see cref="Latitude"/> and <see cref="Longitude"/>. The constructor enforces the
+/// valid WGS 84 ranges so an out-of-range coordinate can never exist; callers parsing untrusted input (e.g. a
+/// third-party geocoding response) should use <see cref="TryCreate"/> to get <c>null</c> instead of an exception.
+/// Serialized form is the minimal <c>{ "latitude": …, "longitude": … }</c> shape.
+/// </remarks>
+public sealed class GeoCoordinate : ValueObject
+{
+    private const double MinLatitude = -90d;
+    private const double MaxLatitude = 90d;
+    private const double MinLongitude = -180d;
+    private const double MaxLongitude = 180d;
+
+    /// <summary>Creates a validated coordinate.</summary>
+    /// <param name="latitude">Latitude in decimal degrees, in the range [-90, 90].</param>
+    /// <param name="longitude">Longitude in decimal degrees, in the range [-180, 180].</param>
+    /// <exception cref="ArgumentOutOfRangeException">When a component is outside its WGS 84 range.</exception>
+    public GeoCoordinate(double latitude, double longitude)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(latitude, MinLatitude);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(latitude, MaxLatitude);
+        ArgumentOutOfRangeException.ThrowIfLessThan(longitude, MinLongitude);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(longitude, MaxLongitude);
+        Latitude = latitude;
+        Longitude = longitude;
+    }
+
+    /// <summary>Latitude in decimal degrees, in the range [-90, 90].</summary>
+    public double Latitude { get; }
+
+    /// <summary>Longitude in decimal degrees, in the range [-180, 180].</summary>
+    public double Longitude { get; }
+
+    /// <summary><c>true</c> when both components are within their valid WGS 84 ranges.</summary>
+    public static bool IsValid(double latitude, double longitude) =>
+        latitude is >= MinLatitude and <= MaxLatitude && longitude is >= MinLongitude and <= MaxLongitude;
+
+    /// <summary>
+    /// Creates a coordinate, or returns <c>null</c> when either component is out of range — the allocation-free
+    /// way to map untrusted input without catching an exception.
+    /// </summary>
+    public static GeoCoordinate? TryCreate(double latitude, double longitude) =>
+        IsValid(latitude, longitude) ? new GeoCoordinate(latitude, longitude) : null;
+
+    /// <inheritdoc />
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Latitude;
+        yield return Longitude;
+    }
+
+    /// <summary>Human-readable form, e.g. <c>50.8503, 4.3517</c> (invariant culture).</summary>
+    public override string ToString() => string.Create(CultureInfo.InvariantCulture, $"{Latitude}, {Longitude}");
+}

--- a/tests/Granit.Geocoding.Abstractions.Tests/PostalAddressTests.cs
+++ b/tests/Granit.Geocoding.Abstractions.Tests/PostalAddressTests.cs
@@ -34,14 +34,4 @@ public sealed class PostalAddressTests
 
         b.ShouldNotBe(a);
     }
-
-    [Fact]
-    public void GeoPoint_carries_latitude_and_longitude()
-    {
-        GeoPoint point = new(50.8503, 4.3517);
-
-        point.Latitude.ShouldBe(50.8503);
-        point.Longitude.ShouldBe(4.3517);
-        point.ShouldBe(new GeoPoint(50.8503, 4.3517));
-    }
 }

--- a/tests/Granit.Geocoding.Nominatim.Tests/NominatimGeocodingProviderTests.cs
+++ b/tests/Granit.Geocoding.Nominatim.Tests/NominatimGeocodingProviderTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Text;
+using Granit.Domain.ValueObjects;
 using Granit.Geocoding.Nominatim.Internal;
 using Granit.Geocoding.Nominatim.Options;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,14 +19,14 @@ public sealed class NominatimGeocodingProviderTests
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
     [Fact]
-    public async Task ResolveAsync_SuccessfulResponse_MapsFirstResultToGeoPoint()
+    public async Task ResolveAsync_SuccessfulResponse_MapsFirstResultToGeoCoordinate()
     {
         const string json = """
             [{"lat":"50.8476","lon":"4.3572","display_name":"Brussels, Belgium"}]
             """;
         NominatimGeocodingProvider sut = CreateProvider(json, out _);
 
-        GeoPoint? result = await sut.ResolveAsync(Brussels, Ct);
+        GeoCoordinate? result = await sut.ResolveAsync(Brussels, Ct);
 
         result.ShouldNotBeNull();
         result.Latitude.ShouldBe(50.8476);

--- a/tests/Granit.Geocoding.Tests/DefaultGeocodingServiceTests.cs
+++ b/tests/Granit.Geocoding.Tests/DefaultGeocodingServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using Granit.Domain.ValueObjects;
 using Granit.Geocoding.Diagnostics;
 using Granit.Geocoding.Internal;
 using Granit.Geocoding.Options;
@@ -15,7 +16,7 @@ public sealed class DefaultGeocodingServiceTests
     private static readonly PostalAddress Brussels =
         new(Street: "Rue de la Loi 16", PostalCode: "1000", Locality: "Brussels", Country: "BE");
 
-    private static readonly GeoPoint BrusselsPoint = new(50.8503, 4.3517);
+    private static readonly GeoCoordinate BrusselsPoint = new(50.8503, 4.3517);
 
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
@@ -73,7 +74,7 @@ public sealed class DefaultGeocodingServiceTests
         IGeocodingProvider faulty = Substitute.For<IGeocodingProvider>();
         faulty.ProviderName.Returns("Faulty");
         faulty.ResolveAsync(Brussels, Arg.Any<CancellationToken>())
-            .Returns<Task<GeoPoint?>>(_ => throw new InvalidOperationException("boom"));
+            .Returns<Task<GeoCoordinate?>>(_ => throw new InvalidOperationException("boom"));
         IGeocodingProvider healthy = StubProvider("Healthy", Brussels, BrusselsPoint);
 
         DefaultGeocodingService sut = CreateService(
@@ -125,14 +126,14 @@ public sealed class DefaultGeocodingServiceTests
     [Fact]
     public async Task GeocodeAsync_ProviderOrder_DeterminesPriority()
     {
-        IGeocodingProvider first = StubProvider("First", Brussels, new GeoPoint(1, 1));
-        IGeocodingProvider second = StubProvider("Second", Brussels, new GeoPoint(2, 2));
+        IGeocodingProvider first = StubProvider("First", Brussels, new GeoCoordinate(1, 1));
+        IGeocodingProvider second = StubProvider("Second", Brussels, new GeoCoordinate(2, 2));
 
         DefaultGeocodingService sut = CreateService(
             [first, second],
             new GranitGeocodingOptions { ProviderOrder = { "Second", "First" } });
 
-        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(new GeoPoint(2, 2));
+        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(new GeoCoordinate(2, 2));
         await first.DidNotReceive().ResolveAsync(Arg.Any<PostalAddress>(), Arg.Any<CancellationToken>());
     }
 
@@ -178,7 +179,7 @@ public sealed class DefaultGeocodingServiceTests
         key.ShouldNotBe(DefaultGeocodingService.BuildCacheKey("paris||paris|fr"));        // distinct per address
     }
 
-    private static IGeocodingProvider StubProvider(string name, PostalAddress address, GeoPoint? result)
+    private static IGeocodingProvider StubProvider(string name, PostalAddress address, GeoCoordinate? result)
     {
         IGeocodingProvider provider = Substitute.For<IGeocodingProvider>();
         provider.ProviderName.Returns(name);

--- a/tests/Granit.Tests/Domain/ValueObjects/GeoCoordinateTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/GeoCoordinateTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using Granit.Domain;
+using Granit.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Domain.ValueObjects;
+
+public sealed class GeoCoordinateTests
+{
+    // -------------------------------------------------------------------------
+    // Construction + validation
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(50.8503, 4.3517)]
+    [InlineData(-90, -180)]
+    [InlineData(90, 180)]
+    [InlineData(0, 0)]
+    public void Ctor_InRange_Succeeds(double latitude, double longitude)
+    {
+        var coordinate = new GeoCoordinate(latitude, longitude);
+
+        coordinate.Latitude.ShouldBe(latitude);
+        coordinate.Longitude.ShouldBe(longitude);
+    }
+
+    [Theory]
+    [InlineData(90.1, 0)]
+    [InlineData(-90.1, 0)]
+    [InlineData(0, 180.1)]
+    [InlineData(0, -180.1)]
+    public void Ctor_OutOfRange_Throws(double latitude, double longitude) =>
+        Should.Throw<ArgumentOutOfRangeException>(() => new GeoCoordinate(latitude, longitude));
+
+    // -------------------------------------------------------------------------
+    // TryCreate — null instead of throwing, for untrusted input
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void TryCreate_InRange_ReturnsCoordinate() =>
+        GeoCoordinate.TryCreate(50.8503, 4.3517).ShouldBe(new GeoCoordinate(50.8503, 4.3517));
+
+    [Theory]
+    [InlineData(91, 0)]
+    [InlineData(0, 181)]
+    [InlineData(double.NaN, 0)]
+    public void TryCreate_OutOfRange_ReturnsNull(double latitude, double longitude) =>
+        GeoCoordinate.TryCreate(latitude, longitude).ShouldBeNull();
+
+    // -------------------------------------------------------------------------
+    // Value semantics
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Equality_IsStructural()
+    {
+        var a = new GeoCoordinate(50.8503, 4.3517);
+        var b = new GeoCoordinate(50.8503, 4.3517);
+        var c = new GeoCoordinate(50.8503, 4.3518);
+
+        a.ShouldBe(b);
+        (a == b).ShouldBeTrue();
+        a.ShouldNotBe(c);
+    }
+
+    [Fact]
+    public void IsValueObject() =>
+        new GeoCoordinate(1, 1).ShouldBeAssignableTo<ValueObject>();
+
+    [Fact]
+    public void ToString_IsInvariantAndHumanReadable() =>
+        new GeoCoordinate(50.8503, 4.3517).ToString().ShouldBe("50.8503, 4.3517");
+
+    // -------------------------------------------------------------------------
+    // Serialization — latitude/longitude only
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Json_RoundTrips()
+    {
+        var original = new GeoCoordinate(50.8503, 4.3517);
+
+        GeoCoordinate? restored = JsonSerializer.Deserialize<GeoCoordinate>(
+            JsonSerializer.Serialize(original));
+
+        restored.ShouldBe(original);
+    }
+}


### PR DESCRIPTION
## Context

Follow-up to the geocoding framework (#2857, merged). During the `/audit` review of the module we flagged that the coordinate type was geocoding-local, while the framework already treats "geographic coordinate" as a cross-cutting concept:

- `Granit.IpGeolocation.Abstractions.GeoLocation` already carries `double? Latitude/Longitude`
- `Granit.Validation` ships `GeoValidatorExtensions` (`GeoLatitude`/`GeoLongitude`) with localized error keys
- `Granit.Domain.ValueObjects` already hosts two-field value objects (e.g. `ImageDimensions`)

So the coordinate is promoted to a reusable domain value object rather than a `record` buried in the geocoding contract.

## Changes

- **New `Granit.Domain.ValueObjects.GeoCoordinate`** — a `ValueObject` (structural equality) with a **range-validated constructor** (WGS 84 `[-90,90]`/`[-180,180]`) plus `TryCreate` / `IsValid` for untrusted input, mirroring `ImageDimensions`. JSON shape unchanged (`{ latitude, longitude }`).
- **Replace `Granit.Geocoding.Abstractions.GeoPoint`** with `GeoCoordinate` across the contract (`IGeocodingService` / `IGeocodingProvider`), the engine (`DefaultGeocodingService`), and the Nominatim provider. `Map()` now delegates the bounds check to `GeoCoordinate.TryCreate` (single source of truth — removes the inline guard).
- **Tests**: coordinate test relocated to the `Granit.Tests` value-object suite and expanded (range validation, `TryCreate`, equality, JSON round-trip); geocoding tests updated.
- READMEs + package description updated.

## Notes

- `GeoPoint` was unreleased (introduced in #2857, same dev cycle) → clean rename, no `[Obsolete]` (pre-1.0).
- **Follow-up (separate issue):** converge `IpGeolocation.GeoLocation.Latitude?/Longitude?` onto an optional `GeoCoordinate?` — deferred to avoid touching another module's public contract in this PR.

## Verification

- Build clean (Granit base + geocoding chain)
- Unit tests: 19 + 23 + 16 (GeoCoordinate) pass
- Architecture shard: 234 + 9 pass
- `dotnet format --verify-no-changes` clean; markdownlint clean