### PR TITLE
feat(geocoding): address autocomplete capability + GeocodingCapabilities

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22765,6 +22765,15 @@
       ]
     },
     {
+      "name": "AddressSuggestion",
+      "fqn": "Granit.Geocoding.AddressSuggestion",
+      "kind": "record",
+      "project": "Granit.Geocoding.Abstractions",
+      "file": "src/Granit.Geocoding.Abstractions/AddressSuggestion.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "GeocodingMetrics",
       "fqn": "Granit.Geocoding.Diagnostics.GeocodingMetrics",
       "kind": "class",
@@ -22815,6 +22824,15 @@
       ]
     },
     {
+      "name": "GeocodingCapabilities",
+      "fqn": "Granit.Geocoding.GeocodingCapabilities",
+      "kind": "record",
+      "project": "Granit.Geocoding.Abstractions",
+      "file": "src/Granit.Geocoding.Abstractions/GeocodingCapabilities.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "GeocodingResult",
       "fqn": "Granit.Geocoding.GeocodingResult",
       "kind": "record",
@@ -22836,6 +22854,38 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAddressAutocompleteProvider",
+      "fqn": "Granit.Geocoding.IAddressAutocompleteProvider",
+      "kind": "interface",
+      "project": "Granit.Geocoding.Abstractions",
+      "file": "src/Granit.Geocoding.Abstractions/IAddressAutocompleteProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "SuggestAsync",
+          "kind": "method",
+          "signature": "SuggestAsync(string query, int limit, CancellationToken cancellationToken = default)",
+          "returnType": "string ProviderName { get; } Task<IReadOnlyList<AddressSuggestion>>"
+        }
+      ]
+    },
+    {
+      "name": "IAddressAutocompleteService",
+      "fqn": "Granit.Geocoding.IAddressAutocompleteService",
+      "kind": "interface",
+      "project": "Granit.Geocoding.Abstractions",
+      "file": "src/Granit.Geocoding.Abstractions/IAddressAutocompleteService.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "SuggestAsync",
+          "kind": "method",
+          "signature": "SuggestAsync(string query, int limit = 5, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<AddressSuggestion>>"
         }
       ]
     },

--- a/src/Granit.Geocoding.Abstractions/AddressSuggestion.cs
+++ b/src/Granit.Geocoding.Abstractions/AddressSuggestion.cs
@@ -1,0 +1,17 @@
+using Granit.Domain.ValueObjects;
+
+namespace Granit.Geocoding;
+
+/// <summary>
+/// A single address-autocomplete suggestion: a display label plus the structured components a UI uses to fill a
+/// form when the user picks it.
+/// </summary>
+/// <param name="Label">Human-readable one-line label for the typeahead list (e.g. <c>"Rue de la Loi 16, 1000 Brussels, BE"</c>).</param>
+/// <param name="Address">The structured postal components of the suggestion.</param>
+/// <param name="Coordinate">The suggestion's coordinate, or <c>null</c> when the provider returned none.</param>
+/// <param name="Precision">Granularity of the suggestion (rooftop / street / locality), or <c>null</c> when unknown.</param>
+public sealed record AddressSuggestion(
+    string Label,
+    PostalAddress Address,
+    GeoCoordinate? Coordinate,
+    GeocodeMatchPrecision? Precision);

--- a/src/Granit.Geocoding.Abstractions/GeocodingCapabilities.cs
+++ b/src/Granit.Geocoding.Abstractions/GeocodingCapabilities.cs
@@ -1,0 +1,11 @@
+namespace Granit.Geocoding;
+
+/// <summary>
+/// Which geocoding capabilities the registered providers collectively support. Computed once from the provider
+/// set so a host (or an endpoint) can branch on what is actually available — e.g. only map an autocomplete
+/// endpoint when an autocomplete-capable provider is installed.
+/// </summary>
+/// <param name="Forward">At least one <see cref="IGeocodingProvider"/> is registered.</param>
+/// <param name="Autocomplete">At least one <see cref="IAddressAutocompleteProvider"/> is registered.</param>
+/// <param name="Reverse">At least one <see cref="IReverseGeocodingProvider"/> is registered.</param>
+public sealed record GeocodingCapabilities(bool Forward, bool Autocomplete, bool Reverse);

