### PR TITLE
fix(addressing): correct AddressEnrichment rename residues + align component bound

### DIFF
--- a/src/Granit.AddressEnrichment/Granit.AddressEnrichment.csproj
+++ b/src/Granit.AddressEnrichment/Granit.AddressEnrichment.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.AddressEnrichment</PackageId>
-    <Description>Address enrichment orchestrator for Granit: turns a domain Address into its geocoding outcome (AddressGeocoding) and deliverability verdict (AddressVerification) by composing the geocoding engine (tier 0) and an optional address-verification provider (tier 1). A thin layer above Granit.Geocoding and Granit.AddressVerification.Abstractions so any address-holding module materializes both axes the same way.</Description>
+    <Description>Address enrichment orchestrator for Granit: turns a domain Address into its geocoding outcome (AddressGeocoding) and deliverability verdict (AddressVerification) by composing the geocoding engine (tier 0) and an optional address-verification provider (tier 1). A thin layer above Granit.Geocoding and Granit.AddressDeliverability.Abstractions so any address-holding module materializes both axes the same way.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.AddressEnrichment/README.md
+++ b/src/Granit.AddressEnrichment/README.md
@@ -22,15 +22,15 @@ public interface IAddressEnrichmentService
 public sealed record AddressEnrichmentResult(AddressGeocoding Geocoding, AddressVerification Verification);
 ```
 
-It sits **above** `Granit.Geocoding` and `Granit.AddressVerification.Abstractions` (it
-never makes the geocoding engine depend on verification).
+It sits **above** `Granit.Geocoding` and `Granit.AddressDeliverability.Abstractions` (it
+never makes the geocoding engine depend on deliverability).
 
 ## Behaviour
 
 - **Tier 0 (always):** geocodes via `IGeocodingService`; a hit becomes
   `AddressGeocoding.Resolved` (or `Approximate` for a locality centroid), a miss becomes
   `AddressGeocoding.Failed`.
-- **Tier 1 (optional):** if an `IAddressVerificationService` provider is registered, it is
+- **Tier 1 (optional):** if an `IAddressDeliverabilityService` provider is registered, it is
   called and the provider outcome is mapped onto `AddressVerificationStatus`
   (`Verified → ProviderVerified`, `Corrected → Corrected`, `Invalid → Invalid`,
   `Unverifiable → Unverified`). With no provider, the verdict stays `Unverified`.
@@ -44,4 +44,4 @@ The verification provider is an optional soft dependency, resolved at registrati
 ## See also
 
 - [`Granit.Geocoding`](../Granit.Geocoding/README.md) — tier 0 engine.
-- [`Granit.AddressVerification.Abstractions`](../Granit.AddressVerification.Abstractions/README.md) — tier 1 contract.
+- [`Granit.AddressDeliverability.Abstractions`](../Granit.AddressDeliverability.Abstractions/README.md) — tier 1 contract.

--- a/src/Granit.Geocoding.Nominatim/Internal/NominatimGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Nominatim/Internal/NominatimGeocodingProvider.cs
@@ -22,7 +22,8 @@ internal sealed partial class NominatimGeocodingProvider : IGeocodingProvider, I
     internal const string HttpClientName = "Granit.Geocoding.Nominatim";
 
     // Upper bound on a parsed address component persisted downstream (hardening against oversized OSM fields).
-    private const int MaxComponentLength = 64;
+    // Aligned with the AddressGeocoding flat-column width (MapAddressGeocoding maps HouseNumber to varchar(32)).
+    private const int MaxComponentLength = 32;
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptions<NominatimGeocodingOptions> _options;

--- a/src/Granit.Geocoding.Photon/Internal/PhotonGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Photon/Internal/PhotonGeocodingProvider.cs
@@ -22,7 +22,8 @@ internal sealed partial class PhotonGeocodingProvider : IGeocodingProvider, IDis
     internal const string HttpClientName = "Granit.Geocoding.Photon";
 
     // Upper bound on a parsed address component persisted downstream (hardening against oversized OSM fields).
-    private const int MaxComponentLength = 64;
+    // Aligned with the AddressGeocoding flat-column width (MapAddressGeocoding maps HouseNumber to varchar(32)).
+    private const int MaxComponentLength = 32;
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptions<PhotonGeocodingOptions> _options;

--- a/src/Granit/Domain/ValueObjects/AddressGeocoding.cs
+++ b/src/Granit/Domain/ValueObjects/AddressGeocoding.cs
@@ -17,7 +17,7 @@ namespace Granit.Domain.ValueObjects;
 /// never the source.
 /// </para>
 /// <para>
-/// Persisted as flat columns via the framework's <c>ConfigureAddressGeocoding</c> EF helper (not the
+/// Persisted as flat columns via the framework's <c>MapAddressGeocoding</c> EF helper (not the
 /// default value-object JSON path), so <see cref="Status"/> stays directly queryable for dashboards and the
 /// coordinate feeds map widgets without a JSON projection. Equality is structural over all stored components.
 /// </para>

--- a/src/Granit/Domain/ValueObjects/AddressVerification.cs
+++ b/src/Granit/Domain/ValueObjects/AddressVerification.cs
@@ -15,7 +15,7 @@ namespace Granit.Domain.ValueObjects;
 /// evidence but can originate from a system signal.
 /// </para>
 /// <para>
-/// Persisted as flat columns via the framework's <c>ConfigureAddressVerification</c> EF helper. Equality is
+/// Persisted as flat columns via the framework's <c>MapAddressVerification</c> EF helper. Equality is
 /// structural over all stored components.
 /// </para>
 /// </remarks>


### PR DESCRIPTION
Follow-up cleanup from the audit of #2864 / #2865 / #2866. All findings are CONVENTION/CLEANUP — no behavior change beyond a tightened component bound.

## Findings fixed

**Rename residues** — the tier-1 package was renamed `AddressVerification.Abstractions` → `AddressDeliverability.Abstractions` (a `Granit.AddressVerification` namespace would shadow the `AddressVerification` value object). The rename didn't propagate to the orchestrator's own metadata; CI can't catch it (namespaces are correct, so the arch-test passes — prose only).

- `Granit.AddressEnrichment.csproj` `<Description>`: stale package name
- `Granit.AddressEnrichment/README.md`: stale package name, wrong interface name (`IAddressVerificationService` → `IAddressDeliverabilityService`), dead relative link

**Doc accuracy** — `AddressGeocoding`/`AddressVerification` XML docs referenced a non-existent `ConfigureAddress*` EF helper; the actual public methods are `MapAddressGeocoding`/`MapAddressVerification`.

**Defense-bound alignment** — the geocoding providers sanitized parsed components to 64 chars, but `AddressGeocoding.HouseNumber` persists to `varchar(32)`. A 33–64-char `house_number` would overflow on PostgreSQL insert (rare, but the bounds should agree). Lowered `MaxComponentLength` 64 → 32 in the Nominatim and Photon providers.

## Verification

- 4 touched projects build clean (0 errors)
- markdownlint clean on the README
- 57 tests pass (Nominatim 25, Photon 26, AddressEnrichment 6)