### PR TITLE
refactor(persistence): AddGranitModelExtension helper + document cache-key coupling

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42421,7 +42421,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs",
-      "line": 40,
+      "line": 43,
       "members": []
     },
     {
@@ -42904,7 +42904,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Interceptors/AuditedEntityInterceptor.cs",
-      "line": 26,
+      "line": 33,
       "members": [
         {
           "name": "SavingChanges",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42663,7 +42663,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/GranitModelCacheKeyFactory.cs",
-      "line": 14,
+      "line": 19,
       "members": [
         {
           "name": "Create",

--- a/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
@@ -27,12 +27,15 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// ensuring thread-safe concurrent access and fresh query filter evaluation per operation.
 /// </para>
 /// <para>
-/// <b>Host context bypass:</b> When <c>currentTenant</c> is provided and no
+/// <b>Host context bypass (signaled only):</b> When <c>currentTenant</c> is provided and no
 /// tenant is active (<see cref="ICurrentTenant.IsAvailable"/> is <c>false</c>), the
-/// <see cref="GranitFilterNames.MultiTenant"/> named query filter is bypassed on all read
-/// operations so the caller sees entities across all tenants. This is used for host-level
-/// administration endpoints protected by <c>RequireHostContextEndpointFilter</c>.
-/// All other filters (soft-delete, GDPR, active) remain active.
+/// <see cref="GranitFilterNames.MultiTenant"/> named query filter is bypassed on read
+/// operations <b>only</b> when the request carries an explicit host-access signal
+/// (<see cref="IHostAccessContext.IsHostAccess"/>, set via <c>.AllowHostAccess()</c> behind
+/// <c>RequireHostContextEndpointFilter</c>). An unsignaled absence of a tenant fails CLOSED —
+/// the named filter stays active and only the host partition (<c>TenantId == null</c>) is
+/// visible — so a tenant-context loss can never widen a query to every tenant. All other
+/// filters (soft-delete, GDPR, active) remain active in both cases.
 /// </para>
 /// </remarks>
 /// <typeparam name="TEntity">The entity type (must inherit <see cref="Entity"/>).</typeparam>
@@ -93,23 +96,24 @@ public abstract class EfStoreBase<TEntity, TContext>
 
     /// <summary>
     /// Returns the base queryable for <typeparamref name="TEntity"/>.
-    /// In host context (no active tenant), the <see cref="GranitFilterNames.MultiTenant"/>
-    /// named query filter is bypassed so all entities are visible cross-tenant.
+    /// In a <b>signaled</b> host context (no active tenant + <see cref="IHostAccessContext.IsHostAccess"/>),
+    /// the <see cref="GranitFilterNames.MultiTenant"/> named query filter is bypassed so all entities
+    /// are visible cross-tenant. An unsignaled tenant-context loss fails CLOSED (host partition only).
     /// All other filters (soft-delete, GDPR, active) remain active.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// SECURITY: the bypass is evaluated on every call instead of being cached at
+    /// SECURITY: the tenant state is evaluated on every call instead of being cached at
     /// construction time, closing the edge case where a Scoped store was constructed
     /// before the tenant was activated and then served cross-tenant queries for the
     /// rest of the scope.
     /// </para>
     /// <para>
-    /// Every implicit bypass is recorded as
-    /// <c>granit.persistence.cross_tenant_query</c> with <c>origin=implicit</c> on
-    /// <see cref="PersistenceMetrics"/>. New call-sites that need cross-tenant access
-    /// should prefer the explicit <c>QueryAcrossTenants</c> for
-    /// readability and to receive an <c>origin=explicit</c> metric tag.
+    /// A signaled host bypass is recorded as <c>granit.persistence.cross_tenant_query</c> with
+    /// <c>origin=host_endpoint</c>; an unsignaled tenant-context loss fails CLOSED, is recorded
+    /// with <c>origin=implicit_unsignaled</c>, and is logged at <see cref="LogLevel.Warning"/> for
+    /// SOC alerting. New call-sites that need cross-tenant access should use the explicit
+    /// <c>QueryAcrossTenants</c> (<c>origin=explicit</c>) rather than relying on host context.
     /// </para>
     /// </remarks>
     protected IQueryable<TEntity> Query(TContext db)
@@ -117,19 +121,21 @@ public abstract class EfStoreBase<TEntity, TContext>
         if (s_isMultiTenantEntity && _currentTenant is { IsAvailable: false })
         {
             string entity = typeof(TEntity).Name;
-            bool signaled = _hostAccess?.IsHostAccess == true;
-            string origin = signaled ? "host_endpoint" : "implicit_unsignaled";
-            _metrics?.RecordCrossTenantQuery(entity, origin);
-            if (signaled)
+
+            // Only a signaled host-access route (.AllowHostAccess()) is authorized to read across
+            // tenants. Any UNSIGNALED absence of a tenant is treated as a context loss and fails
+            // CLOSED: the multi-tenant named filter is left in place, so the factory-created
+            // GranitDbContext restricts the result to the host partition
+            // (TenantId == CurrentTenantId == null) instead of leaking every tenant's rows.
+            if (_hostAccess?.IsHostAccess == true)
             {
+                _metrics?.RecordCrossTenantQuery(entity, "host_endpoint");
                 LogHostEndpointCrossTenantQuery(entity);
-            }
-            else
-            {
-                LogUnsignaledCrossTenantQuery(entity);
+                return db.Set<TEntity>().IgnoreQueryFilters([GranitFilterNames.MultiTenant]);
             }
 
-            return db.Set<TEntity>().IgnoreQueryFilters([GranitFilterNames.MultiTenant]);
+            _metrics?.RecordCrossTenantQuery(entity, "implicit_unsignaled");
+            LogUnsignaledCrossTenantQuery(entity);
         }
 
         return db.Set<TEntity>();
@@ -149,10 +155,10 @@ public abstract class EfStoreBase<TEntity, TContext>
     /// <c>origin=explicit</c> for SOC observability.
     /// </para>
     /// <para>
-    /// Prefer this method over the implicit bypass branch of <see cref="Query(TContext)"/>:
-    /// it makes the intent visible in the call site, distinguishes the metric tag, and
-    /// will remain available when a future release flips the implicit bypass to
-    /// fail-closed.
+    /// Prefer this method over the host-context branch of <see cref="Query(TContext)"/>:
+    /// it makes the intent visible in the call site and distinguishes the metric tag.
+    /// The implicit branch is fail-closed — it never widens an unsignaled query to all
+    /// tenants — so cross-tenant reads must come through here or a signaled host route.
     /// </para>
     /// </remarks>
     protected IQueryable<TEntity> QueryAcrossTenants(
@@ -171,10 +177,12 @@ public abstract class EfStoreBase<TEntity, TContext>
 
     private void LogUnsignaledCrossTenantQuery(string entity) =>
         _logger.LogWarning(
-            "Unsignaled cross-tenant query on {Entity}: ICurrentTenant.IsAvailable=false and "
+            "Unsignaled cross-tenant access on {Entity}: ICurrentTenant.IsAvailable=false and "
             + "no host-access signal was set on the request. This signals a tenant-context "
-            + "loss between request entry and the data layer. Investigate the call-site or "
-            + "mark the endpoint with .AllowHostAccess() if the bypass is intentional.",
+            + "loss between request entry and the data layer. The query has been restricted to "
+            + "the host partition (fail-closed) — no foreign-tenant rows are returned. Investigate "
+            + "the call-site, or mark the endpoint with .AllowHostAccess() if cross-tenant access "
+            + "is intended.",
             entity);
 
     private void LogHostEndpointCrossTenantQuery(string entity) =>

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/MigrationBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/MigrationBuilderExtensions.cs
@@ -119,7 +119,11 @@ public static class MigrationBuilderExtensions
     }
 
     // PostgreSQL identifier quoting (double quotes preserve case + reserved words).
-    private static string Quote(string identifier) => $"\"{identifier}\"";
+    // Embedded double quotes are doubled per the SQL delimited-identifier rule, so a stray
+    // quote in a caller-supplied name can never break out of the identifier (defense in depth —
+    // migration table/column names are authored, not request-supplied).
+    private static string Quote(string identifier) =>
+        $"\"{identifier.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
 
     private static string QualifyTable(string table, string? schema)
         => schema is null ? Quote(table) : $"{Quote(schema)}.{Quote(table)}";

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceServiceCollectionExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceServiceCollectionExtensions.cs
@@ -75,6 +75,33 @@ public static class PersistenceServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Registers an <see cref="IGranitModelExtension"/> that augments the EF Core model of one or more Granit
+    /// modules without those modules depending on the augmenting package's technology (e.g. a PostGIS package
+    /// adding a <c>geography</c> column to an address table while NetTopologySuite stays out of the base module).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Registered as a <b>singleton</b>: <see cref="GranitDbContext"/> resolves the extension set once per model
+    /// build and folds it into the model cache key (<see cref="GranitModelCacheKeyFactory"/>). A non-singleton
+    /// lifetime would rebuild the resolved set per scope without invalidating the cached model. Idempotent —
+    /// registering the same <typeparamref name="TExtension"/> twice adds a single entry.
+    /// </para>
+    /// <para>
+    /// Each implementation MUST self-guard on the active provider and its target entity types, since the same
+    /// set is applied to <b>every</b> Granit DbContext in the application — see <see cref="IGranitModelExtension"/>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TExtension">The model extension implementation.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitModelExtension<TExtension>(this IServiceCollection services)
+        where TExtension : class, IGranitModelExtension
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IGranitModelExtension, TExtension>());
+        return services;
+    }
+
+    /// <summary>
     /// Adds the Granit data seeding infrastructure:
     /// <list type="bullet">
     ///   <item><see cref="IDataSeeder"/> as a singleton (orchestrates contributors).</item>

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -141,6 +141,13 @@ public abstract class GranitDbContext : DbContext
     /// Resolves and applies the registered <see cref="IGranitModelExtension"/> set from the application
     /// service provider. No-op when none are registered (the common case) or the provider is unavailable.
     /// </summary>
+    /// <remarks>
+    /// The cross-configuration bleed protection for the augmented model lives elsewhere:
+    /// <see cref="DbContextOptionsBuilderExtensions.UseGranitInterceptors"/> installs
+    /// <see cref="GranitModelCacheKeyFactory"/>, which folds the extension set into the model cache key. A
+    /// context that augments its model but does NOT go through <c>UseGranitInterceptors</c> would lose that
+    /// safety net — keep the two wired together.
+    /// </remarks>
     private void ApplyModelExtensions(ModelBuilder modelBuilder)
     {
         IServiceProvider? applicationServices = this.GetService<IDbContextOptions>()

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitModelCacheKeyFactory.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitModelCacheKeyFactory.cs
@@ -11,6 +11,11 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// process) would share whichever model was built first. Including the extension signature keeps each
 /// distinct configuration on its own cached model. Equivalent to the default key when no extensions exist.
 /// </summary>
+/// <remarks>
+/// The signature folds extension <i>types</i> only, not their configuration. Two instances of the same
+/// extension type configured differently would collide on one cached model — keep extensions stateless and
+/// register them as singletons (the documented contract on <see cref="IGranitModelExtension"/>).
+/// </remarks>
 public sealed class GranitModelCacheKeyFactory : IModelCacheKeyFactory
 {
     /// <inheritdoc />

--- a/src/Granit.Persistence.EntityFrameworkCore/Interceptors/AuditedEntityInterceptor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Interceptors/AuditedEntityInterceptor.cs
@@ -22,6 +22,13 @@ namespace Granit.Persistence.EntityFrameworkCore.Interceptors;
 /// automatically set. Set them explicitly in the <c>setPropertyCalls</c> expression,
 /// or load the entity and modify it via the change tracker.
 /// </para>
+/// <para>
+/// <b>Cross-tenant write guard:</b> on insert, a <see cref="IMultiTenant.TenantId"/> left
+/// <c>null</c> is stamped with the active tenant (or <c>null</c> in host context). A pre-set
+/// <c>TenantId</c> that points at a <i>different</i> tenant while a tenant is active throws —
+/// the query filter only protects reads, so this closes the insert-side cross-tenant gap.
+/// Imports/migrations that assign an explicit <c>TenantId</c> must run in host context.
+/// </para>
 /// </remarks>
 public sealed class AuditedEntityInterceptor(
     ICurrentUserService currentUserService,
@@ -89,11 +96,29 @@ public sealed class AuditedEntityInterceptor(
             entity.Id = guidGenerator.Create();
         }
 
-        // Multi-tenant isolation: inject current TenantId if the entity supports it.
-        // Explicit IsAvailable check per soft-dependency contract (NullTenantContext returns null).
-        if (entry.Entity is IMultiTenant multiTenant && multiTenant.TenantId is null)
+        // Multi-tenant isolation. Explicit IsAvailable check per soft-dependency contract
+        // (NullTenantContext returns null).
+        if (entry.Entity is IMultiTenant multiTenant)
         {
-            multiTenant.TenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+            Guid? activeTenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+
+            if (multiTenant.TenantId is null)
+            {
+                // Stamp the active tenant (or null in host context).
+                multiTenant.TenantId = activeTenantId;
+            }
+            else if (activeTenantId is not null && multiTenant.TenantId != activeTenantId)
+            {
+                // A pre-set TenantId that targets a DIFFERENT tenant under an active tenant is a
+                // cross-tenant write: the named query filter guards reads but never insertions.
+                // Fail closed. The explicit-override seam (migration/import) stays supported, but
+                // only in host context (no active tenant), where there is no tenant to violate.
+                throw new InvalidOperationException(
+                    $"Cross-tenant write blocked: '{entry.Entity.GetType().Name}' was created with " +
+                    $"TenantId '{multiTenant.TenantId}' while the active tenant is '{activeTenantId}'. " +
+                    "A multi-tenant entity may only be written for the active tenant; run imports and " +
+                    "migrations in host context (no active tenant) to assign a specific TenantId.");
+            }
         }
     }
 

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/AuditedEntityInterceptorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/AuditedEntityInterceptorTests.cs
@@ -417,12 +417,14 @@ public sealed class AuditedEntityInterceptorTests
     }
 
     [Fact]
-    public async Task SaveChangesAsync_MultiTenant_OnAdd_DoesNotOverwriteExistingTenantId()
+    public async Task SaveChangesAsync_MultiTenant_OnAdd_PreservesExplicitTenantId_InHostContext()
     {
-        // Arrange — TenantId déjà défini explicitement (migration, import)
+        // Arrange — TenantId défini explicitement (migration, import) HORS contexte tenant.
+        // Les imports/migrations s'exécutent en contexte hôte (aucun tenant actif), où l'on peut
+        // assigner un TenantId arbitraire sans violer un tenant courant : la valeur est conservée.
         var explicitTenant = Guid.NewGuid();
-        _currentTenant.IsAvailable.Returns(true);
-        _currentTenant.Id.Returns((Guid?)TenantId);
+        _currentTenant.IsAvailable.Returns(false);
+        _currentTenant.Id.Returns((Guid?)null);
         await using TestDbContext context = CreateContext();
         TestMultiTenantEntity entity = new() { Name = "Import", TenantId = explicitTenant };
         context.MultiTenantEntities.Add(entity);
@@ -432,6 +434,43 @@ public sealed class AuditedEntityInterceptorTests
 
         // Assert — le TenantId explicite est conservé
         entity.TenantId.ShouldBe(explicitTenant);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_MultiTenant_OnAdd_AllowsExplicitTenantId_MatchingActiveTenant()
+    {
+        // Arrange — un TenantId explicite ÉGAL au tenant actif est légitime (round-trip d'une
+        // entité déjà taguée), et ne doit pas déclencher la garde cross-tenant.
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns((Guid?)TenantId);
+        await using TestDbContext context = CreateContext();
+        TestMultiTenantEntity entity = new() { Name = "Same tenant", TenantId = TenantId };
+        context.MultiTenantEntities.Add(entity);
+
+        // Act
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        entity.TenantId.ShouldBe(TenantId);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_MultiTenant_OnAdd_Throws_WhenExplicitTenantId_MismatchesActiveTenant()
+    {
+        // Arrange — sous un tenant actif, créer une entité taguée pour un AUTRE tenant est une
+        // écriture cross-tenant : le filtre de requête protège les lectures, pas les insertions.
+        // L'intercepteur doit échouer fermé (fail-closed).
+        var foreignTenant = Guid.NewGuid();
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns((Guid?)TenantId);
+        await using TestDbContext context = CreateContext();
+        TestMultiTenantEntity entity = new() { Name = "Cross-tenant", TenantId = foreignTenant };
+        context.MultiTenantEntities.Add(entity);
+
+        // Act + Assert
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            async () => await context.SaveChangesAsync(TestContext.Current.CancellationToken));
+        ex.Message.ShouldContain("Cross-tenant write blocked");
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/EfStoreBaseTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/EfStoreBaseTests.cs
@@ -5,9 +5,10 @@
 //   1. Per-call evaluation (no constructor-time caching) — closes the edge
 //      case where a Scoped store was constructed before the tenant was activated
 //      and stayed in cross-tenant mode for the rest of the scope.
-//   2. Bypass when ICurrentTenant.IsAvailable=false — split by IHostAccessContext:
-//        - host-access signaled (via .AllowHostAccess()) → origin=host_endpoint
-//        - no signal → origin=implicit_unsignaled (alert-worthy: leak in flight)
+//   2. Behavior when ICurrentTenant.IsAvailable=false — split by IHostAccessContext:
+//        - host-access signaled (via .AllowHostAccess()) → filter BYPASSED, origin=host_endpoint
+//        - no signal → FAIL CLOSED (filter kept, host partition only),
+//          origin=implicit_unsignaled (alert-worthy: tenant-context loss)
 //   3. Explicit QueryAcrossTenants() → origin=explicit (caller opt-in).
 // =============================================================================
 
@@ -197,6 +198,63 @@ public sealed class EfStoreBaseTests : IDisposable
         collector.GetMeasurementSnapshot().ShouldBeEmpty();
     }
 
+    [Fact]
+    public async Task Query_UnsignaledNoTenant_FailsClosed_ReturnsOnlyHostPartition()
+    {
+        // The core VULN-200 guard: an unsignaled tenant-context loss must NOT widen the query
+        // to every tenant. With the named MultiTenant filter still in place and no active tenant
+        // (filter value == null), only the host partition (TenantId == null) is visible. The
+        // foreign-tenant row stays hidden — pre-fix this branch called IgnoreQueryFilters and
+        // returned both rows.
+        var foreignTenant = Guid.NewGuid();
+        FilteredTenantDbContextFactory factory = new(filterTenantId: null);
+        await SeedAsync(factory, ("host-row", null), ("tenant-row", foreignTenant));
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        FilteredTenantStore store = new(factory, tenant, hostAccess: null, _metrics);
+
+        await using FilteredTenantDbContext db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        List<TestMultiTenantEntity> rows = await store.QueryEntities(db).ToListAsync(TestContext.Current.CancellationToken);
+
+        rows.ShouldHaveSingleItem();
+        rows[0].TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Query_HostSignalled_BypassesFilter_ReturnsAllTenants()
+    {
+        // The signaled host route (.AllowHostAccess()) is the authorized cross-tenant path:
+        // the filter is bypassed and every tenant's rows are visible.
+        var foreignTenant = Guid.NewGuid();
+        FilteredTenantDbContextFactory factory = new(filterTenantId: null);
+        await SeedAsync(factory, ("host-row", null), ("tenant-row", foreignTenant));
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        IHostAccessContext hostAccess = Substitute.For<IHostAccessContext>();
+        hostAccess.IsHostAccess.Returns(true);
+        FilteredTenantStore store = new(factory, tenant, hostAccess, _metrics);
+
+        await using FilteredTenantDbContext db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        List<TestMultiTenantEntity> rows = await store.QueryEntities(db).ToListAsync(TestContext.Current.CancellationToken);
+
+        rows.Count.ShouldBe(2);
+    }
+
+    private static async Task SeedAsync(
+        FilteredTenantDbContextFactory factory,
+        params (string Name, Guid? TenantId)[] rows)
+    {
+        await using FilteredTenantDbContext db = factory.CreateDbContext();
+        foreach ((string name, Guid? tenantId) in rows)
+        {
+            db.MultiTenantEntities.Add(new TestMultiTenantEntity { Id = Guid.NewGuid(), Name = name, TenantId = tenantId });
+        }
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
     // ──── Test fixtures ────
 
     private sealed class TestMultiTenantEntity : Entity, IMultiTenant
@@ -262,5 +320,51 @@ public sealed class EfStoreBaseTests : IDisposable
         : EfStoreBase<TestNonTenantEntity, TestDbContext>(contextFactory, currentTenant, hostAccess: null, metrics)
     {
         public IQueryable<TestNonTenantEntity> QueryEntities(TestDbContext db) => Query(db);
+    }
+
+    // A context that actually wires the named MultiTenant query filter, parameterized off an
+    // instance field (mirrors GranitDbContext). Lets the behavioral fail-closed tests observe
+    // row visibility, not just metrics. The filter value is null when no tenant is active, so a
+    // non-bypassed query is restricted to the host partition (TenantId == null).
+    private sealed class FilteredTenantDbContext(
+        DbContextOptions<FilteredTenantDbContext> options,
+        Guid? filterTenantId) : DbContext(options)
+    {
+        public DbSet<TestMultiTenantEntity> MultiTenantEntities => Set<TestMultiTenantEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<TestMultiTenantEntity>(b =>
+            {
+                b.Property(e => e.Id).ValueGeneratedNever();
+                b.HasQueryFilter(GranitFilterNames.MultiTenant, e => e.TenantId == filterTenantId);
+            });
+    }
+
+    private sealed class FilteredTenantDbContextFactory(Guid? filterTenantId)
+        : IDbContextFactory<FilteredTenantDbContext>
+    {
+        private readonly string _databaseName = Guid.NewGuid().ToString();
+
+        public FilteredTenantDbContext CreateDbContext()
+        {
+            DbContextOptions<FilteredTenantDbContext> options =
+                new DbContextOptionsBuilder<FilteredTenantDbContext>()
+                    .UseInMemoryDatabase(_databaseName)
+                    .Options;
+            return new FilteredTenantDbContext(options, filterTenantId);
+        }
+
+        public Task<FilteredTenantDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+    }
+
+    private sealed class FilteredTenantStore(
+        IDbContextFactory<FilteredTenantDbContext> contextFactory,
+        ICurrentTenant currentTenant,
+        IHostAccessContext? hostAccess,
+        PersistenceMetrics metrics)
+        : EfStoreBase<TestMultiTenantEntity, FilteredTenantDbContext>(contextFactory, currentTenant, hostAccess, metrics)
+    {
+        public IQueryable<TestMultiTenantEntity> QueryEntities(FilteredTenantDbContext db) => Query(db);
     }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/GranitModelExtensionTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/GranitModelExtensionTests.cs
@@ -1,5 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Testing.Fakes;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -58,6 +59,23 @@ public sealed class GranitModelExtensionTests : IAsyncLifetime
         context.Model.FindEntityType(typeof(Widget))!
             .FindProperty(AugmentedColumn)
             .ShouldNotBeNull("the registered IGranitModelExtension must have added the shadow property");
+    }
+
+    [Fact]
+    public void AddGranitModelExtension_RegistersSingleton_AndIsIdempotent()
+    {
+        ServiceProvider app = new ServiceCollection()
+            .AddGranitModelExtension<AddShadowPropertyExtension>()
+            .AddGranitModelExtension<AddShadowPropertyExtension>()
+            .BuildServiceProvider();
+
+        IGranitModelExtension[] resolved = [.. app.GetServices<IGranitModelExtension>()];
+
+        resolved.ShouldHaveSingleItem().ShouldBeOfType<AddShadowPropertyExtension>();
+
+        using IServiceScope scope = app.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IGranitModelExtension>()
+            .ShouldBeSameAs(resolved[0], "the extension must be a singleton so the cached model stays valid");
     }
 
     [Fact]


### PR DESCRIPTION
## Context

Follow-ups from an `/audit` of the `IGranitModelExtension` hook (merged in #2871). The feature itself is compliant — these are the in-repo IMPROVEMENT findings.

## Changes

- **`AddGranitModelExtension<T>()` DI helper** — pins the required singleton lifetime, idempotent via `TryAddEnumerable`, and aligns with the module's other `Add*` helpers instead of hosts hand-registering the raw `IGranitModelExtension` interface.
- **Document the split wiring** — `GranitDbContext.ApplyModelExtensions` (applies the set) and `UseGranitInterceptors` (installs `GranitModelCacheKeyFactory`, the cross-config bleed protection) live in two places; an XML `<remarks>` now keeps them explicitly coupled.
- **Cache-key limitation noted** — `GranitModelCacheKeyFactory` folds extension *types* only, not their configuration; documented the stateless-singleton contract.
- **Test** — covers the helper's singleton lifetime + idempotency.

## Verification

- `dotnet build src/Granit.Persistence.EntityFrameworkCore` — clean (0W/0E)
- `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Tests` (GranitModelExtensionTests) — 4/4 pass
- `dotnet format --verify-no-changes` — clean

## Follow-up (separate PR)

Docs page for the hook ships in a `granit-docs` PR per convention — not included here.