### PR TITLE
feat(workflow): scheduled workflow transitions bridge (#2921)

### DIFF
--- a/.github/shard-filters/application.slnf
+++ b/.github/shard-filters/application.slnf
@@ -54,6 +54,7 @@
       "src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj",
       "src/Granit.QueryEngine.EntityFrameworkCore/Granit.QueryEngine.EntityFrameworkCore.csproj",
       "src/Granit.QueryEngine/Granit.QueryEngine.csproj",
+      "src/Granit.Scheduling/Granit.Scheduling.csproj",
       "src/Granit.Settings/Granit.Settings.csproj",
       "src/Granit.Templating.AI/Granit.Templating.AI.csproj",
       "src/Granit.Templating.Endpoints/Granit.Templating.Endpoints.csproj",
@@ -76,6 +77,7 @@
       "src/Granit.Workflow.Endpoints/Granit.Workflow.Endpoints.csproj",
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
+      "src/Granit.Workflow.Scheduling/Granit.Workflow.Scheduling.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
@@ -121,6 +123,7 @@
       "tests/Granit.Workflow.Endpoints.Tests/Granit.Workflow.Endpoints.Tests.csproj",
       "tests/Granit.Workflow.EntityFrameworkCore.Tests/Granit.Workflow.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj",
+      "tests/Granit.Workflow.Scheduling.Tests/Granit.Workflow.Scheduling.Tests.csproj",
       "tests/Granit.Workflow.Tests/Granit.Workflow.Tests.csproj",
       "tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj"
     ]

--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -341,6 +341,7 @@
       "src/Granit.Workflow.Endpoints/Granit.Workflow.Endpoints.csproj",
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
+      "src/Granit.Workflow.Scheduling/Granit.Workflow.Scheduling.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",

--- a/.github/shard-filters/src-only.slnf
+++ b/.github/shard-filters/src-only.slnf
@@ -343,6 +343,7 @@
       "src/Granit.Workflow.Endpoints/Granit.Workflow.Endpoints.csproj",
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
+      "src/Granit.Workflow.Scheduling/Granit.Workflow.Scheduling.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -100,6 +100,7 @@
         "tests/Granit.Workflow.Endpoints.Tests",
         "tests/Granit.Workflow.EntityFrameworkCore.Tests",
         "tests/Granit.Workflow.Notifications.Tests",
+        "tests/Granit.Workflow.Scheduling.Tests",
         "tests/Granit.Workflow.Tests",
         "tests/Granit.Workspaces.Abstractions.Tests",
         "tests/Granit.DataExchange.AI.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3010,6 +3010,14 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.Workflow.Scheduling",
+      "deps": [
+        "Granit.Scheduling",
+        "Granit.Workflow"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.Workspaces.Abstractions",
       "deps": [
         "Granit"
@@ -59450,6 +59458,139 @@
       "file": "src/Granit.Workflow/IWorkflowTransitionRecorder.cs",
       "line": 6,
       "members": []
+    },
+    {
+      "name": "WorkflowSchedulingServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.Scheduling.Extensions.WorkflowSchedulingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/Extensions/WorkflowSchedulingServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddWorkflowScheduling",
+          "kind": "method",
+          "signature": "AddWorkflowScheduling(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowSchedulingModule",
+      "fqn": "Granit.Workflow.Scheduling.GranitWorkflowSchedulingModule",
+      "kind": "class",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/GranitWorkflowSchedulingModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IScheduledTransitionService",
+      "fqn": "Granit.Workflow.Scheduling.IScheduledTransitionService",
+      "kind": "interface",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/IScheduledTransitionService.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "ScheduleTransitionAsync",
+          "kind": "method",
+          "signature": "ScheduleTransitionAsync(string workflowEntityType, Guid entityId, string targetState, DateTimeOffset executeAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ScheduledActionId>"
+        },
+        {
+          "name": "CancelScheduledTransitionAsync",
+          "kind": "method",
+          "signature": "CancelScheduledTransitionAsync(string workflowEntityType, Guid entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RescheduleTransitionAsync",
+          "kind": "method",
+          "signature": "RescheduleTransitionAsync(string workflowEntityType, Guid entityId, string targetState, DateTimeOffset newExecuteAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ScheduledActionId>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowTransitionApplier",
+      "fqn": "Granit.Workflow.Scheduling.IWorkflowTransitionApplier",
+      "kind": "interface",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/IWorkflowTransitionApplier.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "ApplyAsync",
+          "kind": "method",
+          "signature": "ApplyAsync(Guid entityId, string targetState, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowTransitionApplierRegistry",
+      "fqn": "Granit.Workflow.Scheduling.IWorkflowTransitionApplierRegistry",
+      "kind": "interface",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/IWorkflowTransitionApplierRegistry.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Resolve",
+          "kind": "method",
+          "signature": "Resolve(string workflowEntityType)",
+          "returnType": "IWorkflowTransitionApplier"
+        }
+      ]
+    },
+    {
+      "name": "ScheduledWorkflowTransitionHandler",
+      "fqn": "Granit.Workflow.Scheduling.ScheduledWorkflowTransitionHandler",
+      "kind": "class",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/ScheduledWorkflowTransitionHandler.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "method",
+          "signature": "Handle(ScheduledWorkflowTransitionPayload payload, IWorkflowTransitionApplierRegistry registry, ILogger<ScheduledWorkflowTransitionHandler> logger, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ScheduledWorkflowTransitionPayload",
+      "fqn": "Granit.Workflow.Scheduling.ScheduledWorkflowTransitionPayload",
+      "kind": "record",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/ScheduledWorkflowTransitionPayload.cs",
+      "line": 39,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionApplierBase",
+      "fqn": "Granit.Workflow.Scheduling.WorkflowTransitionApplierBase",
+      "kind": "class",
+      "project": "Granit.Workflow.Scheduling",
+      "file": "src/Granit.Workflow.Scheduling/WorkflowTransitionApplierBase.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ApplyAsync",
+          "kind": "method",
+          "signature": "ApplyAsync(Guid entityId, string targetState, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "TransitionBuilder",

--- a/.slnf/application.slnf
+++ b/.slnf/application.slnf
@@ -57,6 +57,7 @@
       "src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj",
       "src/Granit.QueryEngine.EntityFrameworkCore/Granit.QueryEngine.EntityFrameworkCore.csproj",
       "src/Granit.QueryEngine/Granit.QueryEngine.csproj",
+      "src/Granit.Scheduling/Granit.Scheduling.csproj",
       "src/Granit.Settings.Endpoints/Granit.Settings.Endpoints.csproj",
       "src/Granit.Settings.EntityFrameworkCore/Granit.Settings.EntityFrameworkCore.csproj",
       "src/Granit.Settings/Granit.Settings.csproj",
@@ -81,6 +82,7 @@
       "src/Granit.Workflow.Endpoints/Granit.Workflow.Endpoints.csproj",
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
+      "src/Granit.Workflow.Scheduling/Granit.Workflow.Scheduling.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
@@ -133,6 +135,7 @@
       "tests/Granit.Workflow.Endpoints.Tests/Granit.Workflow.Endpoints.Tests.csproj",
       "tests/Granit.Workflow.EntityFrameworkCore.Tests/Granit.Workflow.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj",
+      "tests/Granit.Workflow.Scheduling.Tests/Granit.Workflow.Scheduling.Tests.csproj",
       "tests/Granit.Workflow.Tests/Granit.Workflow.Tests.csproj"
     ]
   }

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -226,6 +226,7 @@
     <Project Path="src/Granit.Workflow.Endpoints/Granit.Workflow.Endpoints.csproj" />
     <Project Path="src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj" />
     <Project Path="src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj" />
