### PR TITLE
feat(queryengine): per-row currency-code column reference on money columns

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -48748,7 +48748,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "Url",
@@ -49139,7 +49139,7 @@
       "kind": "record",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/Meta/ColumnDefinition.cs",
-      "line": 21,
+      "line": 25,
       "members": []
     },
     {

--- a/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Granit.DataLookup.Descriptors;
 
 namespace Granit.QueryEngine;
@@ -17,6 +18,7 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     internal string? FormatValue { get; private set; }
     internal LookupDescriptor? LookupValue { get; private set; }
     internal string? CurrencyCodeValue { get; private set; }
+    internal string? CurrencyCodeFieldValue { get; private set; }
     internal ValueKind? ValueKindValue { get; private set; }
 
     /// <summary>
@@ -158,10 +160,32 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     }
 
     /// <summary>
+    /// Tags this column as a monetary amount whose ISO 4217 code is carried per-row by a sibling
+    /// column (selected by <paramref name="currencyCodeSelector"/>) rather than fixed at design time.
+    /// Use for multi-currency entities where different rows carry different currencies; use the
+    /// <see cref="Currency(string)"/> overload when a single fixed code is correct.
+    /// </summary>
+    /// <remarks>
+    /// The selected property's name is recorded as <see cref="ColumnDescriptor.CurrencyCodeField"/>
+    /// (the sibling column's wire <c>Name</c>), so the frontend reads the ISO code from that field on
+    /// each row. The referenced property must be present in the result rows (declared as a column or
+    /// included in the projection). Mutually exclusive with <see cref="Currency(string)"/> — a fixed
+    /// code takes precedence on the frontend.
+    /// </remarks>
+    /// <param name="currencyCodeSelector">Selector for the sibling column holding the ISO 4217 code.</param>
+    public ColumnBuilder<TEntity> Currency(Expression<Func<TEntity, string?>> currencyCodeSelector)
+    {
+        ArgumentNullException.ThrowIfNull(currencyCodeSelector);
+        CurrencyCodeFieldValue = QueryDefinitionBuilder<TEntity>.GetPropertyName(currencyCodeSelector);
+        ValueKindValue = QueryEngine.ValueKind.Currency;
+        return this;
+    }
+
+    /// <summary>
     /// Tags this column with a semantic <see cref="QueryEngine.ValueKind"/> — a display-type hint
     /// telling the frontend what the value means (percentage, URL, email, …) so it can pick the
     /// right renderer. Prefer the dedicated helpers (<see cref="Percentage"/>, <see cref="Url"/>,
-    /// <see cref="Email"/>, <see cref="Phone"/>, <see cref="Bytes"/>, <see cref="Currency"/>) where
+    /// <see cref="Email"/>, <see cref="Phone"/>, <see cref="Bytes"/>, <see cref="Currency(string)"/>) where
     /// one exists; use this for the remaining kinds.
     /// </summary>
     /// <param name="kind">The semantic value-kind.</param>

--- a/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
@@ -44,6 +44,14 @@ public sealed class ColumnDescriptor
     public string? CurrencyCode { get; init; }
 
     /// <summary>
+    /// Name of the sibling column carrying this column's ISO 4217 code per row, when the amount is
+    /// multi-currency; <c>null</c> otherwise. Set via
+    /// <see cref="ColumnBuilder{TEntity}.Currency(System.Linq.Expressions.Expression{System.Func{TEntity, string}})"/>.
+    /// Mutually exclusive with <see cref="CurrencyCode"/> (a fixed code wins on the frontend).
+    /// </summary>
+    public string? CurrencyCodeField { get; init; }
+
+    /// <summary>
     /// Semantic display-type of the column (<c>Currency</c>, <c>Percentage</c>, <c>Url</c>, …),
     /// or <c>null</c> to let the frontend fall back to the CLR type. Set via the
     /// <see cref="ColumnBuilder{TEntity}"/> helpers (<c>Currency</c>, <c>Percentage</c>,

--- a/src/Granit.QueryEngine.Abstractions/Meta/ColumnDefinition.cs
+++ b/src/Granit.QueryEngine.Abstractions/Meta/ColumnDefinition.cs
@@ -16,7 +16,11 @@ namespace Granit.QueryEngine.Meta;
 /// to fall back to <paramref name="Type"/>. Lets the table pick a renderer from the column itself.
 /// </param>
 /// <param name="CurrencyCode">
