### PR TITLE
fix(queryengine): keyset cursor for string/Guid sorts + reject scalar-member column paths

### DIFF
--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -548,8 +548,11 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
     // Extracts a (possibly dotted) member path for a column or group-by key. Unlike the single-level
     // GetPropertyName, this accepts a chain of member accesses over an EF complex-type member
     // (a => a.Value.Street1) and returns the dotted path "Value.Street1" plus whether the access is
-    // nested. It still rejects drilling into a SingleValueObject's `.Value` (#2767): that inner value
-    // is a whole-value ValueConverter column, not an independently queryable scalar column.
+    // nested. Two build-time guards keep a dotted path to a genuinely mapped column: it rejects
+    // drilling into a SingleValueObject's `.Value` (#2767, a whole-value ValueConverter column), and
+    // it rejects drilling into a scalar's CLR sub-member (e.g. string.Length) — only a member of an
+    // EF complex type is a nested column, and failing fast here beats an opaque EF translation error
+    // at query time.
     private static (string Path, bool IsNested) GetMemberPath<TProp>(Expression<Func<TEntity, TProp>> expression)
     {
         Expression body = expression.Body is UnaryExpression { NodeType: ExpressionType.Convert } convert
@@ -568,6 +571,21 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
                     $"value-object column, mark it [QueryableValueObject] and select the object itself " +
                     $"(x => x.Slug); to reach a nested field, select a member of an EF complex type. " +
                     $"See issue #2767.",
+                    nameof(expression));
+            }
+
+            // An intermediate hop must be an EF complex type (always a user-defined class/struct). A
+            // scalar's CLR sub-member (string.Length, DateTime.Year, …) is not a mapped column, so a
+            // path drilling into one is rejected here rather than silently accepted then failing to
+            // translate at query time.
+            if (member.Expression is MemberExpression container && IsScalarType(container.Type))
+            {
+                throw new ArgumentException(
+                    $"Expression '{expression.Body}' drills into a CLR member of the scalar column " +
+                    $"'{container.Member.Name}' ({container.Type.Name}); only a member of an EF Core " +
+                    $"complex type is a queryable nested column (a scalar's sub-members such as " +
+                    $"string.Length are not mapped columns). Select a top-level column or an EF " +
+                    $"complex-type member.",
                     nameof(expression));
             }
 
@@ -598,6 +616,27 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
         }
 
         return false;
+    }
+
+    // A scalar (primitive / string / enum / date-time / Guid / …) can never be an EF Core complex-type
+    // hop, so drilling into one of its CLR sub-members does not reach a mapped column. Complex types
+    // are always user-defined classes/structs, so anything outside this closed set is treated as a
+    // candidate complex type and accepted (its mapping is enforced at query time).
+    private static bool IsScalarType(Type type)
+    {
+        Type t = Nullable.GetUnderlyingType(type) ?? type;
+        return t.IsPrimitive
+            || t.IsEnum
+            || t == typeof(string)
+            || t == typeof(decimal)
+            || t == typeof(DateTime)
+            || t == typeof(DateTimeOffset)
+            || t == typeof(DateOnly)
+            || t == typeof(TimeOnly)
+            || t == typeof(TimeSpan)
+            || t == typeof(Guid)
+            || t == typeof(Uri)
+            || t == typeof(byte[]);
     }
 
     // A value-object selector is allowed in global search / group-by when the property opts into the

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/CompositeCursorBuilder.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/CompositeCursorBuilder.cs
@@ -247,9 +247,47 @@ internal static class CompositeCursorBuilder
         Expression member = BuildMemberAccess(parameter, targetField.Path);
         ConstantExpression constant = Expression.Constant(converted, targetField.Property.PropertyType);
 
-        // Descending sort → cursor moves backward (less than), ascending → forward (greater than)
-        return targetField.Descending
+        // Descending sort → cursor moves backward (less than), ascending → forward (greater than).
+        return BuildOrderComparison(member, constant, targetField.Descending);
+    }
+
+    // Builds the keyset "member {<,>} value" comparison. Numeric / temporal / enum columns expose the
+    // relational operators directly. string, Guid and other operator-less IComparable scalars (e.g. the
+    // default Guid `Id` tiebreaker, or any string sort field) have no `>`/`<` operator — building one
+    // throws at expression-construction time — so they compare through `CompareTo`, which EF Core maps
+    // to a relational SQL comparison.
+    private static BinaryExpression BuildOrderComparison(Expression member, Expression constant, bool descending)
+    {
+        Type type = Nullable.GetUnderlyingType(member.Type) ?? member.Type;
+
+        if (!HasRelationalOperator(type))
+        {
+            MethodInfo? compareTo = member.Type.GetMethod(nameof(IComparable.CompareTo), [member.Type]);
+            if (compareTo is not null)
+            {
+                MethodCallExpression comparison = Expression.Call(member, compareTo, constant);
+                ConstantExpression zero = Expression.Constant(0);
+                return descending
+                    ? Expression.LessThan(comparison, zero)
+                    : Expression.GreaterThan(comparison, zero);
+            }
+        }
+
+        return descending
             ? Expression.LessThan(member, constant)
             : Expression.GreaterThan(member, constant);
     }
