### PR TITLE
fix(quality): resolve SonarQube findings across modules

### DIFF
--- a/src/Granit.AI.Chat/Domain/Conversation.cs
+++ b/src/Granit.AI.Chat/Domain/Conversation.cs
@@ -49,7 +49,7 @@ public sealed class Conversation : FullAuditedAggregateRoot, IMultiTenant, IOwna
     /// </summary>
     public string? WorkspaceKey { get; private set; }
 
-    private List<Message> _messages = [];
+    private readonly List<Message> _messages = [];
 
     /// <summary>The messages exchanged, oldest first.</summary>
     public IReadOnlyList<Message> Messages => _messages;

--- a/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.fr.html
+++ b/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.fr.html
@@ -4,7 +4,7 @@
   <p>La tâche récurrente <strong><code>{{ model.job_name }}</code></strong> a échoué lors de <strong>{{ model.consecutive_failure_count }}</strong> exécutions consécutives et risque d'être suspendue automatiquement. Les traitements critiques pour les SLA (rapports de conformité, clôtures de facturation) risquent de s'interrompre si la cause n'est pas identifiée rapidement.</p>
   {{- if model.last_error_message }}
   <p>Dernière erreur remontée par l'exécuteur :</p>
-  <pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
+  <pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; overflow-wrap: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
   {{- end }}
 </mj-text>
 <mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/jobs/{{ model.job_id }}">Ouvrir les diagnostics</mj-button>

--- a/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.html
+++ b/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.html
@@ -4,7 +4,7 @@
   <p>The recurring job <strong><code>{{ model.job_name }}</code></strong> has failed <strong>{{ model.consecutive_failure_count }}</strong> consecutive runs and is at risk of being automatically paused. SLA-critical batches (compliance reports, billing rollups) may stop progressing if this is not investigated promptly.</p>
   {{- if model.last_error_message }}
   <p>Last error reported by the runner:</p>
-  <pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
+  <pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; overflow-wrap: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
   {{- end }}
 </mj-text>
 <mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/jobs/{{ model.job_id }}">Open job diagnostics</mj-button>

