### PR TITLE
feat(timing): promote period resolver to framework, timezone + first-day aware

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -52436,6 +52436,18 @@
           "returnType": "DateTimeOffset"
         },
         {
+          "name": "ResolveUserTimeZone",
+          "kind": "method",
+          "signature": "ResolveUserTimeZone()",
+          "returnType": "TimeZoneInfo"
+        },
+        {
+          "name": "ToUtcFromUserLocal",
+          "kind": "method",
+          "signature": "ToUtcFromUserLocal(DateTime wallClock)",
+          "returnType": "DateTimeOffset"
+        },
+        {
           "name": "Advance",
           "kind": "method",
           "signature": "Advance(TimeSpan duration)",
@@ -54800,8 +54812,29 @@
           "kind": "method",
           "signature": "ConvertToUserTime(DateTimeOffset utcDateTime)",
           "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUtc",
+          "kind": "method",
+          "signature": "ConvertToUtc(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ResolveUserTimeZone",
+          "kind": "method",
+          "signature": "ResolveUserTimeZone()",
+          "returnType": "TimeZoneInfo"
         }
       ]
+    },
+    {
+      "name": "CurrentFirstDayOfWeekProvider",
+      "fqn": "Granit.Timing.CurrentFirstDayOfWeekProvider",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/CurrentFirstDayOfWeekProvider.cs",
+      "line": 7,
+      "members": []
     },
     {
       "name": "CurrentTimezoneProvider",
@@ -54878,8 +54911,29 @@
           "kind": "method",
           "signature": "ConvertToUtc(DateTimeOffset dateTime)",
           "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ResolveUserTimeZone",
+          "kind": "method",
+          "signature": "ResolveUserTimeZone()",
+          "returnType": "TimeZoneInfo"
+        },
+        {
+          "name": "ToUtcFromUserLocal",
+          "kind": "method",
+          "signature": "ToUtcFromUserLocal(DateTime wallClock)",
+          "returnType": "DateTimeOffset"
         }
       ]
+    },
+    {
+      "name": "ICurrentFirstDayOfWeekProvider",
+      "fqn": "Granit.Timing.ICurrentFirstDayOfWeekProvider",
+      "kind": "interface",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/ICurrentFirstDayOfWeekProvider.cs",
+      "line": 11,
+      "members": []
     },
     {
       "name": "ICurrentTimezoneProvider",
@@ -54889,6 +54943,28 @@
       "file": "src/Granit.Timing/ICurrentTimezoneProvider.cs",
       "line": 6,
       "members": []
+    },
+    {
+      "name": "IPeriodResolver",
+      "fqn": "Granit.Timing.IPeriodResolver",
+      "kind": "interface",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/IPeriodResolver.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Resolve",
+          "kind": "method",
+          "signature": "Resolve(PeriodSpec spec)",
+          "returnType": "ResolvedPeriod"
+        },
+        {
+          "name": "ResolveComparison",
+          "kind": "method",
+          "signature": "ResolveComparison(PeriodSpec spec, ResolvedPeriod main)",
+          "returnType": "ResolvedPeriod"
+        }
+      ]
     },
     {
       "name": "ClockOptions",
@@ -54905,7 +54981,7 @@
       "kind": "record",
       "project": "Granit.Timing",
       "file": "src/Granit.Timing/PeriodSpec.cs",
-      "line": 21,
+      "line": 30,
       "members": [
         {
           "name": "FromToken",

--- a/src/Granit.Settings.Endpoints/Internal/WellKnownSettingDefinitionProvider.cs
+++ b/src/Granit.Settings.Endpoints/Internal/WellKnownSettingDefinitionProvider.cs
@@ -25,5 +25,14 @@ internal sealed class WellKnownSettingDefinitionProvider : ISettingDefinitionPro
             Description = "IANA timezone identifier for the user's preferred timezone (e.g. Europe/Brussels).",
             Providers = { "U", "T", "G" },
         });
+
+        context.Add(new SettingDefinition(WellKnownSettingNames.PreferredFirstDayOfWeek)
+        {
+            IsVisibleToClients = true,
+            DisplayName = "Preferred first day of week",
+            Description = "First day of the week used by week-relative period tokens (a DayOfWeek name, e.g. Monday).",
+            AllowedValues = Enum.GetNames<DayOfWeek>(),
+            Providers = { "U", "T", "G" },
+        });
     }
 }

--- a/src/Granit.Settings.Endpoints/Internal/WellKnownSettingNames.cs
+++ b/src/Granit.Settings.Endpoints/Internal/WellKnownSettingNames.cs
@@ -14,4 +14,14 @@ public static class WellKnownSettingNames
 
     /// <summary>Preferred timezone (IANA identifier, e.g. "Europe/Brussels").</summary>
     public const string PreferredTimezone = "Granit.Timing.PreferredTimezone";
+
+    /// <summary>
+    /// Preferred first day of the week (a <see cref="DayOfWeek"/> name, e.g. "Monday").
+    /// Drives week-relative period tokens (<c>wtd</c>, <c>pw</c>). When unset, the effective
+    /// first day is derived from the preferred culture. Grouped with
+    /// <see cref="PreferredTimezone"/> under <c>Granit.Timing.*</c>: both feed the period
+    /// resolver and both back an ambient provider in <c>Granit.Timing</c> — the culture link
+    /// is only the fallback.
+    /// </summary>
+    public const string PreferredFirstDayOfWeek = "Granit.Timing.PreferredFirstDayOfWeek";
 }

--- a/src/Granit.Settings.Endpoints/Middleware/SettingsCultureMiddleware.cs
+++ b/src/Granit.Settings.Endpoints/Middleware/SettingsCultureMiddleware.cs
@@ -53,6 +53,22 @@ public sealed class SettingsCultureMiddleware(RequestDelegate next)
                     timezoneProvider.Timezone = timezone;
                 }
             }
+
+            string? firstDayOfWeek = await settingProvider
+                .GetOrNullAsync(WellKnownSettingNames.PreferredFirstDayOfWeek, context.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (firstDayOfWeek is not null
+                && Enum.TryParse(firstDayOfWeek, ignoreCase: true, out DayOfWeek day))
+            {
+                ICurrentFirstDayOfWeekProvider? firstDayOfWeekProvider =
+                    context.RequestServices.GetService<ICurrentFirstDayOfWeekProvider>();
+
+                if (firstDayOfWeekProvider is not null)
+                {
+                    firstDayOfWeekProvider.FirstDayOfWeek = day;
+                }
+            }
         }
 
         await _next(context).ConfigureAwait(false);

--- a/src/Granit.Testing/Fakes/FakeClock.cs
+++ b/src/Granit.Testing/Fakes/FakeClock.cs
@@ -41,6 +41,13 @@ public sealed class FakeClock : IClock
     /// <inheritdoc/>
     public DateTimeOffset ConvertToUtc(DateTimeOffset dateTime) => dateTime.ToUniversalTime();
 
+    /// <inheritdoc/>
+    public TimeZoneInfo ResolveUserTimeZone() => TimeZoneInfo.Utc;
+
+    /// <inheritdoc/>
+    public DateTimeOffset ToUtcFromUserLocal(DateTime wallClock) =>
+        new(DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified), TimeSpan.Zero);
+
     /// <summary>
     /// Advances the clock by the specified duration.
     /// </summary>

