### PR TITLE
test(queryengine): guard the query catalog against unreviewed bespoke query definitions

### DIFF
--- a/tests/Granit.ArchitectureTests.Abstractions.Tests/QueryDefinitionCatalogRulesTests.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions.Tests/QueryDefinitionCatalogRulesTests.cs
@@ -1,0 +1,74 @@
+using Granit.ArchitectureTests.Abstractions.Rules;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests.Abstractions.Tests;
+
+/// <summary>
+/// Behavioural tests for <see cref="QueryDefinitionCatalogRules"/>: a concrete definition without a
+/// public parameterless constructor (a hand-registered "bespoke" definition) fails unless exempt,
+/// while a definition that can use the <c>new()</c>-constrained registration helper passes. Uses
+/// synthetic definitions so the rule is validated without a dependency on <c>Granit.QueryEngine</c>.
+/// </summary>
+public sealed class QueryDefinitionCatalogRulesTests
+{
+    private static readonly Type OpenBase = typeof(FakeQueryDefinition<>);
+
+    [Fact]
+    public void Bespoke_definition_without_parameterless_constructor_fails()
+    {
+        Should.Throw<ShouldAssertException>(() =>
+            QueryDefinitionCatalogRules.EveryBespokeDefinitionIsExempt(
+                [typeof(BespokeDefinition)], OpenBase));
+    }
+
+    [Fact]
+    public void Bespoke_definition_passes_when_exempted()
+    {
+        HashSet<string> exemptions = new(StringComparer.Ordinal)
+        {
+            typeof(BespokeDefinition).FullName!,
+        };
+
+        Should.NotThrow(() =>
+            QueryDefinitionCatalogRules.EveryBespokeDefinitionIsExempt(
+                [typeof(BespokeDefinition)], OpenBase, exemptions));
+    }
+
+    [Fact]
+    public void Definition_with_public_parameterless_constructor_passes()
+    {
+        // Can flow through AddQueryDefinition<TEntity, TDefinition>() (new()-constrained), which binds
+        // IQueryDefinitionDescriptor for free — so it is not bespoke and needs no exemption.
+        Should.NotThrow(() =>
+            QueryDefinitionCatalogRules.EveryBespokeDefinitionIsExempt(
+                [typeof(StandardDefinition)], OpenBase));
+    }
+
+    [Fact]
+    public void Abstract_and_open_generic_definitions_are_ignored()
+    {
+        // The abstract base and the open generic definition are not concrete closed types, so the
+        // rule skips them even though the open generic lacks a usable parameterless constructor.
+        Should.NotThrow(() =>
+            QueryDefinitionCatalogRules.EveryBespokeDefinitionIsExempt(
+                [OpenBase, typeof(OpenGenericDefinition<>)], OpenBase));
+    }
+
+    // ── Synthetic fixtures ───────────────────────────────────────────────────────────────────────
+
+    private sealed class FakeEntity;
+
+    private abstract class FakeQueryDefinition<TEntity>;
+
+    private sealed class StandardDefinition : FakeQueryDefinition<FakeEntity>;
+
+    private sealed class OpenGenericDefinition<TEntity> : FakeQueryDefinition<TEntity>;
+
+    private sealed class BespokeDefinition : FakeQueryDefinition<FakeEntity>
+    {
+        public BespokeDefinition(string typeName) => TypeName = typeName;
+
+        public string TypeName { get; }
+    }
+}

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/QueryDefinitionCatalogRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/QueryDefinitionCatalogRules.cs
@@ -1,0 +1,163 @@
+using System.Reflection;
+using Shouldly;
+
+namespace Granit.ArchitectureTests.Abstractions.Rules;
+
+/// <summary>
+/// Query-catalog completeness guard. A <c>QueryDefinition&lt;T&gt;</c> reaches
+/// <c>IQueryDefinitionRegistry</c> — and therefore <c>GET /catalog</c> and the dashboard-widget
+/// query picker — only if it is registered as a non-keyed <c>IQueryDefinitionDescriptor</c>. The
+/// standard <c>AddQueryDefinition&lt;TEntity, TDefinition&gt;()</c> helper does that binding for
+/// free, but it is constrained to <c>new()</c>: a definition <b>without a public parameterless
+/// constructor</b> cannot use it and must be wired by hand, where the descriptor binding is easy to
+/// drop (the type then silently vanishes from the catalog). This rule forces every such bespoke
+/// definition through a reviewed exemption list, keeping the manual binding on the reviewer's radar.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rule is deliberately <i>structural</i>: it flags the bespoke registration <i>path</i>, not a
+/// proven-missing binding — proving the binding requires a DI-resolution test against the owning
+/// module. The two form a defence in depth: this guard makes hand-wired definitions visible; the
+/// module's DI test proves each one actually resolves as a descriptor.
+/// </para>
+/// <para>
+/// The open generic base is passed as a parameter (pass <c>typeof(QueryDefinition&lt;&gt;)</c>) so
+/// this package takes no dependency on <c>Granit.QueryEngine</c>. Discovery runs by reflection over
+/// the assemblies matched by the glob, so downstream repos reuse the rule against their own
+/// assemblies; each supplies its own exemption set.
+/// </para>
+/// </remarks>
+public static class QueryDefinitionCatalogRules
+{
+    /// <summary>
+    /// Discovers every concrete <c>QueryDefinition&lt;T&gt;</c> in the assemblies matched by
+    /// <paramref name="assemblyGlob"/> next to <paramref name="callerAssembly"/> and asserts that
+    /// each one lacking a public parameterless constructor (i.e. registered by hand rather than via
+    /// the <c>new()</c>-constrained helper) is listed in <paramref name="exemptDefinitions"/>.
+    /// </summary>
+    /// <param name="callerAssembly">Test assembly — used to locate DLLs in the output directory.</param>
+    /// <param name="assemblyGlob">Glob to select assemblies (e.g. <c>"Granit.*.dll"</c>).</param>
+    /// <param name="queryDefinitionOpenType">Open generic base. Pass <c>typeof(QueryDefinition&lt;&gt;)</c>.</param>
+    /// <param name="exemptDefinitions">
+    /// Bespoke definitions intentionally hand-registered, keyed by <c>Type.FullName</c>. Each should
+    /// carry an inline justification and be covered by a DI-resolution test proving the descriptor binding.
+    /// </param>
+    public static void EveryBespokeDefinitionIsExempt(
+        Assembly callerAssembly,
+        string assemblyGlob,
+        Type queryDefinitionOpenType,
+        IReadOnlySet<string>? exemptDefinitions = null)
+    {
+        ArgumentNullException.ThrowIfNull(callerAssembly);
+        ArgumentException.ThrowIfNullOrEmpty(assemblyGlob);
+        ArgumentNullException.ThrowIfNull(queryDefinitionOpenType);
+
+        string outputDir = Path.GetDirectoryName(callerAssembly.Location)!;
+
+        List<Type> definitions =
+        [
+            .. Directory.GetFiles(outputDir, assemblyGlob)
+                .Where(path =>
+                {
+                    string name = Path.GetFileNameWithoutExtension(path);
+                    return !name.Contains("Tests", StringComparison.Ordinal)
+                        && !name.EndsWith(".resources", StringComparison.Ordinal);
+                })
+                .Select(TryLoad)
+                .Where(a => a is not null)
+                .SelectMany(GetLoadableTypes!)
+                .Where(t => IsConcreteDefinition(t, queryDefinitionOpenType)),
+        ];
+
+        // Discovery tripwire: a glob typo, a renamed base type, or a signature drift would otherwise
+        // leave the rule silently green over zero definitions. The codebase always ships concrete
+        // QueryDefinition<T> types, so an empty set means the rule is broken, not that there is
+        // nothing to check.
+        definitions.ShouldNotBeEmpty(
+            $"Query-catalog guard discovered no concrete {queryDefinitionOpenType.Name} types under " +
+            $"'{assemblyGlob}' next to {callerAssembly.GetName().Name}. The rule is mis-wired (wrong glob " +
+            "or wrong open generic) — fix the wiring rather than assuming there is nothing to check.");
+
+        EveryBespokeDefinitionIsExempt(definitions, queryDefinitionOpenType, exemptDefinitions);
+    }
+
+    /// <summary>
+    /// Pure overload over an explicit candidate type set — asserts every concrete
+    /// <c>QueryDefinition&lt;T&gt;</c> without a public parameterless constructor is exempt. Useful
+    /// in unit tests with synthetic definitions.
+    /// </summary>
+    public static void EveryBespokeDefinitionIsExempt(
+        IEnumerable<Type> candidateTypes,
+        Type queryDefinitionOpenType,
+        IReadOnlySet<string>? exemptDefinitions = null)
+    {
+        ArgumentNullException.ThrowIfNull(candidateTypes);
+        ArgumentNullException.ThrowIfNull(queryDefinitionOpenType);
+        exemptDefinitions ??= new HashSet<string>(StringComparer.Ordinal);
+
+        List<string> violations =
+        [
+            .. candidateTypes
+                .Where(t => IsConcreteDefinition(t, queryDefinitionOpenType))
+                .Where(t => !HasPublicParameterlessConstructor(t))
+                .Select(t => t.FullName!)
+                .Where(name => !exemptDefinitions.Contains(name)),
+        ];
+
+        violations.Sort(StringComparer.Ordinal);
+
+        violations.ShouldBeEmpty(
+            "Query-catalog guard: every concrete QueryDefinition<T> without a public parameterless " +
+            "constructor is registered by hand — it cannot use AddQueryDefinition<TEntity, TDefinition>(), " +
+            "which is constrained to new(). Hand-wiring MUST also bind IQueryDefinitionDescriptor, otherwise " +
+            "the type never reaches IQueryDefinitionRegistry / GET /catalog / the dashboard-widget query " +
+            "picker. Confirm the descriptor binding (cover it with a DI-resolution test) and add the type to " +
+            "the exemption list with a justification. " +
+            $"Bespoke and unexempt: {string.Join("; ", violations)}");
+    }
+
+    private static bool IsConcreteDefinition(Type type, Type queryDefinitionOpenType) =>
+        type is { IsAbstract: false, IsClass: true }
+        && !type.IsGenericTypeDefinition
+        && DerivesFromOpenGeneric(type, queryDefinitionOpenType);
+
+    private static bool HasPublicParameterlessConstructor(Type type) =>
+        type.GetConstructor(Type.EmptyTypes) is not null;
+
+    private static bool DerivesFromOpenGeneric(Type candidate, Type openGenericBase)
+    {
+        for (Type? cursor = candidate.BaseType; cursor is not null; cursor = cursor.BaseType)
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == openGenericBase)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Type[] GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return [.. ex.Types.Where(t => t is not null)!];
+        }
+    }
+
+    private static Assembly? TryLoad(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileLoadException)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Granit.ArchitectureTests/QueryDefinitionCatalogExemptions.cs
+++ b/tests/Granit.ArchitectureTests/QueryDefinitionCatalogExemptions.cs
@@ -1,0 +1,28 @@
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// <c>QueryDefinition&lt;T&gt;</c> types intentionally registered by hand rather than through the
+/// <c>new()</c>-constrained <c>AddQueryDefinition&lt;TEntity, TDefinition&gt;()</c> helper. Consumed by
+/// <c>QueryDefinitionCatalogTests</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A concrete definition without a public parameterless constructor cannot use the standard helper
+/// (which binds <c>IQueryDefinitionDescriptor</c> for free) and must be wired by hand. Hand-wiring is
+/// where the descriptor binding is easy to drop — dropping it removes the query from
+/// <c>IQueryDefinitionRegistry</c> / <c>GET /catalog</c> / the dashboard-widget query picker. Adding an
+/// entry here asserts the manual binding has been verified — cover it with a DI-resolution test — and
+/// requires a one-line justification (inline comment).
+/// </para>
+/// <para>
+/// The framework currently ships <b>none</b>: every framework <c>QueryDefinition&lt;T&gt;</c> has a public
+/// parameterless constructor and registers through the helper. Downstream repos with parameterised
+/// definitions list them here — e.g. granit-business's dynamically declared reference-data
+/// <c>ReferenceDataQueryDefinition</c>, whose descriptor binding is proven by a DI-resolution test in
+/// <c>Granit.ReferenceData.EntityFrameworkCore.Tests</c>.
+/// </para>
+/// </remarks>
+internal static class QueryDefinitionCatalogExemptions
+{
+    public static readonly HashSet<string> Definitions = new(StringComparer.Ordinal);
+}

