### PR TITLE
fix(http): map body-binding failures to 400 with safe JSON path

### DIFF
--- a/src/Granit.Http.ExceptionHandling/Internal/DefaultExceptionStatusCodeMapper.cs
+++ b/src/Granit.Http.ExceptionHandling/Internal/DefaultExceptionStatusCodeMapper.cs
@@ -28,6 +28,11 @@ internal sealed class DefaultExceptionStatusCodeMapper : IExceptionStatusCodeMap
         NotImplementedException => StatusCodes.Status501NotImplemented,
         OperationCanceledException => 499,
         TimeoutException => StatusCodes.Status408RequestTimeout,
+        // Body binding failures (malformed JSON, payload too large, …) surface as
+        // BadHttpRequestException with a status ASP.NET has already resolved
+        // (400, 413, …). Honour it instead of hardcoding 400 so a too-large body
+        // still maps to 413.
+        BadHttpRequestException badRequest => badRequest.StatusCode,
         _ => null
     };
 }

--- a/src/Granit.Http.ExceptionHandling/Internal/GranitExceptionHandler.cs
+++ b/src/Granit.Http.ExceptionHandling/Internal/GranitExceptionHandler.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using Granit.Exceptions;
 using Granit.Http.ExceptionHandling.Options;
 using Microsoft.AspNetCore.Diagnostics;
