### PR TITLE
feat(persistence): add IGranitModelExtension hook for cross-package model augmentation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42432,7 +42432,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextOptionsBuilderExtensions.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "UseGranitInterceptors",
@@ -42559,7 +42559,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs",
-      "line": 45,
+      "line": 47,
       "members": [
         {
           "name": "IsMultiTenantFilterEnabled",
@@ -42624,6 +42624,22 @@
       "file": "src/Granit.Persistence.EntityFrameworkCore/GranitFilterNames.cs",
       "line": 13,
       "members": []
+    },
+    {
+      "name": "GranitModelCacheKeyFactory",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.GranitModelCacheKeyFactory",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/GranitModelCacheKeyFactory.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(DbContext context, bool designTime)",
+          "returnType": "object"
+        }
+      ]
     },
     {
       "name": "GranitPersistenceAnnotationNames",
@@ -42815,6 +42831,22 @@
           "kind": "method",
           "signature": "FromSeconds(5)",
           "returnType": "TimeSpan RetryDelay { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "IGranitModelExtension",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.IGranitModelExtension",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/IGranitModelExtension.cs",
+      "line": 36,
+      "members": [
+        {
+          "name": "Apply",
+          "kind": "method",
+          "signature": "Apply(ModelBuilder modelBuilder, DbContext context)",
+          "returnType": "void"
         }
       ]
     },

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextOptionsBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextOptionsBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -67,6 +68,10 @@ public static class DbContextOptionsBuilderExtensions
         // build options manually, so without this call the lookup returns null and
         // audit capture is silently skipped on every isolated DbContext.
         options.UseApplicationServiceProvider(serviceProvider);
+
+        // Make the model cache aware of the registered IGranitModelExtension set (applied at the end of
+        // GranitDbContext.OnModelCreating), so a different extension set yields a distinct cached model.
+        options.ReplaceService<IModelCacheKeyFactory, GranitModelCacheKeyFactory>();
 
         // Order matters: Audit → Versioning → ConcurrencyStamp → DomainEvents → SoftDelete.
         // SoftDelete must be last because it converts Deleted → Modified,

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -5,7 +5,9 @@ using Granit.Domain;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Persistence.EntityFrameworkCore;
 
@@ -127,6 +129,32 @@ public abstract class GranitDbContext : DbContext
         //    filter separately, with parameterised SQL. Runs LAST so the SVO cleanup
         //    is the final pass over the model surface.
         modelBuilder.ApplyGranitConventions(currentTenant: null, DataFilter);
+
+        // 4) External, opt-in model extensions registered in DI by separate packages — applied LAST so they
+        //    get the final say (after conventions). Lets e.g. a PostGIS package add a generated geography
+        //    column to a module's address table without the module depending on NetTopologySuite. Each
+        //    extension self-guards on provider + target entity type (it sees every context's model).
+        ApplyModelExtensions(modelBuilder);
+    }
+
+    /// <summary>
+    /// Resolves and applies the registered <see cref="IGranitModelExtension"/> set from the application
+    /// service provider. No-op when none are registered (the common case) or the provider is unavailable.
+    /// </summary>
+    private void ApplyModelExtensions(ModelBuilder modelBuilder)
+    {
+        IServiceProvider? applicationServices = this.GetService<IDbContextOptions>()
+            .FindExtension<CoreOptionsExtension>()?.ApplicationServiceProvider;
+
+        if (applicationServices is null)
+        {
+            return;
+        }
+
+        foreach (IGranitModelExtension extension in applicationServices.GetServices<IGranitModelExtension>())
+        {
+            extension.Apply(modelBuilder, this);
+        }
     }
 
     /// <summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitModelCacheKeyFactory.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitModelCacheKeyFactory.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Persistence.EntityFrameworkCore;
