### PR TITLE
feat(geocoding): enrich forward geocoding with match precision + parsed components

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22724,6 +22724,15 @@
       ]
     },
     {
+      "name": "GeocodingResult",
+      "fqn": "Granit.Geocoding.GeocodingResult",
+      "kind": "record",
+      "project": "Granit.Geocoding.Abstractions",
+      "file": "src/Granit.Geocoding.Abstractions/GeocodingResult.cs",
+      "line": 19,
+      "members": []
+    },
+    {
       "name": "GranitGeocodingModule",
       "fqn": "Granit.Geocoding.GranitGeocodingModule",
       "kind": "class",
@@ -22745,13 +22754,13 @@
       "kind": "interface",
       "project": "Granit.Geocoding.Abstractions",
       "file": "src/Granit.Geocoding.Abstractions/IGeocodingProvider.cs",
-      "line": 12,
+      "line": 10,
       "members": [
         {
           "name": "ResolveAsync",
           "kind": "method",
           "signature": "ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)",
-          "returnType": "string ProviderName { get; } Task<GeoCoordinate?>"
+          "returnType": "string ProviderName { get; } Task<GeocodingResult?>"
         }
       ]
     },
@@ -22761,13 +22770,13 @@
       "kind": "interface",
       "project": "Granit.Geocoding.Abstractions",
       "file": "src/Granit.Geocoding.Abstractions/IGeocodingService.cs",
-      "line": 13,
+      "line": 11,
       "members": [
         {
           "name": "GeocodeAsync",
           "kind": "method",
           "signature": "GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default)",
-          "returnType": "Task<GeoCoordinate?>"
+          "returnType": "Task<GeocodingResult?>"
         }
       ]
     },

--- a/src/Granit.Geocoding.Abstractions/GeocodingResult.cs
+++ b/src/Granit.Geocoding.Abstractions/GeocodingResult.cs
@@ -1,0 +1,24 @@
+using Granit.Domain.ValueObjects;
+
+namespace Granit.Geocoding;
+
+/// <summary>
+/// The outcome of a successful forward-geocoding lookup: the resolved <see cref="GeoCoordinate"/> plus the
+/// match granularity and the provider-parsed address components.
+/// </summary>
+/// <remarks>
+/// The components are used downstream to enrich the stored geocoding (<c>HouseNumber</c>) and to cross-check
+/// the result against the submitted address (a mismatched <c>PostalCode</c>/<c>CountryCode</c> flags a
+/// likely typo). They are best-effort: a provider that returns only a coordinate leaves them <c>null</c>.
+/// </remarks>
+/// <param name="Coordinate">The resolved coordinate.</param>
+/// <param name="Precision">Granularity of the match (rooftop / street / locality).</param>
+/// <param name="HouseNumber">House / building number parsed by the provider, or <c>null</c>.</param>
+/// <param name="PostalCode">Postal code parsed by the provider, or <c>null</c>.</param>
+/// <param name="CountryCode">ISO 3166-1 alpha-2 country code parsed by the provider, or <c>null</c>.</param>
+public sealed record GeocodingResult(
+    GeoCoordinate Coordinate,
+    GeocodeMatchPrecision Precision,
+    string? HouseNumber = null,
+    string? PostalCode = null,
+    string? CountryCode = null);

--- a/src/Granit.Geocoding.Abstractions/IGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Abstractions/IGeocodingProvider.cs
@@ -1,5 +1,3 @@
-using Granit.Domain.ValueObjects;
-
 namespace Granit.Geocoding;
 
 /// <summary>
@@ -21,6 +19,9 @@ public interface IGeocodingProvider
     /// </summary>
     /// <param name="address">The address to geocode.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The resolved coordinate, or <c>null</c> when this provider has no match for the address.</returns>
-    Task<GeoCoordinate?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default);
+    /// <returns>
+    /// The resolved result (coordinate, match precision and any parsed components), or <c>null</c> when this
+    /// provider has no match for the address.
+    /// </returns>
+    Task<GeocodingResult?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Geocoding.Abstractions/IGeocodingService.cs
+++ b/src/Granit.Geocoding.Abstractions/IGeocodingService.cs
@@ -1,9 +1,7 @@
-using Granit.Domain.ValueObjects;
-
 namespace Granit.Geocoding;
 
 /// <summary>
-/// Forward-geocodes a <see cref="PostalAddress"/> to an approximate <see cref="GeoCoordinate"/>, applying the
+/// Forward-geocodes a <see cref="PostalAddress"/> to an approximate <see cref="GeocodingResult"/>, applying the
 /// configured provider fallback order and result caching.
 /// </summary>
 /// <remarks>
