### PR TITLE
feat(queryengine): semantic ValueKind on query columns and form fields

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20939,7 +20939,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs",
-      "line": 16,
+      "line": 17,
       "members": []
     },
     {
@@ -20948,7 +20948,7 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs",
-      "line": 10,
+      "line": 11,
       "members": []
     },
     {
@@ -48749,7 +48749,32 @@
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs",
       "line": 9,
-      "members": []
+      "members": [
+        {
+          "name": "Url",
+          "kind": "method",
+          "signature": "Url()",
+          "returnType": "ColumnBuilder<TEntity>"
+        },
+        {
+          "name": "Email",
+          "kind": "method",
+          "signature": "Email()",
+          "returnType": "ColumnBuilder<TEntity>"
+        },
+        {
+          "name": "Phone",
+          "kind": "method",
+          "signature": "Phone()",
+          "returnType": "ColumnBuilder<TEntity>"
+        },
+        {
+          "name": "Bytes",
+          "kind": "method",
+          "signature": "Bytes()",
+          "returnType": "ColumnBuilder<TEntity>"
+        }
+      ]
     },
     {
       "name": "ColumnDescriptor",
@@ -49114,7 +49139,7 @@
       "kind": "record",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/Meta/ColumnDefinition.cs",
-      "line": 14,
+      "line": 21,
       "members": []
     },
     {
@@ -49389,6 +49414,15 @@
           "returnType": "IQueryable<TEntity>"
         }
       ]
+    },
+    {
+      "name": "ValueKind",
+      "fqn": "Granit.QueryEngine.ValueKind",
+      "kind": "enum",
+      "project": "Granit.QueryEngine.Abstractions",
+      "file": "src/Granit.QueryEngine.Abstractions/ValueKind.cs",
+      "line": 17,
+      "members": []
     },
     {
       "name": "IRateLimitCounterStore",

--- a/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Granit.DataLookup.Descriptors;
 using Granit.Entities.Visibility;
+using Granit.QueryEngine;
 
 namespace Granit.Entities.Forms;
 
@@ -27,6 +28,7 @@ public sealed class FieldBuilder<TEntity, TProperty>
     private bool _readOnly;
     private VisibilityCondition? _visibleIf;
     private LookupDescriptor? _lookup;
+    private ValueKind? _valueKind;
 
     internal FieldBuilder(Expression<Func<TEntity, TProperty>> propertySelector, int order)
     {
@@ -100,6 +102,21 @@ public sealed class FieldBuilder<TEntity, TProperty>
     }
 
     /// <summary>
+    /// Tags this field with a semantic <see cref="QueryEngine.ValueKind"/> — the same display-type
+    /// vocabulary a query column carries via <c>ColumnBuilder</c>. On the write side it lets the
+    /// frontend pick a better default edit input (e.g. <c>Currency</c> → money, <c>Url</c> → url)
+    /// when <see cref="Component(string, IReadOnlyDictionary{string, object?}?)"/> was left at its
+    /// CLR-type default; an explicit component always wins. Orthogonal to validation, which keeps
+    /// flowing from the request validators / OpenAPI schema.
+    /// </summary>
+    /// <param name="kind">The semantic value-kind.</param>
+    public FieldBuilder<TEntity, TProperty> ValueKind(Granit.QueryEngine.ValueKind kind)
+    {
+        _valueKind = kind;
+        return this;
+    }
+
+    /// <summary>
     /// Conditional visibility rule against another field (closed enum operators per
     /// ADR-040). Evaluated client-side; permission gating
     /// (<see cref="RequiresPermission"/>) is server-side and takes precedence.
@@ -162,6 +179,7 @@ public sealed class FieldBuilder<TEntity, TProperty>
             ReadOnly = _readOnly,
             VisibleIf = _visibleIf,
             Lookup = _lookup,
+            ValueKind = _valueKind,
         };
 
     /// <summary>

--- a/src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs
@@ -1,5 +1,6 @@
 using Granit.DataLookup.Descriptors;
 using Granit.Entities.Visibility;
+using Granit.QueryEngine;
 
 namespace Granit.Entities.Forms;
 
@@ -64,4 +65,12 @@ public sealed record FieldDescriptor
     /// fields without a declared lookup.
     /// </summary>
     public LookupDescriptor? Lookup { get; init; }
