### PR TITLE
feat(queryengine): group-by on a nested complex-type member path

### DIFF
--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -267,13 +267,25 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
     /// Allows grouping by the specified property. Only explicitly declared
     /// properties can be used for group-by (whitelist-first).
     /// </summary>
+    /// <remarks>
+    /// Accepts a top-level scalar (<c>a =&gt; a.Kind</c>), a <see cref="QueryableValueObjectAttribute"/>
+    /// column (grouped by its underlying <c>.Value</c> scalar), or a member of an EF Core complex type
+    /// (<c>a =&gt; a.Value.Country</c>) — the latter is stored as the dotted path <c>"Value.Country"</c>
+    /// and surfaces on the wire as <c>?groupBy=Value.Country</c>. Drilling into a
+    /// <see cref="SingleValueObject{T}"/>'s <c>.Value</c> is still rejected: it is a whole-value
+    /// ValueConverter column, not a groupable scalar (issue #2767).
+    /// </remarks>
     /// <typeparam name="TProp">The property type.</typeparam>
     /// <param name="property">Expression selecting the property.</param>
     public QueryDefinitionBuilder<TEntity> AllowGroupBy<TProp>(
         Expression<Func<TEntity, TProp>> property)
     {
-        string propertyName = GetPropertyName(property);
-        if (!IsQueryableValueObjectMember(property.Body))
+        (string propertyName, bool isNested) = GetGroupByPath(property);
+
+        // A nested leaf (a member of an EF complex type) is a plain scalar column, so the whole-value
+        // VO guard does not apply. For a top-level member, reject a converter-mapped SingleValueObject
+        // unless it opted into the queryable (ComplexProperty) strategy.
+        if (!isNested && !IsQueryableValueObjectMember(property.Body))
         {
             ThrowIfValueObjectColumn<TProp>(propertyName, "grouped by", nameof(property));
         }
@@ -521,6 +533,60 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
         }
 
         return member.Member.Name;
