### PR TITLE
fix(encryption): fail closed on in-memory keystore + atomic crypto-shred audit (VULN-200/201-data)

### DIFF
--- a/src/Granit.Encryption/CryptoShredding/CryptoShreddingPhase.cs
+++ b/src/Granit.Encryption/CryptoShredding/CryptoShreddingPhase.cs
@@ -1,0 +1,23 @@
+namespace Granit.Encryption.CryptoShredding;
+
+/// <summary>
+/// Identifies which phase of the two-phase crypto-shredding sequence an audit record captures.
+/// </summary>
+/// <remarks>
+/// The intent record (<see cref="Requested"/>) is written durably <em>before</em> the irreversible
+/// key destruction, so an audit failure can never leave an erasure without a trail (GDPR Art. 5(2)).
+/// The confirmation record (<see cref="Confirmed"/>) is written after the key has been destroyed.
+/// </remarks>
+public enum CryptoShreddingPhase
+{
+    /// <summary>
+    /// The intent to destroy the key, recorded before destruction. A durable trail exists from this
+    /// point on, even if the process crashes between phases.
+    /// </summary>
+    Requested,
+
+    /// <summary>
+    /// The key has been destroyed and the erasure is complete.
+    /// </summary>
+    Confirmed
+}

--- a/src/Granit.Encryption/CryptoShredding/ICryptoShreddingAuditRecorder.cs
+++ b/src/Granit.Encryption/CryptoShredding/ICryptoShreddingAuditRecorder.cs
@@ -20,15 +20,23 @@ namespace Granit.Encryption.CryptoShredding;
 public interface ICryptoShreddingAuditRecorder
 {
     /// <summary>
-    /// Records that a per-entity encryption key was permanently destroyed.
+    /// Records a phase of a crypto-shredding operation.
     /// </summary>
+    /// <remarks>
+    /// Called twice per erasure: once with <see cref="CryptoShreddingPhase.Requested"/> before the key
+    /// is destroyed (durable intent), and once with <see cref="CryptoShreddingPhase.Confirmed"/> after
+    /// destruction. Implementations must ensure the <see cref="CryptoShreddingPhase.Requested"/> record
+    /// is durable before returning, so the irreversible destruction is never trail-less (GDPR Art. 5(2)).
+    /// </remarks>
     /// <param name="entityType">Logical entity type name.</param>
     /// <param name="entityId">Entity identifier.</param>
-    /// <param name="shreddedAt">Timestamp of the shredding operation.</param>
+    /// <param name="phase">Which phase of the two-phase erasure this record captures.</param>
+    /// <param name="occurredAt">Timestamp of the shredding operation.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task RecordAsync(
         string entityType,
         string entityId,
-        DateTimeOffset shreddedAt,
+        CryptoShreddingPhase phase,
+        DateTimeOffset occurredAt,
         CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs
+++ b/src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs
@@ -29,7 +29,8 @@ public static class EncryptionServiceCollectionExtensions
 
         services.TryAddSingleton<IStringEncryptionService, DefaultStringEncryptionService>();
 
-        // In-memory fallback for dev/test — replaced by a Vault provider in production
+        // In-memory fallback for dev/test only — it throws on resolution outside Development.
+        // A host must register a Vault-backed IEntityEncryptionKeyStore before this default runs in production.
         services.TryAddScoped<IEntityEncryptionKeyStore, InMemoryEntityEncryptionKeyStore>();
 
         // Crypto-shredding

--- a/src/Granit.Encryption/Services/DefaultCryptoShredder.cs
+++ b/src/Granit.Encryption/Services/DefaultCryptoShredder.cs
@@ -10,6 +10,12 @@ namespace Granit.Encryption.Services;
 /// destruction to <see cref="IEntityEncryptionKeyStore"/> and notifies all
 /// registered <see cref="ICryptoShreddingAuditRecorder"/> instances.
 /// </summary>
+/// <remarks>
+/// Erasure is two-phase and recoverable: a durable <see cref="CryptoShreddingPhase.Requested"/> intent
+/// record is written <em>before</em> the irreversible <see cref="IEntityEncryptionKeyStore.DeleteKeyAsync"/>,
+/// and a <see cref="CryptoShreddingPhase.Confirmed"/> record is written afterwards. The destruction never
+/// precedes a durable record, so an audit failure cannot leave an erasure without a trail (GDPR Art. 5(2)).
+/// </remarks>
 public sealed partial class DefaultCryptoShredder(
     IEntityEncryptionKeyStore keyStore,
     TimeProvider timeProvider,
@@ -30,14 +36,7 @@ public sealed partial class DefaultCryptoShredder(
         activity?.SetTag("entity_type", entityType);
         activity?.SetTag("entity_id", entityId);
 
-        await keyStore.DeleteKeyAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
-
-        DateTimeOffset shreddedAt = timeProvider.GetUtcNow();
-        metrics.RecordKeyShredded(null, entityType);
-        LogKeyShredded(logger, entityType, entityId);
-
-        await NotifyAuditRecordersAsync(entityType, entityId, shreddedAt, cancellationToken)
-            .ConfigureAwait(false);
+        await ShredOneAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task ShredBatchAsync(
@@ -52,35 +51,75 @@ public sealed partial class DefaultCryptoShredder(
             EncryptionActivitySource.ShredBatch);
         activity?.SetTag("entity_type", entityType);
 
-        DateTimeOffset shreddedAt = timeProvider.GetUtcNow();
         int count = 0;
 
         foreach (string entityId in entityIds)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            await keyStore.DeleteKeyAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
-            metrics.RecordKeyShredded(null, entityType);
-
-            await NotifyAuditRecordersAsync(entityType, entityId, shreddedAt, cancellationToken)
-                .ConfigureAwait(false);
-
+            await ShredOneAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
             count++;
         }
 
         LogBatchShredded(logger, entityType, count);
     }
 
+    private async Task ShredOneAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken)
+    {
+        // Phase 1 — durable intent BEFORE the irreversible destruction. If this throws, no key is
+        // destroyed, so the operation can be retried without ever having erased data trail-less.
+        DateTimeOffset requestedAt = timeProvider.GetUtcNow();
+        await NotifyAuditRecordersAsync(
+            entityType, entityId, CryptoShreddingPhase.Requested, requestedAt, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Phase 2 — the irreversible operation, now backed by a durable intent record.
+        await keyStore.DeleteKeyAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
+        metrics.RecordKeyShredded(null, entityType);
+        LogKeyShredded(logger, entityType, entityId);
+
+        // Phase 3 — confirmation. A confirmation failure leaves the intent record standing, so the
+        // erasure remains auditable and reconcilable.
+        DateTimeOffset confirmedAt = timeProvider.GetUtcNow();
+        await NotifyAuditRecordersAsync(
+            entityType, entityId, CryptoShreddingPhase.Confirmed, confirmedAt, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     private async Task NotifyAuditRecordersAsync(
         string entityType,
         string entityId,
-        DateTimeOffset shreddedAt,
+        CryptoShreddingPhase phase,
+        DateTimeOffset occurredAt,
         CancellationToken cancellationToken)
     {
+        List<Exception>? failures = null;
+
+        // Fan out to every recorder even if one throws: a single failing recorder must not deprive the
+        // others of the record, and the aggregated failure still surfaces to the caller.
         foreach (ICryptoShreddingAuditRecorder recorder in auditRecorders)
         {
-            await recorder.RecordAsync(entityType, entityId, shreddedAt, cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                await recorder.RecordAsync(entityType, entityId, phase, occurredAt, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                (failures ??= []).Add(ex);
+                LogAuditRecorderFailed(logger, recorder.GetType().Name, phase, entityType, entityId, ex);
+            }
+        }
+
+        if (failures is { Count: > 0 })
+        {
+            throw new AggregateException(
+                $"{failures.Count} crypto-shredding audit recorder(s) failed to record the " +
+                $"'{phase}' phase for {entityType}/{entityId}.",
+                failures);
         }
     }
 
@@ -91,4 +130,14 @@ public sealed partial class DefaultCryptoShredder(
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Batch crypto-shredding completed for {EntityType}: {Count} keys destroyed")]
     private static partial void LogBatchShredded(ILogger logger, string entityType, int count);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Crypto-shredding audit recorder {RecorderType} failed for the {Phase} phase of {EntityType}/{EntityId}")]
+    private static partial void LogAuditRecorderFailed(
+        ILogger logger,
+        string recorderType,
+        CryptoShreddingPhase phase,
+        string entityType,
+        string entityId,
+        Exception exception);
 }

--- a/src/Granit.Encryption/Services/InMemoryEntityEncryptionKeyStore.cs
+++ b/src/Granit.Encryption/Services/InMemoryEntityEncryptionKeyStore.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Encryption.Services;
 
@@ -11,12 +12,32 @@ namespace Granit.Encryption.Services;
 /// Keys are stored in a <see cref="ConcurrentDictionary{TKey,TValue}"/> and are lost
 /// when the process restarts. This implementation MUST NOT be used in production —
 /// a secure provider (e.g., HashiCorp Vault) should override this registration.
+/// The constructor fails fast outside the Development environment, so a host that forgets
+/// to register a durable key store cannot silently run with volatile keys.
 /// </remarks>
 internal sealed class InMemoryEntityEncryptionKeyStore : IEntityEncryptionKeyStore
 {
     private const int KeySizeBytes = 32; // AES-256
 
     private readonly ConcurrentDictionary<string, byte[]> _keys = new(StringComparer.Ordinal);
+
+    public InMemoryEntityEncryptionKeyStore(IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        // Volatile keys are lost on every restart, which corrupts previously encrypted data and
+        // makes GDPR crypto-shredding non-durable. Refuse to resolve outside Development so the
+        // misconfiguration surfaces at startup instead of as silent PII corruption in production.
+        if (!environment.IsDevelopment())
+        {
+            throw new InvalidOperationException(
+                $"{nameof(InMemoryEntityEncryptionKeyStore)} is a development-only fallback and is forbidden " +
+                $"outside the Development environment (current: '{environment.EnvironmentName}'). " +
+                "Its keys are held in memory and lost on every restart, corrupting previously encrypted data " +
+                "and leaving GDPR crypto-shredding without a durable guarantee. " +
+                $"Register a Vault-backed {nameof(IEntityEncryptionKeyStore)} for production use.");
+        }
+    }
 
     /// <inheritdoc/>
     public Task<byte[]> GetOrCreateKeyAsync(

--- a/tests/Granit.Encryption.Tests/DefaultCryptoShredderTests.cs
+++ b/tests/Granit.Encryption.Tests/DefaultCryptoShredderTests.cs
@@ -45,15 +45,59 @@ public sealed class DefaultCryptoShredderTests
     }
 
     [Fact]
-    public async Task ShredAsync_CallsAuditRecorder()
+    public async Task ShredAsync_RecordsRequestedThenConfirmedPhases()
     {
         await _sut.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
 
         await _auditRecorder.Received(1).RecordAsync(
             "Patient",
             "abc-123",
+            CryptoShreddingPhase.Requested,
             Arg.Any<DateTimeOffset>(),
             Arg.Any<CancellationToken>());
+        await _auditRecorder.Received(1).RecordAsync(
+            "Patient",
+            "abc-123",
+            CryptoShreddingPhase.Confirmed,
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShredAsync_RecordsRequestedIntent_BeforeKeyDestruction()
+    {
+        List<string> callOrder = [];
+
+        _auditRecorder
+            .When(r => r.RecordAsync(
+                Arg.Any<string>(), Arg.Any<string>(), CryptoShreddingPhase.Requested,
+                Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>()))
+            .Do(_ => callOrder.Add("intent"));
+        _keyStore
+            .When(k => k.DeleteKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(_ => callOrder.Add("delete"));
+
+        await _sut.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        // The durable intent record MUST precede the irreversible key destruction (GDPR Art. 5(2)).
+        callOrder.IndexOf("intent").ShouldBeLessThan(callOrder.IndexOf("delete"));
+    }
+
+    [Fact]
+    public async Task ShredAsync_WhenIntentRecordingFails_DoesNotDestroyKey()
+    {
+        _auditRecorder
+            .RecordAsync(
+                Arg.Any<string>(), Arg.Any<string>(), CryptoShreddingPhase.Requested,
+                Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("audit store down")));
+
+        await Should.ThrowAsync<AggregateException>(
+            () => _sut.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken));
+
+        // Fail-closed: no durable trail means no destruction.
+        await _keyStore.DidNotReceive().DeleteKeyAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -91,7 +135,7 @@ public sealed class DefaultCryptoShredderTests
     }
 
     [Fact]
-    public async Task ShredBatchAsync_CallsAuditRecorder_ForEachEntityId()
+    public async Task ShredBatchAsync_RecordsBothPhases_ForEachEntityId()
     {
         string[] entityIds = ["id-1", "id-2"];
 
@@ -100,6 +144,13 @@ public sealed class DefaultCryptoShredderTests
         await _auditRecorder.Received(2).RecordAsync(
             "Patient",
             Arg.Any<string>(),
+            CryptoShreddingPhase.Requested,
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+        await _auditRecorder.Received(2).RecordAsync(
+            "Patient",
+            Arg.Any<string>(),
+            CryptoShreddingPhase.Confirmed,
             Arg.Any<DateTimeOffset>(),
             Arg.Any<CancellationToken>());
     }
@@ -137,6 +188,69 @@ public sealed class DefaultCryptoShredderTests
     public async Task ShredAsync_WithWhitespaceEntityId_ThrowsArgumentException() =>
         await Should.ThrowAsync<ArgumentException>(
             () => _sut.ShredAsync("Patient", "   ", TestContext.Current.CancellationToken));
+
+    // ──── Recorder fan-out does not abort on the first failure ────
+
+    [Fact]
+    public async Task ShredAsync_WhenOneConfirmRecorderFails_StillNotifiesTheOthers()
+    {
+        ICryptoShreddingAuditRecorder failing = Substitute.For<ICryptoShreddingAuditRecorder>();
+        ICryptoShreddingAuditRecorder healthy = Substitute.For<ICryptoShreddingAuditRecorder>();
+
+        // Only the confirmation phase fails, so the destruction has already happened by then.
+        failing
+            .RecordAsync(
+                Arg.Any<string>(), Arg.Any<string>(), CryptoShreddingPhase.Confirmed,
+                Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("recorder A down")));
+
+        DefaultCryptoShredder shredder = new(
+            _keyStore,
+            TimeProvider.System,
+            _metrics,
+            NullLogger<DefaultCryptoShredder>.Instance,
+            [failing, healthy]);
+
+        AggregateException ex = await Should.ThrowAsync<AggregateException>(
+            () => shredder.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken));
+
+        ex.InnerExceptions.Count.ShouldBe(1);
+
+        // The healthy recorder is still notified of the confirmation despite the sibling failure.
+        await healthy.Received(1).RecordAsync(
+            "Patient", "abc-123", CryptoShreddingPhase.Confirmed,
+            Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShredAsync_AggregatesFailures_AcrossAllRecorders()
+    {
+        ICryptoShreddingAuditRecorder failingA = Substitute.For<ICryptoShreddingAuditRecorder>();
+        ICryptoShreddingAuditRecorder failingB = Substitute.For<ICryptoShreddingAuditRecorder>();
+
+        failingA
+            .RecordAsync(
+                Arg.Any<string>(), Arg.Any<string>(), CryptoShreddingPhase.Confirmed,
+                Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("A")));
+        failingB
+            .RecordAsync(
+                Arg.Any<string>(), Arg.Any<string>(), CryptoShreddingPhase.Confirmed,
+                Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("B")));
+
+        DefaultCryptoShredder shredder = new(
+            _keyStore,
+            TimeProvider.System,
+            _metrics,
+            NullLogger<DefaultCryptoShredder>.Instance,
+            [failingA, failingB]);
+
+        AggregateException ex = await Should.ThrowAsync<AggregateException>(
+            () => shredder.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken));
+
+        ex.InnerExceptions.Count.ShouldBe(2);
+    }
 
     /// <summary>Minimal IMeterFactory for testing.</summary>
     private sealed class TestMeterFactory : System.Diagnostics.Metrics.IMeterFactory

--- a/tests/Granit.Encryption.Tests/EncryptionServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Encryption.Tests/EncryptionServiceCollectionExtensionsTests.cs
@@ -13,6 +13,8 @@ using Granit.Encryption.Options;
 using Granit.Encryption.Providers;
 using Granit.Encryption.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -152,5 +154,44 @@ public sealed class EncryptionServiceCollectionExtensionsTests
 
         int count = services.Count(d => d.ServiceType == typeof(ICryptoShredder));
         count.ShouldBe(1);
+    }
+
+    // ──── Fail-closed default key store (resolution behavior, not just declaration) ────
+
+    [Fact]
+    public void ResolvingDefaultKeyStore_InDevelopment_Succeeds()
+    {
+        using ServiceProvider provider = BuildProvider(Environments.Development);
+        using IServiceScope scope = provider.CreateScope();
+
+        IEntityEncryptionKeyStore store = scope.ServiceProvider.GetRequiredService<IEntityEncryptionKeyStore>();
+
+        store.ShouldBeOfType<InMemoryEntityEncryptionKeyStore>();
+    }
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    public void ResolvingDefaultKeyStore_OutsideDevelopment_Throws(string environmentName)
+    {
+        using ServiceProvider provider = BuildProvider(environmentName);
+        using IServiceScope scope = provider.CreateScope();
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(
+            () => scope.ServiceProvider.GetRequiredService<IEntityEncryptionKeyStore>());
+
+        ex.Message.ShouldContain("Vault");
+    }
+
+    private static ServiceProvider BuildProvider(string environmentName)
+    {
+        ServiceCollection services = new();
+
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+        services.AddSingleton(environment);
+
+        services.AddGranitEncryption();
+        return services.BuildServiceProvider();
     }
 }

--- a/tests/Granit.Encryption.Tests/InMemoryEntityEncryptionKeyStoreTests.cs
+++ b/tests/Granit.Encryption.Tests/InMemoryEntityEncryptionKeyStoreTests.cs
@@ -14,6 +14,8 @@
 // =============================================================================
 
 using Granit.Encryption.Services;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -21,7 +23,41 @@ namespace Granit.Encryption.Tests;
 
 public sealed class InMemoryEntityEncryptionKeyStoreTests
 {
-    private readonly InMemoryEntityEncryptionKeyStore _sut = new();
+    private readonly InMemoryEntityEncryptionKeyStore _sut = new(DevelopmentEnvironment());
+
+    private static IHostEnvironment DevelopmentEnvironment()
+    {
+        IHostEnvironment env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns(Environments.Development);
+        return env;
+    }
+
+    private static IHostEnvironment EnvironmentNamed(string name)
+    {
+        IHostEnvironment env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns(name);
+        return env;
+    }
+
+    // ──── Production guard (fails closed) ────
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    [InlineData("QA")]
+    public void Constructor_ThrowsOutsideDevelopment(string environmentName)
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(
+            () => new InMemoryEntityEncryptionKeyStore(EnvironmentNamed(environmentName)));
+
+        ex.Message.ShouldContain("Development");
+        ex.Message.ShouldContain("Vault");
+        ex.Message.ShouldContain(environmentName);
+    }
+
+    [Fact]
+    public void Constructor_DoesNotThrow_InDevelopment() =>
+        Should.NotThrow(() => new InMemoryEntityEncryptionKeyStore(EnvironmentNamed(Environments.Development)));
 
     // ──── GetOrCreateKeyAsync ────
 


### PR DESCRIPTION
## Security fix — VULN-200-data (Medium, CWE-1188/311) + VULN-201-data (Medium, CWE-460/778, GDPR Art.5(2)/17)

Part of the security-audit Cluster 1 (GDPR/encryption fail-open defaults).

### VULN-200-data — in-memory key store failed open in production
`InMemoryEntityEncryptionKeyStore` was the default `IEntityEncryptionKeyStore` (`TryAddScoped`) with **no environment guard** — a host that forgot a Vault key store silently ran on volatile in-memory keys (PII corruption on restart + non-durable crypto-shredding). Now its constructor injects `IHostEnvironment` and **throws at startup outside Development**, mirroring the existing `AesStringEncryptionProvider` guard. Development/test unaffected.

### VULN-201-data — non-atomic crypto-shred (destroy-then-audit)
`DefaultCryptoShredder` destroyed the key **before** writing the audit record; an audit failure left an irreversible erasure with no immutable trail. Reworked to a **two-phase recoverable** sequence (shared `ShredOneAsync` for single + batch): durable `Requested` intent record → `DeleteKeyAsync` → `Confirmed`. `NotifyAuditRecordersAsync` now aggregates recorder failures (throws `AggregateException`) instead of aborting the fan-out on the first.

## Tests (with teeth)
`Granit.Encryption.Tests` **130 passed**, `Granit.Encryption.EntityFrameworkCore.Tests` **44 passed**. New: intent-recorded-before-destruction (call-order proof), no-destroy-without-record, recorder-fan-out-aggregation, keystore throws for Prod/Staging/QA + resolves in Dev (real-container DI-resolution test). `dotnet format` clean.

## ⚠️ Breaking (pre-1.0, clean break)
`ICryptoShreddingAuditRecorder.RecordAsync` gains a `CryptoShreddingPhase` param and is invoked twice per erasure. No in-framework implementations affected (grep-confirmed). **Consumer-provided recorders (granit-business / host Timeline recorders) must adopt the new signature** and treat `Requested` as the durable intent — cross-repo handoff to follow.

Behavior change: hosts on the in-memory key store outside Development now fail fast at startup (intended fail-closed).