+    <Project Path="src/Granit.Workflow.Scheduling/Granit.Workflow.Scheduling.csproj" />
     <Project Path="src/Granit.Workflow/Granit.Workflow.csproj" />
   </Folder>
   <Folder Name="/src/Infrastructure/">
@@ -607,6 +608,7 @@
     <Project Path="tests/Granit.Workflow.Endpoints.Tests/Granit.Workflow.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Workflow.EntityFrameworkCore.Tests/Granit.Workflow.EntityFrameworkCore.Tests.csproj" />
     <Project Path="tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj" />
+    <Project Path="tests/Granit.Workflow.Scheduling.Tests/Granit.Workflow.Scheduling.Tests.csproj" />
     <Project Path="tests/Granit.Workflow.Tests/Granit.Workflow.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/Infrastructure/">

--- a/src/Granit.Workflow.Scheduling/Extensions/WorkflowSchedulingServiceCollectionExtensions.cs
+++ b/src/Granit.Workflow.Scheduling/Extensions/WorkflowSchedulingServiceCollectionExtensions.cs
@@ -1,0 +1,48 @@
+using Granit.Workflow.Scheduling.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.Workflow.Scheduling.Extensions;
+
+/// <summary>
+/// Extension methods for registering Granit.Workflow.Scheduling services.
+/// </summary>
+public static class WorkflowSchedulingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the scheduled-workflow-transition bridge: <see cref="IScheduledTransitionService"/>
+    /// and <see cref="IWorkflowTransitionApplierRegistry"/>. Register an
+    /// <see cref="IWorkflowTransitionApplier"/> per entity type with
+    /// <see cref="AddWorkflowTransitionApplier{TApplier}"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddWorkflowScheduling(this IServiceCollection services)
+    {
+        services.TryAddScoped<IScheduledTransitionService, DefaultScheduledTransitionService>();
+        services.TryAddScoped<IWorkflowTransitionApplierRegistry, WorkflowTransitionApplierRegistry>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IWorkflowTransitionApplier"/> under the given workflow entity type
+    /// key, so scheduled transitions carrying that <c>WorkflowEntityType</c> are dispatched to it.
+    /// </summary>
+    /// <typeparam name="TApplier">The applier implementation type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="workflowEntityType">
+    /// The logical workflow entity type key (matching
+    /// <c>ScheduledWorkflowTransitionPayload.WorkflowEntityType</c> and the entity's
+    /// <c>IWorkflowStateful.WorkflowEntityType</c>), e.g. <c>"BlogPost"</c>.
+    /// </param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddWorkflowTransitionApplier<TApplier>(
+        this IServiceCollection services,
+        string workflowEntityType)
+        where TApplier : class, IWorkflowTransitionApplier
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowEntityType);
+        services.AddKeyedScoped<IWorkflowTransitionApplier, TApplier>(workflowEntityType);
+        return services;
+    }
+}

--- a/src/Granit.Workflow.Scheduling/Granit.Workflow.Scheduling.csproj
+++ b/src/Granit.Workflow.Scheduling/Granit.Workflow.Scheduling.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Workflow.Scheduling</PackageId>
+    <Description>Bridge between Granit.Workflow (FSM validation + ISO 27001 audit) and Granit.Scheduling (durable one-shot execution): schedule, cancel and reschedule time-based workflow transitions for any workflow-stateful entity. Ships the ScheduledWorkflowTransitionPayload, a minimal IScheduledTransitionService, a keyed IWorkflowTransitionApplier registry, a Wolverine handler and a WorkflowTransitionApplierBase&lt;TEntity, TState&gt; reference base. Scheduled transitions run in system context (pre-authorized at scheduling time).</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Workflow.Scheduling.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.Scheduling\Granit.Scheduling.csproj" />
+    <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Workflow.Scheduling/GranitWorkflowSchedulingModule.cs
+++ b/src/Granit.Workflow.Scheduling/GranitWorkflowSchedulingModule.cs
@@ -1,0 +1,25 @@
+using Granit.Modularity;
+using Granit.Scheduling;
+using Granit.Workflow.Scheduling.Extensions;
+
+namespace Granit.Workflow.Scheduling;
+
+/// <summary>
+/// Granit module that bridges <c>Granit.Workflow</c> and <c>Granit.Scheduling</c>: registers the
+/// scheduled-workflow-transition service and applier registry, and contributes the
+/// <see cref="ScheduledWorkflowTransitionHandler"/> to Wolverine handler discovery.
+/// </summary>
+/// <remarks>
+/// A durable <c>IScheduler</c> provider (e.g. <c>Granit.Scheduling.Wolverine</c>) must also be
+/// registered by the host for scheduled transitions to be delivered. The
+/// <c>ScheduledActionStatusMiddleware</c> from that provider automatically wraps this handler.
+/// </remarks>
+[DependsOn(
+    typeof(GranitWorkflowModule),
+    typeof(GranitSchedulingModule))]
+public sealed class GranitWorkflowSchedulingModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkflowScheduling();
+}

