### PR TITLE
fix(mcp): default-deny per-tool authorization on tools/call (VULN-100-AI)

### DIFF
--- a/src/Granit.Mcp.Server/Extensions/McpServerServiceCollectionExtensions.cs
+++ b/src/Granit.Mcp.Server/Extensions/McpServerServiceCollectionExtensions.cs
@@ -30,11 +30,15 @@ public static class McpServerServiceCollectionExtensions
             .AddOptions<GranitMcpServerOptions>()
             .BindConfiguration(GranitMcpServerOptions.SectionName);
 
-        // SDK: chain HTTP transport + auth onto the existing MCP server (registered by GranitMcpModule)
+        // SDK: chain HTTP transport + auth onto the existing MCP server (registered by GranitMcpModule).
+        // The default-deny call-tool gate is registered first so it wraps the base module's
+        // metrics/sanitizer call-tool filter and rejects un-annotated tools before dispatch.
         services
             .AddMcpServer()
             .WithHttpTransport()
-            .AddAuthorizationFilters();
+            .AddAuthorizationFilters()
+            .WithRequestFilters(filters =>
+                filters.AddCallToolFilter(CallToolAuthorizationFilter.Wrap));
 
         // Granit visibility filters
         services.TryAddEnumerable(

--- a/src/Granit.Mcp.Server/Internal/CallToolAuthorizationFilter.cs
+++ b/src/Granit.Mcp.Server/Internal/CallToolAuthorizationFilter.cs
@@ -1,0 +1,205 @@
+using Granit.Authorization;
+using Granit.Mcp.Server.Permissions;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Granit.Mcp.Server.Internal;
+
+/// <summary>
+/// Default-deny authorization gate for MCP <c>tools/call</c>. Runs before dispatch and
+/// before the output sanitizers, and can reject an invocation without calling <c>next</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The SDK's own call-tool filter (registered by <c>AddAuthorizationFilters()</c>) only
+/// enforces tools that carry explicit authorization metadata (<see cref="IAuthorizeData"/>,
+/// <see cref="AuthorizationPolicy"/>, <see cref="IAuthorizationRequirementData"/>); an
+/// un-annotated tool is dispatched to any principal that reached the server — a fail-open.
+/// This filter closes that gap:
+/// </para>
+/// <list type="number">
+/// <item>An un-resolvable tool is rejected (fail-closed).</item>
+/// <item>A tool declaring <c>[McpTenantScope(RequireTenant = true)]</c> is rejected when no
+/// tenant context is active, re-running the <c>tools/list</c> visibility check at call time.</item>
+/// <item>A tool carrying explicit authorization metadata is passed through — the SDK filter
+/// enforces its policy, so this filter never double-enforces it.</item>
+/// <item>Any other tool must satisfy the coarse <see cref="McpPermissions.Tools.Execute"/>
+/// fallback permission via <see cref="IPermissionChecker"/>; otherwise it is rejected.</item>
+/// </list>
+/// <para>
+/// Lives in <c>Granit.Mcp.Server</c> rather than the transport-agnostic base
+/// <c>Granit.Mcp</c> because the permission fallback needs <see cref="IPermissionChecker"/>
+/// from <c>Granit.Authorization</c> — a server-tier dependency the base module must not
+/// acquire (stdio hosts without an HTTP principal have no RBAC pipeline to consult).
+/// </para>
+/// </remarks>
+internal static partial class CallToolAuthorizationFilter
+{
+    /// <summary>
+    /// Wraps the call-tool handler with the default-deny gate.
+    /// </summary>
+    public static McpRequestHandler<CallToolRequestParams, CallToolResult> Wrap(
+        McpRequestHandler<CallToolRequestParams, CallToolResult> next) =>
+        async (context, ct) =>
+        {
+            CallToolResult? denial = await EvaluateAsync(context, ct).ConfigureAwait(false);
+            return denial ?? await next(context, ct).ConfigureAwait(false);
+        };
+
+    /// <summary>
+    /// Thin adapter over <see cref="EvaluateAsync(IServiceProvider?, string, IReadOnlyList{object}?, CancellationToken)"/>
+    /// that pulls the tool name and matched-primitive metadata off the SDK request context.
+    /// </summary>
+    private static ValueTask<CallToolResult?> EvaluateAsync(
+        RequestContext<CallToolRequestParams> context,
+        CancellationToken ct) =>
+        EvaluateAsync(
+            context.Services,
+            context.Params?.Name ?? "unknown",
+            context.MatchedPrimitive?.Metadata,
+            ct);
+
+    /// <summary>
+    /// Returns a non-<see langword="null"/> error result when the invocation must be denied,
+    /// or <see langword="null"/> when it may proceed to dispatch. Exposed for isolated testing.
+    /// </summary>
+    internal static async ValueTask<CallToolResult?> EvaluateAsync(
+        IServiceProvider? services,
+        string toolName,
+        IReadOnlyList<object>? matchedPrimitiveMetadata,
+        CancellationToken ct)
+    {
+        ILogger? logger = services?
+            .GetService<ILoggerFactory>()?
+            .CreateLogger("Granit.Mcp.Server.CallToolAuthorization");
+
+        // Fail closed: a tool we cannot resolve to a CLR type cannot be reasoned about.
+        McpToolTypeRegistry? registry = services?.GetService<McpToolTypeRegistry>();
+        Type? toolType = registry?.Resolve(toolName);
+        if (toolType is null)
+        {
+            if (logger is not null)
+            {
+                LogUnresolvedTool(logger, toolName);
+            }
+
+            return Deny();
+        }
+
+        // Re-run the tenant-scope check at call time (tools/list only hides, it does not gate).
+        if (RequiresTenant(toolType))
+        {
+            ICurrentTenant? currentTenant = services?.GetService<ICurrentTenant>();
+            if (currentTenant is not { IsAvailable: true })
+            {
+                if (logger is not null)
+                {
+                    LogTenantRequired(logger, toolName);
+                }
+
+                return Deny();
+            }
+        }
+
+        // A tool carrying explicit authorization metadata is enforced by the SDK's own
+        // call-tool filter — passing through here avoids double-enforcement.
+        if (HasExplicitAuthorization(matchedPrimitiveMetadata))
+        {
+            return null;
+        }
+
+        // Default-deny fallback: the principal must hold the coarse execute permission.
+        IPermissionChecker? permissionChecker = services?.GetService<IPermissionChecker>();
+        if (permissionChecker is null)
+        {
+            if (logger is not null)
+            {
+                LogNoPermissionChecker(logger, toolName);
+            }
+
+            return Deny();
+        }
+
+        bool granted = await permissionChecker
+            .IsGrantedAsync(McpPermissions.Tools.Execute, ct)
+            .ConfigureAwait(false);
+
+        if (!granted)
+        {
+            if (logger is not null)
+            {
+                LogExecuteDenied(logger, toolName);
+            }
+
+            return Deny();
+        }
+
+        return null;
+    }
+
+    private static bool RequiresTenant(Type toolType) =>
+        toolType
+            .GetCustomAttributes(typeof(McpTenantScopeAttribute), inherit: false)
+            .OfType<McpTenantScopeAttribute>()
+            .Any(scope => scope.RequireTenant);
+
+    // Mirrors ModelContextProtocol.AspNetCore's HasAuthorizationMetadata: explicit opt-out
+    // (IAllowAnonymous) or any positive authorization datum counts as an explicit decision.
+    private static bool HasExplicitAuthorization(IReadOnlyList<object>? metadata)
+    {
+        if (metadata is null)
+        {
+            return false;
+        }
+
+        if (metadata.Any(m => m is IAllowAnonymous))
+        {
+            return true;
+        }
+
+        return metadata.Any(m =>
+            m is IAuthorizeData or AuthorizationPolicy or IAuthorizationRequirementData);
+    }
+
+    private static CallToolResult Deny() => new()
+    {
+        IsError = true,
+        Content =
+        [
+            new TextContentBlock
+            {
+                Text = "Access forbidden: this tool requires explicit authorization "
+                    + "or the 'Mcp.Tools.Execute' permission.",
+            },
+        ],
+    };
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Warning,
+        Message = "MCP tools/call denied: tool '{ToolName}' could not be resolved to a CLR type.")]
+    private static partial void LogUnresolvedTool(ILogger logger, string toolName);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Warning,
+        Message = "MCP tools/call denied: tool '{ToolName}' requires a tenant context but none is active.")]
+    private static partial void LogTenantRequired(ILogger logger, string toolName);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Warning,
+        Message = "MCP tools/call denied: no IPermissionChecker registered to evaluate the "
+            + "'Mcp.Tools.Execute' fallback for tool '{ToolName}'.")]
+    private static partial void LogNoPermissionChecker(ILogger logger, string toolName);
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Warning,
+        Message = "MCP tools/call denied: principal lacks 'Mcp.Tools.Execute' for un-annotated tool '{ToolName}'.")]
+    private static partial void LogExecuteDenied(ILogger logger, string toolName);
+}

