### PR TITLE
feat(analyzers): GRENUM001 redundant enum value + framework cleanup

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7505,6 +7505,34 @@
       ]
     },
     {
+      "name": "RedundantEnumValueCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.RedundantEnumValueCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/RedundantEnumValueCodeFixProvider.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "SynchronousSaveChangesCodeFixProvider",
       "fqn": "Granit.Analyzers.CodeFixes.SynchronousSaveChangesCodeFixProvider",
       "kind": "class",
@@ -7725,6 +7753,15 @@
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs",
       "line": 40,
+      "members": []
+    },
+    {
+      "name": "RedundantEnumValueAnalyzer",
+      "fqn": "Granit.Analyzers.RedundantEnumValueAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/RedundantEnumValueAnalyzer.cs",
+      "line": 36,
       "members": []
     },
     {

--- a/src/Granit.AddressDeliverability.Abstractions/AddressDeliverabilityOutcome.cs
+++ b/src/Granit.AddressDeliverability.Abstractions/AddressDeliverabilityOutcome.cs
@@ -8,14 +8,14 @@ namespace Granit.AddressDeliverability;
 public enum AddressDeliverabilityOutcome
 {
     /// <summary>The address was confirmed deliverable as submitted.</summary>
-    Verified = 0,
+    Verified,
 
     /// <summary>The address was confirmed after the provider standardized / corrected it.</summary>
-    Corrected = 1,
+    Corrected,
 
     /// <summary>The provider could not confirm the address (no authoritative match) — neither valid nor invalid.</summary>
-    Unverifiable = 2,
+    Unverifiable,
 
     /// <summary>The provider determined the address is not deliverable.</summary>
-    Invalid = 3,
+    Invalid,
 }

--- a/src/Granit.Analyzers.CodeFixes/RedundantEnumValueCodeFixProvider.cs
+++ b/src/Granit.Analyzers.CodeFixes/RedundantEnumValueCodeFixProvider.cs
@@ -1,0 +1,71 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Granit.Analyzers.CodeFixes;
+
+/// <summary>
+/// CodeFix for GRENUM001 — removes the redundant <c>= N</c> initializer from an enum member,
+/// leaving the implicit ordinal value unchanged.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RedundantEnumValueCodeFixProvider))]
+[Shared]
+public sealed class RedundantEnumValueCodeFixProvider : CodeFixProvider
+{
+    private const string Title = "Remove redundant enum value";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(RedundantEnumValueAnalyzer.DiagnosticId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode? root = await context.Document
+            .GetSyntaxRootAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+
+        if (root is null)
+        {
+            return;
+        }
+
+        Diagnostic diagnostic = context.Diagnostics[0];
+        SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
+
+        EnumMemberDeclarationSyntax? member = node.FirstAncestorOrSelf<EnumMemberDeclarationSyntax>();
+        if (member?.EqualsValue is null)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                Title,
+                cancellationToken => RemoveInitializerAsync(context.Document, member, cancellationToken),
+                equivalenceKey: Title),
+            diagnostic);
+    }
+
+    private static async Task<Document> RemoveInitializerAsync(
+        Document document,
+        EnumMemberDeclarationSyntax member,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))!;
+
+        // Move the initializer's trailing trivia (the newline on a last member, empty otherwise)
+        // onto the identifier so the member closes cleanly once `= N` is gone.
+        EnumMemberDeclarationSyntax newMember = member
+            .WithIdentifier(member.Identifier.WithTrailingTrivia(member.EqualsValue!.Value.GetTrailingTrivia()))
+            .WithEqualsValue(null);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(member, newMember));
+    }
+}

--- a/src/Granit.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Granit.Analyzers/AnalyzerReleases.Unshipped.md
@@ -22,3 +22,4 @@ GRMOD001 | Architecture | Error | CrossModuleReferenceAnalyzer, IsEnabledByDefau
 GRSEC010 | Security | Error | TagListPiiAnalyzer, IsEnabledByDefault=True
 GRSEC011 | Security | Error | LoggerMessagePiiAnalyzer, IsEnabledByDefault=True
 GRBROWSING001 | Security | Warning | EvaluateAsyncStringInterpolationAnalyzer, IsEnabledByDefault=True (Granit.Browsing IBrowserPage JS-injection guard)
+GRENUM001 | Design | Warning | RedundantEnumValueAnalyzer, IsEnabledByDefault=True (enums persist by name per ADR-059; flags redundant sequential-from-zero explicit values, skips [Flags]/[PersistAsInt])

