### PR TITLE
refactor(ipgeolocation): converge GeoLocation coordinate on GeoCoordinate

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33850,7 +33850,7 @@
       "kind": "record",
       "project": "Granit.IpGeolocation.Abstractions",
       "file": "src/Granit.IpGeolocation.Abstractions/GeoLocation.cs",
-      "line": 12,
+      "line": 14,
       "members": []
     },
     {

--- a/src/Granit.Identity.AnomalyDetection/Handlers/UserSessionCreatedHandler.cs
+++ b/src/Granit.Identity.AnomalyDetection/Handlers/UserSessionCreatedHandler.cs
@@ -78,8 +78,9 @@ public class UserSessionCreatedHandler
     // A coarse geographic bucket (whole-degree latitude/longitude, ~111 km) — enough to recognise a habitual
     // area without storing a precise position.
     private static string? CoarseLocation(GeoLocation? location) =>
-        location is { Latitude: { } lat, Longitude: { } lon }
-            ? string.Create(CultureInfo.InvariantCulture, $"{(int)Math.Round(lat)},{(int)Math.Round(lon)}")
+        location?.Coordinate is { } coord
+            ? string.Create(CultureInfo.InvariantCulture,
+                $"{(int)Math.Round(coord.Latitude)},{(int)Math.Round(coord.Longitude)}")
             : null;
 
     // The provider returns the user's other sessions with raw IPs but no resolved location; resolve each here so

--- a/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
+++ b/src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs
@@ -144,7 +144,7 @@ internal sealed class UserSessionAnomalyDetector(
         IReadOnlyList<UserSessionDescriptor> history,
         IdentityAnomalyDetectionOptions opts)
     {
-        if (candidate.Location is not { Latitude: { } lat, Longitude: { } lon })
+        if (candidate.Location is not { Coordinate: { } coord })
         {
             return TravelOutcome.None;
         }
@@ -153,12 +153,13 @@ internal sealed class UserSessionAnomalyDetector(
         foreach (UserSessionDescriptor prior in history)
         {
             if (prior.SessionId == candidate.SessionId
-                || prior.Location is not { Latitude: { } priorLat, Longitude: { } priorLon })
+                || prior.Location is not { Coordinate: { } priorCoord })
             {
                 continue;
             }
 
-            double km = GeoDistance.HaversineKm(lat, lon, priorLat, priorLon);
+            double km = GeoDistance.HaversineKm(
+                coord.Latitude, coord.Longitude, priorCoord.Latitude, priorCoord.Longitude);
             DateTimeOffset priorTime = prior.LastAccessedAt ?? prior.CreatedAt;
             double hours = Math.Abs((candidate.CreatedAt - priorTime).TotalHours);
 

--- a/src/Granit.IpGeolocation.Abstractions/GeoLocation.cs
+++ b/src/Granit.IpGeolocation.Abstractions/GeoLocation.cs
@@ -1,3 +1,5 @@
+using Granit.Domain.ValueObjects;
+
 namespace Granit.IpGeolocation;
 
 /// <summary>
@@ -7,7 +9,7 @@ namespace Granit.IpGeolocation;
 /// The shape is deliberately source-agnostic — a city/region/country is a location regardless of how it was
 /// resolved — so a future non-IP geolocation module (e.g. address geocoding) can reuse this contract.
 /// Every member is optional: a provider populates only what its data source supports (an offline
-/// country-only database leaves <see cref="City"/> and the coordinates <c>null</c>).
+/// country-only database leaves <see cref="City"/> and the <see cref="Coordinate"/> <c>null</c>).
 /// </remarks>
 public sealed record GeoLocation
 {
@@ -23,11 +25,12 @@ public sealed record GeoLocation
     /// <summary>ISO 3166-1 alpha-2 country code (e.g. <c>"BE"</c>).</summary>
     public string? CountryCode { get; init; }
 
-    /// <summary>Approximate latitude in decimal degrees, when available.</summary>
-    public double? Latitude { get; init; }
-
-    /// <summary>Approximate longitude in decimal degrees, when available.</summary>
-    public double? Longitude { get; init; }
+    /// <summary>
+    /// Approximate WGS 84 coordinate, when the source resolves to one. Latitude and longitude are a single unit —
+    /// a source provides both or neither — so they are modelled as one range-validated value object rather than two
+    /// independently-nullable doubles.
+    /// </summary>
+    public GeoCoordinate? Coordinate { get; init; }
 
     /// <summary>
     /// Radius in kilometres within which the true position lies with ~67% confidence, when the source reports

--- a/src/Granit.IpGeolocation.Abstractions/README.md
+++ b/src/Granit.IpGeolocation.Abstractions/README.md
@@ -24,18 +24,19 @@ regardless of how it was resolved — so a future non-IP geolocation module
 ```csharp
 public sealed record GeoLocation
 {
-    public string? City { get; init; }         // "Brussels"
-    public string? Region { get; init; }       // "Brussels-Capital"
-    public string? Country { get; init; }      // "Belgium"
-    public string? CountryCode { get; init; }  // ISO 3166-1 alpha-2, "BE"
-    public double? Latitude { get; init; }
-    public double? Longitude { get; init; }
+    public string? City { get; init; }              // "Brussels"
+    public string? Region { get; init; }            // "Brussels-Capital"
+    public string? Country { get; init; }           // "Belgium"
+    public string? CountryCode { get; init; }       // ISO 3166-1 alpha-2, "BE"
+    public GeoCoordinate? Coordinate { get; init; }  // shared Granit.Domain.ValueObjects value object
 }
 ```
 
 Every member is optional: a provider populates only what its data source
-supports. An offline country-only database leaves `City` and the coordinates
-`null`; a city-grade source fills them in.
+supports. An offline country-only database leaves `City` and the `Coordinate`
+`null`; a city-grade source fills them in. The coordinate is the shared,
+range-validated `Granit.Domain.ValueObjects.GeoCoordinate` — the same type address
+geocoding produces — so latitude and longitude always travel together as one unit.
 
 ## See also
 

--- a/src/Granit.IpGeolocation.IpInfo/Internal/IpInfoIpGeolocationProvider.cs
+++ b/src/Granit.IpGeolocation.IpInfo/Internal/IpInfoIpGeolocationProvider.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Granit.Domain.ValueObjects;
 using Granit.IpGeolocation.IpInfo.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -110,8 +111,9 @@ internal sealed partial class IpInfoIpGeolocationProvider(
             City = body.City,
             Region = body.Region,
             CountryCode = body.Country,
-            Latitude = latitude,
-            Longitude = longitude,
+            Coordinate = latitude is { } lat && longitude is { } lon
+                ? GeoCoordinate.TryCreate(lat, lon)
+                : null,
             IsAnonymousProxy = anonymousProxy,
             IsHostingProvider = privacy?.Hosting,
             IsVpn = privacy?.Vpn,

--- a/src/Granit.IpGeolocation.MaxMind/Internal/MaxMindDatabaseProvider.cs
+++ b/src/Granit.IpGeolocation.MaxMind/Internal/MaxMindDatabaseProvider.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Granit.Domain.ValueObjects;
 using Granit.IpGeolocation.MaxMind.Options;
 using MaxMind.Db;
 using MaxMind.GeoIP2;
@@ -68,8 +69,9 @@ internal sealed partial class MaxMindDatabaseProvider : IDisposable
             Region = response.MostSpecificSubdivision?.Name,
             Country = response.Country?.Name,
             CountryCode = response.Country?.IsoCode,
-            Latitude = response.Location?.Latitude,
-            Longitude = response.Location?.Longitude,
+            Coordinate = response.Location is { Latitude: { } lat, Longitude: { } lon }
+                ? GeoCoordinate.TryCreate(lat, lon)
+                : null,
             // The City database supplies an accuracy radius (km) — the primary low-confidence signal (mobile
             // NAT / sparse data give a large radius). Anonymising-IP classification (VPN/proxy/hosting) needs a
             // separate MaxMind Anonymous-IP database and is left to the IpInfo privacy provider / a follow-up,

--- a/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionAnomalyDetectorTests.cs
+++ b/tests/Granit.Identity.AnomalyDetection.Tests/UserSessionAnomalyDetectorTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Metrics;
 using Granit.AI;
 using Granit.AI.RateLimiting;
+using Granit.Domain.ValueObjects;
 using Granit.Identity.AnomalyDetection.Diagnostics;
 using Granit.Identity.AnomalyDetection.Internal;
 using Granit.Identity.AnomalyDetection.Options;
@@ -17,9 +18,9 @@ public sealed class UserSessionAnomalyDetectorTests
     private static readonly DateTimeOffset Now = new(2026, 6, 12, 12, 0, 0, TimeSpan.Zero);
 
     // Brussels and Sydney — ~16,000 km apart.
-    private static readonly GeoLocation Brussels = new() { City = "Brussels", CountryCode = "BE", Latitude = 50.85, Longitude = 4.35 };
-    private static readonly GeoLocation Paris = new() { City = "Paris", CountryCode = "FR", Latitude = 48.85, Longitude = 2.35 };
-    private static readonly GeoLocation Sydney = new() { City = "Sydney", CountryCode = "AU", Latitude = -33.87, Longitude = 151.2 };
+    private static readonly GeoLocation Brussels = new() { City = "Brussels", CountryCode = "BE", Coordinate = new GeoCoordinate(50.85, 4.35) };
+    private static readonly GeoLocation Paris = new() { City = "Paris", CountryCode = "FR", Coordinate = new GeoCoordinate(48.85, 2.35) };
+    private static readonly GeoLocation Sydney = new() { City = "Sydney", CountryCode = "AU", Coordinate = new GeoCoordinate(-33.87, 151.2) };
 
     private const string Desktop = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/140";
     private const string Mobile = "Mozilla/5.0 (iPhone; CPU iPhone OS 19_0) Safari/605";

--- a/tests/Granit.IpGeolocation.Abstractions.Tests/GeoLocationTests.cs
+++ b/tests/Granit.IpGeolocation.Abstractions.Tests/GeoLocationTests.cs
@@ -1,3 +1,4 @@
+using Granit.Domain.ValueObjects;
 using Shouldly;
 using Xunit;
 
@@ -14,8 +15,7 @@ public sealed class GeoLocationTests
         location.CountryCode.ShouldBe("BE");
         location.City.ShouldBeNull();
         location.Region.ShouldBeNull();
-        location.Latitude.ShouldBeNull();
-        location.Longitude.ShouldBeNull();
+        location.Coordinate.ShouldBeNull();
     }
 
     [Fact]
@@ -27,8 +27,7 @@ public sealed class GeoLocationTests
             Region = "Brussels-Capital",
             Country = "Belgium",
             CountryCode = "BE",
-            Latitude = 50.8476,
-            Longitude = 4.3572,
+            Coordinate = new GeoCoordinate(50.8476, 4.3572),
         };
         GeoLocation b = new()
         {
@@ -36,8 +35,7 @@ public sealed class GeoLocationTests
             Region = "Brussels-Capital",
             Country = "Belgium",
             CountryCode = "BE",
-            Latitude = 50.8476,
-            Longitude = 4.3572,
+            Coordinate = new GeoCoordinate(50.8476, 4.3572),
         };
 
         b.ShouldBe(a);
@@ -47,8 +45,8 @@ public sealed class GeoLocationTests
     [Fact]
     public void Differing_coordinates_break_equality()
     {
-        GeoLocation a = new() { City = "Brussels", Latitude = 50.85 };
-        GeoLocation b = a with { Latitude = 51.0 };
+        GeoLocation a = new() { City = "Brussels", Coordinate = new GeoCoordinate(50.85, 4.35) };
+        GeoLocation b = a with { Coordinate = new GeoCoordinate(51.0, 4.35) };
 
         b.ShouldNotBe(a);
     }

--- a/tests/Granit.IpGeolocation.IpInfo.Tests/IpInfoIpGeolocationProviderTests.cs
+++ b/tests/Granit.IpGeolocation.IpInfo.Tests/IpInfoIpGeolocationProviderTests.cs
@@ -30,8 +30,9 @@ public sealed class IpInfoIpGeolocationProviderTests
         result.Region.ShouldBe("California");
         result.CountryCode.ShouldBe("US");
         result.Country.ShouldBeNull();
-        result.Latitude.ShouldBe(37.4056);
-        result.Longitude.ShouldBe(-122.0775);
+        result.Coordinate.ShouldNotBeNull();
+        result.Coordinate.Latitude.ShouldBe(37.4056);
+        result.Coordinate.Longitude.ShouldBe(-122.0775);
     }
 
     [Fact]

--- a/tests/Granit.IpGeolocation.MaxMind.Tests/MaxMindDatabaseProviderTests.cs
+++ b/tests/Granit.IpGeolocation.MaxMind.Tests/MaxMindDatabaseProviderTests.cs
@@ -54,8 +54,7 @@ public sealed class MaxMindDatabaseProviderTests
         location.ShouldNotBeNull();
         location.CountryCode.ShouldBe("GB");
         location.City.ShouldNotBeNullOrEmpty();
-        location.Latitude.ShouldNotBeNull();
-        location.Longitude.ShouldNotBeNull();
+        location.Coordinate.ShouldNotBeNull();
         location.AccuracyRadiusKm.ShouldNotBeNull();
     }
 
@@ -70,7 +69,7 @@ public sealed class MaxMindDatabaseProviderTests
         location.CountryCode.ShouldBe("GB");
         // The country database carries no city / coordinate data.
         location.City.ShouldBeNull();
-        location.Latitude.ShouldBeNull();
+        location.Coordinate.ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Context

Follow-up requested after #2858 (promotion of `GeoPoint` → `Granit.Domain.ValueObjects.GeoCoordinate`). This converges the **second** coordinate representation in the framework: `IpGeolocation.GeoLocation` carried two independently-nullable doubles (`Latitude` / `Longitude`).

> ⚠️ **Stacked on #2858** (base = `feature/geocoding-geocoordinate-vo`, since `GeoCoordinate` is not yet in `develop`). **Retarget to `develop` once #2858 merges.**

## Why

Latitude and longitude always come from a source as a pair — "both or neither". Modelling them as one `GeoCoordinate? Coordinate` (range-validated, shared primitive) is more correct than two nullable doubles, and removes the duplication the `/audit` flagged.

## Changes

- **`GeoLocation`**: `double? Latitude` + `double? Longitude` → `GeoCoordinate? Coordinate`.
- **Providers** ([MaxMind](src/Granit.IpGeolocation.MaxMind/Internal/MaxMindDatabaseProvider.cs), [IpInfo](src/Granit.IpGeolocation.IpInfo/Internal/IpInfoIpGeolocationProvider.cs)): build the coordinate via `GeoCoordinate.TryCreate` — untrusted external input maps to `null` on out-of-range instead of throwing.
- **[Anomaly detection](src/Granit.Identity.AnomalyDetection/Internal/UserSessionAnomalyDetector.cs)**: impossible-travel/distance heuristic and the coarse-location habitual bucket now read `Coordinate.Latitude/Longitude`. Behaviour unchanged (same haversine, same thresholds).
- Tests (IpGeoloc abstractions/MaxMind/IpInfo, AnomalyDetection) + Abstractions README updated.

## No migration impact

`GeoLocation` is **not persisted** — it is resolved from the IP at read time (confirmed: no Identity EFCore mapping, behavioural profile stores only country/device tokens). So this is purely a contract/runtime change, no schema migration in consuming apps.

## ⚠️ Wire-format change (cross-repo handoff)

The session API now serialises:

```jsonc
// before
"location": { "city": "...", "latitude": 50.85, "longitude": 4.35 }
// after
"location": { "city": "...", "coordinate": { "latitude": 50.85, "longitude": 4.35 } }
```

**granit-front** and **granit-showcase-react** consumers of the session/device location need a matching update — handoff to be issued separately (per cross-repo policy).

## Verification

- Build clean (IpGeoloc ×3 + Identity.AnomalyDetection)
- Tests: IpGeoloc abstractions 3, MaxMind 15, IpInfo 24, resolver 44, AnomalyDetection 24, Identity.Endpoints UserSession 17, **Persistence 380** (local sample `GeoCoordinate` unaffected — member-type lookup wins)
- Architecture shard: 234 + 9
- `dotnet format` + markdownlint clean