### PR TITLE
docs(readme): fix integration steps and stale APIs in module READMEs

### DIFF
--- a/src/Granit.BlobStorage.Endpoints/README.md
+++ b/src/Granit.BlobStorage.Endpoints/README.md
@@ -17,6 +17,23 @@ dotnet add package Granit.BlobStorage.Endpoints
 - `Granit.QueryEngine.AspNetCore`
 - `Granit.Validation`
 
+## Integration
+
+Map the administration endpoints in `Program.cs` after the app is built:
+
+```csharp
+api.MapGranitBlobStorage();
+// or customize the prefix (default: /blob-storage):
+api.MapGranitBlobStorage(opts => opts.RoutePrefix = "admin/blobs");
+```
+
+This exposes upload initiation (presigned URLs), confirmation, download,
+deletion (crypto-shredding), orphan cleanup, and queryable `BlobDescriptor`
+endpoints. They are role-gated by the module-provided permissions
+`BlobStoragePermissions.Administration.Read` (list / descriptors / query) and
+`.Manage` (upload / download / delete / confirm / cleanup) — grant these in
+your authorization configuration.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.BlobStorage.S3/README.md
+++ b/src/Granit.BlobStorage.S3/README.md
@@ -14,6 +14,39 @@ dotnet add package Granit.BlobStorage.S3
 
 - `Granit.BlobStorage`
 
+## Configuration
+
+Register the provider in your host (or infrastructure) module:
+
+```csharp
+context.Builder.AddGranitBlobStorageS3();
+```
+
+This binds `S3BlobOptions` from the `BlobStorage` configuration section and
+validates it on startup, so the section is **mandatory**:
+
+```json
+{
+  "BlobStorage": {
+    "ServiceUrl": "https://s3.<region>.amazonaws.com",
+    "DefaultBucket": "my-bucket",
+    "ForcePathStyle": false
+  }
+}
+```
+
+For MinIO use `"ServiceUrl": "http://localhost:9000"` and `"ForcePathStyle": true`.
+
+`AccessKey` / `SecretKey` are secrets: inject them from `Granit.Vault` or
+environment variables (`BlobStorage__AccessKey`, `BlobStorage__SecretKey`) —
+never commit them to `appsettings.json`.
+
+Optionally add an S3 connectivity readiness probe:
+
+```csharp
+healthChecks.AddGranitS3HealthCheck();
+```
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Encryption/README.md
+++ b/src/Granit.Encryption/README.md
@@ -14,6 +14,51 @@ dotnet add package Granit.Encryption
 
 - `Granit`
 
+## Configuration
+
+A pass phrase is **mandatory**. Options are bound from the `Encryption`
+configuration section with `ValidateOnStart`, and `AllowEphemeralPassPhrase`
+defaults to `false`, so a missing `Encryption:PassPhrase` fails the host at
+startup:
+
+```json
+{
+  "Encryption": {
+    "PassPhrase": "<32+ character secret — inject from Granit.Vault / env>",
+    "ProviderName": "Aes",
+    "KeySize": 256,
+    "AllowEphemeralPassPhrase": false
+  }
+}
+```
+
+`ProviderName` is `Aes` (AES-256-CBC) or `Vault` (Transit; set `VaultKeyName`).
+`AllowEphemeralPassPhrase: true` is for dev/test only.
+
+## Usage
+
+The module's `ConfigureServices` calls `AddGranitEncryption()` for you — wire
+the module into your dependency graph rather than calling it by hand:
+
+```csharp
+[DependsOn(typeof(GranitEncryptionModule))]   // or GranitEncryptionEntityFrameworkCoreModule, which pulls this in transitively
+public sealed class AppHostModule : GranitModule { }
+```
+
+Then inject the services:
+
+```csharp
+public sealed class MyService(IStringEncryptionService cipher, ICryptoShredder shredder)
+{
+    public string Protect(string plain) => cipher.Encrypt(plain);
+    public string Reveal(string cipherText) => cipher.Decrypt(cipherText);
+    // shredder.ShredAsync(key) drops the per-subject key for crypto-shredding (GDPR erasure).
+}
+```
+
+For EF Core field-level encryption, the `Granit.Encryption.EntityFrameworkCore`
+package adds the `[Encrypted]` attribute / `EncryptedStringConverter`.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Geocoding.Endpoints/README.md
+++ b/src/Granit.Geocoding.Endpoints/README.md
@@ -17,6 +17,19 @@ Each endpoint is **capability-gated**: it is mapped only when a capable provider
 Nominatim only, `/reverse` exists but `/autocomplete` does not; add Photon and `/autocomplete`
 appears too.
 