@@ -13,13 +11,13 @@ namespace Granit.Geocoding;
 public interface IGeocodingService
 {
     /// <summary>
-    /// Resolves <paramref name="address"/> to an approximate coordinate.
+    /// Resolves <paramref name="address"/> to an approximate coordinate with its match precision and parsed components.
     /// </summary>
     /// <param name="address">The address to geocode.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
-    /// The resolved coordinate, or <c>null</c> when the address is not geocodable, no provider is enabled, or every
+    /// The resolved result, or <c>null</c> when the address is not geocodable, no provider is enabled, or every
     /// provider in the fallback chain failed or had no match. <strong>Never throws</strong> for these cases.
     /// </returns>
-    Task<GeoCoordinate?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default);
+    Task<GeocodingResult?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Geocoding.Nominatim/Internal/NominatimGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Nominatim/Internal/NominatimGeocodingProvider.cs
@@ -21,6 +21,9 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
 {
     internal const string HttpClientName = "Granit.Geocoding.Nominatim";
 
+    // Upper bound on a parsed address component persisted downstream (hardening against oversized OSM fields).
+    private const int MaxComponentLength = 64;
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptions<NominatimGeocodingOptions> _options;
     private readonly ILogger<NominatimGeocodingProvider> _logger;
@@ -47,7 +50,7 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
 
     public void Dispose() => _throttleGate.Dispose();
 
-    public async Task<GeoCoordinate?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)
+    public async Task<GeocodingResult?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(address);
 
@@ -71,15 +74,15 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
                 .ReadFromJsonAsync<List<NominatimPlace>>(cancellationToken)
                 .ConfigureAwait(false);
 
-            GeoCoordinate? point = Map(places);
-            if (point is null && places is { Count: > 0 })
+            GeocodingResult? result = Map(places);
+            if (result is null && places is { Count: > 0 })
             {
                 // A result was returned but its coordinate was unparseable or out of WGS 84 range — treat the
                 // untrusted response as a miss rather than surfacing a bogus coordinate.
                 LogLookupFailed("InvalidCoordinate");
             }
 
-            return point;
+            return result;
         }
         catch (HttpRequestException)
         {
@@ -118,7 +121,9 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
         AppendIfPresent(parameters, "country", address.Country);
         parameters.Add("format=jsonv2");
         parameters.Add("limit=1");
-        parameters.Add("addressdetails=0");
+        // addressdetails=1 returns the parsed address components (house_number, postcode, country_code) and,
+        // with addresstype/place_rank, the match granularity — used for the result's precision and cross-check.
+        parameters.Add("addressdetails=1");
         return string.Join('&', parameters);
     }
 
@@ -130,7 +135,7 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
         }
     }
 
-    private static GeoCoordinate? Map(List<NominatimPlace>? places)
+    private static GeocodingResult? Map(List<NominatimPlace>? places)
     {
         if (places is not { Count: > 0 })
         {
@@ -141,10 +146,54 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
 
         // Untrusted external input: TryCreate returns null for an unparseable or out-of-range coordinate, which
         // ResolveAsync reports as a miss rather than surfacing a bogus point.
-        return double.TryParse(first.Lat, NumberStyles.Float, CultureInfo.InvariantCulture, out double lat)
-            && double.TryParse(first.Lon, NumberStyles.Float, CultureInfo.InvariantCulture, out double lon)
-            ? GeoCoordinate.TryCreate(lat, lon)
-            : null;
+        if (!double.TryParse(first.Lat, NumberStyles.Float, CultureInfo.InvariantCulture, out double lat)
+            || !double.TryParse(first.Lon, NumberStyles.Float, CultureInfo.InvariantCulture, out double lon)
+            || GeoCoordinate.TryCreate(lat, lon) is not { } coordinate)
+        {
+            return null;
+        }
+
+        return new GeocodingResult(
+            coordinate,
+            DeterminePrecision(first),
+            HouseNumber: Sanitize(first.Address?.HouseNumber),
+            PostalCode: Sanitize(first.Address?.Postcode),
+            CountryCode: Sanitize(first.Address?.CountryCode));
+    }
+
+    // Map the Nominatim granularity hints to a coarse precision: a parsed house number (or a house/building
+    // address type) is rooftop; a road is street; everything else falls back to a place_rank threshold.
+    private static GeocodeMatchPrecision DeterminePrecision(NominatimPlace place)
+    {
+        if (!string.IsNullOrWhiteSpace(place.Address?.HouseNumber))
+        {
+            return GeocodeMatchPrecision.Rooftop;
+        }
+
+        return place.AddressType switch
+        {
+            "house" or "building" or "residential" => GeocodeMatchPrecision.Rooftop,
+            "road" or "street" or "pedestrian" or "footway" => GeocodeMatchPrecision.Street,
+            _ => place.PlaceRank switch
+            {
+                >= 30 => GeocodeMatchPrecision.Rooftop,
+                >= 26 => GeocodeMatchPrecision.Street,
+                _ => GeocodeMatchPrecision.Locality,
+            },
+        };
+    }
+
+    // Hardening: provider responses are untrusted input we persist downstream — trim and bound the length so a
+    // garbage / oversized OSM field cannot bloat a stored row.
+    private static string? Sanitize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        return trimmed.Length <= MaxComponentLength ? trimmed : trimmed[..MaxComponentLength];
     }
 
     private async Task ThrottleAsync(CancellationToken cancellationToken)