@@ -47,6 +48,11 @@ internal sealed partial class GranitExceptionHandler(
     private const string FallbackTitle409 = "Conflict.";
     private const string FallbackTitle422 = "Validation failed.";
     private const string FallbackTitle4xx = "Invalid request.";
+
+    // Stable error code surfaced when a request body fails to bind (malformed JSON,
+    // invalid enum, wrong shape). Exposed as-is on the ProblemDetails; it is not an
+    // IHasErrorCode-backed code, so no localization key is required for it.
+    private const string MalformedRequestBodyErrorCode = "Http:MalformedRequestBody";
 
     private readonly ILogger _logger = loggerFactory.CreateLogger<GranitExceptionHandler>();
 
@@ -147,6 +153,20 @@ internal sealed partial class GranitExceptionHandler(
         {
             problemDetails.Extensions["errors"] =
                 validationErrorsSanitizer.Sanitize(hasValidationErrors.ValidationErrors);
+        }
+
+        // Body binding failure (e.g. invalid enum in the JSON payload) arrives as a
+        // BadHttpRequestException wrapping a JsonException. Surface a stable error code
+        // and the JSON path of the faulty member so clients can pinpoint it. Only the
+        // schema path is exposed — never the received value or raw message — so the
+        // ISO 27001 masking of non-IUserFriendlyException 4xx titles stays intact.
+        if (exception is BadHttpRequestException { InnerException: JsonException json })
+        {
+            problemDetails.Extensions["errorCode"] = MalformedRequestBodyErrorCode;
+            if (json.Path is { Length: > 0 } jsonPath)
+            {
+                problemDetails.Extensions["jsonPath"] = jsonPath;
+            }
         }
 
         return problemDetails;

--- a/tests/Granit.Http.ExceptionHandling.Tests/DefaultExceptionStatusCodeMapperTests.cs
+++ b/tests/Granit.Http.ExceptionHandling.Tests/DefaultExceptionStatusCodeMapperTests.cs
@@ -178,6 +178,34 @@ public sealed class DefaultExceptionStatusCodeMapperTests
     }
 
     // -------------------------------------------------------------------------
+    // BadHttpRequestException: honours the status ASP.NET already resolved
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void TryGetStatusCode_BadHttpRequestException_Returns400()
+    {
+        DefaultExceptionStatusCodeMapper mapper = Create();
+
+        int? result = mapper.TryGetStatusCode(
+            new BadHttpRequestException("Malformed request body", StatusCodes.Status400BadRequest));
+
+        result.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public void TryGetStatusCode_BadHttpRequestExceptionWithNon400StatusCode_ReturnsThatStatusCode()
+    {
+        // A too-large body surfaces as BadHttpRequestException with StatusCode 413.
+        // The mapper must honour it rather than hardcoding 400.
+        DefaultExceptionStatusCodeMapper mapper = Create();
+
+        int? result = mapper.TryGetStatusCode(
+            new BadHttpRequestException("Request body too large", StatusCodes.Status413PayloadTooLarge));
+
+        result.ShouldBe(StatusCodes.Status413PayloadTooLarge);
+    }
+
+    // -------------------------------------------------------------------------
     // Fallback: unknown exception -> null (delegates to next mapper or handler)
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Http.ExceptionHandling.Tests/GranitExceptionHandlerTests.cs
+++ b/tests/Granit.Http.ExceptionHandling.Tests/GranitExceptionHandlerTests.cs
@@ -644,6 +644,58 @@ public sealed class GranitExceptionHandlerTests
     }
 
     // -------------------------------------------------------------------------
+    // BadHttpRequestException: body binding failure -> 400 with safe metadata
+    // -------------------------------------------------------------------------
+    // A malformed body (e.g. an invalid enum in $.definition.chartType) surfaces
+    // as BadHttpRequestException wrapping a JsonException. It must return the
+    // status ASP.NET already resolved (400), expose a stable errorCode and the
+    // JSON path of the faulty member — but never the raw message in production.
+
+    [Fact]
+    public async Task TryHandleAsync_BadHttpRequestException_ReturnsStatus400()
+    {
+        using ServiceProvider sp = BuildServiceProvider();
+
+        (int statusCode, _, _, _) = await InvokeHandlerAsync(
+            sp, CreateMalformedBodyException("$.definition.chartType"));
+
+        statusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_BadHttpRequestException_ExposesErrorCodeAndJsonPath()
+    {
+        using ServiceProvider sp = BuildServiceProvider();
+
+        (_, IDictionary<string, object?> extensions, _, _) = await InvokeHandlerAsync(
+            sp, CreateMalformedBodyException("$.definition.chartType"));
+
+        extensions.ShouldContainKey("errorCode");
+        extensions["errorCode"]!.ToString().ShouldBe("Http:MalformedRequestBody");
+        extensions.ShouldContainKey("jsonPath");
+        extensions["jsonPath"]!.ToString().ShouldBe("$.definition.chartType");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_BadHttpRequestException_Production_DoesNotLeakRawMessage()
+    {
+        // ExposeInternalErrorDetails = false (production). The raw JSON parsing
+        // message may echo the offending value — it must never reach the client.
+        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+
+        BadHttpRequestException exception = CreateMalformedBodyException(
+            "$.definition.chartType",
+            rawMessage: "The JSON value 'Sunburst' could not be converted to ChartType.");
+
+        (_, _, string? title, string? detail) = await InvokeHandlerAsync(sp, exception);
+
+        title.ShouldBe("Invalid request.");
+        title!.ShouldNotContain("Sunburst");
+        title!.ShouldNotContain("ChartType");
+        detail.ShouldBeNull("body binding failures must not leak the raw parsing message in production");
+    }
+
+    // -------------------------------------------------------------------------
     // BusinessRuleViolationException: more specific than BusinessException
     // -------------------------------------------------------------------------
 
@@ -661,6 +713,20 @@ public sealed class GranitExceptionHandlerTests
     // -------------------------------------------------------------------------
     // Test doubles
     // -------------------------------------------------------------------------
+
+    // Mirrors how ASP.NET Core wraps a body-binding failure: a BadHttpRequestException
+    // (StatusCode already set to 400) whose InnerException is the JsonException carrying
+    // the JSON path of the faulty member.
+    private static BadHttpRequestException CreateMalformedBodyException(
+        string jsonPath,
+        string rawMessage = "The JSON value could not be converted.")
+    {
+        System.Text.Json.JsonException inner = new(rawMessage, jsonPath, lineNumber: 1, bytePositionInLine: 20);
+        return new BadHttpRequestException(
+            "Failed to read parameter from the request body as JSON.",
+            StatusCodes.Status400BadRequest,
+            inner);
+    }
 
     private sealed class DomainException(string errorCode) : Exception("fallback"), IHasErrorCode
     {


### PR DESCRIPTION
## Problem

A malformed request body — e.g. an invalid enum in `$.definition.chartType` on a Minimal API POST — surfaces as `System.Text.Json.JsonException`, which ASP.NET wraps in `BadHttpRequestException` (whose `.StatusCode` is already `400`). No `IExceptionStatusCodeMapper` claimed it, so `GranitExceptionHandler.ResolveStatusCode` applied the **500 fallback**.

Result: a **client** error (invalid payload) was reported as a **server** error — polluting error alerting — and the useful detail (the JSON path of the faulty field) was lost inside the un-surfaced `InnerException`.

## Fix

**`DefaultExceptionStatusCodeMapper`** — maps `BadHttpRequestException` to its own `.StatusCode` (before `_ => null`), honouring the code ASP.NET already resolved (e.g. `413` for an oversized body) rather than hardcoding `400`.

**`GranitExceptionHandler.BuildProblemDetails`** — when the exception is a `BadHttpRequestException` wrapping a `JsonException`, enriches the RFC 7807 `ProblemDetails`:
- `Extensions["errorCode"] = "Http:MalformedRequestBody"` (stable code; `BadHttpRequestException` is not `IHasErrorCode`, so no localization key is required)
- `Extensions["jsonPath"] = json.Path` (schema path only — **never the received value or raw message**)

The path alone is safe: the ISO 27001 masking of non-`IUserFriendlyException` 4xx titles stays intact (production title remains `"Invalid request."`, `detail` null). In dev/staging, `ExposeInternalErrorDetails` still layers the raw message on top, unchanged.

## Tests

5 new (90 total, all green):
- Mapper: `BadHttpRequestException(400) → 400`, and `(413) → 413` — proves 400 is not hardcoded.
- Handler: `→ 400`; `errorCode` + `jsonPath` populated; and a production case asserting the raw parsing message (`'Sunburst'`, `ChartType`) does **not** leak into title or detail.

## DoD
- `dotnet build src/Granit.Http.ExceptionHandling` — 0 warnings
- `dotnet test tests/Granit.Http.ExceptionHandling.Tests` — 90 passed
- `dotnet format --verify-no-changes` (src + tests) — clean

Docs: any framework page describing exception-handling behaviour will be updated in a **separate** `granit-docs` PR.