+
+    /// <summary>
+    /// Optional semantic display-type (<c>Currency</c>, <c>Url</c>, <c>Email</c>, …) — the same
+    /// vocabulary a query column carries (<see cref="QueryEngine.ValueKind"/>). Lets the frontend
+    /// pick a better default edit input when <see cref="Component"/> was left at its CLR-type
+    /// default; an explicit component still wins. <c>null</c> when no hint is declared.
+    /// </summary>
+    public ValueKind? ValueKind { get; init; }
 }

--- a/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
@@ -17,6 +17,7 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     internal string? FormatValue { get; private set; }
     internal LookupDescriptor? LookupValue { get; private set; }
     internal string? CurrencyCodeValue { get; private set; }
+    internal ValueKind? ValueKindValue { get; private set; }
 
     /// <summary>
     /// Sets the user-facing label for this column.
@@ -152,6 +153,36 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(isoCode);
         CurrencyCodeValue = isoCode;
+        ValueKindValue = QueryEngine.ValueKind.Currency;
         return this;
     }
+
+    /// <summary>
+    /// Tags this column with a semantic <see cref="QueryEngine.ValueKind"/> — a display-type hint
+    /// telling the frontend what the value means (percentage, URL, email, …) so it can pick the
+    /// right renderer. Prefer the dedicated helpers (<see cref="Percentage"/>, <see cref="Url"/>,
+    /// <see cref="Email"/>, <see cref="Phone"/>, <see cref="Bytes"/>, <see cref="Currency"/>) where
+    /// one exists; use this for the remaining kinds.
+    /// </summary>
+    /// <param name="kind">The semantic value-kind.</param>
+    public ColumnBuilder<TEntity> ValueKind(QueryEngine.ValueKind kind)
+    {
+        ValueKindValue = kind;
+        return this;
+    }
+
+    /// <summary>Tags this column as a ratio in <c>[0, 1]</c> rendered as a percentage.</summary>
+    public ColumnBuilder<TEntity> Percentage() => ValueKind(QueryEngine.ValueKind.Percentage);
+
+    /// <summary>Tags this column as a URL rendered as a clickable link.</summary>
+    public ColumnBuilder<TEntity> Url() => ValueKind(QueryEngine.ValueKind.Url);
+
+    /// <summary>Tags this column as an email address rendered as a <c>mailto:</c> link.</summary>
+    public ColumnBuilder<TEntity> Email() => ValueKind(QueryEngine.ValueKind.Email);
+
+    /// <summary>Tags this column as a telephone number rendered as a <c>tel:</c> link.</summary>
+    public ColumnBuilder<TEntity> Phone() => ValueKind(QueryEngine.ValueKind.Phone);
+
+    /// <summary>Tags this column as a data size in bytes rendered humanized (KB / MB / GB).</summary>
+    public ColumnBuilder<TEntity> Bytes() => ValueKind(QueryEngine.ValueKind.Bytes);
 }

--- a/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
@@ -44,6 +44,15 @@ public sealed class ColumnDescriptor
     public string? CurrencyCode { get; init; }
 
     /// <summary>
+    /// Semantic display-type of the column (<c>Currency</c>, <c>Percentage</c>, <c>Url</c>, …),
+    /// or <c>null</c> to let the frontend fall back to the CLR type. Set via the
+    /// <see cref="ColumnBuilder{TEntity}"/> helpers (<c>Currency</c>, <c>Percentage</c>,
+    /// <c>Url</c>, …) or <see cref="ColumnBuilder{TEntity}.ValueKind(QueryEngine.ValueKind)"/>.
+    /// Surfaced on the wire <see cref="Meta.ColumnDefinition"/> so tables pick the right renderer.
+    /// </summary>
+    public ValueKind? ValueKind { get; init; }
+
+    /// <summary>
     /// Whether this column maps to an EF Core Shadow Property (not a CLR property).
     /// Shadow columns are accessed via <c>EF.Property&lt;T&gt;(entity, name)</c> instead of
     /// direct member access.