--- a/src/Granit.Geocoding.Nominatim/Internal/NominatimPlace.cs
+++ b/src/Granit.Geocoding.Nominatim/Internal/NominatimPlace.cs
@@ -3,8 +3,9 @@ using System.Text.Json.Serialization;
 namespace Granit.Geocoding.Nominatim.Internal;
 
 /// <summary>
-/// A single place from the Nominatim <c>/search</c> JSON array response. <c>lat</c> and <c>lon</c> are returned as
-/// strings in WGS 84 decimal degrees.
+/// A single place from the Nominatim <c>/search</c> JSON array response (<c>format=jsonv2</c>,
+/// <c>addressdetails=1</c>). <c>lat</c>/<c>lon</c> are WGS 84 decimal degrees as strings; <c>addresstype</c>
+/// and <c>place_rank</c> give the match granularity; the nested <c>address</c> object carries the parsed components.
 /// </summary>
 internal sealed record NominatimPlace
 {
@@ -13,4 +14,26 @@ internal sealed record NominatimPlace
 
     [JsonPropertyName("lon")]
     public string? Lon { get; init; }
+
+    [JsonPropertyName("addresstype")]
+    public string? AddressType { get; init; }
+
+    [JsonPropertyName("place_rank")]
+    public int PlaceRank { get; init; }
+
+    [JsonPropertyName("address")]
+    public NominatimAddress? Address { get; init; }
+}
+
+/// <summary>Parsed address components from Nominatim's <c>addressdetails=1</c> payload.</summary>
+internal sealed record NominatimAddress
+{
+    [JsonPropertyName("house_number")]
+    public string? HouseNumber { get; init; }
+
+    [JsonPropertyName("postcode")]
+    public string? Postcode { get; init; }
+
+    [JsonPropertyName("country_code")]
+    public string? CountryCode { get; init; }
 }

--- a/src/Granit.Geocoding.Photon/Internal/PhotonGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Photon/Internal/PhotonGeocodingProvider.cs
@@ -21,6 +21,9 @@ internal sealed partial class PhotonGeocodingProvider : IGeocodingProvider, IDis
 {
     internal const string HttpClientName = "Granit.Geocoding.Photon";
 
+    // Upper bound on a parsed address component persisted downstream (hardening against oversized OSM fields).
+    private const int MaxComponentLength = 64;
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptions<PhotonGeocodingOptions> _options;
     private readonly ILogger<PhotonGeocodingProvider> _logger;
@@ -47,7 +50,7 @@ internal sealed partial class PhotonGeocodingProvider : IGeocodingProvider, IDis
 
     public void Dispose() => _throttleGate.Dispose();
 
-    public async Task<GeoCoordinate?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)
+    public async Task<GeocodingResult?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(address);
 
@@ -71,15 +74,15 @@ internal sealed partial class PhotonGeocodingProvider : IGeocodingProvider, IDis
                 .ReadFromJsonAsync<PhotonResponse>(cancellationToken)
                 .ConfigureAwait(false);
 
-            GeoCoordinate? point = Map(body);
-            if (point is null && body?.Features is { Count: > 0 })
+            GeocodingResult? result = Map(body);
+            if (result is null && body?.Features is { Count: > 0 })
             {
                 // A result was returned but its coordinate was missing or out of WGS 84 range — treat the
                 // untrusted response as a miss rather than surfacing a bogus coordinate.
                 LogLookupFailed("InvalidCoordinate");
             }
 