--- a/tests/Granit.ArchitectureTests/QueryDefinitionCatalogTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryDefinitionCatalogTests.cs
@@ -1,0 +1,25 @@
+using Granit.ArchitectureTests.Abstractions.Rules;
+using Granit.QueryEngine;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces query-catalog completeness: every concrete <c>QueryDefinition&lt;T&gt;</c> that cannot use
+/// the <c>new()</c>-constrained <c>AddQueryDefinition&lt;TEntity, TDefinition&gt;()</c> helper (no public
+/// parameterless constructor) is registered by hand and must be listed in
+/// <see cref="QueryDefinitionCatalogExemptions"/> — the review gate that keeps the manual
+/// <c>IQueryDefinitionDescriptor</c> binding from being dropped, which would silently remove the query
+/// from <c>GET /catalog</c> and the dashboard-widget query picker. Logic lives in
+/// <c>Granit.ArchitectureTests.Abstractions</c> so downstream repos reuse it.
+/// </summary>
+public sealed class QueryDefinitionCatalogTests
+{
+    [Fact]
+    public void Every_bespoke_query_definition_should_be_exempt() =>
+        QueryDefinitionCatalogRules.EveryBespokeDefinitionIsExempt(
+            typeof(QueryDefinitionCatalogTests).Assembly,
+            "Granit.*.dll",
+            typeof(QueryDefinition<>),
+            QueryDefinitionCatalogExemptions.Definitions);
+}


