### PR TITLE
fix(auth): invalidate API-key auth cache on revocation and re-scope (VULN-100-IAM)

### DIFF
--- a/src/Granit.Authentication.ApiKeys/Cache/ApiKeyCacheInvalidationHandler.cs
+++ b/src/Granit.Authentication.ApiKeys/Cache/ApiKeyCacheInvalidationHandler.cs
@@ -1,0 +1,67 @@
+using Granit.Authentication.ApiKeys.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Authentication.ApiKeys.Cache;
+
+/// <summary>
+/// Wolverine message handler — evicts the stale <see cref="IApiKeyCacheService"/>
+/// entry when an API key is revoked or its scopes change.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Discovered by Wolverine's handler-scanning convention: the class name ends in
+/// <c>"Handler"</c> and the method is named <c>HandleAsync</c> with the message as its
+/// first parameter. Remaining parameters are resolved from the application's DI
+/// container, so no <c>WolverineFx</c> package reference is required here (mirror of
+/// <c>Granit.Authorization.Cache.PermissionCacheInvalidationHandler</c>).
+/// </para>
+/// <para>
+/// Without this handler a revoked or leaked key keeps authenticating for up to
+/// <c>ApiKeyAuthenticationOptions.CacheDuration</c> (default 5 minutes), because the
+/// authentication handler caches the resolved <see cref="Domain.ApiKeyEntry"/> under its
+/// hashed key. Both integration events carry the <c>HashedKey</c> precisely so the cache
+/// can be evicted here — a hard <see cref="IApiKeyCacheService.RemoveAsync"/> (not a soft
+/// expire) so stale-while-revalidate can never serve the revoked or over-scoped entry.
+/// </para>
+/// <para>
+/// The cache is a soft dependency: when <c>Granit.Caching</c> is not installed, no
+/// <see cref="IApiKeyCacheService"/> is registered and Wolverine simply cannot dispatch to
+/// this handler — authentication then reads the store directly and revocation is immediate.
+/// </para>
+/// </remarks>
+public partial class ApiKeyCacheInvalidationHandler
+{
+    /// <summary>
+    /// Evicts the cached entry for a revoked API key so authentication fails immediately
+    /// instead of after the cache TTL.
+    /// </summary>
+    public static async Task HandleAsync(
+        ApiKeyRevokedEto evt,
+        IApiKeyCacheService cacheService,
+        ILogger<ApiKeyCacheInvalidationHandler> logger,
+        CancellationToken cancellationToken)
+    {
+        await cacheService.RemoveAsync(evt.HashedKey, cancellationToken).ConfigureAwait(false);
+        LogRevocationEviction(logger, evt.ApiKeyId);
+    }
+
+    /// <summary>
+    /// Evicts the cached entry when an API key's scopes change so the new permissions take
+    /// effect immediately instead of after the cache TTL.
+    /// </summary>
+    public static async Task HandleAsync(
+        ApiKeyScopesUpdatedEto evt,
+        IApiKeyCacheService cacheService,
+        ILogger<ApiKeyCacheInvalidationHandler> logger,
+        CancellationToken cancellationToken)
+    {
+        await cacheService.RemoveAsync(evt.HashedKey, cancellationToken).ConfigureAwait(false);
+        LogScopeEviction(logger, evt.ApiKeyId);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Evicted cached API key {ApiKeyId} after revocation.")]
+    private static partial void LogRevocationEviction(ILogger logger, Guid apiKeyId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Evicted cached API key {ApiKeyId} after scope update.")]
+    private static partial void LogScopeEviction(ILogger logger, Guid apiKeyId);
+}

--- a/tests/Granit.Authentication.ApiKeys.Tests/Cache/ApiKeyCacheInvalidationHandlerTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/Cache/ApiKeyCacheInvalidationHandlerTests.cs
@@ -1,0 +1,111 @@
+using System.Reflection;
+using Granit.Authentication.ApiKeys.Cache;
+using Granit.Authentication.ApiKeys.Domain;
+using Granit.Authentication.ApiKeys.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.ApiKeys.Tests.Cache;
+
+/// <summary>
+/// Behavioural tests proving the fix for VULN-100-IAM: dispatching an
+/// <see cref="ApiKeyRevokedEto"/> (or <see cref="ApiKeyScopesUpdatedEto"/>) evicts the
+/// cached entry keyed by the exact <c>HashedKey</c> carried on the event, so a revoked or
+/// re-scoped key can no longer authenticate from the stale cache.
+/// </summary>
+public sealed class ApiKeyCacheInvalidationHandlerTests
+{
+    private const string HashedKey = "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+    [Fact]
+    public async Task HandleAsync_Revoked_RemovesCacheEntryWithExactHashedKey()
+    {
+        var cache = new CapturingApiKeyCacheService();
+        var evt = new ApiKeyRevokedEto(Guid.NewGuid(), HashedKey);
+
+        await ApiKeyCacheInvalidationHandler.HandleAsync(
+            evt, cache, NullLogger<ApiKeyCacheInvalidationHandler>.Instance, TestContext.Current.CancellationToken);
+
+        cache.RemoveCalls.ShouldHaveSingleItem().ShouldBe(HashedKey);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ScopesUpdated_RemovesCacheEntryWithExactHashedKey()
+    {
+        var cache = new CapturingApiKeyCacheService();
+        var evt = new ApiKeyScopesUpdatedEto(Guid.NewGuid(), HashedKey);
+
+        await ApiKeyCacheInvalidationHandler.HandleAsync(
+            evt, cache, NullLogger<ApiKeyCacheInvalidationHandler>.Instance, TestContext.Current.CancellationToken);
+
+        cache.RemoveCalls.ShouldHaveSingleItem().ShouldBe(HashedKey);
+    }
+
+    [Fact]
+    public async Task HandleAsync_Revoked_PropagatesCancellationToken()
+    {
+        var cache = new CapturingApiKeyCacheService();
+        using var cts = new CancellationTokenSource();
+        var evt = new ApiKeyRevokedEto(Guid.NewGuid(), HashedKey);
+
+        await ApiKeyCacheInvalidationHandler.HandleAsync(
+            evt, cache, NullLogger<ApiKeyCacheInvalidationHandler>.Instance, cts.Token);
+
+        cache.LastToken.ShouldBe(cts.Token);
+    }
+
+    // =========================================================================
+    // Wolverine discoverability guard — teeth beyond declaration.
+    //
+    // Wolverine discovers handlers by convention (class ends in "Handler", public,
+    // non-static, with a public static "Handle"/"HandleAsync" whose FIRST parameter is
+    // the message). If a future refactor renames the method, makes it internal, or turns
+    // the class static, Wolverine SILENTLY stops dispatching and the vulnerability
+    // reopens with no failing test. These reflection checks fail loudly instead.
+    // =========================================================================
+
+    [Theory]
+    [InlineData(typeof(ApiKeyRevokedEto))]
+    [InlineData(typeof(ApiKeyScopesUpdatedEto))]
+    public void Handler_ExposesWolverineDiscoverableHandleMethodFor(Type messageType)
+    {
+        MethodInfo? handle = typeof(ApiKeyCacheInvalidationHandler)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .SingleOrDefault(m =>
+                m.Name == "HandleAsync" &&
+                m.GetParameters() is { Length: > 0 } p &&
+                p[0].ParameterType == messageType);
+
+        handle.ShouldNotBeNull($"Wolverine cannot dispatch {messageType.Name} without a public static HandleAsync whose first parameter is that message.");
+        handle.ReturnType.ShouldBe(typeof(Task));
+    }
+
+    [Fact]
+    public void Handler_IsPublicNonStaticClass_SoWolverineCanScanIt()
+    {
+        Type t = typeof(ApiKeyCacheInvalidationHandler);
+        t.IsPublic.ShouldBeTrue("Wolverine scans Assembly.ExportedTypes.");
+        t.IsAbstract.ShouldBeFalse("A static class (abstract+sealed) is skipped by Wolverine.");
+    }
+
+    private sealed class CapturingApiKeyCacheService : IApiKeyCacheService
+    {
+        public List<string> RemoveCalls { get; } = [];
+        public CancellationToken LastToken { get; private set; }
+
+        public Task<ApiKeyEntry?> GetOrLoadAsync(
+            string hashedKey,
+            Func<CancellationToken, Task<ApiKeyEntry?>> factory,
+            TimeSpan duration,
+            CancellationToken cancellationToken = default) =>
+            factory(cancellationToken);
+
+        public Task RemoveAsync(string hashedKey, CancellationToken cancellationToken = default)
+        {
+            RemoveCalls.Add(hashedKey);
+            LastToken = cancellationToken;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Security fix — VULN-100-IAM (HIGH, CWE-613, CVSS 6.5)

**Problem.** `IApiKeyCacheService.RemoveAsync` existed but had **zero callers**. Revoking a key only flipped `RevokedAt` in the DB; the auth handler caches the resolved `ApiKeyEntry` under its hashed key for `CacheDuration` (default 5 min). A **revoked/leaked key kept authenticating for up to 5 minutes** on any node with the entry warm.

## Fix
- New `ApiKeyCacheInvalidationHandler` (base module, Wolverine-discovered — mirrors `PermissionCacheInvalidationHandler`, no Wolverine dep in the base module) consuming the already-published `ApiKeyRevokedEto` and calling `IApiKeyCacheService.RemoveAsync(evt.HashedKey)`.
- **Also fixes the sibling staleness bug**: `ApiKeyScopesUpdatedEto` (emitted by `UpdatePermissions`) likewise had no handler — a re-scoped key served old permissions for up to `CacheDuration`. Same handler, second overload.

## Tests
- Behavioural teeth: a capturing `IApiKeyCacheService` fake asserts the exact hashed key + `CancellationToken` propagation for both ETOs.
- Discovery teeth (per the 'test registration not declaration' convention): reflection guards on handler visibility/signature so a refactor that silently breaks Wolverine dispatch fails loudly.
- `Granit.Authentication.ApiKeys.Tests`: 138 passed. `dotnet format` clean.

## Notes
- No dependency changes. Docs unaffected.
- Part of the security-audit remediation (Critical + High wave). See also PRs for VULN-001 / VULN-100-AI / VULN-100-OBS.