### PR TITLE
feat(domain): mutualized address geocoding + verification value objects

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19538,7 +19538,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(string street1, string city, string postalCode, string country, string? street2 = null, string? state = null)",
+          "signature": "Create(string street1, string city, string postalCode, string country, string? street2 = null, string? state = null, AddressDeliveryPointType? deliveryPointType = null)",
           "returnType": "Address"
         },
         {
@@ -19558,8 +19558,130 @@
           "kind": "property",
           "signature": "string? State",
           "returnType": "string?"
+        },
+        {
+          "name": "GetEqualityComponents",
+          "kind": "method",
+          "signature": "GetEqualityComponents()",
+          "returnType": "AddressDeliveryPointType? DeliveryPointType { get; init; } protected IEnumerable<object?>"
         }
       ]
+    },
+    {
+      "name": "AddressDeliveryPointType",
+      "fqn": "Granit.Domain.ValueObjects.AddressDeliveryPointType",
+      "kind": "enum",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/AddressDeliveryPointType.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AddressGeocoding",
+      "fqn": "Granit.Domain.ValueObjects.AddressGeocoding",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/AddressGeocoding.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "AddressGeocoding Pending { get; } ="
+        },
+        {
+          "name": "Resolved",
+          "kind": "method",
+          "signature": "Resolved(GeoCoordinate coordinate, GeocodeMatchPrecision precision, DateTimeOffset geocodedAt, string? houseNumber = null, string? poBox = null)",
+          "returnType": "AddressGeocoding"
+        },
+        {
+          "name": "AsStale",
+          "kind": "method",
+          "signature": "AsStale()",
+          "returnType": "AddressGeocoding"
+        },
+        {
+          "name": "Latitude",
+          "kind": "property",
+          "signature": "double? Latitude",
+          "returnType": "double?"
+        },
+        {
+          "name": "MatchPrecision",
+          "kind": "property",
+          "signature": "GeocodeMatchPrecision? MatchPrecision",
+          "returnType": "GeocodeMatchPrecision?"
+        }
+      ]
+    },
+    {
+      "name": "AddressGeocodingStatus",
+      "fqn": "Granit.Domain.ValueObjects.AddressGeocodingStatus",
+      "kind": "enum",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/AddressGeocodingStatus.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "AddressVerification",
+      "fqn": "Granit.Domain.ValueObjects.AddressVerification",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/AddressVerification.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "AddressVerification Unverified { get; } ="
+        },
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(AddressVerificationStatus status, AddressVerificationSource source, DateTimeOffset verifiedAt, string? verifiedBy = null, string? evidence = null)",
+          "returnType": "AddressVerification"
+        },
+        {
+          "name": "Status",
+          "kind": "property",
+          "signature": "AddressVerificationStatus Status",
+          "returnType": "AddressVerificationStatus"
+        },
+        {
+          "name": "Source",
+          "kind": "property",
+          "signature": "AddressVerificationSource Source",
+          "returnType": "AddressVerificationSource"
+        },
+        {
+          "name": "GetEqualityComponents",
+          "kind": "method",
+          "signature": "GetEqualityComponents()",
+          "returnType": "DateTimeOffset? VerifiedAt { get; init; } public string? VerifiedBy { get; init; } public string? Evidence { get; init; } protected IEnumerable<object?>"
+        }
+      ]
+    },
+    {
+      "name": "AddressVerificationSource",
+      "fqn": "Granit.Domain.ValueObjects.AddressVerificationSource",
+      "kind": "enum",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/AddressVerificationSource.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AddressVerificationStatus",
+      "fqn": "Granit.Domain.ValueObjects.AddressVerificationStatus",
+      "kind": "enum",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/AddressVerificationStatus.cs",
+      "line": 8,
+      "members": []
     },
     {
       "name": "BlobReference",
@@ -19706,6 +19828,15 @@
           "returnType": "GeoCoordinate?"
         }
       ]
+    },
+    {
+      "name": "GeocodeMatchPrecision",
+      "fqn": "Granit.Domain.ValueObjects.GeocodeMatchPrecision",
+      "kind": "enum",
+      "project": "Granit",
+      "file": "src/Granit/Domain/ValueObjects/GeocodeMatchPrecision.cs",
+      "line": 8,
+      "members": []
     },
     {
       "name": "HexColor",
@@ -22539,6 +22670,22 @@
           "kind": "method",
           "signature": "BeforeAsync(object message, IFeatureChecker featureChecker, CancellationToken cancellationToken)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AddressExtensions",
+      "fqn": "Granit.Geocoding.AddressExtensions",
+      "kind": "class",
+      "project": "Granit.Geocoding.Abstractions",
+      "file": "src/Granit.Geocoding.Abstractions/AddressExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ToPostalAddress",
+          "kind": "method",
+          "signature": "ToPostalAddress(this Address address)",
+          "returnType": "PostalAddress"
         }
       ]
     },
@@ -41970,6 +42117,15 @@
           "returnType": "bool"
         }
       ]
