### PR TITLE
feat(queryengine): support nested complex-member column paths for filter/sort

### DIFF
--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -45,7 +45,11 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
 
     /// <summary>
     /// Declares a column on the target entity. Only explicitly declared columns are
-    /// exposed to the frontend (whitelist-first).
+    /// exposed to the frontend (whitelist-first). Accepts a top-level property
+    /// (<c>a =&gt; a.Kind</c>) or a member of an EF Core complex type
+    /// (<c>a =&gt; a.Value.Street1</c>), the latter recorded as the dotted path
+    /// <c>"Value.Street1"</c> and resolved to its mapped scalar column for
+    /// filtering / sorting / group-by.
     /// </summary>
     /// <typeparam name="TProp">The property type.</typeparam>
     /// <param name="property">Expression selecting the property.</param>
@@ -54,7 +58,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
         Expression<Func<TEntity, TProp>> property,
         Action<ColumnBuilder<TEntity>>? configure = null)
     {
-        string propertyName = GetPropertyName(property);
+        (string propertyName, _) = GetMemberPath(property);
         ColumnBuilder<TEntity> builder = new();
         configure?.Invoke(builder);
 
@@ -286,7 +290,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
     public QueryDefinitionBuilder<TEntity> AllowGroupBy<TProp>(
         Expression<Func<TEntity, TProp>> property)
     {
-        (string propertyName, bool isNested) = GetGroupByPath(property);
+        (string propertyName, bool isNested) = GetMemberPath(property);
 
         // A nested leaf (a member of an EF complex type) is a plain scalar column, so the whole-value
         // VO guard does not apply. For a top-level member, reject a converter-mapped SingleValueObject
@@ -541,12 +545,12 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
         return member.Member.Name;
     }
 
-    // Extracts a (possibly dotted) member path for group-by. Unlike the single-level GetPropertyName,
-    // this accepts a chain of member accesses over an EF complex-type member (a => a.Value.Country) and
-    // returns the dotted path "Value.Country" plus whether the access is nested. It still rejects
-    // drilling into a SingleValueObject's `.Value` (#2767): that inner value is a whole-value
-    // ValueConverter column, not an independently groupable scalar column.
-    private static (string Path, bool IsNested) GetGroupByPath<TProp>(Expression<Func<TEntity, TProp>> expression)
+    // Extracts a (possibly dotted) member path for a column or group-by key. Unlike the single-level
+    // GetPropertyName, this accepts a chain of member accesses over an EF complex-type member
+    // (a => a.Value.Street1) and returns the dotted path "Value.Street1" plus whether the access is
+    // nested. It still rejects drilling into a SingleValueObject's `.Value` (#2767): that inner value
+    // is a whole-value ValueConverter column, not an independently queryable scalar column.
+    private static (string Path, bool IsNested) GetMemberPath<TProp>(Expression<Func<TEntity, TProp>> expression)
     {
         Expression body = expression.Body is UnaryExpression { NodeType: ExpressionType.Convert } convert
             ? convert.Operand
@@ -558,11 +562,12 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             if (IsSingleValueObjectType(member.Expression?.Type))
             {
                 throw new ArgumentException(
-                    $"Group-by expression '{expression.Body}' drills into the '.Value' of a " +
+                    $"Expression '{expression.Body}' drills into the '.Value' of a " +
                     $"SingleValueObject ('{member.Expression!.Type.Name}'), which is mapped as an opaque " +
-                    $"whole-value ValueConverter and cannot be a GROUP BY key. To group by a value-object " +
-                    $"column, mark it [QueryableValueObject] and select the object itself (x => x.Slug); to " +
-                    $"group by a nested field, select a member of an EF complex type. See issue #2767.",
+                    $"whole-value ValueConverter and cannot be an independently queryable column. To use a " +
+                    $"value-object column, mark it [QueryableValueObject] and select the object itself " +
+                    $"(x => x.Slug); to reach a nested field, select a member of an EF complex type. " +
+                    $"See issue #2767.",
                     nameof(expression));
             }
 
@@ -576,7 +581,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
         }
 
         throw new ArgumentException(
-            "Group-by expression must be a property access (e.g. x => x.Kind) or a nested complex-type " +
+            "Expression must be a property access (e.g. x => x.Kind) or a nested complex-type " +
             "member access (e.g. x => x.Address.Country).",
             nameof(expression));
     }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/CompositeCursorBuilder.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/CompositeCursorBuilder.cs