+
+    // Whether the type carries the built-in relational operators (so Expression.GreaterThan/LessThan is
+    // valid). Excludes bool (no ordering) and reference/struct types like string and Guid that order
+    // only through CompareTo.
+    private static bool HasRelationalOperator(Type type) =>
+        (type.IsPrimitive && type != typeof(bool))
+        || type.IsEnum
+        || type == typeof(decimal)
+        || type == typeof(DateTime)
+        || type == typeof(DateTimeOffset)
+        || type == typeof(DateOnly)
+        || type == typeof(TimeOnly)
+        || type == typeof(TimeSpan);
 }

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/CompositeCursorBuilderTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/CompositeCursorBuilderTests.cs
@@ -147,10 +147,55 @@ public sealed class CompositeCursorBuilderTests
     }
 
     [Fact]
+    public void BuildCursorPredicate_builds_string_comparison_for_a_string_sort_field()
+    {
+        // Regression: a string column has no `>` operator, so the keyset must compare through
+        // CompareTo. Expression.GreaterThan(string, string) throws "not defined for the types
+        // 'System.String'" — the reason cursor pagination with a string sort field was broken.
+        List<CompositeCursorBuilder.SortField> fields =
+            CompositeCursorBuilder.ParseSortFields<TestProduct>("Name");
+
+        var cursorValues = new Dictionary<string, string> { ["Name"] = "Laptop" };
+
+        Expression<Func<TestProduct, bool>>? predicate =
+            CompositeCursorBuilder.BuildCursorPredicate<TestProduct>(fields, cursorValues);
+
+        predicate.ShouldNotBeNull();
+
+        Func<TestProduct, bool> compiled = predicate.Compile();
+        compiled(new TestProduct { Name = "Monitor" }).ShouldBeTrue();  // "Monitor" > "Laptop"
+        compiled(new TestProduct { Name = "Laptop" }).ShouldBeFalse();
+        compiled(new TestProduct { Name = "Bag" }).ShouldBeFalse();     // "Bag" < "Laptop"
+    }
+
+    [Fact]
+    public void BuildCursorPredicate_builds_comparison_for_a_guid_tiebreaker()
+    {
+        // Regression: Guid also lacks a `>` operator. Since the default cursor tiebreaker is `Id`
+        // (a Guid) and every explicit-sort cursor page appends it, this path would have thrown for
+        // the common case. CompareTo makes the keyset build for Guid and match its ordering.
+        List<CompositeCursorBuilder.SortField> fields =
+            CompositeCursorBuilder.ParseSortFields<TestProduct>("Id");
+
+        var pivot = Guid.NewGuid();
+        var other = Guid.NewGuid();
+        var cursorValues = new Dictionary<string, string> { ["Id"] = pivot.ToString() };
+
+        Expression<Func<TestProduct, bool>>? predicate =
+            CompositeCursorBuilder.BuildCursorPredicate<TestProduct>(fields, cursorValues);
+
+        predicate.ShouldNotBeNull();
+
+        Func<TestProduct, bool> compiled = predicate.Compile();
+        compiled(new TestProduct { Id = pivot }).ShouldBeFalse();
+        compiled(new TestProduct { Id = other }).ShouldBe(other.CompareTo(pivot) > 0);
+    }
+
+    [Fact]
     public void BuildCursorPredicate_builds_compound_expression_for_multiple_fields()
     {
-        // Sort: -Price, Amount (descending price, then ascending amount)
-        // Uses two numeric fields to avoid GreaterThan not defined for String
+        // Sort: -Price, Amount (descending price, then ascending amount). Two numeric fields keep the
+        // arithmetic assertions simple; string/Guid keyset comparison is covered by the tests above.
         List<CompositeCursorBuilder.SortField> fields =
             CompositeCursorBuilder.ParseSortFields<TestProduct>("-Price,Amount");
 

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
@@ -1,4 +1,6 @@
 using System.Linq.Expressions;
+using System.Reflection;
+using Granit.Domain;
 using Granit.QueryEngine.EntityFrameworkCore.Internal;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -154,6 +156,47 @@ public sealed class NestedComplexColumnTests : IDisposable
         compiled(new PartyAddress { Id = Guid.NewGuid(), Value = new Address { Street1 = "x", City = "x", Number = 10, Region = new GeoRegion { Continent = "EU" } } }).ShouldBeFalse();
     }
 