+## Registration
+
+Register the module **before** mapping the endpoints — `MapGranitGeocoding()`
+resolves `GeocodingCapabilities` from DI and throws at startup otherwise. The
+Granit module loader discovers modules strictly by traversing `[DependsOn]`
+from the root (no assembly auto-scan), so declare the dependency on your host
+module:
+
+```csharp
+[DependsOn(typeof(GranitGeocodingEndpointsModule))]   // transitively pulls GranitGeocodingModule (supplies GeocodingCapabilities)
+public sealed class AppHostModule : GranitModule { }
+```
+
 ## Usage
 
 ```csharp

--- a/src/Granit.Http.Idempotency/README.md
+++ b/src/Granit.Http.Idempotency/README.md
@@ -13,7 +13,27 @@ dotnet add package Granit.Http.Idempotency
 ## Dependencies
 
 - `Granit.Caching`
-- `Granit.Users`
+
+## Quick start
+
+Two steps are required:
+
+1. **Register the module** — adds `IdempotencyMiddleware` + DI (the module does
+   not add middleware to the pipeline by itself):
+
+   ```csharp
+   [DependsOn(typeof(GranitHttpIdempotencyModule))]
+   public sealed class AppHostModule : GranitModule { }
+   ```
+
+2. **Wire the middleware** in `Program.cs`, **after** authentication so
+   `ICurrentUserService` / `ICurrentTenant` are populated when it runs:
+
+   ```csharp
+   app.UseAuthentication();
+   app.UseAuthorization();
+   app.UseGranitIdempotency();   // must run after auth
+   ```
 
 ## Documentation
 

--- a/src/Granit.Http.ODataExposure/README.md
+++ b/src/Granit.Http.ODataExposure/README.md
@@ -20,7 +20,7 @@ filtering, soft-delete, and per-EntitySet permissions.
 ```csharp
 // Program.cs
 builder.Services
-    .AddGranitOData()                // wires the OData runtime + ODataQueryOptions<T> binding
+    .AddGranitODataExposure()        // wires the OData runtime + ODataQueryOptions<T> binding
     .AddGranitQueryEngine()          // host's existing QueryEngine registration
     .AddQueryDefinition<Invoice, InvoiceQueryDefinition>();
 

--- a/src/Granit.Http.OutputCaching/README.md
+++ b/src/Granit.Http.OutputCaching/README.md
@@ -16,6 +16,40 @@ dotnet add package Granit.Http.OutputCaching
 
 - `Granit`
 
+## Quick start
+
+Two steps are required:
+
+1. **Register the module** (services are auto-registered by its `ConfigureServices`):
+
+   ```csharp
+   [DependsOn(typeof(GranitHttpOutputCachingModule))]
+   public sealed class AppHostModule : GranitModule { }
+   ```
+
+2. **Wire the middleware** in `Program.cs`. Ordering is load-bearing: it must run
+   after routing/CORS, **after** authentication, and **after** the multi-tenancy
+   middleware so the tenant id enters the cache key (cross-tenant disclosure risk
+   otherwise), and before authorization:
+
+   ```csharp
+   app.UseRouting();
+   app.UseCors();
+   app.UseGranitMultiTenancy();
+   app.UseAuthentication();
+   app.UseGranitOutputCaching();   // after tenant + auth
+   app.UseAuthorization();
+   ```
+
+Configure cache-key variance under the `Http:OutputCaching` section:
+
+```json
+{ "Http": { "OutputCaching": { "VaryByQueryKeys": [ "page", "culture" ] } } }
+```
+
+The in-memory store is the default; add `Granit.Http.OutputCaching.StackExchangeRedis`
+for distributed caching.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.IpGeolocation.IpInfo/README.md
+++ b/src/Granit.IpGeolocation.IpInfo/README.md
@@ -22,10 +22,26 @@ distributed cache means one API call per IP per cluster.
 
 ## Registration
 
+The `builder.AddGranitIpGeolocationIpInfo()` call alone is **not sufficient**:
+it registers only the IpInfo provider (`IIpGeolocationProvider`) + options +
+`HttpClient`. The resolver consumers actually inject — `IIpGeolocationResolver` —
+is registered by `GranitIpGeolocationModule`, which the Granit module loader
+only pulls in when it is reachable via `[DependsOn]` from the root (there is no
+assembly auto-scan). Declare the module on your host, then make the registration
+call:
+
+```csharp
+[DependsOn(typeof(GranitIpGeolocationIpInfoModule))]   // pulls GranitIpGeolocationModule → registers IIpGeolocationResolver
+public sealed class AppHostModule : GranitModule { }
+```
+
 ```csharp
 // Program.cs
 builder.AddGranitIpGeolocationIpInfo();
 ```
