### PR TITLE
docs(endpoints): prose for host-access opt-in (follow-up to #2897)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -8945,6 +8945,22 @@
       ]
     },
     {
+      "name": "ApiKeyCacheInvalidationHandler",
+      "fqn": "Granit.Authentication.ApiKeys.Cache.ApiKeyCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Cache/ApiKeyCacheInvalidationHandler.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(ApiKeyRevokedEto evt, IApiKeyCacheService cacheService, ILogger<ApiKeyCacheInvalidationHandler> logger, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "CacheBehavior",
       "fqn": "Granit.Authentication.ApiKeys.CacheBehavior",
       "kind": "enum",
@@ -42838,7 +42854,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceServiceCollectionExtensions.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "AddGranitPersistence",
@@ -43187,6 +43203,15 @@
           "returnType": "Task<int>"
         }
       ]
+    },
+    {
+      "name": "ITenantQueryScope",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.ITenantQueryScope",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/ITenantQueryScope.cs",
+      "line": 25,
+      "members": []
     },
     {
       "name": "AuditedEntityInterceptor",

--- a/src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs
@@ -51,9 +51,10 @@ public static class AIEndpointRouteBuilderExtensions
         RouteGroupBuilder usageGroup = group.MapGranitGroup("usage")
             .WithTags(options.UsageTagName)
             .RequireAuthorization(AIPermissions.Usage.Read);
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission if cross-tenant AI usage visibility is intended.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. To expose cross-tenant AI-usage visibility, mark this route
+        // .AllowHostAccess(); a platform admin holding Usage.Read at global scope then reads across
+        // tenants, while the multi-tenant filter stays enforced for every tenant-scoped caller.
         usageGroup.MapGranitQuery<AIUsageRecord>();
 
         // Discovery endpoints — provider and model listing

--- a/src/Granit.Auditing.Endpoints/Extensions/AuditingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Auditing.Endpoints/Extensions/AuditingEndpointRouteBuilderExtensions.cs
@@ -42,16 +42,18 @@ public static class AuditingEndpointRouteBuilderExtensions
 
         // Audit entries: query engine (list/meta/saved-views) + custom lookups + GDPR ops.
         RouteGroupBuilder entriesGroup = group.MapGranitGroup("audit-entries");
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default — a host admin with no
-        // resolved tenant sees only the host partition. For ISO 27001 cross-tenant audit review,
-        // add .AllowHostAccess() here plus a distinct host-scoped permission (not the tenant Read).
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. For ISO 27001 cross-tenant audit review, mark this route
+        // .AllowHostAccess(); a platform admin holding AuditEntries.Read at global scope then reads
+        // across tenants, while the multi-tenant filter stays enforced for every tenant-scoped caller.
         entriesGroup.MapGranitQuery<AuditEntry>();
         entriesGroup.MapAuditingReadEndpoints();
         entriesGroup.MapAuditingManagementEndpoints();
 
         // Audit entity changes: query engine only (cross-cutting analysis).
         // Detail of an entity change is reached via the parent AuditEntry detail endpoint.
-        // TODO(VULN-001): add .AllowHostAccess() + host-scoped permission for cross-tenant review.
+        // Fail-closed to the host partition by default; cross-tenant review is opt-in via
+        // .AllowHostAccess() plus a global-scoped AuditEntries.Read grant.
         group.MapGranitGroup("audit-entity-changes").MapGranitQuery<AuditEntityChange>();
 
         return group;

--- a/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
@@ -58,9 +58,10 @@ public static class AuthorizationEndpointRouteBuilderExtensions
         // Admin query surfaces — paginated/filterable lists for the entity discovery.
         // Routed under their own subgroups so they coexist with the bespoke grant
         // management endpoints under "/roles/{roleName}" without colliding.
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission on these groups for ISO 27001 cross-tenant authorization review.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. For ISO 27001 cross-tenant authorization review, mark these
+        // groups .AllowHostAccess(); a platform admin holding each group's read permission at global
+        // scope then reads across tenants, while the filter stays enforced for tenant-scoped callers.
         group.MapGranitGroup("grants").MapGranitQuery<PermissionGrant>(configure: opts =>
         {
             opts.AuthorizationPolicy = AuthorizationEndpointsPermissions.Grants.Manage;

--- a/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
@@ -64,9 +64,10 @@ public static class BlobStorageEndpointRouteBuilderExtensions
             .RequireAuthorization(BlobStoragePermissions.Administration.Manage)
             .MapOperationEndpoints();
 
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission if cross-tenant blob-descriptor visibility is intended.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. To expose cross-tenant blob-descriptor visibility, mark this
+        // route .AllowHostAccess(); a platform admin holding Administration.Read at global scope then
+        // reads across tenants, while the multi-tenant filter stays enforced for tenant callers.
         group.MapGranitGroup("blobs")
             .RequireAuthorization(BlobStoragePermissions.Administration.Read)
             .MapGranitQuery<BlobDescriptor>();

--- a/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
@@ -86,9 +86,10 @@ public static class LocalizationEndpointRouteBuilderExtensions
             .RequireAuthorization(LocalizationOverridesPermissions.Overrides.Manage)
             .WithTags(options.TagName);
 
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission if cross-tenant localization-override visibility is intended.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. To expose cross-tenant localization-override visibility, mark
+        // this route .AllowHostAccess(); a platform admin holding this group's read permission at
+        // global scope then reads across tenants, while the filter stays enforced for tenant callers.
         group.MapGranitQuery<LocalizationOverride>();
         group.MapLocalizationWriteEndpoints();
 

--- a/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
@@ -42,9 +42,10 @@ internal static class LegalDocumentAdminEndpoints
         // GET /meta    → query metadata (columns, filters, sorts, presets)
         // The "published" quick filter is the default; pass ?quickFilters=draft to see drafts.
         // Filter by document ID via ?filter[documentId.eq]=privacy-policy to view version history.
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission if cross-tenant legal-document visibility is intended.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. To expose cross-tenant legal-document visibility, mark this
+        // route .AllowHostAccess(); a platform admin holding LegalDocuments.Read at global scope then
+        // reads across tenants, while the multi-tenant filter stays enforced for tenant callers.
         group.MapGranitQuery<LegalDocument>(configure: opts =>
             opts.AuthorizationPolicy = PrivacyPermissions.LegalDocuments.Read);
 

--- a/src/Granit.Scheduling.Endpoints/Extensions/SchedulingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Scheduling.Endpoints/Extensions/SchedulingEndpointRouteBuilderExtensions.cs
@@ -49,9 +49,10 @@ public static class SchedulingEndpointRouteBuilderExtensions
         actionsGroup.RequireAuthorization(SchedulingPermissions.Actions.Manage).MapWriteEndpoints();
 
         // QueryEngine-powered list endpoint with pagination, filtering, and sorting
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission if cross-tenant scheduled-action visibility is intended.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. To expose cross-tenant scheduled-action visibility, mark this
+        // route .AllowHostAccess(); a platform admin holding Actions.Read at global scope then reads
+        // across tenants, while the multi-tenant filter stays enforced for every tenant-scoped caller.
         actionsGroup.RequireAuthorization(SchedulingPermissions.Actions.Read)
             .MapGranitQuery<ScheduledAction>();
 

--- a/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
@@ -61,9 +61,10 @@ public static class TemplatingEndpointRouteBuilderExtensions
 
         // Template CRUD + lifecycle + preview + variables + history
         RouteGroupBuilder templateGroup = group.MapGranitGroup("templates");
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission if cross-tenant template visibility is intended.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. To expose cross-tenant template visibility, mark this route
+        // .AllowHostAccess(); a platform admin holding Templates.Read at global scope then reads
+        // across tenants, while the multi-tenant filter stays enforced for every tenant-scoped caller.
         templateGroup.MapGranitQuery<Granit.Templating.Store.TemplateSummary>(configure: q =>
             q.AuthorizationPolicy = Granit.Templating.Endpoints.Permissions.TemplatingPermissions.Templates.Read);
         templateGroup.MapTemplatingCrudEndpoints();

--- a/src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs
@@ -66,9 +66,10 @@ public static class WebhooksEndpointRouteBuilderExtensions
             .RequireAuthorization(WebhooksPermissions.Subscriptions.Manage);
 
         // Query endpoints for subscription list and delivery attempts.
-        // TODO(VULN-001): cross-tenant reads are now fail-closed by default. A host admin with no
-        // resolved tenant sees only the host partition — add .AllowHostAccess() + a host-scoped
-        // permission on these groups if cross-tenant webhook visibility is intended.
+        // Cross-tenant reads are fail-closed by default: a host operator with no resolved tenant
+        // sees only the host partition. To expose cross-tenant webhook visibility, mark these
+        // groups .AllowHostAccess(); a platform admin holding Subscriptions.Read at global scope
+        // then reads across tenants, while the multi-tenant filter stays enforced for tenant callers.
         group.MapGranitGroup("subscriptions").MapGranitQuery<WebhookSubscription>();
         group.MapGranitGroup("deliveries").MapGranitQuery<WebhookDeliveryAttempt>();
 


### PR DESCRIPTION
## Follow-up to #2897 (VULN-001)

The fail-closed QueryEngine change (#2897) left `TODO(VULN-001)` markers on the 9 admin list endpoints. Repo convention is to document rationale in **prose**, not audit-ID tags — so this rewrites all 10 markers.

It also **corrects the guidance** they carried. The original comments said to add `.AllowHostAccess()` + a *distinct host-scoped permission*. Verified against `PermissionChecker` ([PermissionChecker.cs:67-68,261](src/Granit.Authorization/Services/PermissionChecker.cs)): in host context (no resolved tenant) the checker evaluates the permission with `tenantId = null`, matching **global grants only** (`perm:global:...`). So the correct, simpler guidance is:

> Cross-tenant host view is opt-in via `.AllowHostAccess()`; grant the platform admin the **existing** read permission at **global scope**. No separate `*.ReadAcrossTenants` permission is needed — a tenant-scoped grant can't satisfy the global lookup, so tenant callers stay fail-closed.

Both existing `.AllowHostAccess()` sites (ApiKeys, Webhooks subscription-read) were verified sound under this model.

## Changes
- 9 endpoint files, **comment-only** (no behavior change).
- `.mcp-code-index.json`: regenerated by the pre-push hook — also absorbs the index drift from #2894/#2895/#2896/#2897 (those merged via `--no-verify` from worktrees, so the index hadn't been regenerated since).

No dependency, API, or test changes.