--- a/src/Granit.Geocoding.Abstractions/IAddressAutocompleteProvider.cs
+++ b/src/Granit.Geocoding.Abstractions/IAddressAutocompleteProvider.cs
@@ -1,0 +1,25 @@
+namespace Granit.Geocoding;
+
+/// <summary>
+/// Low-level address-autocomplete (typeahead) lookup — an optional provider capability.
+/// </summary>
+/// <remarks>
+/// A provider package implements this only when its backend is built for typeahead (e.g. Photon). A pure
+/// forward/reverse geocoder (e.g. Nominatim, whose usage policy discourages per-keystroke queries) does not.
+/// Registering the same provider instance for every capability it supports keeps one shared rate-limit throttle.
+/// </remarks>
+public interface IAddressAutocompleteProvider
+{
+    /// <summary>
+    /// Stable identifier used to order this provider in the geocoding <c>ProviderOrder</c> (e.g. <c>"Photon"</c>).
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>Returns up to <paramref name="limit"/> suggestions for the partial <paramref name="query"/>.</summary>
+    /// <param name="query">The partial address text typed so far.</param>
+    /// <param name="limit">Maximum number of suggestions to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The suggestions (possibly empty); never <c>null</c>.</returns>
+    Task<IReadOnlyList<AddressSuggestion>> SuggestAsync(
+        string query, int limit, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Geocoding.Abstractions/IAddressAutocompleteService.cs
+++ b/src/Granit.Geocoding.Abstractions/IAddressAutocompleteService.cs
@@ -1,0 +1,20 @@
+namespace Granit.Geocoding;
+
+/// <summary>
+/// Suggests addresses for a partial query (typeahead), applying the configured provider order.
+/// </summary>
+/// <remarks>
+/// Privacy-first no-op: returns an empty list when no autocomplete-capable provider is registered, and never
+/// surfaces a provider failure to the caller. Not cached — typeahead queries have a low cache-hit rate and are
+/// expected to be debounced by the caller.
+/// </remarks>
+public interface IAddressAutocompleteService
+{
+    /// <summary>Returns up to <paramref name="limit"/> suggestions for the partial <paramref name="query"/>.</summary>
+    /// <param name="query">The partial address text typed so far.</param>
+    /// <param name="limit">Maximum number of suggestions to return (clamped to a sane range).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The suggestions (empty when the query is blank or no provider is enabled); never <c>null</c>.</returns>
+    Task<IReadOnlyList<AddressSuggestion>> SuggestAsync(
+        string query, int limit = 5, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Geocoding.Photon/Extensions/GeocodingPhotonHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Geocoding.Photon/Extensions/GeocodingPhotonHostApplicationBuilderExtensions.cs
@@ -76,6 +76,8 @@ public static class GeocodingPhotonHostApplicationBuilderExtensions
             static sp => sp.GetRequiredService<PhotonGeocodingProvider>());
         builder.Services.AddSingleton<IReverseGeocodingProvider>(
             static sp => sp.GetRequiredService<PhotonGeocodingProvider>());
+        builder.Services.AddSingleton<IAddressAutocompleteProvider>(
+            static sp => sp.GetRequiredService<PhotonGeocodingProvider>());
 
         return builder;
     }

--- a/src/Granit.Geocoding.Photon/Internal/PhotonGeocodingProvider.cs
+++ b/src/Granit.Geocoding.Photon/Internal/PhotonGeocodingProvider.cs
@@ -17,7 +17,8 @@ namespace Granit.Geocoding.Photon.Internal;
 /// <see cref="PhotonGeocodingOptions.RateLimitPerSecond"/>, honouring komoot's fair-use policy. Failures are caught
 /// here and the address is never logged.
 /// </remarks>
-internal sealed partial class PhotonGeocodingProvider : IGeocodingProvider, IReverseGeocodingProvider, IDisposable
+internal sealed partial class PhotonGeocodingProvider
+    : IGeocodingProvider, IReverseGeocodingProvider, IAddressAutocompleteProvider, IDisposable
 {
     internal const string HttpClientName = "Granit.Geocoding.Photon";
 
@@ -163,6 +164,142 @@ internal sealed partial class PhotonGeocodingProvider : IGeocodingProvider, IRev
             LogLookupFailed(nameof(NotSupportedException));
             return null;
         }
+    }
+
+    public async Task<IReadOnlyList<AddressSuggestion>> SuggestAsync(
+        string query, int limit, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+
+        string requestQuery = BuildAutocompleteQuery(query, limit, _options.Value.Language);
+        HttpClient client = _httpClientFactory.CreateClient(HttpClientName);
+
+        try
+        {
+            // Shared throttle: autocomplete paces through the same gate as forward/reverse (komoot fair-use policy).
+            await ThrottleAsync(cancellationToken).ConfigureAwait(false);
+
+            using HttpRequestMessage request = new(HttpMethod.Get, $"api?{requestQuery}");
+            using HttpResponseMessage response =
+                await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                LogRequestUnsuccessful((int)response.StatusCode);
+                return [];
+            }
+
+            PhotonResponse? body = await response.Content
+                .ReadFromJsonAsync<PhotonResponse>(cancellationToken)
+                .ConfigureAwait(false);
+
+            return MapSuggestions(body);
+        }
+        catch (HttpRequestException)
+        {
+            LogLookupFailed(nameof(HttpRequestException));
+            return [];
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            LogLookupFailed("Timeout");
+            return [];
+        }
+        catch (JsonException)
+        {
+            LogLookupFailed(nameof(JsonException));
+            return [];
+        }
+        catch (NotSupportedException)
+        {
+            LogLookupFailed(nameof(NotSupportedException));
+            return [];
+        }
+    }
+
+    private static string BuildAutocompleteQuery(string query, int limit, string? language)
+    {
+        List<string> parameters =
+        [
+            $"q={Uri.EscapeDataString(query.Trim())}",
+            $"limit={limit.ToString(System.Globalization.CultureInfo.InvariantCulture)}",
+        ];
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            parameters.Add($"lang={Uri.EscapeDataString(language.Trim())}");
+        }
+
+        return string.Join('&', parameters);
+    }
+
+    private static List<AddressSuggestion> MapSuggestions(PhotonResponse? response)
+    {
+        if (response?.Features is not { Count: > 0 } features)
+        {
+            return [];
+        }
+
+        List<AddressSuggestion> suggestions = new(features.Count);
+        foreach (PhotonFeature feature in features)
+        {
+            PhotonProperties? properties = feature.Properties;
+            if (properties is null)
+            {
+                continue;
+            }
+
+            IReadOnlyList<double>? coordinates = feature.Geometry?.Coordinates;
+            GeoCoordinate? coordinate = coordinates is { Count: >= 2 }
+                ? GeoCoordinate.TryCreate(coordinates[1], coordinates[0])
+                : null;
+
+            PostalAddress address = new(
+                Street: BuildStreet(properties),
+                PostalCode: Sanitize(properties.Postcode),
+                Locality: Sanitize(properties.City) ?? string.Empty,
+                Country: Sanitize(properties.CountryCode)?.ToUpperInvariant() ?? string.Empty);
+
+            suggestions.Add(new AddressSuggestion(
+                BuildLabel(properties),
+                address,
+                coordinate,
+                DeterminePrecision(properties)));
+        }
+
+        return suggestions;
+    }
+
+    private static string BuildLabel(PhotonProperties properties)
+    {
+        List<string> parts = [];
+
+        string? street = BuildStreet(properties);
+        if (street is not null)
+        {
+            parts.Add(street);
+        }
+        else if (Sanitize(properties.Name) is { } name)
+        {
+            parts.Add(name);
+        }
+
+        string locality = string.Join(' ', new[] { Sanitize(properties.Postcode), Sanitize(properties.City) }
+            .Where(static p => p is not null));
+        if (locality.Length > 0)
+        {
+            parts.Add(locality);
+        }
+
+        if (Sanitize(properties.CountryCode)?.ToUpperInvariant() is { } country)
+        {
+            parts.Add(country);
+        }
+
+        // Fall back to the raw name so a suggestion always has a non-empty label.
+        return parts.Count > 0 ? string.Join(", ", parts) : Sanitize(properties.Name) ?? string.Empty;
     }
 
     private static string BuildReverseQuery(GeoCoordinate coordinate, string? language)

