### PR TITLE
feat(queryengine): whitelist top-level enum columns for group-by

### DIFF
--- a/src/Granit.Auditing/Queries/AuditEntityChangeQueryDefinition.cs
+++ b/src/Granit.Auditing/Queries/AuditEntityChangeQueryDefinition.cs
@@ -21,6 +21,7 @@ public sealed class AuditEntityChangeQueryDefinition : QueryDefinition<AuditEnti
             .Column(e => e.EntityType, c => c.Label("Entity Type").LabelKey("Auditing.Columns.EntityType").Filterable().Sortable())
             .Column(e => e.EntityId, c => c.Label("Entity ID").LabelKey("Auditing.Columns.EntityId").Filterable())
             .Column(e => e.ChangeType, c => c.Label("Change Type").LabelKey("Auditing.Columns.ChangeType").Filterable().Sortable())
+            .AllowGroupBy(e => e.ChangeType)
             .GlobalSearch(e => e.EntityType, e => e.EntityId)
             .DefaultSort("-auditEntryId")
             .DefaultPageSize(25)

--- a/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
+++ b/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
@@ -29,6 +29,7 @@ public sealed class AuditEntryQueryDefinition : QueryDefinition<AuditEntry>
             .Column(e => e.UserName, c => c.Label("User Name").LabelKey("Auditing.Columns.UserName").Filterable().Sortable())
             .Column(e => e.IpAddress, c => c.Label("IP Address").LabelKey("Auditing.Columns.IpAddress").Filterable())
             .Column(e => e.CorrelationId, c => c.Label("Correlation ID").LabelKey("Auditing.Columns.CorrelationId").Filterable())
+            .AllowGroupBy(e => e.Category)
             .GlobalSearch(e => e.UserId, e => e.UserName, e => e.CorrelationId)
             .DateFilter(e => e.Timestamp)
             .DefaultSort("-timestamp")

--- a/src/Granit.Authentication.ApiKeys/Queries/ApiKeyEntryQueryDefinition.cs
+++ b/src/Granit.Authentication.ApiKeys/Queries/ApiKeyEntryQueryDefinition.cs
@@ -40,6 +40,7 @@ public sealed class ApiKeyEntryQueryDefinition : QueryDefinition<ApiKeyEntry>
             .Column(e => e.LastUsedAt, c => c.Label("Last Used At").LabelKey("ApiKeys.Columns.LastUsedAt").Sortable())
             .Column(e => e.RevokedAt, c => c.Label("Revoked At").LabelKey("ApiKeys.Columns.RevokedAt").Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("ApiKeys.Columns.CreatedAt").Sortable())