--- a/src/Granit.QueryEngine.Abstractions/Meta/ColumnDefinition.cs
+++ b/src/Granit.QueryEngine.Abstractions/Meta/ColumnDefinition.cs
@@ -11,6 +11,13 @@ namespace Granit.QueryEngine.Meta;
 /// <param name="IsFilterable">Whether filtering is allowed.</param>
 /// <param name="IsVisible">Whether the column is visible by default.</param>
 /// <param name="Format">Display format hint, or <c>null</c>.</param>
+/// <param name="ValueKind">
+/// Semantic display-type (<c>"Currency"</c>, <c>"Percentage"</c>, <c>"Url"</c>, …), or <c>null</c>
+/// to fall back to <paramref name="Type"/>. Lets the table pick a renderer from the column itself.
+/// </param>
+/// <param name="CurrencyCode">
+/// ISO 4217 code accompanying a <c>Currency</c> <paramref name="ValueKind"/>, or <c>null</c>.
+/// </param>
 public sealed record ColumnDefinition(
     string Name,
     string Label,
@@ -19,4 +26,6 @@ public sealed record ColumnDefinition(
     bool IsSortable,
     bool IsFilterable,
     bool IsVisible,
-    string? Format);
+    string? Format,
+    ValueKind? ValueKind = null,
+    string? CurrencyCode = null);

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -71,6 +71,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
             CurrencyCode = builder.CurrencyCodeValue,
+            ValueKind = builder.ValueKindValue,
         });
 
         return this;
@@ -105,6 +106,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
             CurrencyCode = builder.CurrencyCodeValue,
+            ValueKind = builder.ValueKindValue,
             IsShadowProperty = true,
         });
 
@@ -141,6 +143,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
             CurrencyCode = builder.CurrencyCodeValue,
+            ValueKind = builder.ValueKindValue,
             IsShadowProperty = true,
         });
 