--- a/src/Granit.Geocoding/GranitGeocodingModule.cs
+++ b/src/Granit.Geocoding/GranitGeocodingModule.cs
@@ -37,5 +37,13 @@ public sealed class GranitGeocodingModule : GranitModule
         context.Services.TryAddSingleton<GeocodingMetrics>();
         context.Services.TryAddSingleton<IGeocodingService, DefaultGeocodingService>();
         context.Services.TryAddSingleton<IReverseGeocodingService, DefaultReverseGeocodingService>();
+        context.Services.TryAddSingleton<IAddressAutocompleteService, DefaultAddressAutocompleteService>();
+
+        // Computed once from the registered provider set so hosts/endpoints can branch on what is available
+        // (e.g. only map an autocomplete endpoint when an autocomplete-capable provider is installed).
+        context.Services.TryAddSingleton(serviceProvider => new GeocodingCapabilities(
+            Forward: serviceProvider.GetServices<IGeocodingProvider>().Any(),
+            Autocomplete: serviceProvider.GetServices<IAddressAutocompleteProvider>().Any(),
+            Reverse: serviceProvider.GetServices<IReverseGeocodingProvider>().Any()));
     }
 }

--- a/src/Granit.Geocoding/Internal/DefaultAddressAutocompleteService.cs
+++ b/src/Granit.Geocoding/Internal/DefaultAddressAutocompleteService.cs
@@ -1,0 +1,116 @@
+using Granit.Geocoding.Diagnostics;
+using Granit.Geocoding.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Geocoding.Internal;
+
+/// <summary>
+/// Default <see cref="IAddressAutocompleteService"/>: orders the autocomplete-capable providers per
+/// <see cref="GranitGeocodingOptions.ProviderOrder"/> and returns the first provider's suggestions.
+/// </summary>
+/// <remarks>
+/// No caching — typeahead queries have a low cache-hit rate and are expected to be debounced by the caller.
+/// Provider exceptions are swallowed (logged with the provider name only — <strong>never the query</strong>, which
+/// is partial personal data) so a failing provider degrades to the next, and an empty provider set is a silent
+/// no-op. Blank or too-short queries short-circuit to an empty list before any provider is called.
+/// </remarks>
+internal sealed partial class DefaultAddressAutocompleteService : IAddressAutocompleteService
+{
+    private const int MinLimit = 1;
+    private const int MaxLimit = 10;
+    private const int MinQueryLength = 2;
+
+    private readonly List<IAddressAutocompleteProvider> _providers;
+    private readonly GeocodingMetrics _metrics;
+    private readonly ILogger<DefaultAddressAutocompleteService> _logger;
+
+    public DefaultAddressAutocompleteService(
+        IEnumerable<IAddressAutocompleteProvider> providers,
+        IOptions<GranitGeocodingOptions> options,
+        GeocodingMetrics metrics,
+        ILogger<DefaultAddressAutocompleteService> logger)
+    {
+        _metrics = metrics;
+        _logger = logger;
+        _providers = OrderProviders(providers, options.Value.ProviderOrder);
+    }
+
+    public async Task<IReadOnlyList<AddressSuggestion>> SuggestAsync(
+        string query, int limit = 5, CancellationToken cancellationToken = default)
+    {
+        if (_providers.Count == 0 || string.IsNullOrWhiteSpace(query) || query.Trim().Length < MinQueryLength)
+        {
+            return [];
+        }
+
+        int clampedLimit = Math.Clamp(limit, MinLimit, MaxLimit);
+        string trimmed = query.Trim();
+
+        foreach (IAddressAutocompleteProvider provider in _providers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                IReadOnlyList<AddressSuggestion> suggestions =
+                    await provider.SuggestAsync(trimmed, clampedLimit, cancellationToken).ConfigureAwait(false);
+                if (suggestions.Count > 0)
+                {
+                    _metrics.RecordProviderAttempt(provider.ProviderName, "hit");
+                    return suggestions;
+                }
+
+                _metrics.RecordProviderAttempt(provider.ProviderName, "miss");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Provider failures must degrade to the next provider, never bubble up.
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _metrics.RecordProviderAttempt(provider.ProviderName, "error");
+
+                // GDPR: log the provider and the exception only — never the partial query being autocompleted.
+                LogProviderFailed(provider.ProviderName, ex);
+            }
+        }
+
+        return [];
+    }
+
+    private static List<IAddressAutocompleteProvider> OrderProviders(
+        IEnumerable<IAddressAutocompleteProvider> providers, IList<string> order)
+    {
+        List<IAddressAutocompleteProvider> registered = [.. providers];
+        if (order.Count == 0)
+        {
+            return registered;
+        }
+
+        Dictionary<string, IAddressAutocompleteProvider> byName = new(StringComparer.OrdinalIgnoreCase);
+        foreach (IAddressAutocompleteProvider provider in registered)
+        {
+            byName.TryAdd(provider.ProviderName, provider);
+        }
+
+        List<IAddressAutocompleteProvider> ordered = [];
+        foreach (string name in order)
+        {
+            if (byName.TryGetValue(name, out IAddressAutocompleteProvider? provider))
+            {
+                ordered.Add(provider);
+            }
+        }
+
+        return ordered;
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Warning,
+        Message = "Address autocomplete provider '{Provider}' failed; falling back to the next provider.")]
+    private partial void LogProviderFailed(string provider, Exception exception);
+}