+
+/// <summary>
+/// <see cref="IModelCacheKeyFactory"/> that folds the registered <see cref="IGranitModelExtension"/> set into
+/// the model cache key. EF Core caches a built model per context type; without this, two contexts of the same
+/// type configured with <i>different</i> extension sets (a multi-provider host, or independent tests in one
+/// process) would share whichever model was built first. Including the extension signature keeps each
+/// distinct configuration on its own cached model. Equivalent to the default key when no extensions exist.
+/// </summary>
+public sealed class GranitModelCacheKeyFactory : IModelCacheKeyFactory
+{
+    /// <inheritdoc />
+    public object Create(DbContext context, bool designTime)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        IServiceProvider? applicationServices = context.GetService<IDbContextOptions>()
+            .FindExtension<CoreOptionsExtension>()?.ApplicationServiceProvider;
+
+        string extensionSignature = applicationServices is null
+            ? string.Empty
+            : string.Join(
+                ',',
+                applicationServices.GetServices<IGranitModelExtension>()
+                    .Select(static extension => extension.GetType().FullName)
+                    .OrderBy(static name => name, StringComparer.Ordinal));
+
+        return (context.GetType(), designTime, extensionSignature);
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/IGranitModelExtension.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/IGranitModelExtension.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Persistence.EntityFrameworkCore;
+
+/// <summary>
+/// Opt-in hook that lets a separate package augment a Granit module's EF Core model without the module taking
+/// a dependency on the augmenting package's technology.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are registered in DI and applied by <see cref="GranitDbContext"/> at the very end of model
+/// building — after the module's own <c>OnGranitModelCreating</c> and after <c>ApplyGranitConventions</c>, so
+/// an extension gets the final say. The same set of registered extensions is applied to <b>every</b> Granit
+/// DbContext in the application, so each implementation MUST guard on the entity types it targets — they only
+/// exist in some contexts' models:
+/// </para>
+/// <code>
+/// public void Apply(ModelBuilder modelBuilder, DbContext context)
+/// {
+///     if (!context.Database.IsNpgsql()) return;                        // provider-gate
+///     if (modelBuilder.Model.FindEntityType(typeof(Foo)) is null) return; // entity-gate
+///     modelBuilder.Entity&lt;Foo&gt;().Property&lt;Point&gt;("Location")...;
+/// }
+/// </code>
+/// <para>
+/// Canonical use: a PostGIS package adds a generated <c>geography(Point)</c> column + GiST index to an
+/// address table while NetTopologySuite stays out of the base module. The host owns any migration; this hook
+/// only shapes the model.
+/// </para>
+/// <para>
+/// <b>Registration:</b> register as a singleton — the model is built (and cached) once per context type, and
+/// the resolved extension set is read from the application service provider at that time. Registering
+/// extensions conditionally per request is not supported (the cached model would not reflect later changes).
+/// </para>
+/// </remarks>
+public interface IGranitModelExtension
+{
+    /// <summary>
+    /// Applies model customizations. Called once per model build, after the module's configuration and the
+    /// Granit conventions. Implementations must guard on provider and target entity types.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder for the context being built.</param>
+    /// <param name="context">The context being built — exposes the active provider (e.g. <c>context.Database.IsNpgsql()</c>).</param>
+    void Apply(ModelBuilder modelBuilder, DbContext context);
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/GranitModelExtensionTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/GranitModelExtensionTests.cs
@@ -1,0 +1,139 @@
+using Granit.DataFiltering;
+using Granit.MultiTenancy;
+using Granit.Testing.Fakes;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Covers the <see cref="IGranitModelExtension"/> hook: a separate package can augment a Granit module's EF
+/// model (here, add a shadow property to <see cref="Widget"/>) by registering an extension in DI —
+/// <see cref="GranitDbContext"/> resolves the set from the application service provider and applies it at the
+/// end of model building. With none registered, the model is untouched.
+/// </summary>
+public sealed class GranitModelExtensionTests : IAsyncLifetime
+{
+    private const string AugmentedColumn = "Augmented";
+
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    private DbContextOptions<WidgetDbContext> BuildOptions(IServiceProvider? applicationServices)
+    {
+        DbContextOptionsBuilder<WidgetDbContext> builder = new DbContextOptionsBuilder<WidgetDbContext>()
+            .UseSqlite(_connection)
+            // Mirror the framework wiring so each distinct extension set gets its own cached model
+            // (otherwise EF caches one model per context type and the tests bleed into each other).
+            .ReplaceService<IModelCacheKeyFactory, GranitModelCacheKeyFactory>();
+
+        if (applicationServices is not null)
+        {
+            builder.UseApplicationServiceProvider(applicationServices);
+        }
+
+        return builder.Options;
+    }
+
+    [Fact]
+    public void RegisteredExtension_AugmentsTheModel()
+    {
+        ServiceProvider app = new ServiceCollection()
+            .AddSingleton<IGranitModelExtension, AddShadowPropertyExtension>()
+            .BuildServiceProvider();
+
+        using WidgetDbContext context = new(BuildOptions(app), new FakeCurrentTenant());
+
+        context.Model.FindEntityType(typeof(Widget))!
+            .FindProperty(AugmentedColumn)
+            .ShouldNotBeNull("the registered IGranitModelExtension must have added the shadow property");
+    }
+
+    [Fact]
+    public void NoExtensions_LeavesModelUntouched()
+    {
+        // No application service provider at all — the hook must short-circuit gracefully.
+        using WidgetDbContext context = new(BuildOptions(applicationServices: null), new FakeCurrentTenant());
+
+        context.Model.FindEntityType(typeof(Widget))!
+            .FindProperty(AugmentedColumn)
+            .ShouldBeNull("with no extensions registered the model must be untouched");
+    }
+
+    [Fact]
+    public void Extension_TargetingAnotherEntity_IsAGracefulNoOp()
+    {
+        ServiceProvider app = new ServiceCollection()
+            .AddSingleton<IGranitModelExtension, TargetsUnknownEntityExtension>()
+            .BuildServiceProvider();
+
+        // The extension self-guards on an entity type absent from this context — must not throw.
+        using WidgetDbContext context = new(BuildOptions(app), new FakeCurrentTenant());
+
+        context.Model.FindEntityType(typeof(Widget))!
+            .FindProperty(AugmentedColumn)
+            .ShouldBeNull();
+    }
+
+    // ── Test doubles ──────────────────────────────────────────────────
+
+    public sealed class Widget
+    {
+        public int Id { get; set; }
+    }
+
+    private sealed class AddShadowPropertyExtension : IGranitModelExtension
+    {
+        public void Apply(ModelBuilder modelBuilder, DbContext context)
+        {
+            // Entity-gate: only touch contexts whose model owns Widget.
+            if (modelBuilder.Model.FindEntityType(typeof(Widget)) is null)
+            {
+                return;
+            }
+
+            modelBuilder.Entity<Widget>().Property<string>(AugmentedColumn);
+        }
+    }
+
+    private sealed class TargetsUnknownEntityExtension : IGranitModelExtension
+    {
+        private sealed class NotInThisContext
+        {
+            public int Id { get; set; }
+        }
+
+        public void Apply(ModelBuilder modelBuilder, DbContext context)
+        {
+            if (modelBuilder.Model.FindEntityType(typeof(NotInThisContext)) is null)
+            {
+                return;
+            }
+
+            modelBuilder.Entity<NotInThisContext>().Property<string>(AugmentedColumn);
+        }
+    }
+
+    private sealed class WidgetDbContext(
+        DbContextOptions<WidgetDbContext> options,
+        ICurrentTenant tenant,
+        IDataFilter? dataFilter = null)
+        : GranitDbContext(options, tenant, dataFilter)
+    {
+        public DbSet<Widget> Widgets { get; set; } = null!;
+
+        protected override void OnGranitModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Widget>().HasKey(w => w.Id);
+    }
+}


### PR DESCRIPTION
## Summary

Lets a separate package augment a Granit module's EF Core model **without the module depending on the augmenting package's technology**. Implementations are registered in DI and applied by `GranitDbContext` at the end of model building (after `OnGranitModelCreating` + `ApplyGranitConventions`), resolved from the application service provider. Each extension self-guards on provider + target entity type since it sees every context's model.

**Motivating use** (granit-business Phase 7): a `Granit.Parties.PostGIS` package adds a generated `geography(Point)` column + GiST index to `parties_addresses` while NetTopologySuite stays out of the base `Granit.Parties.EntityFrameworkCore`.

## Changes

- **`IGranitModelExtension.Apply(ModelBuilder, DbContext)`** — the hook contract.
- **`GranitDbContext.OnModelCreating`** resolves the registered extension set from the application service provider and applies each, last.
- **`GranitModelCacheKeyFactory`** folds the registered extension set into the model cache key (wired via `ReplaceService` in the shared DbContext options) — so two contexts of the same type with different extension sets never share a stale cached model. Equivalent to the default key when no extensions exist (the documented EF pattern for OnModelCreating depending on external state).

## Tests

`GranitModelExtensionTests` (SQLite, no container): a registered extension augments the model; no extensions = no-op; an extension targeting an absent entity is a graceful no-op. **Full persistence (386) + hosting (38) suites green** — no regression on existing model-build behaviour.

## Follow-up

Unblocks granit-business `Granit.Parties.PostGIS` (spatial proximity), which consumes this hook once published.