### PR DESCRIPTION
## Why

A `QueryDefinition<T>` reaches `IQueryDefinitionRegistry` — and therefore `GET /catalog` and the **dashboard-widget query picker** — only when registered as a non-keyed `IQueryDefinitionDescriptor`. `AddQueryDefinition<TEntity, TDefinition>()` binds it automatically, but is constrained to `new()`: a definition **without a public parameterless constructor** must be wired by hand, where the descriptor binding is easy to drop (the type then silently vanishes from the catalog).

This surfaced downstream in granit-business, where dynamically declared reference-data types were absent from the widget query combobox (fixed there separately).

## What

- Reusable `QueryDefinitionCatalogRules.EveryBespokeDefinitionIsExempt` in `Granit.ArchitectureTests.Abstractions` (so granit-business / showcase reuse it): flags every concrete `QueryDefinition<T>` lacking a public parameterless ctor unless it is listed in a reviewed exemption set with a justification.
- `QueryDefinitionCatalogTests` wires it over `Granit.*.dll`; `QueryDefinitionCatalogExemptions` is **empty** — the framework ships no bespoke definition today.
- Rule unit tests (teeth): a bespoke definition fails unless exempt; a `new()`-able one passes; abstract/open-generic are ignored.

## Scope

Structural guard = it flags the bespoke *registration path*; proving the actual binding is the owning module's DI-resolution test (defence in depth). Additive test-only change — no new project/dep, no shard or lockfile change. Abstractions.Tests **19/19**, wiring test green, format clean.