--- a/src/Granit.QueryEngine.Abstractions/ValueKind.cs
+++ b/src/Granit.QueryEngine.Abstractions/ValueKind.cs
@@ -1,0 +1,93 @@
+namespace Granit.QueryEngine;
+
+/// <summary>
+/// Semantic kind of a column (or metric) value — a display-type hint that tells the frontend
+/// <em>what a value means</em> so it can pick the right cell renderer (and, on the write side,
+/// the right edit input) without inspecting the CLR type. Orthogonal to the raw
+/// <see cref="ColumnBuilder{TEntity}.Format(string)"/> hint, which only refines <em>how</em> a
+/// value is rendered.
+/// </summary>
+/// <remarks>
+/// Carried by name on the wire (<c>JsonStringEnumConverter</c>) — metadata only, never persisted,
+/// so the enum-as-string persistence convention does not apply. A <c>null</c> value-kind means
+/// "fall back to the CLR type", preserving the pre-existing behaviour. Only <see cref="Currency"/>
+/// needs a companion parameter (the sibling <see cref="ColumnDescriptor.CurrencyCode"/>); the enum
+/// itself carries no embedded parameter.
+/// </remarks>
+public enum ValueKind
+{
+    // --- Tier 1: shared with the Analytics metric vocabulary (names are wire-frozen) ---
+
+    /// <summary>Plain count of items, rendered as an integer.</summary>
+    Count,
+
+    /// <summary>Generic numeric value — locale separators, optional decimals.</summary>
+    Number,
+
+    /// <summary>
+    /// Monetary amount. Pair with <see cref="ColumnDescriptor.CurrencyCode"/> (ISO 4217) so the
+    /// frontend formats with the right symbol and locale.
+    /// </summary>
+    Currency,
+
+    /// <summary>Ratio in <c>[0, 1]</c>, rendered as a percentage.</summary>
+    Percentage,
+
+    /// <summary>Duration in seconds, rendered with the locale's duration formatting.</summary>
+    Duration,
+
+    /// <summary>Date (no time component), rendered with the locale's date formatting.</summary>
+    Date,
+
+    // --- Tier 2: high-value display types ---
+
+    /// <summary>Absolute or relative URL, rendered as a clickable link.</summary>
+    Url,
+
+    /// <summary>Email address, rendered as a <c>mailto:</c> link.</summary>
+    Email,
+
+    /// <summary>Telephone number, rendered as a <c>tel:</c> link.</summary>
+    Phone,
+
+    /// <summary>Data size in bytes, rendered humanized (KB / MB / GB).</summary>
+    Bytes,
+
+    /// <summary>Date and time instant, rendered with the locale's date+time formatting.</summary>
+    DateTime,
+
+    /// <summary>Boolean flag, rendered as a checkmark or yes/no badge.</summary>
+    Boolean,
+
+    /// <summary>Enumeration value, rendered as a (localized) badge or chip.</summary>
+    Enum,
+
+    // --- Tier 3: richer renderers ---
+
+    /// <summary>Instant rendered relative to now (e.g. "3 hours ago").</summary>
+    RelativeTime,
+
+    /// <summary>Time of day (no date component).</summary>
+    Time,
+
+    /// <summary>Color value (e.g. hex), rendered as a swatch.</summary>
+    Color,
+
+    /// <summary>Image URL, rendered as a thumbnail.</summary>
+    Image,
+
+    /// <summary>Structured JSON payload, rendered in a code block.</summary>
+    Json,
+
+    /// <summary>Markdown source, rendered as formatted text.</summary>
+    Markdown,
+
+    /// <summary>Collection of labels, rendered as a list of chips.</summary>
+    Tags,
+
+    /// <summary>Numeric score, rendered as stars.</summary>
+    Rating,
+
+    /// <summary>Opaque identifier (e.g. GUID / key), rendered in monospace.</summary>
+    Identifier,
+}

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -311,7 +311,9 @@ internal sealed class QueryEngine<TEntity>(
                 c.IsSortable,
                 c.IsFilterable,
                 c.IsVisible,
-                c.Format)).ToList(),
+                c.Format,
+                c.ValueKind,
+                c.CurrencyCode)).ToList(),
             FilterableFields = _builder.Columns
                 .Where(c => c.IsFilterable)
                 .Select(c => new FilterableField(

--- a/tests/Granit.Entities.Abstractions.Tests/FieldValueKindTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/FieldValueKindTests.cs
@@ -1,0 +1,57 @@
+using Granit.Entities.Forms;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests;
+
+public sealed class FieldValueKindTests
+{
+    [Fact]
+    public void Field_without_value_kind_has_null_value_kind()
+    {
+        FieldDescriptor title = FieldsOf(new SampleEntityDefinition())["Title"];
+
+        title.ValueKind.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValueKind_is_captured_on_the_descriptor()
+    {
+        FieldDescriptor homepage = FieldsOf(new SampleEntityDefinition())["Homepage"];
+
+        homepage.ValueKind.ShouldBe(ValueKind.Url);
+    }
+
+    [Fact]
+    public void ValueKind_does_not_override_an_explicit_component()
+    {
+        FieldDescriptor homepage = FieldsOf(new SampleEntityDefinition())["Homepage"];
+
+        // ValueKind is a semantic hint alongside Component, not a replacement — the explicit
+        // component the caller set stays intact.
+        homepage.Component.ShouldBe("url");
+    }
+
+    private static Dictionary<string, FieldDescriptor> FieldsOf(SampleEntityDefinition definition) =>
+        definition.Descriptor.Forms[0].Sections
+            .SelectMany(s => s.Fields)
+            .ToDictionary(f => f.PropertyName);
+
+    private sealed class SampleEntity
+    {
+        public string Title { get; set; } = "";
+        public string Homepage { get; set; } = "";
+    }
+
+    private sealed class SampleEntityDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.ValueKindEntity";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b) =>
+            b.Form("default", f => f
+                .Section("general", s => s
+                    .Field(x => x.Title)
+                    .Field(x => x.Homepage, fld => fld.Component("url").ValueKind(ValueKind.Url))));
+    }
+}

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
@@ -340,6 +340,39 @@ public sealed class QueryEngineTests : IAsyncLifetime
         field.Lookup.ScopeKeys.ShouldBe(["tenantId"]);
     }
 
+    [Fact]
+    public void GetMetadata_surfaces_value_kind_and_currency_code_on_columns()
+    {
+        ValueKindDefinition definition = new();
+        QueryEngine<TestProduct> engine = new(definition, NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        QueryMetadata metadata = engine.GetMetadata();
+
+        ColumnDefinition price = metadata.Columns.First(c => c.Name == "Price");
+        price.ValueKind.ShouldBe(ValueKind.Currency);
+        price.CurrencyCode.ShouldBe("EUR");
+
+        ColumnDefinition name = metadata.Columns.First(c => c.Name == "Name");
+        name.ValueKind.ShouldBe(ValueKind.Url);
+        name.CurrencyCode.ShouldBeNull();
+
+        ColumnDefinition category = metadata.Columns.First(c => c.Name == "Category");
+        category.ValueKind.ShouldBeNull();
+        category.CurrencyCode.ShouldBeNull();
+    }
+
+    private sealed class ValueKindDefinition : QueryDefinition<TestProduct>
+    {
+        public override string Name => "Test.Products.ValueKind";
+
+        protected override void Configure(QueryDefinitionBuilder<TestProduct> builder) =>
+            builder
+                .Column(p => p.Name, c => c.Label("Name").Url())
+                .Column(p => p.Price, c => c.Label("Price").Currency("EUR"))
+                .Column(p => p.Category, c => c.Label("Category"))
+                .DefaultPageSize(10);
+    }
+
     private sealed class LookupDefinition : QueryDefinition<TestProduct>
     {
         public override string Name => "Test.Products.Lookup";

--- a/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
+++ b/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
@@ -169,4 +169,64 @@ public sealed class ColumnBuilderTests
 
         Should.Throw<ArgumentNullException>(() => builder.Lookup(null!));
     }
+
+    [Fact]
+    public void ValueKindValue_defaults_to_null()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.ValueKindValue.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Currency_sets_kind_and_code()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.Currency("EUR");
+
+        builder.ValueKindValue.ShouldBe(ValueKind.Currency);
+        builder.CurrencyCodeValue.ShouldBe("EUR");
+    }
+
+    [Fact]
+    public void Currency_throws_when_iso_code_is_blank()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        Should.Throw<ArgumentException>(() => builder.Currency(" "));
+    }
+
+    [Theory]
+    [InlineData(ValueKind.Percentage)]
+    [InlineData(ValueKind.Url)]
+    [InlineData(ValueKind.Email)]
+    [InlineData(ValueKind.Phone)]
+    [InlineData(ValueKind.Bytes)]
+    public void Dedicated_helpers_set_matching_kind(ValueKind expected)
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        _ = expected switch
+        {
+            ValueKind.Percentage => builder.Percentage(),
+            ValueKind.Url => builder.Url(),
+            ValueKind.Email => builder.Email(),
+            ValueKind.Phone => builder.Phone(),
+            ValueKind.Bytes => builder.Bytes(),
+            _ => builder,
+        };
+
+        builder.ValueKindValue.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ValueKind_sets_arbitrary_kind()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.ValueKind(ValueKind.Rating);
+
+        builder.ValueKindValue.ShouldBe(ValueKind.Rating);
+    }
 }