+    },
+    {
+      "name": "AddressEnrichmentModelBuilderExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Extensions.AddressEnrichmentModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/AddressEnrichmentModelBuilderExtensions.cs",
+      "line": 20,
+      "members": []
     },
     {
       "name": "ConcurrencyStampExtensions",

--- a/src/Granit.Geocoding.Abstractions/AddressExtensions.cs
+++ b/src/Granit.Geocoding.Abstractions/AddressExtensions.cs
@@ -1,0 +1,24 @@
+using Granit.Domain.ValueObjects;
+
+namespace Granit.Geocoding;
+
+/// <summary>
+/// Conversions from the domain <see cref="Address"/> value object to the geocoding
+/// <see cref="PostalAddress"/> input contract.
+/// </summary>
+public static class AddressExtensions
+{
+    /// <summary>
+    /// Projects a domain <see cref="Address"/> onto the looser geocoding <see cref="PostalAddress"/>
+    /// input — <see cref="Address.Street1"/> → <see cref="PostalAddress.Street"/>,
+    /// <see cref="Address.City"/> → <see cref="PostalAddress.Locality"/>. This is the single shared
+    /// conversion so every consumer geocodes addresses identically.
+    /// </summary>
+    /// <param name="address">The domain address to convert.</param>
+    /// <returns>A geocoding input carrying the street, postal code, locality and country.</returns>
+    public static PostalAddress ToPostalAddress(this Address address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        return new PostalAddress(address.Street1, address.PostalCode, address.City, address.Country);
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/AddressEnrichmentModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/AddressEnrichmentModelBuilderExtensions.cs
@@ -1,0 +1,83 @@
+using System.Linq.Expressions;
+using Granit.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Persistence.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Maps the framework address-enrichment value objects (<see cref="AddressGeocoding"/>,
+/// <see cref="AddressVerification"/>) to flat, typed columns via EF Core's <c>ComplexProperty</c> — the
+/// convention-sanctioned alternative to the default JSON serialization for multi-field value objects (see
+/// <c>ApplyGranitConventions</c>). Centralizes the mapping so every address-holding entity persists these
+/// the same way (status columns stay queryable for dashboards, the coordinate feeds map widgets) without
+/// re-declaring the <c>ComplexProperty</c> shape per entity.
+/// </summary>
+/// <remarks>
+/// The value-object convention's enum-as-string pass only reaches entity properties, not complex-type
+/// sub-properties, so the enum conversions are applied explicitly here — this helper is the single site
+/// that guarantees the framework's PascalCase-string enum persistence for these owned types.
+/// </remarks>
+public static class AddressEnrichmentModelBuilderExtensions
+{
+    // Covers the longest enum value name across the address-enrichment enums
+    // ("VerificationProvider" = 20) with the convention's +4 buffer.
+    private const int EnumColumnLength = 24;
+
+    /// <summary>
+    /// Maps an <see cref="AddressGeocoding"/> property to flat columns. The computed
+    /// <see cref="AddressGeocoding.Coordinate"/> is ignored (the scalar latitude/longitude columns are the
+    /// source of truth) and the <see cref="AddressGeocodingStatus"/> / <see cref="GeocodeMatchPrecision"/>
+    /// enums are persisted as their PascalCase string names.
+    /// </summary>
+    /// <typeparam name="TEntity">The owning entity type.</typeparam>
+    /// <param name="builder">The entity type builder.</param>
+    /// <param name="selector">Selects the <see cref="AddressGeocoding"/> property to map.</param>
+    /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+    public static EntityTypeBuilder<TEntity> MapAddressGeocoding<TEntity>(
+        this EntityTypeBuilder<TEntity> builder,
+        Expression<Func<TEntity, AddressGeocoding?>> selector)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(selector);
+
+        builder.ComplexProperty(selector, geocoding =>
+        {
+            geocoding.Ignore(nameof(AddressGeocoding.Coordinate));
+            geocoding.Property(g => g.Status).HasConversion<string>().HasMaxLength(EnumColumnLength);
+            geocoding.Property(g => g.MatchPrecision).HasConversion<string>().HasMaxLength(EnumColumnLength);
+            geocoding.Property(g => g.HouseNumber).HasMaxLength(32);
+            geocoding.Property(g => g.PoBox).HasMaxLength(32);
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Maps an <see cref="AddressVerification"/> property to flat columns, persisting the
+    /// <see cref="AddressVerificationStatus"/> / <see cref="AddressVerificationSource"/> enums as their
+    /// PascalCase string names.
+    /// </summary>
+    /// <typeparam name="TEntity">The owning entity type.</typeparam>
+    /// <param name="builder">The entity type builder.</param>
+    /// <param name="selector">Selects the <see cref="AddressVerification"/> property to map.</param>
+    /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+    public static EntityTypeBuilder<TEntity> MapAddressVerification<TEntity>(
+        this EntityTypeBuilder<TEntity> builder,
+        Expression<Func<TEntity, AddressVerification?>> selector)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(selector);
+
+        builder.ComplexProperty(selector, verification =>
+        {
+            verification.Property(v => v.Status).HasConversion<string>().HasMaxLength(EnumColumnLength);
+            verification.Property(v => v.Source).HasConversion<string>().HasMaxLength(EnumColumnLength);
+            verification.Property(v => v.VerifiedBy).HasMaxLength(256);
+            verification.Property(v => v.Evidence).HasMaxLength(256);
+        });
+
+        return builder;
+    }
+}

--- a/src/Granit/Domain/ValueObjects/Address.cs
+++ b/src/Granit/Domain/ValueObjects/Address.cs
@@ -23,13 +23,15 @@ public sealed class Address : ValueObject
     /// <param name="country">ISO 3166-1 alpha-2 country code (required, exactly 2 chars).</param>
     /// <param name="street2">Optional second street line.</param>
     /// <param name="state">Optional administrative subdivision.</param>
+    /// <param name="deliveryPointType">Optional kind of delivery point (street, PO box, …).</param>
     public static Address Create(
         string street1,
         string city,
         string postalCode,
         string country,
         string? street2 = null,
-        string? state = null)
+        string? state = null,
+        AddressDeliveryPointType? deliveryPointType = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(street1);
         ArgumentException.ThrowIfNullOrWhiteSpace(city);
@@ -50,6 +52,7 @@ public sealed class Address : ValueObject
             PostalCode = postalCode,
             State = state,
             Country = country.ToUpperInvariant(),
+            DeliveryPointType = deliveryPointType,
         };
     }
 
@@ -74,6 +77,12 @@ public sealed class Address : ValueObject
     /// <summary>ISO 3166-1 alpha-2 country code (always upper-case after construction).</summary>
     public string Country { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Optional kind of delivery point (street, PO box, …). Drives deliverability semantics — a PO box can
+    /// never be confirmed by a courier delivery. <c>null</c> when unknown.
+    /// </summary>
+    public AddressDeliveryPointType? DeliveryPointType { get; init; }
+
     /// <inheritdoc />
     protected override IEnumerable<object?> GetEqualityComponents()
     {
@@ -83,5 +92,6 @@ public sealed class Address : ValueObject
         yield return PostalCode;
         yield return State;
         yield return Country;
+        yield return DeliveryPointType;
     }
 }

--- a/src/Granit/Domain/ValueObjects/AddressDeliveryPointType.cs
+++ b/src/Granit/Domain/ValueObjects/AddressDeliveryPointType.cs
@@ -1,0 +1,17 @@
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Kind of delivery point an <see cref="Address"/> represents. Affects deliverability semantics: a
+/// <see cref="PoBox"/> can be confirmed by postal mail but never by a courier delivery.
+/// </summary>
+public enum AddressDeliveryPointType
+{
+    /// <summary>A regular street address.</summary>
+    Street = 0,
+
+    /// <summary>A post-office box — postal mail only, no courier delivery.</summary>
+    PoBox = 1,
+
+    /// <summary>Any other delivery point (military, poste restante, …).</summary>
+    Other = 2,
+}

--- a/src/Granit/Domain/ValueObjects/AddressGeocoding.cs
+++ b/src/Granit/Domain/ValueObjects/AddressGeocoding.cs
@@ -1,0 +1,134 @@
+using System.Text.Json.Serialization;
+using Granit.DataProtection;
+
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Materialized geocoding outcome for a postal address — the "can we place it on a map?" axis, independent
+/// of <see cref="AddressVerification"/> (the "is it real / deliverable?" axis). A reusable owned value
+/// object embedded by any address-holding entity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The portable source of truth is the <see cref="Latitude"/>/<see cref="Longitude"/> scalar pair: it
+/// works on every database (SQLite included) and feeds the dashboard map widget's lat/lng column path.
+/// <see cref="Coordinate"/> is a computed convenience excluded from persistence and JSON. A PostGIS
+/// <c>geography(Point)</c> column, when a host opts in, is a derived spatial index over the same scalars —
+/// never the source.
+/// </para>
+/// <para>
+/// Persisted as flat columns via the framework's <c>ConfigureAddressGeocoding</c> EF helper (not the
+/// default value-object JSON path), so <see cref="Status"/> stays directly queryable for dashboards and the
+/// coordinate feeds map widgets without a JSON projection. Equality is structural over all stored components.
+/// </para>
+/// </remarks>
+public sealed class AddressGeocoding : ValueObject
+{
+    private AddressGeocoding() { }
+
+    /// <summary>Initial state for a freshly attached address — awaiting a first geocoding attempt.</summary>
+    public static AddressGeocoding Pending { get; } = new() { Status = AddressGeocodingStatus.Pending };
+
+    /// <summary>
+    /// Creates a resolved geocoding from a provider result. The status is
+    /// <see cref="AddressGeocodingStatus.Approximate"/> when the match is only a locality centroid,
+    /// otherwise <see cref="AddressGeocodingStatus.Resolved"/>.
+    /// </summary>
+    /// <param name="coordinate">The resolved coordinate (required).</param>
+    /// <param name="precision">Granularity of the match.</param>
+    /// <param name="geocodedAt">When the geocoding ran.</param>
+    /// <param name="houseNumber">Optional house/building number parsed by the provider.</param>
+    /// <param name="poBox">Optional PO box parsed by the provider.</param>
+    public static AddressGeocoding Resolved(
+        GeoCoordinate coordinate,
+        GeocodeMatchPrecision precision,
+        DateTimeOffset geocodedAt,
+        string? houseNumber = null,
+        string? poBox = null)
+    {
+        ArgumentNullException.ThrowIfNull(coordinate);
+        return new AddressGeocoding
+        {
+            Latitude = coordinate.Latitude,
+            Longitude = coordinate.Longitude,
+            Status = precision == GeocodeMatchPrecision.Locality
+                ? AddressGeocodingStatus.Approximate
+                : AddressGeocodingStatus.Resolved,
+            MatchPrecision = precision,
+            GeocodedAt = geocodedAt,
+            HouseNumber = houseNumber,
+            PoBox = poBox,
+        };
+    }
+
+    /// <summary>Creates a failed geocoding (no match) stamped with the attempt time.</summary>
+    /// <param name="attemptedAt">When the failed attempt ran.</param>
+    public static AddressGeocoding Failed(DateTimeOffset attemptedAt) =>
+        new() { Status = AddressGeocodingStatus.Failed, GeocodedAt = attemptedAt };
+
+    /// <summary>
+    /// Returns a stale copy (the owning address changed since the last geocoding): the previous coordinate
+    /// is retained transiently so a map stays populated until the next resolve replaces it. A
+    /// <see cref="AddressGeocodingStatus.Pending"/> geocoding has nothing to retain and is returned as-is.
+    /// </summary>
+    public AddressGeocoding AsStale() =>
+        Status == AddressGeocodingStatus.Pending
+            ? this
+            : new AddressGeocoding
+            {
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Status = AddressGeocodingStatus.Stale,
+                MatchPrecision = MatchPrecision,
+                GeocodedAt = GeocodedAt,
+                HouseNumber = HouseNumber,
+                PoBox = PoBox,
+            };
+
+    /// <summary>Latitude in decimal degrees, or <c>null</c> until resolved. Portable source of truth.</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public double? Latitude { get; init; }
+
+    /// <summary>Longitude in decimal degrees, or <c>null</c> until resolved. Portable source of truth.</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public double? Longitude { get; init; }
+
+    /// <summary>Lifecycle state of the geocoding attempt.</summary>
+    public AddressGeocodingStatus Status { get; init; } = AddressGeocodingStatus.Pending;
+
+    /// <summary>Granularity of the resolved match, or <c>null</c> when not resolved.</summary>
+    public GeocodeMatchPrecision? MatchPrecision { get; init; }
+
+    /// <summary>When the last geocoding attempt ran, or <c>null</c> if never attempted.</summary>
+    public DateTimeOffset? GeocodedAt { get; init; }
+
+    /// <summary>House / building number parsed by the geocoding provider (axis-2 enrichment), or <c>null</c>.</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public string? HouseNumber { get; init; }
+
+    /// <summary>PO box parsed by the geocoding provider, or <c>null</c>.</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public string? PoBox { get; init; }
+
+    /// <summary>
+    /// The resolved coordinate as a <see cref="GeoCoordinate"/>, or <c>null</c> when not resolved. Computed
+    /// from the scalar pair — excluded from EF mapping (the flat lat/lon columns are the source) and from JSON.
+    /// </summary>
+    [JsonIgnore]
+    public GeoCoordinate? Coordinate =>
+        Latitude is { } latitude && Longitude is { } longitude
+            ? GeoCoordinate.TryCreate(latitude, longitude)
+            : null;
+
+    /// <inheritdoc />
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Latitude;
+        yield return Longitude;
+        yield return Status;
+        yield return MatchPrecision;
+        yield return GeocodedAt;
+        yield return HouseNumber;
+        yield return PoBox;
+    }
+}

--- a/src/Granit/Domain/ValueObjects/AddressGeocodingStatus.cs
+++ b/src/Granit/Domain/ValueObjects/AddressGeocodingStatus.cs
@@ -1,0 +1,24 @@
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Lifecycle of an address geocoding attempt — the "can we place it on a map?" signal, distinct from
+/// <see cref="AddressVerificationStatus"/> (deliverability). The two axes are independent: an address may
+/// be <see cref="Failed"/> here yet <see cref="AddressVerificationStatus.DeliveryConfirmed"/>.
+/// </summary>
+public enum AddressGeocodingStatus
+{
+    /// <summary>Address attached, never geocoded — awaiting a first attempt.</summary>
+    Pending = 0,
+
+    /// <summary>Resolved to a precise coordinate (rooftop or street-level match).</summary>
+    Resolved = 1,
+
+    /// <summary>Resolved, but only to a locality / postcode centroid — coarse.</summary>
+    Approximate = 2,
+
+    /// <summary>No match found (likely a typo, or a gap in the provider's coverage). Not the same as invalid.</summary>
+    Failed = 3,
+
+    /// <summary>The address changed since the last successful geocoding — to be re-resolved.</summary>
+    Stale = 4,
+}

--- a/src/Granit/Domain/ValueObjects/AddressVerification.cs
+++ b/src/Granit/Domain/ValueObjects/AddressVerification.cs
@@ -1,0 +1,77 @@
+using Granit.DataProtection;
+
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Deliverability verdict for a postal address — the "is it real / deliverable?" axis, independent of
+/// <see cref="AddressGeocoding"/> (the "can we place it on a map?" axis). A reusable owned value object
+/// embedded by any address-holding entity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The verdict carries its <see cref="Source"/> (which evidence asserted it) and <see cref="VerifiedBy"/>
+/// (which principal / module), so a confirmation is attributable rather than a bare status — important for
+/// anti-repudiation, since <see cref="AddressVerificationStatus.DeliveryConfirmed"/> is the strongest
+/// evidence but can originate from a system signal.
+/// </para>
+/// <para>
+/// Persisted as flat columns via the framework's <c>ConfigureAddressVerification</c> EF helper. Equality is
+/// structural over all stored components.
+/// </para>
+/// </remarks>
+public sealed class AddressVerification : ValueObject
+{
+    private AddressVerification() { }
+
+    /// <summary>Initial state — no verification evidence yet.</summary>
+    public static AddressVerification Unverified { get; } =
+        new() { Status = AddressVerificationStatus.Unverified, Source = AddressVerificationSource.None };
+
+    /// <summary>Creates a verification verdict with its provenance.</summary>
+    /// <param name="status">The verdict.</param>
+    /// <param name="source">Which evidence asserted it.</param>
+    /// <param name="verifiedAt">When the verdict was recorded.</param>
+    /// <param name="verifiedBy">The asserting principal / module (provenance), or <c>null</c>.</param>
+    /// <param name="evidence">Optional evidence reference (e.g. a shipment or correspondence id).</param>
+    public static AddressVerification Create(
+        AddressVerificationStatus status,
+        AddressVerificationSource source,
+        DateTimeOffset verifiedAt,
+        string? verifiedBy = null,
+        string? evidence = null) =>
+        new()
+        {
+            Status = status,
+            Source = source,
+            VerifiedAt = verifiedAt,
+            VerifiedBy = verifiedBy,
+            Evidence = evidence,
+        };
+
+    /// <summary>The deliverability verdict.</summary>
+    public AddressVerificationStatus Status { get; init; } = AddressVerificationStatus.Unverified;
+
+    /// <summary>Which evidence asserted the verdict (provenance).</summary>
+    public AddressVerificationSource Source { get; init; } = AddressVerificationSource.None;
+
+    /// <summary>When the verdict was recorded, or <c>null</c> when unverified.</summary>
+    public DateTimeOffset? VerifiedAt { get; init; }
+
+    /// <summary>The asserting principal / module, or <c>null</c>. Provenance for anti-repudiation.</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public string? VerifiedBy { get; init; }
+
+    /// <summary>Optional evidence reference (e.g. shipment / correspondence id), or <c>null</c>.</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public string? Evidence { get; init; }
+
+    /// <inheritdoc />
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Status;
+        yield return Source;
+        yield return VerifiedAt;
+        yield return VerifiedBy;
+        yield return Evidence;
+    }
+}

--- a/src/Granit/Domain/ValueObjects/AddressVerificationSource.cs
+++ b/src/Granit/Domain/ValueObjects/AddressVerificationSource.cs
@@ -1,0 +1,26 @@
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Provenance of an <see cref="AddressVerification"/> verdict — which evidence asserted it. Recorded
+/// alongside the verdict so a confirmation is attributable (anti-repudiation), never just a bare status.
+/// </summary>
+public enum AddressVerificationSource
+{
+    /// <summary>No source (the default for <see cref="AddressVerificationStatus.Unverified"/>).</summary>
+    None = 0,
+
+    /// <summary>Inferred from geocoding plausibility — weak (existence, not deliverability).</summary>
+    Geocoding = 1,
+
+    /// <summary>An authoritative address-verification provider.</summary>
+    VerificationProvider = 2,
+
+    /// <summary>A human operator confirmed it.</summary>
+    Manual = 3,
+
+    /// <summary>A successful courier delivery to the address.</summary>
+    Delivery = 4,
+
+    /// <summary>A successful postal mailing (non-returned mail).</summary>
+    PostalMail = 5,
+}

--- a/src/Granit/Domain/ValueObjects/AddressVerificationStatus.cs
+++ b/src/Granit/Domain/ValueObjects/AddressVerificationStatus.cs
@@ -1,0 +1,27 @@
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Deliverability / existence of an address — the "is it real?" signal, independent of
+/// <see cref="AddressGeocodingStatus"/>. A rural address can be <see cref="AddressGeocodingStatus.Failed"/>
+/// (a gap in OpenStreetMap) yet <see cref="DeliveryConfirmed"/> because mail actually arrived there.
+/// </summary>
+public enum AddressVerificationStatus
+{
+    /// <summary>No verification evidence yet.</summary>
+    Unverified = 0,
+
+    /// <summary>Confirmed by an authoritative verification provider (DPV / RDI).</summary>
+    ProviderVerified = 1,
+
+    /// <summary>Confirmed by a provider, which standardized / corrected the input.</summary>
+    Corrected = 2,
+
+    /// <summary>Confirmed manually by an operator.</summary>
+    ManuallyConfirmed = 3,
+
+    /// <summary>Confirmed by a real-world positive outcome (successful courier delivery or postal mail).</summary>
+    DeliveryConfirmed = 4,
+
+    /// <summary>Known bad — a provider rejected it, or a delivery / mailing came back undeliverable.</summary>
+    Invalid = 5,
+}

--- a/src/Granit/Domain/ValueObjects/GeocodeMatchPrecision.cs
+++ b/src/Granit/Domain/ValueObjects/GeocodeMatchPrecision.cs
@@ -1,0 +1,18 @@
+namespace Granit.Domain.ValueObjects;
+
+/// <summary>
+/// Granularity of a geocoding match, derived from the provider response (e.g. Nominatim
+/// <c>addresstype</c>/<c>place_rank</c>, Photon feature <c>type</c>). Drives whether a result is treated
+/// as <see cref="AddressGeocodingStatus.Resolved"/> or <see cref="AddressGeocodingStatus.Approximate"/>.
+/// </summary>
+public enum GeocodeMatchPrecision
+{
+    /// <summary>Matched to an exact building / house number.</summary>
+    Rooftop = 0,
+
+    /// <summary>Matched to a street (interpolated along the road).</summary>
+    Street = 1,
+
+    /// <summary>Matched only to a locality / postcode centroid.</summary>
+    Locality = 2,
+}

--- a/tests/Granit.Geocoding.Abstractions.Tests/AddressExtensionsTests.cs
+++ b/tests/Granit.Geocoding.Abstractions.Tests/AddressExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Granit.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Geocoding.Abstractions.Tests;
+
+public sealed class AddressExtensionsTests
+{
+    [Fact]
+    public void ToPostalAddress_MapsDomainFieldsOntoGeocodingInput()
+    {
+        var address = Address.Create(
+            street1: "Rue de la Loi 16",
+            city: "Brussels",
+            postalCode: "1000",
+            country: "BE",
+            street2: "Bte 2",
+            state: "BRU");
+
+        var postal = address.ToPostalAddress();
+
+        postal.Street.ShouldBe("Rue de la Loi 16");
+        postal.PostalCode.ShouldBe("1000");
+        postal.Locality.ShouldBe("Brussels");
+        postal.Country.ShouldBe("BE");
+    }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/AddressEnrichmentModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/AddressEnrichmentModelBuilderExtensionsTests.cs
@@ -1,0 +1,88 @@
+using Granit.Domain.ValueObjects;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class AddressEnrichmentModelBuilderExtensionsTests
+{
+    [Fact]
+    public void MapAddressGeocoding_MapsFlatColumns_IgnoresComputedCoordinate_AndIsNotAnEntityType()
+    {
+        using EnrichmentDbContext context = NewContext();
+
+        IReadOnlyList<string> entityNames = [.. context.Model.GetEntityTypes().Select(et => et.ClrType.Name)];
+        entityNames.ShouldNotContain(nameof(AddressGeocoding), "AddressGeocoding must be a complex type, not an entity");
+
+        IComplexProperty geocoding = context.Model
+            .FindEntityType(typeof(AddressHolder))!
+            .FindComplexProperty(nameof(AddressHolder.Geocoding))
+            .ShouldNotBeNull("Geocoding must be mapped as a complex property");
+
+        IReadOnlyList<string> columns = [.. geocoding.ComplexType.GetProperties().Select(p => p.Name)];
+        columns.ShouldNotContain(nameof(AddressGeocoding.Coordinate), "the computed coordinate must be ignored");
+        columns.ShouldContain(nameof(AddressGeocoding.Latitude));
+        columns.ShouldContain(nameof(AddressGeocoding.Longitude));
+        columns.ShouldContain(nameof(AddressGeocoding.Status));
+    }
+
+    [Fact]
+    public void MapAddressGeocoding_PersistsEnumsAsString()
+    {
+        using EnrichmentDbContext context = NewContext();
+        IComplexProperty geocoding = context.Model
+            .FindEntityType(typeof(AddressHolder))!
+            .FindComplexProperty(nameof(AddressHolder.Geocoding))!;
+
+        ProviderType(geocoding, nameof(AddressGeocoding.Status)).ShouldBe(typeof(string));
+        ProviderType(geocoding, nameof(AddressGeocoding.MatchPrecision)).ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void MapAddressVerification_PersistsEnumsAsString()
+    {
+        using EnrichmentDbContext context = NewContext();
+        IComplexProperty verification = context.Model
+            .FindEntityType(typeof(AddressHolder))!
+            .FindComplexProperty(nameof(AddressHolder.Verification))!;
+
+        ProviderType(verification, nameof(AddressVerification.Status)).ShouldBe(typeof(string));
+        ProviderType(verification, nameof(AddressVerification.Source)).ShouldBe(typeof(string));
+    }
+
+    private static Type? ProviderType(IComplexProperty complex, string propertyName)
+    {
+        IProperty property = complex.ComplexType.FindProperty(propertyName)!;
+        return property.GetValueConverter()?.ProviderClrType ?? property.GetProviderClrType();
+    }
+
+    private static EnrichmentDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<EnrichmentDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    public sealed class AddressHolder
+    {
+        public Guid Id { get; set; }
+        public AddressGeocoding Geocoding { get; set; } = AddressGeocoding.Pending;
+        public AddressVerification Verification { get; set; } = AddressVerification.Unverified;
+    }
+
+    private sealed class EnrichmentDbContext(DbContextOptions<EnrichmentDbContext> options) : DbContext(options)
+    {
+        public DbSet<AddressHolder> Holders => Set<AddressHolder>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<AddressHolder>(builder =>
+            {
+                builder.MapAddressGeocoding(e => e.Geocoding);
+                builder.MapAddressVerification(e => e.Verification);
+            });
+            modelBuilder.ApplyGranitConventions();
+        }
+    }
+}

--- a/tests/Granit.Tests/Domain/ValueObjects/AddressGeocodingTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/AddressGeocodingTests.cs
@@ -1,0 +1,88 @@
+using Granit.DataProtection;
+using Granit.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Domain.ValueObjects;
+
+public sealed class AddressGeocodingTests
+{
+    [Fact]
+    public void Pending_IsTheInitialState()
+    {
+        AddressGeocoding.Pending.Status.ShouldBe(AddressGeocodingStatus.Pending);
+        AddressGeocoding.Pending.Coordinate.ShouldBeNull();
+        AddressGeocoding.Pending.GeocodedAt.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(GeocodeMatchPrecision.Rooftop, AddressGeocodingStatus.Resolved)]
+    [InlineData(GeocodeMatchPrecision.Street, AddressGeocodingStatus.Resolved)]
+    [InlineData(GeocodeMatchPrecision.Locality, AddressGeocodingStatus.Approximate)]
+    public void Resolved_MapsPrecisionToStatus(GeocodeMatchPrecision precision, AddressGeocodingStatus expected)
+    {
+        DateTimeOffset at = DateTimeOffset.UnixEpoch;
+
+        var geocoding = AddressGeocoding.Resolved(new GeoCoordinate(50.85, 4.35), precision, at);
+
+        geocoding.Status.ShouldBe(expected);
+        geocoding.MatchPrecision.ShouldBe(precision);
+        geocoding.GeocodedAt.ShouldBe(at);
+        geocoding.Latitude.ShouldBe(50.85);
+        geocoding.Longitude.ShouldBe(4.35);
+        geocoding.Coordinate.ShouldBe(new GeoCoordinate(50.85, 4.35));
+    }
+
+    [Fact]
+    public void Failed_HasNoCoordinate_ButStampsAttemptTime()
+    {
+        DateTimeOffset at = DateTimeOffset.UnixEpoch;
+
+        var geocoding = AddressGeocoding.Failed(at);
+
+        geocoding.Status.ShouldBe(AddressGeocodingStatus.Failed);
+        geocoding.Coordinate.ShouldBeNull();
+        geocoding.GeocodedAt.ShouldBe(at);
+    }
+
+    [Fact]
+    public void AsStale_RetainsPreviousCoordinate()
+    {
+        var resolved = AddressGeocoding.Resolved(
+            new GeoCoordinate(50.85, 4.35), GeocodeMatchPrecision.Rooftop, DateTimeOffset.UnixEpoch);
+
+        AddressGeocoding stale = resolved.AsStale();
+
+        stale.Status.ShouldBe(AddressGeocodingStatus.Stale);
+        stale.Coordinate.ShouldBe(new GeoCoordinate(50.85, 4.35));
+    }
+
+    [Fact]
+    public void AsStale_OnPending_IsNoOp() =>
+        AddressGeocoding.Pending.AsStale().ShouldBeSameAs(AddressGeocoding.Pending);
+
+    [Fact]
+    public void Equality_IsStructural()
+    {
+        var a = AddressGeocoding.Resolved(new GeoCoordinate(1, 2), GeocodeMatchPrecision.Rooftop, DateTimeOffset.UnixEpoch);
+        var b = AddressGeocoding.Resolved(new GeoCoordinate(1, 2), GeocodeMatchPrecision.Rooftop, DateTimeOffset.UnixEpoch);
+
+        a.ShouldBe(b);
+    }
+
+    // Decision E: the coordinate / parsed components are PII. Asserting the registry resolves them
+    // proves the [SensitiveData] attribute lands on the init property (not a positional-record backing
+    // field, where redaction would silently no-op) and documents the framework-wide Confidential classification.
+    [Theory]
+    [InlineData(nameof(AddressGeocoding.Latitude))]
+    [InlineData(nameof(AddressGeocoding.Longitude))]
+    [InlineData(nameof(AddressGeocoding.HouseNumber))]
+    [InlineData(nameof(AddressGeocoding.PoBox))]
+    public void SensitiveFields_AreClassifiedConfidential(string propertyName)
+    {
+        SensitivePropertyRegistry registry = new([typeof(AddressGeocoding).Assembly]);
+
+        registry.TryGet(propertyName, out SensitivePropertyEntry entry).ShouldBeTrue();
+        entry.Level.ShouldBe(Sensitivity.Confidential);
+    }
+}

--- a/tests/Granit.Tests/Domain/ValueObjects/AddressTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/AddressTests.cs
@@ -77,4 +77,23 @@ public sealed class AddressTests
 
         a.ShouldNotBe(b);
     }
+
+    [Fact]
+    public void Create_WithDeliveryPointType_SetsIt()
+    {
+        var addr = Address.Create(
+            "L1", "C", "1000", "BE", deliveryPointType: AddressDeliveryPointType.PoBox);
+
+        addr.DeliveryPointType.ShouldBe(AddressDeliveryPointType.PoBox);
+    }
+
+    [Fact]
+    public void DeliveryPointType_DefaultsToNull_AndIsPartOfEquality()
+    {
+        var a = Address.Create("L1", "C", "1000", "BE");
+        var b = Address.Create("L1", "C", "1000", "BE", deliveryPointType: AddressDeliveryPointType.Street);
+
+        a.DeliveryPointType.ShouldBeNull();
+        a.ShouldNotBe(b);
+    }
 }

