### PR TITLE
fix(privacy): deletion saga fan-in + provider acknowledgements (VULN-204-data)

### DIFF
--- a/src/Granit.AI.Chat.Privacy/DataDeletion/ConversationPersonalDataDeletionHandler.cs
+++ b/src/Granit.AI.Chat.Privacy/DataDeletion/ConversationPersonalDataDeletionHandler.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using Granit.AI.Chat.Privacy.DataExport;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 
 namespace Granit.AI.Chat.Privacy.DataDeletion;
@@ -16,11 +18,20 @@ namespace Granit.AI.Chat.Privacy.DataDeletion;
 /// with a public constructor and a public static Handle method. The eraser is idempotent, so a
 /// Wolverine retry after a transient failure converges. Transient attachment blobs are owned by the
 /// application's blob store, which erases them through its own deletion handler.
+/// <para>
+/// On success the handler returns a <see cref="PersonalDataDeletedEto"/> acknowledgement carrying
+/// the exact provider name this module registers
+/// (<see cref="ConversationPrivacyDataProvider.ProviderName"/>) and the number of rows erased.
+/// Wolverine cascades it back to the deletion saga (routed by <c>[SagaIdentity]</c>), which drains
+/// this provider from its pending set. On failure the eraser throws before the return, so no ack is
+/// published — Wolverine retries / dead-letters and the saga surfaces the request as
+/// PartiallyExecuted.
+/// </para>
 /// </remarks>
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class ConversationPersonalDataDeletionHandler
 {
-    public static async Task Handle(
+    public static async Task<PersonalDataDeletedEto> Handle(
         PersonalDataDeletionRequestedEto @event,
         IConversationDataStore dataManager,
         ICurrentTenant currentTenant,
@@ -31,6 +42,14 @@ public class ConversationPersonalDataDeletionHandler
         ArgumentNullException.ThrowIfNull(currentTenant);
 
         Guid? tenantId = @event.TenantId ?? currentTenant.Id;
-        await dataManager.EraseOwnerAsync(tenantId, @event.UserId, cancellationToken).ConfigureAwait(false);
+        int erased = await dataManager.EraseOwnerAsync(tenantId, @event.UserId, cancellationToken).ConfigureAwait(false);
+
+        return new PersonalDataDeletedEto(
+            @event.RequestId,
+            ConversationPrivacyDataProvider.ProviderName,
+            DeletionAction.PhysicalDelete,
+            erased,
+            Details: null,
+            @event.TenantId);
     }
 }

--- a/src/Granit.AI.Prompts.Privacy/DataDeletion/PromptTemplatePersonalDataDeletionHandler.cs
+++ b/src/Granit.AI.Prompts.Privacy/DataDeletion/PromptTemplatePersonalDataDeletionHandler.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using Granit.AI.Prompts.Privacy.DataExport;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 
 namespace Granit.AI.Prompts.Privacy.DataDeletion;
@@ -15,11 +17,20 @@ namespace Granit.AI.Prompts.Privacy.DataDeletion;
 /// Wolverine discovers handlers via <c>Assembly.ExportedTypes</c>; the class is therefore public
 /// with a public constructor and a public static Handle method. The eraser is idempotent, so a
 /// Wolverine retry after a transient failure converges.
+/// <para>
+/// On success the handler returns a <see cref="PersonalDataDeletedEto"/> acknowledgement carrying
+/// the exact provider name this module registers
+/// (<see cref="PromptTemplatePrivacyDataProvider.ProviderName"/>) and the number of rows erased.
+/// Wolverine cascades it back to the deletion saga (routed by <c>[SagaIdentity]</c>), which drains
+/// this provider from its pending set. On failure the eraser throws before the return, so no ack is
+/// published — Wolverine retries / dead-letters and the saga surfaces the request as
+/// PartiallyExecuted.
+/// </para>
 /// </remarks>
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class PromptTemplatePersonalDataDeletionHandler
 {
-    public static async Task Handle(
+    public static async Task<PersonalDataDeletedEto> Handle(
         PersonalDataDeletionRequestedEto @event,
         IPromptTemplateDataManager dataManager,
         ICurrentTenant currentTenant,
@@ -30,6 +41,14 @@ public class PromptTemplatePersonalDataDeletionHandler
         ArgumentNullException.ThrowIfNull(currentTenant);
 
         Guid? tenantId = @event.TenantId ?? currentTenant.Id;
-        await dataManager.EraseOwnerAsync(tenantId, @event.UserId, cancellationToken).ConfigureAwait(false);
+        int erased = await dataManager.EraseOwnerAsync(tenantId, @event.UserId, cancellationToken).ConfigureAwait(false);
+
+        return new PersonalDataDeletedEto(
+            @event.RequestId,
+            PromptTemplatePrivacyDataProvider.ProviderName,
+            DeletionAction.PhysicalDelete,
+            erased,
+            Details: null,
+            @event.TenantId);
     }
 }

--- a/src/Granit.Auditing.Privacy/DataDeletion/AuditingPersonalDataDeletionHandler.cs
+++ b/src/Granit.Auditing.Privacy/DataDeletion/AuditingPersonalDataDeletionHandler.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.CodeAnalysis;
+using Granit.Auditing.Privacy.DataExport;
+using Granit.Privacy.DataDeletion;
+using Granit.Privacy.DataDeletion.Events;
+
+namespace Granit.Auditing.Privacy.DataDeletion;
+
+/// <summary>
+/// Wolverine handler that acknowledges — without erasing — a data subject's audit trail on a
+/// <see cref="PersonalDataDeletionRequestedEto"/>. The audit trail is intentionally retained: an
+/// immutable, append-only record of security-relevant events is an ISO 27001 A.12.4 control and,
+/// under GDPR Art. 17(3)(b), erasure does not apply where processing is necessary for compliance
+/// with a legal obligation. The trail therefore survives the erasure by design.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Auditing registers itself with the privacy data-provider registry (for the Art. 15 export of a
+/// subject's own audit entries), so the deletion saga snapshots <c>"auditing"</c> into its expected
+/// acknowledgement set. Without an acknowledgement the saga would wait for this provider forever and
+/// every deletion would time out to <c>PartiallyExecuted</c>. This handler closes that gap by
+/// emitting a <see cref="PersonalDataDeletedEto"/> with <see cref="DeletionAction.Retained"/> and
+/// zero affected records — a truthful "nothing erased, retention is deliberate" acknowledgement that
+/// drains the provider from the saga's pending set.
+/// </para>
+/// <para>
+/// Wolverine discovers handlers via <c>Assembly.ExportedTypes</c>; the class is therefore public
+/// with a public constructor and a public static Handle method. The acknowledgement is a pure,
+/// side-effect-free projection of the incoming event, so it is trivially idempotent under
+/// Wolverine at-least-once redelivery — the saga's fan-in dedupes duplicates.
+/// </para>
+/// </remarks>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
+public class AuditingPersonalDataDeletionHandler
+{
+    public static PersonalDataDeletedEto Handle(PersonalDataDeletionRequestedEto @event)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+
+        return new PersonalDataDeletedEto(
+            @event.RequestId,
+            AuditingPrivacyDataProvider.ProviderName,
+            DeletionAction.Retained,
+            AffectedRecords: 0,
+            Details: "Audit trail retained for legal/compliance obligations (GDPR Art. 17(3)(b), ISO 27001 A.12.4).",
+            @event.TenantId);
+    }
+}

--- a/src/Granit.Auditing.Privacy/GranitAuditingPrivacyModule.cs
+++ b/src/Granit.Auditing.Privacy/GranitAuditingPrivacyModule.cs
@@ -10,8 +10,12 @@ namespace Granit.Auditing.Privacy;
 /// trail participates in the privacy export scatter-gather saga (GDPR Art. 15).
 /// </summary>
 /// <remarks>
-/// The matching Wolverine handler (<see cref="AuditingPersonalDataExportHandler"/>) is
-/// discovered automatically by assembly scanning. Apps opt in via
+/// Two Wolverine handlers are discovered automatically by assembly scanning:
+/// <see cref="AuditingPersonalDataExportHandler"/> (Art. 15 export of the subject's audit entries)
+/// and <c>AuditingPersonalDataDeletionHandler</c> (Art. 17 fan-in). Because auditing registers as a
+/// privacy provider, the deletion saga waits on its acknowledgement — the deletion handler emits a
+/// <c>Retained</c> acknowledgement (the audit trail is intentionally never erased) so the saga can
+/// reach a terminal state. Apps opt in via
 /// <c>AddGranitPrivacy(p =&gt; p.AddGranitAuditingPrivacyProvider())</c> to register the
 /// provider with the scatter-gather registry.
 /// </remarks>

--- a/src/Granit.Identity.Federated.Privacy/DataDeletion/IdentityFederatedPersonalDataDeletionHandler.cs
+++ b/src/Granit.Identity.Federated.Privacy/DataDeletion/IdentityFederatedPersonalDataDeletionHandler.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using Granit.Identity.Federated.Privacy.DataExport;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 
 namespace Granit.Identity.Federated.Privacy.DataDeletion;
@@ -15,11 +17,19 @@ namespace Granit.Identity.Federated.Privacy.DataDeletion;
 /// Wolverine discovers handlers via <c>Assembly.ExportedTypes</c>; the class is therefore public
 /// with a public constructor and a public static Handle method. The eraser is idempotent, so a
 /// Wolverine retry after a transient failure converges.
+/// <para>
+/// On success the handler returns a <see cref="PersonalDataDeletedEto"/> acknowledgement carrying
+/// the exact provider name this module registers
+/// (<see cref="IdentityFederatedPrivacyDataProvider.ProviderName"/>). Wolverine cascades it back to
+/// the deletion saga (routed by <c>[SagaIdentity]</c>), which drains this provider from its pending
+/// set. On failure the eraser throws before the return, so no ack is published — Wolverine retries
+/// / dead-letters and the saga surfaces the request as PartiallyExecuted.
+/// </para>
 /// </remarks>
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class IdentityFederatedPersonalDataDeletionHandler
 {
-    public static async Task Handle(
+    public static async Task<PersonalDataDeletedEto> Handle(
         PersonalDataDeletionRequestedEto @event,
         IFederatedUserCacheEraser cacheEraser,
         ICurrentTenant currentTenant,
@@ -31,5 +41,13 @@ public class IdentityFederatedPersonalDataDeletionHandler
 
         Guid? tenantId = @event.TenantId ?? currentTenant.Id;
         await cacheEraser.EraseAsync(@event.UserId.ToString(), tenantId, cancellationToken).ConfigureAwait(false);
+
+        return new PersonalDataDeletedEto(
+            @event.RequestId,
+            IdentityFederatedPrivacyDataProvider.ProviderName,
+            DeletionAction.PhysicalDelete,
+            AffectedRecords: 0,
+            Details: null,
+            @event.TenantId);
     }
 }

--- a/src/Granit.Identity.Local.Privacy/DataDeletion/IdentityLocalPersonalDataDeletionHandler.cs
+++ b/src/Granit.Identity.Local.Privacy/DataDeletion/IdentityLocalPersonalDataDeletionHandler.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
+using Granit.Identity.Local.Privacy.DataExport;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 
 namespace Granit.Identity.Local.Privacy.DataDeletion;
@@ -22,11 +24,21 @@ namespace Granit.Identity.Local.Privacy.DataDeletion;
 /// <c>@event.TenantId ?? currentTenant.Id</c> fallback used by the other reference deletion
 /// handlers (e.g. <c>ConversationPersonalDataDeletionHandler</c>) rather than relying solely on
 /// implicit restoration by Wolverine's <c>TenantContextBehavior</c> middleware.
+/// <para>
+/// On success the handler returns a <see cref="PersonalDataDeletedEto"/> acknowledgement, which
+/// Wolverine cascades back to the deletion saga (routed by <c>[SagaIdentity]</c> on
+/// <c>RequestId</c>). The saga drains this provider from its pending set; only when every provider
+/// acknowledges does it mark the request Executed. The ack is emitted with the exact provider name
+/// this module registers (<see cref="IdentityLocalPrivacyDataProvider.ProviderName"/>) so the
+/// saga's set matches. If <see cref="IAccountDeletionService.InitiateAsync"/> throws, the return is
+/// never reached, so no ack is published and Wolverine retries / dead-letters — the saga then
+/// correctly surfaces the request as PartiallyExecuted rather than Executed.
+/// </para>
 /// </remarks>
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class IdentityLocalPersonalDataDeletionHandler
 {
-    public static async Task Handle(
+    public static async Task<PersonalDataDeletedEto> Handle(
         PersonalDataDeletionRequestedEto @event,
         IAccountDeletionService deletionService,
         ICurrentTenant currentTenant,
@@ -39,5 +51,16 @@ public class IdentityLocalPersonalDataDeletionHandler
         Guid? tenantId = @event.TenantId ?? currentTenant.Id;
         using IDisposable scope = currentTenant.Change(tenantId);
         await deletionService.InitiateAsync(@event.UserId.ToString(), cancellationToken).ConfigureAwait(false);
+
+        // Soft-delete + lockout + token revocation — the account row is retained in a
+        // deactivated, unusable state (the identity subsystem's erasure contract), so the
+        // audit action is SoftDelete.
+        return new PersonalDataDeletedEto(
+            @event.RequestId,
+            IdentityLocalPrivacyDataProvider.ProviderName,
+            DeletionAction.SoftDelete,
+            AffectedRecords: 0,
+            Details: null,
+            @event.TenantId);
     }
 }

--- a/src/Granit.Notifications.Privacy/DataDeletion/NotificationsPersonalDataDeletionHandler.cs
+++ b/src/Granit.Notifications.Privacy/DataDeletion/NotificationsPersonalDataDeletionHandler.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
+using Granit.Notifications.Privacy.DataExport;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 
 namespace Granit.Notifications.Privacy.DataDeletion;
@@ -16,11 +18,19 @@ namespace Granit.Notifications.Privacy.DataDeletion;
 /// Wolverine discovers handlers via <c>Assembly.ExportedTypes</c>; the class is therefore public
 /// with a public constructor and a public static Handle method. The eraser is idempotent, so a
 /// Wolverine retry after a transient failure converges.
+/// <para>
+/// On success the handler returns a <see cref="PersonalDataDeletedEto"/> acknowledgement carrying
+/// the exact provider name this module registers
+/// (<see cref="NotificationsPrivacyDataProvider.ProviderName"/>). Wolverine cascades it back to the
+/// deletion saga (routed by <c>[SagaIdentity]</c>), which drains this provider from its pending set.
+/// On failure the eraser throws before the return, so no ack is published — Wolverine retries /
+/// dead-letters and the saga surfaces the request as PartiallyExecuted.
+/// </para>
 /// </remarks>
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class NotificationsPersonalDataDeletionHandler
 {
-    public static async Task Handle(
+    public static async Task<PersonalDataDeletedEto> Handle(
         PersonalDataDeletionRequestedEto @event,
         INotificationsPersonalDataEraser eraser,
         ICurrentTenant currentTenant,
@@ -32,5 +42,13 @@ public class NotificationsPersonalDataDeletionHandler
 
         Guid? tenantId = @event.TenantId ?? currentTenant.Id;
         await eraser.EraseUserDataAsync(@event.UserId.ToString(), tenantId, cancellationToken).ConfigureAwait(false);
+
+        return new PersonalDataDeletedEto(
+            @event.RequestId,
+            NotificationsPrivacyDataProvider.ProviderName,
+            DeletionAction.PhysicalDelete,
+            AffectedRecords: 0,
+            Details: null,
+            @event.TenantId);
     }
 }

--- a/src/Granit.Privacy.BackgroundJobs/Services/DeletionDeadlineEnforcementService.cs
+++ b/src/Granit.Privacy.BackgroundJobs/Services/DeletionDeadlineEnforcementService.cs
@@ -7,10 +7,22 @@ using Microsoft.Extensions.Logging;
 namespace Granit.Privacy.BackgroundJobs.Services;
 
 /// <summary>
-/// Scans for expired deferred deletion requests and forces execution.
-/// Idempotent — skips requests already in
-/// <see cref="DeletionRequestState.Executed"/> or <see cref="DeletionRequestState.Cancelled"/> state.
+/// Safety-net that scans for expired deletion requests still in
+/// <see cref="DeletionRequestState.Deferred"/> and forces execution — it only fires when the
+/// saga's own deadline timer never did (job outage, scheduler backlog, persistence lag).
+/// Idempotent by construction: <see cref="IDeletionRequestTrackerReader.GetExpiredDeferredAsync"/>
+/// returns only <see cref="DeletionRequestState.Deferred"/> rows, so requests the saga already
+/// advanced to <see cref="DeletionRequestState.Executing"/>,
+/// <see cref="DeletionRequestState.Executed"/>, <see cref="DeletionRequestState.PartiallyExecuted"/>,
+/// or <see cref="DeletionRequestState.Cancelled"/> are skipped.
 /// </summary>
+/// <remarks>
+/// This fallback path has no saga instance to run the provider-acknowledgement fan-in, so it marks
+/// the request <see cref="DeletionRequestState.Executed"/> directly. That trade-off is deliberate:
+/// reaching this path already means the saga machinery is unhealthy, and a forced execution without
+/// per-provider proof is preferable to leaving a deletion permanently unhonoured (GDPR Art. 17
+/// "without undue delay"). The deadline-slip metric/log already flags that this path was taken.
+/// </remarks>
 public sealed partial class DeletionDeadlineEnforcementService(
     IDeletionRequestTrackerReader trackerReader,
     IDeletionRequestTrackerWriter trackerWriter,

--- a/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/DeletionRequestEntityConfiguration.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/DeletionRequestEntityConfiguration.cs
@@ -34,6 +34,11 @@ internal sealed class DeletionRequestEntityConfiguration : IEntityTypeConfigurat
         builder.Property(e => e.Regulation)
             .HasMaxLength(40);
 
+        // Comma-joined provider names that never acknowledged erasure (PartiallyExecuted only).
+        // Bounded generously — provider names are short and the list is a handful at most.
+        builder.Property(e => e.MissingProviders)
+            .HasMaxLength(1000);
+
         // User timeline lookup (GET /privacy/erasure → GetByUserAsync).
         builder.HasIndex(e => new { e.TenantId, e.UserId, e.RequestedAt })
             .IsDescending(false, false, true)

--- a/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/EfDeletionRequestTracker.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataDeletion/Internal/EfDeletionRequestTracker.cs
@@ -79,6 +79,7 @@ internal sealed class EfDeletionRequestTracker<TContext>(
         {
             e.State = DeletionRequestState.Executed;
             e.ExecutedAt = executedAt;
+            e.MissingProviders = null;
         }, cancellationToken);
 
     public Task MarkCancelledAsync(Guid requestId, DateTimeOffset cancelledAt, CancellationToken cancellationToken = default) =>
@@ -86,6 +87,29 @@ internal sealed class EfDeletionRequestTracker<TContext>(
         {
             e.State = DeletionRequestState.Cancelled;
             e.CancelledAt = cancelledAt;
+        }, cancellationToken);
+
+    public Task MarkExecutingAsync(Guid requestId, CancellationToken cancellationToken = default) =>
+        ApplyTransitionAsync(requestId, e =>
+        {
+            // Only advance Deferred → Executing. A late acknowledgement or the enforcement-service
+            // fallback may already have driven the row to Executed; never regress it.
+            if (e.State == DeletionRequestState.Deferred)
+            {
+                e.State = DeletionRequestState.Executing;
+            }
+        }, cancellationToken);
+
+    public Task MarkPartiallyExecutedAsync(
+        Guid requestId,
+        DateTimeOffset executedAt,
+        IReadOnlyList<string> missingProviders,
+        CancellationToken cancellationToken = default) =>
+        ApplyTransitionAsync(requestId, e =>
+        {
+            e.State = DeletionRequestState.PartiallyExecuted;
+            e.ExecutedAt = executedAt;
+            e.MissingProviders = missingProviders.Count == 0 ? null : string.Join(',', missingProviders);
         }, cancellationToken);
 
     private async Task ApplyTransitionAsync(
@@ -120,5 +144,8 @@ internal sealed class EfDeletionRequestTracker<TContext>(
             entity.CancelledAt,
             entity.ExecutedAt,
             entity.Regulation,
-            entity.TenantId);
+            entity.TenantId,
+            string.IsNullOrEmpty(entity.MissingProviders)
+                ? null
+                : entity.MissingProviders.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
 }

--- a/src/Granit.Privacy.EntityFrameworkCore/Entities/DeletionRequestEntity.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Entities/DeletionRequestEntity.cs
@@ -39,6 +39,14 @@ public sealed class DeletionRequestEntity : Entity, IMultiTenant
     /// <summary>Applicable privacy regulation code (e.g., <c>EU_GDPR</c>, <c>BR_LGPD</c>).</summary>
     public string? Regulation { get; set; }
 
+    /// <summary>
+    /// Comma-separated provider names that never acknowledged erasure when the request landed in
+    /// <see cref="DeletionRequestState.PartiallyExecuted"/>; <c>null</c> otherwise. Stored flat
+    /// (not a join table) because it is a rare, human-reconciliation aid rather than a queried
+    /// relationship — the operator reads it once from the stuck-deletion alert.
+    /// </summary>
+    public string? MissingProviders { get; set; }
+
     /// <inheritdoc/>
     public Guid? TenantId { get; set; }
 }

--- a/src/Granit.Privacy/DataDeletion/DeletionRequestState.cs
+++ b/src/Granit.Privacy/DataDeletion/DeletionRequestState.cs
@@ -8,9 +8,30 @@ public enum DeletionRequestState
     /// <summary>Grace period active — deletion not yet executed, user may cancel.</summary>
     Deferred = 0,
 
-    /// <summary>Deadline reached — <see cref="Events.PersonalDataDeletionRequestedEto"/> published, providers are deleting.</summary>
+    /// <summary>
+    /// Deadline reached and every registered provider has acknowledged erasure of its data.
+    /// This is the only state that proves GDPR Art. 17 completion — the fan-in over provider
+    /// acknowledgements guarantees it is never reached while a downstream deletion is still pending.
+    /// </summary>
     Executed = 1,
 
     /// <summary>User cancelled the deletion request during the grace period.</summary>
     Cancelled = 2,
+
+    /// <summary>
+    /// Deadline reached and the provider fan-out has started, but not every provider has
+    /// acknowledged yet. Intermediate state between <see cref="Deferred"/> and
+    /// <see cref="Executed"/>: the request stays here until the last acknowledgement arrives
+    /// (<see cref="Events.PersonalDataDeletedEto"/> from each provider) or the acknowledgement
+    /// window elapses.
+    /// </summary>
+    Executing = 3,
+
+    /// <summary>
+    /// The acknowledgement window elapsed before every provider confirmed erasure. At least one
+    /// provider never acknowledged (permanent failure, dead-letter, or an unregistered handler).
+    /// The request is NOT provably complete — an operator must reconcile the missing providers
+    /// (surfaced by the stuck-deletion metric/log) before the erasure can be attested for Art. 17.
+    /// </summary>
+    PartiallyExecuted = 4,
 }

--- a/src/Granit.Privacy/DataDeletion/DeletionRequestStatus.cs
+++ b/src/Granit.Privacy/DataDeletion/DeletionRequestStatus.cs
@@ -16,4 +16,5 @@ public sealed record DeletionRequestStatus(
     DateTimeOffset? CancelledAt,
     DateTimeOffset? ExecutedAt,
     string? Regulation = null,
-    Guid? TenantId = null);
+    Guid? TenantId = null,
+    IReadOnlyList<string>? MissingProviders = null);

--- a/src/Granit.Privacy/DataDeletion/Events/DeletionAcknowledgementTimedOutEvent.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/DeletionAcknowledgementTimedOutEvent.cs
@@ -1,0 +1,12 @@
+using Wolverine.Persistence.Sagas;
+
+namespace Granit.Privacy.DataDeletion.Events;
+
+/// <summary>
+/// Internal saga timeout event: scheduled when the deletion deadline is reached and the provider
+/// fan-out begins. If it fires before every registered provider has acknowledged erasure (via
+/// <see cref="PersonalDataDeletedEto"/>), the saga transitions the request to
+/// <see cref="DeletionRequestState.PartiallyExecuted"/> and surfaces the missing providers so
+/// operators can reconcile stuck / dead-lettered deletions (GDPR Art. 17 provability).
+/// </summary>
+public sealed record DeletionAcknowledgementTimedOutEvent([property: SagaIdentity] Guid RequestId);

--- a/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletedEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletedEto.cs
@@ -1,14 +1,34 @@
 using Granit.Events;
+using Wolverine.Persistence.Sagas;
 
 namespace Granit.Privacy.DataDeletion.Events;
 
 /// <summary>
-/// Published by each data provider after handling a personal data deletion request.
-/// Provides a complete audit trail of what was done (ISO 27001 compliance).
+/// Published by each data provider after erasing (or crypto-shredding / anonymising / retaining)
+/// its slice of a data subject's personal data in response to a
+/// <see cref="PersonalDataDeletionRequestedEto"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// This is the provider's <b>acknowledgement</b> in the deletion fan-in — the deletion counterpart
+/// of the export saga's <c>PersonalDataPreparedEto</c>. <see cref="RequestId"/> carries
+/// <c>[SagaIdentity]</c> so Wolverine routes the event back to the originating
+/// <c>PersonalDataDeletionSaga</c>, which only marks the request
+/// <see cref="DeletionRequestState.Executed"/> once every registered provider has acknowledged.
+/// It doubles as the ISO 27001 audit record of what each provider actually did.
+/// </para>
+/// <para>
+/// Every provider handling <see cref="PersonalDataDeletionRequestedEto"/> MUST publish exactly one
+/// of these per request once its work is durably committed, using the provider name it registered
+/// with <c>AddPrivacyDataProvider</c>. Wolverine's at-least-once delivery means a provider may
+/// emit it more than once on retry; the saga's fan-in is idempotent (a duplicate acknowledgement
+/// is a no-op).
+/// </para>
+/// </remarks>
 public sealed record PersonalDataDeletedEto(
-    Guid RequestId,
+    [property: SagaIdentity] Guid RequestId,
     string ProviderName,
     DeletionAction Action,
     int AffectedRecords,
-    string? Details) : IIntegrationEvent;
+    string? Details,
+    Guid? TenantId = null) : IIntegrationEvent;

--- a/src/Granit.Privacy/DataDeletion/IDeletionRequestTrackerWriter.cs
+++ b/src/Granit.Privacy/DataDeletion/IDeletionRequestTrackerWriter.cs
@@ -23,6 +23,32 @@ public interface IDeletionRequestTrackerWriter
     Task MarkCancelledAsync(Guid requestId, DateTimeOffset cancelledAt, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Transitions a request to <see cref="DeletionRequestState.Executing"/> — the deadline was
+    /// reached and the provider fan-out has begun, but no provider has acknowledged yet.
+    /// The default implementation is a no-op so pre-existing trackers keep compiling; the
+    /// request simply stays in its prior state until an acknowledgement or the timeout resolves
+    /// it. Implementations SHOULD override to record the intermediate state, otherwise a request
+    /// whose providers all fail is indistinguishable from one still deferred.
+    /// </summary>
+    Task MarkExecutingAsync(Guid requestId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    /// <summary>
+    /// Transitions a request to <see cref="DeletionRequestState.PartiallyExecuted"/> — the
+    /// acknowledgement window elapsed before every provider confirmed erasure. The
+    /// <paramref name="missingProviders"/> list names the providers that never acknowledged so an
+    /// operator can reconcile them (their handlers may have permanently failed or dead-lettered).
+    /// The default implementation delegates to <see cref="MarkExecutedAsync"/> so pre-existing
+    /// trackers degrade to the legacy "mark executed" behaviour; implementations SHOULD override
+    /// to persist the partial state and the missing-provider set for GDPR Art. 17 provability.
+    /// </summary>
+    Task MarkPartiallyExecutedAsync(
+        Guid requestId,
+        DateTimeOffset executedAt,
+        IReadOnlyList<string> missingProviders,
+        CancellationToken cancellationToken = default) =>
+        MarkExecutedAsync(requestId, executedAt, cancellationToken);
+
+    /// <summary>
     /// Records an immediate deletion (no grace period) in terminal <see cref="DeletionRequestState.Executed"/> state.
     /// Default implementation delegates to <see cref="RecordDeferredAsync"/> + <see cref="MarkExecutedAsync"/>
     /// for backward compatibility. Implementations may override for a single atomic operation.

--- a/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
+++ b/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
@@ -1,15 +1,18 @@
 using Granit.DataProtection;
 using Granit.Encryption;
 using Granit.Privacy.DataDeletion.Events;
+using Granit.Privacy.DataExport;
 using Granit.Privacy.Diagnostics;
 using Granit.Privacy.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Wolverine;
 
 namespace Granit.Privacy.DataDeletion;
 
 /// <summary>
-/// Stateful Saga implementing the privacy deletion cooling-off period (GDPR Art. 17, LGPD Art. 18, CCPA).
+/// Stateful Saga implementing the privacy deletion cooling-off period plus the provider-deletion
+/// fan-in (GDPR Art. 17, LGPD Art. 18, CCPA).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -18,19 +21,35 @@ namespace Granit.Privacy.DataDeletion;
 ///   <item><see cref="DeletionDeferredEto"/> starts the Saga and schedules a reminder + deadline.</item>
 ///   <item>When the reminder fires, the Saga publishes <see cref="DeletionReminderDueEto"/>
 ///   for the notification bridge to send a reminder email.</item>
-///   <item>When the deadline fires, the Saga publishes <see cref="PersonalDataDeletionRequestedEto"/>
-///   (triggering actual deletion by providers) and <see cref="DeletionExecutedEto"/>
-///   (triggering a confirmation email).</item>
+///   <item>When the deadline fires, the Saga snapshots the set of registered providers, marks the
+///   request <see cref="DeletionRequestState.Executing"/>, publishes
+///   <see cref="PersonalDataDeletionRequestedEto"/> (fanning the deletion out to every provider)
+///   and <see cref="DeletionExecutedEto"/> (the user-facing confirmation that the grace period
+///   ended), then schedules a <see cref="DeletionAcknowledgementTimedOutEvent"/>.</item>
+///   <item>Each provider erases its slice and publishes <see cref="PersonalDataDeletedEto"/> as its
+///   acknowledgement. The Saga collects these; only once <b>every</b> expected provider has
+///   acknowledged does it mark the request <see cref="DeletionRequestState.Executed"/> — the only
+///   state that proves Art. 17 completion.</item>
+///   <item>If the acknowledgement window elapses first, the Saga marks the request
+///   <see cref="DeletionRequestState.PartiallyExecuted"/>, records the missing providers, and emits
+///   a stuck-deletion metric + warning log so DLQ monitoring can alert.</item>
 ///   <item>If the user cancels (<see cref="DeletionCancelledEto"/>), the Saga terminates
 ///   and future scheduled events are discarded by Wolverine.</item>
 /// </list>
 /// </para>
 /// <para>
-/// Race condition safety: <c>MarkCompleted()</c> guarantees that whichever event arrives
-/// second (cancel vs deadline) is silently discarded.
+/// This mirrors the export saga's scatter-gather fan-in (<c>PersonalDataExportSaga</c>): the
+/// expected-provider set is the fan-out target, each provider acknowledgement removes one entry,
+/// and a timeout surfaces whatever is still outstanding. The fan-in is idempotent under
+/// Wolverine's at-least-once delivery — a duplicate <see cref="PersonalDataDeletedEto"/> is a no-op.
+/// </para>
+/// <para>
+/// Race condition safety: <c>MarkCompleted()</c> guarantees that whichever event arrives after the
+/// Saga completes (a late cancel, a straggler acknowledgement, or the acknowledgement timeout after
+/// the last ack already completed the Saga) is silently discarded by Wolverine.
 /// </para>
 /// </remarks>
-public sealed class PersonalDataDeletionSaga : Saga
+public sealed partial class PersonalDataDeletionSaga : Saga
 {
     /// <summary>Saga correlation ID — equals <see cref="DeletionDeferredEto.RequestId"/>.</summary>
     public Guid Id { get; set; }
@@ -62,6 +81,19 @@ public sealed class PersonalDataDeletionSaga : Saga
 
     /// <summary>Whether the reminder notification has been sent.</summary>
     public bool ReminderSent { get; set; }
+
+    /// <summary>
+    /// Providers that still owe an acknowledgement. Snapshotted from
+    /// <see cref="IDataProviderRegistry"/> when the deadline is reached; each
+    /// <see cref="PersonalDataDeletedEto"/> removes one entry. Empty ⇒ every provider acknowledged.
+    /// </summary>
+    public List<string> PendingProviders { get; set; } = [];
+
+    /// <summary>Number of providers the fan-out targeted (snapshot of the registry at deadline).</summary>
+    public int ExpectedProviderCount { get; set; }
+
+    /// <summary>When the deletion deadline was reached and the provider fan-out began.</summary>
+    public DateTimeOffset? DeletionStartedAt { get; set; }
 
     /// <summary>
     /// Starts the Saga when a user defers their deletion request.
@@ -122,28 +154,130 @@ public sealed class PersonalDataDeletionSaga : Saga
     }
 
     /// <summary>
-    /// Handles the deadline timeout — triggers actual deletion by publishing
-    /// <see cref="PersonalDataDeletionRequestedEto"/> and sends a confirmation
-    /// via <see cref="DeletionExecutedEto"/>.
+    /// Handles the deadline timeout — begins the provider fan-out by publishing
+    /// <see cref="PersonalDataDeletionRequestedEto"/> and the user-facing confirmation
+    /// <see cref="DeletionExecutedEto"/>, marks the request
+    /// <see cref="DeletionRequestState.Executing"/>, and schedules the acknowledgement timeout.
+    /// The request is NOT marked <see cref="DeletionRequestState.Executed"/> here — that only
+    /// happens once every provider acknowledges (<see cref="Handle(PersonalDataDeletedEto,
+    /// IDeletionRequestTrackerWriter, PrivacyMetrics, TimeProvider)"/>).
     /// </summary>
+    /// <remarks>
+    /// When no providers are registered the fan-out is empty, so the request is marked executed
+    /// immediately and the Saga completes — mirroring the export saga's zero-provider fast path.
+    /// The user-facing <see cref="DeletionExecutedEto"/> fires as soon as the grace period ends
+    /// (unchanged behaviour): it confirms the deadline was reached, independent of how long the
+    /// downstream provider erasure takes.
+    /// </remarks>
     // NOTE: Named `Handle` (no `Async` suffix) — see the comment on `Start` above.
     public async Task<object[]> Handle(
         DeletionDeadlineReachedEvent @event,
         IDeletionRequestTrackerWriter tracker,
+        IDataProviderRegistry providerRegistry,
+        IOptions<GranitPrivacyOptions> options,
+        IMessageContext context,
         PrivacyMetrics metrics,
         TimeProvider timeProvider)
     {
         DateTimeOffset now = timeProvider.GetUtcNow();
+        DeletionStartedAt = now;
 
+        PendingProviders = [.. providerRegistry.GetAll()];
+        ExpectedProviderCount = PendingProviders.Count;
+
+        PersonalDataDeletionRequestedEto deletionRequested =
+            new(Id, UserId, RequestedBy, now, Reason, Regulation, TenantId);
+        DeletionExecutedEto executed = new(Id, UserId, now);
+
+        if (ExpectedProviderCount == 0)
+        {
+            // No providers to fan out to — the erasure is trivially complete the moment the
+            // deadline is reached (mirrors the export saga's ExpectedCount == 0 fast path).
+            await tracker.MarkExecutedAsync(Id, now).ConfigureAwait(false);
+            metrics.RecordDeletionExecuted(TenantId, Regulation);
+            MarkCompleted();
+            return [deletionRequested, executed];
+        }
+
+        await tracker.MarkExecutingAsync(Id).ConfigureAwait(false);
+
+        // Schedule the acknowledgement window. If a provider never acknowledges, this timeout
+        // resolves the request to PartiallyExecuted rather than leaving it stuck in Executing.
+        await context.ScheduleAsync(
+            new DeletionAcknowledgementTimedOutEvent(Id),
+            TimeSpan.FromMinutes(options.Value.DeletionAcknowledgementTimeoutMinutes)).ConfigureAwait(false);
+
+        return [deletionRequested, executed];
+    }
+
+    /// <summary>
+    /// Collects a provider's deletion acknowledgement (<see cref="PersonalDataDeletedEto"/>).
+    /// When the last expected provider acknowledges, marks the request
+    /// <see cref="DeletionRequestState.Executed"/> and completes the Saga. Idempotent: a duplicate
+    /// acknowledgement (Wolverine at-least-once redelivery) or an unregistered provider's event is
+    /// counted for observability but does not double-complete the Saga.
+    /// </summary>
+    public async Task Handle(
+        PersonalDataDeletedEto @event,
+        IDeletionRequestTrackerWriter tracker,
+        PrivacyMetrics metrics,
+        TimeProvider timeProvider)
+    {
+        bool expected = PendingProviders.Remove(@event.ProviderName);
+        metrics.RecordDeletionAcknowledged(TenantId, expected ? @event.ProviderName : "unknown", Regulation);
+
+        // Still waiting on providers (or this was a duplicate / unexpected ack that drained
+        // nothing) — stay active. A duplicate ack after completion cannot reach here because
+        // MarkCompleted deletes the saga state.
+        if (PendingProviders.Count > 0)
+        {
+            return;
+        }
+
+        DateTimeOffset now = timeProvider.GetUtcNow();
         await tracker.MarkExecutedAsync(Id, now).ConfigureAwait(false);
         metrics.RecordDeletionExecuted(TenantId, Regulation);
         MarkCompleted();
+    }
 
-        return
-        [
-            new PersonalDataDeletionRequestedEto(Id, UserId, RequestedBy, now, Reason, Regulation, TenantId),
-            new DeletionExecutedEto(Id, UserId, now),
-        ];
+    /// <summary>
+    /// Handles the acknowledgement timeout — at least one provider never acknowledged erasure.
+    /// Marks the request <see cref="DeletionRequestState.PartiallyExecuted"/>, records the missing
+    /// providers, and emits a stuck-deletion metric + warning log per missing provider so DLQ
+    /// monitoring can alert. If every provider had already acknowledged, the Saga is already
+    /// completed and Wolverine discards this event before it reaches the handler.
+    /// </summary>
+    // NOTE: Named `Handle` (no `Async` suffix) — see the comment on `Start` above.
+    public async Task Handle(
+        DeletionAcknowledgementTimedOutEvent @event,
+        IDeletionRequestTrackerWriter tracker,
+        PrivacyMetrics metrics,
+        ILogger<PersonalDataDeletionSaga> logger,
+        TimeProvider timeProvider)
+    {
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        IReadOnlyList<string> missing = [.. PendingProviders];
+
+        await tracker.MarkPartiallyExecutedAsync(Id, now, missing).ConfigureAwait(false);
+
+        foreach (string provider in missing)
+        {
+            metrics.RecordDeletionStuck(TenantId, provider, Regulation);
+            Log.DeletionProviderStuck(logger, Id, UserId, provider, ExpectedProviderCount - PendingProviders.Count, ExpectedProviderCount);
+        }
+
+        MarkCompleted();
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Deletion request {RequestId} (user {UserId}) timed out awaiting provider {Provider} — "
+                + "{Acknowledged}/{Expected} providers acknowledged. Request marked PartiallyExecuted; "
+                + "reconcile the stuck / dead-lettered provider (GDPR Art. 17 provability).")]
+        public static partial void DeletionProviderStuck(
+            ILogger logger, Guid requestId, Guid userId, string provider, int acknowledged, int expected);
     }
 
     /// <summary>

--- a/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
+++ b/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
@@ -22,6 +22,8 @@ public sealed class PrivacyMetrics
     private readonly Counter<long> _deletionDeferred;
     private readonly Counter<long> _deletionCancelled;
     private readonly Counter<long> _deletionExecuted;
+    private readonly Counter<long> _deletionAcknowledged;
+    private readonly Counter<long> _deletionStuck;
     private readonly Counter<long> _deletionReminders;
     private readonly Counter<long> _optOutRequests;
     private readonly Counter<long> _optOutRevocations;
@@ -58,6 +60,17 @@ public sealed class PrivacyMetrics
         _deletionExecuted = meter.CreateCounter<long>(
             "granit.privacy.deletion.executed",
             description: "Number of personal data deletions executed (immediate or after grace period).");
+
+        _deletionAcknowledged = meter.CreateCounter<long>(
+            "granit.privacy.deletion.acknowledged",
+            description: "Number of per-provider deletion acknowledgements received by the deletion saga.");
+
+        _deletionStuck = meter.CreateCounter<long>(
+            "granit.privacy.deletion.stuck",
+            description:
+                "Number of deletion requests that timed out with at least one provider never "
+                + "acknowledging erasure (PartiallyExecuted). Tagged by provider_name so DLQ "
+                + "monitoring can alert on a specific stuck / dead-lettered provider (GDPR Art. 17).");
 
         _deletionReminders = meter.CreateCounter<long>(
             "granit.privacy.deletion.reminders",
@@ -127,6 +140,29 @@ public sealed class PrivacyMetrics
     /// <summary>Records an executed deletion.</summary>
     public void RecordDeletionExecuted(Guid? tenantId, string? regulation = null) =>
         _deletionExecuted.Add(1, CreateTags(tenantId, regulation));
+
+    /// <summary>Records a per-provider deletion acknowledgement received by the saga.</summary>
+    public void RecordDeletionAcknowledged(Guid? tenantId, string providerName, string? regulation = null) =>
+        _deletionAcknowledged.Add(1, new TagList
+        {
+            { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
+            { TagRegulation, regulation ?? DefaultRegulation },
+            { "provider_name", providerName },
+        });
+
+    /// <summary>
+    /// Records a provider that never acknowledged erasure before the acknowledgement window
+    /// elapsed (request landed in <see cref="DataDeletion.DeletionRequestState.PartiallyExecuted"/>).
+    /// One increment per missing provider so DLQ monitoring can alert on the specific
+    /// <c>provider_name</c> that is stuck.
+    /// </summary>
+    public void RecordDeletionStuck(Guid? tenantId, string providerName, string? regulation = null) =>
+        _deletionStuck.Add(1, new TagList
+        {
+            { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
+            { TagRegulation, regulation ?? DefaultRegulation },
+            { "provider_name", providerName },
+        });
 
     /// <summary>Records a deletion reminder notification sent.</summary>
     public void RecordDeletionReminderSent(Guid? tenantId, string? regulation = null) =>

--- a/src/Granit.Privacy/Options/GranitPrivacyOptions.cs
+++ b/src/Granit.Privacy/Options/GranitPrivacyOptions.cs
@@ -75,6 +75,18 @@ public sealed class GranitPrivacyOptions
     [Range(0, 30)]
     public int ReminderDaysBefore { get; set; } = 3;
 
+    /// <summary>
+    /// Window, in minutes, the deletion saga waits for every registered provider to acknowledge
+    /// erasure (via <c>PersonalDataDeletedEto</c>) after the deadline is reached. If a provider
+    /// has not acknowledged when this elapses, the request is marked
+    /// <see cref="DataDeletion.DeletionRequestState.PartiallyExecuted"/> and the missing providers
+    /// are surfaced for operator reconciliation. Sized in hours by default because provider
+    /// erasure can be heavy (re-indexing, blob purges) and Wolverine may retry a failing provider
+    /// several times before it succeeds or dead-letters. Default: 720 minutes (12 hours).
+    /// </summary>
+    [Range(1, 43_200)]
+    public int DeletionAcknowledgementTimeoutMinutes { get; set; } = 720;
+
     // ── Per-regulation overrides ────────────────────────────────────────────
 
     /// <summary>

--- a/tests/Granit.AI.Chat.Privacy.Tests/ConversationPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.AI.Chat.Privacy.Tests/ConversationPersonalDataDeletionHandlerTests.cs
@@ -1,7 +1,10 @@
 using Granit.AI.Chat.Privacy.DataDeletion;
+using Granit.AI.Chat.Privacy.DataExport;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Granit.AI.Chat.Privacy.Tests;
@@ -37,5 +40,35 @@ public sealed class ConversationPersonalDataDeletionHandlerTests
             Eto(tenantId: null), dataManager, currentTenant, TestContext.Current.CancellationToken);
 
         await dataManager.Received(1).EraseOwnerAsync(Tenant, User, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_acknowledges_with_the_registered_provider_name_and_erased_count()
+    {
+        IConversationDataStore dataManager = Substitute.For<IConversationDataStore>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        dataManager.EraseOwnerAsync(Tenant, User, Arg.Any<CancellationToken>()).Returns(7);
+        PersonalDataDeletionRequestedEto eto = Eto(Tenant);
+
+        PersonalDataDeletedEto ack = await ConversationPersonalDataDeletionHandler.Handle(
+            eto, dataManager, currentTenant, TestContext.Current.CancellationToken);
+
+        ack.RequestId.ShouldBe(eto.RequestId);
+        ack.ProviderName.ShouldBe(ConversationPrivacyDataProvider.ProviderName);
+        ack.Action.ShouldBe(DeletionAction.PhysicalDelete);
+        ack.AffectedRecords.ShouldBe(7);
+        ack.TenantId.ShouldBe(Tenant);
+    }
+
+    [Fact]
+    public async Task Handle_does_not_acknowledge_when_the_erasure_fails()
+    {
+        IConversationDataStore dataManager = Substitute.For<IConversationDataStore>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        dataManager.EraseOwnerAsync(Arg.Any<Guid?>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns<Task<int>>(_ => throw new InvalidOperationException("conversation erase failed"));
+
+        await Should.ThrowAsync<InvalidOperationException>(() => ConversationPersonalDataDeletionHandler.Handle(
+            Eto(Tenant), dataManager, currentTenant, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Granit.AI.Prompts.Privacy.Tests/PromptTemplatePersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.AI.Prompts.Privacy.Tests/PromptTemplatePersonalDataDeletionHandlerTests.cs
@@ -1,7 +1,10 @@
 using Granit.AI.Prompts.Privacy.DataDeletion;
+using Granit.AI.Prompts.Privacy.DataExport;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Granit.AI.Prompts.Privacy.Tests;
@@ -37,5 +40,35 @@ public sealed class PromptTemplatePersonalDataDeletionHandlerTests
             Eto(tenantId: null), dataManager, currentTenant, TestContext.Current.CancellationToken);
 
         await dataManager.Received(1).EraseOwnerAsync(Tenant, User, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_acknowledges_with_the_registered_provider_name_and_erased_count()
+    {
+        IPromptTemplateDataManager dataManager = Substitute.For<IPromptTemplateDataManager>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        dataManager.EraseOwnerAsync(Tenant, User, Arg.Any<CancellationToken>()).Returns(3);
+        PersonalDataDeletionRequestedEto eto = Eto(Tenant);
+
+        PersonalDataDeletedEto ack = await PromptTemplatePersonalDataDeletionHandler.Handle(
+            eto, dataManager, currentTenant, TestContext.Current.CancellationToken);
+
+        ack.RequestId.ShouldBe(eto.RequestId);
+        ack.ProviderName.ShouldBe(PromptTemplatePrivacyDataProvider.ProviderName);
+        ack.Action.ShouldBe(DeletionAction.PhysicalDelete);
+        ack.AffectedRecords.ShouldBe(3);
+        ack.TenantId.ShouldBe(Tenant);
+    }
+
+    [Fact]
+    public async Task Handle_does_not_acknowledge_when_the_erasure_fails()
+    {
+        IPromptTemplateDataManager dataManager = Substitute.For<IPromptTemplateDataManager>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        dataManager.EraseOwnerAsync(Arg.Any<Guid?>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns<Task<int>>(_ => throw new InvalidOperationException("prompt erase failed"));
+
+        await Should.ThrowAsync<InvalidOperationException>(() => PromptTemplatePersonalDataDeletionHandler.Handle(
+            Eto(Tenant), dataManager, currentTenant, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Granit.Auditing.Privacy.Tests/DataDeletion/AuditingPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Auditing.Privacy.Tests/DataDeletion/AuditingPersonalDataDeletionHandlerTests.cs
@@ -1,0 +1,43 @@
+using Granit.Auditing.Privacy.DataDeletion;
+using Granit.Auditing.Privacy.DataExport;
+using Granit.Privacy.DataDeletion;
+using Granit.Privacy.DataDeletion.Events;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Auditing.Privacy.Tests.DataDeletion;
+
+public sealed class AuditingPersonalDataDeletionHandlerTests
+{
+    private static readonly Guid User = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Tenant = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    private static PersonalDataDeletionRequestedEto Eto(Guid? tenantId) =>
+        new(Guid.NewGuid(), User, "admin", new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), "account deletion", "GDPR", tenantId);
+
+    [Fact]
+    public void Handle_acknowledges_retention_with_the_registered_provider_name()
+    {
+        PersonalDataDeletionRequestedEto eto = Eto(Tenant);
+
+        PersonalDataDeletedEto ack = AuditingPersonalDataDeletionHandler.Handle(eto);
+
+        // Auditing is a registered privacy provider (for Art. 15 export) so the saga waits on its
+        // acknowledgement. It never erases — the immutable audit trail is retained by law — so it
+        // must still ack (with Retained) to drain the saga's pending set, otherwise every deletion
+        // would time out to PartiallyExecuted.
+        ack.RequestId.ShouldBe(eto.RequestId);
+        ack.ProviderName.ShouldBe(AuditingPrivacyDataProvider.ProviderName);
+        ack.Action.ShouldBe(DeletionAction.Retained);
+        ack.AffectedRecords.ShouldBe(0);
+        ack.TenantId.ShouldBe(Tenant);
+    }
+
+    [Fact]
+    public void Handle_propagates_the_events_tenant_when_absent()
+    {
+        PersonalDataDeletedEto ack = AuditingPersonalDataDeletionHandler.Handle(Eto(tenantId: null));
+
+        ack.TenantId.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Identity.Federated.Privacy.Tests/DataDeletion/IdentityFederatedPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/DataDeletion/IdentityFederatedPersonalDataDeletionHandlerTests.cs
@@ -1,7 +1,10 @@
 using Granit.Identity.Federated.Privacy.DataDeletion;
+using Granit.Identity.Federated.Privacy.DataExport;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Granit.Identity.Federated.Privacy.Tests.DataDeletion;
@@ -37,5 +40,33 @@ public sealed class IdentityFederatedPersonalDataDeletionHandlerTests
             Eto(tenantId: null), cacheEraser, currentTenant, TestContext.Current.CancellationToken);
 
         await cacheEraser.Received(1).EraseAsync(User.ToString(), Tenant, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_acknowledges_with_the_registered_provider_name_and_request_id()
+    {
+        IFederatedUserCacheEraser cacheEraser = Substitute.For<IFederatedUserCacheEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        PersonalDataDeletionRequestedEto eto = Eto(Tenant);
+
+        PersonalDataDeletedEto ack = await IdentityFederatedPersonalDataDeletionHandler.Handle(
+            eto, cacheEraser, currentTenant, TestContext.Current.CancellationToken);
+
+        ack.RequestId.ShouldBe(eto.RequestId);
+        ack.ProviderName.ShouldBe(IdentityFederatedPrivacyDataProvider.ProviderName);
+        ack.Action.ShouldBe(DeletionAction.PhysicalDelete);
+        ack.TenantId.ShouldBe(Tenant);
+    }
+
+    [Fact]
+    public async Task Handle_does_not_acknowledge_when_the_erasure_fails()
+    {
+        IFederatedUserCacheEraser cacheEraser = Substitute.For<IFederatedUserCacheEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        cacheEraser.EraseAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("cache erase failed"));
+
+        await Should.ThrowAsync<InvalidOperationException>(() => IdentityFederatedPersonalDataDeletionHandler.Handle(
+            Eto(Tenant), cacheEraser, currentTenant, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Granit.Identity.Local.Privacy.Tests/DataDeletion/IdentityLocalPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Identity.Local.Privacy.Tests/DataDeletion/IdentityLocalPersonalDataDeletionHandlerTests.cs
@@ -1,8 +1,11 @@
 using Granit.Identity.Local.Privacy.DataDeletion;
+using Granit.Identity.Local.Privacy.DataExport;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Granit.Identity.Local.Privacy.Tests.DataDeletion;
@@ -54,5 +57,37 @@ public sealed class IdentityLocalPersonalDataDeletionHandlerTests
 
         currentTenant.Received(1).Change(Tenant);
         await deletionService.Received(1).InitiateAsync(User.ToString(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_acknowledges_with_the_registered_provider_name_and_request_id()
+    {
+        IAccountDeletionService deletionService = Substitute.For<IAccountDeletionService>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Change(Arg.Any<Guid?>()).Returns(Substitute.For<IDisposable>());
+        PersonalDataDeletionRequestedEto eto = Eto(Tenant);
+
+        PersonalDataDeletedEto ack = await IdentityLocalPersonalDataDeletionHandler.Handle(
+            eto, deletionService, currentTenant, TestContext.Current.CancellationToken);
+
+        ack.RequestId.ShouldBe(eto.RequestId);
+        ack.ProviderName.ShouldBe(IdentityLocalPrivacyDataProvider.ProviderName);
+        ack.Action.ShouldBe(DeletionAction.SoftDelete);
+        ack.TenantId.ShouldBe(Tenant);
+    }
+
+    [Fact]
+    public async Task Handle_does_not_acknowledge_when_the_erasure_fails()
+    {
+        IAccountDeletionService deletionService = Substitute.For<IAccountDeletionService>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Change(Arg.Any<Guid?>()).Returns(Substitute.For<IDisposable>());
+        deletionService.InitiateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("account deletion failed"));
+
+        // The exception propagates so Wolverine retries / dead-letters; no ack is produced,
+        // so the saga correctly keeps this provider pending → PartiallyExecuted on timeout.
+        await Should.ThrowAsync<InvalidOperationException>(() => IdentityLocalPersonalDataDeletionHandler.Handle(
+            Eto(Tenant), deletionService, currentTenant, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Granit.Notifications.Privacy.Tests/DataDeletion/NotificationsPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Notifications.Privacy.Tests/DataDeletion/NotificationsPersonalDataDeletionHandlerTests.cs
@@ -1,8 +1,11 @@
 using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Privacy.DataDeletion;
+using Granit.Notifications.Privacy.DataExport;
+using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Granit.Notifications.Privacy.Tests.DataDeletion;
@@ -38,5 +41,33 @@ public sealed class NotificationsPersonalDataDeletionHandlerTests
             Eto(tenantId: null), eraser, currentTenant, TestContext.Current.CancellationToken);
 
         await eraser.Received(1).EraseUserDataAsync(User.ToString(), Tenant, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_acknowledges_with_the_registered_provider_name_and_request_id()
+    {
+        INotificationsPersonalDataEraser eraser = Substitute.For<INotificationsPersonalDataEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        PersonalDataDeletionRequestedEto eto = Eto(Tenant);
+
+        PersonalDataDeletedEto ack = await NotificationsPersonalDataDeletionHandler.Handle(
+            eto, eraser, currentTenant, TestContext.Current.CancellationToken);
+
+        ack.RequestId.ShouldBe(eto.RequestId);
+        ack.ProviderName.ShouldBe(NotificationsPrivacyDataProvider.ProviderName);
+        ack.Action.ShouldBe(DeletionAction.PhysicalDelete);
+        ack.TenantId.ShouldBe(Tenant);
+    }
+
+    [Fact]
+    public async Task Handle_does_not_acknowledge_when_the_erasure_fails()
+    {
+        INotificationsPersonalDataEraser eraser = Substitute.For<INotificationsPersonalDataEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        eraser.EraseUserDataAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("notifications erase failed"));
+
+        await Should.ThrowAsync<InvalidOperationException>(() => NotificationsPersonalDataDeletionHandler.Handle(
+            Eto(Tenant), eraser, currentTenant, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfDeletionRequestTrackerTests.cs
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/EfDeletionRequestTrackerTests.cs
@@ -123,6 +123,68 @@ public sealed class EfDeletionRequestTrackerTests : IAsyncDisposable
     }
 
     [Fact]
+    public async Task MarkExecutingAsync_TransitionsDeferred_ToExecuting()
+    {
+        var id = Guid.NewGuid();
+        await _sut.RecordDeferredAsync(id, Guid.NewGuid(), "reason", Now, Now.AddDays(30), TestContext.Current.CancellationToken);
+
+        await _sut.MarkExecutingAsync(id, TestContext.Current.CancellationToken);
+
+        DeletionRequestStatus? status = await _sut.GetStatusAsync(id, TestContext.Current.CancellationToken);
+        status.ShouldNotBeNull();
+        status.State.ShouldBe(DeletionRequestState.Executing);
+        status.ExecutedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MarkExecutingAsync_DoesNotRegress_AlreadyExecuted()
+    {
+        var id = Guid.NewGuid();
+        await _sut.RecordDeferredAsync(id, Guid.NewGuid(), "reason", Now, Now.AddDays(30), TestContext.Current.CancellationToken);
+        await _sut.MarkExecutedAsync(id, Now.AddDays(31), TestContext.Current.CancellationToken);
+
+        // A late enforcement-fallback / straggler must not drag a completed request back to Executing.
+        await _sut.MarkExecutingAsync(id, TestContext.Current.CancellationToken);
+
+        DeletionRequestStatus? status = await _sut.GetStatusAsync(id, TestContext.Current.CancellationToken);
+        status.ShouldNotBeNull();
+        status.State.ShouldBe(DeletionRequestState.Executed);
+    }
+
+    [Fact]
+    public async Task MarkPartiallyExecutedAsync_PersistsState_AndMissingProviders()
+    {
+        var id = Guid.NewGuid();
+        await _sut.RecordDeferredAsync(id, Guid.NewGuid(), "reason", Now, Now.AddDays(30), TestContext.Current.CancellationToken);
+
+        await _sut.MarkPartiallyExecutedAsync(
+            id, Now.AddDays(31), ["indexing", "notifications"], TestContext.Current.CancellationToken);
+
+        DeletionRequestStatus? status = await _sut.GetStatusAsync(id, TestContext.Current.CancellationToken);
+        status.ShouldNotBeNull();
+        status.State.ShouldBe(DeletionRequestState.PartiallyExecuted);
+        status.ExecutedAt.ShouldBe(Now.AddDays(31));
+        status.MissingProviders.ShouldBe(["indexing", "notifications"]);
+    }
+
+    [Fact]
+    public async Task MarkExecutedAsync_ClearsMissingProviders_FromPriorPartial()
+    {
+        var id = Guid.NewGuid();
+        await _sut.RecordDeferredAsync(id, Guid.NewGuid(), "reason", Now, Now.AddDays(30), TestContext.Current.CancellationToken);
+        await _sut.MarkPartiallyExecutedAsync(id, Now.AddDays(31), ["indexing"], TestContext.Current.CancellationToken);
+
+        // A late acknowledgement reconciles the deletion to fully Executed — the stale
+        // missing-provider marker must be cleared.
+        await _sut.MarkExecutedAsync(id, Now.AddDays(32), TestContext.Current.CancellationToken);
+
+        DeletionRequestStatus? status = await _sut.GetStatusAsync(id, TestContext.Current.CancellationToken);
+        status.ShouldNotBeNull();
+        status.State.ShouldBe(DeletionRequestState.Executed);
+        status.MissingProviders.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task MarkExecutedAsync_UnknownId_NoOp() =>
         await Should.NotThrowAsync(() => _sut.MarkExecutedAsync(
             Guid.NewGuid(), Now, TestContext.Current.CancellationToken));

--- a/tests/Granit.Privacy.Tests/DataDeletion/PersonalDataDeletionSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/DataDeletion/PersonalDataDeletionSagaTests.cs
@@ -273,6 +273,29 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     }
 
     [Fact]
+    public async Task Handle_EndToEnd_RealProviderNames_AllAck_ReachesExecuted()
+    {
+        // Uses the exact provider names the shipped bridge handlers register + acknowledge with
+        // (ai-chat / ai-prompts / identity-local / identity-federated / notifications / auditing).
+        // This is the integration seam that silently breaks if a handler's ack name diverges from
+        // its registered IDataProviderRegistry name — the saga would never drain.
+        string[] providers = ["ai-chat", "ai-prompts", "identity-local", "identity-federated", "notifications", "auditing"];
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
+        await ReachDeadlineAsync(saga, Registry(providers));
+
+        foreach (string provider in providers)
+        {
+            await AcknowledgeAsync(saga, provider);
+        }
+
+        saga.PendingProviders.ShouldBeEmpty();
+        await _tracker.Received(1).MarkExecutedAsync(
+            saga.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await _tracker.DidNotReceive().MarkPartiallyExecutedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_UnknownProviderAcknowledge_DoesNotComplete()
     {
         PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());

--- a/tests/Granit.Privacy.Tests/DataDeletion/PersonalDataDeletionSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/DataDeletion/PersonalDataDeletionSagaTests.cs
@@ -1,9 +1,12 @@
 using System.Diagnostics.Metrics;
 using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Internal;
 using Granit.Privacy.Diagnostics;
 using Granit.Privacy.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
@@ -35,6 +38,17 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     private static IOptions<GranitPrivacyOptions> DefaultOptions() =>
         Microsoft.Extensions.Options.Options.Create(new GranitPrivacyOptions());
 
+    private static DataProviderRegistry Registry(params string[] providers)
+    {
+        DataProviderRegistry registry = new();
+        foreach (string name in providers)
+        {
+            registry.Register(name);
+        }
+
+        return registry;
+    }
+
     private static DeletionDeferredEto CreateDeferredEvent(
         Guid? requestId = null,
         Guid? userId = null,
@@ -49,16 +63,33 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
             now.AddDays(graceDays), "EU_GDPR");
     }
 
+    private async Task<PersonalDataDeletionSaga> StartedSagaAsync(DeletionDeferredEto startEvt)
+    {
+        PersonalDataDeletionSaga saga = new();
+        IMessageContext context = Substitute.For<IMessageContext>();
+        await saga.Start(startEvt, DefaultOptions(), context, _tracker, _metrics);
+        return saga;
+    }
+
+    private Task<object[]> ReachDeadlineAsync(
+        PersonalDataDeletionSaga saga, IDataProviderRegistry registry) =>
+        saga.Handle(
+            new DeletionDeadlineReachedEvent(saga.Id),
+            _tracker,
+            registry,
+            DefaultOptions(),
+            Substitute.For<IMessageContext>(),
+            _metrics,
+            _timeProvider);
+
     // ── StartAsync ───────────────────────────────────────────────────────────
 
     [Fact]
     public async Task StartAsync_InitializesState_FromEvent()
     {
-        PersonalDataDeletionSaga saga = new();
-        IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto evt = CreateDeferredEvent();
 
-        await saga.Start(evt, DefaultOptions(), context, _tracker, _metrics);
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(evt);
 
         saga.Id.ShouldBe(evt.RequestId);
         saga.UserId.ShouldBe(evt.UserId);
@@ -70,11 +101,9 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     [Fact]
     public async Task StartAsync_RecordsDeferredRequest_InTracker()
     {
-        PersonalDataDeletionSaga saga = new();
-        IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto evt = CreateDeferredEvent();
 
-        await saga.Start(evt, DefaultOptions(), context, _tracker, _metrics);
+        await StartedSagaAsync(evt);
 
         await _tracker.Received(1).RecordDeferredAsync(
             evt.RequestId, evt.UserId, evt.Reason, evt.RequestedAt, evt.ScheduledDeletionAt,
@@ -116,10 +145,8 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     [Fact]
     public async Task Handle_ReminderDueEvent_PublishesReminderEto()
     {
-        PersonalDataDeletionSaga saga = new();
-        IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto startEvt = CreateDeferredEvent();
-        await saga.Start(startEvt, DefaultOptions(), context, _tracker, _metrics);
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(startEvt);
 
         DeletionReminderDueEto result = saga.Handle(
             new DeletionReminderDueEvent(startEvt.RequestId), _metrics);
@@ -133,28 +160,21 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     [Fact]
     public async Task Handle_ReminderDueEvent_SetsReminderSent()
     {
-        PersonalDataDeletionSaga saga = new();
-        IMessageContext context = Substitute.For<IMessageContext>();
-        await saga.Start(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
 
         saga.Handle(new DeletionReminderDueEvent(saga.Id), _metrics);
 
         saga.ReminderSent.ShouldBeTrue();
     }
 
-    // ── Deadline ─────────────────────────────────────────────────────────────
+    // ── Deadline / fan-out ─────────────────────────────────────────────────────
 
     [Fact]
     public async Task HandleAsync_DeadlineReached_PublishesDeletionAndExecutedEvents()
     {
-        PersonalDataDeletionSaga saga = new();
-        IMessageContext context = Substitute.For<IMessageContext>();
-        DeletionDeferredEto startEvt = CreateDeferredEvent();
-        await saga.Start(startEvt, DefaultOptions(), context, _tracker, _metrics);
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
 
-        object[] results = await saga.Handle(
-            new DeletionDeadlineReachedEvent(startEvt.RequestId),
-            _tracker, _metrics, _timeProvider);
+        object[] results = await ReachDeadlineAsync(saga, Registry("identity", "indexing"));
 
         results.Length.ShouldBe(2);
         results[0].ShouldBeOfType<PersonalDataDeletionRequestedEto>();
@@ -162,18 +182,134 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     }
 
     [Fact]
-    public async Task HandleAsync_DeadlineReached_MarksTrackerExecuted()
+    public async Task HandleAsync_DeadlineReached_WithProviders_MarksExecuting_NotExecuted()
     {
-        PersonalDataDeletionSaga saga = new();
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
+
+        await ReachDeadlineAsync(saga, Registry("identity", "indexing"));
+
+        // Fan-out started but no provider acknowledged yet: the tracker must NOT be told the
+        // deletion is Executed — that is the whole point of the fan-in (GDPR Art. 17 provability).
+        await _tracker.DidNotReceive().MarkExecutedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await _tracker.Received(1).MarkExecutingAsync(saga.Id, Arg.Any<CancellationToken>());
+        saga.PendingProviders.ShouldBe(["identity", "indexing"], ignoreOrder: true);
+        saga.ExpectedProviderCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DeadlineReached_SchedulesAcknowledgementTimeout()
+    {
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
         IMessageContext context = Substitute.For<IMessageContext>();
-        await saga.Start(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
 
         await saga.Handle(
             new DeletionDeadlineReachedEvent(saga.Id),
-            _tracker, _metrics, _timeProvider);
+            _tracker, Registry("identity"), DefaultOptions(), context, _metrics, _timeProvider);
 
+        // ScheduleAsync is an extension method calling PublishAsync with DeliveryOptions;
+        // NSubstitute cannot intercept the extension, so we verify the underlying call.
+        await context.Received(1).PublishAsync(
+            Arg.Any<DeletionAcknowledgementTimedOutEvent>(),
+            Arg.Any<DeliveryOptions>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_DeadlineReached_NoProviders_MarksExecutedImmediately()
+    {
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
+
+        await ReachDeadlineAsync(saga, Registry());
+
+        // Zero-provider fast path mirrors the export saga: nothing to fan out to, so the
+        // request is provably complete the moment the deadline is reached.
         await _tracker.Received(1).MarkExecutedAsync(
             saga.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await _tracker.DidNotReceive().MarkExecutingAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Fan-in: acknowledgements ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_AllProvidersAcknowledge_MarksExecuted()
+    {
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
+        await ReachDeadlineAsync(saga, Registry("identity", "indexing"));
+
+        await AcknowledgeAsync(saga, "identity");
+        // First ack does NOT complete: one provider still outstanding.
+        await _tracker.DidNotReceive().MarkExecutedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+
+        await AcknowledgeAsync(saga, "indexing");
+
+        // Last ack drains PendingProviders → Executed.
+        saga.PendingProviders.ShouldBeEmpty();
+        await _tracker.Received(1).MarkExecutedAsync(
+            saga.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await _tracker.DidNotReceive().MarkPartiallyExecutedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateAcknowledge_IsIdempotent()
+    {
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
+        await ReachDeadlineAsync(saga, Registry("identity", "indexing"));
+
+        // Wolverine at-least-once: "identity" acknowledges twice. The duplicate must not
+        // spuriously drain "indexing" or complete the saga early.
+        await AcknowledgeAsync(saga, "identity");
+        await AcknowledgeAsync(saga, "identity");
+
+        saga.PendingProviders.ShouldBe(["indexing"]);
+        await _tracker.DidNotReceive().MarkExecutedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+
+        // The genuinely-outstanding provider then acknowledges once → Executed.
+        await AcknowledgeAsync(saga, "indexing");
+        await _tracker.Received(1).MarkExecutedAsync(
+            saga.Id, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UnknownProviderAcknowledge_DoesNotComplete()
+    {
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
+        await ReachDeadlineAsync(saga, Registry("identity"));
+
+        // An event from a provider that was not part of the fan-out set must not drain a slot.
+        await AcknowledgeAsync(saga, "ghost");
+
+        saga.PendingProviders.ShouldBe(["identity"]);
+        await _tracker.DidNotReceive().MarkExecutedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Fan-in: timeout ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_AcknowledgementTimeout_OneProviderNeverAcks_MarksPartiallyExecuted()
+    {
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
+        await ReachDeadlineAsync(saga, Registry("identity", "indexing"));
+
+        // Only "identity" acknowledged; "indexing" is stuck.
+        await AcknowledgeAsync(saga, "identity");
+
+        await saga.Handle(
+            new DeletionAcknowledgementTimedOutEvent(saga.Id),
+            _tracker, _metrics, NullLogger<PersonalDataDeletionSaga>.Instance, _timeProvider);
+
+        await _tracker.Received(1).MarkPartiallyExecutedAsync(
+            saga.Id,
+            Arg.Any<DateTimeOffset>(),
+            Arg.Is<IReadOnlyList<string>>(m => m.Count == 1 && m[0] == "indexing"),
+            Arg.Any<CancellationToken>());
+
+        // Crucially: it must NOT be reported Executed — the deletion is not provably complete.
+        await _tracker.DidNotReceive().MarkExecutedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
 
     // ── Cancellation ─────────────────────────────────────────────────────────
@@ -181,9 +317,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     [Fact]
     public async Task HandleAsync_Cancelled_MarksTrackerCancelled()
     {
-        PersonalDataDeletionSaga saga = new();
-        IMessageContext context = Substitute.For<IMessageContext>();
-        await saga.Start(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
 
         DateTimeOffset cancelledAt = DateTimeOffset.UtcNow;
         await saga.Handle(
@@ -197,10 +331,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     [Fact]
     public async Task HandleAsync_Cancelled_DoesNotPublishDeletionEvent()
     {
-        PersonalDataDeletionSaga saga = new();
-        IMessageContext context = Substitute.For<IMessageContext>();
-        DeletionDeferredEto startEvt = CreateDeferredEvent();
-        await saga.Start(startEvt, DefaultOptions(), context, _tracker, _metrics);
+        PersonalDataDeletionSaga saga = await StartedSagaAsync(CreateDeferredEvent());
 
         await saga.Handle(
             new DeletionCancelledEto(saga.Id, saga.UserId, DateTimeOffset.UtcNow),
@@ -209,4 +340,11 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         await _tracker.DidNotReceive().MarkExecutedAsync(
             Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
+
+    private Task AcknowledgeAsync(PersonalDataDeletionSaga saga, string providerName) =>
+        saga.Handle(
+            new PersonalDataDeletedEto(saga.Id, providerName, DeletionAction.PhysicalDelete, 1, null, saga.TenantId),
+            _tracker,
+            _metrics,
+            _timeProvider);
 }

--- a/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
+++ b/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
@@ -71,6 +71,26 @@ public sealed class PrivacySagaWolverineCodegenTests
         chain.ExistingCalls.ShouldContain(c => c.Method.Name == "Handle");
     }
 
+    [Fact]
+    public async Task DeletionSaga_provider_ack_chain_wires_Handle_method()
+    {
+        using IHost host = await BuildHostAsync();
+        SagaChain chain = GetSagaChain(host, typeof(PersonalDataDeletedEto));
+
+        chain.ExistingCalls.ShouldNotBeEmpty();
+        chain.ExistingCalls.ShouldContain(c => c.Method.Name == "Handle");
+    }
+
+    [Fact]
+    public async Task DeletionSaga_ack_timeout_chain_wires_Handle_method()
+    {
+        using IHost host = await BuildHostAsync();
+        SagaChain chain = GetSagaChain(host, typeof(DeletionAcknowledgementTimedOutEvent));
+
+        chain.ExistingCalls.ShouldNotBeEmpty();
+        chain.ExistingCalls.ShouldContain(c => c.Method.Name == "Handle");
+    }
+
     private static Task<IHost> BuildHostAsync() =>
         Host.CreateDefaultBuilder()
             .ConfigureServices(services =>


### PR DESCRIPTION
## Security/correctness fix — VULN-204-data (Medium, CWE-460/778, GDPR Art.17 + Art.5(2))

Part of Cluster 1. **Complete end-to-end** (saga fan-in + provider acks in one atomic change).

**Problem.** `PersonalDataDeletionSaga` called `MarkExecutedAsync`+`MarkCompleted` the instant the grace deadline was reached, **before** any provider confirmed erasure — no fan-in, no compensation. The tracker could report `Executed` while a downstream deletion silently dead-lettered, undermining Art.17 provability.

## Fix — fan-in mirroring `PersonalDataExportSaga`
- Deadline → snapshot registered providers (`IDataProviderRegistry.GetAll()`) into `PendingProviders`, mark `Executing`, fan out `PersonalDataDeletionRequestedEto`, schedule an ack timeout. Zero providers → immediate `Executed`.
- Each provider ack (`PersonalDataDeletedEto`, `[SagaIdentity]` on `RequestId`) drains one entry; set empty ⇒ `MarkExecuted`. Idempotent (dup/unknown acks metered, never double-complete).
- Ack timeout ⇒ `PartiallyExecuted` + persisted `MissingProviders` + `granit.privacy.deletion.stuck` metric/warning per missing provider.
- Additive/back-compat tracker API (default-implemented `MarkExecutingAsync`/`MarkPartiallyExecutedAsync`; new `Executing`/`PartiallyExecuted` states; optional `MissingProviders`). New `DeletionAcknowledgementTimeoutMinutes` (default 720).

## Provider acknowledgements (the completing half)
Every **registered** deletion provider now publishes its ack via **cascaded return** of `PersonalDataDeletedEto` — success-gated by construction (built after the eraser succeeds; on failure the return is never reached → no ack → Wolverine retries/DLQ → saga honestly reports `PartiallyExecuted`). Ack provider name = the module's own `ProviderName` constant, so registration and ack can't diverge.

Reconciled provider set (ack-emitters == saga-awaited set):
| Provider | Module | Action |
|---|---|---|
| `ai-chat` | AI.Chat.Privacy | PhysicalDelete |
| `ai-prompts` | AI.Prompts.Privacy | PhysicalDelete |
| `identity-local` | Identity.Local.Privacy | SoftDelete |
| `identity-federated` | Identity.Federated.Privacy | PhysicalDelete |
| `notifications` | Notifications.Privacy | PhysicalDelete |
| `auditing` | Auditing.Privacy | **Retained** (Art.17(3)(b) — new no-op ack so the saga drains instead of hanging) |

`indexing` and `presence` are **not** registered deletion providers (pure cascade / separate eraser) — correctly do not ack.

## Tests (all green)
`Granit.Privacy.Tests` **291** (incl. an end-to-end driving all six real provider-name strings through the fan-in to `Executed` — the exact seam that breaks if an ack name diverges from its registry name); per-module handler tests (success ⇒ one ack w/ correct id+name+action, failure ⇒ no ack): identity-local 14, identity-federated 13, ai-chat 11, ai-prompts 9, notifications 13, auditing 12; EFCore 33, BackgroundJobs 9, arch 7. `dotnet format` clean (13 projects).

## Migration
Host `deletion_requests` table needs a `MissingProviders` column (framework ships no migrations by policy).