--- a/tests/Granit.QueryEngine.Tests/ColumnDescriptorTests.cs
+++ b/tests/Granit.QueryEngine.Tests/ColumnDescriptorTests.cs
@@ -115,6 +115,33 @@ public sealed class ColumnDescriptorTests
         descriptor.IsShadowProperty.ShouldBeFalse();
     }
 
+    [Fact]
+    public void ValueKind_DefaultsToNull()
+    {
+        ColumnDescriptor descriptor = new()
+        {
+            PropertyName = "Name",
+            ClrType = typeof(string),
+        };
+
+        descriptor.ValueKind.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValueKind_CanBeSet()
+    {
+        ColumnDescriptor descriptor = new()
+        {
+            PropertyName = "Amount",
+            ClrType = typeof(decimal),
+            ValueKind = QueryEngine.ValueKind.Currency,
+            CurrencyCode = "EUR",
+        };
+
+        descriptor.ValueKind.ShouldBe(QueryEngine.ValueKind.Currency);
+        descriptor.CurrencyCode.ShouldBe("EUR");
+    }
+
     // ──── Optional properties ────
 
     [Fact]

--- a/tests/Granit.QueryEngine.Tests/Meta/MetaRecordTests.cs
+++ b/tests/Granit.QueryEngine.Tests/Meta/MetaRecordTests.cs
@@ -247,6 +247,35 @@ public sealed class ColumnDefinitionEqualityTests
 
         a.ShouldNotBe(b);
     }