--- a/src/Granit.Timing/Clock.cs
+++ b/src/Granit.Timing/Clock.cs
@@ -23,22 +23,28 @@ public sealed class Clock(TimeProvider timeProvider, ICurrentTimezoneProvider ti
         dateTime.ToUniversalTime();
 
     /// <inheritdoc />
-    public DateTimeOffset ConvertToUserTime(DateTimeOffset utcDateTime)
-    {
-        string? tz = _timezoneProvider.Timezone;
-        if (string.IsNullOrWhiteSpace(tz))
-        {
-            return utcDateTime;
-        }
-
-        if (!TimeZoneInfo.TryFindSystemTimeZoneById(tz, out TimeZoneInfo? tzInfo))
-        {
-            return utcDateTime;
-        }
-
-        return TimeZoneInfo.ConvertTime(utcDateTime, tzInfo);
-    }
+    public DateTimeOffset ConvertToUserTime(DateTimeOffset utcDateTime) =>
+        TimeZoneInfo.ConvertTime(utcDateTime, ResolveUserTimeZone());
 
     /// <inheritdoc />
     public DateTimeOffset ConvertToUtc(DateTimeOffset dateTime) => dateTime.ToUniversalTime();
+
+    /// <inheritdoc />
+    public TimeZoneInfo ResolveUserTimeZone()
+    {
+        string? tz = _timezoneProvider.Timezone;
+
+        // No configured timezone (or an unknown identifier) → treat the user as operating in UTC.
+        return !string.IsNullOrWhiteSpace(tz) && TimeZoneInfo.TryFindSystemTimeZoneById(tz, out TimeZoneInfo? tzInfo)
+            ? tzInfo
+            : TimeZoneInfo.Utc;
+    }
+
+    /// <inheritdoc />
+    public DateTimeOffset ToUtcFromUserLocal(DateTime wallClock)
+    {
+        var unspecified = DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified);
+        DateTime utc = TimeZoneInfo.ConvertTimeToUtc(unspecified, ResolveUserTimeZone());
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
 }

--- a/src/Granit.Timing/CurrentFirstDayOfWeekProvider.cs
+++ b/src/Granit.Timing/CurrentFirstDayOfWeekProvider.cs
@@ -1,0 +1,17 @@
+namespace Granit.Timing;
+
+/// <summary>
+/// <see cref="AsyncLocal{T}"/>-based implementation of <see cref="ICurrentFirstDayOfWeekProvider"/>.
+/// Thread-safe and isolated per async execution context.
+/// </summary>
+public sealed class CurrentFirstDayOfWeekProvider : ICurrentFirstDayOfWeekProvider
+{
+    private readonly AsyncLocal<DayOfWeek?> _current = new();
+
+    /// <inheritdoc />
+    public DayOfWeek? FirstDayOfWeek
+    {
+        get => _current.Value;
+        set => _current.Value = value;
+    }
+}

--- a/src/Granit.Timing/Extensions/TimingServiceCollectionExtensions.cs
+++ b/src/Granit.Timing/Extensions/TimingServiceCollectionExtensions.cs
@@ -10,7 +10,8 @@ namespace Granit.Timing.Extensions;
 public static class TimingServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds Timing module services (IClock, ICurrentTimezoneProvider, TimeProvider).