--- a/src/Granit.Workflow.Scheduling/IScheduledTransitionService.cs
+++ b/src/Granit.Workflow.Scheduling/IScheduledTransitionService.cs
@@ -1,0 +1,79 @@
+using Granit.Scheduling.Domain.ValueObjects;
+
+namespace Granit.Workflow.Scheduling;
+
+/// <summary>
+/// Schedules, cancels and reschedules time-based workflow transitions for a
+/// workflow-stateful entity. The single entry point a consumer needs to make
+/// "transition this entity to state X at instant T" trivial.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A transition is keyed by <c>(workflowEntityType, entityId)</c>: the service derives a
+/// deterministic correlation identifier (<c>workflow:{workflowEntityType}:{entityId}</c>)
+/// so a pending transition can be found and cancelled or rescheduled when an editor changes
+/// the date — without the caller tracking a <see cref="ScheduledActionId"/>.
+/// </para>
+/// <para>
+/// <c>executeAt</c> is an <strong>absolute instant</strong>. Converting a wall
+/// time in a site's IANA time zone (e.g. "2026-08-01 09:00 in <c>Europe/Brussels</c>") to an
+/// instant is the caller's responsibility — use <c>Granit.Timing</c>. This service stays
+/// zone-agnostic and minimal.
+/// </para>
+/// <para>
+/// Authorization happens here, at scheduling time (the calling endpoint is permission-gated).
+/// The transition later executes in system context and is not re-authorized — see
+/// <see cref="IWorkflowTransitionApplier"/>.
+/// </para>
+/// </remarks>
+public interface IScheduledTransitionService
+{
+    /// <summary>
+    /// Schedules a transition of the entity to <paramref name="targetState"/> at
+    /// <paramref name="executeAt"/>.
+    /// </summary>
+    /// <param name="workflowEntityType">
+    /// The logical workflow entity type (matching <c>IWorkflowStateful.WorkflowEntityType</c>
+    /// and the applier registration key), e.g. <c>"BlogPost"</c>.
+    /// </param>
+    /// <param name="entityId">The identifier of the entity to transition.</param>
+    /// <param name="targetState">The target workflow state name, e.g. <c>"Published"</c>.</param>
+    /// <param name="executeAt">The absolute instant at which the transition should run.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The identifier of the created scheduled action.</returns>
+    Task<ScheduledActionId> ScheduleTransitionAsync(
+        string workflowEntityType,
+        Guid entityId,
+        string targetState,
+        DateTimeOffset executeAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Cancels any pending scheduled transition for the entity. No-op when none is pending.
+    /// </summary>
+    /// <param name="workflowEntityType">The logical workflow entity type.</param>
+    /// <param name="entityId">The identifier of the entity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task CancelScheduledTransitionAsync(
+        string workflowEntityType,
+        Guid entityId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reschedules the entity's transition to a new instant (and optionally a new target
+    /// state). Any pending transition for the entity is cancelled and a fresh one is
+    /// scheduled, so the call is safe whether or not a transition is currently pending.
+    /// </summary>
+    /// <param name="workflowEntityType">The logical workflow entity type.</param>
+    /// <param name="entityId">The identifier of the entity.</param>
+    /// <param name="targetState">The target workflow state name.</param>
+    /// <param name="newExecuteAt">The new absolute instant at which the transition should run.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The identifier of the newly created scheduled action.</returns>
+    Task<ScheduledActionId> RescheduleTransitionAsync(
+        string workflowEntityType,
+        Guid entityId,
+        string targetState,
+        DateTimeOffset newExecuteAt,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Workflow.Scheduling/IWorkflowTransitionApplier.cs
+++ b/src/Granit.Workflow.Scheduling/IWorkflowTransitionApplier.cs
@@ -1,0 +1,38 @@
+namespace Granit.Workflow.Scheduling;
+
+/// <summary>
+/// Applies a scheduled workflow transition to a specific entity type. One implementation per
+/// workflow entity type, registered under its <c>WorkflowEntityType</c> key and resolved by
+/// <see cref="IWorkflowTransitionApplierRegistry"/> at execution time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An applier is the "caller" in the <c>IWorkflowManager</c> contract: it loads the aggregate,
+/// validates that the requested transition is legal, sets the entity status and calls
+/// <c>SaveChangesAsync</c>. On save, <c>WorkflowTransitionInterceptor</c> records the ISO 27001
+/// <c>WorkflowTransitionRecord</c> and raises <c>WorkflowStateChangedEvent</c> in the same
+/// transaction — the applier gets that audit for free.
+/// </para>
+/// <para>
+/// <strong>System-context execution (deliberate).</strong> Scheduled transitions run with no
+/// authenticated user. The transition was authorized when it was scheduled (the scheduling
+/// endpoint is permission-gated), and the catch-up safety net re-dispatches with no user, so an
+/// applier <strong>must not</strong> re-evaluate user permissions here — it would couple
+/// execution to the scheduling user's live (possibly revoked) permissions and make execution
+/// non-deterministic. Validate only the <em>FSM legality</em> of the transition against the
+/// <c>IWorkflowDefinition&lt;TState&gt;</c> (permission-free), not via the permission-gated
+/// <c>IWorkflowManager.TransitionAsync</c>. <see cref="WorkflowTransitionApplierBase{TEntity, TState}"/>
+/// encodes this correctly; derive from it rather than re-implementing the decision.
+/// </para>
+/// </remarks>
+public interface IWorkflowTransitionApplier
+{
+    /// <summary>
+    /// Loads the entity, validates the transition, applies <paramref name="targetState"/> and
+    /// persists the change.
+    /// </summary>
+    /// <param name="entityId">The identifier of the entity to transition.</param>
+    /// <param name="targetState">The target workflow state name (the <c>TState</c> enum member name).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ApplyAsync(Guid entityId, string targetState, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Workflow.Scheduling/IWorkflowTransitionApplierRegistry.cs
+++ b/src/Granit.Workflow.Scheduling/IWorkflowTransitionApplierRegistry.cs
@@ -1,0 +1,22 @@
+namespace Granit.Workflow.Scheduling;
+
+/// <summary>
+/// Resolves the <see cref="IWorkflowTransitionApplier"/> registered for a given workflow entity
+/// type. Used by <see cref="ScheduledWorkflowTransitionHandler"/> to dispatch a scheduled
+/// transition to the correct entity-specific applier.
+/// </summary>
+public interface IWorkflowTransitionApplierRegistry
+{
+    /// <summary>
+    /// Returns the applier registered under <paramref name="workflowEntityType"/>.
+    /// </summary>
+    /// <param name="workflowEntityType">
+    /// The logical workflow entity type key (matching
+    /// <c>ScheduledWorkflowTransitionPayload.WorkflowEntityType</c>).
+    /// </param>
+    /// <returns>The registered applier.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no applier is registered for <paramref name="workflowEntityType"/>.
+    /// </exception>
+    IWorkflowTransitionApplier Resolve(string workflowEntityType);
+}

--- a/src/Granit.Workflow.Scheduling/Internal/DefaultScheduledTransitionService.cs
+++ b/src/Granit.Workflow.Scheduling/Internal/DefaultScheduledTransitionService.cs
@@ -42,12 +42,9 @@ internal sealed class DefaultScheduledTransitionService(
             .GetByCorrelationIdAsync(correlationId, cancellationToken)
             .ConfigureAwait(false);
 
-        foreach (ScheduledAction action in actions)
+        foreach (ScheduledAction action in actions.Where(a => a.Status == ScheduledActionStatus.Pending))
         {
-            if (action.Status == ScheduledActionStatus.Pending)
-            {
-                await scheduler.CancelAsync(ScheduledActionId.Create(action.Id), cancellationToken).ConfigureAwait(false);
-            }
+            await scheduler.CancelAsync(ScheduledActionId.Create(action.Id), cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Granit.Workflow.Scheduling/Internal/DefaultScheduledTransitionService.cs
+++ b/src/Granit.Workflow.Scheduling/Internal/DefaultScheduledTransitionService.cs
@@ -1,0 +1,75 @@
+using Granit.Scheduling;
+using Granit.Scheduling.Domain;
+using Granit.Scheduling.Domain.ValueObjects;
+
+namespace Granit.Workflow.Scheduling.Internal;
+
+/// <summary>
+/// Default <see cref="IScheduledTransitionService"/> that delegates to <see cref="IScheduler"/>
+/// and keys scheduled transitions by a deterministic correlation identifier.
+/// </summary>
+internal sealed class DefaultScheduledTransitionService(
+    IScheduler scheduler,
+    IScheduledActionReader actionReader) : IScheduledTransitionService
+{
+    /// <inheritdoc/>
+    public Task<ScheduledActionId> ScheduleTransitionAsync(
+        string workflowEntityType,
+        Guid entityId,
+        string targetState,
+        DateTimeOffset executeAt,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowEntityType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetState);
+
+        string correlationId = BuildCorrelationId(workflowEntityType, entityId);
+        var payload = new ScheduledWorkflowTransitionPayload(workflowEntityType, entityId, targetState, correlationId);
+
+        return scheduler.ScheduleAsync(payload, executeAt, correlationId, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task CancelScheduledTransitionAsync(
+        string workflowEntityType,
+        Guid entityId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowEntityType);
+
+        string correlationId = BuildCorrelationId(workflowEntityType, entityId);
+        IReadOnlyList<ScheduledAction> actions = await actionReader
+            .GetByCorrelationIdAsync(correlationId, cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (ScheduledAction action in actions)
+        {
+            if (action.Status == ScheduledActionStatus.Pending)
+            {
+                await scheduler.CancelAsync(ScheduledActionId.Create(action.Id), cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<ScheduledActionId> RescheduleTransitionAsync(
+        string workflowEntityType,
+        Guid entityId,
+        string targetState,
+        DateTimeOffset newExecuteAt,
+        CancellationToken cancellationToken = default)
+    {
+        // Cancel-then-schedule: robust whether or not a transition is pending, and correct when
+        // the editor changes the target state as well as the date.
+        await CancelScheduledTransitionAsync(workflowEntityType, entityId, cancellationToken).ConfigureAwait(false);
+        return await ScheduleTransitionAsync(workflowEntityType, entityId, targetState, newExecuteAt, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds the deterministic correlation identifier <c>workflow:{workflowEntityType}:{entityId}</c>
+    /// used to find an entity's pending transition for cancel/reschedule.
+    /// </summary>
+    internal static string BuildCorrelationId(string workflowEntityType, Guid entityId) =>
+        $"workflow:{workflowEntityType}:{entityId}";
+}

--- a/src/Granit.Workflow.Scheduling/Internal/WorkflowTransitionApplierRegistry.cs
+++ b/src/Granit.Workflow.Scheduling/Internal/WorkflowTransitionApplierRegistry.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Workflow.Scheduling.Internal;
+
+/// <summary>
+/// Resolves keyed <see cref="IWorkflowTransitionApplier"/> registrations from the current scope.
+/// </summary>
+/// <remarks>
+/// Registered as scoped so the injected <see cref="IServiceProvider"/> is the scoped provider,
+/// allowing scoped appliers (which typically own a request/handler-scoped DbContext) to resolve
+/// correctly within the Wolverine handler scope.
+/// </remarks>
+internal sealed class WorkflowTransitionApplierRegistry(IServiceProvider serviceProvider)
+    : IWorkflowTransitionApplierRegistry
+{
+    /// <inheritdoc/>
+    public IWorkflowTransitionApplier Resolve(string workflowEntityType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowEntityType);
+
+        IWorkflowTransitionApplier? applier =
+            serviceProvider.GetKeyedService<IWorkflowTransitionApplier>(workflowEntityType);
+
+        return applier ?? throw new InvalidOperationException(
+            $"No {nameof(IWorkflowTransitionApplier)} is registered for workflow entity type '{workflowEntityType}'. "
+            + $"Register one via services.AddWorkflowTransitionApplier<T>(\"{workflowEntityType}\").");
+    }
+}

--- a/src/Granit.Workflow.Scheduling/README.md
+++ b/src/Granit.Workflow.Scheduling/README.md
@@ -1,0 +1,72 @@
+# Granit.Workflow.Scheduling
+
+Time-based workflow transitions as a reusable framework primitive. Bridges
+[`Granit.Workflow`](../Granit.Workflow) (FSM validation + ISO 27001 audit) and
+[`Granit.Scheduling`](../Granit.Scheduling) (durable one-shot execution): schedule a
+workflow-stateful entity to move from one state to another at a future instant, then cancel
+or reschedule it per entity when the date changes.
+
+## What it provides
+
+- `ScheduledWorkflowTransitionPayload` — the persisted `IScheduledPayload`. Non-generic:
+  the target state travels as a string and the concrete `TState` enum is resolved by an
+  entity-specific applier.
+- `IScheduledTransitionService` — minimal `ScheduleTransitionAsync` /
+  `CancelScheduledTransitionAsync` / `RescheduleTransitionAsync`, keyed by
+  `(workflowEntityType, entityId)` via a deterministic correlation id.
+- `IWorkflowTransitionApplier` (+ `WorkflowTransitionApplierBase<TEntity, TState>`) —
+  loads the aggregate, validates FSM legality, sets the status and saves. One per entity type.
+- `ScheduledWorkflowTransitionHandler` — Wolverine handler that dispatches a scheduled
+  transition to the right applier.
+
+Audit (`WorkflowTransitionRecord`) and `WorkflowStateChangedEvent` are produced automatically
+by the workflow EF Core interceptor on save. Atomic single-execution, retry and status
+transitions come from `Granit.Scheduling.Wolverine`.
+
+## System-context execution
+
+Scheduled transitions run with **no authenticated user**. Authorization happens once, at
+scheduling time (the scheduling endpoint is permission-gated). At execution time the applier
+validates only the **FSM legality** of the transition against `IWorkflowDefinition<TState>` and
+does **not** re-evaluate user permissions — the scheduling user may have been revoked and the
+catch-up safety net carries no user. `WorkflowTransitionApplierBase<TEntity, TState>` encodes
+this decision.
+
+## Usage
+
+```csharp
+// Registration
+services.AddWorkflowScheduling();
+services.AddWorkflowTransitionApplier<BlogPostTransitionApplier>("BlogPost");
+
+// Schedule publication at an absolute instant (convert wall time + IANA zone with Granit.Timing)
+await scheduledTransitions.ScheduleTransitionAsync(
+    workflowEntityType: "BlogPost",
+    entityId: post.Id,
+    targetState: nameof(BlogPostStatus.Published),
+    executeAt: publishAtUtc,
+    cancellationToken);
+
+// Editor moved the date
+await scheduledTransitions.RescheduleTransitionAsync(
+    "BlogPost", post.Id, nameof(BlogPostStatus.Published), newPublishAtUtc, cancellationToken);
+```
+
+An applier derives from the base and supplies the four entity-specific steps:
+
+```csharp
+internal sealed class BlogPostTransitionApplier(
+    BlogDbContext db,
+    IWorkflowDefinition<BlogPostStatus> definition)
+    : WorkflowTransitionApplierBase<BlogPost, BlogPostStatus>(definition)
+{
+    protected override Task<BlogPost?> LoadAsync(Guid id, CancellationToken ct) =>
+        db.BlogPosts.FirstOrDefaultAsync(p => p.Id == id, ct);
+
+    protected override BlogPostStatus GetCurrentState(BlogPost post) => post.Status;
+
+    protected override void SetState(BlogPost post, BlogPostStatus target) => post.TransitionTo(target);
+
+    protected override Task SaveAsync(BlogPost post, CancellationToken ct) => db.SaveChangesAsync(ct);
+}
+```

--- a/src/Granit.Workflow.Scheduling/ScheduledWorkflowTransitionHandler.cs
+++ b/src/Granit.Workflow.Scheduling/ScheduledWorkflowTransitionHandler.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Workflow.Scheduling;
+
+/// <summary>
+/// Wolverine handler for <see cref="ScheduledWorkflowTransitionPayload"/>. Resolves the
+/// entity-specific <see cref="IWorkflowTransitionApplier"/> by
+/// <see cref="ScheduledWorkflowTransitionPayload.WorkflowEntityType"/> and applies the transition.
+/// </summary>
+/// <remarks>
+/// Atomic single-execution (Pending → Processing), retry and terminal status transitions are
+/// handled by <c>Granit.Scheduling.Wolverine</c>'s <c>ScheduledActionStatusMiddleware</c>, which
+/// wraps every <c>IScheduledPayload</c> handler — so this handler only needs to dispatch.
+/// The type is a non-static <c>public class</c> with a <c>public static</c> handle method per the
+/// Granit Wolverine discovery contract.
+/// </remarks>
+public partial class ScheduledWorkflowTransitionHandler
+{
+    /// <summary>Applies the scheduled transition described by <paramref name="payload"/>.</summary>
+    /// <param name="payload">The scheduled transition payload.</param>
+    /// <param name="registry">The applier registry.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static Task Handle(
+        ScheduledWorkflowTransitionPayload payload,
+        IWorkflowTransitionApplierRegistry registry,
+        ILogger<ScheduledWorkflowTransitionHandler> logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(registry);
+
+        Log.ApplyingTransition(logger, payload.WorkflowEntityType, payload.EntityId, payload.TargetState);
+
+        IWorkflowTransitionApplier applier = registry.Resolve(payload.WorkflowEntityType);
+        return applier.ApplyAsync(payload.EntityId, payload.TargetState, cancellationToken);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Applying scheduled workflow transition for {WorkflowEntityType} {EntityId} to state {TargetState}")]
+        public static partial void ApplyingTransition(
+            ILogger logger, string workflowEntityType, Guid entityId, string targetState);
+    }
+}

--- a/src/Granit.Workflow.Scheduling/ScheduledWorkflowTransitionPayload.cs
+++ b/src/Granit.Workflow.Scheduling/ScheduledWorkflowTransitionPayload.cs
@@ -1,0 +1,43 @@
+using Granit.Scheduling;
+
+namespace Granit.Workflow.Scheduling;
+
+/// <summary>
+/// A scheduled payload that transitions a workflow-stateful entity to a target state at a
+/// future instant. Persisted as JSON by <c>Granit.Scheduling</c> and delivered to
+/// <see cref="ScheduledWorkflowTransitionHandler"/> at execution time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The payload is deliberately <strong>non-generic</strong>: the target state travels as a
+/// string and the concrete <c>TState</c> enum is resolved by the entity-type-specific
+/// <see cref="IWorkflowTransitionApplier"/> at execution time. This keeps dispatch, storage
+/// and the Wolverine handler free of any generic type parameter while confining the generic
+/// complexity to each applier.
+/// </para>
+/// <para>
+/// Scheduled via <see cref="IScheduledTransitionService"/>, which stamps a deterministic
+/// <see cref="CorrelationId"/> (<c>workflow:{WorkflowEntityType}:{EntityId}</c>) so the
+/// action can be cancelled or rescheduled by entity when an editor changes the date.
+/// </para>
+/// </remarks>
+/// <param name="WorkflowEntityType">
+/// The logical workflow entity type, matching <c>IWorkflowStateful.WorkflowEntityType</c> and
+/// the key under which the target <see cref="IWorkflowTransitionApplier"/> is registered
+/// (e.g. <c>"BlogPost"</c>).
+/// </param>
+/// <param name="EntityId">The identifier of the entity to transition.</param>
+/// <param name="TargetState">
+/// The name of the target workflow state (the <c>TState</c> enum member name, e.g.
+/// <c>"Published"</c>). Parsed to the concrete enum by the applier.
+/// </param>
+/// <param name="CorrelationId">
+/// Optional correlation identifier linking the scheduled action to its entity. Set by
+/// <see cref="IScheduledTransitionService"/> to the deterministic
+/// <c>workflow:{WorkflowEntityType}:{EntityId}</c> form.
+/// </param>
+public sealed record ScheduledWorkflowTransitionPayload(
+    string WorkflowEntityType,
+    Guid EntityId,
+    string TargetState,
+    string? CorrelationId = null) : IScheduledPayload;

--- a/src/Granit.Workflow.Scheduling/WorkflowTransitionApplierBase.cs
+++ b/src/Granit.Workflow.Scheduling/WorkflowTransitionApplierBase.cs
@@ -1,0 +1,96 @@
+namespace Granit.Workflow.Scheduling;
+
+/// <summary>
+/// Reference base for an <see cref="IWorkflowTransitionApplier"/>. Encodes the
+/// load → validate → set → save flow once, so a consumer only supplies the four
+/// entity-specific steps. Centralises the deliberate system-context validation decision
+/// (see <see cref="IWorkflowTransitionApplier"/>): the transition is validated for FSM
+/// legality against the <see cref="IWorkflowDefinition{TState}"/> only — user permissions are
+/// <strong>not</strong> re-evaluated at execution time.
+/// </summary>
+/// <typeparam name="TEntity">The workflow-stateful aggregate type.</typeparam>
+/// <typeparam name="TState">The workflow state enum.</typeparam>
+/// <param name="definition">The workflow definition for <typeparamref name="TState"/>.</param>
+public abstract class WorkflowTransitionApplierBase<TEntity, TState>(IWorkflowDefinition<TState> definition)
+    : IWorkflowTransitionApplier
+    where TEntity : class
+    where TState : struct, Enum
+{
+    /// <summary>The workflow definition used for FSM-legality validation.</summary>
+    protected IWorkflowDefinition<TState> Definition { get; } = definition;
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="targetState"/> is not a valid <typeparamref name="TState"/>
+    /// value, when the entity is not found (see <see cref="OnEntityNotFoundAsync"/>), or when
+    /// the current → target transition is not defined (the entity state likely changed since
+    /// the transition was scheduled).
+    /// </exception>
+    public async Task ApplyAsync(Guid entityId, string targetState, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetState);
+
+        if (!Enum.TryParse(targetState, out TState target))
+        {
+            throw new InvalidOperationException(
+                $"'{targetState}' is not a valid {typeof(TState).Name} value for a scheduled transition of {typeof(TEntity).Name} '{entityId}'.");
+        }
+
+        TEntity? entity = await LoadAsync(entityId, cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+        {
+            await OnEntityNotFoundAsync(entityId, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        TState current = GetCurrentState(entity);
+
+        // Idempotent: a concurrent dispatch or catch-up re-run that finds the entity already
+        // in the target state is a no-op, not an error.
+        if (EqualityComparer<TState>.Default.Equals(current, target))
+        {
+            return;
+        }
+
+        // System-context validation: FSM legality only. Never re-check user permissions here —
+        // the transition was authorized at scheduling time and there is no user at execution time.
+        bool isDefined = Definition.GetAllowedTransitions(current)
+            .Any(t => EqualityComparer<TState>.Default.Equals(t.To, target));
+
+        if (!isDefined)
+        {
+            throw new InvalidOperationException(
+                $"Transition {current} -> {target} is not defined for {typeof(TEntity).Name} '{entityId}'. "
+                + "The entity state may have changed since the transition was scheduled.");
+        }
+
+        SetState(entity, target);
+        await SaveAsync(entity, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Loads the aggregate by identifier, or returns <c>null</c> when it no longer exists.</summary>
+    protected abstract Task<TEntity?> LoadAsync(Guid entityId, CancellationToken cancellationToken);
+
+    /// <summary>Returns the entity's current workflow state.</summary>
+    protected abstract TState GetCurrentState(TEntity entity);
+
+    /// <summary>
+    /// Applies <paramref name="target"/> to the entity via its behaviour method
+    /// (e.g. <c>Publish()</c> or <c>SetLifecycleStatus(...)</c>) — not by mutating a raw setter.
+    /// </summary>
+    protected abstract void SetState(TEntity entity, TState target);
+
+    /// <summary>Persists the transitioned entity, letting the workflow interceptor record the audit trail.</summary>
+    protected abstract Task SaveAsync(TEntity entity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Called when the entity is not found at execution time (e.g. deleted after scheduling).
+    /// The default throws, surfacing the anomaly as a scheduled-action failure; override to
+    /// treat a missing entity as a silent no-op.
+    /// </summary>
+    /// <param name="entityId">The identifier of the missing entity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    protected virtual Task OnEntityNotFoundAsync(Guid entityId, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(
+            $"{typeof(TEntity).Name} '{entityId}' was not found for its scheduled workflow transition.");
+}

--- a/src/Granit.Workflow.Scheduling/packages.lock.json
+++ b/src/Granit.Workflow.Scheduling/packages.lock.json
@@ -1,0 +1,296 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.16.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.scheduling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.*, )",
+        "resolved": "1.16.0",
+        "contentHash": "WZP8Eb6vZTeNqeV+fjBitc7iefBoTHIhaWorqg/h/YiQBlcQJu0bICuTqKV0XRyjiE0eWs80yLlnUtHAFSkFWA=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -370,6 +370,7 @@
     <ProjectReference Include="..\..\src\Granit.Workflow.Endpoints\Granit.Workflow.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Workflow.EntityFrameworkCore\Granit.Workflow.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.Workflow.Notifications\Granit.Workflow.Notifications.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Workflow.Scheduling\Granit.Workflow.Scheduling.csproj" />
     <ProjectReference Include="..\..\src\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 

--- a/tests/Granit.Workflow.Scheduling.Tests/DefaultScheduledTransitionServiceTests.cs
+++ b/tests/Granit.Workflow.Scheduling.Tests/DefaultScheduledTransitionServiceTests.cs
@@ -1,0 +1,122 @@
+using Granit.Scheduling;
+using Granit.Scheduling.Domain;
+using Granit.Scheduling.Domain.ValueObjects;
+using Granit.Workflow.Scheduling.Internal;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workflow.Scheduling.Tests;
+
+public sealed class DefaultScheduledTransitionServiceTests
+{
+    private const string EntityType = "BlogPost";
+    private static readonly Guid EntityId = Guid.Parse("3fa85f64-5717-4562-b3fc-2c963f66afa6");
+    private static readonly DateTimeOffset ExecuteAt = new(2026, 8, 1, 9, 0, 0, TimeSpan.Zero);
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private readonly IScheduler _scheduler = Substitute.For<IScheduler>();
+    private readonly IScheduledActionReader _reader = Substitute.For<IScheduledActionReader>();
+    private readonly DefaultScheduledTransitionService _sut;
+
+    public DefaultScheduledTransitionServiceTests()
+    {
+        _scheduler.ScheduleAsync(
+                Arg.Any<ScheduledWorkflowTransitionPayload>(),
+                Arg.Any<DateTimeOffset>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ScheduledActionId.Create(Guid.NewGuid()));
+
+        _sut = new DefaultScheduledTransitionService(_scheduler, _reader);
+    }
+
+    [Fact]
+    public void BuildCorrelationId_uses_deterministic_workflow_prefix() =>
+        DefaultScheduledTransitionService.BuildCorrelationId(EntityType, EntityId)
+            .ShouldBe($"workflow:{EntityType}:{EntityId}");
+
+    [Fact]
+    public async Task ScheduleTransitionAsync_schedules_payload_with_deterministic_correlation()
+    {
+        await _sut.ScheduleTransitionAsync(EntityType, EntityId, nameof(TestState.Published), ExecuteAt, Ct);
+
+        string expectedCorrelation = $"workflow:{EntityType}:{EntityId}";
+        await _scheduler.Received(1).ScheduleAsync(
+            Arg.Is<ScheduledWorkflowTransitionPayload>(p =>
+                p.WorkflowEntityType == EntityType
+                && p.EntityId == EntityId
+                && p.TargetState == nameof(TestState.Published)
+                && p.CorrelationId == expectedCorrelation),
+            ExecuteAt,
+            expectedCorrelation,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ScheduleTransitionAsync_rejects_blank_entity_type(string entityType) =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.ScheduleTransitionAsync(entityType, EntityId, nameof(TestState.Published), ExecuteAt, Ct));
+
+    [Fact]
+    public async Task ScheduleTransitionAsync_rejects_blank_target_state() =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.ScheduleTransitionAsync(EntityType, EntityId, "  ", ExecuteAt, Ct));
+
+    [Fact]
+    public async Task CancelScheduledTransitionAsync_cancels_only_pending_actions()
+    {
+        string correlation = $"workflow:{EntityType}:{EntityId}";
+        var pendingId = Guid.NewGuid();
+
+        var pending = ScheduledAction.Create(pendingId, "type", "{}", ExecuteAt, correlation);
+        var cancelled = ScheduledAction.Create(Guid.NewGuid(), "type", "{}", ExecuteAt, correlation);
+        cancelled.Cancel(cancelledBy: "someone"); // now non-pending
+
+        _reader.GetByCorrelationIdAsync(correlation, Arg.Any<CancellationToken>())
+            .Returns([pending, cancelled]);
+
+        await _sut.CancelScheduledTransitionAsync(EntityType, EntityId, Ct);
+
+        await _scheduler.Received(1).CancelAsync(
+            Arg.Is<ScheduledActionId>(id => id.Value == pendingId), Arg.Any<CancellationToken>());
+        await _scheduler.Received(1).CancelAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelScheduledTransitionAsync_is_noop_when_none_pending()
+    {
+        _reader.GetByCorrelationIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.CancelScheduledTransitionAsync(EntityType, EntityId, Ct);
+
+        await _scheduler.DidNotReceive().CancelAsync(Arg.Any<ScheduledActionId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RescheduleTransitionAsync_cancels_pending_then_schedules_fresh()
+    {
+        string correlation = $"workflow:{EntityType}:{EntityId}";
+        var pendingId = Guid.NewGuid();
+        var pending = ScheduledAction.Create(pendingId, "type", "{}", ExecuteAt, correlation);
+
+        _reader.GetByCorrelationIdAsync(correlation, Arg.Any<CancellationToken>())
+            .Returns([pending]);
+
+        DateTimeOffset newExecuteAt = ExecuteAt.AddDays(2);
+
+        await _sut.RescheduleTransitionAsync(EntityType, EntityId, nameof(TestState.Published), newExecuteAt, Ct);
+
+        await _scheduler.Received(1).CancelAsync(
+            Arg.Is<ScheduledActionId>(id => id.Value == pendingId), Arg.Any<CancellationToken>());
+        await _scheduler.Received(1).ScheduleAsync(
+            Arg.Is<ScheduledWorkflowTransitionPayload>(p => p.TargetState == nameof(TestState.Published)),
+            newExecuteAt,
+            correlation,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Workflow.Scheduling.Tests/Granit.Workflow.Scheduling.Tests.csproj
+++ b/tests/Granit.Workflow.Scheduling.Tests/Granit.Workflow.Scheduling.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Workflow.Scheduling\Granit.Workflow.Scheduling.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Workflow.Scheduling.Tests/ScheduledWorkflowTransitionHandlerTests.cs
+++ b/tests/Granit.Workflow.Scheduling.Tests/ScheduledWorkflowTransitionHandlerTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workflow.Scheduling.Tests;
+
+public sealed class ScheduledWorkflowTransitionHandlerTests
+{
+    [Fact]
+    public async Task Handle_resolves_applier_by_entity_type_and_applies_transition()
+    {
+        var entityId = Guid.NewGuid();
+        var payload = new ScheduledWorkflowTransitionPayload("BlogPost", entityId, nameof(TestState.Published));
+
+        IWorkflowTransitionApplier applier = Substitute.For<IWorkflowTransitionApplier>();
+        IWorkflowTransitionApplierRegistry registry = Substitute.For<IWorkflowTransitionApplierRegistry>();
+        registry.Resolve("BlogPost").Returns(applier);
+
+        await ScheduledWorkflowTransitionHandler.Handle(
+            payload,
+            registry,
+            NullLogger<ScheduledWorkflowTransitionHandler>.Instance,
+            CancellationToken.None);
+
+        registry.Received(1).Resolve("BlogPost");
+        await applier.Received(1).ApplyAsync(entityId, nameof(TestState.Published), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_propagates_registry_resolution_failure()
+    {
+        var payload = new ScheduledWorkflowTransitionPayload("Unknown", Guid.NewGuid(), nameof(TestState.Published));
+        IWorkflowTransitionApplierRegistry registry = Substitute.For<IWorkflowTransitionApplierRegistry>();
+        registry.Resolve("Unknown").Returns(_ => throw new InvalidOperationException("no applier"));
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            ScheduledWorkflowTransitionHandler.Handle(
+                payload,
+                registry,
+                NullLogger<ScheduledWorkflowTransitionHandler>.Instance,
+                CancellationToken.None));
+    }
+}

--- a/tests/Granit.Workflow.Scheduling.Tests/TestWorkflow.cs
+++ b/tests/Granit.Workflow.Scheduling.Tests/TestWorkflow.cs
@@ -1,0 +1,19 @@
+namespace Granit.Workflow.Scheduling.Tests;
+
+/// <summary>Test workflow states used across the scheduling bridge tests.</summary>
+internal enum TestState
+{
+    Draft,
+    Published,
+    Archived,
+}
+
+/// <summary>A minimal reachable workflow definition: Draft → Published → Archived.</summary>
+internal static class TestWorkflow
+{
+    public static WorkflowDefinition<TestState> Definition { get; } =
+        WorkflowDefinition<TestState>.Create(builder => builder
+            .InitialState(TestState.Draft)
+            .Transition(TestState.Draft, TestState.Published)
+            .Transition(TestState.Published, TestState.Archived));
+}

--- a/tests/Granit.Workflow.Scheduling.Tests/WorkflowSchedulingRegistrationTests.cs
+++ b/tests/Granit.Workflow.Scheduling.Tests/WorkflowSchedulingRegistrationTests.cs
@@ -1,0 +1,64 @@
+using Granit.Scheduling;
+using Granit.Workflow.Scheduling.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workflow.Scheduling.Tests;
+
+public sealed class WorkflowSchedulingRegistrationTests
+{
+    private sealed class FakeApplier : IWorkflowTransitionApplier
+    {
+        public Task ApplyAsync(Guid entityId, string targetState, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IScheduler>());
+        services.AddSingleton(Substitute.For<IScheduledActionReader>());
+        services.AddWorkflowScheduling();
+        services.AddWorkflowTransitionApplier<FakeApplier>("BlogPost");
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AddWorkflowScheduling_registers_service_and_registry()
+    {
+        using ServiceProvider provider = BuildProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        scope.ServiceProvider.GetService<IScheduledTransitionService>().ShouldNotBeNull();
+        scope.ServiceProvider.GetService<IWorkflowTransitionApplierRegistry>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Registry_resolves_applier_registered_for_entity_type()
+    {
+        using ServiceProvider provider = BuildProvider();
+        using IServiceScope scope = provider.CreateScope();
+        IWorkflowTransitionApplierRegistry registry = scope.ServiceProvider.GetRequiredService<IWorkflowTransitionApplierRegistry>();
+
+        registry.Resolve("BlogPost").ShouldBeOfType<FakeApplier>();
+    }
+
+    [Fact]
+    public void Registry_throws_for_unregistered_entity_type()
+    {
+        using ServiceProvider provider = BuildProvider();
+        using IServiceScope scope = provider.CreateScope();
+        IWorkflowTransitionApplierRegistry registry = scope.ServiceProvider.GetRequiredService<IWorkflowTransitionApplierRegistry>();
+
+        Should.Throw<InvalidOperationException>(() => registry.Resolve("Unknown"));
+    }
+
+    [Fact]
+    public void AddWorkflowTransitionApplier_rejects_blank_entity_type()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentException>(() => services.AddWorkflowTransitionApplier<FakeApplier>("  "));
+    }
+}

--- a/tests/Granit.Workflow.Scheduling.Tests/WorkflowTransitionApplierBaseTests.cs
+++ b/tests/Granit.Workflow.Scheduling.Tests/WorkflowTransitionApplierBaseTests.cs
@@ -1,0 +1,89 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workflow.Scheduling.Tests;
+
+public sealed class WorkflowTransitionApplierBaseTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private sealed class FakeEntity(Guid id, TestState state)
+    {
+        public Guid Id { get; } = id;
+        public TestState State { get; private set; } = state;
+        public void SetState(TestState state) => State = state;
+    }
+
+    private sealed class FakeApplier(FakeEntity? entity)
+        : WorkflowTransitionApplierBase<FakeEntity, TestState>(TestWorkflow.Definition)
+    {
+        public FakeEntity? Saved { get; private set; }
+
+        protected override Task<FakeEntity?> LoadAsync(Guid entityId, CancellationToken cancellationToken) =>
+            Task.FromResult(entity);
+
+        protected override TestState GetCurrentState(FakeEntity e) => e.State;
+
+        protected override void SetState(FakeEntity e, TestState target) => e.SetState(target);
+
+        protected override Task SaveAsync(FakeEntity e, CancellationToken cancellationToken)
+        {
+            Saved = e;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ApplyAsync_applies_and_saves_a_valid_transition()
+    {
+        var entity = new FakeEntity(Guid.NewGuid(), TestState.Draft);
+        var applier = new FakeApplier(entity);
+
+        await applier.ApplyAsync(entity.Id, nameof(TestState.Published), Ct);
+
+        entity.State.ShouldBe(TestState.Published);
+        applier.Saved.ShouldBeSameAs(entity);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_is_idempotent_when_already_in_target_state()
+    {
+        var entity = new FakeEntity(Guid.NewGuid(), TestState.Published);
+        var applier = new FakeApplier(entity);
+
+        await applier.ApplyAsync(entity.Id, nameof(TestState.Published), Ct);
+
+        applier.Saved.ShouldBeNull(); // no save for a no-op
+    }
+
+    [Fact]
+    public async Task ApplyAsync_throws_for_transition_not_defined_from_current_state()
+    {
+        // Draft -> Archived is not a defined transition (only Draft -> Published).
+        var entity = new FakeEntity(Guid.NewGuid(), TestState.Draft);
+        var applier = new FakeApplier(entity);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            applier.ApplyAsync(entity.Id, nameof(TestState.Archived), Ct));
+        applier.Saved.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ApplyAsync_throws_for_unparseable_target_state()
+    {
+        var entity = new FakeEntity(Guid.NewGuid(), TestState.Draft);
+        var applier = new FakeApplier(entity);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            applier.ApplyAsync(entity.Id, "NotAState", Ct));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_throws_by_default_when_entity_not_found()
+    {
+        var applier = new FakeApplier(entity: null);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            applier.ApplyAsync(Guid.NewGuid(), nameof(TestState.Published), Ct));
+    }
+}

--- a/tests/Granit.Workflow.Scheduling.Tests/packages.lock.json
+++ b/tests/Granit.Workflow.Scheduling.Tests/packages.lock.json
@@ -1,0 +1,590 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.Diagnostics.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.7.0",
+        "contentHash": "2G1QonlvuybwwvJjguUcNXMnFN8jBnWiAn3Z3If5L8wkVvW1AEQyakF1RUZbad+bqAtgPoxJ6JBAwGj1MikcWQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.7.0",
+          "Microsoft.TestPlatform.TestHost": "18.7.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.ObjectPool": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "KZENCkfqO7Ciax6goUWQHDSxKH+x763hkBWMz9KpE87EyKW+EKEas9EFe9i1KgtQShG8KwKxaeJ5gd9sj6TuTQ=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.ObjectPool": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.7.0",
+        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.16.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.scheduling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workflow.scheduling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Scheduling": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9ylcH/xjs4nfPvWXeA0qDztbj33LX1Rcuy5g/bo1MhDbVCobnVzlgg1mMfuTbQOHQp9rvS/Fy+tKJNmAbIIekA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "5Q8Q1+tD5punC+lZTaWqaolLX2bms7dPY2oaxGcXMQbSLwhlTla38qMyRK6G+gFmfKIgRsXWD4redIl0CHD7jA=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.*, )",
+        "resolved": "1.16.0",
+        "contentHash": "WZP8Eb6vZTeNqeV+fjBitc7iefBoTHIhaWorqg/h/YiQBlcQJu0bICuTqKV0XRyjiE0eWs80yLlnUtHAFSkFWA=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #2921.

## What

Adds **`Granit.Workflow.Scheduling`**, a framework primitive that bridges `Granit.Workflow`
(FSM validation + ISO 27001 audit) and `Granit.Scheduling` (durable one-shot execution), so
consumers stop re-implementing time-based workflow transitions. First consumer: a Blog module
(granit-website) needing scheduled publication `Draft → Scheduled → Published → Archived`; the
same primitive serves Releases, Pages, LegalDocument and Invoicing.

The heavy lifting (persistence, atomic claim, retry, delivery) already lived in
`Granit.Scheduling`; this PR is the missing **bridge**.

## Surface

| Type | Role |
| ---- | ---- |
| `ScheduledWorkflowTransitionPayload : IScheduledPayload` | Persisted payload. Non-generic — target state travels as a string, resolved per entity type at execution. |
| `IScheduledTransitionService` (+ default impl) | Minimal `ScheduleTransitionAsync` / `CancelScheduledTransitionAsync` / `RescheduleTransitionAsync`, keyed by `(workflowEntityType, entityId)` via a deterministic correlation id `workflow:{type}:{id}`. Delegates to `IScheduler`. |
| `IWorkflowTransitionApplier` + `IWorkflowTransitionApplierRegistry` | Keyed seam resolved by `WorkflowEntityType`; one applier per entity type. |
| `WorkflowTransitionApplierBase<TEntity, TState>` | Reference base encoding load → validate → set → save once. |
| `ScheduledWorkflowTransitionHandler` | Wolverine handler dispatching to the applier. |
| `AddWorkflowScheduling()` / `AddWorkflowTransitionApplier<T>(entityType)` | DI. |

`[DependsOn]` `Granit.Workflow` + `Granit.Scheduling`. Audit (`WorkflowTransitionRecord`) and
`WorkflowStateChangedEvent` are produced automatically by the existing workflow EF Core
interceptor on save; atomic single-execution, retry and status transitions come from
`Granit.Scheduling.Wolverine`'s middleware.

## Key decision — system-context execution (documented in XML docs + README)

Scheduled transitions run with **no authenticated user**. Authorization happens once, at
scheduling time (the scheduling endpoint is permission-gated). At execution time the applier
validates only the **FSM legality** of the transition against `IWorkflowDefinition<TState>` and
does **not** re-evaluate user permissions — routing through the permission-gated
`IWorkflowManager.TransitionAsync` would couple execution to the scheduling user's live
(possibly revoked) permissions, and the catch-up safety net re-dispatches with no user at all.
`WorkflowTransitionApplierBase` encodes this so consumers can't get it wrong.

The design brief left the abstractions/runtime split to my judgement: I kept **one package**.
The seam interfaces, payload and base applier are always co-consumed by the same module (the
one that both schedules and applies), so a separate `.Abstractions` would only ever be
co-referenced — it can be extracted later, non-breaking, if a schedule-only consumer appears.

## Tests

- **19 unit tests**: schedule persists payload with deterministic correlation; cancel targets
  only pending actions; reschedule = cancel-then-schedule; handler resolves applier and applies
  the right target state; registry resolve/throw; base applier valid/invalid/idempotent/bad-enum/
  not-found; DI registration.
- **244 architecture/convention tests** pass (module wired into `Granit.ArchitectureTests`).
- `dotnet build` / `dotnet format --verify-no-changes` clean; markdownlint clean; new project
  registered in `Granit.slnx`, `.github/test-shards.json` (`application` shard) + regenerated
  shard filters. No new third-party dependency.

## Follow-ups (separate PRs)

- ADR for the system-context execution decision → `granit-docs`.
- Module reference page → `granit-docs`.
- Blog consumer wiring → granit-website (separate session).