-            return point;
+            return result;
         }
         catch (HttpRequestException)
         {
@@ -138,19 +141,60 @@ internal sealed partial class PhotonGeocodingProvider : IGeocodingProvider, IDis
         }
     }
 
-    private static GeoCoordinate? Map(PhotonResponse? response)
+    private static GeocodingResult? Map(PhotonResponse? response)
     {
         if (response?.Features is not { Count: > 0 })
         {
             return null;
         }
 
+        PhotonFeature feature = response.Features[0];
+
         // Untrusted external input: GeoJSON orders coordinates [longitude, latitude]. TryCreate returns null for a
         // missing or out-of-range pair, which ResolveAsync reports as a miss.
-        IReadOnlyList<double>? coordinates = response.Features[0].Geometry?.Coordinates;
-        return coordinates is { Count: >= 2 }
-            ? GeoCoordinate.TryCreate(coordinates[1], coordinates[0])
-            : null;
+        IReadOnlyList<double>? coordinates = feature.Geometry?.Coordinates;
+        if (coordinates is not { Count: >= 2 }
+            || GeoCoordinate.TryCreate(coordinates[1], coordinates[0]) is not { } coordinate)
+        {
+            return null;
+        }
+
+        PhotonProperties? properties = feature.Properties;
+        return new GeocodingResult(
+            coordinate,
+            DeterminePrecision(properties),
+            HouseNumber: Sanitize(properties?.HouseNumber),
+            PostalCode: Sanitize(properties?.Postcode),
+            CountryCode: Sanitize(properties?.CountryCode));
+    }
+
+    // Photon's feature type carries the granularity: a house number (or type "house") is rooftop, "street" is
+    // street, everything else (locality/city/district/region/country) is locality.
+    private static GeocodeMatchPrecision DeterminePrecision(PhotonProperties? properties)
+    {
+        if (!string.IsNullOrWhiteSpace(properties?.HouseNumber))
+        {
+            return GeocodeMatchPrecision.Rooftop;
+        }
+
+        return properties?.Type switch
+        {
+            "house" => GeocodeMatchPrecision.Rooftop,
+            "street" => GeocodeMatchPrecision.Street,
+            _ => GeocodeMatchPrecision.Locality,
+        };
+    }
+
+    // Hardening: provider responses are untrusted input we persist downstream — trim and bound the length.
+    private static string? Sanitize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        return trimmed.Length <= MaxComponentLength ? trimmed : trimmed[..MaxComponentLength];
     }
 
     private async Task ThrottleAsync(CancellationToken cancellationToken)

--- a/src/Granit.Geocoding.Photon/Internal/PhotonResponse.cs
+++ b/src/Granit.Geocoding.Photon/Internal/PhotonResponse.cs
@@ -3,8 +3,8 @@ using System.Text.Json.Serialization;
 namespace Granit.Geocoding.Photon.Internal;
 
 /// <summary>
-/// The Photon <c>/api</c> response — a GeoJSON <c>FeatureCollection</c>. Only the geometry is read; the rich
-/// textual properties of each feature are ignored (we need only the coordinate).
+/// The Photon <c>/api</c> response — a GeoJSON <c>FeatureCollection</c>. The geometry yields the coordinate and
+/// the feature <c>properties</c> the match granularity and parsed components.
 /// </summary>
 internal sealed record PhotonResponse
 {
@@ -17,6 +17,9 @@ internal sealed record PhotonFeature
 {
     [JsonPropertyName("geometry")]
     public PhotonGeometry? Geometry { get; init; }
+
+    [JsonPropertyName("properties")]
+    public PhotonProperties? Properties { get; init; }
 }
 
 /// <summary>
@@ -27,4 +30,23 @@ internal sealed record PhotonGeometry
 {
     [JsonPropertyName("coordinates")]
     public IReadOnlyList<double>? Coordinates { get; init; }
+}
+
+/// <summary>
+/// Photon feature properties: <c>type</c> (<c>house</c>/<c>street</c>/<c>locality</c>/…) gives the match
+/// granularity; the remaining fields are the parsed address components.
+/// </summary>
+internal sealed record PhotonProperties
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("housenumber")]
+    public string? HouseNumber { get; init; }
+
+    [JsonPropertyName("postcode")]
+    public string? Postcode { get; init; }
+
+    [JsonPropertyName("countrycode")]
+    public string? CountryCode { get; init; }
 }