--- a/tests/Granit.Geocoding.Photon.Tests/PhotonGeocodingProviderTests.cs
+++ b/tests/Granit.Geocoding.Photon.Tests/PhotonGeocodingProviderTests.cs
@@ -209,6 +209,59 @@ public sealed class PhotonGeocodingProviderTests
         uri.ShouldContain("lon=4.3572");
     }
 
+    [Fact]
+    public async Task SuggestAsync_ParsesFeaturesToSuggestions()
+    {
+        const string json = """
+            {"features":[
+              {"geometry":{"coordinates":[4.3572,50.8476]},
+               "properties":{"type":"house","street":"Rue de la Loi","housenumber":"16","postcode":"1000","city":"Brussels","countrycode":"BE"}},
+              {"geometry":{"coordinates":[4.35,50.85]},
+               "properties":{"type":"city","name":"Brussels","city":"Brussels","countrycode":"BE"}}]}
+            """;
+        PhotonGeocodingProvider sut = CreateProvider(json, out _);
+
+        IReadOnlyList<AddressSuggestion> suggestions = await sut.SuggestAsync("rue de la loi", 5, Ct);
+
+        suggestions.Count.ShouldBe(2);
+        suggestions[0].Label.ShouldBe("Rue de la Loi 16, 1000 Brussels, BE");
+        suggestions[0].Address.Locality.ShouldBe("Brussels");
+        suggestions[0].Address.Country.ShouldBe("BE");
+        suggestions[0].Coordinate.ShouldBe(new GeoCoordinate(50.8476, 4.3572));
+        suggestions[0].Precision.ShouldBe(GeocodeMatchPrecision.Rooftop);
+    }
+
+    [Fact]
+    public async Task SuggestAsync_EmptyFeatureCollection_ReturnsEmpty()
+    {
+        PhotonGeocodingProvider sut = CreateProvider("""{"features":[]}""", out _);
+
+        (await sut.SuggestAsync("brussels", 5, Ct)).ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SuggestAsync_BlankQuery_Throws(string query)
+    {
+        PhotonGeocodingProvider sut = CreateProvider("""{"features":[]}""", out _);
+
+        await Should.ThrowAsync<ArgumentException>(async () => await sut.SuggestAsync(query, 5, Ct));
+    }
+
+    [Fact]
+    public async Task SuggestAsync_BuildsQueryWithLimit()
+    {
+        PhotonGeocodingProvider sut = CreateProvider("""{"features":[]}""", out StubHttpMessageHandler handler);
+
+        await sut.SuggestAsync("rue de la loi", 7, Ct);
+
+        string uri = handler.LastRequest!.RequestUri!.AbsoluteUri;
+        uri.ShouldContain("api?");
+        uri.ShouldContain("q=");
+        uri.ShouldContain("limit=7");
+    }
+
     private static PhotonGeocodingProvider CreateProvider(
         string json,
         out StubHttpMessageHandler handler,

--- a/tests/Granit.Geocoding.Tests/DefaultAddressAutocompleteServiceTests.cs
+++ b/tests/Granit.Geocoding.Tests/DefaultAddressAutocompleteServiceTests.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics.Metrics;
+using Granit.Domain.ValueObjects;
+using Granit.Geocoding.Diagnostics;
+using Granit.Geocoding.Internal;
+using Granit.Geocoding.Options;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Geocoding.Tests;
+
+public sealed class DefaultAddressAutocompleteServiceTests
+{
+    private static readonly AddressSuggestion Sample = new(
+        "Rue de la Loi 16, 1000 Brussels, BE",
+        new PostalAddress("Rue de la Loi 16", "1000", "Brussels", "BE"),
+        new GeoCoordinate(50.8503, 4.3517),
+        GeocodeMatchPrecision.Rooftop);
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task SuggestAsync_NoProviders_ReturnsEmpty()
+    {
+        DefaultAddressAutocompleteService sut = CreateService([]);
+
+        (await sut.SuggestAsync("brus", 5, Ct)).ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("a")]
+    public async Task SuggestAsync_BlankOrTooShortQuery_ReturnsEmptyWithoutCallingProvider(string query)
+    {
+        IAddressAutocompleteProvider provider = StubProvider("Photon", [Sample]);
+        DefaultAddressAutocompleteService sut = CreateService([provider]);
+
+        (await sut.SuggestAsync(query, 5, Ct)).ShouldBeEmpty();
+        await provider.DidNotReceive().SuggestAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SuggestAsync_FirstProviderHits_ReturnsItsSuggestions()
+    {
+        DefaultAddressAutocompleteService sut = CreateService([StubProvider("Photon", [Sample])]);
+
+        IReadOnlyList<AddressSuggestion> result = await sut.SuggestAsync("brussels", 5, Ct);
+
+        result.ShouldHaveSingleItem().ShouldBe(Sample);
+    }
+
+    [Fact]
+    public async Task SuggestAsync_FirstProviderEmpty_FallsBackToNext()
+    {
+        IAddressAutocompleteProvider first = StubProvider("First", []);
+        IAddressAutocompleteProvider second = StubProvider("Second", [Sample]);
+
+        DefaultAddressAutocompleteService sut = CreateService(
+            [first, second],
+            new GranitGeocodingOptions { ProviderOrder = { "First", "Second" } });
+
+        (await sut.SuggestAsync("brussels", 5, Ct)).ShouldHaveSingleItem().ShouldBe(Sample);
+    }
+
+    [Fact]
+    public async Task SuggestAsync_FirstProviderThrows_DegradesToNext()
+    {
+        IAddressAutocompleteProvider faulty = Substitute.For<IAddressAutocompleteProvider>();
+        faulty.ProviderName.Returns("Faulty");
+        faulty.SuggestAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<AddressSuggestion>>>(_ => throw new InvalidOperationException("boom"));
+        IAddressAutocompleteProvider healthy = StubProvider("Healthy", [Sample]);
+
+        DefaultAddressAutocompleteService sut = CreateService(
+            [faulty, healthy],
+            new GranitGeocodingOptions { ProviderOrder = { "Faulty", "Healthy" } });
+
+        (await sut.SuggestAsync("brussels", 5, Ct)).ShouldHaveSingleItem().ShouldBe(Sample);
+    }
+
+    [Theory]
+    [InlineData(99, 10)]   // clamped down to the max
+    [InlineData(0, 1)]     // clamped up to the min
+    [InlineData(5, 5)]     // passed through
+    public async Task SuggestAsync_ClampsLimitBeforeCallingProvider(int requested, int expected)
+    {
+        IAddressAutocompleteProvider provider = StubProvider("Photon", [Sample]);
+        DefaultAddressAutocompleteService sut = CreateService([provider]);
+
+        await sut.SuggestAsync("brussels", requested, Ct);
+
+        await provider.Received(1).SuggestAsync("brussels", expected, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SuggestAsync_TrimsQueryBeforeCallingProvider()
+    {
+        IAddressAutocompleteProvider provider = StubProvider("Photon", [Sample]);
+        DefaultAddressAutocompleteService sut = CreateService([provider]);
+
+        await sut.SuggestAsync("  brussels  ", 5, Ct);
+
+        await provider.Received(1).SuggestAsync("brussels", Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    private static IAddressAutocompleteProvider StubProvider(string name, IReadOnlyList<AddressSuggestion> suggestions)
+    {
+        IAddressAutocompleteProvider provider = Substitute.For<IAddressAutocompleteProvider>();
+        provider.ProviderName.Returns(name);
+        provider.SuggestAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(suggestions);
+        return provider;
+    }
+
+    private static DefaultAddressAutocompleteService CreateService(
+        IEnumerable<IAddressAutocompleteProvider> providers,
+        GranitGeocodingOptions? options = null) =>
+        new(
+            providers,
+            Microsoft.Extensions.Options.Options.Create(options ?? new GranitGeocodingOptions()),
+            CreateMetrics(),
+            NullLogger<DefaultAddressAutocompleteService>.Instance);
+
+    private static GeocodingMetrics CreateMetrics()
+    {
+        IMeterFactory factory = Substitute.For<IMeterFactory>();
+        factory.Create(Arg.Any<MeterOptions>()).Returns(call => new Meter(call.Arg<MeterOptions>().Name));
+        return new GeocodingMetrics(factory);
+    }
+}


### PR DESCRIPTION
## Context

Phase 5 (part 1) of the **address platform**. Adds **address autocomplete (typeahead)** as an opt-in provider capability, plus the **`GeocodingCapabilities`** aggregate used to gate features on what's actually installed.

## What's in this PR

- **`Granit.Geocoding.Abstractions`**: `IAddressAutocompleteProvider` + `IAddressAutocompleteService` + `AddressSuggestion` (label + structured `PostalAddress` + coordinate + precision), and `GeocodingCapabilities(Forward, Autocomplete, Reverse)`.
- **`Granit.Geocoding`**: `DefaultAddressAutocompleteService` — orders autocomplete-capable providers by the shared `ProviderOrder`, returns the first provider's suggestions, **clamps the limit**, short-circuits blank/too-short queries, no-op empty when none registered, **never logs the query** (partial PII), not cached (typeahead). A `GeocodingCapabilities` singleton is computed from the registered provider set.
- **Photon** implements `IAddressAutocompleteProvider` (it's a typeahead engine); the shared instance is now `IGeocodingProvider` + `IReverseGeocodingProvider` + `IAddressAutocompleteProvider` behind **one rate-limit throttle**. **Nominatim deliberately does not** — its usage policy discourages per-keystroke queries — which is exactly what the capability model expresses.

## Verification
- `Granit.Geocoding.Tests` 38/38 (no-op, blank/short-query short-circuit, fallback, error-degrade, **limit clamp**, query trim, ordering), `Granit.Geocoding.Photon.Tests` 34/34 (feature → suggestion mapping incl. label, empty/blank handling, query+limit shape).
- **Architecture suite 234/234**; `dotnet format --verify-no-changes` clean.

## Follow-up (Phase 5 part 2)
The capability-gated HTTP endpoints — `GET /geocoding/autocomplete` + `GET /geocoding/reverse`, mapped only when `GeocodingCapabilities` says so, with **per-principal rate limiting** — ship in a separate `Granit.Geocoding.Endpoints` package, alongside the granit-front typeahead handoff. No new package or migrations here.