--- a/src/Granit.Analyzers/README.md
+++ b/src/Granit.Analyzers/README.md
@@ -45,6 +45,12 @@ Part of the [granit](https://granit-fx.dev) framework.
 | GRAPI001 | Warning | Yes | Use TypedResults instead of Results for OpenAPI |
 | GRAPI002 | Warning | Yes | Use TypedResults.Problem() instead of BadRequest (RFC 7807) |
 
+### Design
+
+| Rule | Severity | CodeFix | Description |
+| ---- | -------- | ------- | ----------- |
+| GRENUM001 | Warning | Yes | Redundant sequential-from-zero explicit enum value — enums persist by name (ADR-059); skips `[Flags]` and `[PersistAsInt]` |
+
 ## Installation
 
 ```bash

--- a/src/Granit.Analyzers/RedundantEnumValueAnalyzer.cs
+++ b/src/Granit.Analyzers/RedundantEnumValueAnalyzer.cs
@@ -1,0 +1,269 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Granit.Analyzers;
+
+/// <summary>
+/// GRENUM001 — Reports a redundant explicit value on an enum member when the whole enum
+/// merely restates the implicit ordinal sequence (<c>= 0, 1, 2, …</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Granit persists enum properties as their PascalCase string name (ADR-059) and serialises
+/// them by name on the wire (<c>JsonStringEnumConverter</c>). A sequential-from-zero explicit
+/// value is therefore inert — it changes neither the stored value nor the JSON — while
+/// misleadingly implying a stable numeric contract, which discourages the safe
+/// "append a member anywhere" refactor the string-persistence convention is designed to enable.
+/// </para>
+/// <para>
+/// The analyzer is deliberately conservative. It fires only when <em>every</em> member carries a
+/// plain decimal integer literal equal to its zero-based position. It never fires on:
+/// </para>
+/// <list type="bullet">
+///   <item><c>[Flags]</c> enums — bitmask composition needs explicit power-of-two values.</item>
+///   <item>Enums consumed by a <c>[PersistAsInt]</c> property or field anywhere in the
+///     compilation — there the integer is the persisted contract and reordering corrupts data.</item>
+///   <item>Enums with a gap, a non-zero start, or a non-literal initializer
+///     (<c>1 &lt;&lt; 2</c>, <c>Other</c>, <c>301</c>) — a deliberate numeric contract.</item>
+/// </list>
+/// <para>Suppress with <c>[SuppressMessage("Design", "GRENUM001")]</c> for the rare enum whose
+/// values are load-bearing in a way the analyzer cannot see (e.g. an external numeric protocol).</para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RedundantEnumValueAnalyzer : SingleRuleAnalyzerBase
+{
+    /// <summary>Diagnostic identifier.</summary>
+    public const string DiagnosticId = "GRENUM001";
+
+    private const string PersistAsIntAttributeMetadataName = "Granit.Domain.PersistAsIntAttribute";
+    private const string FlagsAttributeMetadataName = "System.FlagsAttribute";
+
+    private static readonly DiagnosticDescriptor _rule = new(
+        DiagnosticId,
+        title: "Redundant explicit enum value",
+        messageFormat: "Enum member '{0}' explicitly assigns its implicit ordinal value; omit '= {1}' — "
+            + "Granit persists enums by name (ADR-059), so explicit values matter only for "
+            + "[Flags] or [PersistAsInt] enums",
+        category: "Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Granit persists enum properties as their PascalCase string name and serialises "
+            + "them by name on the wire (ADR-059). Explicit sequential-from-zero values are inert and "
+            + "misleadingly imply a numeric contract, discouraging the safe 'append a member anywhere' "
+            + "refactor the string-persistence convention enables. Reserve explicit values for [Flags] "
+            + "bitmasks and [PersistAsInt] columns, where the integer is a real contract.");
+
+    /// <inheritdoc/>
+    protected override DiagnosticDescriptor Rule => _rule;
+
+    /// <inheritdoc/>
+    protected override void RegisterActions(AnalysisContext context)
+        => context.RegisterCompilationStartAction(OnCompilationStart);
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        Compilation compilation = context.Compilation;
+        INamedTypeSymbol? persistAsIntAttribute =
+            compilation.GetTypeByMetadataName(PersistAsIntAttributeMetadataName);
+
+        // Enum types whose underlying integer IS a persisted contract because a [PersistAsInt]
+        // member somewhere in the compilation stores them as an integer column. Computed on first
+        // use, so a single walk covers all enum declarations regardless of analysis order.
+        var persistedAsIntEnums = new Lazy<ImmutableHashSet<INamedTypeSymbol>>(
+            () => CollectPersistedAsIntEnums(compilation, persistAsIntAttribute));
+
+        context.RegisterSyntaxNodeAction(
+            syntaxContext => AnalyzeEnum(syntaxContext, persistedAsIntEnums),
+            SyntaxKind.EnumDeclaration);
+    }
+
+    private static void AnalyzeEnum(SyntaxNodeAnalysisContext context, Lazy<ImmutableHashSet<INamedTypeSymbol>> persistedAsIntEnums)
+    {
+        var enumDeclaration = (EnumDeclarationSyntax)context.Node;
+
+        if (context.SemanticModel.GetDeclaredSymbol(enumDeclaration, context.CancellationToken)
+            is not INamedTypeSymbol enumSymbol)
+        {
+            return;
+        }
+
+        // [Flags] enums need explicit power-of-two values — never redundant.
+        if (enumSymbol.GetAttributes().Any(attribute =>
+                attribute.AttributeClass?.ToDisplayString() == FlagsAttributeMetadataName))
+        {
+            return;
+        }
+
+        SeparatedSyntaxList<EnumMemberDeclarationSyntax> members = enumDeclaration.Members;
+        if (members.Count == 0)
+        {
+            return;
+        }
+
+        var redundant = new List<Diagnostic>(members.Count);
+
+        for (int index = 0; index < members.Count; index++)
+        {
+            EnumMemberDeclarationSyntax member = members[index];
+            EqualsValueClauseSyntax? equalsValue = member.EqualsValue;
+
+            // A member without an explicit value means this is not the fully-restated pattern.
+            if (equalsValue is null)
+            {
+                return;
+            }
+
+            // Only plain decimal integer literals count. `1 << 2`, `A | B`, `Other`, `-1`, `0x01`
+            // all signal a deliberate value and disqualify the whole enum.
+            if (equalsValue.Value is not LiteralExpressionSyntax literal
+                || !literal.IsKind(SyntaxKind.NumericLiteralExpression)
+                || !IsPlainDecimalLiteral(literal.Token.Text))
+            {
+                return;
+            }
+
+            Optional<object?> constant = context.SemanticModel.GetConstantValue(literal, context.CancellationToken);
+            if (!constant.HasValue || ToInt64(constant.Value) is not { } value || value != index)
+            {
+                return;
+            }
+
+            redundant.Add(Diagnostic.Create(
+                _rule, equalsValue.GetLocation(), member.Identifier.ValueText, index));
+        }
+
+        // The integer is a persisted contract for this enum — leave the explicit values alone.
+        if (persistedAsIntEnums.Value.Contains(enumSymbol))
+        {
+            return;
+        }
+
+        foreach (Diagnostic diagnostic in redundant)
+        {
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    private static ImmutableHashSet<INamedTypeSymbol> CollectPersistedAsIntEnums(
+        Compilation compilation,
+        INamedTypeSymbol? persistAsIntAttribute)
+    {
+        if (persistAsIntAttribute is null)
+        {
+            return ImmutableHashSet<INamedTypeSymbol>.Empty;
+        }
+
+        ImmutableHashSet<INamedTypeSymbol>.Builder builder =
+            ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (INamedTypeSymbol type in EnumerateNamedTypes(compilation.GlobalNamespace))
+        {
+            foreach (ISymbol member in type.GetMembers())
+            {
+                ITypeSymbol? memberType = member switch
+                {
+                    IPropertySymbol property => property.Type,
+                    IFieldSymbol field => field.Type,
+                    _ => null,
+                };
+
+                if (memberType is null)
+                {
+                    continue;
+                }
+
+                bool hasPersistAsInt = member.GetAttributes().Any(attribute =>
+                    SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, persistAsIntAttribute));
+
+                if (hasPersistAsInt && UnwrapEnum(memberType) is { } enumType)
+                {
+                    builder.Add(enumType);
+                }
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNamedTypes(INamespaceSymbol root)
+    {
+        foreach (INamespaceOrTypeSymbol member in root.GetMembers())
+        {
+            if (member is INamespaceSymbol childNamespace)
+            {
+                foreach (INamedTypeSymbol nested in EnumerateNamedTypes(childNamespace))
+                {
+                    yield return nested;
+                }
+            }
+            else if (member is INamedTypeSymbol type)
+            {
+                yield return type;
+
+                foreach (INamedTypeSymbol nested in EnumerateNestedTypes(type))
+                {
+                    yield return nested;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(INamedTypeSymbol type)
+    {
+        foreach (INamedTypeSymbol nested in type.GetTypeMembers())
+        {
+            yield return nested;
+
+            foreach (INamedTypeSymbol deeper in EnumerateNestedTypes(nested))
+            {
+                yield return deeper;
+            }
+        }
+    }
+
+    private static bool IsPlainDecimalLiteral(string tokenText)
+    {
+        if (tokenText.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (char character in tokenText)
+        {
+            if (character is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static INamedTypeSymbol? UnwrapEnum(ITypeSymbol type)
+    {
+        if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullable
+            && nullable.TypeArguments.Length == 1
+            && nullable.TypeArguments[0] is INamedTypeSymbol underlying)
+        {
+            type = underlying;
+        }
+
+        return type is INamedTypeSymbol { TypeKind: TypeKind.Enum } enumType ? enumType : null;
+    }
+
+    private static long? ToInt64(object? value) => value switch
+    {
+        sbyte number => number,
+        byte number => number,
+        short number => number,
+        ushort number => number,
+        int number => number,
+        uint number => number,
+        long number => number,
+        ulong number when number <= long.MaxValue => (long)number,
+        _ => null,
+    };
+}

--- a/src/Granit.Auditing.Abstractions/Domain/AuditCategory.cs
+++ b/src/Granit.Auditing.Abstractions/Domain/AuditCategory.cs
@@ -15,21 +15,21 @@ namespace Granit.Auditing.Domain;
 public enum AuditCategory
 {
     /// <summary>Entity Create / Update / Delete / SoftDelete operations.</summary>
-    DataMutation = 0,
+    DataMutation,
 
     /// <summary>Settings and feature flag changes (always-on, non-disableable).</summary>
-    ConfigurationChange = 1,
+    ConfigurationChange,
 
     /// <summary>Read operations (opt-in, disabled by default).</summary>
-    DataAccess = 2,
+    DataAccess,
 
     /// <summary>Authorization failures (opt-in).</summary>
-    AccessDenied = 3,
+    AccessDenied,
 
     /// <summary>
     /// Privileged-access operations that were granted (e.g. host tenant impersonation, admin masquerading).
     /// Recorded as a counterpart to <see cref="AccessDenied"/> so RSSI dashboards can answer
     /// "what did privileged actors successfully do" without joining against logs/metrics.
     /// </summary>
-    PrivilegedAccess = 4,
+    PrivilegedAccess,
 }

--- a/src/Granit.Auditing.Abstractions/Domain/AuditChangeType.cs
+++ b/src/Granit.Auditing.Abstractions/Domain/AuditChangeType.cs
@@ -6,14 +6,14 @@ namespace Granit.Auditing.Domain;
 public enum AuditChangeType
 {
     /// <summary>A new entity was created.</summary>
-    Created = 0,
+    Created,
 
     /// <summary>An existing entity was modified.</summary>
-    Modified = 1,
+    Modified,
 
     /// <summary>An entity was physically deleted.</summary>
-    Deleted = 2,
+    Deleted,
 
     /// <summary>An entity was soft-deleted (IsDeleted set to true).</summary>
-    SoftDeleted = 3,
+    SoftDeleted,
 }

--- a/src/Granit.Auditing.Abstractions/Domain/AuditPersistenceMode.cs
+++ b/src/Granit.Auditing.Abstractions/Domain/AuditPersistenceMode.cs
@@ -15,12 +15,12 @@ public enum AuditPersistenceMode
     /// <c>AuditingOptions.PersistenceMode</c> never silently
     /// falls back to a lossy mode. Opt into <see cref="Async"/> explicitly for throughput.
     /// </remarks>
-    Strict = 0,
+    Strict,
 
     /// <summary>
     /// Entries are published to a <c>Channel&lt;T&gt;</c> and persisted asynchronously
     /// by a background worker. Best performance, but buffered entries may be lost on an
     /// ungraceful crash (the graceful-shutdown drain only covers SIGTERM, not SIGKILL).
     /// </summary>
-    Async = 1,
+    Async,
 }

--- a/src/Granit.Authorization/OrphanedRolePolicy.cs
+++ b/src/Granit.Authorization/OrphanedRolePolicy.cs
@@ -22,7 +22,7 @@ public enum OrphanedRolePolicy
     /// Zero-config upgrade target: existing Phase 2 consumers stay on this policy
     /// unless they explicitly opt in to a stricter one.
     /// </remarks>
-    KeepAndLog = 0,
+    KeepAndLog,
 
     /// <summary>
     /// The sync flips <c>IsOrphaned = true</c> and stamps <c>OrphanedAt</c> on any
@@ -32,7 +32,7 @@ public enum OrphanedRolePolicy
     /// restores (admin re-adds the role upstream, the next sync clears the flag) or
     /// hard-deletes (via the admin endpoint, tracked separately).
     /// </summary>
-    SoftDelete = 1,
+    SoftDelete,
 
     /// <summary>
     /// The sync removes the <see cref="Domain.RoleMetadata"/> row entirely. The
@@ -42,5 +42,5 @@ public enum OrphanedRolePolicy
     /// of truth (IaC rewrites, SSO group mapping) or during a migration that
     /// explicitly accepts the blast radius.
     /// </summary>
-    HardDelete = 2,
+    HardDelete,
 }

--- a/src/Granit.BackgroundJobs/Domain/JobStoreMode.cs
+++ b/src/Granit.BackgroundJobs/Domain/JobStoreMode.cs
@@ -11,12 +11,12 @@ public enum JobStoreMode
     /// No database required. State is lost on application restart.
     /// Suitable for development and integration tests.
     /// </summary>
-    InMemory = 0,
+    InMemory,
 
     /// <summary>
     /// Jobs are persisted in a relational database via EF Core.
     /// Supports SQL Server and PostgreSQL (GDPR/ISO 27001 compliant).
     /// Requires <see cref="BackgroundJobsOptions.ConnectionString"/>.
     /// </summary>
-    Durable = 1,
+    Durable,
 }

--- a/src/Granit.DataExchange/Export/ExportJobStatus.cs
+++ b/src/Granit.DataExchange/Export/ExportJobStatus.cs
@@ -6,14 +6,14 @@ namespace Granit.DataExchange.Export;
 public enum ExportJobStatus
 {
     /// <summary>Job created and queued for background execution.</summary>
-    Queued = 0,
+    Queued,
 
     /// <summary>Export is currently being generated.</summary>
-    Exporting = 1,
+    Exporting,
 
     /// <summary>Export completed successfully — file available for download.</summary>
-    Completed = 2,
+    Completed,
 
     /// <summary>Export failed.</summary>
-    Failed = 3,
+    Failed,
 }

--- a/src/Granit.DataExchange/Import/Domain/ImportJobStatus.cs
+++ b/src/Granit.DataExchange/Import/Domain/ImportJobStatus.cs
@@ -6,26 +6,26 @@ namespace Granit.DataExchange.Import.Domain;
 public enum ImportJobStatus
 {
     /// <summary>File uploaded, job created.</summary>
-    Created = 0,
+    Created,
 
     /// <summary>Headers extracted, preview and mapping suggestions generated.</summary>
-    Previewed = 1,
+    Previewed,
 
     /// <summary>Column mappings confirmed by the user.</summary>
-    Mapped = 2,
+    Mapped,
 
     /// <summary>Import is currently executing (Wolverine background handler).</summary>
-    Executing = 3,
+    Executing,
 
     /// <summary>All rows imported successfully.</summary>
-    Completed = 4,
+    Completed,
 
     /// <summary>Some rows failed but others succeeded.</summary>
-    PartiallyCompleted = 5,
+    PartiallyCompleted,
 
     /// <summary>Import failed entirely.</summary>
-    Failed = 6,
+    Failed,
 
     /// <summary>Import was cancelled by the user.</summary>
-    Cancelled = 7,
+    Cancelled,
 }

--- a/src/Granit.DataExchange/Import/Mapping/MappingConfidence.cs
+++ b/src/Granit.DataExchange/Import/Mapping/MappingConfidence.cs
@@ -7,17 +7,17 @@ namespace Granit.DataExchange.Import.Mapping;
 public enum MappingConfidence
 {
     /// <summary>User-confirmed manual mapping (highest priority).</summary>
-    Manual = 0,
+    Manual,
 
     /// <summary>Mapping previously saved and reused.</summary>
-    Saved = 1,
+    Saved,
 
     /// <summary>Exact case-insensitive match on property name or display name.</summary>
-    Exact = 2,
+    Exact,
 
     /// <summary>Fuzzy match (Levenshtein distance within threshold).</summary>
-    Fuzzy = 3,
+    Fuzzy,
 
     /// <summary>AI-assisted semantic match (header metadata only, GDPR-safe).</summary>
-    Semantic = 4,
+    Semantic,
 }

--- a/src/Granit.DataLookup.Abstractions/Descriptors/LookupKind.cs
+++ b/src/Granit.DataLookup.Abstractions/Descriptors/LookupKind.cs
@@ -15,23 +15,23 @@ public enum LookupKind
     /// Backed by a <c>Granit.QueryEngine</c> definition. Full text search, pagination,
     /// tenant isolation and authorization are inherited from the query endpoint.
     /// </summary>
-    QueryEngine = 0,
+    QueryEngine,
 
     /// <summary>
     /// Backed by a custom lightweight HTTP endpoint that returns the canonical
     /// <see cref="LookupResult"/> shape but is not a QueryEngine endpoint.
     /// </summary>
-    Simple = 1,
+    Simple,
 
     /// <summary>
     /// Backed by a <c>Granit.ReferenceData</c> set. Labels are resolved in the user's
     /// culture from the <c>Label{Culture}</c> columns of the reference-data entity.
     /// </summary>
-    ReferenceData = 2,
+    ReferenceData,
 
     /// <summary>
     /// Backed by a CLR <c>enum</c> type. Values are the enum names; labels are resolved
     /// via <c>Granit.Localization</c> keys <c>Enum:{TypeName}.{Value}</c>.
     /// </summary>
-    Enum = 3,
+    Enum,
 }

--- a/src/Granit.DocumentGeneration.Pdf/PdfA/PdfAConversionOptions.cs
+++ b/src/Granit.DocumentGeneration.Pdf/PdfA/PdfAConversionOptions.cs
@@ -40,8 +40,8 @@ public sealed class PdfAConversionOptions
 public enum PdfAConformanceLevel
 {
     /// <summary>PDF/A-3b — visual appearance preserved, embedded files allowed. Required for Factur-X.</summary>
-    PdfA3b = 0,
+    PdfA3b,
 
     /// <summary>PDF/A-2a — tagged PDF with accessibility support. Suitable for medical document archival.</summary>
-    PdfA2a = 1,
+    PdfA2a,
 }

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionKind.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionKind.cs
@@ -8,13 +8,13 @@ namespace Granit.Entities.Actions;
 public enum EntityActionKind
 {
     /// <summary>HTTP write call (POST / PUT / DELETE) to <c>UrlTemplate</c>; optional confirmation modal.</summary>
-    ApiCall = 0,
+    ApiCall,
 
     /// <summary>HTTP GET against <c>UrlTemplate</c> returning a binary payload — opens the browser's download dialog.</summary>
-    Download = 1,
+    Download,
 
     /// <summary>Client-side navigation to <c>UrlTemplate</c> (route or external URL).</summary>
-    Navigate = 2,
+    Navigate,
 
     /// <summary>
     /// Workflow state transition resolved through the entity's
@@ -22,7 +22,7 @@ public enum EntityActionKind
     /// to know whether the transition is currently allowed for the row.
     /// <c>WorkflowTransitionName</c> carries the target state name.
     /// </summary>
-    WorkflowTransition = 3,
+    WorkflowTransition,
 
     /// <summary>
     /// Pure-frontend action that opens the entity's side drawer (peek). When
@@ -31,7 +31,7 @@ public enum EntityActionKind
     /// the renderer fetches the URL and renders the result inside the drawer
     /// (escape hatch for non-default detail surfaces).
     /// </summary>
-    OpenDrawer = 4,
+    OpenDrawer,
 
     /// <summary>
     /// Pure-frontend action that opens a modal dialog. When
@@ -40,5 +40,5 @@ public enum EntityActionKind
     /// inline-edit case). When set, the renderer fetches the URL and renders
     /// the result inside the modal (e.g. import / export wizards).
     /// </summary>
-    OpenModal = 5,
+    OpenModal,
 }

--- a/src/Granit.Entities.Abstractions/EntityEndpointMetadata.cs
+++ b/src/Granit.Entities.Abstractions/EntityEndpointMetadata.cs
@@ -11,7 +11,7 @@ public enum EntityEndpointKind
     /// Paginated query / collection endpoint. By convention the frontend calls
     /// <c>{path}</c> for the page and <c>{path}/meta</c> for the column metadata.
     /// </summary>
-    List = 0,
+    List,
 }
 
 /// <summary>

--- a/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutKind.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutKind.cs
@@ -9,14 +9,14 @@ namespace Granit.Entities.Layouts;
 public enum EntityListLayoutKind
 {
     /// <summary>Default tabular layout — driven by the entity's <c>QueryDefinition</c> columns.</summary>
-    List = 0,
+    List,
 
     /// <summary>Card-board layout grouped by a discrete property (typically an enum or lookup).</summary>
-    Kanban = 1,
+    Kanban,
 
     /// <summary>Time-axis layout (month / week / day grid) keyed on a date or datetime property.</summary>
-    Calendar = 2,
+    Calendar,
 
     /// <summary>Image-card grid layout keyed on a <c>BlobReference</c> property.</summary>
-    Gallery = 3,
+    Gallery,
 }

--- a/src/Granit.Entities.Abstractions/Layouts/GalleryCardSize.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/GalleryCardSize.cs
@@ -8,11 +8,11 @@ namespace Granit.Entities.Layouts;
 public enum GalleryCardSize
 {
     /// <summary>Compact tile — high density, smaller thumbnails.</summary>
-    Small = 0,
+    Small,
 
     /// <summary>Default tile — balanced density vs preview clarity.</summary>
-    Medium = 1,
+    Medium,
 
     /// <summary>Showcase tile — large preview area, lower density.</summary>
-    Large = 2,
+    Large,
 }

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanColor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanColor.cs
@@ -8,29 +8,29 @@ namespace Granit.Entities.Layouts;
 public enum KanbanColor
 {
     /// <summary>Theme-neutral grey — for archived / terminal states.</summary>
-    Neutral = 0,
+    Neutral,
 
     /// <summary>Cool grey — for draft / pending states.</summary>
-    Gray = 1,
+    Gray,
 
     /// <summary>Blue — for in-progress / active states.</summary>
-    Blue = 2,
+    Blue,
 
     /// <summary>Green — for completed / success states.</summary>
-    Green = 3,
+    Green,
 
     /// <summary>Orange — for waiting / attention states.</summary>
-    Orange = 4,
+    Orange,
 
     /// <summary>Red — for blocked / error states.</summary>
-    Red = 5,
+    Red,
 
     /// <summary>Yellow — for warning / soft-attention states.</summary>
-    Yellow = 6,
+    Yellow,
 
     /// <summary>Purple — for special / categorical highlights.</summary>
-    Purple = 7,
+    Purple,
 
     /// <summary>Cyan — for informational / secondary highlights.</summary>
-    Cyan = 8,
+    Cyan,
 }

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanColumnState.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanColumnState.cs
@@ -7,11 +7,11 @@ namespace Granit.Entities.Layouts;
 public enum KanbanColumnState
 {
     /// <summary>Expanded — header + cards visible.</summary>
-    Open = 0,
+    Open,
 
     /// <summary>Collapsed — header + count only.</summary>
-    Collapsed = 1,
+    Collapsed,
 
     /// <summary>Hidden — column is not rendered (toggleable from the column manager).</summary>
-    Hidden = 2,
+    Hidden,
 }

--- a/src/Granit.EntityMerge/WinnerSide.cs
+++ b/src/Granit.EntityMerge/WinnerSide.cs
@@ -4,8 +4,8 @@ namespace Granit.EntityMerge;
 public enum WinnerSide
 {
     /// <summary>Keep the survivor's value (default for most fields).</summary>
-    Survivor = 0,
+    Survivor,
 
     /// <summary>Replace the survivor's value with the loser's.</summary>
-    Loser = 1,
+    Loser,
 }

--- a/src/Granit.Hostnames/Domain/DnsConflictType.cs
+++ b/src/Granit.Hostnames/Domain/DnsConflictType.cs
@@ -4,20 +4,20 @@ namespace Granit.Hostnames.Domain;
 public enum DnsConflictType
 {
     /// <summary>An unexpected A record is present (e.g. pointing at a different IP).</summary>
-    UnexpectedA = 0,
+    UnexpectedA,
 
     /// <summary>An unexpected AAAA record is present.</summary>
-    UnexpectedAaaa = 1,
+    UnexpectedAaaa,
 
     /// <summary>A CNAME record points to the wrong target.</summary>
-    DivergentCname = 2,
+    DivergentCname,
 
     /// <summary>The expected CNAME record is missing.</summary>
-    MissingCname = 3,
+    MissingCname,
 
     /// <summary>The expected TXT verification challenge record is absent or wrong.</summary>
-    MissingTxt = 4,
+    MissingTxt,
 
     /// <summary>DNS resolution failed or timed out.</summary>
-    ResolutionFailure = 5,
+    ResolutionFailure,
 }

--- a/src/Granit.Hostnames/Domain/DnsRecordType.cs
+++ b/src/Granit.Hostnames/Domain/DnsRecordType.cs
@@ -4,14 +4,14 @@ namespace Granit.Hostnames.Domain;
 public enum DnsRecordType
 {
     /// <summary>IPv4 address record.</summary>
-    A = 0,
+    A,
 
     /// <summary>IPv6 address record.</summary>
-    Aaaa = 1,
+    Aaaa,
 
     /// <summary>Canonical name record (alias).</summary>
-    Cname = 2,
+    Cname,
 
     /// <summary>Text record, used for verification challenges.</summary>
-    Txt = 3,
+    Txt,
 }

--- a/src/Granit.Hostnames/Domain/HostnameStatus.cs
+++ b/src/Granit.Hostnames/Domain/HostnameStatus.cs
@@ -8,14 +8,14 @@ namespace Granit.Hostnames.Domain;
 public enum HostnameStatus
 {
     /// <summary>Registered but not yet verified — no DNS challenge attempted.</summary>
-    Pending = 0,
+    Pending,
 
     /// <summary>Verification in progress — DNS is being polled against the expected records.</summary>
-    Verifying = 1,
+    Verifying,
 
     /// <summary>Verified and serving — eligible for host-based routing.</summary>
-    Active = 2,
+    Active,
 
     /// <summary>Verification failed — misconfigured DNS or a conflicting record.</summary>
-    Error = 3,
+    Error,
 }

--- a/src/Granit.Http.Cookies/CookieCategory.cs
+++ b/src/Granit.Http.Cookies/CookieCategory.cs
@@ -6,17 +6,17 @@ namespace Granit.Http.Cookies;
 public enum CookieCategory
 {
     /// <summary>Cookies essential for the application to function (no consent required).</summary>
-    StrictlyNecessary = 0,
+    StrictlyNecessary,
 
     /// <summary>Cookies that remember user preferences (language, theme).</summary>
-    Preferences = 1,
+    Preferences,
 
     /// <summary>Cookies used for analytics and usage tracking.</summary>
-    Analytics = 2,
+    Analytics,
 
     /// <summary>Cookies used for advertising and marketing.</summary>
-    Marketing = 3,
+    Marketing,
 
     /// <summary>Cookies used for selling or sharing personal information (CCPA "Do Not Sell or Share").</summary>
-    SaleOrSharing = 4,
+    SaleOrSharing,
 }

--- a/src/Granit.Http.Cookies/CookieConsentMode.cs
+++ b/src/Granit.Http.Cookies/CookieConsentMode.cs
@@ -7,14 +7,14 @@ namespace Granit.Http.Cookies;
 public enum CookieConsentMode
 {
     /// <summary>User must explicitly opt in before non-essential cookies are set (GDPR, LGPD).</summary>
-    OptIn = 0,
+    OptIn,
 
     /// <summary>Cookies allowed by default; user can opt out (CCPA).</summary>
-    OptOut = 1,
+    OptOut,
 
     /// <summary>Opt-in for sensitive categories, opt-out for non-sensitive (some US states).</summary>
-    Hybrid = 2,
+    Hybrid,
 
     /// <summary>No specific consent requirement for this jurisdiction.</summary>
-    None = 3,
+    None,
 }

--- a/src/Granit.Http.Idempotency/Models/IdempotencyState.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyState.cs
@@ -6,10 +6,10 @@ namespace Granit.Http.Idempotency.Models;
 public enum IdempotencyState : byte
 {
     /// <summary>Request is being executed. Lock held via InProgress TTL.</summary>
-    InProgress = 0,
+    InProgress,
 
     /// <summary>Request completed. Response stored for replay.</summary>
-    Completed = 1,
+    Completed,
 
     /// <summary>
     /// Request completed but its response cannot be replayed (e.g. exceeded
@@ -19,5 +19,5 @@ public enum IdempotencyState : byte
     /// logic. Preserves the at-most-once idempotency guarantee when the
     /// response itself is not cacheable.
     /// </summary>
-    Tombstoned = 2,
+    Tombstoned,
 }

--- a/src/Granit.Http.Idempotency/Models/IdempotencyTombstoneReason.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyTombstoneReason.cs
@@ -15,5 +15,5 @@ public enum IdempotencyTombstoneReason : byte
     /// Response body exceeded <see cref="IdempotencyOptions.MaxResponseSizeBytes"/>.
     /// Replays return HTTP 413 Payload Too Large.
     /// </summary>
-    ResponseTooLarge = 0,
+    ResponseTooLarge,
 }

--- a/src/Granit.Identity.Abstractions/DeviceTrustLevel.cs
+++ b/src/Granit.Identity.Abstractions/DeviceTrustLevel.cs
@@ -7,17 +7,17 @@ namespace Granit.Identity;
 public enum DeviceTrustLevel
 {
     /// <summary>No trust recorded — the device is treated as new/unknown.</summary>
-    None = 0,
+    None,
 
     /// <summary>
     /// Trust established from a signed, revocable device token ("remember this device"). Bound to a
     /// data-protected cookie, time-bounded; spoofable only by exfiltrating the token.
     /// </summary>
-    Remembered = 1,
+    Remembered,
 
     /// <summary>
     /// Trust backed by a device-bound credential (passkey / WebAuthn) — the strongest signal, since the
     /// credential cannot leave the authenticator.
     /// </summary>
-    Strong = 2,
+    Strong,
 }

--- a/src/Granit.Imaging/ImageFormat.cs
+++ b/src/Granit.Imaging/ImageFormat.cs
@@ -6,23 +6,23 @@ namespace Granit.Imaging;
 public enum ImageFormat
 {
     /// <summary>JPEG format — lossy compression, no transparency.</summary>
-    Jpeg = 0,
+    Jpeg,
 
     /// <summary>PNG format — lossless compression, supports transparency.</summary>
-    Png = 1,
+    Png,
 
     /// <summary>WebP format — modern lossy/lossless, smaller than JPEG at equivalent quality.</summary>
-    WebP = 2,
+    WebP,
 
     /// <summary>AVIF format — next-gen lossy/lossless based on AV1, best compression ratio.</summary>
-    Avif = 3,
+    Avif,
 
     /// <summary>GIF format — limited to 256 colors, supports animation.</summary>
-    Gif = 4,
+    Gif,
 
     /// <summary>BMP format — uncompressed bitmap.</summary>
-    Bmp = 5,
+    Bmp,
 
     /// <summary>TIFF format — lossless, used in print and medical imaging.</summary>
-    Tiff = 6,
+    Tiff,
 }

--- a/src/Granit.Imaging/ResizeMode.cs
+++ b/src/Granit.Imaging/ResizeMode.cs
@@ -9,29 +9,29 @@ public enum ResizeMode
     /// Fit within bounds, preserving aspect ratio. The result may be smaller
     /// than the target dimensions (no padding added).
     /// </summary>
-    Max = 0,
+    Max,
 
     /// <summary>
     /// Fit within bounds, preserving aspect ratio. The result is padded
     /// (with transparent pixels) to match the exact target dimensions.
     /// </summary>
-    Pad = 1,
+    Pad,
 
     /// <summary>
     /// Fill the target dimensions exactly by resizing and cropping the overflow.
     /// The image is centered before cropping.
     /// </summary>
-    Crop = 2,
+    Crop,
 
     /// <summary>
     /// Stretch the image to fill the target dimensions exactly.
     /// The aspect ratio is not preserved (image may appear distorted).
     /// </summary>
-    Stretch = 3,
+    Stretch,
 
     /// <summary>
     /// Resize to the minimum bounds, preserving aspect ratio. The result
     /// covers the target dimensions entirely (may exceed them).
     /// </summary>
-    Min = 4,
+    Min,
 }

--- a/src/Granit.Imaging/WatermarkPosition.cs
+++ b/src/Granit.Imaging/WatermarkPosition.cs
@@ -6,17 +6,17 @@ namespace Granit.Imaging;
 public enum WatermarkPosition
 {
     /// <summary>Centered on the image.</summary>
-    Center = 0,
+    Center,
 
     /// <summary>Top-left corner.</summary>
-    TopLeft = 1,
+    TopLeft,
 
     /// <summary>Top-right corner.</summary>
-    TopRight = 2,
+    TopRight,
 
     /// <summary>Bottom-left corner.</summary>
-    BottomLeft = 3,
+    BottomLeft,
 
     /// <summary>Bottom-right corner.</summary>
-    BottomRight = 4,
+    BottomRight,
 }

--- a/src/Granit.Indexing.Elasticsearch/ElasticsearchTenancyStrategy.cs
+++ b/src/Granit.Indexing.Elasticsearch/ElasticsearchTenancyStrategy.cs
@@ -10,7 +10,7 @@ public enum ElasticsearchTenancyStrategy
     /// on <c>tenant_id</c> applied to every read and write. Cheap on cluster resources;
     /// relies on the framework's filter discipline to keep tenants apart.
     /// </summary>
-    Shared = 0,
+    Shared,
 
     /// <summary>
     /// One physical index per <c>(TKey, TenantId)</c> pair. Stricter isolation
@@ -18,5 +18,5 @@ public enum ElasticsearchTenancyStrategy
     /// extra index per tenant. Recommended for ISO 27001 deployments with hard tenant
     /// separation requirements.
     /// </summary>
-    PerTenant = 1,
+    PerTenant,
 }

--- a/src/Granit.Notifications.Abstractions/Domain/UserNotificationState.cs
+++ b/src/Granit.Notifications.Abstractions/Domain/UserNotificationState.cs
@@ -3,6 +3,6 @@ namespace Granit.Notifications.Domain;
 /// <summary>State of an in-app notification.</summary>
 public enum UserNotificationState
 {
-    Unread = 0,
-    Read = 1,
+    Unread,
+    Read,
 }

--- a/src/Granit.Notifications.Abstractions/NotificationSeverity.cs
+++ b/src/Granit.Notifications.Abstractions/NotificationSeverity.cs
@@ -4,13 +4,13 @@ namespace Granit.Notifications;
 public enum NotificationSeverity
 {
     /// <summary>Informational notification.</summary>
-    Info = 0,
+    Info,
     /// <summary>Success notification.</summary>
-    Success = 1,
+    Success,
     /// <summary>Warning notification.</summary>
-    Warning = 2,
+    Warning,
     /// <summary>Error notification.</summary>
-    Error = 3,
+    Error,
     /// <summary>Fatal/critical notification.</summary>
-    Fatal = 4,
+    Fatal,
 }

--- a/src/Granit.Notifications.MobilePush/MobilePlatform.cs
+++ b/src/Granit.Notifications.MobilePush/MobilePlatform.cs
@@ -4,8 +4,8 @@ namespace Granit.Notifications.MobilePush;
 public enum MobilePlatform
 {
     /// <summary>Android device.</summary>
-    Android = 0,
+    Android,
 
     /// <summary>iOS device (iPhone, iPad).</summary>
-    Ios = 1,
+    Ios,
 }

--- a/src/Granit.OpenIddict/Domain/SigningKey.cs
+++ b/src/Granit.OpenIddict/Domain/SigningKey.cs
@@ -100,11 +100,11 @@ public sealed class SigningKey : CreationAuditedEntity, IConcurrencyAware
 public enum SigningKeyStatus
 {
     /// <summary>Key is actively used for signing new tokens.</summary>
-    Active = 0,
+    Active,
 
     /// <summary>Key is retired but still valid for verification (grace period).</summary>
-    Retired = 1,
+    Retired,
 
     /// <summary>Key is revoked and should not be used for anything.</summary>
-    Revoked = 2,
+    Revoked,
 }

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/MigrationPhase.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/MigrationPhase.cs
@@ -9,17 +9,17 @@ public enum MigrationPhase
     /// Add the new column (nullable or with a default value).
     /// Application writes to both old and new columns; reads from the old column only.
     /// </summary>
-    Expand = 0,
+    Expand,
 
     /// <summary>
     /// Background batch job backfills the new column from the old one.
     /// No schema changes occur during this phase.
     /// </summary>
-    Migrate = 1,
+    Migrate,
 
     /// <summary>
     /// Remove the old column. Application reads and writes only the new column.
     /// Requires <see cref="MigrationCycleAttribute"/> annotating the EF Core migration class.
     /// </summary>
-    Contract = 2,
+    Contract,
 }

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/MigrationStatus.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/MigrationStatus.cs
@@ -6,14 +6,14 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations;
 public enum MigrationStatus
 {
     /// <summary>The cycle has been registered but the backfill job has not started yet.</summary>
-    Pending = 0,
+    Pending,
 
     /// <summary>The backfill job is actively processing batches.</summary>
-    InProgress = 1,
+    InProgress,
 
     /// <summary>All rows have been successfully migrated.</summary>
-    Completed = 2,
+    Completed,
 
     /// <summary>The backfill job failed. Inspect <c>MigrationProgress.Error</c> for details.</summary>
-    Failed = 3,
+    Failed,
 }

--- a/src/Granit.Presence/Domain/PresenceConnectivity.cs
+++ b/src/Granit.Presence/Domain/PresenceConnectivity.cs
@@ -6,11 +6,11 @@ namespace Granit.Presence.Domain;
 public enum PresenceConnectivity
 {
     /// <summary>Active heartbeat recently and reported activity recently.</summary>
-    Online = 0,
+    Online,
 
     /// <summary>Active heartbeat but user reported being idle for longer than the away threshold.</summary>
-    Away = 1,
+    Away,
 
     /// <summary>No heartbeat within the offline threshold.</summary>
-    Offline = 2,
+    Offline,
 }

--- a/src/Granit.Presence/Domain/PresenceStatus.cs
+++ b/src/Granit.Presence/Domain/PresenceStatus.cs
@@ -8,17 +8,17 @@ namespace Granit.Presence.Domain;
 public enum PresenceStatus
 {
     /// <summary>User is connected and recently active.</summary>
-    Online = 0,
+    Online,
 
     /// <summary>User is connected but has been idle longer than the configured threshold.</summary>
-    Away = 1,
+    Away,
 
     /// <summary>User has no active connection (or has manually chosen to appear offline).</summary>
-    Offline = 2,
+    Offline,
 
     /// <summary>User is online but has marked themselves as busy. Push notifications still delivered.</summary>
-    Busy = 3,
+    Busy,
 
     /// <summary>User has muted intrusive push notifications. Store-and-forward channels keep delivering.</summary>
-    DoNotDisturb = 4,
+    DoNotDisturb,
 }

--- a/src/Granit.Privacy.AI/Options/PrivacyAIOptions.cs
+++ b/src/Granit.Privacy.AI/Options/PrivacyAIOptions.cs
@@ -51,8 +51,8 @@ public sealed class PrivacyAIOptions
 public enum PiiDetectionFailMode
 {
     /// <summary>Assume PII is present on failure (conservative — safe default).</summary>
-    Closed = 0,
+    Closed,
 
     /// <summary>Assume no PII on failure (permissive — for development/testing only).</summary>
-    Open = 1,
+    Open,
 }

--- a/src/Granit.Privacy.Regulations/ConsentModel.cs
+++ b/src/Granit.Privacy.Regulations/ConsentModel.cs
@@ -6,14 +6,14 @@ namespace Granit.Privacy.Regulations;
 public enum ConsentModel
 {
     /// <summary>User must explicitly opt in before processing (GDPR, LGPD, PIPL, DPDPA).</summary>
-    OptIn = 0,
+    OptIn,
 
     /// <summary>Processing allowed by default; user can opt out (CCPA).</summary>
-    OptOut = 1,
+    OptOut,
 
     /// <summary>Opt-in for sensitive data, opt-out for non-sensitive (some US states).</summary>
-    Hybrid = 2,
+    Hybrid,
 
     /// <summary>No specific consent requirement for this jurisdiction.</summary>
-    None = 3,
+    None,
 }

--- a/src/Granit.Privacy.Regulations/ResponseDeadline/PrivacyRequestType.cs
+++ b/src/Granit.Privacy.Regulations/ResponseDeadline/PrivacyRequestType.cs
@@ -6,20 +6,20 @@ namespace Granit.Privacy.Regulations.ResponseDeadline;
 public enum PrivacyRequestType
 {
     /// <summary>Data subject access request (GDPR Art. 15, LGPD Art. 18, CCPA).</summary>
-    SubjectAccessRequest = 0,
+    SubjectAccessRequest,
 
     /// <summary>Data deletion request (GDPR Art. 17, LGPD Art. 18, CCPA).</summary>
-    DeletionRequest = 1,
+    DeletionRequest,
 
     /// <summary>Data rectification request (GDPR Art. 16).</summary>
-    RectificationRequest = 2,
+    RectificationRequest,
 
     /// <summary>Data portability request (GDPR Art. 20).</summary>
-    DataPortability = 3,
+    DataPortability,
 
     /// <summary>Processing restriction request (GDPR Art. 18).</summary>
-    ProcessingRestriction = 4,
+    ProcessingRestriction,
 
     /// <summary>Opt-out of sale/sharing (CCPA).</summary>
-    OptOut = 5,
+    OptOut,
 }

--- a/src/Granit.Privacy/DataDeletion/DeletionAction.cs
+++ b/src/Granit.Privacy/DataDeletion/DeletionAction.cs
@@ -7,20 +7,20 @@ namespace Granit.Privacy.DataDeletion;
 public enum DeletionAction
 {
     /// <summary>Data was permanently removed from the database.</summary>
-    PhysicalDelete = 0,
+    PhysicalDelete,
 
     /// <summary>Data was soft-deleted via <c>ISoftDeletable</c>.</summary>
-    SoftDelete = 1,
+    SoftDelete,
 
     /// <summary>PII was replaced with pseudonymized values (ISO 27001 retention — data preserved, identity removed).</summary>
-    Anonymized = 2,
+    Anonymized,
 
     /// <summary>Data was retained as-is due to a legal obligation (e.g., ISO 27001 20-year retention).</summary>
-    Retained = 3,
+    Retained,
 
     /// <summary>Combination of multiple actions (e.g., PII anonymized + medical data retained).</summary>
-    Mixed = 4,
+    Mixed,
 
     /// <summary>Per-entity encryption key was permanently destroyed — ciphertext is mathematically unreadable (GDPR Art. 17 crypto-shredding).</summary>
-    CryptoShredding = 5
+    CryptoShredding
 }

--- a/src/Granit.Privacy/DataDeletion/DeletionRequestState.cs
+++ b/src/Granit.Privacy/DataDeletion/DeletionRequestState.cs
@@ -6,17 +6,17 @@ namespace Granit.Privacy.DataDeletion;
 public enum DeletionRequestState
 {
     /// <summary>Grace period active — deletion not yet executed, user may cancel.</summary>
-    Deferred = 0,
+    Deferred,
 
     /// <summary>
     /// Deadline reached and every registered provider has acknowledged erasure of its data.
     /// This is the only state that proves GDPR Art. 17 completion — the fan-in over provider
     /// acknowledgements guarantees it is never reached while a downstream deletion is still pending.
     /// </summary>
-    Executed = 1,
+    Executed,
 
     /// <summary>User cancelled the deletion request during the grace period.</summary>
-    Cancelled = 2,
+    Cancelled,
 
     /// <summary>
     /// Deadline reached and the provider fan-out has started, but not every provider has
@@ -25,7 +25,7 @@ public enum DeletionRequestState
     /// (<see cref="Events.PersonalDataDeletedEto"/> from each provider) or the acknowledgement
     /// window elapses.
     /// </summary>
-    Executing = 3,
+    Executing,
 
     /// <summary>
     /// The acknowledgement window elapsed before every provider confirmed erasure. At least one
@@ -33,5 +33,5 @@ public enum DeletionRequestState
     /// The request is NOT provably complete — an operator must reconcile the missing providers
     /// (surfaced by the stuck-deletion metric/log) before the erasure can be attested for Art. 17.
     /// </summary>
-    PartiallyExecuted = 4,
+    PartiallyExecuted,
 }

--- a/src/Granit.Privacy/DataExport/ExportRequestState.cs
+++ b/src/Granit.Privacy/DataExport/ExportRequestState.cs
@@ -6,20 +6,20 @@ namespace Granit.Privacy.DataExport;
 public enum ExportRequestState
 {
     /// <summary>Request submitted, scatter-gather saga in progress.</summary>
-    Pending = 0,
+    Pending,
 
     /// <summary>All data providers responded — archive is ready for download.</summary>
-    Completed = 1,
+    Completed,
 
     /// <summary>Saga timed out but some providers responded — partial archive available.</summary>
-    PartiallyCompleted = 2,
+    PartiallyCompleted,
 
     /// <summary>Saga timed out with no provider responses.</summary>
-    TimedOut = 3,
+    TimedOut,
 
     /// <summary>
     /// Archive assembly aborted because the ZIP exceeded
     /// <see cref="Options.GranitPrivacyOptions.ExportMaxSizeMb"/>.
     /// </summary>
-    SizeLimitExceeded = 4,
+    SizeLimitExceeded,
 }

--- a/src/Granit.Privacy/OptOut/OptOutState.cs
+++ b/src/Granit.Privacy/OptOut/OptOutState.cs
@@ -6,8 +6,8 @@ namespace Granit.Privacy.OptOut;
 public enum OptOutState
 {
     /// <summary>Opt-out is active — data must not be sold or shared.</summary>
-    Active = 0,
+    Active,
 
     /// <summary>Opt-out has been revoked by the user.</summary>
-    Revoked = 1,
+    Revoked,
 }

--- a/src/Granit.RateLimiting/Options/CounterStoreFailureBehavior.cs
+++ b/src/Granit.RateLimiting/Options/CounterStoreFailureBehavior.cs
@@ -9,11 +9,11 @@ public enum CounterStoreFailureBehavior : byte
     /// Open degradation: allow the request and log a warning.
     /// Prevents a Redis outage from causing complete service unavailability.
     /// </summary>
-    Allow = 0,
+    Allow,
 
     /// <summary>
     /// Closed degradation: reject the request with 429.
     /// Conservative approach — prefer availability loss over quota bypass.
     /// </summary>
-    Deny = 1,
+    Deny,
 }

--- a/src/Granit.RateLimiting/Options/RateLimitAlgorithm.cs
+++ b/src/Granit.RateLimiting/Options/RateLimitAlgorithm.cs
@@ -6,14 +6,14 @@ namespace Granit.RateLimiting.Options;
 public enum RateLimitAlgorithm : byte
 {
     /// <summary>Sliding window with configurable segments. Most accurate, moderate memory.</summary>
-    SlidingWindow = 0,
+    SlidingWindow,
 
     /// <summary>Fixed window with single counter. Lightest but subject to burst at window edges.</summary>
-    FixedWindow = 1,
+    FixedWindow,
 
     /// <summary>Token bucket with configurable refill rate. Best for controlled burst allowance.</summary>
-    TokenBucket = 2,
+    TokenBucket,
 
     /// <summary>Concurrency limiter. Limits simultaneous in-flight requests, not rate.</summary>
-    Concurrency = 3,
+    Concurrency,
 }

--- a/src/Granit.RateLimiting/Options/RateLimitPartition.cs
+++ b/src/Granit.RateLimiting/Options/RateLimitPartition.cs
@@ -7,17 +7,17 @@ namespace Granit.RateLimiting.Options;
 public enum RateLimitPartition : byte
 {
     /// <summary>Partition by tenant only. All users of a tenant share the same quota.</summary>
-    Tenant = 0,
+    Tenant,
 
     /// <summary>Partition by tenant and client IP. Each IP gets its own quota within a tenant.</summary>
-    TenantAndIp = 1,
+    TenantAndIp,
 
     /// <summary>Partition by client IP only. Recommended for unauthenticated endpoints (login, password reset).</summary>
-    Ip = 2,
+    Ip,
 
     /// <summary>Partition by authenticated user. Each user gets their own quota.</summary>
-    User = 3,
+    User,
 
     /// <summary>Partition by tenant and authenticated user. Each user gets their own quota within a tenant.</summary>
-    TenantAndUser = 4,
+    TenantAndUser,
 }

--- a/src/Granit.Scheduling/Domain/ScheduledActionStatus.cs
+++ b/src/Granit.Scheduling/Domain/ScheduledActionStatus.cs
@@ -8,26 +8,26 @@ public enum ScheduledActionStatus
     /// <summary>
     /// The action is waiting for its scheduled execution time.
     /// </summary>
-    Pending = 0,
+    Pending,
 
     /// <summary>
     /// The action has been executed successfully.
     /// </summary>
-    Executed = 1,
+    Executed,
 
     /// <summary>
     /// The action was cancelled before execution.
     /// </summary>
-    Cancelled = 2,
+    Cancelled,
 
     /// <summary>
     /// The action failed during execution (handler threw after exhausting retries).
     /// </summary>
-    Failed = 3,
+    Failed,
 
     /// <summary>
     /// The action has been claimed for execution and is currently being processed.
     /// Transitional status that prevents double-execution via concurrent dispatch.
     /// </summary>
-    Processing = 4,
+    Processing,
 }

--- a/src/Granit.Templating/Keys/DocumentFormat.cs
+++ b/src/Granit.Templating/Keys/DocumentFormat.cs
@@ -11,11 +11,11 @@ namespace Granit.Templating.Keys;
 public enum DocumentFormat
 {
     /// <summary>HTML text output — used by <c>ITextTemplateRenderer</c> for email, SMS and push notifications.</summary>
-    Html = 0,
+    Html,
 
     /// <summary>PDF binary output — requires <c>Granit.DocumentGeneration.Pdf</c>.</summary>
-    Pdf = 1,
+    Pdf,
 
     /// <summary>Excel binary output — requires <c>Granit.DocumentGeneration.Excel</c>.</summary>
-    Excel = 2,
+    Excel,
 }

--- a/src/Granit.TextExtraction/ExtractionConfidence.cs
+++ b/src/Granit.TextExtraction/ExtractionConfidence.cs
@@ -18,14 +18,14 @@ public enum ExtractionConfidence
     /// PdfPig, Markdig). The same input always produces the same output; no opportunity for
     /// an attacker to hijack the extraction loop through the document contents.
     /// </summary>
-    Deterministic = 0,
+    Deterministic,
 
     /// <summary>
     /// Output of a deterministic parser running on degraded input — typically a recovery
     /// path (e.g. PdfPig's raw-word fallback on a layout-analysis failure). The result is
     /// still produced by code, not a model, but ordering or punctuation may be wrong.
     /// </summary>
-    Heuristic = 1,
+    Heuristic,
 
     /// <summary>
     /// Output produced by an LLM or VLM (vision OCR, future structured-extraction prompts).
@@ -33,5 +33,5 @@ public enum ExtractionConfidence
     /// an explicit envelope (<c>&lt;extracted&gt;...&lt;/extracted&gt;</c>) in the downstream
     /// system message, or strip before re-use.
     /// </summary>
-    ModelGenerated = 2,
+    ModelGenerated,
 }

--- a/src/Granit.Timeline/Domain/TimelineEntryType.cs
+++ b/src/Granit.Timeline/Domain/TimelineEntryType.cs
@@ -7,11 +7,11 @@ namespace Granit.Timeline.Domain;
 public enum TimelineEntryType
 {
     /// <summary>Human-authored comment visible to all followers. Soft-deletable (GDPR).</summary>
-    Comment = 0,
+    Comment,
 
     /// <summary>Auto-generated immutable system log. INSERT-only for ISO 27001 audit trail.</summary>
-    SystemLog = 1,
+    SystemLog,
 
     /// <summary>Human-authored internal note visible only to staff. Soft-deletable (GDPR).</summary>
-    InternalNote = 2,
+    InternalNote,
 }

--- a/src/Granit.Timeline/Events/ReactionToggledEvent.cs
+++ b/src/Granit.Timeline/Events/ReactionToggledEvent.cs
@@ -22,8 +22,8 @@ public sealed record ReactionToggledEvent(
 public enum ReactionToggleAction
 {
     /// <summary>The reaction was previously absent and has been added.</summary>
-    Added = 0,
+    Added,
 
     /// <summary>The reaction was previously present and has been removed.</summary>
-    Removed = 1,
+    Removed,
 }

--- a/src/Granit.Timeline/Exceptions/TimelineEntryNotEditableException.cs
+++ b/src/Granit.Timeline/Exceptions/TimelineEntryNotEditableException.cs
@@ -19,14 +19,14 @@ public sealed class TimelineEntryNotEditableException(TimelineEntryNotEditableRe
 public enum TimelineEntryNotEditableReason
 {
     /// <summary>The entry is projected from an external <see cref="ITimelineSource"/> (anchor shadow or live projection).</summary>
-    ExternalOrigin = 0,
+    ExternalOrigin,
 
     /// <summary>The entry is a <c>SystemLog</c> — immutable by design (ISO 27001).</summary>
-    SystemLog = 1,
+    SystemLog,
 
     /// <summary>The current user is not the author of the entry.</summary>
-    NotAuthor = 2,
+    NotAuthor,
 
     /// <summary>The edit window configured in <c>TimelineOptions.EditWindow</c> has elapsed.</summary>
-    WindowExpired = 3,
+    WindowExpired,
 }

--- a/src/Granit.Timeline/Options/TimelineOptions.cs
+++ b/src/Granit.Timeline/Options/TimelineOptions.cs
@@ -47,8 +47,8 @@ public enum SourceFailurePolicy
     /// Drop the failing source from the merged response and surface it via the
     /// <c>X-Timeline-Degraded-Sources</c> header. Recommended for production.
     /// </summary>
-    DegradeGracefully = 0,
+    DegradeGracefully,
 
     /// <summary>Rethrow the first source failure as a 500. Use in dev/test to fail loud.</summary>
-    ThrowAll = 1,
+    ThrowAll,
 }

--- a/src/Granit.Timeline/TimelineEntryOrigin.cs
+++ b/src/Granit.Timeline/TimelineEntryOrigin.cs
@@ -11,8 +11,8 @@ namespace Granit.Timeline;
 public enum TimelineEntryOrigin
 {
     /// <summary>Entry stored directly in the Timeline table (Comment, InternalNote, or native SystemLog).</summary>
-    Native = 0,
+    Native,
 
     /// <summary>Entry projected from a registered <see cref="Abstractions.ITimelineSource"/>.</summary>
-    External = 1,
+    External,
 }

--- a/src/Granit.Timeline/TimelineStreamEntryType.cs
+++ b/src/Granit.Timeline/TimelineStreamEntryType.cs
@@ -12,11 +12,11 @@ namespace Granit.Timeline;
 public enum TimelineStreamEntryType
 {
     /// <summary>Human-authored comment.</summary>
-    Comment = 0,
+    Comment,
 
     /// <summary>Auto-generated system log entry.</summary>
-    SystemLog = 1,
+    SystemLog,
 
     /// <summary>Human-authored internal note (staff-only).</summary>
-    InternalNote = 2,
+    InternalNote,
 }

--- a/src/Granit.Webhooks/Domain/WebhookSigningKeyStatus.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSigningKeyStatus.cs
@@ -18,14 +18,14 @@ namespace Granit.Webhooks.Domain;
 public enum WebhookSigningKeyStatus
 {
     /// <summary>Currently used to sign outgoing deliveries.</summary>
-    Active = 0,
+    Active,
 
     /// <summary>
     /// Replaced by a newer <see cref="Active"/> key but still accepted during the
     /// rotation grace period (controlled by <see cref="WebhookSigningKey.ExpiresAt"/>).
     /// </summary>
-    Retired = 1,
+    Retired,
 
     /// <summary>Explicitly invalidated by an operator. Never accepted.</summary>
-    Revoked = 2,
+    Revoked,
 }

--- a/src/Granit.Webhooks/Domain/WebhookSubscriptionStatus.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscriptionStatus.cs
@@ -6,16 +6,16 @@ namespace Granit.Webhooks.Domain;
 public enum WebhookSubscriptionStatus
 {
     /// <summary>Subscription is active and receives delivery attempts.</summary>
-    Active = 0,
+    Active,
 
     /// <summary>
     /// Subscription is temporarily suspended (e.g., after repeated HTTP failures).
     /// Can be reactivated by an operator.
     /// </summary>
-    Suspended = 1,
+    Suspended,
 
     /// <summary>
     /// Subscription has been permanently deactivated and will never receive deliveries.
     /// </summary>
-    Deactivated = 2,
+    Deactivated,
 }

--- a/src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs
+++ b/src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs
@@ -134,14 +134,14 @@ public sealed class RetryWebhookResult
 public enum RetryWebhookErrorKind
 {
     /// <summary>No error.</summary>
-    None = 0,
+    None,
 
     /// <summary>The delivery attempt or subscription was not found (404).</summary>
-    NotFound = 1,
+    NotFound,
 
     /// <summary>The delivery attempt is not eligible for retry (400).</summary>
-    InvalidRequest = 2,
+    InvalidRequest,
 
     /// <summary>The subscription is deactivated (409).</summary>
-    Conflict = 3,
+    Conflict,
 }

--- a/src/Granit.Workflow/Domain/WorkflowLifecycleStatus.cs
+++ b/src/Granit.Workflow/Domain/WorkflowLifecycleStatus.cs
@@ -8,21 +8,21 @@ namespace Granit.Workflow.Domain;
 public enum WorkflowLifecycleStatus
 {
     /// <summary>Being edited. Not visible to standard queries (filtered by IPublishable).</summary>
-    Draft = 0,
+    Draft,
 
     /// <summary>Submitted for review. Awaiting approval from a user with the required permission.</summary>
-    PendingReview = 1,
+    PendingReview,
 
     /// <summary>
     /// Active published version. Exactly one per <see cref="IVersioned.VersionId"/>
     /// at any time (enforced by unique filtered index).
     /// Maps to <c>IPublishable.IsPublished = true</c>.
     /// </summary>
-    Published = 2,
+    Published,
 
     /// <summary>
     /// Former published version, superseded by a newer publication.
     /// Preserved indefinitely for ISO 27001 audit trail (3-year retention).
     /// </summary>
-    Archived = 3,
+    Archived,
 }

--- a/src/Granit/DataProtection/SensitiveDataMode.cs
+++ b/src/Granit/DataProtection/SensitiveDataMode.cs
@@ -10,18 +10,18 @@ public enum SensitiveDataMode
     /// Replace the value with a fixed mask (<c>"***"</c>).
     /// Default — suitable for most PII (names, emails, addresses).
     /// </summary>
-    Mask = 0,
+    Mask,
 
     /// <summary>
     /// Remove the property entirely from the output.
     /// Use for secrets, passwords, tokens — values that should never leave the system boundary.
     /// </summary>
-    Omit = 1,
+    Omit,
 
     /// <summary>
     /// Replace the value with a one-way SHA-256 hash.
     /// Preserves correlation capability (same input → same hash) without exposing the actual value.
     /// Use for identifiers that consumers need to group or deduplicate (e.g., external user IDs).
     /// </summary>
-    Hash = 2,
+    Hash,
 }

--- a/src/Granit/DataProtection/Sensitivity.cs
+++ b/src/Granit/DataProtection/Sensitivity.cs
@@ -21,17 +21,17 @@ public enum Sensitivity
     /// Low-sensitivity personal data — not a direct identifier on its own.
     /// Examples: first name, last name, username, display name, job title.
     /// </summary>
-    Internal = 0,
+    Internal,
 
     /// <summary>
     /// PII that can identify a person directly or indirectly.
     /// Examples: email, phone number, IP address, postal address, date of birth.
     /// </summary>
-    Confidential = 1,
+    Confidential,
 
     /// <summary>
     /// Highly sensitive data — secrets, credentials, or special-category PII (GDPR Art. 9).
     /// Examples: password hash, API key, token, SSN, health data, bank account, biometric data.
     /// </summary>
-    Restricted = 2,
+    Restricted,
 }

--- a/src/Granit/Domain/ValueObjects/AddressDeliveryPointType.cs
+++ b/src/Granit/Domain/ValueObjects/AddressDeliveryPointType.cs
@@ -7,11 +7,11 @@ namespace Granit.Domain.ValueObjects;
 public enum AddressDeliveryPointType
 {
     /// <summary>A regular street address.</summary>
-    Street = 0,
+    Street,
 
     /// <summary>A post-office box — postal mail only, no courier delivery.</summary>
-    PoBox = 1,
+    PoBox,
 
     /// <summary>Any other delivery point (military, poste restante, …).</summary>
-    Other = 2,
+    Other,
 }

--- a/src/Granit/Domain/ValueObjects/AddressGeocodingStatus.cs
+++ b/src/Granit/Domain/ValueObjects/AddressGeocodingStatus.cs
@@ -8,17 +8,17 @@ namespace Granit.Domain.ValueObjects;
 public enum AddressGeocodingStatus
 {
     /// <summary>Address attached, never geocoded — awaiting a first attempt.</summary>
-    Pending = 0,
+    Pending,
 
     /// <summary>Resolved to a precise coordinate (rooftop or street-level match).</summary>
-    Resolved = 1,
+    Resolved,
 
     /// <summary>Resolved, but only to a locality / postcode centroid — coarse.</summary>
-    Approximate = 2,
+    Approximate,
 
     /// <summary>No match found (likely a typo, or a gap in the provider's coverage). Not the same as invalid.</summary>
-    Failed = 3,
+    Failed,
 
     /// <summary>The address changed since the last successful geocoding — to be re-resolved.</summary>
-    Stale = 4,
+    Stale,
 }

--- a/src/Granit/Domain/ValueObjects/AddressVerificationSource.cs
+++ b/src/Granit/Domain/ValueObjects/AddressVerificationSource.cs
@@ -7,20 +7,20 @@ namespace Granit.Domain.ValueObjects;
 public enum AddressVerificationSource
 {
     /// <summary>No source (the default for <see cref="AddressVerificationStatus.Unverified"/>).</summary>
-    None = 0,
+    None,
 
     /// <summary>Inferred from geocoding plausibility — weak (existence, not deliverability).</summary>
-    Geocoding = 1,
+    Geocoding,
 
     /// <summary>An authoritative address-verification provider.</summary>
-    VerificationProvider = 2,
+    VerificationProvider,
 
     /// <summary>A human operator confirmed it.</summary>
-    Manual = 3,
+    Manual,
 
     /// <summary>A successful courier delivery to the address.</summary>
-    Delivery = 4,
+    Delivery,
 
     /// <summary>A successful postal mailing (non-returned mail).</summary>
-    PostalMail = 5,
+    PostalMail,
 }

--- a/src/Granit/Domain/ValueObjects/AddressVerificationStatus.cs
+++ b/src/Granit/Domain/ValueObjects/AddressVerificationStatus.cs
@@ -8,20 +8,20 @@ namespace Granit.Domain.ValueObjects;
 public enum AddressVerificationStatus
 {
     /// <summary>No verification evidence yet.</summary>
-    Unverified = 0,
+    Unverified,
 
     /// <summary>Confirmed by an authoritative verification provider (DPV / RDI).</summary>
-    ProviderVerified = 1,
+    ProviderVerified,
 
     /// <summary>Confirmed by a provider, which standardized / corrected the input.</summary>
-    Corrected = 2,
+    Corrected,
 
     /// <summary>Confirmed manually by an operator.</summary>
-    ManuallyConfirmed = 3,
+    ManuallyConfirmed,
 
     /// <summary>Confirmed by a real-world positive outcome (successful courier delivery or postal mail).</summary>
-    DeliveryConfirmed = 4,
+    DeliveryConfirmed,
 
     /// <summary>Known bad — a provider rejected it, or a delivery / mailing came back undeliverable.</summary>
-    Invalid = 5,
+    Invalid,
 }

--- a/src/Granit/Domain/ValueObjects/GeocodeMatchPrecision.cs
+++ b/src/Granit/Domain/ValueObjects/GeocodeMatchPrecision.cs
@@ -8,11 +8,11 @@ namespace Granit.Domain.ValueObjects;
 public enum GeocodeMatchPrecision
 {
     /// <summary>Matched to an exact building / house number.</summary>
-    Rooftop = 0,
+    Rooftop,
 
     /// <summary>Matched to a street (interpolated along the road).</summary>
-    Street = 1,
+    Street,
 
     /// <summary>Matched only to a locality / postcode centroid.</summary>
-    Locality = 2,
+    Locality,
 }

--- a/tests/Granit.Analyzers.CodeFixes.Tests/RedundantEnumValueCodeFixProviderTests.cs
+++ b/tests/Granit.Analyzers.CodeFixes.Tests/RedundantEnumValueCodeFixProviderTests.cs
@@ -1,0 +1,52 @@
+using Xunit;
+
+namespace Granit.Analyzers.CodeFixes.Tests;
+
+public sealed class RedundantEnumValueCodeFixProviderTests
+{
+    [Fact]
+    public async Task Removes_redundant_initializer_from_first_member()
+    {
+        string source = """
+            public enum ChartType
+            {
+                Bar = 0,
+                Line = 1,
+                Area = 2,
+            }
+            """;
+
+        string expected = """
+            public enum ChartType
+            {
+                Bar,
+                Line = 1,
+                Area = 2,
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<RedundantEnumValueAnalyzer, RedundantEnumValueCodeFixProvider>(
+            source, expected);
+    }
+
+    [Fact]
+    public async Task Removes_redundant_initializer_from_single_member_enum()
+    {
+        string source = """
+            public enum SingleKind
+            {
+                Only = 0,
+            }
+            """;
+
+        string expected = """
+            public enum SingleKind
+            {
+                Only,
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<RedundantEnumValueAnalyzer, RedundantEnumValueCodeFixProvider>(
+            source, expected);
+    }
+}

--- a/tests/Granit.Analyzers.Tests/RedundantEnumValueAnalyzerTests.cs
+++ b/tests/Granit.Analyzers.Tests/RedundantEnumValueAnalyzerTests.cs
@@ -1,0 +1,190 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analyzers.Tests;
+
+public sealed class RedundantEnumValueAnalyzerTests
+{
+    private const string PersistAsIntStub = """
+        namespace Granit.Domain
+        {
+            [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
+            public sealed class PersistAsIntAttribute : System.Attribute { }
+        }
+        """;
+
+    private static async Task<ImmutableArray<Diagnostic>> RunAsync(string source, params string[] additionalSources)
+        => await AnalyzerTestHelpers.RunAnalyzerAsync<RedundantEnumValueAnalyzer>(
+            source, additionalSources, TestContext.Current.CancellationToken);
+
+    private static int CountGrEnum(ImmutableArray<Diagnostic> diagnostics)
+        => diagnostics.Count(d => d.Id == RedundantEnumValueAnalyzer.DiagnosticId);
+
+    [Fact]
+    public async Task GRENUM001_fires_on_every_member_of_a_sequential_from_zero_enum()
+    {
+        string source = """
+            public enum ChartType
+            {
+                Bar = 0,
+                Line = 1,
+                Area = 2,
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await RunAsync(source);
+
+        CountGrEnum(diagnostics).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_on_enum_without_explicit_values()
+    {
+        string source = """
+            public enum ChartType
+            {
+                Bar,
+                Line,
+                Area,
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_on_flags_enum()
+    {
+        string source = """
+            [System.Flags]
+            public enum Capabilities
+            {
+                None = 0,
+                Read = 1,
+                Write = 2,
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_on_non_zero_start()
+    {
+        string source = """
+            public enum Tier
+            {
+                Deterministic = 1,
+                Blocking = 2,
+                Fuzzy = 3,
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_on_gapped_wire_codes()
+    {
+        string source = """
+            public enum RedirectType
+            {
+                MovedPermanently = 301,
+                Found = 302,
+                TemporaryRedirect = 307,
+                PermanentRedirect = 308,
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_on_shift_expressions()
+    {
+        string source = """
+            public enum Sides
+            {
+                Host = 1 << 0,
+                Tenant = 1 << 1,
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_on_partial_explicit_values()
+    {
+        string source = """
+            public enum DeviceKind
+            {
+                Unknown = 0,
+                Phone,
+                Tablet,
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_when_enum_is_consumed_by_a_PersistAsInt_property()
+    {
+        string source = """
+            using Granit.Domain;
+
+            public enum ManualStatus
+            {
+                Available = 0,
+                Busy = 1,
+                Away = 2,
+            }
+
+            public class UserPresence
+            {
+                [PersistAsInt]
+                public ManualStatus Status { get; set; }
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source, PersistAsIntStub)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_silent_when_enum_is_consumed_by_a_nullable_PersistAsInt_property()
+    {
+        string source = """
+            using Granit.Domain;
+
+            public enum ManualStatus
+            {
+                Available = 0,
+                Busy = 1,
+            }
+
+            public class UserPresence
+            {
+                [PersistAsInt]
+                public ManualStatus? Status { get; set; }
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source, PersistAsIntStub)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GRENUM001_fires_on_single_member_enum()
+    {
+        string source = """
+            public enum SingleKind
+            {
+                Only = 0,
+            }
+            """;
+
+        CountGrEnum(await RunAsync(source)).ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## What

Adds **`GRENUM001`** (`RedundantEnumValueAnalyzer` + batch code-fix, category **Design**/Warning) and strips redundant sequential `= 0, 1, 2, …` explicit values from **68 string-persisted enums (258 members)** across the framework.

## Why

Under [ADR-059](https://granit-fx.dev/dotnet/architecture/adr/059-enum-persistence-strategy/), enums persist as their PascalCase **name** (`varchar`) and serialise by name on the wire. A sequential-from-zero explicit value is therefore **inert** — it changes neither storage nor JSON — while misleadingly implying a numeric contract, which discourages the safe "append a member anywhere" refactor the convention is built to enable. A 2026-07 audit of all four .NET repos found 162 such enums with no rule governing them (the same drift ADR-059 solved for `HasConversion<string>()`).

## The analyzer

`GRENUM001` fires only when **every** member restates its zero-based ordinal as a plain decimal literal. It never fires on:

- `[Flags]` enums (bitmask power-of-two values),
- enums consumed by a `[PersistAsInt]` member anywhere in the compilation (the integer is the persisted contract — reordering corrupts data; e.g. `ManualPresenceStatus`),
- enums with a gap, non-zero start, or non-literal initializer (`1 << 2`, `Other`, `301` — deliberate contracts like `RedirectType`).

Standard `[SuppressMessage("Design", "GRENUM001")]` covers rare external numeric protocols. The batch code-fix removes the redundant initializer, so `dotnet format analyzers --diagnostics GRENUM001` cleans a repo in one pass.

## Safety of the bulk change

Declaration order is unchanged, so **every ordinal, cast, and comparison is byte-identical** — a pure no-op. `[Flags]`, `[PersistAsInt]`, and gapped/wire-code enums are left untouched (verified: only `ManualPresenceStatus` uses an int converter, and it is correctly excluded).

## Verification

- 12 new analyzer + code-fix tests; full `Granit.Analyzers.Tests` (126) and `Granit.Analyzers.CodeFixes.Tests` (34) green.
- All **31 affected projects build with zero `GRENUM001`** remaining.
- `dotnet format --verify-no-changes` clean; representative module tests pass (DataExchange 368, Privacy 299, Imaging 42, Notifications).
- `AnalyzerReleases.Unshipped.md` + `Granit.Analyzers/README.md` updated.

## Follow-up (separate, GitLab repos)

Downstream inherits the guard on the next `Granit.Analyzers` bump; cleanup is one `dotnet format` pass each: **granit-business 57**, **granit-website 31**, **granit-iot 3** enums.