+    [Fact]
+    public async Task Cursor_pagination_by_a_nested_member_walks_pages_without_gap_or_overlap()
+    {
+        // Full two-page keyset roundtrip through the engine (not just the predicate in isolation):
+        // page 1 with an empty cursor, then page 2 fed the returned NextCursor. If the nested sort
+        // field did not participate in the keyset, the second page would skip or repeat a boundary row.
+        await using AddressCtx ctx = new(_options);
+        QueryEngine<PartyAddress> engine = NewEngine();
+
+        PagedResult<PartyAddress> page1 = await engine.ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Sort = "Value.Street1", PageSize = 2, Cursor = "" },
+            TestContext.Current.CancellationToken);
+
+        page1.Items.Select(a => a.Value.Street1).ShouldBe(["10 Rue A", "20 Rue B"]);
+        page1.NextCursor.ShouldNotBeNull();
+
+        PagedResult<PartyAddress> page2 = await engine.ExecuteAsync(
+            ctx.Addresses,
+            new QueryRequest { Sort = "Value.Street1", PageSize = 2, Cursor = page1.NextCursor },
+            TestContext.Current.CancellationToken);
+
+        page2.Items.Select(a => a.Value.Street1).ShouldBe(["30 Rue C", "40 Ave D"]);
+
+        // Both pages together cover every row exactly once — no gap, no overlap at the page boundary.
+        page1.Items.Concat(page2.Items).Select(a => a.Id).Distinct().Count().ShouldBe(4);
+    }
+
+    [Fact]
+    public void MemberPathResolver_drills_a_nested_queryable_value_object_leaf_to_its_value_scalar()
+    {
+        // A [QueryableValueObject] leaf reached through a complex-type hop must still resolve to its
+        // `.Value` scalar column (ADR-070) — the VO drill is not special-cased to top-level members.
+        ParameterExpression parameter = Expression.Parameter(typeof(Party), "e");
+        (Expression? member, PropertyInfo? leaf) = MemberPathResolver.Resolve(parameter, "Home.Code");
+
+        member.ShouldNotBeNull();
+        member!.ToString().ShouldBe("e.Home.Code.Value");
+        leaf!.Name.ShouldBe("Code");
+    }
+
     private static QueryEngine<PartyAddress> NewEngine() => new(
         new AddressQueryDefinition(),
         NullLogger<QueryEngine<PartyAddress>>.Instance,
@@ -169,7 +212,8 @@ public sealed class NestedComplexColumnTests : IDisposable
             builder
                 .Column(a => a.Value.Street1, c => c.Filterable().Sortable())
                 .Column(a => a.Value.City, c => c.Filterable().Sortable())
-                .Column(a => a.Value.Region.Continent, c => c.Filterable().Sortable());
+                .Column(a => a.Value.Region.Continent, c => c.Filterable().Sortable())
+                .SupportsCursorPagination(a => a.Id);
     }
 
     private sealed class Address
@@ -190,6 +234,25 @@ public sealed class NestedComplexColumnTests : IDisposable
     {
         public Guid Id { get; set; }
         public required Address Value { get; init; }
+    }
+
+    // Types used only by the nested [QueryableValueObject] resolver test (no EF mapping needed —
+    // the assertion is on the resolved expression shape, not a SQL roundtrip).
+    private sealed class PostalCode : SingleValueObject<string>
+    {
+        public override required string Value { get; init; }
+    }
+
+    private sealed class HomeInfo
+    {
+        [QueryableValueObject]
+        public required PostalCode Code { get; init; }
+    }
+
+    private sealed class Party
+    {
+        public Guid Id { get; set; }
+        public required HomeInfo Home { get; init; }
     }
 
     private sealed class AddressCtx(DbContextOptions<AddressCtx> options) : DbContext(options)

--- a/tests/Granit.QueryEngine.Tests/QueryDefinitionBuilderTests.cs
+++ b/tests/Granit.QueryEngine.Tests/QueryDefinitionBuilderTests.cs
@@ -150,15 +150,27 @@ public sealed class QueryDefinitionBuilderTests
     }
 
     [Fact]