--- a/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
@@ -17,6 +17,8 @@ namespace Granit.BlobStorage.Endpoints.Extensions;
 /// </summary>
 public static class BlobStorageEndpointRouteBuilderExtensions
 {
+    private const string BlobsRouteSegment = "blobs";
+
     /// <summary>
     /// Maps the blob storage administration endpoints onto the given route builder.
     /// </summary>
@@ -52,15 +54,15 @@ public static class BlobStorageEndpointRouteBuilderExtensions
         // is a convention that applies to EVERY endpoint mapped from it, so reusing a single group would
         // make every endpoint require the union of all policies — read endpoints would silently demand
         // Manage as well. Distinct group builders sharing the same URL prefix keep the conventions isolated.
-        group.MapGranitGroup("blobs")
+        group.MapGranitGroup(BlobsRouteSegment)
             .RequireAuthorization(BlobStoragePermissions.Administration.Read)
             .MapReadEndpoints();
 
-        group.MapGranitGroup("blobs")
+        group.MapGranitGroup(BlobsRouteSegment)
             .RequireAuthorization(BlobStoragePermissions.Administration.Manage)
             .MapWriteEndpoints();
 
-        group.MapGranitGroup("blobs")
+        group.MapGranitGroup(BlobsRouteSegment)
             .RequireAuthorization(BlobStoragePermissions.Administration.Manage)
             .MapOperationEndpoints();
 
@@ -68,7 +70,7 @@ public static class BlobStorageEndpointRouteBuilderExtensions
         // sees only the host partition. To expose cross-tenant blob-descriptor visibility, mark this
         // route .AllowHostAccess(); a platform admin holding Administration.Read at global scope then
         // reads across tenants, while the multi-tenant filter stays enforced for tenant callers.
-        group.MapGranitGroup("blobs")
+        group.MapGranitGroup(BlobsRouteSegment)
             .RequireAuthorization(BlobStoragePermissions.Administration.Read)
             .MapGranitQuery<BlobDescriptor>();
 

--- a/src/Granit.Geocoding/Internal/DefaultGeocodingService.cs
+++ b/src/Granit.Geocoding/Internal/DefaultGeocodingService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -69,12 +70,14 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
         // lookups of the same uncached address await that single result instead of each hitting a provider. This
         // bounds cost, third-party rate limits, and duplicate GDPR transfers. Negative results are cached too —
         // with the shorter FailureCacheDuration applied adaptively inside the factory.
-        bool resolvedFresh = false;
+        // The flag lives in a heap holder so the factory closure can signal back whether it actually executed; a
+        // plain captured local reads as never-assigned to static flow analysis (the delegate's run isn't provable).
+        StrongBox<bool> resolvedFresh = new(false);
         GeocodingResult? resolved = await _cache.GetOrSetAsync<GeocodingResult?>(
             cacheKey,
             async (ctx, ct) =>
             {
-                resolvedFresh = true;
+                resolvedFresh.Value = true;
                 long start = Stopwatch.GetTimestamp();
                 GeocodingResult? r = await QueryProvidersAsync(address, ct).ConfigureAwait(false);
                 ctx.Options.Duration = r is null ? _options.FailureCacheDuration : _options.SuccessCacheDuration;
@@ -85,7 +88,7 @@ internal sealed partial class DefaultGeocodingService : IGeocodingService
 
         // A caller that did not execute the factory was served from the cache (or coalesced onto the in-flight
         // resolution) — count it as a hit; only the factory-executing caller is the real miss.
-        if (resolvedFresh)
+        if (resolvedFresh.Value)
         {
             _metrics.RecordCacheMiss();
             activity?.SetTag("cache.hit", false);

--- a/src/Granit.Geocoding/Internal/DefaultReverseGeocodingService.cs
+++ b/src/Granit.Geocoding/Internal/DefaultReverseGeocodingService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using Granit.Domain.ValueObjects;
@@ -63,19 +64,21 @@ internal sealed partial class DefaultReverseGeocodingService : IReverseGeocoding
 
         string cacheKey = BuildCacheKey(coordinate);
 
-        bool resolvedFresh = false;
+        // The flag lives in a heap holder so the factory closure can signal back whether it actually executed; a
+        // plain captured local reads as never-assigned to static flow analysis (the delegate's run isn't provable).
+        StrongBox<bool> resolvedFresh = new(false);
         ReverseGeocodingResult? resolved = await _cache.GetOrSetAsync<ReverseGeocodingResult?>(
             cacheKey,
             async (ctx, ct) =>
             {
-                resolvedFresh = true;
+                resolvedFresh.Value = true;
                 ReverseGeocodingResult? r = await QueryProvidersAsync(coordinate, ct).ConfigureAwait(false);
                 ctx.Options.Duration = r is null ? _options.FailureCacheDuration : _options.SuccessCacheDuration;
                 return r;
             },
             token: cancellationToken).ConfigureAwait(false);
 
-        if (resolvedFresh)
+        if (resolvedFresh.Value)
         {
             _metrics.RecordCacheMiss();
             activity?.SetTag("cache.hit", false);

--- a/src/Granit.Mcp.Server/Internal/CallToolAuthorizationFilter.cs
+++ b/src/Granit.Mcp.Server/Internal/CallToolAuthorizationFilter.cs
@@ -4,6 +4,7 @@ using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -73,34 +74,32 @@ internal static partial class CallToolAuthorizationFilter
         IReadOnlyList<object>? matchedPrimitiveMetadata,
         CancellationToken ct)
     {
-        ILogger? logger = services?
-            .GetService<ILoggerFactory>()?
-            .CreateLogger("Granit.Mcp.Server.CallToolAuthorization");
+        // Fail closed: without a service provider nothing — tool type, tenant, permission
+        // checker — can be resolved or reasoned about.
+        if (services is null)
+        {
+            return Deny();
+        }
+
+        ILogger logger = services.GetService<ILoggerFactory>()?
+            .CreateLogger("Granit.Mcp.Server.CallToolAuthorization") ?? NullLogger.Instance;
 
         // Fail closed: a tool we cannot resolve to a CLR type cannot be reasoned about.
-        McpToolTypeRegistry? registry = services?.GetService<McpToolTypeRegistry>();
+        McpToolTypeRegistry? registry = services.GetService<McpToolTypeRegistry>();
         Type? toolType = registry?.Resolve(toolName);
         if (toolType is null)
         {
-            if (logger is not null)
-            {
-                LogUnresolvedTool(logger, toolName);
-            }
-
+            LogUnresolvedTool(logger, toolName);
             return Deny();
         }
 
         // Re-run the tenant-scope check at call time (tools/list only hides, it does not gate).
         if (RequiresTenant(toolType))
         {
-            ICurrentTenant? currentTenant = services?.GetService<ICurrentTenant>();
+            ICurrentTenant? currentTenant = services.GetService<ICurrentTenant>();
             if (currentTenant is not { IsAvailable: true })
             {
-                if (logger is not null)
-                {
-                    LogTenantRequired(logger, toolName);
-                }
-
+                LogTenantRequired(logger, toolName);
                 return Deny();
             }
         }
@@ -113,14 +112,10 @@ internal static partial class CallToolAuthorizationFilter
         }
 
         // Default-deny fallback: the principal must hold the coarse execute permission.
-        IPermissionChecker? permissionChecker = services?.GetService<IPermissionChecker>();
+        IPermissionChecker? permissionChecker = services.GetService<IPermissionChecker>();
         if (permissionChecker is null)
         {
-            if (logger is not null)
-            {
-                LogNoPermissionChecker(logger, toolName);
-            }
-
+            LogNoPermissionChecker(logger, toolName);
             return Deny();
         }
 
@@ -130,11 +125,7 @@ internal static partial class CallToolAuthorizationFilter
 
         if (!granted)
         {
-            if (logger is not null)
-            {
-                LogExecuteDenied(logger, toolName);
-            }
-
+            LogExecuteDenied(logger, toolName);
             return Deny();
         }
 

--- a/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
+++ b/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
@@ -269,17 +269,6 @@ public sealed partial class PersonalDataDeletionSaga : Saga
         MarkCompleted();
     }
 
-    private static partial class Log
-    {
-        [LoggerMessage(
-            Level = LogLevel.Warning,
-            Message = "Deletion request {RequestId} (user {UserId}) timed out awaiting provider {Provider} — "
-                + "{Acknowledged}/{Expected} providers acknowledged. Request marked PartiallyExecuted; "
-                + "reconcile the stuck / dead-lettered provider (GDPR Art. 17 provability).")]
-        public static partial void DeletionProviderStuck(
-            ILogger logger, Guid requestId, Guid userId, string provider, int acknowledged, int expected);
-    }
-
     /// <summary>
     /// Handles cancellation — the Saga terminates and future scheduled events
     /// (reminder, deadline) are silently discarded by Wolverine.
@@ -293,5 +282,16 @@ public sealed partial class PersonalDataDeletionSaga : Saga
         await tracker.MarkCancelledAsync(Id, @event.CancelledAt).ConfigureAwait(false);
         metrics.RecordDeletionCancelled(TenantId, Regulation);
         MarkCompleted();
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Deletion request {RequestId} (user {UserId}) timed out awaiting provider {Provider} — "
+                + "{Acknowledged}/{Expected} providers acknowledged. Request marked PartiallyExecuted; "
+                + "reconcile the stuck / dead-lettered provider (GDPR Art. 17 provability).")]
+        public static partial void DeletionProviderStuck(
+            ILogger logger, Guid requestId, Guid userId, string provider, int acknowledged, int expected);
     }
 }

