### PR TITLE
fix(webhooks): stop trace-context leak + auto-redirect on delivery egress (VULN-100-OBS)

### DIFF
--- a/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
@@ -66,6 +66,16 @@ public static class WebhooksHostApplicationBuilderExtensions
         }).ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
         {
             ConnectCallback = WebhookSsrfConnectCallback.ConnectAsync,
+
+            // Suppress W3C trace-context propagation: the delivery target is a customer-controlled
+            // URL, so emitting internal traceparent/tracestate headers leaks our service topology
+            // and correlation IDs to an untrusted egress boundary (VULN-100-OBS).
+            ActivityHeadersPropagator = null,
+
+            // A 3xx from a subscriber endpoint is a subscription misconfiguration, not a redirect to
+            // follow: chasing it would defeat the SSRF ConnectCallback (the redirect target bypasses
+            // the vetted URL) and mask the delivery failure the subscriber must see (VULN-300-infra).
+            AllowAutoRedirect = false,
         });
 
         // Default (replaceable) store registrations.

--- a/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
+++ b/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
@@ -384,6 +384,39 @@ public sealed partial class SourceCodeAntiPatternTests
             + $"Violators: {string.Join(", ", violations)}");
     }
 
+    /// <summary>
+    /// The webhook delivery <c>SocketsHttpHandler</c> targets customer-controlled URLs at an
+    /// untrusted egress boundary. It MUST suppress W3C trace-context propagation
+    /// (<c>ActivityHeadersPropagator = null</c>) so internal traceparent/tracestate headers never
+    /// leak our topology (VULN-100-OBS), and MUST disable auto-redirect
+    /// (<c>AllowAutoRedirect = false</c>) so a 3xx cannot bypass the SSRF ConnectCallback nor mask a
+    /// delivery failure (VULN-300-infra). This source-regex guard lives in the architecture shard so
+    /// the convention is enforced repo-wide even if the Webhooks unit tests are skipped or the module
+    /// is refactored; a companion runtime probe (<c>WebhookDeliveryEgressTests</c>) asserts the same
+    /// two settings on the actual DI-configured handler instance.
+    /// </summary>
+    [Fact]
+    public void Webhook_delivery_handler_must_suppress_trace_propagation_and_auto_redirect()
+    {
+        string handlerFile = Path.Join(
+            RepoRoot, "src", "Granit.Webhooks", "Extensions", "WebhooksHostApplicationBuilderExtensions.cs");
+
+        File.Exists(handlerFile).ShouldBeTrue(
+            $"Expected webhook egress configuration at {handlerFile}. If the file moved, update this guard.");
+
+        string content = File.ReadAllText(handlerFile);
+
+        WebhookNullsActivityHeadersPropagator().IsMatch(content).ShouldBeTrue(
+            "Webhook delivery SocketsHttpHandler must set 'ActivityHeadersPropagator = null' to stop "
+            + "leaking internal W3C trace context (traceparent/tracestate) to customer-controlled "
+            + "webhook URLs (VULN-100-OBS). Re-enabling propagation is a topology-disclosure regression.");
+
+        WebhookDisablesAutoRedirect().IsMatch(content).ShouldBeTrue(
+            "Webhook delivery SocketsHttpHandler must set 'AllowAutoRedirect = false' — a 3xx from a "
+            + "subscriber is a delivery failure, and following it would bypass the SSRF ConnectCallback "
+            + "(VULN-300-infra).");
+    }
+
     private static string FindRepoRoot()
     {
         string? dir = Path.GetDirectoryName(typeof(SourceCodeAntiPatternTests).Assembly.Location);
@@ -491,4 +524,18 @@ public sealed partial class SourceCodeAntiPatternTests
     /// </summary>
     [GeneratedRegex(@"\bclass\s+\w+[^{]*:\s*[^{]*\bICurrentTenant\b")]
     private static partial Regex LocalICurrentTenantImpl();
+
+    /// <summary>
+    /// Matches <c>ActivityHeadersPropagator = null</c> on the webhook delivery handler —
+    /// the egress guard that stops internal trace-context leaking to customer URLs.
+    /// </summary>
+    [GeneratedRegex(@"ActivityHeadersPropagator\s*=\s*null")]
+    private static partial Regex WebhookNullsActivityHeadersPropagator();
+
+    /// <summary>
+    /// Matches <c>AllowAutoRedirect = false</c> on the webhook delivery handler —
+    /// a subscriber 3xx is a delivery failure, never a redirect to follow.
+    /// </summary>
+    [GeneratedRegex(@"AllowAutoRedirect\s*=\s*false")]
+    private static partial Regex WebhookDisablesAutoRedirect();
 }