@@ -19,9 +19,11 @@ namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
 internal static class CompositeCursorBuilder
 {
     /// <summary>
-    /// Describes a sort field with its direction and resolved property info.
+    /// Describes a sort field with its direction, resolved leaf property, and the (possibly dotted)
+    /// canonical member path. <see cref="Path"/> equals the property name for a top-level field and a
+    /// dotted path such as <c>"Value.Street1"</c> for a nested complex-type member.
     /// </summary>
-    internal readonly record struct SortField(PropertyInfo Property, bool Descending);
+    internal readonly record struct SortField(string Path, PropertyInfo Property, bool Descending);
 
     /// <summary>
     /// Parses a sort specification string into a list of <see cref="SortField"/> entries.
@@ -49,16 +51,79 @@ internal static class CompositeCursorBuilder
                 continue;
             }
 
-            PropertyInfo? property = typeof(T).GetProperty(
-                fieldName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-            if (property is not null)
+            // Walk a (possibly dotted) path so a nested complex-member sort field such as
+            // "Value.Street1" participates in the keyset — otherwise it would be silently dropped and
+            // the cursor predicate would disagree with the ORDER BY, skipping/duplicating rows at
+            // page boundaries. Canonicalises segment casing off the resolved PropertyInfo.
+            (string CanonicalPath, PropertyInfo Leaf)? resolved = ResolvePath(typeof(T), fieldName);
+            if (resolved is not null)
             {
-                fields.Add(new SortField(property, descending));
+                fields.Add(new SortField(resolved.Value.CanonicalPath, resolved.Value.Leaf, descending));
             }
         }
 
         return fields;
+    }
+
+    // Resolves a (possibly dotted) member path to its leaf PropertyInfo plus the canonical dotted path
+    // (segment casing taken from the resolved properties). Returns null if any segment is unknown.
+    private static (string CanonicalPath, PropertyInfo Leaf)? ResolvePath(Type root, string path)
+    {
+        Type current = root;
+        PropertyInfo? property = null;
+        List<string> canonical = [];
+
+        foreach (string segment in path.Split('.'))
+        {
+            property = current.GetProperty(
+                segment, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property is null)
+            {
+                return null;
+            }
+
+            canonical.Add(property.Name);
+            current = property.PropertyType;
+        }
+
+        return property is null ? null : (string.Join('.', canonical), property);
+    }
+
+    // Builds a plain member-access chain for a (possibly dotted) path — no [QueryableValueObject]
+    // drilling, so a top-level VO cursor key keeps comparing whole-value as it did before.
+    private static Expression BuildMemberAccess(ParameterExpression parameter, string path)
+    {
+        Expression member = parameter;
+        foreach (string segment in path.Split('.'))
+        {
+            member = Expression.Property(member, segment);
+        }
+
+        return member;
+    }
+
+    // Reads a (possibly dotted) member path off a materialized instance for cursor encoding.
+    private static object? ReadPath(object instance, string path)
+    {
+        object? current = instance;
+        foreach (string segment in path.Split('.'))
+        {
+            if (current is null)
+            {
+                return null;
+            }
+
+            PropertyInfo? property = current.GetType().GetProperty(
+                segment, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property is null)
+            {
+                return null;
+            }
+
+            current = property.GetValue(current);
+        }
+
+        return current;
     }
 
     /// <summary>