--- a/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
+++ b/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
@@ -13,6 +13,7 @@ public sealed class PrivacyMetrics
 
     private const string TagTenantId = "tenant_id";
     private const string TagRegulation = "regulation";
+    private const string TagProviderName = "provider_name";
     private const string DefaultTenant = "global";
     private const string DefaultRegulation = "EU_GDPR";
 
@@ -122,7 +123,7 @@ public sealed class PrivacyMetrics
         {
             { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
             { TagRegulation, regulation ?? DefaultRegulation },
-            { "provider_name", providerName },
+            { TagProviderName, providerName },
         });
 
     /// <summary>Records a deletion request.</summary>
@@ -147,7 +148,7 @@ public sealed class PrivacyMetrics
         {
             { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
             { TagRegulation, regulation ?? DefaultRegulation },
-            { "provider_name", providerName },
+            { TagProviderName, providerName },
         });
 
     /// <summary>
@@ -161,7 +162,7 @@ public sealed class PrivacyMetrics
         {
             { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
             { TagRegulation, regulation ?? DefaultRegulation },
-            { "provider_name", providerName },
+            { TagProviderName, providerName },
         });
 
     /// <summary>Records a deletion reminder notification sent.</summary>
@@ -208,7 +209,7 @@ public sealed class PrivacyMetrics
         _scopeProbeDuration.Record(duration.TotalMilliseconds, new TagList
         {
             { TagTenantId, tenantId?.ToString() ?? DefaultTenant },
-            { "provider_name", providerName },
+            { TagProviderName, providerName },
         });
 
     /// <summary>