+
+    [Fact]
+    public void ValueKind_And_CurrencyCode_DefaultToNull()
+    {
+        ColumnDefinition column = new("Name", "Nom", "String", 1, true, true, true, null);
+
+        column.ValueKind.ShouldBeNull();
+        column.CurrencyCode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValueKind_And_CurrencyCode_CanBeSet()
+    {
+        ColumnDefinition column = new(
+            "Amount", "Montant", "Decimal", 1, true, true, true, null,
+            ValueKind.Currency, "EUR");
+
+        column.ValueKind.ShouldBe(ValueKind.Currency);
+        column.CurrencyCode.ShouldBe("EUR");
+    }
+
+    [Fact]
+    public void Equality_DifferentValueKind_AreNotEqual()
+    {
+        ColumnDefinition a = new("Amount", "Montant", "Decimal", 1, true, true, true, null, ValueKind.Currency, "EUR");
+        ColumnDefinition b = new("Amount", "Montant", "Decimal", 1, true, true, true, null, ValueKind.Percentage);
+
+        a.ShouldNotBe(b);
+    }
 }
 
 public sealed class FilterableFieldEqualityTests


### PR DESCRIPTION
## Context

Table columns declared via `QueryDefinition<T>` carry only a CLR type name and a raw `Format` string on the wire. The single ad-hoc semantic tag — `ColumnBuilder.Currency(isoCode)` — doesn't even reach `/meta`. So the frontend can't pick a cell renderer from the column itself; it must join the entity manifest's `component` id to columns by name.

This promotes the concept to a first-class semantic **`ValueKind`** carried on the column (and, on the write side, on the form field), aligned with the existing business `MetricValueKind` vocabulary so the two can converge later.

## What's in this PR (Phase 1 + 6.1 — framework core)

**Read side**
- New `ValueKind` enum in `Granit.QueryEngine.Abstractions` — Tier 1 (frozen `MetricValueKind` names: Count/Number/Currency/Percentage/Duration/Date) + Tier 2 (Url/Email/Phone/Bytes/DateTime/Boolean/Enum) + Tier 3 (RelativeTime/Time/Color/Image/Json/Markdown/Tags/Rating/Identifier).
- `ColumnBuilder`: `Percentage/Url/Email/Phone/Bytes` helpers + general `ValueKind(kind)`; `Currency()` now also sets `ValueKind.Currency`.
- `ColumnDescriptor` + the 3 `QueryDefinitionBuilder` creation sites carry it.
- `Meta/ColumnDefinition` surfaces `ValueKind` and (finally) `CurrencyCode` as **optional trailing** params — no existing construction breaks (mirrors the `FilterableField.Lookup` precedent).
- `GetMetadata()` mapping updated.

**Write side (edit)**
- `FieldBuilder.ValueKind(kind)` + `FieldDescriptor` expose the same vocabulary on the form manifest; an explicit `Component` still wins. Display/edit stay decoupled; validation untouched.

Enum refs inside the builders are qualified because the `ValueKind` method shadows the type name within the class scope.

## Design decisions (locked with maintainer)
- Enum lives in the **framework** (`QueryEngine.Abstractions`); all consumers — columns, `FieldBuilder`, business Analytics — already reference it → zero new coupling.
- Only `Currency` carries a companion param (`CurrencyCode`); render precision rides the existing `Format`. `null` ValueKind = fall back to CLR type (behaviour preserved).

## Verification
- Tests: QueryEngine.Tests **290** · EFCore.Tests **212** · Entities.Abstractions.Tests **110** · AspNetCore.Tests **63** · AspNetCore.Integration **14** — all green (incl. new coverage for builder helpers, wire surfacing, and the write-side field hint).
- `dotnet format --verify-no-changes`: clean on the 3 changed src projects.
- No dependency changes → `THIRD-PARTY-NOTICES.md` unchanged.

## Follow-ups (separate PRs, gated on the dev package)
- **granit-front**: consume `valueKind` for cell rendering (Phase 2) + input resolution (Phase 6.2).
- **granit-business**: converge `MetricValueKind` onto this enum + annotate money columns (Phase 3).
- **granit-website / granit-iot**: producer annotations (Phase 4/5).
- **granit-docs**: document the builder methods + wire field (decoupled doc PR).