+    /// Adds Timing module services (IClock, ICurrentTimezoneProvider,
+    /// ICurrentFirstDayOfWeekProvider, IPeriodResolver, TimeProvider).
     /// </summary>
     public static IServiceCollection AddGranitTiming(
         this IServiceCollection services,
@@ -21,9 +22,13 @@ public static class TimingServiceCollectionExtensions
 
         // Singleton + AsyncLocal: the runtime isolates the value per async context
         services.TryAddSingleton<ICurrentTimezoneProvider, CurrentTimezoneProvider>();
+        services.TryAddSingleton<ICurrentFirstDayOfWeekProvider, CurrentFirstDayOfWeekProvider>();
 
         // Singleton because Clock is stateless (TimeProvider.System is thread-safe)
         services.TryAddSingleton<IClock, Clock>();
+
+        // Scoped: resolution depends on the per-request ambient timezone / first-day providers
+        services.TryAddScoped<IPeriodResolver, PeriodResolver>();
 
         if (configure is not null)
         {

--- a/src/Granit.Timing/Granit.Timing.csproj
+++ b/src/Granit.Timing/Granit.Timing.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\Granit\Granit.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Timing.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Granit.Timing/GranitTimingModule.cs
+++ b/src/Granit.Timing/GranitTimingModule.cs
@@ -4,8 +4,8 @@ using Granit.Timing.Extensions;
 namespace Granit.Timing;
 
 /// <summary>
-/// Granit module for IClock, ICurrentTimezoneProvider and TimeProvider.
-/// No dependency on other Granit modules.
+/// Granit module for IClock, ICurrentTimezoneProvider, ICurrentFirstDayOfWeekProvider,
+/// IPeriodResolver and TimeProvider. No dependency on other Granit modules.
 /// </summary>
 public sealed class GranitTimingModule : GranitModule
 {

--- a/src/Granit.Timing/IClock.cs
+++ b/src/Granit.Timing/IClock.cs
@@ -34,4 +34,30 @@ public interface IClock
     /// If no timezone is configured, returns the value unchanged.
     /// </summary>
     DateTimeOffset ConvertToUtc(DateTimeOffset dateTime);
+
+    /// <summary>
+    /// Resolves the current user's timezone (via <see cref="ICurrentTimezoneProvider"/>),
+    /// falling back to <see cref="TimeZoneInfo.Utc"/> when none is configured or the
+    /// identifier is unknown.
+    /// </summary>
+    TimeZoneInfo ResolveUserTimeZone();
+
+    /// <summary>
+    /// Converts a wall-clock local time — interpreted in the current user's timezone
+    /// (<see cref="ResolveUserTimeZone"/>) — to the corresponding UTC instant, honouring
+    /// DST transitions. Unlike <see cref="ConvertToUtc"/> (which applies a fixed offset),
+    /// this handles a constructed local time (e.g. local midnight), where a "day" may span
+    /// 23 or 25 hours across a transition.
+    /// </summary>
+    /// <param name="wallClock">
+    /// The local wall-clock time. Its <see cref="DateTime.Kind"/> is ignored (treated as
+    /// <see cref="DateTimeKind.Unspecified"/>).
+    /// </param>
+    /// <remarks>
+    /// Ambiguous (fall-back) and invalid (spring-forward gap) local times follow the default
+    /// <see cref="TimeZoneInfo.ConvertTimeToUtc(DateTime, TimeZoneInfo)"/> behaviour: ambiguous
+    /// times resolve to standard (non-DST) time; an invalid time throws
+    /// <see cref="ArgumentException"/>. No custom disambiguation rule is applied.
+    /// </remarks>
+    DateTimeOffset ToUtcFromUserLocal(DateTime wallClock);
 }

--- a/src/Granit.Timing/ICurrentFirstDayOfWeekProvider.cs
+++ b/src/Granit.Timing/ICurrentFirstDayOfWeekProvider.cs
@@ -1,0 +1,18 @@
+namespace Granit.Timing;
+
+/// <summary>
+/// Provides the current user's preferred first day of the week (per-request via AsyncLocal).
+/// </summary>
+/// <remarks>
+/// Symmetric to <see cref="ICurrentTimezoneProvider"/>. A <c>null</c> value means
+/// "no explicit preference" — consumers derive the effective first day from
+/// <c>CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek</c> instead.
+/// </remarks>
+public interface ICurrentFirstDayOfWeekProvider
+{
+    /// <summary>
+    /// The current user's preferred first day of the week, or <c>null</c> to derive it
+    /// from the current culture.
+    /// </summary>
+    DayOfWeek? FirstDayOfWeek { get; set; }
+}

--- a/src/Granit.Timing/IPeriodResolver.cs
+++ b/src/Granit.Timing/IPeriodResolver.cs
@@ -1,0 +1,28 @@
+namespace Granit.Timing;
+
+/// <summary>
+/// Resolves a <see cref="PeriodSpec"/> (explicit bounds or a named calendar token) into an
+/// absolute <see cref="ResolvedPeriod"/> — a half-open <c>[From, To)</c> UTC window.
+/// </summary>
+/// <remarks>
+/// The framework-wide implementation resolves calendar tokens in the current user's
+/// <em>local</em> wall-clock (via <see cref="ICurrentTimezoneProvider"/> /
+/// <see cref="ICurrentFirstDayOfWeekProvider"/>) and converts the bounds back to UTC
+/// DST-correctly, so every module (analytics, dashboards, audit, reporting) expands the
+/// same token to the same instants.
+/// </remarks>
+public interface IPeriodResolver
+{
+    /// <summary>
+    /// Resolves the main period to absolute UTC bounds.
+    /// </summary>
+    /// <param name="spec">The period specification (named token or explicit bounds).</param>
+    ResolvedPeriod Resolve(PeriodSpec spec);
+
+    /// <summary>
+    /// Resolves the comparison window. Supports the special token <c>previous_period</c>,
+    /// which returns the equal-length window immediately preceding <paramref name="main"/>;
+    /// any other spec resolves like <see cref="Resolve"/>.
+    /// </summary>
+    ResolvedPeriod ResolveComparison(PeriodSpec spec, ResolvedPeriod main);
+}

--- a/src/Granit.Timing/PeriodResolver.cs
+++ b/src/Granit.Timing/PeriodResolver.cs
@@ -1,0 +1,164 @@
+using System.Globalization;
+using Granit.Exceptions;
+
+namespace Granit.Timing;
+
+/// <summary>
+/// Framework implementation of <see cref="IPeriodResolver"/>. Resolves named calendar tokens
+/// in the current user's local wall-clock and converts the bounds back to UTC DST-correctly,
+/// using <see cref="IClock"/> as the sole time source (never <c>DateTimeOffset.UtcNow</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sub-day rolling tokens (<c>last_5m</c>, <c>last_24h</c>, …) are timezone-independent — they
+/// resolve to <c>[now - duration, now)</c> in UTC. Calendar tokens (<c>today</c>, <c>wtd</c>,
+/// <c>mtd</c>, …) are day-aligned in the user's local time: their bounds are built as local
+/// wall-clock instants and translated to UTC via <see cref="IClock.ToUtcFromUserLocal"/>, so a
+/// "day" correctly spans 23/24/25 hours across a DST transition.
+/// </para>
+/// <para>
+/// With no configured timezone the user operates in UTC and the bounds match the client-side
+/// resolver (<c>@granit/dashboards</c> <c>resolveTimeWindowToRenderRequest</c>) exactly.
+/// </para>
+/// </remarks>
+internal sealed class PeriodResolver(IClock clock, ICurrentFirstDayOfWeekProvider firstDayOfWeekProvider)
+    : IPeriodResolver
+{
+    private const string SupportedTokens =
+        "today, yesterday, day_before_yesterday, this_day_last_week, last_60s, last_5m, last_15m, "
+        + "last_30m, last_1h, last_3h, last_6h, last_12h, last_24h, last_2d, last_7d, last_30d, "
+        + "last_3mo, last_6mo, last_1y, last_2y, last_5y, wtd, mtd, qtd, ytd, pw, pm, pq, py.";
+
+    private readonly IClock _clock = clock;
+    private readonly ICurrentFirstDayOfWeekProvider _firstDayOfWeekProvider = firstDayOfWeekProvider;
+
+    /// <inheritdoc />
+    public ResolvedPeriod Resolve(PeriodSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+
+        if (!string.IsNullOrWhiteSpace(spec.Token))
+        {
+            return ResolveToken(spec.Token, _clock.Now, EffectiveFirstDayOfWeek);
+        }
+
+        // Bounds validation is normally enforced upstream by the request validator; these
+        // guards are defence-in-depth for callers that bypass it (internal jobs, tests).
+        if (spec.From is null || spec.To is null)
+        {
+            throw new BusinessRuleViolationException(
+                "Granit.Timing:PeriodSpecBounds",
+                "PeriodSpec requires either Token or both From and To.");
+        }
+
+        if (spec.From >= spec.To)
+        {
+            throw new BusinessRuleViolationException(
+                "Granit.Timing:PeriodSpecOrdering",
+                "PeriodSpec.From must be strictly before PeriodSpec.To.");
+        }
+
+        return new ResolvedPeriod(spec.From.Value, spec.To.Value);
+    }
+
+    /// <inheritdoc />
+    public ResolvedPeriod ResolveComparison(PeriodSpec spec, ResolvedPeriod main)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+
+        if (string.Equals(spec.Token, "previous_period", StringComparison.OrdinalIgnoreCase))
+        {
+            TimeSpan length = main.To - main.From;
+            return new ResolvedPeriod(main.From - length, main.From);
+        }
+
+        return Resolve(spec);
+    }
+
+    /// <summary>
+    /// Effective first day of the week: the explicit user preference, or the current culture's
+    /// default when unset. The culture is hydrated from the user's preferred locale upstream,
+    /// so this fallback already reflects the user's preference.
+    /// </summary>
+    private DayOfWeek EffectiveFirstDayOfWeek =>
+        _firstDayOfWeekProvider.FirstDayOfWeek ?? CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek;
+
+    private ResolvedPeriod ResolveToken(string rawToken, DateTimeOffset nowUtc, DayOfWeek w)
+    {
+        string token = rawToken.ToLowerInvariant();
+
+        // Current instant expressed in the user's local wall-clock, then day-aligned.
+        DateTime day0 = _clock.ConvertToUserTime(nowUtc).DateTime.Date;
+        DateTime endOfToday = day0.AddDays(1);
+
+        return token switch
+        {
+            // Rolling sub-day windows — timezone-independent, end at "now".
+            "last_60s" => Utc(nowUtc.AddSeconds(-60), nowUtc),
+            "last_5m" => Utc(nowUtc.AddMinutes(-5), nowUtc),
+            "last_15m" => Utc(nowUtc.AddMinutes(-15), nowUtc),
+            "last_30m" => Utc(nowUtc.AddMinutes(-30), nowUtc),
+            "last_1h" => Utc(nowUtc.AddHours(-1), nowUtc),
+            "last_3h" => Utc(nowUtc.AddHours(-3), nowUtc),
+            "last_6h" => Utc(nowUtc.AddHours(-6), nowUtc),
+            "last_12h" => Utc(nowUtc.AddHours(-12), nowUtc),
+            "last_24h" => Utc(nowUtc.AddHours(-24), nowUtc),
+
+            // Relative single days — day-aligned (local).
+            "today" => Local(day0, endOfToday),
+            "yesterday" => Local(day0.AddDays(-1), day0),
+            "day_before_yesterday" => Local(day0.AddDays(-2), day0.AddDays(-1)),
+            "this_day_last_week" => Local(day0.AddDays(-7), day0.AddDays(-6)),
+
+            // Rolling day/month/year windows — day-aligned, through end of today.
+            "last_2d" => Local(day0.AddDays(-2), endOfToday),
+            "last_7d" => Local(day0.AddDays(-7), endOfToday),
+            "last_30d" => Local(day0.AddDays(-30), endOfToday),
+            "last_3mo" => Local(day0.AddMonths(-3), endOfToday),
+            "last_6mo" => Local(day0.AddMonths(-6), endOfToday),
+            "last_1y" => Local(day0.AddYears(-1), endOfToday),
+            "last_2y" => Local(day0.AddYears(-2), endOfToday),
+            "last_5y" => Local(day0.AddYears(-5), endOfToday),
+
+            // To-date ("so far") — start of the current period through end of today.
+            "wtd" => Local(WeekStart(day0, w), endOfToday),
+            "mtd" => Local(FirstOfMonth(day0), endOfToday),
+            "qtd" => Local(QuarterStart(day0), endOfToday),
+            "ytd" => Local(FirstOfYear(day0), endOfToday),
+
+            // Previous complete periods.
+            "pw" => Local(WeekStart(day0, w).AddDays(-7), WeekStart(day0, w)),
+            "pm" => Local(FirstOfMonth(day0).AddMonths(-1), FirstOfMonth(day0)),
+            "pq" => Local(QuarterStart(day0).AddMonths(-3), QuarterStart(day0)),
+            "py" => Local(FirstOfYear(day0).AddYears(-1), FirstOfYear(day0)),
+
+            _ => throw new BusinessRuleViolationException(
+                "Granit.Timing:UnknownPeriodToken",
+                $"Unknown period token '{rawToken}'. Supported: {SupportedTokens}"),
+        };
+    }
+
+    /// <summary>Builds a UTC window from two instants that are already absolute.</summary>
+    private static ResolvedPeriod Utc(DateTimeOffset from, DateTimeOffset to) => new(from, to);
+
+    /// <summary>Builds a window from two local wall-clock bounds, converting each to UTC DST-correctly.</summary>
+    private ResolvedPeriod Local(DateTime from, DateTime to) =>
+        new(_clock.ToUtcFromUserLocal(from), _clock.ToUtcFromUserLocal(to));
+
+    /// <summary>Most recent day <c>&lt;= <paramref name="d"/></c> whose weekday equals <paramref name="w"/>.</summary>
+    private static DateTime WeekStart(DateTime d, DayOfWeek w)
+    {
+        int diff = ((int)d.DayOfWeek - (int)w + 7) % 7;
+        return d.AddDays(-diff);
+    }
+
+    private static DateTime FirstOfMonth(DateTime d) => new(d.Year, d.Month, 1);
+
+    private static DateTime FirstOfYear(DateTime d) => new(d.Year, 1, 1);
+
+    private static DateTime QuarterStart(DateTime d)
+    {
+        int quarterStartMonth = ((d.Month - 1) / 3 * 3) + 1;
+        return new DateTime(d.Year, quarterStartMonth, 1);
+    }
+}

--- a/src/Granit.Timing/PeriodSpec.cs
+++ b/src/Granit.Timing/PeriodSpec.cs
@@ -7,11 +7,20 @@ namespace Granit.Timing;
 /// <param name="From">Inclusive start (only valid when <see cref="Token"/> is null).</param>
 /// <param name="To">Exclusive end (only valid when <see cref="Token"/> is null).</param>
 /// <param name="Token">
-/// Named period (case-insensitive). Supported tokens (v1):
-/// <c>today</c>, <c>yesterday</c>, <c>last_7d</c>, <c>last_30d</c>, <c>last_60s</c>,
-/// <c>last_5m</c>, <c>mtd</c> (month-to-date), <c>qtd</c> (quarter-to-date),
-/// <c>ytd</c> (year-to-date), <c>previous_period</c> (only valid for the comparison
-/// window — refers to the period of equal length immediately preceding the main one).
+/// Named period (case-insensitive), resolved by <see cref="IPeriodResolver"/>. Supported:
+/// <list type="bullet">
+/// <item>Rolling sub-day (UTC, timezone-independent): <c>last_60s</c>, <c>last_5m</c>,
+/// <c>last_15m</c>, <c>last_30m</c>, <c>last_1h</c>, <c>last_3h</c>, <c>last_6h</c>,
+/// <c>last_12h</c>, <c>last_24h</c>.</item>
+/// <item>Relative days (local, day-aligned): <c>today</c>, <c>yesterday</c>,
+/// <c>day_before_yesterday</c>, <c>this_day_last_week</c>.</item>
+/// <item>Rolling day/month/year: <c>last_2d</c>, <c>last_7d</c>, <c>last_30d</c>,
+/// <c>last_3mo</c>, <c>last_6mo</c>, <c>last_1y</c>, <c>last_2y</c>, <c>last_5y</c>.</item>
+/// <item>To-date: <c>wtd</c>, <c>mtd</c>, <c>qtd</c>, <c>ytd</c>.</item>
+/// <item>Previous complete periods: <c>pw</c>, <c>pm</c>, <c>pq</c>, <c>py</c>.</item>
+/// <item><c>previous_period</c> — only valid for the comparison window; refers to the period
+/// of equal length immediately preceding the main one.</item>
+/// </list>
 /// </param>
 /// <remarks>
 /// Lives in <c>Granit.Timing</c> so any module needing a time-window primitive

--- a/tests/Granit.Settings.Endpoints.Tests/SettingsCultureMiddlewareTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/SettingsCultureMiddlewareTests.cs
@@ -17,6 +17,7 @@ public sealed class SettingsCultureMiddlewareTests
     private readonly ISettingProvider _settingProvider = Substitute.For<ISettingProvider>();
     private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ICurrentTimezoneProvider _timezoneProvider = Substitute.For<ICurrentTimezoneProvider>();
+    private readonly ICurrentFirstDayOfWeekProvider _firstDayOfWeekProvider = Substitute.For<ICurrentFirstDayOfWeekProvider>();
 
     [Fact]
     public async Task Authenticated_User_With_Locale_Sets_CurrentUICulture()
@@ -191,12 +192,51 @@ public sealed class SettingsCultureMiddlewareTests
         capturedCulture.Name.ShouldBe("es", "CurrentCulture (pas seulement CurrentUICulture) doit être défini");
     }
 