@@ -112,9 +177,9 @@ internal static class CompositeCursorBuilder
         where T : class
     {
         var values = sortFields
-            .Select(field => (field.Property.Name, Value: field.Property.GetValue(lastItem)))
+            .Select(field => (field.Path, Value: ReadPath(lastItem, field.Path)))
             .Where(x => x.Value is not null)
-            .ToDictionary(x => x.Name, x => x.Value!.ToString()!, StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(x => x.Path, x => x.Value!.ToString()!, StringComparer.OrdinalIgnoreCase);
 
         return CursorEncoder.EncodeComposite(values, hmacKey);
     }
@@ -132,19 +197,19 @@ internal static class CompositeCursorBuilder
         for (int j = 0; j < targetIndex; j++)
         {
             SortField field = sortFields[j];
-            if (!cursorValues.TryGetValue(field.Property.Name, out string? rawValue))
+            if (!cursorValues.TryGetValue(field.Path, out string? rawValue))
             {
                 return null; // Missing cursor value — cannot build this branch
             }
 
             Type propertyType = Nullable.GetUnderlyingType(field.Property.PropertyType) ?? field.Property.PropertyType;
-            object? converted = FilterExpressionBuilder.ConvertValue(rawValue, propertyType, logger, field.Property.Name);
+            object? converted = FilterExpressionBuilder.ConvertValue(rawValue, propertyType, logger, field.Path);
             if (converted is null)
             {
                 return null;
             }
 
-            MemberExpression member = Expression.Property(parameter, field.Property);
+            Expression member = BuildMemberAccess(parameter, field.Path);
             ConstantExpression constant = Expression.Constant(converted, field.Property.PropertyType);
             BinaryExpression equality = Expression.Equal(member, constant);
 
@@ -167,19 +232,19 @@ internal static class CompositeCursorBuilder
         Dictionary<string, string> cursorValues,
         ILogger? logger)
     {
-        if (!cursorValues.TryGetValue(targetField.Property.Name, out string? rawValue))
+        if (!cursorValues.TryGetValue(targetField.Path, out string? rawValue))
         {
             return null;
         }
 
         Type propertyType = Nullable.GetUnderlyingType(targetField.Property.PropertyType) ?? targetField.Property.PropertyType;
-        object? converted = FilterExpressionBuilder.ConvertValue(rawValue, propertyType, logger, targetField.Property.Name);
+        object? converted = FilterExpressionBuilder.ConvertValue(rawValue, propertyType, logger, targetField.Path);
         if (converted is null)
         {
             return null;
         }
 
-        MemberExpression member = Expression.Property(parameter, targetField.Property);
+        Expression member = BuildMemberAccess(parameter, targetField.Path);
         ConstantExpression constant = Expression.Constant(converted, targetField.Property.PropertyType);
 
         // Descending sort → cursor moves backward (less than), ascending → forward (greater than)

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/FilterExpressionBuilder.cs
@@ -43,29 +43,31 @@ internal static class FilterExpressionBuilder
         IReadOnlyDictionary<string, ColumnDescriptor>? shadowColumns = null)
         where TEntity : class
     {
-        PropertyInfo? property = typeof(TEntity).GetProperty(
-            criteria.Field,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
         ParameterExpression parameter = Expression.Parameter(typeof(TEntity), "e");
+
+        // Resolve the (possibly dotted) field to a member access. A nested path such as
+        // "Value.Street1" walks the EF complex-type hops; the leaf still drills a
+        // [QueryableValueObject] into its `.Value` scalar. Returns (null, null) for an unknown field.
+        (Expression? resolvedMember, PropertyInfo? property) = MemberPathResolver.Resolve(parameter, criteria.Field);
+
         Expression member;
         Type propertyType;
 
-        if (property is not null)
+        if (resolvedMember is not null)
         {
             // A [QueryableValueObject] column resolves to its `.Value` string column (ADR-070,
             // strategy B) so equality/IN/substring operate on the real scalar. Range operators are
             // dropped (a string value object has no meaningful ordering — the same stance as a
             // converter-mapped VO). A plain value-object column stays the VO type (equality
             // reconstructs it).
-            if (ValueObjectMemberResolver.IsQueryableValueObject(property)
+            if (ValueObjectMemberResolver.IsQueryableValueObject(property!)
                 && criteria.Operator is FilterOperator.Gt or FilterOperator.Gte
                     or FilterOperator.Lt or FilterOperator.Lte or FilterOperator.Between)
             {
                 return null;
             }
 
-            member = ValueObjectMemberResolver.Resolve(parameter, property);
+            member = resolvedMember;
             propertyType = Nullable.GetUnderlyingType(member.Type) ?? member.Type;
         }
         else if (shadowColumns is not null

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/GroupByPathResolver.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/GroupByPathResolver.cs
@@ -1,15 +1,12 @@
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// Builds the group-by key-selector body for a (possibly dotted) member path such as
-/// <c>"Kind"</c> or <c>"Value.Country"</c>. A dotted path walks EF Core complex-type hops with
-/// chained <see cref="Expression.Property(Expression, PropertyInfo)"/>; the leaf still goes through
-/// <see cref="ValueObjectMemberResolver"/> so a <c>[QueryableValueObject]</c> column groups by its
-/// underlying <c>.Value</c> scalar (ADR-070). Shared by <see cref="QueryableGroupByExtensions"/>
-/// (SQL key selector) and the in-memory item bucketing so both resolve to the same key.
+/// <c>"Kind"</c> or <c>"Value.Country"</c>, delegating the walk to <see cref="MemberPathResolver"/>.
+/// Shared by <see cref="QueryableGroupByExtensions"/> (SQL key selector) and the in-memory item
+/// bucketing so both resolve to the same key.
 /// </summary>
 internal static class GroupByPathResolver
 {
@@ -18,30 +15,6 @@ internal static class GroupByPathResolver
     /// <paramref name="instance"/>. Returns <see langword="null"/> when any segment cannot be
     /// resolved (unknown field), matching the legacy "empty grouped result" behavior.
     /// </summary>
-    public static Expression? BuildKeyAccess(Expression instance, string path)
-    {
-        string[] segments = path.Split('.');
-        Expression parent = instance;
-
-        for (int i = 0; i < segments.Length; i++)
-        {
-            PropertyInfo? property = parent.Type.GetProperty(
-                segments[i],
-                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-            if (property is null)
-            {
-                return null;
-            }
-
-            if (i == segments.Length - 1)
-            {
-                return ValueObjectMemberResolver.Resolve(parent, property);
-            }
-
-            parent = Expression.Property(parent, property);
-        }
-
-        return null;
-    }
+    public static Expression? BuildKeyAccess(Expression instance, string path) =>
+        MemberPathResolver.Resolve(instance, path).Member;
 }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/MemberPathResolver.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/MemberPathResolver.cs
@@ -1,0 +1,47 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Walks a (possibly dotted) member path such as <c>"Kind"</c> or <c>"Value.Street1"</c> rooted at an
+/// arbitrary expression, chaining <see cref="Expression.Property(Expression, PropertyInfo)"/> for each
+/// EF Core complex-type hop. The leaf goes through <see cref="ValueObjectMemberResolver"/> so a
+/// <c>[QueryableValueObject]</c> leaf resolves to its underlying <c>.Value</c> scalar (ADR-070).
+/// Shared by filtering, sorting, and group-by so a nested column resolves identically everywhere.
+/// </summary>
+internal static class MemberPathResolver
+{
+    /// <summary>
+    /// Resolves the member access for <paramref name="path"/> rooted at <paramref name="instance"/>,
+    /// returning both the (VO-drilled) leaf access expression and the leaf <see cref="PropertyInfo"/>.
+    /// Returns <c>(null, null)</c> when any segment cannot be resolved (unknown field), matching the
+    /// existing "unresolved field is dropped / empty result" behavior.
+    /// </summary>
+    public static (Expression? Member, PropertyInfo? Leaf) Resolve(Expression instance, string path)
+    {
+        string[] segments = path.Split('.');
+        Expression parent = instance;
+
+        for (int i = 0; i < segments.Length; i++)
+        {
+            PropertyInfo? property = parent.Type.GetProperty(
+                segments[i],
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+            if (property is null)
+            {
+                return (null, null);
+            }
+
+            if (i == segments.Length - 1)
+            {
+                return (ValueObjectMemberResolver.Resolve(parent, property), property);
+            }
+
+            parent = Expression.Property(parent, property);
+        }
+
+        return (null, null);
+    }
+}

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryablePaginationExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryablePaginationExtensions.cs
@@ -90,9 +90,9 @@ internal static class QueryablePaginationExtensions
             sortFields = CompositeCursorBuilder.ParseSortFields<T>(effectiveSort, sortableFields);
 
             // Ensure cursor property is included as tiebreaker (append if missing)
-            if (!sortFields.Exists(f => f.Property.Name.Equals(cursorPropertyName, StringComparison.OrdinalIgnoreCase)))
+            if (!sortFields.Exists(f => f.Path.Equals(cursorPropertyName, StringComparison.OrdinalIgnoreCase)))
             {
-                sortFields.Add(new CompositeCursorBuilder.SortField(cursorProperty, Descending: false));
+                sortFields.Add(new CompositeCursorBuilder.SortField(cursorProperty.Name, cursorProperty, Descending: false));
             }
         }
 

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableSortExtensions.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryableSortExtensions.cs
@@ -92,13 +92,14 @@ internal static class QueryableSortExtensions
             return (ApplyOrderByShadow(source, fieldName, shadowCol.ClrType, descending, isFirst), true);
         }
 
-        PropertyInfo? property = typeof(TEntity).GetProperty(
-            fieldName,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+        // Resolve the (possibly dotted) field to a member access, walking EF complex-type hops for a
+        // nested column such as "Value.Street1". An unknown field leaves the source untouched.
+        ParameterExpression parameter = Expression.Parameter(typeof(TEntity), "e");
+        (Expression? member, _) = MemberPathResolver.Resolve(parameter, fieldName);
 
-        return property is null
+        return member is null
             ? (source, false)
-            : (ApplyOrderBy(source, property, descending, isFirst), true);
+            : (ApplyOrderBy(source, parameter, member, descending, isFirst), true);
     }
 
     /// <summary>
@@ -112,24 +113,23 @@ internal static class QueryableSortExtensions
         QueryDefinitionBuilder<TEntity> builder)
         where TEntity : class
     {
-        PropertyInfo? property = ResolveProperty<TEntity>(builder.CursorPropertyName)
-            ?? ResolveProperty<TEntity>("Id")
+        ParameterExpression parameter = Expression.Parameter(typeof(TEntity), "e");
+
+        Expression? member = ResolveMember<TEntity>(parameter, builder.CursorPropertyName)
+            ?? ResolveMember<TEntity>(parameter, "Id")
             ?? builder.Columns
                 .Where(c => c.IsSortable && !c.IsShadowProperty)
-                .Select(c => ResolveProperty<TEntity>(c.PropertyName))
-                .FirstOrDefault(p => p is not null);
+                .Select(c => ResolveMember<TEntity>(parameter, c.PropertyName))
+                .FirstOrDefault(m => m is not null);
 
-        return property is null
+        return member is null
             ? source
-            : ApplyOrderBy(source, property, descending: false, isFirst: true);
+            : ApplyOrderBy(source, parameter, member, descending: false, isFirst: true);
     }
 
-    private static PropertyInfo? ResolveProperty<TEntity>(string? name) =>
-        string.IsNullOrEmpty(name)
-            ? null
-            : typeof(TEntity).GetProperty(
-                name,
-                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+    private static Expression? ResolveMember<TEntity>(ParameterExpression parameter, string? name)
+        where TEntity : class =>
+        string.IsNullOrEmpty(name) ? null : MemberPathResolver.Resolve(parameter, name).Member;
 
     private static IQueryable<TEntity> ApplyOrderByShadow<TEntity>(
         IQueryable<TEntity> source,
@@ -169,15 +169,15 @@ internal static class QueryableSortExtensions
 
     private static IQueryable<TEntity> ApplyOrderBy<TEntity>(
         IQueryable<TEntity> source,
-        PropertyInfo property,
+        ParameterExpression parameter,
+        Expression member,
         bool descending,
         bool isFirst)
         where TEntity : class
     {
-        ParameterExpression parameter = Expression.Parameter(typeof(TEntity), "e");
-        // A [QueryableValueObject] column sorts by its real `.Value` scalar column (ADR-070);
-        // a plain converter-mapped VO still sorts whole-value (the converter round-trips).
-        Expression member = ValueObjectMemberResolver.Resolve(parameter, property);
+        // `member` is already resolved by MemberPathResolver — a nested complex-member path is walked,
+        // and a [QueryableValueObject] leaf sorts by its real `.Value` scalar column (ADR-070); a plain
+        // converter-mapped VO still sorts whole-value (the converter round-trips).
         LambdaExpression keySelector = Expression.Lambda(member, parameter);
 
         string methodName = (isFirst, descending) switch

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
@@ -1,0 +1,206 @@
+using System.Linq.Expressions;
+using Granit.QueryEngine.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.EntityFrameworkCore.Tests.Internal;
+
+// Columns declared on a nested EF Core complex-type member (a => a.Value.Street1), recorded as the
+// dotted path "Value.Street1" and translated to SQL WHERE/ORDER BY on the mapped scalar column.
+// End-to-end against real SQLite. Motivating case: granit-business Parties (PartyAddress.Value : Address).
+public sealed class NestedComplexColumnTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<AddressCtx> _options;
+    private readonly List<string> _sql = [];
+
+    public NestedComplexColumnTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<AddressCtx>()
+            .UseSqlite(_connection)
+            .LogTo(_sql.Add, [RelationalEventId.CommandExecuted])
+            .Options;
+
+        using AddressCtx seed = new(_options);
+        seed.Database.EnsureCreated();
+        seed.Addresses.AddRange(
+            new PartyAddress { Id = Guid.NewGuid(), Value = new Address { Street1 = "10 Rue A", City = "Brussels", Region = new GeoRegion { Continent = "EU" } } },
+            new PartyAddress { Id = Guid.NewGuid(), Value = new Address { Street1 = "20 Rue B", City = "Ghent", Region = new GeoRegion { Continent = "EU" } } },
+            new PartyAddress { Id = Guid.NewGuid(), Value = new Address { Street1 = "30 Rue C", City = "Paris", Region = new GeoRegion { Continent = "EU" } } },
+            new PartyAddress { Id = Guid.NewGuid(), Value = new Address { Street1 = "40 Ave D", City = "New York", Region = new GeoRegion { Continent = "NA" } } });
+        seed.SaveChanges();
+    }
+
+    [Fact]
+    public void Column_on_a_nested_complex_member_records_the_dotted_path()
+    {
+        AddressQueryDefinition definition = new();
+
+        definition.GetColumns().Select(c => c.PropertyName)
+            .ShouldBe(["Value.Street1", "Value.City", "Value.Region.Continent"]);
+    }
+
+    [Fact]
+    public async Task Filter_eq_on_a_nested_member_matches_server_side()
+    {
+        await using AddressCtx ctx = new(_options);
+
+        PagedResult<PartyAddress> result = await NewEngine().ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Filter = new Dictionary<string, string> { ["Value.Street1.eq"] = "20 Rue B" } },
+            TestContext.Current.CancellationToken);
+
+        result.Items.Select(a => a.Value.City).ShouldBe(["Ghent"]);
+        _sql.ShouldContain(s => s.Contains("WHERE", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Filter_contains_on_a_nested_member_matches_server_side()
+    {
+        await using AddressCtx ctx = new(_options);
+
+        PagedResult<PartyAddress> result = await NewEngine().ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Filter = new Dictionary<string, string> { ["Value.City.contains"] = "e" } },
+            TestContext.Current.CancellationToken);
+
+        // Brussels, Ghent, New York contain 'e' (case-sensitive LIKE on SQLite collation-dependent —
+        // seed values chosen so the ASCII 'e' is unambiguous).
+        result.Items.Select(a => a.Value.City).OrderBy(c => c)
+            .ShouldBe(["Brussels", "Ghent", "New York"]);
+    }
+
+    [Fact]
+    public async Task Filter_on_a_two_level_nested_member_matches_server_side()
+    {
+        await using AddressCtx ctx = new(_options);
+
+        PagedResult<PartyAddress> result = await NewEngine().ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Filter = new Dictionary<string, string> { ["Value.Region.Continent.eq"] = "NA" } },
+            TestContext.Current.CancellationToken);
+
+        result.Items.Select(a => a.Value.City).ShouldBe(["New York"]);
+    }
+
+    [Fact]
+    public async Task Sort_by_a_nested_member_orders_server_side()
+    {
+        await using AddressCtx ctx = new(_options);
+
+        PagedResult<PartyAddress> asc = await NewEngine().ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Sort = "Value.Street1" },
+            TestContext.Current.CancellationToken);
+
+        asc.Items.Select(a => a.Value.Street1)
+            .ShouldBe(["10 Rue A", "20 Rue B", "30 Rue C", "40 Ave D"]);
+
+        PagedResult<PartyAddress> desc = await NewEngine().ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Sort = "-Value.Street1" },
+            TestContext.Current.CancellationToken);
+
+        desc.Items.Select(a => a.Value.Street1)
+            .ShouldBe(["40 Ave D", "30 Rue C", "20 Rue B", "10 Rue A"]);
+
+        _sql.ShouldContain(s => s.Contains("ORDER BY", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Filter_on_a_non_declared_nested_path_is_dropped()
+    {
+        await using AddressCtx ctx = new(_options);
+
+        // PostalCode is a real column but not declared filterable — the criterion is ignored,
+        // so every row is returned (matching the whitelist-first "unknown field dropped" behavior).
+        PagedResult<PartyAddress> result = await NewEngine().ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Filter = new Dictionary<string, string> { ["Value.PostalCode.eq"] = "0000" } },
+            TestContext.Current.CancellationToken);
+
+        result.Items.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public void CompositeCursor_resolves_and_roundtrips_a_nested_sort_field()
+    {
+        // A nested sort field must participate in the keyset — otherwise it is silently dropped and
+        // the cursor predicate disagrees with the ORDER BY, skipping/duplicating rows at page edges.
+        List<CompositeCursorBuilder.SortField> fields = CompositeCursorBuilder.ParseSortFields<PartyAddress>(
+            "Value.Number",
+            new HashSet<string>(["Value.Number"], StringComparer.OrdinalIgnoreCase));
+
+        fields.Count.ShouldBe(1);
+        fields[0].Path.ShouldBe("Value.Number");
+
+        PartyAddress last = new() { Id = Guid.NewGuid(), Value = new Address { Street1 = "x", City = "Ghent", Number = 20, Region = new GeoRegion { Continent = "EU" } } };
+        string cursor = CompositeCursorBuilder.EncodeCompositeCursor(last, fields);
+        Dictionary<string, string>? decoded = CursorEncoder.DecodeComposite(cursor);
+        decoded.ShouldNotBeNull();
+
+        Expression<Func<PartyAddress, bool>>? predicate = CompositeCursorBuilder.BuildCursorPredicate<PartyAddress>(fields, decoded);
+        predicate.ShouldNotBeNull();
+
+        // The keyset predicate walks the nested member: rows with Value.Number > 20.
+        Func<PartyAddress, bool> compiled = predicate.Compile();
+        compiled(new PartyAddress { Id = Guid.NewGuid(), Value = new Address { Street1 = "x", City = "x", Number = 30, Region = new GeoRegion { Continent = "EU" } } }).ShouldBeTrue();
+        compiled(new PartyAddress { Id = Guid.NewGuid(), Value = new Address { Street1 = "x", City = "x", Number = 10, Region = new GeoRegion { Continent = "EU" } } }).ShouldBeFalse();
+    }
+
+    private static QueryEngine<PartyAddress> NewEngine() => new(
+        new AddressQueryDefinition(),
+        NullLogger<QueryEngine<PartyAddress>>.Instance,
+        Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+    public void Dispose() => _connection.Dispose();
+
+    private sealed class AddressQueryDefinition : QueryDefinition<PartyAddress>
+    {
+        public override string Name => "Test.NestedColumns";
+
+        protected override void Configure(QueryDefinitionBuilder<PartyAddress> builder) =>
+            builder
+                .Column(a => a.Value.Street1, c => c.Filterable().Sortable())
+                .Column(a => a.Value.City, c => c.Filterable().Sortable())
+                .Column(a => a.Value.Region.Continent, c => c.Filterable().Sortable());
+    }
+
+    private sealed class Address
+    {
+        public required string Street1 { get; init; }
+        public required string City { get; init; }
+        public string PostalCode { get; init; } = "";
+        public int Number { get; init; }
+        public required GeoRegion Region { get; init; }
+    }
+
+    private sealed class GeoRegion
+    {
+        public required string Continent { get; init; }
+    }
+
+    private sealed class PartyAddress
+    {
+        public Guid Id { get; set; }
+        public required Address Value { get; init; }
+    }
+
+    private sealed class AddressCtx(DbContextOptions<AddressCtx> options) : DbContext(options)
+    {
+        public DbSet<PartyAddress> Addresses => Set<PartyAddress>();
+
+        protected override void OnModelCreating(ModelBuilder b) =>
+            b.Entity<PartyAddress>(e =>
+            {
+                e.HasKey(p => p.Id);
+                e.ComplexProperty(p => p.Value, v => v.ComplexProperty(a => a.Region));
+            });
+    }
+}

--- a/tests/Granit.QueryEngine.Tests/QueryDefinitionBuilderTests.cs
+++ b/tests/Granit.QueryEngine.Tests/QueryDefinitionBuilderTests.cs
@@ -144,8 +144,21 @@ public sealed class QueryDefinitionBuilderTests
     {
         QueryDefinitionBuilder<TestEntity> builder = new();
 
+        // A non-member expression (method call) is not a resolvable column path.
         Should.Throw<ArgumentException>(() =>
-            builder.Column(e => e.Name.Length));
+            builder.Column(e => e.Name.Substring(0)));
+    }
+
+    [Fact]
+    public void Column_on_a_nested_member_records_the_dotted_path()
+    {
+        QueryDefinitionBuilder<TestEntity> builder = new();
+
+        // Nested member access is accepted and recorded as a dotted path (EF complex-type members);
+        // whether it resolves to a mapped column is enforced at query time, not here.
+        builder.Column(e => e.Name.Length);
+
+        builder.Columns.Single().PropertyName.ShouldBe("Name.Length");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

QueryEngine columns could only bind to a **top-level** property. `Column(a => a.Value.Street1)` threw at build time (`GetPropertyName` rejects nested access), and the runtime filter/sort resolvers reflected a single-level name. So a field living inside an EF Core **ComplexProperty** — e.g. `Address.Street1` on `PartyAddress.Value` — was invisible as a filterable/sortable grid column, even though it is a real mapped scalar column and EF can filter/sort on it.

Group-by already gained nested complex-member support in #2907 (`GroupByPathResolver`). This brings the same capability to **columns** (filter + sort), closing the asymmetry.

## Change

- **Shared `MemberPathResolver`** — walks a dotted path (`"Value.Street1"`) with chained `Expression.Property` hops; the leaf still drills a `[QueryableValueObject]` into its `.Value` scalar (ADR-070). `GroupByPathResolver` now delegates to it (single walker, no duplication).
- **`QueryDefinitionBuilder.Column`** records the dotted path via the renamed, generalized `GetMemberPath` (was `GetGroupByPath`). Still rejects drilling into a `SingleValueObject.Value` (#2767).
- **`FilterExpressionBuilder`** and **`QueryableSortExtensions`** (order-by + deterministic fallback) resolve the path via `MemberPathResolver`.
- **`CompositeCursorBuilder`** resolves nested keyset fields (canonicalised casing, plain member chain, path-based value read) so a nested sort field stays consistent with the ORDER BY under cursor pagination — otherwise it would be silently dropped from the keyset and skip/duplicate rows at page boundaries.
- **Wire/meta unchanged** — `PropertyName` ships verbatim, exactly as group-by's dotted paths (`?groupBy=Value.Country`) already do.

## Behaviour change

`Column(e => e.Name.Length)` (nested member access on a scalar) previously threw; it is now accepted as the path `"Name.Length"` — consistent with the group-by contract, and resolution to a mapped column is enforced at query time. The one test asserting the old single-level-only rejection was updated (and now covers both the accepted-nested case and a still-invalid method-call expression). No public API break; `Column` overload signature is unchanged (additive capability).

## Tests

`NestedComplexColumnTests` (end-to-end on real SQLite): nested filter (`eq`/`contains`, 1- and 2-level paths), nested sort (asc/desc, server-side ORDER BY), non-declared nested path dropped, and a nested cursor keyset roundtrip. All QueryEngine suites green (Abstractions 31, core 298, EFCore 220, AspNetCore 63, AI 38); `dotnet format` clean.

## Downstream

Unblocks granit-business declaring `Street1`/`Street2`/`PostalCode` as filterable/sortable columns on `PartyAddressQueryDefinition` (follow-up once this ships to a dev package). Motivating case: the Parties map/address-quality grid.