### PR TITLE
feat(queryengine): whitelist high-value bool columns for group-by

### DIFF
--- a/src/Granit.Identity.Federated/Queries/FederatedIdentityQueryDefinition.cs
+++ b/src/Granit.Identity.Federated/Queries/FederatedIdentityQueryDefinition.cs
@@ -32,6 +32,7 @@ public sealed class FederatedIdentityQueryDefinition : QueryDefinition<Federated
             // Audit
             .Column(u => u.CreatedAt, c => c.Label("Created At").LabelKey("Identity.Federated.Columns.CreatedAt").Sortable())
             .Column(u => u.ModifiedAt, c => c.Label("Modified At").LabelKey("Identity.Federated.Columns.ModifiedAt").Sortable())
+            .AllowGroupBy(u => u.Enabled)
             .GlobalSearch(u => u.ExternalUserId, u => u.Username, u => u.Email, u => u.FirstName, u => u.LastName)
             .DateFilter(u => u.LastSyncedAt)
             .DefaultSort("-lastSyncedAt")

--- a/src/Granit.Identity/Queries/UserQueryDefinition.cs
+++ b/src/Granit.Identity/Queries/UserQueryDefinition.cs
@@ -34,6 +34,7 @@ public sealed class UserQueryDefinition : QueryDefinition<User>
             .Column(u => u.TenantId, c => c.Label("Tenant").LabelKey("Identity.Columns.Tenant").Filterable().Sortable())
             .Column(u => u.CreatedAt, c => c.Label("Created At").LabelKey("Identity.Columns.CreatedAt").Sortable())
             .Column(u => u.ModifiedAt, c => c.Label("Modified At").LabelKey("Identity.Columns.ModifiedAt").Sortable())
+            .AllowGroupBy(u => u.IsEnabled)
             .GlobalSearch(u => u.DisplayName!, u => u.Email!, u => u.FirstName!, u => u.LastName!)
             .DefaultSort("-CreatedAt")
             .DefaultPageSize(25);

--- a/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
+++ b/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
@@ -25,6 +25,7 @@ public sealed class TenantQueryDefinition : QueryDefinition<Tenant>
             .Column(t => t.IsDeleted, c => c.Label("Deleted").LabelKey("MultiTenancy.Columns.IsDeleted").Filterable().Sortable())
             .Column(t => t.CreatedAt, c => c.Label("Created At").LabelKey("MultiTenancy.Columns.CreatedAt").Sortable())
             .Column(t => t.ModifiedAt, c => c.Label("Modified At").LabelKey("MultiTenancy.Columns.ModifiedAt").Sortable())
+            .AllowGroupBy(t => t.Activated)
             .GlobalSearch(t => t.Name, t => t.Identifier, t => t.ContactEmail)
             .DateFilter(t => t.CreatedAt)
             .DefaultSort("-createdAt")

--- a/src/Granit.Webhooks/Queries/WebhookDeliveryAttemptQueryDefinition.cs
+++ b/src/Granit.Webhooks/Queries/WebhookDeliveryAttemptQueryDefinition.cs
@@ -29,6 +29,7 @@ public sealed class WebhookDeliveryAttemptQueryDefinition : QueryDefinition<Webh
             .Column(d => d.OccurredAt, c => c.Label("Occurred At").LabelKey("Webhooks.Columns.OccurredAt").Sortable())
             .Column(d => d.DurationMs, c => c.Label("Duration (ms)").LabelKey("Webhooks.Columns.DurationMs").Sortable())
             .Column(d => d.ErrorMessage, c => c.Label("Error Message").LabelKey("Webhooks.Columns.ErrorMessage"))
+            .AllowGroupBy(d => d.IsSuccess)
             .GlobalSearch(d => d.EventType, d => d.TargetUrl)
             .DateFilter(d => d.OccurredAt)
             .DefaultSort("-occurredAt")


### PR DESCRIPTION
## Summary

Follow-up to #2909 (enum group-by). Enables `GROUP BY` on the **operational-state boolean** columns these admin `QueryDefinition`s already expose as `.Column(...)`, so dashboards can chart the binary breakdown.

| Module | Entity.Column | Axis |
|---|---|---|
| Webhooks | `WebhookDeliveryAttempt.IsSuccess` | delivery success/failure rate (KPI) |
| MultiTenancy | `Tenant.Activated` | tenant activation ratio |
| Identity | `User.IsEnabled` | active vs disabled users |
| Identity.Federated | `FederatedIdentity.Enabled` | enabled vs disabled federated logins |

## Curation

Only genuine KPIs / account-state flags. **Deliberately excluded** as low analytical value:
- config-inventory flags: `RoleMetadata.IsSystem`, `PromptTemplate/PromptCategory.IsSystem`, `ManagedHostname.IsPrimary`, `TemplateSummary.HasPublishedVersion`
- soft-delete flags: `Tenant.IsDeleted`, `TimelineEntry.IsDeleted` (grids filter these out; not a chart axis)
- per-config toggles: `BackgroundJobDefinition.IsEnabled`, `NotificationPreference.IsEnabled` (borderline — easy to add later if a dashboard wants them)

## Scope / safety

- **No new columns, no schema change, no dashboard widgets.** Group-by stays whitelist-gated → capability + `GetMetadata().GroupByFields` only; a non-whitelisted `groupBy` still returns empty.
- Builds green; unit suites pass (Webhooks 216, MultiTenancy 115, Identity 153, Identity.Federated 65). `dotnet format --verify-no-changes` clean.