-/// ISO 4217 code accompanying a <c>Currency</c> <paramref name="ValueKind"/>, or <c>null</c>.
+/// Fixed ISO 4217 code accompanying a <c>Currency</c> <paramref name="ValueKind"/>, or <c>null</c>.
+/// </param>
+/// <param name="CurrencyCodeField">
+/// Name of the sibling column carrying the ISO 4217 code per row (multi-currency amounts), or
+/// <c>null</c>. The frontend prefers <paramref name="CurrencyCode"/> when both are set.
 /// </param>
 public sealed record ColumnDefinition(
     string Name,
@@ -28,4 +32,5 @@ public sealed record ColumnDefinition(
     bool IsVisible,
     string? Format,
     ValueKind? ValueKind = null,
-    string? CurrencyCode = null);
+    string? CurrencyCode = null,
+    string? CurrencyCodeField = null);

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -71,6 +71,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
             CurrencyCode = builder.CurrencyCodeValue,
+            CurrencyCodeField = builder.CurrencyCodeFieldValue,
             ValueKind = builder.ValueKindValue,
         });
 
@@ -106,6 +107,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
             CurrencyCode = builder.CurrencyCodeValue,
+            CurrencyCodeField = builder.CurrencyCodeFieldValue,
             ValueKind = builder.ValueKindValue,
             IsShadowProperty = true,
         });
@@ -143,6 +145,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
             CurrencyCode = builder.CurrencyCodeValue,
+            CurrencyCodeField = builder.CurrencyCodeFieldValue,
             ValueKind = builder.ValueKindValue,
             IsShadowProperty = true,
         });

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -313,7 +313,8 @@ internal sealed class QueryEngine<TEntity>(
                 c.IsVisible,
                 c.Format,
                 c.ValueKind,
-                c.CurrencyCode)).ToList(),
+                c.CurrencyCode,
+                c.CurrencyCodeField)).ToList(),
             FilterableFields = _builder.Columns
                 .Where(c => c.IsFilterable)
                 .Select(c => new FilterableField(

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
@@ -359,6 +359,21 @@ public sealed class QueryEngineTests : IAsyncLifetime
         ColumnDefinition category = metadata.Columns.First(c => c.Name == "Category");
         category.ValueKind.ShouldBeNull();
         category.CurrencyCode.ShouldBeNull();
+        category.CurrencyCodeField.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetMetadata_surfaces_per_row_currency_code_field()
+    {
+        PerRowCurrencyDefinition definition = new();
+        QueryEngine<TestProduct> engine = new(definition, NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        QueryMetadata metadata = engine.GetMetadata();
+
+        ColumnDefinition price = metadata.Columns.First(c => c.Name == "Price");
+        price.ValueKind.ShouldBe(ValueKind.Currency);
+        price.CurrencyCode.ShouldBeNull();
+        price.CurrencyCodeField.ShouldBe("Name");
     }
 
     private sealed class ValueKindDefinition : QueryDefinition<TestProduct>
@@ -370,6 +385,17 @@ public sealed class QueryEngineTests : IAsyncLifetime
                 .Column(p => p.Name, c => c.Label("Name").Url())
                 .Column(p => p.Price, c => c.Label("Price").Currency("EUR"))
                 .Column(p => p.Category, c => c.Label("Category"))
+                .DefaultPageSize(10);
+    }
+
+    private sealed class PerRowCurrencyDefinition : QueryDefinition<TestProduct>
+    {
+        public override string Name => "Test.Products.PerRowCurrency";
+
+        protected override void Configure(QueryDefinitionBuilder<TestProduct> builder) =>
+            builder
+                .Column(p => p.Price, c => c.Label("Price").Currency(p => p.Name))
+                .Column(p => p.Name, c => c.Label("Currency"))
                 .DefaultPageSize(10);
     }
 

--- a/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
+++ b/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
@@ -197,6 +197,34 @@ public sealed class ColumnBuilderTests
         Should.Throw<ArgumentException>(() => builder.Currency(" "));
     }
 
+    [Fact]
+    public void Currency_by_selector_sets_kind_and_field()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.Currency(e => e.Name);
+
+        builder.ValueKindValue.ShouldBe(ValueKind.Currency);
+        builder.CurrencyCodeFieldValue.ShouldBe(nameof(TestEntity.Name));
+        builder.CurrencyCodeValue.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Currency_by_selector_throws_when_null()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        Should.Throw<ArgumentNullException>(() => builder.Currency((System.Linq.Expressions.Expression<Func<TestEntity, string?>>)null!));
+    }
+
+    [Fact]
+    public void CurrencyCodeFieldValue_defaults_to_null()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.CurrencyCodeFieldValue.ShouldBeNull();
+    }
+
     [Theory]
     [InlineData(ValueKind.Percentage)]
     [InlineData(ValueKind.Url)]