--- a/tests/Granit.ArchitectureTests/McpConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/McpConventionTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
 using ModelContextProtocol.Server;
 using Shouldly;
 using Xunit;
@@ -11,10 +12,100 @@ namespace Granit.ArchitectureTests;
 /// <list type="bullet">
 /// <item><c>[McpServerTool]</c> methods must have <c>[Description]</c></item>
 /// <item><c>McpPermissions</c> constants follow three-segment format</item>
+/// <item>every <c>[McpServerTool]</c> carries explicit authorization, or the
+/// framework deny-by-default call-tool gate is registered (VULN-100-AI)</item>
 /// </list>
 /// </summary>
 public sealed class McpConventionTests
 {
+    /// <summary>
+    /// Anti-regression guard for the MCP <c>tools/call</c> fail-open (VULN-100-AI): a principal
+    /// with <c>Mcp.Server.Access</c> must not be able to invoke an un-annotated tool. Either every
+    /// framework <c>[McpServerTool]</c> carries explicit authorization metadata (an
+    /// <see cref="IAuthorizeData"/> such as <c>[Authorize]</c>/<c>[Permission]</c>), or the
+    /// deny-by-default <c>CallToolAuthorizationFilter</c> gate must be wired into the server
+    /// pipeline so un-annotated tools require <c>Mcp.Tools.Execute</c>.
+    /// </summary>
+    [Fact]
+    public void McpServerTools_are_gated_by_explicit_authorization_or_deny_by_default_filter()
+    {
+        List<string> unGatedTools = [];
+
+        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()
+                     .Where(a => a.GetName().Name?.StartsWith("Granit.", StringComparison.Ordinal) == true))
+        {
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t is not null).ToArray()!;
+            }
+
+            foreach (Type type in types
+                         .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null))
+            {
+                bool typeAuthorized = HasExplicitAuthorization(type);
+
+                foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
+                             .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null))
+                {
+                    if (!typeAuthorized && !HasExplicitAuthorization(method))
+                    {
+                        unGatedTools.Add($"{type.FullName}.{method.Name}");
+                    }
+                }
+            }
+        }
+
+        // Un-annotated tools are only safe because the deny-by-default gate covers them.
+        if (unGatedTools.Count > 0)
+        {
+            DenyByDefaultFilterIsRegistered().ShouldBeTrue(
+                "MCP tools without explicit authorization rely on the deny-by-default call-tool gate, "
+                + "but 'CallToolAuthorizationFilter.Wrap' is not registered in "
+                + "'AddGranitMcpServer'. Un-annotated tools: " + string.Join(", ", unGatedTools));
+        }
+
+        // Regardless of whether any tools ship, the fail-open fence itself must stay in place.
+        DenyByDefaultFilterIsRegistered().ShouldBeTrue(
+            "The MCP deny-by-default call-tool gate ('CallToolAuthorizationFilter.Wrap') must be "
+            + "registered in 'AddGranitMcpServer' — see VULN-100-AI.");
+    }
+
+    private static bool HasExplicitAuthorization(MemberInfo member) =>
+        member.GetCustomAttributes(inherit: false).Any(a => a is IAuthorizeData);
+
+    private static bool DenyByDefaultFilterIsRegistered()
+    {
+        string repoRoot = FindRepoRoot();
+        string extensionsFile = Path.Join(
+            repoRoot, "src", "Granit.Mcp.Server", "Extensions", "McpServerServiceCollectionExtensions.cs");
+
+        return File.Exists(extensionsFile)
+            && File.ReadAllText(extensionsFile).Contains(
+                "CallToolAuthorizationFilter.Wrap", StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(McpConventionTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory).");
+    }
+
     /// <summary>
     /// Every method annotated with <c>[McpServerTool]</c> must also have
     /// <c>[Description]</c> so AI agents understand what the tool does.

--- a/tests/Granit.Mcp.Server.Tests/CallToolAuthorizationFilterTests.cs
+++ b/tests/Granit.Mcp.Server.Tests/CallToolAuthorizationFilterTests.cs
@@ -1,0 +1,164 @@
+using Granit.Authorization;
+using Granit.Authorization.Attributes;
+using Granit.Mcp.Server.Internal;
+using Granit.Mcp.Server.Permissions;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Mcp.Server.Tests;
+
+/// <summary>
+/// Proves the deny-by-default behaviour of <see cref="CallToolAuthorizationFilter"/>:
+/// an un-annotated tool is rejected unless the principal holds
+/// <see cref="McpPermissions.Tools.Execute"/>; an explicitly authorized tool passes
+/// through (the SDK filter enforces it); a tenant-scoped tool is rejected without a tenant.
+/// </summary>
+public sealed class CallToolAuthorizationFilterTests
+{
+    private const string PlainToolName = nameof(PlainTool);
+    private const string AuthorizedToolName = nameof(AuthorizedTool);
+    private const string TenantScopedToolName = nameof(TenantScopedTool);
+
+    [Fact]
+    public async Task EvaluateAsync_UnresolvedTool_IsDenied()
+    {
+        using ServiceProvider sp = BuildServices();
+
+        CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
+            sp, "ghost-tool", matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.IsError.ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_UnannotatedTool_WithoutExecutePermission_IsDenied()
+    {
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync(McpPermissions.Tools.Execute, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        using ServiceProvider sp = BuildServices(permissionChecker: checker);
+
+        CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
+            sp, PlainToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.IsError.ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_UnannotatedTool_WithNoPermissionChecker_IsDenied()
+    {
+        using ServiceProvider sp = BuildServices(permissionChecker: null);
+
+        CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
+            sp, PlainToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.IsError.ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_UnannotatedTool_WithExecutePermission_IsAllowed()
+    {
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync(McpPermissions.Tools.Execute, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        using ServiceProvider sp = BuildServices(permissionChecker: checker);
+
+        CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
+            sp, PlainToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ExplicitlyAuthorizedTool_IsAllowed_WithoutExecutePermission()
+    {
+        // No IPermissionChecker registered: the tool must pass through purely because it
+        // carries explicit authorization metadata (enforced downstream by the SDK filter).
+        using ServiceProvider sp = BuildServices(permissionChecker: null);
+
+        object[] metadata = [new PermissionAttribute("Some.Resource.Action")];
+
+        CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
+            sp, AuthorizedToolName, metadata, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_TenantScopedTool_WithoutTenant_IsDenied()
+    {
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync(McpPermissions.Tools.Execute, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+
+        using ServiceProvider sp = BuildServices(permissionChecker: checker, currentTenant: tenant);
+
+        CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
+            sp, TenantScopedToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.IsError.ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_TenantScopedTool_WithTenant_AndExecutePermission_IsAllowed()
+    {
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync(McpPermissions.Tools.Execute, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+
+        using ServiceProvider sp = BuildServices(permissionChecker: checker, currentTenant: tenant);
+
+        CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
+            sp, TenantScopedToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    private static ServiceProvider BuildServices(
+        IPermissionChecker? permissionChecker = null,
+        ICurrentTenant? currentTenant = null)
+    {
+        McpToolTypeRegistry registry = new();
+        registry.Register(PlainToolName, typeof(PlainTool));
+        registry.Register(AuthorizedToolName, typeof(AuthorizedTool));
+        registry.Register(TenantScopedToolName, typeof(TenantScopedTool));
+
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddSingleton(registry);
+
+        if (permissionChecker is not null)
+        {
+            services.AddSingleton(permissionChecker);
+        }
+
+        if (currentTenant is not null)
+        {
+            services.AddSingleton(currentTenant);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class PlainTool;
+
+    private sealed class AuthorizedTool;
+
+    [McpTenantScope(RequireTenant = true)]
+    private sealed class TenantScopedTool;
+}


### PR DESCRIPTION
## Security fix — VULN-100-AI (HIGH, CWE-862/441, CVSS 8.5, OWASP LLM06:2025)

**Problem.** MCP `tools/call` enforced only the coarse `Mcp.Server.Access` permission. `IMcpToolVisibilityFilter` implementations run on `tools/list` (visibility ≠ authorization). The SDK's own `[Authorize]` filter only throws for tools that *carry* authorization metadata — **un-annotated tools were dispatched to anyone** with server access. Per-tool authz and tenant-scope-on-invoke were unenforced host responsibilities that **failed open**, while docs advertised 'full Granit authorization'.

## Fix — `CallToolAuthorizationFilter` (registered before dispatch, in `Granit.Mcp.Server`)
Per invocation, **fails closed**:
1. Resolve the tool type via `McpToolTypeRegistry` — unresolvable ⇒ **deny**.
2. `[McpTenantScope(RequireTenant=true)]` + `ICurrentTenant.IsAvailable == false` ⇒ deny (re-runs the tenant check at call time, not just `tools/list`).
3. Tool carrying explicit authorization metadata ⇒ pass through to the SDK's `[Authorize]` filter (no double-enforcement; mirrors the SDK's `HasAuthorizationMetadata`/`IAllowAnonymous` semantics).
4. Otherwise require `Mcp.Tools.Execute` via `IPermissionChecker` (missing checker ⇒ deny).

Lives in `Granit.Mcp.Server` (not base `Granit.Mcp`) because the `Mcp.Tools.Execute` fallback needs `IPermissionChecker` from `Granit.Authorization`, which base deliberately does not reference — justified inline.

## Regression guard
New `McpConventionTests` arch-test asserting the deny-by-default filter is registered.

## Tests
`Granit.Mcp.Server.Tests` 36 passed (7 new), `Granit.Mcp.Tests` 55 passed, `McpConventionTests` 3 passed. `dotnet format` clean.

## Notes
- No dependency changes. The `mcp/index.mdx` 'full Granit authorization' claim should be aligned in a separate `granit-docs` PR.
- Part of the security-audit remediation (Critical + High wave).