### PR TITLE
fix(identity): return 404 for malformed user id instead of 500

### DIFF
--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityUserLookupService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityUserLookupService.cs
@@ -16,6 +16,14 @@ internal sealed class AspNetIdentityUserLookupService(
     public async Task<IIdentityUser?> FindByIdAsync(
         string userId, CancellationToken cancellationToken = default)
     {
+        // Local identities are Guid-keyed; a malformed id is a non-existent user,
+        // not a server error. Short-circuit before ASP.NET Identity's UserStore
+        // calls Guid.Parse and throws FormatException (unhandled 500).
+        if (!Guid.TryParse(userId, out _))
+        {
+            return null;
+        }
+
         LocalIdentity? user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
         return user;
     }
@@ -24,7 +32,19 @@ internal sealed class AspNetIdentityUserLookupService(
     public async Task<IReadOnlyList<IIdentityUser>> FindByIdsAsync(
         IReadOnlyCollection<string> userIds, CancellationToken cancellationToken = default)
     {
-        var guidIds = userIds.Select(Guid.Parse).ToList();
+        // Silently omit ids that aren't valid Guids — batch resolve treats
+        // unknown ids as absent, and a malformed id can never match a row.
+        var guidIds = userIds
+            .Select(id => Guid.TryParse(id, out Guid guid) ? guid : (Guid?)null)
+            .Where(guid => guid is not null)
+            .Select(guid => guid!.Value)
+            .ToList();
+
+        if (guidIds.Count == 0)
+        {
+            return [];
+        }
+
         List<LocalIdentity> users = await _userManager.Users.AsNoTracking()
             .Where(u => guidIds.Contains(u.Id))
             .ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityUserLookupServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityUserLookupServiceTests.cs
@@ -19,11 +19,12 @@ public sealed class AspNetIdentityUserLookupServiceTests
     [Fact]
     public async Task FindByIdAsync_WhenUserNotFound_ReturnsNull()
     {
+        string userId = Guid.NewGuid().ToString();
         UserManager<LocalIdentity> userManager = CreateUserManager();
         userManager.FindByIdAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
         AspNetIdentityUserLookupService sut = new(userManager);
 
-        IIdentityUser? result = await sut.FindByIdAsync("nonexistent", TestContext.Current.CancellationToken);
+        IIdentityUser? result = await sut.FindByIdAsync(userId, TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -31,14 +32,30 @@ public sealed class AspNetIdentityUserLookupServiceTests
     [Fact]
     public async Task FindByIdAsync_WhenUserFound_ReturnsUser()
     {
+        string userId = Guid.NewGuid().ToString();
         UserManager<LocalIdentity> userManager = CreateUserManager();
         var user = new LocalIdentity { UserName = "alice" };
-        userManager.FindByIdAsync("user-id").Returns(user);
+        userManager.FindByIdAsync(userId).Returns(user);
         AspNetIdentityUserLookupService sut = new(userManager);
 
-        IIdentityUser? result = await sut.FindByIdAsync("user-id", TestContext.Current.CancellationToken);
+        IIdentityUser? result = await sut.FindByIdAsync(userId, TestContext.Current.CancellationToken);
 
         result.ShouldBeSameAs(user);
+    }
+
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("")]
+    [InlineData("12345")]
+    public async Task FindByIdAsync_WhenIdIsNotAGuid_ReturnsNullWithoutQueryingStore(string malformedId)
+    {
+        UserManager<LocalIdentity> userManager = CreateUserManager();
+        AspNetIdentityUserLookupService sut = new(userManager);
+
+        IIdentityUser? result = await sut.FindByIdAsync(malformedId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+        await userManager.DidNotReceive().FindByIdAsync(Arg.Any<string>());
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`GET /{userId}` on the identity-user-cache endpoint returns an **unhandled 500** when the id isn't a GUID, instead of the documented 404.

```
System.FormatException: Unrecognized Guid format.
  at System.Guid.TryParseGuid(...)
  at Microsoft.AspNetCore.Identity.UserStoreBase.ConvertIdFromString(String id)
  at ...UserStore.FindByIdAsync(String userId, ...)
  at Granit.Identity.Local.AspNetIdentity.Internal.AspNetIdentityUserLookupService.FindByIdAsync(...)
  at Granit.Identity.Endpoints...IdentityUserCacheReadEndpoints.GetByIdAsync(...)
```

`LocalIdentity` is GUID-keyed, so ASP.NET Identity's `UserStoreBase.ConvertIdFromString` runs `Guid.Parse` on the raw route string. `FindByIdsAsync` had the same latent fault via `Select(Guid.Parse)` on the `/batch` endpoint.

## Fix

Guard both methods with `Guid.TryParse` in the GUID-specific adapter — the route constraint can't be `:guid` because `IUserLookupService` is provider-agnostic (federated/Keycloak ids are opaque strings, keyed on `ExternalUserId`, and were already safe).

- `FindByIdAsync`: malformed id → `null` → endpoint yields **404** (contract match).
- `FindByIdsAsync`: unparseable ids silently omitted — already how batch resolve treats unknown ids.

## Tests

- New theory (`not-a-guid`, `""`, `12345`) asserting `null` + that the store is never queried.
- Corrected two pre-existing tests that used non-GUID literals (would now short-circuit for the wrong reason).

9/9 pass; build + `dotnet format --verify-no-changes` clean.