+            .AllowGroupBy(e => e.Type)
             .QuickFilter(
                 "active",
                 "Active keys only",

--- a/src/Granit.Authorization/Queries/RoleMetadataQueryDefinition.cs
+++ b/src/Granit.Authorization/Queries/RoleMetadataQueryDefinition.cs
@@ -24,6 +24,7 @@ public sealed class RoleMetadataQueryDefinition : QueryDefinition<RoleMetadata>
             .Column(r => r.IsSystem, c => c.Label("System").LabelKey("Authorization.Columns.IsSystem").Filterable().Sortable())
             .Column(r => r.CreatedAt, c => c.Label("Created At").LabelKey("Authorization.Columns.CreatedAt").Sortable())
             .Column(r => r.ModifiedAt, c => c.Label("Modified At").LabelKey("Authorization.Columns.ModifiedAt").Sortable())
+            .AllowGroupBy(r => r.MultiTenancySides)
             .GlobalSearch(r => r.Name, r => r.Description!)
             .DateFilter(r => r.CreatedAt)
             .DefaultSort("name")

--- a/src/Granit.BlobStorage/Queries/BlobDescriptorQueryDefinition.cs
+++ b/src/Granit.BlobStorage/Queries/BlobDescriptorQueryDefinition.cs
@@ -30,6 +30,7 @@ public sealed class BlobDescriptorQueryDefinition : QueryDefinition<BlobDescript
             .Column(b => b.ValidatedAt, c => c.Label("Validated At").LabelKey("BlobStorage.Columns.ValidatedAt").Sortable())
             .Column(b => b.DeletedAt, c => c.Label("Deleted At").LabelKey("BlobStorage.Columns.DeletedAt").Sortable())
             .Column(b => b.RejectionReason, c => c.Label("Rejection Reason").LabelKey("BlobStorage.Columns.RejectionReason"))
+            .AllowGroupBy(b => b.Status)
             .QuickFilter(
                 "ValidOnly",
                 "Valid uploads only",

--- a/src/Granit.DataExchange/Queries/ExportJobQueryDefinition.cs
+++ b/src/Granit.DataExchange/Queries/ExportJobQueryDefinition.cs
@@ -24,6 +24,7 @@ public sealed class ExportJobQueryDefinition : QueryDefinition<ExportJob>
             .Column(e => e.RowCount, c => c.Label("Row Count").LabelKey("DataExchange.Columns.RowCount").Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("DataExchange.Columns.CreatedAt").Sortable())
             .Column(e => e.CompletedAt, c => c.Label("Completed At").LabelKey("DataExchange.Columns.CompletedAt").Sortable())
+            .AllowGroupBy(e => e.Status)
             .GlobalSearch(e => e.FileName, e => e.DefinitionName)
             .DateFilter(e => e.CreatedAt)
             .DefaultSort("-createdAt")

--- a/src/Granit.DataExchange/Queries/ImportJobQueryDefinition.cs
+++ b/src/Granit.DataExchange/Queries/ImportJobQueryDefinition.cs
@@ -24,6 +24,7 @@ public sealed class ImportJobQueryDefinition : QueryDefinition<ImportJob>
             .Column(e => e.FileSizeBytes, c => c.Label("Size (bytes)").LabelKey("DataExchange.Columns.FileSizeBytes").Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("DataExchange.Columns.CreatedAt").Sortable())
             .Column(e => e.CompletedAt, c => c.Label("Completed At").LabelKey("DataExchange.Columns.CompletedAt").Sortable())
+            .AllowGroupBy(e => e.Status)
             .GlobalSearch(e => e.OriginalFileName, e => e.DefinitionName, e => e.EntityTypeName)
             .DateFilter(e => e.CreatedAt)
             .DefaultSort("-createdAt")

--- a/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
+++ b/src/Granit.Hostnames/Queries/ManagedHostnameQueryDefinition.cs
@@ -25,6 +25,7 @@ public sealed class ManagedHostnameQueryDefinition : QueryDefinition<ManagedHost
             .Column(e => e.Status, c => c.Label("Status").LabelKey("Hostnames.Columns.Status").Filterable().Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("Hostnames.Columns.CreatedAt").Sortable())
             .Column(e => e.ModifiedAt, c => c.Label("Modified At").LabelKey("Hostnames.Columns.ModifiedAt").Sortable())
+            .AllowGroupBy(e => e.Status)
             .GlobalSearch(e => e.OwnerType)
             .DateFilter(e => e.CreatedAt)
             .DefaultSort("host")

--- a/src/Granit.Notifications/Queries/UserNotificationQueryDefinition.cs
+++ b/src/Granit.Notifications/Queries/UserNotificationQueryDefinition.cs
@@ -24,6 +24,8 @@ public sealed class UserNotificationQueryDefinition : QueryDefinition<UserNotifi
             .Column(e => e.RelatedEntityType, c => c.Label("Related Entity Type").LabelKey("Notifications.Columns.RelatedEntityType").Filterable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("Notifications.Columns.CreatedAt").Sortable())
             .Column(e => e.ReadAt, c => c.Label("Read At").LabelKey("Notifications.Columns.ReadAt").Sortable())
+            .AllowGroupBy(e => e.Severity)
+            .AllowGroupBy(e => e.State)
             .GlobalSearch(e => e.RecipientUserId, e => e.NotificationTypeName)
             .DateFilter(e => e.CreatedAt)
             .DefaultSort("-createdAt")

--- a/src/Granit.Privacy/Queries/LegalDocumentQueryDefinition.cs
+++ b/src/Granit.Privacy/Queries/LegalDocumentQueryDefinition.cs
@@ -52,6 +52,7 @@ public sealed class LegalDocumentQueryDefinition : QueryDefinition<LegalDocument
                 .Label("Modified At")
                 .LabelKey("Privacy.LegalDocuments.Columns.LastModifiedAt")
                 .Sortable())
+            .AllowGroupBy(e => e.LifecycleStatus)
             .QuickFilter(
                 "draft",
                 "Drafts",

--- a/src/Granit.Scheduling/Queries/ScheduledActionQueryDefinition.cs
+++ b/src/Granit.Scheduling/Queries/ScheduledActionQueryDefinition.cs
@@ -28,6 +28,7 @@ public sealed class ScheduledActionQueryDefinition : QueryDefinition<ScheduledAc
             .Column(a => a.CorrelationId, c => c.Label("Correlation ID").LabelKey("Scheduling.Columns.CorrelationId").Filterable())
             .Column(a => a.CancelledBy, c => c.Label("Cancelled By").LabelKey("Scheduling.Columns.CancelledBy").Filterable())
             .Column(a => a.FailureReason, c => c.Label("Failure Reason").LabelKey("Scheduling.Columns.FailureReason"))
+            .AllowGroupBy(a => a.Status)
             .GlobalSearch(a => a.PayloadType, a => a.CorrelationId)
             .DateFilter(a => a.ExecuteAt)
             .DefaultSort("-executeAt")

--- a/src/Granit.Timeline/Queries/TimelineEntryQueryDefinition.cs
+++ b/src/Granit.Timeline/Queries/TimelineEntryQueryDefinition.cs
@@ -23,6 +23,7 @@ public sealed class TimelineEntryQueryDefinition : QueryDefinition<TimelineEntry
             .Column(e => e.AuthorId, c => c.Label("Author").LabelKey("Timeline.Columns.AuthorId").Filterable().Sortable().Lookup("users", requiredPermission: "Identity.Users.Read"))
             .Column(e => e.IsDeleted, c => c.Label("Deleted").LabelKey("Timeline.Columns.IsDeleted").Filterable().Sortable())
             .Column(e => e.CreatedAt, c => c.Label("Created At").LabelKey("Timeline.Columns.CreatedAt").Sortable())
+            .AllowGroupBy(e => e.EntryType)
             .GlobalSearch(e => e.EntityType, e => e.EntityId, e => e.Body)
             .DateFilter(e => e.CreatedAt)
             .DefaultSort("-createdAt")

--- a/src/Granit.Webhooks/Queries/WebhookSubscriptionQueryDefinition.cs
+++ b/src/Granit.Webhooks/Queries/WebhookSubscriptionQueryDefinition.cs
@@ -32,6 +32,7 @@ public sealed class WebhookSubscriptionQueryDefinition : QueryDefinition<Webhook
             .Column(s => s.LastSuccessAt, c => c.Label("Last Success At").LabelKey("Webhooks.Columns.LastSuccessAt").Sortable())
             .Column(s => s.SuspendedAt, c => c.Label("Suspended At").LabelKey("Webhooks.Columns.SuspendedAt").Sortable())
             .Column(s => s.SuspendedBy, c => c.Label("Suspended By").LabelKey("Webhooks.Columns.SuspendedBy").Filterable())
+            .AllowGroupBy(s => s.Status)
             .GlobalSearch(s => s.EventType)
             .DefaultSort("-lastSuccessAt")
             .DefaultPageSize(25);


### PR DESCRIPTION
## Summary

Declares `AllowGroupBy` on the categorical **enum** columns that these admin `QueryDefinition`s already expose as `.Column(...)` but never whitelisted for grouping. Dashboards/charts can now `GROUP BY` them via the query engine.

Every target is a bounded, low-cardinality enum persisted as a **PascalCase string** (framework convention), so `GROUP BY` translates cleanly and group labels are the enum names.

## Columns enabled (13 across 11 modules)

| Module | Entity.Column | Enum |
|---|---|---|
| BlobStorage | `BlobDescriptor.Status` | `BlobStatus` |
| DataExchange | `ExportJob.Status` / `ImportJob.Status` | `*JobStatus` |
| Hostnames | `ManagedHostname.Status` | `HostnameStatus` |
| Scheduling | `ScheduledAction.Status` | `ScheduledActionStatus` |
| Webhooks | `WebhookSubscription.Status` | `WebhookSubscriptionStatus` |
| Notifications | `UserNotification.Severity` + `.State` | `NotificationSeverity` / `UserNotificationState` |
| Auditing | `AuditEntry.Category`, `AuditEntityChange.ChangeType` | `AuditCategory` / `AuditChangeType` |
| ApiKeys | `ApiKeyEntry.Type` | `ApiKeyType` |
| Authorization | `RoleMetadata.MultiTenancySides` | `MultiTenancySides` |
| Privacy | `LegalDocument.LifecycleStatus` | `WorkflowLifecycleStatus` |
| Timeline | `TimelineEntry.EntryType` | `TimelineEntryType` |

## Scope / safety

- **No new columns, no schema change, no dashboard widgets.** Group-by stays whitelist-gated, so this only adds capability + `GetMetadata().GroupByFields` entries. A non-whitelisted `groupBy` still returns an empty result.
- Builds green for all 11 modules; full unit suites pass (BlobStorage 159, DataExchange 368, Hostnames 68, Notifications 259, Scheduling 11, Webhooks 216, Auditing 111, Authorization 263, Privacy 299, Timeline 174, ApiKeys 138+33). `dotnet format --verify-no-changes` clean.

## Follow-up (separate PRs)

Surfacing any of these as a **chart widget** on a dashboard (+ loc keys) is a per-module follow-up — deliberately out of scope to keep this reviewable. Bool axes (e.g. `WebhookDeliveryAttempt.IsSuccess`, `Tenant.Activated`) are also left for a follow-up.