--- a/tests/Granit.Webhooks.Tests/WebhookDeliveryEgressTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookDeliveryEgressTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+using Granit.Webhooks.Extensions;
+using Granit.Webhooks.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Tests;
+
+/// <summary>
+/// Egress hardening for the real, DI-configured webhook delivery pipeline
+/// (<c>WebhooksConstants.HttpClientName</c>). Rather than a loopback round-trip — impossible here
+/// because <see cref="WebhookSsrfConnectCallback"/> deliberately blocks loopback/private targets —
+/// these tests resolve the ACTUAL primary <see cref="SocketsHttpHandler"/> that
+/// <c>AddGranitWebhooks</c> wires through <c>ConfigurePrimaryHttpMessageHandler</c> (via
+/// <see cref="IHttpMessageHandlerFactory"/>) and assert its egress settings directly:
+/// <list type="bullet">
+///   <item><c>ActivityHeadersPropagator == null</c> — no internal W3C trace context
+///   (traceparent/tracestate) is emitted to customer-controlled URLs (VULN-100-OBS).</item>
+///   <item><c>AllowAutoRedirect == false</c> — a subscriber 3xx is a delivery failure, never a
+///   redirect to follow, which would also bypass the SSRF ConnectCallback (VULN-300-infra).</item>
+/// </list>
+/// This inspects the production handler instance, so a refactor that drops either setting fails here.
+/// </summary>
+public sealed class WebhookDeliveryEgressTests
+{
+    private static SocketsHttpHandler ResolvePrimaryDeliveryHandler(IServiceProvider services)
+    {
+        IHttpMessageHandlerFactory handlerFactory = services.GetRequiredService<IHttpMessageHandlerFactory>();
+        HttpMessageHandler handler = handlerFactory.CreateHandler(WebhooksConstants.HttpClientName);
+
+        // Walk the DelegatingHandler chain (resilience, logging, …) down to the primary handler.
+        while (handler is DelegatingHandler delegating)
+        {
+            delegating.InnerHandler.ShouldNotBeNull(
+                "The webhook delivery handler chain terminated without a primary handler.");
+            handler = delegating.InnerHandler;
+        }
+
+        return handler.ShouldBeOfType<SocketsHttpHandler>(
+            "AddGranitWebhooks must configure a SocketsHttpHandler as the primary webhook delivery handler "
+            + "(it carries the SSRF ConnectCallback and the egress-hardening settings).");
+    }
+
+    private static ServiceProvider BuildWebhookHost()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.AddGranitWebhooks();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Delivery_handler_suppresses_trace_context_propagation()
+    {
+        using ServiceProvider provider = BuildWebhookHost();
+
+        SocketsHttpHandler handler = ResolvePrimaryDeliveryHandler(provider);
+
+        // ActivityHeadersPropagator has no public getter in all TFMs — read it reflectively.
+        PropertyInfo? propagatorProperty = typeof(SocketsHttpHandler)
+            .GetProperty("ActivityHeadersPropagator", BindingFlags.Public | BindingFlags.Instance);
+        propagatorProperty.ShouldNotBeNull(
+            "SocketsHttpHandler.ActivityHeadersPropagator not found — the runtime API changed; "
+            + "revisit the webhook egress hardening.");
+
+        object? propagator = propagatorProperty.GetValue(handler);
+        propagator.ShouldBeNull(
+            "Webhook delivery must null ActivityHeadersPropagator so internal W3C trace context "
+            + "(traceparent/tracestate) never leaks to customer-controlled webhook URLs (VULN-100-OBS).");
+    }
+
+    [Fact]
+    public void Delivery_handler_disables_auto_redirect()
+    {
+        using ServiceProvider provider = BuildWebhookHost();
+
+        SocketsHttpHandler handler = ResolvePrimaryDeliveryHandler(provider);
+
+        handler.AllowAutoRedirect.ShouldBeFalse(
+            "Webhook delivery must set AllowAutoRedirect = false — a 3xx from a subscriber is a delivery "
+            + "failure, and following it would bypass the SSRF ConnectCallback (VULN-300-infra).");
+    }
+}


### PR DESCRIPTION
## Security fix — VULN-100-OBS (HIGH per boundary policy, CWE-200) + VULN-300-infra (LOW, CWE-441)

**Problem.** The webhook delivery `SocketsHttpHandler` (named client shared by `SendWebhookHandler` and `WebhookTestPingService`) customized only `ConnectCallback` (SSRF). With HttpClient trace instrumentation active, every delivery injected internal W3C `traceparent`/`tracestate` into requests to **customer-controlled webhook URLs** (topology / correlation-ID disclosure per tenant, boundary B5). It also followed auto-redirects, replaying the signed payload to another public host.

## Fix (one handler covers delivery + test-ping)
- `ActivityHeadersPropagator = null` — no internal trace context leaves toward customer URLs (local spans still record the delivery).
- `AllowAutoRedirect = false` — a subscriber 3xx is a delivery failure, not a redirect to chase (also avoids bypassing the SSRF-vetted target).
Each with an inline security rationale.

## Regression guard
- New `WebhookDeliveryEgressTests`: resolves the **real wired primary handler** via `IHttpMessageHandlerFactory` and asserts both settings on the production instance.
- New `SourceCodeAntiPatternTests` arch-test asserting both settings are present, so a refactor can't silently re-enable propagation.

## Tests
`Granit.Webhooks.Tests` 216 passed (2 new), arch-test 1 passed. `dotnet format` clean.

## Notes
- No dependency changes. Docs note ships separately on `granit-docs`.
- Part of the security-audit remediation (Critical + High wave).