+
+Without the `[DependsOn]`, `IIpGeolocationResolver` is never registered and
+consumers fail at DI build / `ValidateOnStart`.
 
 ```json
 {

--- a/src/Granit.Templating.Endpoints/README.md
+++ b/src/Granit.Templating.Endpoints/README.md
@@ -16,9 +16,10 @@ dotnet add package Granit.Templating.Endpoints
 
 - `Granit.Http.ApiDocumentation`
 - `Granit.Authorization`
-- `Granit.Users`
+- `Granit.QueryEngine.AspNetCore`
 - `Granit.Templating`
 - `Granit.Validation`
+- `Granit.Workspaces.Abstractions`
 
 ## Documentation
 

--- a/src/Granit.Timeline.Endpoints/README.md
+++ b/src/Granit.Timeline.Endpoints/README.md
@@ -16,6 +16,24 @@ dotnet add package Granit.Timeline.Endpoints
 - `Granit.Authorization`
 - `Granit.Timeline`
 
+## Usage
+
+Map the endpoints in your application startup (`Program.cs`):
+
+```csharp
+app.MapGranitTimeline();
+// customize the prefix (default: "timeline"):
+app.MapGranitTimeline(opts => opts.RoutePrefix = "admin/timeline");
+```
+
+Under the route prefix this registers: `GET /{entityType}/{entityId}`
+(activity stream), `POST /{entityType}/{entityId}/entries` (comment / note),
+`DELETE /{entityType}/{entityId}/entries/{id}` (GDPR soft-delete),
+`POST` / `DELETE /{entityType}/{entityId}/follow`,
+`GET /{entityType}/{entityId}/followers`, plus reaction routes. The route group
+requires the `Timeline.Entries.Read` permission; individual endpoints may
+require more (e.g. `Timeline.Entries.Create`).
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Timeline.EntityFrameworkCore/README.md
+++ b/src/Granit.Timeline.EntityFrameworkCore/README.md
@@ -16,6 +16,23 @@ dotnet add package Granit.Timeline.EntityFrameworkCore
 - `Granit.Persistence`
 - `Granit.Timeline`
 
+## Usage
+
+EF Core persistence is opt-in: without it, `Granit.Timeline` keeps its in-memory
+stores. After `AddGranitTimeline()`, wire the EF Core store in your host module:
+
+```csharp
+builder.AddGranitTimelineEntityFrameworkCore(options =>
+    options.UseNpgsql(connectionString));
+```
+
+This replaces `InMemoryTimelineStore` / `InMemoryTimelineQuery` with
+`EfCoreTimelineStore` / `EfCoreTimelineQuery` and registers the internal
+`TimelineDbContext` via `IDbContextFactory`. The module manages that
+`TimelineDbContext` itself (it already calls `ConfigureTimelineModule`
+internally) — consumers do **not** need to add `ConfigureTimelineModule()` to
+their own `DbContext`.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).


### PR DESCRIPTION
## Context

Audit of Granit module READMEs **as standalone integration guides** — can a developer or AI wire a module into a fresh host using only its README? Compared each README against the showcase's real wiring (`[DependsOn]`, `Add*/Configure*/Use*/Map*`, config sections) and the framework source.

This PR fixes the **confirmed critical defects** in granit-dotnet — cases where following the README literally would fail to compile, fail at startup, or silently never run.

## Changes (11 READMEs)

| README | Fix |
| --- | --- |
| `Http.ODataExposure` | `AddGranitOData()` → **`AddGranitODataExposure()`** (method never existed) |
| `BlobStorage.S3` | Document `AddGranitBlobStorageS3()` + mandatory `BlobStorage` config section + secret injection + health check |
| `BlobStorage.Endpoints` | Document `MapGranitBlobStorage()` + role permissions |
| `Encryption` | Document mandatory `Encryption:PassPhrase` (ValidateOnStart), `[DependsOn]` wiring, `IStringEncryptionService`/`ICryptoShredder`, EF `[Encrypted]` |
| `Geocoding.Endpoints` | Document required `[DependsOn(GranitGeocodingEndpointsModule)]` before `MapGranitGeocoding()` |
| `Http.Idempotency` | Document `[DependsOn]` + `UseGranitIdempotency()` ordering; drop nonexistent `Granit.Users` dep |
| `Http.OutputCaching` | Document `[DependsOn]` + `UseGranitOutputCaching()` ordering (after tenant + auth) + config |
| `IpGeolocation.IpInfo` | Clarify `[DependsOn]` is required or `IIpGeolocationResolver` is never registered |
| `Templating.Endpoints` | Correct Dependencies: drop nonexistent `Granit.Users`, add `QueryEngine.AspNetCore` + `Workspaces.Abstractions` |
| `Timeline.EntityFrameworkCore` | Document `AddGranitTimelineEntityFrameworkCore()` (opt-in persistence) |
| `Timeline.Endpoints` | Document `MapGranitTimeline()` + routes + permission |

All asserted APIs/types/module names verified against framework source. `markdownlint-cli2`: 0 errors.

## Scope

Critical fixes only. The broader systemic gap (most `*.Endpoints` / `*.EntityFrameworkCore` / `*.BackgroundJobs` READMEs omit the `[DependsOn]` + `Map*` wiring steps — ~100 findings) is tracked separately for a follow-up sweep.