--- a/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
@@ -63,7 +63,7 @@ internal static class QueryCatalogEndpoints
         // value is always bound into the matching path segment. Reading RoutePattern.RawText
         // directly would expose the unsubstituted template and the frontend would 404.
         // Same mechanism as Granit.Entities' entity-discovery surface.
-        RouteValueDictionary routeValues = new();
+        RouteValueDictionary routeValues = [];
         if (httpContext.Request.RouteValues.TryGetValue("version", out object? version) && version is not null)
         {
             routeValues["version"] = version;

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableSortExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableSortExtensions.cs
@@ -45,43 +45,60 @@ internal static class QueryableSortExtensions
 
             foreach (string part in parts)
             {
-                bool descending = part.StartsWith('-');
-                string fieldName = descending ? part[1..] : part;
-
-                if (!sortableFields.Contains(fieldName))
+                bool applied;
+                (source, applied) = TryApplySortPart(source, part, sortableFields, builder, isFirst);
+                if (applied)
                 {
-                    continue;
-                }
-
-                // Check for shadow property first
-                ColumnDescriptor? shadowCol = builder.Columns
-                    .FirstOrDefault(c => c.IsShadowProperty
-                        && string.Equals(c.PropertyName, fieldName, StringComparison.OrdinalIgnoreCase));
-
-                if (shadowCol is not null)
-                {
-                    source = ApplyOrderByShadow(source, fieldName, shadowCol.ClrType, descending, isFirst);
                     isFirst = false;
-                    continue;
                 }
-
-                PropertyInfo? property = typeof(TEntity).GetProperty(
-                    fieldName,
-                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-                if (property is null)
-                {
-                    continue;
-                }
-
-                source = ApplyOrderBy(source, property, descending, isFirst);
-                isFirst = false;
             }
         }
 
         // No explicit ordering resolved — guarantee a deterministic order so that
         // Skip/Take downstream is stable and EF Core does not warn.
         return isFirst ? ApplyFallbackOrder(source, builder) : source;
+    }
+
+    /// <summary>
+    /// Applies a single <c>"field"</c> / <c>"-field"</c> sort token to <paramref name="source"/>,
+    /// resolving it against the whitelisted shadow properties first and then the CLR type. Returns
+    /// the (possibly reordered) queryable and whether an ordering was actually applied — an
+    /// unrecognised or non-whitelisted token leaves the source untouched and reports
+    /// <see langword="false"/>.
+    /// </summary>
+    private static (IQueryable<TEntity> Source, bool Applied) TryApplySortPart<TEntity>(
+        IQueryable<TEntity> source,
+        string part,
+        HashSet<string> sortableFields,
+        QueryDefinitionBuilder<TEntity> builder,
+        bool isFirst)
+        where TEntity : class
+    {
+        bool descending = part.StartsWith('-');
+        string fieldName = descending ? part[1..] : part;
+
+        if (!sortableFields.Contains(fieldName))
+        {
+            return (source, false);
+        }
+
+        // Check for shadow property first
+        ColumnDescriptor? shadowCol = builder.Columns
+            .FirstOrDefault(c => c.IsShadowProperty
+                && string.Equals(c.PropertyName, fieldName, StringComparison.OrdinalIgnoreCase));
+
+        if (shadowCol is not null)
+        {
+            return (ApplyOrderByShadow(source, fieldName, shadowCol.ClrType, descending, isFirst), true);
+        }
+
+        PropertyInfo? property = typeof(TEntity).GetProperty(
+            fieldName,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+        return property is null
+            ? (source, false)
+            : (ApplyOrderBy(source, property, descending, isFirst), true);
     }
 
     /// <summary>

--- a/src/Granit.Scheduling.Notifications/Templates/scheduling.action_failed.fr.html
+++ b/src/Granit.Scheduling.Notifications/Templates/scheduling.action_failed.fr.html
@@ -5,7 +5,7 @@
 <p>Corrélation : <code>{{ model.correlation_id }}</code></p>
 {{ end }}
 <p>Dernière erreur remontée par l'exécuteur :</p>
-<pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.failure_reason | html.escape }}</pre>
+<pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; overflow-wrap: break-word; color: #111827;">{{ model.failure_reason | html.escape }}</pre>
 <p style="text-align: center; margin: 32px 0;">
   <a href="{{ app.base_url }}/admin/scheduling/{{ model.action_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Examiner l'action planifiée</a>
 </p>

