### PR TITLE
fix(openapi-generator): emit capability-gated geocoding paths via stub provider

### DIFF
--- a/src/Granit.OpenApi.Generator/GeneratorStubGeocodingProvider.cs
+++ b/src/Granit.OpenApi.Generator/GeneratorStubGeocodingProvider.cs
@@ -1,0 +1,30 @@
+using Granit.Domain.ValueObjects;
+using Granit.Geocoding;
+
+namespace Granit.OpenApi.Generator;
+
+/// <summary>
+/// No-op geocoding provider registered only by the contract generator so the capability-gated geocoding
+/// endpoints (<c>/autocomplete</c>, <c>/reverse</c>) are mapped and appear in the emitted OpenAPI document.
+/// </summary>
+/// <remarks>
+/// The generator builds a provider-less module graph; geocoding endpoints are mapped only when a matching
+/// provider is registered (<see cref="GeocodingCapabilities"/>), so without this stub the geocoding contract
+/// would ship with an empty <c>paths</c> object. The stub never runs at request time — the generator only
+/// probes minimal-API bindings — so every method returns the empty result.
+/// </remarks>
+internal sealed class GeneratorStubGeocodingProvider
+    : IGeocodingProvider, IReverseGeocodingProvider, IAddressAutocompleteProvider
+{
+    public string ProviderName => "GeneratorStub";
+
+    public Task<GeocodingResult?> ResolveAsync(PostalAddress address, CancellationToken cancellationToken = default) =>
+        Task.FromResult<GeocodingResult?>(null);
+
+    public Task<ReverseGeocodingResult?> ReverseAsync(GeoCoordinate coordinate, CancellationToken cancellationToken = default) =>
+        Task.FromResult<ReverseGeocodingResult?>(null);
+
+    public Task<IReadOnlyList<AddressSuggestion>> SuggestAsync(
+        string query, int limit, CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<AddressSuggestion>>([]);
+}

--- a/src/Granit.OpenApi.Generator/Program.cs
+++ b/src/Granit.OpenApi.Generator/Program.cs
@@ -1,5 +1,6 @@
 using Granit.Authentication.ApiKeys.Endpoints.Extensions;
 using Granit.BlobStorage.Endpoints.Extensions;
+using Granit.Geocoding;
 using Granit.Identity.Endpoints.Extensions;
 using Granit.OpenApi.Generation;
 using Granit.OpenApi.Generator;
@@ -19,4 +20,16 @@ await OpenApiContractGenerator.RunAsync<GeneratorModule>(
         builder.Services.AddGranitApiKeysEndpoints();
         builder.Services.AddGranitIdentityEndpoints();
         builder.Services.AddGranitWorkflowEndpoints();
+
+        // Geocoding endpoints are capability-gated on the registered provider set, so a provider-less graph
+        // emits an empty geocoding contract. Register a no-op provider covering all three capabilities so the
+        // generated document includes the geocoding paths without pulling in a real (billable, config-bound)
+        // provider package.
+        builder.Services.AddSingleton<GeneratorStubGeocodingProvider>();
+        builder.Services.AddSingleton<IGeocodingProvider>(
+            static sp => sp.GetRequiredService<GeneratorStubGeocodingProvider>());
+        builder.Services.AddSingleton<IReverseGeocodingProvider>(
+            static sp => sp.GetRequiredService<GeneratorStubGeocodingProvider>());
+        builder.Services.AddSingleton<IAddressAutocompleteProvider>(
+            static sp => sp.GetRequiredService<GeneratorStubGeocodingProvider>());
     });


### PR DESCRIPTION
## Problem

`Granit.OpenApi.Generator_geocoding.json` shipped with an empty `"paths": {}` object.

The geocoding HTTP endpoints (`GET /geocoding/autocomplete`, `GET /geocoding/reverse`) are **capability-gated**: they are only mapped when a matching provider is registered, via `GeocodingCapabilities` computed from the registered `IGeocodingProvider` / `IAddressAutocompleteProvider` / `IReverseGeocodingProvider` set (`GranitGeocodingModule`). The contract generator composes a **provider-less** module graph (it only references `Granit.Geocoding.Endpoints`, never `.Nominatim` / `.Photon`), so all three capabilities were `false` and both endpoints were skipped.

## Fix

Register a no-op `GeneratorStubGeocodingProvider` (implements all three provider interfaces, returns `null` / empty) as a single singleton aliased to the three interfaces, in the generator's bootstrap delegate. This flips all capabilities to `true` so the geocoding paths are emitted — **without** pulling in a real, billable, config-bound provider package (`Photon` would drag in `BindConfiguration` + `ValidateOnStart()`).

The stub never runs at request time: the generator only probes minimal-API bindings to build the document.

This mirrors the existing pattern for BFF (config-collection-driven, needs a stub frontend to emit paths).

## Verification

- `dotnet build src/Granit.OpenApi.Generator` — succeeds; generated geocoding doc now has `/geocoding/autocomplete` + `/geocoding/reverse`.
- `dotnet format src/Granit.OpenApi.Generator --verify-no-changes` — clean.
- `OpenApiGeneratorCompletenessTests` unaffected (module graph / endpoint list unchanged).