--- a/tests/Granit.Tests/Domain/ValueObjects/AddressVerificationTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjects/AddressVerificationTests.cs
@@ -1,0 +1,59 @@
+using Granit.DataProtection;
+using Granit.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Domain.ValueObjects;
+
+public sealed class AddressVerificationTests
+{
+    [Fact]
+    public void Unverified_IsTheInitialState()
+    {
+        AddressVerification.Unverified.Status.ShouldBe(AddressVerificationStatus.Unverified);
+        AddressVerification.Unverified.Source.ShouldBe(AddressVerificationSource.None);
+        AddressVerification.Unverified.VerifiedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_CapturesVerdictAndProvenance()
+    {
+        DateTimeOffset at = DateTimeOffset.UnixEpoch;
+
+        var verification = AddressVerification.Create(
+            AddressVerificationStatus.DeliveryConfirmed,
+            AddressVerificationSource.Delivery,
+            at,
+            verifiedBy: "logistics",
+            evidence: "SHP-1");
+
+        verification.Status.ShouldBe(AddressVerificationStatus.DeliveryConfirmed);
+        verification.Source.ShouldBe(AddressVerificationSource.Delivery);
+        verification.VerifiedAt.ShouldBe(at);
+        verification.VerifiedBy.ShouldBe("logistics");
+        verification.Evidence.ShouldBe("SHP-1");
+    }
+
+    [Fact]
+    public void Equality_IsStructural()
+    {
+        var a = AddressVerification.Create(
+            AddressVerificationStatus.ManuallyConfirmed, AddressVerificationSource.Manual, DateTimeOffset.UnixEpoch, "op");
+        var b = AddressVerification.Create(
+            AddressVerificationStatus.ManuallyConfirmed, AddressVerificationSource.Manual, DateTimeOffset.UnixEpoch, "op");
+
+        a.ShouldBe(b);
+    }
+
+    // Decision E: provenance (VerifiedBy) and evidence references are PII — see AddressGeocodingTests for rationale.
+    [Theory]
+    [InlineData(nameof(AddressVerification.VerifiedBy))]
+    [InlineData(nameof(AddressVerification.Evidence))]
+    public void SensitiveFields_AreClassifiedConfidential(string propertyName)
+    {
+        SensitivePropertyRegistry registry = new([typeof(AddressVerification).Assembly]);
+
+        registry.TryGet(propertyName, out SensitivePropertyEntry entry).ShouldBeTrue();
+        entry.Level.ShouldBe(Sensitivity.Confidential);
+    }
+}


### PR DESCRIPTION
## Context

Phase 0 of the **address platform** (approved plan): the shared, mutualized *shapes* that every later phase builds on. Three orthogonal axes for an address — **postal** (`Address`), **geocoding outcome** (`AddressGeocoding`), **deliverability verification** (`AddressVerification`) — reusable by any address-holding entity (Parties, Invoicing, …) so geocoding/verification is never re-implemented per module.

Framework-only, additive. No behavior is wired yet (Phase 1 enriches geocoding; Phase 3 makes Parties consume it).

## What's in this PR

**base `Granit`** (`Domain/ValueObjects/`)
- `AddressGeocoding` / `AddressVerification` value objects — declared as `ValueObject` classes with `init` properties (not positional records) so `[SensitiveData]` targets the property and the redaction registry resolves it.
- Enums: `AddressGeocodingStatus`, `GeocodeMatchPrecision`, `AddressVerificationStatus`, `AddressVerificationSource`, `AddressDeliveryPointType`.
- `Address`: additive nullable `DeliveryPointType` (a PO box can never be confirmed by a courier delivery).

**`Granit.Geocoding.Abstractions`**
- `Address.ToPostalAddress()` — the single shared domain→geocoding conversion.

**`Granit.Persistence.EntityFrameworkCore`**
- `MapAddressGeocoding` / `MapAddressVerification` — reusable EF helper (mirrors `MapImageDimensions`) mapping the value objects to **flat `ComplexProperty` columns** so status stays queryable for dashboards and the coordinate feeds map widgets; ignores the computed `Coordinate` and persists enums as strings (the convention's enum pass does not reach complex-type sub-properties).

## Design notes
- Portable scalars `Latitude`/`Longitude` are the source of truth (works on every provider incl. SQLite); `Coordinate` is a computed convenience, excluded from EF + JSON. PostGIS is a later opt-in over the same scalars.
- `Latitude`/`Longitude`, parsed components, provenance and evidence are `[SensitiveData(Level = Sensitivity.Confidential)]`. Note this classifies those names framework-wide (incl. shared `GeoCoordinate`) — intended (a coordinate is PII).
- Persistence path is the convention-sanctioned explicit `ComplexProperty` (not the default value-object JSON), matching the existing `PartyAddress.Value` / `MapImageDimensions` precedent.

## Verification
- `Granit.Tests` 594/594, `Granit.Persistence.EntityFrameworkCore.Tests` 383/383, `Granit.Geocoding.Abstractions.Tests` 4/4.
- EF helper test asserts flat columns + ignored coordinate + enum-as-string; a `SensitivePropertyRegistry` test asserts the new fields resolve as `Confidential` (proves the `init`-property attribute target).
- `dotnet format --verify-no-changes` clean on all touched projects.

No new dependencies, no new test projects (so no shard changes), no migrations (framework ships none).