--- a/tests/Granit.QueryEngine.Tests/ColumnDescriptorTests.cs
+++ b/tests/Granit.QueryEngine.Tests/ColumnDescriptorTests.cs
@@ -142,6 +142,33 @@ public sealed class ColumnDescriptorTests
         descriptor.CurrencyCode.ShouldBe("EUR");
     }
 
+    [Fact]
+    public void CurrencyCodeField_DefaultsToNull()
+    {
+        ColumnDescriptor descriptor = new()
+        {
+            PropertyName = "Amount",
+            ClrType = typeof(decimal),
+        };
+
+        descriptor.CurrencyCodeField.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CurrencyCodeField_CanBeSet()
+    {
+        ColumnDescriptor descriptor = new()
+        {
+            PropertyName = "Amount",
+            ClrType = typeof(decimal),
+            ValueKind = QueryEngine.ValueKind.Currency,
+            CurrencyCodeField = "Currency",
+        };
+
+        descriptor.CurrencyCodeField.ShouldBe("Currency");
+        descriptor.CurrencyCode.ShouldBeNull();
+    }
+
     // ──── Optional properties ────
 
     [Fact]

--- a/tests/Granit.QueryEngine.Tests/Meta/MetaRecordTests.cs
+++ b/tests/Granit.QueryEngine.Tests/Meta/MetaRecordTests.cs
@@ -276,6 +276,25 @@ public sealed class ColumnDefinitionEqualityTests
 
         a.ShouldNotBe(b);
     }
+
+    [Fact]
+    public void CurrencyCodeField_DefaultsToNull()
+    {
+        ColumnDefinition column = new("Amount", "Montant", "Decimal", 1, true, true, true, null, ValueKind.Currency);
+
+        column.CurrencyCodeField.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CurrencyCodeField_CanBeSet()
+    {
+        ColumnDefinition column = new(
+            "Amount", "Montant", "Decimal", 1, true, true, true, null,
+            ValueKind.Currency, CurrencyCode: null, CurrencyCodeField: "Currency");
+
+        column.CurrencyCodeField.ShouldBe("Currency");
+        column.CurrencyCode.ShouldBeNull();
+    }
 }
 
 public sealed class FilterableFieldEqualityTests


### PR DESCRIPTION
## Context

Follow-up to #2911 (semantic `ValueKind`), driven by a gap found while adopting it in **granit-business**: every business money entity (Payment, Invoice, BalanceAccount/Transaction, Subscription, PlanPrice…) is **multi-currency** — the ISO 4217 code lives in a **per-row `Currency` column**, never a fixed compile-time constant. So `Currency("EUR")` is always wrong there, and the front cannot format amounts from the column metadata alone.

## What this adds

A second `Currency` overload that references the **sibling column holding the per-row ISO code**, plus a descriptor/wire field carrying that column's name.

- `ColumnBuilder.Currency(Expression<Func<TEntity, string?>> selector)` — records the selected property's name in a new `CurrencyCodeField`; both overloads set `ValueKind.Currency`. Reuses `QueryDefinitionBuilder.GetPropertyName` so the stored value matches the sibling column's wire `Name`.
- `ColumnDescriptor.CurrencyCodeField` + the three `QueryDefinitionBuilder` creation sites.
- `Meta/ColumnDefinition` surfaces `CurrencyCodeField` as an **optional trailing** param; `GetMetadata()` passes it through — no existing construction breaks.

**Frontend precedence** (separate granit-front follow-up): fixed `CurrencyCode` wins → else read `CurrencyCodeField` per row → else CLR fallback. The referenced property must be present in the result rows.

**Out of scope:** the write/forms side (`FieldBuilder`) — a single edit input has one row, so a per-row reference is meaningless there.

## Verification
- Tests: QueryEngine.Tests **297** · EFCore.Tests **213** · AspNetCore.Tests **63** · AspNetCore.Integration **14** — all green (new coverage: overload sets kind+field & leaves fixed code null, null-selector throws, descriptor/wire round-trip, and a `.Currency(x => x.Sibling)` definition emits `CurrencyCodeField` on `/meta`).
- `dotnet format --verify-no-changes`: clean. No dependency changes → `THIRD-PARTY-NOTICES.md` unchanged.

## Downstream
Once merged + `0.1.0-dev.*` published: **granit-business** annotates multi-currency amounts `.Currency(x => x.Currency)` (Task A / `MetricValueKind` convergence already done & independent); **granit-front** money cell renderer reads `currencyCodeField` per row.