+    }
+
+    // Extracts a (possibly dotted) member path for group-by. Unlike the single-level GetPropertyName,
+    // this accepts a chain of member accesses over an EF complex-type member (a => a.Value.Country) and
+    // returns the dotted path "Value.Country" plus whether the access is nested. It still rejects
+    // drilling into a SingleValueObject's `.Value` (#2767): that inner value is a whole-value
+    // ValueConverter column, not an independently groupable scalar column.
+    private static (string Path, bool IsNested) GetGroupByPath<TProp>(Expression<Func<TEntity, TProp>> expression)
+    {
+        Expression body = expression.Body is UnaryExpression { NodeType: ExpressionType.Convert } convert
+            ? convert.Operand
+            : expression.Body;
+
+        List<string> segments = [];
+        for (Expression? current = body; current is MemberExpression member; current = member.Expression)
+        {
+            if (IsSingleValueObjectType(member.Expression?.Type))
+            {
+                throw new ArgumentException(
+                    $"Group-by expression '{expression.Body}' drills into the '.Value' of a " +
+                    $"SingleValueObject ('{member.Expression!.Type.Name}'), which is mapped as an opaque " +
+                    $"whole-value ValueConverter and cannot be a GROUP BY key. To group by a value-object " +
+                    $"column, mark it [QueryableValueObject] and select the object itself (x => x.Slug); to " +
+                    $"group by a nested field, select a member of an EF complex type. See issue #2767.",
+                    nameof(expression));
+            }
+
+            segments.Add(member.Member.Name);
+
+            if (member.Expression is ParameterExpression)
+            {
+                segments.Reverse();
+                return (string.Join('.', segments), segments.Count > 1);
+            }
+        }
+
+        throw new ArgumentException(
+            "Group-by expression must be a property access (e.g. x => x.Kind) or a nested complex-type " +
+            "member access (e.g. x => x.Address.Country).",
+            nameof(expression));
+    }
+
+    private static bool IsSingleValueObjectType(Type? type)
+    {
+        Type openType = typeof(SingleValueObject<>);
+        for (Type? current = type; current is not null && current != typeof(object); current = current.BaseType)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == openType)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // A value-object selector is allowed in global search / group-by when the property opts into the

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/GroupByPathResolver.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/GroupByPathResolver.cs
@@ -1,0 +1,47 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Builds the group-by key-selector body for a (possibly dotted) member path such as
+/// <c>"Kind"</c> or <c>"Value.Country"</c>. A dotted path walks EF Core complex-type hops with
+/// chained <see cref="Expression.Property(Expression, PropertyInfo)"/>; the leaf still goes through
+/// <see cref="ValueObjectMemberResolver"/> so a <c>[QueryableValueObject]</c> column groups by its
+/// underlying <c>.Value</c> scalar (ADR-070). Shared by <see cref="QueryableGroupByExtensions"/>
+/// (SQL key selector) and the in-memory item bucketing so both resolve to the same key.
+/// </summary>
+internal static class GroupByPathResolver
+{
+    /// <summary>
+    /// Resolves the key-access expression for <paramref name="path"/> rooted at
+    /// <paramref name="instance"/>. Returns <see langword="null"/> when any segment cannot be
+    /// resolved (unknown field), matching the legacy "empty grouped result" behavior.
+    /// </summary>
+    public static Expression? BuildKeyAccess(Expression instance, string path)
+    {
+        string[] segments = path.Split('.');
+        Expression parent = instance;
+
+        for (int i = 0; i < segments.Length; i++)
+        {
+            PropertyInfo? property = parent.Type.GetProperty(
+                segments[i],
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+            if (property is null)
+            {
+                return null;
+            }
+
+            if (i == segments.Length - 1)
+            {
+                return ValueObjectMemberResolver.Resolve(parent, property);
+            }
+
+            parent = Expression.Property(parent, property);
+        }
+
+        return null;
+    }
+}

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Granit.MultiTenancy;
 using Granit.QueryEngine.Diagnostics;
@@ -220,14 +219,19 @@ internal sealed class QueryEngine<TEntity>(
                 .ToListSafeAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            PropertyInfo? groupProp = typeof(TEntity).GetProperty(
-                request.GroupBy,
-                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            // Resolve the same (possibly dotted, VO-drilling) key access used to build the SQL
+            // GROUP BY so in-memory buckets match the materialized group keys.
+            ParameterExpression bucketParam = Expression.Parameter(typeof(TEntity), "e");
+            Expression? keyAccess = GroupByPathResolver.BuildKeyAccess(bucketParam, request.GroupBy);
+            Func<TEntity, object?>? keyGetter = keyAccess is null
+                ? null
+                : Expression.Lambda<Func<TEntity, object?>>(
+                    Expression.Convert(keyAccess, typeof(object)), bucketParam).Compile();
 
-            ILookup<string, TItem>? itemsByKey = groupProp is null
+            ILookup<string, TItem>? itemsByKey = keyGetter is null
                 ? null
                 : allItems.ToLookup(
-                    e => groupProp.GetValue(e)?.ToString() ?? "(null)",
+                    e => keyGetter(e)?.ToString() ?? "(null)",
                     e => projector is null ? (TItem)(object)e : projector(e));
 
             foreach (GroupEntry<TEntity> group in entityResult.Groups)

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableGroupByExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableGroupByExtensions.cs
@@ -20,16 +20,7 @@ internal static class QueryableGroupByExtensions
         CancellationToken cancellationToken)
         where T : class
     {
-        PropertyInfo? property = typeof(T).GetProperty(
-            groupByField,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-        if (property is null)
-        {
-            return new GroupedResult<T>([], 0);
-        }
-
-        // Verify it's a whitelisted group-by field
+        // Verify it's a whitelisted group-by field (dotted complex-type paths compared verbatim).
         bool isAllowed = builder.GroupByFields
             .Any(g => g.PropertyName.Equals(groupByField, StringComparison.OrdinalIgnoreCase));
 
@@ -38,11 +29,17 @@ internal static class QueryableGroupByExtensions
             return new GroupedResult<T>([], 0);
         }
 
-        // Build dynamic GroupBy: source.GroupBy(e => e.Property)
+        // Build dynamic GroupBy: source.GroupBy(e => e.Property) — or e.Value.Country for a dotted
+        // complex-type path. A [QueryableValueObject] leaf groups by its real `.Value` scalar column
+        // (ADR-070), so the key is the underlying primitive and GROUP BY translates.
         ParameterExpression parameter = Expression.Parameter(typeof(T), "e");
-        // A [QueryableValueObject] column groups by its real `.Value` scalar column (ADR-070), so
-        // the key is the underlying primitive (e.g. string) and GROUP BY translates.
-        Expression member = ValueObjectMemberResolver.Resolve(parameter, property);
+        Expression? member = GroupByPathResolver.BuildKeyAccess(parameter, groupByField);
+
+        if (member is null)
+        {
+            return new GroupedResult<T>([], 0);
+        }
+
         LambdaExpression keySelector = Expression.Lambda(member, parameter);
         Type keyType = member.Type;
 

--- a/src/Granit.QueryEngine.EntityFrameworkCore/README.md
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/README.md
@@ -1,10 +1,19 @@
 # Granit.QueryEngine.EntityFrameworkCore
 
 EF Core query engine for Granit.QueryEngine. Provides `IQueryEngine<T>` with expression
-tree-based filtering, multi-column sorting, offset/keyset pagination, and single-level
-GroupBy with aggregates.
+tree-based filtering, multi-column sorting, offset/keyset pagination, and GroupBy with
+aggregates — including group-by on a nested EF Core complex-type member.
 
 Part of the [granit](https://granit-fx.dev) framework.
+
+## Nested complex-type group-by
+
+`AllowGroupBy` accepts a member of an EF Core complex type, e.g.
+`builder.AllowGroupBy(a => a.Value.Country)` where `Value` is a complex property. The field
+is stored as the dotted path `"Value.Country"` and surfaces on the wire as
+`?groupBy=Value.Country` — the engine translates it to a plain SQL `GROUP BY` on the mapped
+column. Drilling into a `SingleValueObject`'s `.Value` is still rejected (issue #2767); mark
+a value-object column `[QueryableValueObject]` to group by its underlying scalar instead.
 
 ## Installation
 

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexGroupByTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexGroupByTests.cs
@@ -1,0 +1,194 @@
+using Granit.Domain;
+using Granit.QueryEngine.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Tests.Internal;
+
+// Group-by on a nested EF Core complex-type member (a => a.Value.Country), stored as the dotted path
+// "Value.Country" and translated to a SQL GROUP BY on the mapped column. End-to-end against real
+// SQLite. The motivating case is granit-business Parties (PartyAddress.Value : Address complex type).
+public sealed class NestedComplexGroupByTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<PartyCtx> _options;
+    private readonly List<string> _sql = [];
+
+    public NestedComplexGroupByTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<PartyCtx>()
+            .UseSqlite(_connection)
+            .LogTo(_sql.Add, [RelationalEventId.CommandExecuted])
+            .Options;
+
+        using PartyCtx seed = new(_options);
+        seed.Database.EnsureCreated();
+        seed.Addresses.AddRange(
+            new PartyAddress { Id = Guid.NewGuid(), Kind = AddressKind.Billing, Value = new Address { Country = "BE", City = "Brussels" } },
+            new PartyAddress { Id = Guid.NewGuid(), Kind = AddressKind.Shipping, Value = new Address { Country = "BE", City = "Ghent" } },
+            new PartyAddress { Id = Guid.NewGuid(), Kind = AddressKind.Billing, Value = new Address { Country = "FR", City = "Paris" } },
+            new PartyAddress { Id = Guid.NewGuid(), Kind = AddressKind.Billing, Value = new Address { Country = "NL", City = "Amsterdam" } });
+        seed.SaveChanges();
+    }
+
+    [Fact]
+    public void AllowGroupBy_on_a_nested_complex_member_does_not_throw_and_records_the_dotted_path()
+    {
+        QueryDefinition<PartyAddress> definition = new AddressQueryDefinition();
+
+        Should.NotThrow(() => definition.GetGroupByFields());
+        definition.GetGroupByFields().Select(g => g.PropertyName)
+            .ShouldBe(["Kind", "Value.Country"]);
+    }
+
+    [Fact]
+    public async Task ExecuteGroupedAsync_groups_by_the_nested_member_with_correct_counts_server_side()
+    {
+        await using PartyCtx ctx = new(_options);
+        QueryEngine<PartyAddress> engine = NewEngine();
+
+        GroupedResult<PartyAddress> result = await engine.ExecuteGroupedAsync(
+            ctx.Addresses,
+            new QueryRequest { GroupBy = "Value.Country" },
+            TestContext.Current.CancellationToken);
+
+        result.TotalCount.ShouldBe(4);
+        result.Groups.Count.ShouldBe(3);
+        result.Groups.First(g => (string)g.Value! == "BE").Count.ShouldBe(2);
+        result.Groups.First(g => (string)g.Value! == "FR").Count.ShouldBe(1);
+        result.Groups.ShouldAllBe(g => g.Field == "Value.Country");
+
+        // The GROUP BY must execute server-side (no client-eval): EF would throw on an
+        // untranslatable GroupBy, and the emitted SQL groups on the mapped complex column.
+        _sql.ShouldContain(s => s.Contains("GROUP BY", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ExecuteGroupedAsync_with_projection_buckets_items_under_the_nested_key()
+    {
+        await using PartyCtx ctx = new(_options);
+        QueryEngine<PartyAddress> engine = NewEngine();
+
+        GroupedResult<CitySummary> result = await engine.ExecuteGroupedAsync(
+            ctx.Addresses,
+            new QueryRequest { GroupBy = "Value.Country" },
+            a => new CitySummary(a.Value.City),
+            TestContext.Current.CancellationToken);
+
+        GroupEntry<CitySummary> be = result.Groups.First(g => (string)g.Value! == "BE");
+        be.Items.ShouldNotBeNull();
+        be.Items!.Select(i => i.City).ShouldBe(["Brussels", "Ghent"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ExecuteGroupedAsync_single_level_group_by_still_works()
+    {
+        await using PartyCtx ctx = new(_options);
+        QueryEngine<PartyAddress> engine = NewEngine();
+
+        GroupedResult<PartyAddress> result = await engine.ExecuteGroupedAsync(
+            ctx.Addresses,
+            new QueryRequest { GroupBy = "Kind" },
+            TestContext.Current.CancellationToken);
+
+        result.TotalCount.ShouldBe(4);
+        result.Groups.First(g => g.Label == nameof(AddressKind.Billing)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ExecuteGroupedAsync_non_whitelisted_nested_path_returns_empty()
+    {
+        await using PartyCtx ctx = new(_options);
+        QueryEngine<PartyAddress> engine = NewEngine();
+
+        GroupedResult<PartyAddress> result = await engine.ExecuteGroupedAsync(
+            ctx.Addresses,
+            new QueryRequest { GroupBy = "Value.City" },
+            TestContext.Current.CancellationToken);
+
+        result.Groups.ShouldBeEmpty();
+        result.TotalCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void AllowGroupBy_drilling_into_a_single_value_object_value_still_throws()
+    {
+        QueryDefinitionBuilder<Party> builder = new();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(
+            () => builder.AllowGroupBy(p => p.Slug.Value));
+
+        ex.Message.ShouldContain("#2767");
+    }
+
+    private static QueryEngine<PartyAddress> NewEngine() => new(
+        new AddressQueryDefinition(),
+        NullLogger<QueryEngine<PartyAddress>>.Instance,
+        Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+    public void Dispose() => _connection.Dispose();
+
+    private sealed class AddressQueryDefinition : QueryDefinition<PartyAddress>
+    {
+        public override string Name => "Test.PartyAddresses";
+
+        protected override void Configure(QueryDefinitionBuilder<PartyAddress> builder) =>
+            builder
+                .Column(a => a.Kind)
+                .AllowGroupBy(a => a.Kind)
+                .AllowGroupBy(a => a.Value.Country);
+    }
+
+    private sealed record CitySummary(string City);
+
+    // Public so the framework's dynamic ToListAsync binder can bind the enum group key.
+    public enum AddressKind
+    {
+        Billing,
+        Shipping,
+    }
+
+    private sealed class Address
+    {
+        public required string Country { get; init; }
+        public required string City { get; init; }
+    }
+
+    private sealed class PartyAddress
+    {
+        public Guid Id { get; set; }
+        public AddressKind Kind { get; set; }
+        public required Address Value { get; init; }
+    }
+
+    private sealed class Slug : SingleValueObject<string>
+    {
+        public override required string Value { get; init; }
+        public static Slug Create(string v) => new() { Value = v };
+    }
+
+    // Separate entity used only to prove the #2767 SingleValueObject `.Value` drill guard still fires.
+    private sealed class Party
+    {
+        public Guid Id { get; set; }
+        public Slug Slug { get; set; } = null!;
+    }
+
+    private sealed class PartyCtx(DbContextOptions<PartyCtx> options) : DbContext(options)
+    {
+        public DbSet<PartyAddress> Addresses => Set<PartyAddress>();
+
+        protected override void OnModelCreating(ModelBuilder b) =>
+            b.Entity<PartyAddress>(e =>
+            {
+                e.HasKey(p => p.Id);
+                e.ComplexProperty(p => p.Value);
+            });
+    }
+}


### PR DESCRIPTION
## Summary

Lets a `QueryDefinition<T>` whitelist **group-by on a member of an EF Core complex type** (e.g. `a => a.Value.Country`) and translates it to a plain SQL `GROUP BY` on the mapped column. Previously `AllowGroupBy` threw on any nested access, so charts/aggregations could not group on a field living inside an owned/complex value object.

Motivating case (granit-business, Parties): `PartyAddress.Value` is an `Address` complex type; `Value.Country` is a real mapped column but the "addresses by country" chart could not group on it. The rejected business-side workaround (a denormalized `CountryCode` mirror column) triplicated the value — the correct fix is here in the framework.

## Changes

- **Builder** (`QueryDefinitionBuilder.AllowGroupBy`): new nested-aware `GetGroupByPath` extractor (the generic single-level `GetPropertyName` is left untouched — many features depend on it). Stores the dotted path `"Value.Country"`. The **#2767 guard is preserved**: drilling into a `SingleValueObject`'s `.Value` still throws; a `[QueryableValueObject]` column still groups by its underlying `.Value` scalar.
- **`GroupByPathResolver`** (new): walks the dotted path with chained `Expression.Property`, routing the leaf through `ValueObjectMemberResolver`. Shared by `ApplyGroupByAsync` (SQL key selector) and `ExecuteGroupedCoreAsync` (in-memory item bucketing) so both resolve to the same key — this also fixes a latent mismatch in VO item-bucketing.
- **Wire format**: `groupBy` may now contain dots (`?groupBy=Value.Country`). The AspNetCore validator only length-checks `GroupBy`, and the **server-side whitelist still gates** which paths are groupable (unknown dotted paths → empty result, not an error).
- **README**: documents the capability and wire format.

## Tests

`NestedComplexGroupByTests` (SQLite, real `ComplexProperty`):
- `AllowGroupBy(a => a.Value.Country)` does not throw; `GetGroupByFields()` contains `"Value.Country"`.
- Grouped path returns correct per-value counts with a **server-side `GROUP BY`** (asserted via captured command text).
- Projection variant buckets items under the nested key.
- Regressions: single-level group-by still works; non-whitelisted dotted path returns empty; drilling into a `SingleValueObject.Value` still throws (#2767).

All green: QueryEngine.EntityFrameworkCore.Tests 210/210, QueryEngine.Abstractions.Tests 31/31. `dotnet format --verify-no-changes` and markdownlint clean.

## Follow-up (separate PRs)

- **granit-business** (~3 lines, once the dev package is consumed): `PartyAddressQueryDefinition.AllowGroupBy(a => a.Value.Country)`, `addresses-by-country` chart widget, `Widget:Granit.Parties.AddressGeography.addresses-by-country` loc key across the 15 base cultures.
- **granit-docs**: document the dotted `groupBy` wire format (docs ship decoupled from code).