### PR TITLE
fix(queryengine): strip layer suffix when deriving query module name

### DIFF
--- a/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
@@ -30,12 +30,35 @@ public interface IQueryDefinitionDescriptor
     /// <c>Granit.Identity.Local</c> → <c>Identity.Local</c>). A non-framework assembly name is
     /// returned unchanged, so a consumer's queries group under their own assembly name.
     /// </summary>
+    /// <remarks>
+    /// A single trailing layer suffix (<c>.Abstractions</c>, <c>.EntityFrameworkCore</c>,
+    /// <c>.Endpoints</c>) is stripped as well: an entity may legitimately live in a layer
+    /// project — contracts shared via <c>.Abstractions</c> (so <c>Granit.Auditing.Abstractions</c>
+    /// → <c>Auditing</c>), or a persisted row co-located with a shared DbContext in
+    /// <c>.EntityFrameworkCore</c> — and the layer suffix is never the logical owning module.
+    /// A definition whose entity assembly cannot express its real module (e.g. a feature-scoped
+    /// table hosted in a parent module's DbContext) should override <see cref="ModuleName"/>.
+    /// </remarks>
     static string ModuleOf(Type entityType)
     {
         ArgumentNullException.ThrowIfNull(entityType);
 
         string assembly = entityType.Assembly.GetName().Name ?? entityType.Namespace ?? "Unknown";
         const string prefix = "Granit.";
-        return assembly.StartsWith(prefix, StringComparison.Ordinal) ? assembly[prefix.Length..] : assembly;
+        if (!assembly.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return assembly;
+        }
+
+        string module = assembly[prefix.Length..];
+        foreach (string suffix in (ReadOnlySpan<string>)[".Abstractions", ".EntityFrameworkCore", ".Endpoints"])
+        {
+            if (module.Length > suffix.Length && module.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                return module[..^suffix.Length];
+            }
+        }
+
+        return module;
     }
 }

--- a/tests/Granit.QueryEngine.Abstractions.Tests/ModuleOfTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/ModuleOfTests.cs
@@ -1,0 +1,34 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.Abstractions.Tests;
+
+public sealed class ModuleOfTests
+{
+    [Fact]
+    public void Strips_the_Granit_prefix()
+    {
+        // ModuleOfTests lives in this test assembly (Granit.QueryEngine.Abstractions.Tests),
+        // whose name carries no trailing layer suffix (".Tests" is not one), so only the
+        // framework prefix is removed.
+        IQueryDefinitionDescriptor.ModuleOf(typeof(ModuleOfTests))
+            .ShouldBe("QueryEngine.Abstractions.Tests");
+    }
+
+    [Fact]
+    public void Strips_a_trailing_layer_suffix_so_an_Abstractions_hosted_entity_groups_under_its_module()
+    {
+        // QueryRequest lives in Granit.QueryEngine.Abstractions — the .Abstractions layer
+        // suffix is never the logical owning module, so it collapses to "QueryEngine"
+        // (mirrors Granit.Auditing.Abstractions.AuditEntry → "Auditing").
+        IQueryDefinitionDescriptor.ModuleOf(typeof(QueryRequest))
+            .ShouldBe("QueryEngine");
+    }
+
+    [Fact]
+    public void Leaves_a_non_framework_assembly_name_unchanged()
+    {
+        IQueryDefinitionDescriptor.ModuleOf(typeof(string))
+            .ShouldBe(typeof(string).Assembly.GetName().Name);
+    }
+}


### PR DESCRIPTION
## Problem

`IQueryDefinitionDescriptor.ModuleOf` derives a query's owning module from the **entity's assembly name** (with the `Granit.` prefix stripped). When an entity legitimately lives in a *layer* project, that layer leaked into the QueryEngine catalogue:

- `AuditEntry` / `AuditEntityChange` live in `Granit.Auditing.Abstractions` → grouped under **`Auditing.Abstractions`** instead of `Auditing`.
- A persisted row co-located with a shared DbContext (e.g. business `PartyDuplicateCandidate` in `Granit.Parties.EntityFrameworkCore`) → grouped under **`<Module>.EntityFrameworkCore`**.

## Fix

Strip a single trailing layer suffix (`.Abstractions` / `.EntityFrameworkCore` / `.Endpoints`) after the `Granit.` prefix. These are never the logical owning module. Non-framework assemblies and non-suffixed names are unchanged.

A definition whose entity assembly genuinely cannot express its real module (a feature-scoped table hosted in a parent module's DbContext) should still `override ModuleName` — noted in the XML docs.

## Tests

`ModuleOfTests` covers: prefix strip, `.Abstractions` suffix strip (`QueryEngine.Abstractions → QueryEngine`), non-framework passthrough. Existing `QueryEngine.Abstractions.Tests` (31) + `QueryEngine.AspNetCore.Tests` (63) green.

## DoD

- [x] Build green
- [x] Tests green (94)
- [x] `dotnet format --verify-no-changes` clean