+    [Fact]
+    public async Task Authenticated_User_With_FirstDayOfWeek_Sets_Provider_CaseInsensitively()
+    {
+        _currentUserService.IsAuthenticated.Returns(true);
+        _currentUserService.UserId.Returns("user-1");
+        _settingProvider.GetOrNullAsync(WellKnownSettingNames.PreferredCulture, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _settingProvider.GetOrNullAsync(WellKnownSettingNames.PreferredTimezone, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _settingProvider.GetOrNullAsync(WellKnownSettingNames.PreferredFirstDayOfWeek, Arg.Any<CancellationToken>())
+            .Returns("monday");
+
+        SettingsCultureMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(CreateHttpContext());
+
+        _firstDayOfWeekProvider.Received(1).FirstDayOfWeek = DayOfWeek.Monday;
+    }
+
+    [Fact]
+    public async Task Authenticated_User_With_Invalid_FirstDayOfWeek_Is_Ignored()
+    {
+        _currentUserService.IsAuthenticated.Returns(true);
+        _currentUserService.UserId.Returns("user-1");
+        _settingProvider.GetOrNullAsync(WellKnownSettingNames.PreferredCulture, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _settingProvider.GetOrNullAsync(WellKnownSettingNames.PreferredTimezone, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _settingProvider.GetOrNullAsync(WellKnownSettingNames.PreferredFirstDayOfWeek, Arg.Any<CancellationToken>())
+            .Returns("Funday");
+
+        SettingsCultureMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(CreateHttpContext());
+
+        _firstDayOfWeekProvider.DidNotReceiveWithAnyArgs().FirstDayOfWeek = default;
+    }
+
     private DefaultHttpContext CreateHttpContext()
     {
         ServiceCollection services = new();
         services.AddSingleton(_settingProvider);
         services.AddSingleton(_currentUserService);
         services.AddSingleton(_timezoneProvider);
+        services.AddSingleton(_firstDayOfWeekProvider);
 
         DefaultHttpContext httpContext = new()
         {

--- a/tests/Granit.Settings.Endpoints.Tests/WellKnownSettingDefinitionProviderTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/WellKnownSettingDefinitionProviderTests.cs
@@ -76,6 +76,48 @@ public sealed class WellKnownSettingDefinitionProviderTests
     }
 
     [Fact]
+    public void Defines_PreferredFirstDayOfWeek_Setting()
+    {
+        SettingDefinitionRegistry manager = BuildManager();
+
+        SettingDefinition? def = manager.GetOrNull(WellKnownSettingNames.PreferredFirstDayOfWeek);
+
+        def.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void PreferredFirstDayOfWeek_IsVisibleToClients()
+    {
+        SettingDefinitionRegistry manager = BuildManager();
+        SettingDefinition def = manager.Get(WellKnownSettingNames.PreferredFirstDayOfWeek);
+
+        def.IsVisibleToClients.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PreferredFirstDayOfWeek_HasProviders_UTG()
+    {
+        SettingDefinitionRegistry manager = BuildManager();
+        SettingDefinition def = manager.Get(WellKnownSettingNames.PreferredFirstDayOfWeek);
+
+        def.Providers.ShouldContain("U");
+        def.Providers.ShouldContain("T");
+        def.Providers.ShouldContain("G");
+        def.Providers.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void PreferredFirstDayOfWeek_AllowsExactlyTheSevenDayNames()
+    {
+        SettingDefinitionRegistry manager = BuildManager();
+        SettingDefinition def = manager.Get(WellKnownSettingNames.PreferredFirstDayOfWeek);
+
+        def.AllowedValues.ShouldBe(Enum.GetNames<DayOfWeek>(), ignoreOrder: false);
+        def.IsValidValue("Monday").ShouldBeTrue();
+        def.IsValidValue("Funday").ShouldBeFalse();
+    }
+
+    [Fact]
     public void PreferredCulture_HasDisplayName()
     {
         SettingDefinitionRegistry manager = BuildManager();

--- a/tests/Granit.Settings.Endpoints.Tests/WellKnownSettingNamesTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/WellKnownSettingNamesTests.cs
@@ -13,9 +13,13 @@ public sealed class WellKnownSettingNamesTests
     public void PreferredTimezone_HasExpectedValue() => WellKnownSettingNames.PreferredTimezone.ShouldBe("Granit.Timing.PreferredTimezone");
 
     [Fact]
+    public void PreferredFirstDayOfWeek_HasExpectedValue() => WellKnownSettingNames.PreferredFirstDayOfWeek.ShouldBe("Granit.Timing.PreferredFirstDayOfWeek");
+
+    [Fact]
     public void Constants_AreNotNull()
     {
         WellKnownSettingNames.PreferredCulture.ShouldNotBeNullOrWhiteSpace();
         WellKnownSettingNames.PreferredTimezone.ShouldNotBeNullOrWhiteSpace();
+        WellKnownSettingNames.PreferredFirstDayOfWeek.ShouldNotBeNullOrWhiteSpace();
     }
 }

--- a/tests/Granit.Testing.Tests/FakeClockTests.cs
+++ b/tests/Granit.Testing.Tests/FakeClockTests.cs
@@ -88,6 +88,25 @@ public sealed class FakeClockTests
     }
 
     [Fact]
+    public void ResolveUserTimeZone_Returns_Utc()
+    {
+        FakeClock clock = new();
+
+        clock.ResolveUserTimeZone().ShouldBe(TimeZoneInfo.Utc);
+    }
+
+    [Fact]
+    public void ToUtcFromUserLocal_Treats_WallClock_As_Utc()
+    {
+        FakeClock clock = new();
+
+        DateTimeOffset result = clock.ToUtcFromUserLocal(new DateTime(2026, 6, 15, 14, 0, 0));
+
+        result.ShouldBe(new DateTimeOffset(2026, 6, 15, 14, 0, 0, TimeSpan.Zero));
+        result.Offset.ShouldBe(TimeSpan.Zero);
+    }
+
+    [Fact]
     public async Task AsyncLocal_Isolates_State_Across_Tasks()
     {
         FakeClock clock = new();

--- a/tests/Granit.Timing.Tests/ClockTests.cs
+++ b/tests/Granit.Timing.Tests/ClockTests.cs
@@ -240,4 +240,70 @@ public sealed class ClockTests
         userTime.Offset.ShouldBe(TimeSpan.Zero);
         userTime.ShouldBe(utcTime);
     }
+
+    [Fact]
+    public void ResolveUserTimeZone_WithKnownTimezone_ReturnsIt()
+    {
+        _timezoneProvider.Timezone.Returns("Europe/Brussels");
+
+        _clock.ResolveUserTimeZone().ShouldBe(TimeZoneInfo.FindSystemTimeZoneById("Europe/Brussels"));
+    }
+
+    [Fact]
+    public void ResolveUserTimeZone_WithoutTimezone_FallsBackToUtc()
+    {
+        _timezoneProvider.Timezone.Returns((string?)null);
+
+        _clock.ResolveUserTimeZone().ShouldBe(TimeZoneInfo.Utc);
+    }
+
+    [Fact]
+    public void ResolveUserTimeZone_WithInvalidTimezone_FallsBackToUtc()
+    {
+        _timezoneProvider.Timezone.Returns("Invalid/Timezone");
+
+        _clock.ResolveUserTimeZone().ShouldBe(TimeZoneInfo.Utc);
+    }
+
+    [Fact]
+    public void ToUtcFromUserLocal_WithoutTimezone_TreatsWallClockAsUtc()
+    {
+        _timezoneProvider.Timezone.Returns((string?)null);
+
+        DateTimeOffset utc = _clock.ToUtcFromUserLocal(new DateTime(2026, 5, 12, 0, 0, 0));
+
+        utc.ShouldBe(new DateTimeOffset(2026, 5, 12, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void ToUtcFromUserLocal_WithTimezone_ConvertsWallClockDstCorrectly()
+    {
+        _timezoneProvider.Timezone.Returns("Europe/Brussels");
+
+        // Local midnight May 12 is CEST (+2) -> May 11 22:00Z.
+        DateTimeOffset utc = _clock.ToUtcFromUserLocal(new DateTime(2026, 5, 12, 0, 0, 0));
+
+        utc.ShouldBe(new DateTimeOffset(2026, 5, 11, 22, 0, 0, TimeSpan.Zero));
+        utc.Offset.ShouldBe(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void ToUtcFromUserLocal_AmbiguousLocalTime_AssumesStandardTime()
+    {
+        // 2026-10-25 02:30 occurs twice in Brussels (fall-back). Default: standard time (CET, +1).
+        _timezoneProvider.Timezone.Returns("Europe/Brussels");
+
+        DateTimeOffset utc = _clock.ToUtcFromUserLocal(new DateTime(2026, 10, 25, 2, 30, 0));
+
+        utc.ShouldBe(new DateTimeOffset(2026, 10, 25, 1, 30, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void ToUtcFromUserLocal_InvalidLocalTime_ThrowsPerTimeZoneInfoDefault()
+    {
+        // 2026-03-29 02:30 is skipped in Brussels (spring-forward gap); TimeZoneInfo throws.
+        _timezoneProvider.Timezone.Returns("Europe/Brussels");
+
+        Should.Throw<ArgumentException>(() => _clock.ToUtcFromUserLocal(new DateTime(2026, 3, 29, 2, 30, 0)));
+    }
 }

--- a/tests/Granit.Timing.Tests/CurrentFirstDayOfWeekProviderTests.cs
+++ b/tests/Granit.Timing.Tests/CurrentFirstDayOfWeekProviderTests.cs
@@ -1,0 +1,53 @@
+// =============================================================================
+// Tests - CurrentFirstDayOfWeekProvider
+// =============================================================================
+// Verifies the AsyncLocal-backed first-day-of-week provider: default is null
+// ("derive from culture"), stores an explicit override, and isolates the value
+// per async execution context.
+// =============================================================================
+
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timing.Tests;
+
+public sealed class CurrentFirstDayOfWeekProviderTests
+{
+    [Fact]
+    public void FirstDayOfWeek_defaults_to_null()
+    {
+        var provider = new CurrentFirstDayOfWeekProvider();
+
+        provider.FirstDayOfWeek.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FirstDayOfWeek_stores_the_configured_value()
+    {
+        var provider = new CurrentFirstDayOfWeekProvider();
+
+        provider.FirstDayOfWeek = DayOfWeek.Monday;
+
+        provider.FirstDayOfWeek.ShouldBe(DayOfWeek.Monday);
+    }
+
+    [Fact]
+    public async Task FirstDayOfWeek_is_isolated_per_async_context()
+    {
+        var provider = new CurrentFirstDayOfWeekProvider();
+        provider.FirstDayOfWeek = DayOfWeek.Monday;
+
+        DayOfWeek? observed = DayOfWeek.Sunday;
+        await Task.Run(
+            () =>
+            {
+                provider.FirstDayOfWeek = DayOfWeek.Sunday; // mutate inside a nested flow
+                observed = provider.FirstDayOfWeek;
+            },
+            TestContext.Current.CancellationToken);
+
+        observed.ShouldBe(DayOfWeek.Sunday);
+        // The outer context keeps its own value (AsyncLocal does not propagate back up).
+        provider.FirstDayOfWeek.ShouldBe(DayOfWeek.Monday);
+    }
+}

--- a/tests/Granit.Timing.Tests/PeriodResolverTests.cs
+++ b/tests/Granit.Timing.Tests/PeriodResolverTests.cs
@@ -1,0 +1,317 @@
+// =============================================================================
+// Tests - PeriodResolver
+// =============================================================================
+// Verifies the framework period resolver:
+//   - UTC parity with the @granit/dashboards client resolver (28 tokens, no tz)
+//   - Timezone awareness (calendar tokens resolve the user's LOCAL day)
+//   - DST correctness (a "day" spans 23/25h across a transition; bounds stay right)
+//   - First-day-of-week (override wins; Monday vs Sunday for wtd/pw)
+//   - .NET AddMonths day clamping (May 31 -> last_3mo)
+//   - Guard rails (null spec, missing/inverted bounds, unknown token)
+//   - previous_period comparison passthrough
+// The real Clock + FakeTimeProvider + real ambient providers are used so the
+// TimeZoneInfo conversion path is exercised end to end.
+// =============================================================================
+
+using System.Globalization;
+using Granit.Exceptions;
+using Microsoft.Extensions.Time.Testing;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timing.Tests;
+
+public sealed class PeriodResolverTests
+{
+    // 2026-05-12 14:30:45 UTC — a Tuesday, mid-May, middle of Q2.
+    private static readonly DateTimeOffset Now = new(2026, 5, 12, 14, 30, 45, TimeSpan.Zero);
+
+    private readonly FakeTimeProvider _timeProvider = new();
+    private readonly CurrentTimezoneProvider _timezone = new();
+    private readonly CurrentFirstDayOfWeekProvider _firstDayOfWeek = new();
+    private readonly PeriodResolver _resolver;
+
+    public PeriodResolverTests()
+    {
+        _timeProvider.SetUtcNow(Now);
+        _resolver = new PeriodResolver(new Clock(_timeProvider, _timezone), _firstDayOfWeek);
+    }
+
+    private static DateTimeOffset Utc(string iso) =>
+        DateTimeOffset.Parse(iso, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+    // A fresh resolver pinned to a specific instant/timezone — used by cases whose clock predates
+    // the shared field default (FakeTimeProvider refuses to move backwards).
+    private static PeriodResolver ResolverAt(DateTimeOffset now, string timezone)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(now);
+        var timezoneProvider = new CurrentTimezoneProvider { Timezone = timezone };
+        return new PeriodResolver(new Clock(timeProvider, timezoneProvider), new CurrentFirstDayOfWeekProvider());
+    }
+
+    // -- UTC parity (no timezone) — must equal the client resolver's bounds exactly. -----------
+
+    [Theory]
+    // Rolling sub-day windows — [now - duration, now).
+    [InlineData("last_60s", "2026-05-12T14:29:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_5m", "2026-05-12T14:25:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_15m", "2026-05-12T14:15:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_30m", "2026-05-12T14:00:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_1h", "2026-05-12T13:30:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_3h", "2026-05-12T11:30:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_6h", "2026-05-12T08:30:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_12h", "2026-05-12T02:30:45Z", "2026-05-12T14:30:45Z")]
+    [InlineData("last_24h", "2026-05-11T14:30:45Z", "2026-05-12T14:30:45Z")]
+    // Relative single days.
+    [InlineData("today", "2026-05-12T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("yesterday", "2026-05-11T00:00:00Z", "2026-05-12T00:00:00Z")]
+    [InlineData("day_before_yesterday", "2026-05-10T00:00:00Z", "2026-05-11T00:00:00Z")]
+    [InlineData("this_day_last_week", "2026-05-05T00:00:00Z", "2026-05-06T00:00:00Z")]
+    // Rolling day/month/year windows through end of today.
+    [InlineData("last_2d", "2026-05-10T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("last_7d", "2026-05-05T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("last_30d", "2026-04-12T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("last_3mo", "2026-02-12T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("last_6mo", "2025-11-12T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("last_1y", "2025-05-12T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("last_2y", "2024-05-12T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("last_5y", "2021-05-12T00:00:00Z", "2026-05-13T00:00:00Z")]
+    // To-date (default first day = Monday; 05-11 is the Monday of that week).
+    [InlineData("wtd", "2026-05-11T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("mtd", "2026-05-01T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("qtd", "2026-04-01T00:00:00Z", "2026-05-13T00:00:00Z")]
+    [InlineData("ytd", "2026-01-01T00:00:00Z", "2026-05-13T00:00:00Z")]
+    // Previous complete periods.
+    [InlineData("pw", "2026-05-04T00:00:00Z", "2026-05-11T00:00:00Z")]
+    [InlineData("pm", "2026-04-01T00:00:00Z", "2026-05-01T00:00:00Z")]
+    [InlineData("pq", "2026-01-01T00:00:00Z", "2026-04-01T00:00:00Z")]
+    [InlineData("py", "2025-01-01T00:00:00Z", "2026-01-01T00:00:00Z")]
+    public void Resolve_token_without_timezone_matches_utc_table(string token, string from, string to)
+    {
+        _firstDayOfWeek.FirstDayOfWeek = DayOfWeek.Monday;
+
+        ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken(token));
+
+        resolved.From.ShouldBe(Utc(from));
+        resolved.To.ShouldBe(Utc(to));
+    }
+
+    [Fact]
+    public void Resolve_token_is_case_insensitive()
+    {
+        ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("TODAY"));
+
+        resolved.From.ShouldBe(Utc("2026-05-12T00:00:00Z"));
+        resolved.To.ShouldBe(Utc("2026-05-13T00:00:00Z"));
+    }
+
+    // -- Timezone awareness — calendar tokens resolve the user's LOCAL day. --------------------
+
+    [Fact]
+    public void Resolve_today_in_tokyo_returns_local_day_shifted_to_utc()
+    {
+        // 20:00Z is already 2026-05-13 05:00 in Tokyo (UTC+9): the local day is the 13th.
+        _timeProvider.SetUtcNow(new DateTimeOffset(2026, 5, 12, 20, 0, 0, TimeSpan.Zero));
+        _timezone.Timezone = "Asia/Tokyo";
+
+        ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("today"));
+
+        // Local midnight 05-13 JST == 05-12 15:00Z; next local midnight == 05-13 15:00Z.
+        resolved.From.ShouldBe(Utc("2026-05-12T15:00:00Z"));
+        resolved.To.ShouldBe(Utc("2026-05-13T15:00:00Z"));
+    }
+
+    [Fact]
+    public void Resolve_sub_day_token_is_timezone_independent()
+    {
+        _timezone.Timezone = "Asia/Tokyo";
+
+        ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("last_1h"));
+
+        // Sub-day windows are pure UTC instants regardless of timezone.
+        resolved.From.ShouldBe(Utc("2026-05-12T13:30:45Z"));
+        resolved.To.ShouldBe(Now);
+    }
+
+    // -- DST correctness (Europe/Brussels springs forward 2026-03-29 02:00 -> 03:00). ----------
+
+    [Fact]
+    public void Resolve_last_2d_across_spring_forward_is_71_hours_not_72()
+    {
+        PeriodResolver resolver = ResolverAt(new DateTimeOffset(2026, 3, 30, 10, 0, 0, TimeSpan.Zero), "Europe/Brussels");
+
+        ResolvedPeriod resolved = resolver.Resolve(PeriodSpec.FromToken("last_2d"));
+
+        // Local [Mar 28 00:00 CET, Mar 31 00:00 CEST) spans three calendar days, one of which
+        // (Mar 29) loses an hour to the DST gap -> 71h total, not a frozen 72h.
+        resolved.From.ShouldBe(Utc("2026-03-27T23:00:00Z"));
+        resolved.To.ShouldBe(Utc("2026-03-30T22:00:00Z"));
+        (resolved.To - resolved.From).ShouldBe(TimeSpan.FromHours(71));
+    }
+
+    [Fact]
+    public void Resolve_mtd_across_spring_forward_uses_local_month_start()
+    {
+        PeriodResolver resolver = ResolverAt(new DateTimeOffset(2026, 3, 30, 10, 0, 0, TimeSpan.Zero), "Europe/Brussels");
+
+        ResolvedPeriod resolved = resolver.Resolve(PeriodSpec.FromToken("mtd"));
+
+        // Mar 1 00:00 local is still CET (+1) -> Feb 28 23:00Z; end of today is CEST (+2).
+        resolved.From.ShouldBe(Utc("2026-02-28T23:00:00Z"));
+        resolved.To.ShouldBe(Utc("2026-03-30T22:00:00Z"));
+    }
+
+    // -- First day of week. --------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(DayOfWeek.Monday, "2026-05-11T00:00:00Z")] // Mon of the week containing Tue 05-12
+    [InlineData(DayOfWeek.Sunday, "2026-05-10T00:00:00Z")] // Sun of that week
+    public void Resolve_wtd_honours_first_day_of_week(DayOfWeek firstDay, string expectedFrom)
+    {
+        _firstDayOfWeek.FirstDayOfWeek = firstDay;
+
+        ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("wtd"));
+
+        resolved.From.ShouldBe(Utc(expectedFrom));
+        resolved.To.ShouldBe(Utc("2026-05-13T00:00:00Z"));
+    }
+
+    [Theory]
+    [InlineData(DayOfWeek.Monday, "2026-05-04T00:00:00Z", "2026-05-11T00:00:00Z")]
+    [InlineData(DayOfWeek.Sunday, "2026-05-03T00:00:00Z", "2026-05-10T00:00:00Z")]
+    public void Resolve_pw_honours_first_day_of_week(DayOfWeek firstDay, string from, string to)
+    {
+        _firstDayOfWeek.FirstDayOfWeek = firstDay;
+
+        ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("pw"));
+
+        resolved.From.ShouldBe(Utc(from));
+        resolved.To.ShouldBe(Utc(to));
+    }
+
+    [Fact]
+    public void Resolve_wtd_without_override_falls_back_to_current_culture()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            // en-US: first day is Sunday. No explicit override -> derive from culture.
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            _firstDayOfWeek.FirstDayOfWeek = null;
+
+            ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("wtd"));
+
+            resolved.From.ShouldBe(Utc("2026-05-10T00:00:00Z")); // Sunday
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void Resolve_first_day_override_wins_over_culture()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US"); // culture says Sunday
+            _firstDayOfWeek.FirstDayOfWeek = DayOfWeek.Monday; // override says Monday
+
+            ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("wtd"));
+
+            resolved.From.ShouldBe(Utc("2026-05-11T00:00:00Z")); // Monday wins
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    // -- AddMonths day clamping. ---------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_last_3mo_clamps_day_to_target_month()
+    {
+        // day0 = May 31 -> AddMonths(-3) = Feb 31 -> clamped to Feb 28 (2026 is not a leap year).
+        _timeProvider.SetUtcNow(new DateTimeOffset(2026, 5, 31, 12, 0, 0, TimeSpan.Zero));
+
+        ResolvedPeriod resolved = _resolver.Resolve(PeriodSpec.FromToken("last_3mo"));
+
+        resolved.From.ShouldBe(Utc("2026-02-28T00:00:00Z"));
+        resolved.To.ShouldBe(Utc("2026-06-01T00:00:00Z"));
+    }
+
+    // -- Explicit bounds & guard rails. --------------------------------------------------------
+
+    [Fact]
+    public void Resolve_explicit_window_passes_through()
+    {
+        var spec = new PeriodSpec(From: Now.AddDays(-3), To: Now);
+
+        ResolvedPeriod resolved = _resolver.Resolve(spec);
+
+        resolved.From.ShouldBe(Now.AddDays(-3));
+        resolved.To.ShouldBe(Now);
+    }
+
+    [Fact]
+    public void Resolve_null_spec_throws() =>
+        Should.Throw<ArgumentNullException>(() => _resolver.Resolve(null!));
+
+    [Fact]
+    public void Resolve_missing_bounds_throws_business_rule()
+    {
+        var spec = new PeriodSpec(From: Now, To: null);
+
+        BusinessRuleViolationException ex =
+            Should.Throw<BusinessRuleViolationException>(() => _resolver.Resolve(spec));
+        ex.ErrorCode.ShouldBe("Granit.Timing:PeriodSpecBounds");
+    }
+
+    [Fact]
+    public void Resolve_inverted_bounds_throws_business_rule()
+    {
+        var spec = new PeriodSpec(From: Now, To: Now.AddDays(-1));
+
+        BusinessRuleViolationException ex =
+            Should.Throw<BusinessRuleViolationException>(() => _resolver.Resolve(spec));
+        ex.ErrorCode.ShouldBe("Granit.Timing:PeriodSpecOrdering");
+    }
+
+    [Fact]
+    public void Resolve_unknown_token_throws_business_rule()
+    {
+        BusinessRuleViolationException ex =
+            Should.Throw<BusinessRuleViolationException>(() => _resolver.Resolve(PeriodSpec.FromToken("last_decade")));
+
+        ex.ErrorCode.ShouldBe("Granit.Timing:UnknownPeriodToken");
+        ex.Message.ShouldContain("last_decade");
+    }
+
+    // -- Comparison window. --------------------------------------------------------------------
+
+    [Fact]
+    public void ResolveComparison_previous_period_returns_equal_length_window_before_main()
+    {
+        var main = new ResolvedPeriod(Utc("2026-05-05T00:00:00Z"), Utc("2026-05-12T00:00:00Z"));
+
+        ResolvedPeriod comparison = _resolver.ResolveComparison(PeriodSpec.FromToken("previous_period"), main);
+
+        comparison.From.ShouldBe(Utc("2026-04-28T00:00:00Z"));
+        comparison.To.ShouldBe(Utc("2026-05-05T00:00:00Z"));
+    }
+
+    [Fact]
+    public void ResolveComparison_non_previous_period_resolves_like_main()
+    {
+        var main = new ResolvedPeriod(Now.AddDays(-1), Now);
+        _firstDayOfWeek.FirstDayOfWeek = DayOfWeek.Monday;
+
+        ResolvedPeriod comparison = _resolver.ResolveComparison(PeriodSpec.FromToken("yesterday"), main);
+
+        comparison.From.ShouldBe(Utc("2026-05-11T00:00:00Z"));
+        comparison.To.ShouldBe(Utc("2026-05-12T00:00:00Z"));
+    }
+}

--- a/tests/Granit.Timing.Tests/TimingServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Timing.Tests/TimingServiceCollectionExtensionsTests.cs
@@ -49,6 +49,34 @@ public sealed class TimingServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddGranitTiming_RegistersFirstDayOfWeekProvider()
+    {
+        ServiceCollection services = new();
+
+        services.AddGranitTiming();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        ICurrentFirstDayOfWeekProvider? provider = sp.GetService<ICurrentFirstDayOfWeekProvider>();
+        provider.ShouldNotBeNull();
+        provider.ShouldBeOfType<CurrentFirstDayOfWeekProvider>();
+    }
+
+    [Fact]
+    public void AddGranitTiming_RegistersPeriodResolver()
+    {
+        ServiceCollection services = new();
+
+        services.AddGranitTiming();
+
+        using ServiceProvider sp = services.BuildServiceProvider(validateScopes: true);
+        using IServiceScope scope = sp.CreateScope();
+
+        IPeriodResolver? resolver = scope.ServiceProvider.GetService<IPeriodResolver>();
+        resolver.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void AddGranitTiming_RegistersTimeProvider()
     {
         // Arrange


### PR DESCRIPTION
## Context

Follow-up to the Grafana-style dashboard time controls (granit-business !191/!192, granit-front #899). Token→`[from, to)` resolution lived in **granit-business** (`Granit.Analytics.Internal.PeriodResolver`) and computed calendar bounds in **UTC** — wrong for a user outside UTC (Tokyo's "today" at 08:00 JST is yesterday in UTC). This promotes the mechanism into the framework and makes it locale-correct, so every module (analytics, dashboards, audit, reporting) resolves the 28 tokens identically.

## Changes

**Task 1 — first-day-of-week is now a framework setting**
- `PreferredFirstDayOfWeek = "Granit.Localization.PreferredFirstDayOfWeek"` (visible-to-clients, scopes U/T/G, `AllowedValues` = the 7 `DayOfWeek` names).
- New AsyncLocal `ICurrentFirstDayOfWeekProvider` / `CurrentFirstDayOfWeekProvider`, symmetric to the timezone provider.
- `SettingsCultureMiddleware` hydrates it per authenticated request (case-insensitive parse, optional provider).

**Task 2 — DST-correct wall-clock → UTC on `IClock`**
- `ResolveUserTimeZone()` (UTC fallback) + `ToUtcFromUserLocal(DateTime)` via `TimeZoneInfo.ConvertTimeToUtc` — a constructed local midnight converts correctly across a DST transition (a "day" can be 23/25h). `ConvertToUserTime` refactored onto the shared resolver. `FakeClock` keeps UTC-only behaviour.

**Task 3 — `PeriodResolver` promoted to `Granit.Timing`**
- Public `IPeriodResolver`, internal-sealed scoped `PeriodResolver`. Calendar tokens resolve in the user's **local day** then convert bounds back to UTC DST-correctly; sub-day tokens stay UTC. Effective first day = provider override ?? current culture. With no timezone the bounds match the `@granit/dashboards` client resolver **exactly**.

**Design note:** the resolver takes `IClock` + `ICurrentFirstDayOfWeekProvider` — the DST conversion is centralised on `IClock` rather than duplicated (the prompt's DRY option).

## Tests

`Granit.Timing.Tests`, `Granit.Testing.Tests`, `Granit.Settings.Endpoints.Tests` all green. Coverage: full 28-token UTC parity table (vs the front resolver), Asia/Tokyo local-day shift, Europe/Brussels spring-forward (71h `last_2d` + `mtd`), Monday/Sunday `wtd`/`pw`, May-31 `AddMonths` clamp, guard rails, `previous_period`, culture fallback, and the new `IClock` methods (incl. ambiguous/invalid DST). `dotnet format --verify-no-changes` clean. New files only in existing packages → no `Granit.slnx` change.

## Out of scope (separate PRs/MRs)

- **granit-business**: retire the local `PeriodResolver` + business first-day provider, wire `MetricEndpointService` onto framework `IPeriodResolver`.
- **granit-front**: read both settings + `timeZone` in `resolveTimeWindowToRenderRequest` (DST-correct local-day math).