--- a/src/Granit.Scheduling.Notifications/Templates/scheduling.action_failed.html
+++ b/src/Granit.Scheduling.Notifications/Templates/scheduling.action_failed.html
@@ -5,7 +5,7 @@
 <p>Correlation: <code>{{ model.correlation_id }}</code></p>
 {{ end }}
 <p>Last error reported by the runner:</p>
-<pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.failure_reason | html.escape }}</pre>
+<pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; overflow-wrap: break-word; color: #111827;">{{ model.failure_reason | html.escape }}</pre>
 <p style="text-align: center; margin: 32px 0;">
   <a href="{{ app.base_url }}/admin/scheduling/{{ model.action_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Investigate scheduled action</a>
 </p>

--- a/tests/Granit.Mentions.Tests/MentionLookupSourceTests.cs
+++ b/tests/Granit.Mentions.Tests/MentionLookupSourceTests.cs
@@ -61,10 +61,8 @@ public sealed class MentionLookupSourceTests
             Scope: type is null ? null : new Dictionary<string, string?> { ["type"] = type });
 
     [Fact]
-    public void Name_is_mentions()
-    {
+    public void Name_is_mentions() =>
         Build([new FakeLookupSource("user")], "user").Name.ShouldBe("mentions");
-    }
 
     [Fact]
     public async Task Search_fans_out_across_tagged_sources_and_stamps_composite_value()


### PR DESCRIPTION
Batch cleanup of open SonarQube findings. Each change verified: affected projects build clean, tests pass, `dotnet format --verify-no-changes` clean.

## Bugs (S2583 — captured-closure flag read as always-`False`)
- **Geocoding forward + reverse services** — the FusionCache factory mutates a captured `bool` the analyzer can't prove executes, so the cache hit/miss metric branch was flagged unreachable. Signal now travels through a `StrongBox<bool>`. Runtime behaviour unchanged; 38 Geocoding tests pass.

## Structural refactors
- **`CallToolAuthorizationFilter`** — fail-closed early return on null `services` (removes two redundant `services?.` null-conditionals) + `NullLogger.Instance` fallback removes four `if (logger is not null)` guards. Cognitive complexity **16 → ~8**. 36 tests pass.
- **`QueryableSortExtensions`** — per-token branching extracted into a `TryApplySortPart` helper. Cognitive complexity **18 → ~8**. 204 tests pass.
- **`PersonalDataDeletionSaga`** — nested `Log` class moved to class end so all `Handle` overloads are adjacent (S4136). 299 tests pass.

## Code smells
- `Conversation._messages` → `readonly`.
- `PrivacyMetrics` `'provider_name'` and `BlobStorage` `'blobs'` literals → named consts.
- `QueryCatalogEndpoints` `new()` → collection expression.
- `MentionLookupSourceTests` → expression body.
- 4 notification templates: deprecated `word-break: break-word` → `overflow-wrap: break-word`.

## Deliberately skipped (false positives — recommend "Won't Fix")
- **5 Wolverine handlers** (S1118 "add protected ctor / make static") — must stay `public` non-static for Wolverine discovery (per CLAUDE.md).
- **`BlobBackedExportSource` S4456** — the recommended validate/iterate split is already implemented (stale finding).
- **8-param `PostEntryAsync`** (S107) — legit Minimal API binding surface; a wrapper type to hit 7 is the banned `brain-overload` anti-pattern.
- **2 architecture-deviation flags** (`GeneratorEndpoints`, `LegalDocumentAdminEndpoints`) — legitimate `MapGranitQuery` / `QueryEndpointOptions` usage (canonical QueryEngine API); the SonarQube architecture rule should be adjusted, not the code.
- **Empty DI-sentinel marker class** + **2 prose comments ending in `;`** — functional / not actually commented-out code.