--- a/src/Granit.Geocoding/Internal/DefaultGeocodingService.cs
+++ b/src/Granit.Geocoding/Internal/DefaultGeocodingService.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
-using Granit.Domain.ValueObjects;
 using Granit.Geocoding.Diagnostics;
 using Granit.Geocoding.Options;
 using Microsoft.Extensions.Logging;
@@ -47,7 +46,7 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
         _providers = OrderProviders(providers, _options.ProviderOrder);
     }
 
-    public async Task<GeoCoordinate?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default)
+    public async Task<GeocodingResult?> GeocodeAsync(PostalAddress address, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(address);
 
@@ -71,13 +70,13 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
         // bounds cost, third-party rate limits, and duplicate GDPR transfers. Negative results are cached too —
         // with the shorter FailureCacheDuration applied adaptively inside the factory.
         bool resolvedFresh = false;
-        GeoCoordinate? resolved = await _cache.GetOrSetAsync<GeoCoordinate?>(
+        GeocodingResult? resolved = await _cache.GetOrSetAsync<GeocodingResult?>(
             cacheKey,
             async (ctx, ct) =>
             {
                 resolvedFresh = true;
                 long start = Stopwatch.GetTimestamp();
-                GeoCoordinate? r = await QueryProvidersAsync(address, ct).ConfigureAwait(false);
+                GeocodingResult? r = await QueryProvidersAsync(address, ct).ConfigureAwait(false);
                 ctx.Options.Duration = r is null ? _options.FailureCacheDuration : _options.SuccessCacheDuration;
                 _metrics.RecordLookupDuration(r is null ? "not_found" : "found", Stopwatch.GetElapsedTime(start));
                 return r;
@@ -131,7 +130,7 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
             ? string.Empty
             : WhitespaceRegex().Replace(value.Trim(), " ").ToLower(CultureInfo.InvariantCulture);
 
-    private async Task<GeoCoordinate?> QueryProvidersAsync(PostalAddress address, CancellationToken cancellationToken)
+    private async Task<GeocodingResult?> QueryProvidersAsync(PostalAddress address, CancellationToken cancellationToken)
     {
         foreach (IGeocodingProvider provider in _providers)
         {
@@ -139,7 +138,7 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
 
             try
             {
-                GeoCoordinate? result = await provider.ResolveAsync(address, cancellationToken).ConfigureAwait(false);
+                GeocodingResult? result = await provider.ResolveAsync(address, cancellationToken).ConfigureAwait(false);
                 if (result is not null)
                 {
                     _metrics.RecordProviderAttempt(provider.ProviderName, "hit");

--- a/tests/Granit.Geocoding.Nominatim.Tests/NominatimGeocodingProviderTests.cs
+++ b/tests/Granit.Geocoding.Nominatim.Tests/NominatimGeocodingProviderTests.cs
@@ -19,18 +19,49 @@ public sealed class NominatimGeocodingProviderTests
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
     [Fact]
-    public async Task ResolveAsync_SuccessfulResponse_MapsFirstResultToGeoCoordinate()
+    public async Task ResolveAsync_SuccessfulResponse_MapsFirstResultToCoordinate()
     {
         const string json = """
             [{"lat":"50.8476","lon":"4.3572","display_name":"Brussels, Belgium"}]
             """;
         NominatimGeocodingProvider sut = CreateProvider(json, out _);
 
-        GeoCoordinate? result = await sut.ResolveAsync(Brussels, Ct);
+        GeocodingResult? result = await sut.ResolveAsync(Brussels, Ct);
 
         result.ShouldNotBeNull();
-        result.Latitude.ShouldBe(50.8476);
-        result.Longitude.ShouldBe(4.3572);
+        result.Coordinate.Latitude.ShouldBe(50.8476);
+        result.Coordinate.Longitude.ShouldBe(4.3572);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_HouseNumberMatch_IsRooftopWithParsedComponents()
+    {
+        const string json = """
+            [{"lat":"50.8476","lon":"4.3572","addresstype":"house","place_rank":30,
+              "address":{"house_number":"16","postcode":"1000","country_code":"be"}}]
+            """;
+        NominatimGeocodingProvider sut = CreateProvider(json, out _);
+
+        GeocodingResult result = (await sut.ResolveAsync(Brussels, Ct)).ShouldNotBeNull();
+
+        result.Precision.ShouldBe(GeocodeMatchPrecision.Rooftop);
+        result.HouseNumber.ShouldBe("16");
+        result.PostalCode.ShouldBe("1000");
+        result.CountryCode.ShouldBe("be");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_LocalityMatch_IsLocalityPrecisionWithoutHouseNumber()
+    {
+        const string json = """
+            [{"lat":"50.8503","lon":"4.3517","addresstype":"city","place_rank":16,"address":{"country_code":"be"}}]
+            """;
+        NominatimGeocodingProvider sut = CreateProvider(json, out _);
+
+        GeocodingResult result = (await sut.ResolveAsync(Brussels, Ct)).ShouldNotBeNull();
+
+        result.Precision.ShouldBe(GeocodeMatchPrecision.Locality);
+        result.HouseNumber.ShouldBeNull();
     }
 
     [Fact]
@@ -66,6 +97,7 @@ public sealed class NominatimGeocodingProviderTests
         uri.ShouldContain("country=BE");
         uri.ShouldContain("format=jsonv2");
         uri.ShouldContain("limit=1");
+        uri.ShouldContain("addressdetails=1");
     }
 
     [Fact]

--- a/tests/Granit.Geocoding.Photon.Tests/PhotonGeocodingProviderTests.cs
+++ b/tests/Granit.Geocoding.Photon.Tests/PhotonGeocodingProviderTests.cs
@@ -23,15 +23,46 @@ public sealed class PhotonGeocodingProviderTests
         """{"type":"FeatureCollection","features":[{"geometry":{"type":"Point","coordinates":[4.3572,50.8476]}}]}""";
 
     [Fact]
-    public async Task ResolveAsync_SuccessfulResponse_MapsFirstFeatureToGeoCoordinate()
+    public async Task ResolveAsync_SuccessfulResponse_MapsFirstFeatureToCoordinate()
     {
         PhotonGeocodingProvider sut = CreateProvider(BrusselsFeature, out _);
 
-        GeoCoordinate? result = await sut.ResolveAsync(Brussels, Ct);
+        GeocodingResult? result = await sut.ResolveAsync(Brussels, Ct);
 
         result.ShouldNotBeNull();
-        result.Latitude.ShouldBe(50.8476);
-        result.Longitude.ShouldBe(4.3572);
+        result.Coordinate.Latitude.ShouldBe(50.8476);
+        result.Coordinate.Longitude.ShouldBe(4.3572);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_HouseFeature_IsRooftopWithParsedComponents()
+    {
+        const string json = """
+            {"features":[{"geometry":{"coordinates":[4.3572,50.8476]},
+              "properties":{"type":"house","housenumber":"16","postcode":"1000","countrycode":"BE"}}]}
+            """;
+        PhotonGeocodingProvider sut = CreateProvider(json, out _);
+
+        GeocodingResult result = (await sut.ResolveAsync(Brussels, Ct)).ShouldNotBeNull();
+
+        result.Precision.ShouldBe(GeocodeMatchPrecision.Rooftop);
+        result.HouseNumber.ShouldBe("16");
+        result.PostalCode.ShouldBe("1000");
+        result.CountryCode.ShouldBe("BE");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CityFeature_IsLocalityPrecision()
+    {
+        const string json = """
+            {"features":[{"geometry":{"coordinates":[4.3517,50.8503]},"properties":{"type":"city","countrycode":"BE"}}]}
+            """;
+        PhotonGeocodingProvider sut = CreateProvider(json, out _);
+
+        GeocodingResult result = (await sut.ResolveAsync(Brussels, Ct)).ShouldNotBeNull();
+
+        result.Precision.ShouldBe(GeocodeMatchPrecision.Locality);
+        result.HouseNumber.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/Granit.Geocoding.Tests/DefaultGeocodingServiceTests.cs
+++ b/tests/Granit.Geocoding.Tests/DefaultGeocodingServiceTests.cs
@@ -16,7 +16,7 @@ public sealed class DefaultGeocodingServiceTests
     private static readonly PostalAddress Brussels =
         new(Street: "Rue de la Loi 16", PostalCode: "1000", Locality: "Brussels", Country: "BE");
 
-    private static readonly GeoCoordinate BrusselsPoint = new(50.8503, 4.3517);
+    private static readonly GeocodingResult BrusselsResult = Result(50.8503, 4.3517);
 
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
@@ -31,7 +31,7 @@ public sealed class DefaultGeocodingServiceTests
     [Fact]
     public async Task GeocodeAsync_NullAddress_Throws()
     {
-        DefaultGeocodingService sut = CreateService([StubProvider("Nominatim", Brussels, BrusselsPoint)]);
+        DefaultGeocodingService sut = CreateService([StubProvider("Nominatim", Brussels, BrusselsResult)]);
 
         await Should.ThrowAsync<ArgumentNullException>(async () => await sut.GeocodeAsync(null!, Ct));
     }
@@ -39,7 +39,7 @@ public sealed class DefaultGeocodingServiceTests
     [Fact]
     public async Task GeocodeAsync_BlankLocalityAndCountry_SkipsWithoutCallingProvider()
     {
-        IGeocodingProvider provider = StubProvider("Nominatim", Brussels, BrusselsPoint);
+        IGeocodingProvider provider = StubProvider("Nominatim", Brussels, BrusselsResult);
         DefaultGeocodingService sut = CreateService([provider]);
 
         PostalAddress empty = new(Street: null, PostalCode: null, Locality: "  ", Country: "");
@@ -50,22 +50,22 @@ public sealed class DefaultGeocodingServiceTests
     [Fact]
     public async Task GeocodeAsync_FirstProviderHits_ReturnsItsResult()
     {
-        DefaultGeocodingService sut = CreateService([StubProvider("Nominatim", Brussels, BrusselsPoint)]);
+        DefaultGeocodingService sut = CreateService([StubProvider("Nominatim", Brussels, BrusselsResult)]);
 
-        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(BrusselsPoint);
+        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(BrusselsResult);
     }
 
     [Fact]
     public async Task GeocodeAsync_FirstProviderMisses_FallsBackToNext()
     {
         IGeocodingProvider first = StubProvider("First", Brussels, result: null);
-        IGeocodingProvider second = StubProvider("Second", Brussels, BrusselsPoint);
+        IGeocodingProvider second = StubProvider("Second", Brussels, BrusselsResult);
 
         DefaultGeocodingService sut = CreateService(
             [first, second],
             new GranitGeocodingOptions { ProviderOrder = { "First", "Second" } });
 
-        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(BrusselsPoint);
+        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(BrusselsResult);
     }
 
     [Fact]
@@ -74,20 +74,20 @@ public sealed class DefaultGeocodingServiceTests
         IGeocodingProvider faulty = Substitute.For<IGeocodingProvider>();
         faulty.ProviderName.Returns("Faulty");
         faulty.ResolveAsync(Brussels, Arg.Any<CancellationToken>())
-            .Returns<Task<GeoCoordinate?>>(_ => throw new InvalidOperationException("boom"));
-        IGeocodingProvider healthy = StubProvider("Healthy", Brussels, BrusselsPoint);
+            .Returns<Task<GeocodingResult?>>(_ => throw new InvalidOperationException("boom"));
+        IGeocodingProvider healthy = StubProvider("Healthy", Brussels, BrusselsResult);
 
         DefaultGeocodingService sut = CreateService(
             [faulty, healthy],
             new GranitGeocodingOptions { ProviderOrder = { "Faulty", "Healthy" } });
 
-        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(BrusselsPoint);
+        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(BrusselsResult);
     }
 
     [Fact]
     public async Task GeocodeAsync_RepeatedLookup_IsCachedAndProviderCalledOnce()
     {
-        IGeocodingProvider provider = StubProvider("Nominatim", Brussels, BrusselsPoint);
+        IGeocodingProvider provider = StubProvider("Nominatim", Brussels, BrusselsResult);
         DefaultGeocodingService sut = CreateService([provider]);
 
         await sut.GeocodeAsync(Brussels, Ct);
@@ -114,7 +114,7 @@ public sealed class DefaultGeocodingServiceTests
         // Same address, different casing/padding — must hit one provider call thanks to key normalisation.
         IGeocodingProvider provider = Substitute.For<IGeocodingProvider>();
         provider.ProviderName.Returns("Nominatim");
-        provider.ResolveAsync(Arg.Any<PostalAddress>(), Arg.Any<CancellationToken>()).Returns(BrusselsPoint);
+        provider.ResolveAsync(Arg.Any<PostalAddress>(), Arg.Any<CancellationToken>()).Returns(BrusselsResult);
         DefaultGeocodingService sut = CreateService([provider]);
 
         await sut.GeocodeAsync(new PostalAddress("Rue de la Loi 16", "1000", "Brussels", "BE"), Ct);
@@ -126,21 +126,23 @@ public sealed class DefaultGeocodingServiceTests
     [Fact]
     public async Task GeocodeAsync_ProviderOrder_DeterminesPriority()
     {
-        IGeocodingProvider first = StubProvider("First", Brussels, new GeoCoordinate(1, 1));
-        IGeocodingProvider second = StubProvider("Second", Brussels, new GeoCoordinate(2, 2));
+        GeocodingResult firstResult = Result(1, 1);
+        GeocodingResult secondResult = Result(2, 2);
+        IGeocodingProvider first = StubProvider("First", Brussels, firstResult);
+        IGeocodingProvider second = StubProvider("Second", Brussels, secondResult);
 
         DefaultGeocodingService sut = CreateService(
             [first, second],
             new GranitGeocodingOptions { ProviderOrder = { "Second", "First" } });
 
-        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(new GeoCoordinate(2, 2));
+        (await sut.GeocodeAsync(Brussels, Ct)).ShouldBe(secondResult);
         await first.DidNotReceive().ResolveAsync(Arg.Any<PostalAddress>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GeocodeAsync_UnknownProviderInOrder_IsSkipped()
     {
-        IGeocodingProvider provider = StubProvider("Nominatim", Brussels, BrusselsPoint);
+        IGeocodingProvider provider = StubProvider("Nominatim", Brussels, BrusselsResult);
         DefaultGeocodingService sut = CreateService(
             [provider],
             new GranitGeocodingOptions { ProviderOrder = { "DoesNotExist" } });
@@ -179,7 +181,10 @@ public sealed class DefaultGeocodingServiceTests
         key.ShouldNotBe(DefaultGeocodingService.BuildCacheKey("paris||paris|fr"));        // distinct per address
     }
 
-    private static IGeocodingProvider StubProvider(string name, PostalAddress address, GeoCoordinate? result)
+    private static GeocodingResult Result(double latitude, double longitude) =>
+        new(new GeoCoordinate(latitude, longitude), GeocodeMatchPrecision.Rooftop);
+
+    private static IGeocodingProvider StubProvider(string name, PostalAddress address, GeocodingResult? result)
     {
         IGeocodingProvider provider = Substitute.For<IGeocodingProvider>();
         provider.ProviderName.Returns(name);


### PR DESCRIPTION
## Context

Phase 1 of the **address platform** (builds on #2864). The geocoding contract now returns a **`GeocodingResult`** (coordinate + match precision + parsed components) instead of a bare `GeoCoordinate`. This is the *tier-0 plausibility* signal — and it's essentially free: the data already rides the existing Nominatim/Photon responses, which the providers previously discarded.

Downstream (Phase 2 enrichment, Phase 3 Parties) can now distinguish a rooftop match from a locality centroid (`Resolved` vs `Approximate`) and cross-check the result against the submitted address.

## What's in this PR

- **`Granit.Geocoding.Abstractions`**: new `GeocodingResult` record. `IGeocodingProvider.ResolveAsync` and `IGeocodingService.GeocodeAsync` now return `GeocodingResult?` (**breaking**, pre-1.0).
- **`DefaultGeocodingService`**: caches/chains `GeocodingResult?` — cache key, stampede protection and the GDPR posture (no address in logs/keys) unchanged.
- **Nominatim**: requests `addressdetails=1`; maps `addresstype`/`place_rank` + the parsed `address` block to a precision (rooftop/street/locality) and components (house number, postcode, country code).
- **Photon**: parses the feature `properties` (`type`/`housenumber`/`postcode`/`countrycode`) it previously ignored.
- **Hardening**: parsed provider components (untrusted external input we persist downstream) are trimmed and length-bounded.

## Scope notes
- OSM geocoding gives a *plausibility* signal, **not** authoritative deliverability — that's the later tier-1 `Granit.AddressVerification` abstraction (Phase 2) and tier-2 evidence (Phase 3).
- Blast radius is contained to the geocoding packages — no other granit-dotnet consumer of `IGeocodingService` exists (`Granit.Analytics.MapRunner` in granit-business consumes via NuGet and adapts in its own phase).
- Autocomplete/reverse **capability interfaces are deferred** to the phases that implement them (5/6) rather than shipped unused.

## Verification
- `Granit.Geocoding.Tests` 19/19, `Granit.Geocoding.Nominatim.Tests` 25/25, `Granit.Geocoding.Photon.Tests` 26/26, `Granit.Geocoding.Abstractions.Tests` 4/4 — including new precision/component cases per provider.
- `dotnet format --verify-no-changes` clean on all touched projects.

No new dependencies, no new test projects (no shard changes), no migrations.