-    public void Column_on_a_nested_member_records_the_dotted_path()
+    public void Column_on_a_nested_complex_member_records_the_dotted_path()
     {
         QueryDefinitionBuilder<TestEntity> builder = new();
 
-        // Nested member access is accepted and recorded as a dotted path (EF complex-type members);
+        // A member of a (user-defined) complex type is accepted and recorded as a dotted path;
         // whether it resolves to a mapped column is enforced at query time, not here.
-        builder.Column(e => e.Name.Length);
+        builder.Column(e => e.Address.City);
 
-        builder.Columns.Single().PropertyName.ShouldBe("Name.Length");
+        builder.Columns.Single().PropertyName.ShouldBe("Address.City");
+    }
+
+    [Fact]
+    public void Column_drilling_into_a_scalar_sub_member_throws()
+    {
+        QueryDefinitionBuilder<TestEntity> builder = new();
+
+        // string.Length is a CLR sub-member of a scalar column, not an EF complex-type member — the
+        // path cannot reach a mapped column, so it is rejected at build time (fail-fast) rather than
+        // surfacing as an opaque EF translation error at query time.
+        ArgumentException ex = Should.Throw<ArgumentException>(() => builder.Column(e => e.Name.Length));
+        ex.Message.ShouldContain("Name");
     }
 
     [Fact]
@@ -252,4 +264,11 @@ public sealed class TestEntity
     public int Age { get; set; }
     public DateTimeOffset? BirthDate { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
+    public TestAddress Address { get; set; } = new();
+}
+
+// A user-defined complex type used to exercise nested column paths (a => a.Address.City).
+public sealed class TestAddress
+{
+    public string City { get; set; } = string.Empty;
 }


### PR DESCRIPTION
Follow-up hardening on the nested complex-member columns feature (#2916), from a review of that PR. Two independent fixes plus targeted tests.

## 1. Cursor keyset broken for string / Guid sort fields (real bug)

`CompositeCursorBuilder` built the keyset inequality with `Expression.GreaterThan` / `Expression.LessThan`, which **throw at expression-construction time** for any type without a relational operator:

> `System.InvalidOperationException : The binary operator GreaterThan is not defined for the types 'System.String' and 'System.String'.`

This was latent because the composite-keyset path only runs when an **explicit sort** is combined with cursor pagination, and the existing suite only ever exercised **numeric** sorts — one test even sidesteps it with a comment: *"Uses two numeric fields to avoid GreaterThan not defined for String"*. Two common cases were affected:

- **any string sort field** under cursor pagination, and
- **every explicit-sort cursor page**, because it appends the default `Id` (a `Guid`) as the keyset tiebreaker — and `Guid` has no `>` operator either.

Fix: operator-less `IComparable` scalars (string, Guid) now compare through `CompareTo`, which EF Core maps to a relational SQL comparison. Numeric / temporal / enum columns keep the direct operator.

## 2. Build-time rejection of scalar-member column paths

#2916 accepted `Column(e => e.Name.Length)` as the path `"Name.Length"`, deferring "is it a real column?" to query time. Since columns are declared with a **strongly-typed lambda**, typos can't compile — the only footgun was drilling into a *scalar's* CLR sub-member (`string.Length`, `DateTime.Year`, …), which isn't an EF-mapped column and surfaces as an opaque EF translation error (or silently odd SQL) at query time.

`GetMemberPath` (shared by `Column` **and** `AllowGroupBy`) now rejects a nested hop whose container is a scalar type, restoring fail-fast at definition time — in the Abstractions layer, no EF model needed. Genuine EF complex-type members (`e.Value.Street1`) are unaffected.

## Tests

- `Cursor_pagination_by_a_nested_member_walks_pages_without_gap_or_overlap` — full two-page keyset roundtrip through the engine on a **nested string** sort against real SQLite (page 1 → feed `NextCursor` → page 2; union covers every row exactly once). This is the test that surfaced bug #1.
- `MemberPathResolver_drills_a_nested_queryable_value_object_leaf_to_its_value_scalar` — a `[QueryableValueObject]` leaf reached through a complex-type hop still resolves to its `.Value` scalar (ADR-070); the VO drill is not special-cased to top-level members.
- `BuildCursorPredicate_builds_string_comparison_for_a_string_sort_field` / `..._for_a_guid_tiebreaker` — direct regressions for the keyset comparison.
- Abstractions: `Column_drilling_into_a_scalar_sub_member_throws` (replaces the #2916 test that asserted `Name.Length` was accepted) + `Column_on_a_nested_complex_member_records_the_dotted_path` on a real user complex type.

All QueryEngine suites green: Abstractions/core **299**, EFCore **224**, AspNetCore **63**, AI **38**. `dotnet format --verify-no-changes` clean on all touched projects.

## Notes

- No public API change; `Column` / `AllowGroupBy` signatures unchanged.
- Value-object **whole-value** cursor keys remain equality-only (unchanged, pre-existing) — this PR does not add ordering for converter-mapped VOs.
- Docs for the nested-columns capability ship separately in `granit-docs` (per repo convention).