### PR TITLE
feat(workflow): keyed workflow definitions by entity type

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -59249,6 +59249,15 @@
       ]
     },
     {
+      "name": "IWorkflowManagerFactory",
+      "fqn": "Granit.Workflow.IWorkflowManagerFactory",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowManagerFactory.cs",
+      "line": 23,
+      "members": []
+    },
+    {
       "name": "IWorkflowPermissionChecker",
       "fqn": "Granit.Workflow.IWorkflowPermissionChecker",
       "kind": "interface",

--- a/src/Granit.Workflow/Extensions/WorkflowServiceCollectionExtensions.cs
+++ b/src/Granit.Workflow/Extensions/WorkflowServiceCollectionExtensions.cs
@@ -25,7 +25,8 @@ public static class WorkflowServiceCollectionExtensions
     /// <remarks>
     /// <para>
     /// To register a specific workflow definition and manager, use
-    /// <see cref="AddWorkflow{TState}"/>.
+    /// <see cref="AddWorkflow{TState}(IServiceCollection, IWorkflowDefinition{TState})"/>
+    /// (single-entity) or its keyed overload (several entities sharing a state enum).
     /// </para>
     /// <para>
     /// The <see cref="IWorkflowPermissionChecker"/> default always grants permissions.
@@ -36,6 +37,7 @@ public static class WorkflowServiceCollectionExtensions
     public static IServiceCollection AddGranitWorkflow(this IServiceCollection services)
     {
         services.TryAddScoped<IWorkflowPermissionChecker, NullWorkflowPermissionChecker>();
+        services.TryAddScoped<IWorkflowManagerFactory, WorkflowManagerFactory>();
 
         // Diagnostics
         services.TryAddSingleton<WorkflowMetrics>();
@@ -52,6 +54,19 @@ public static class WorkflowServiceCollectionExtensions
     /// Registers a workflow definition and its <see cref="IWorkflowManager{TState}"/>
     /// for the specified state type.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use this for a module with a single entity per <typeparamref name="TState"/>: inject
+    /// <see cref="IWorkflowManager{TState}"/> directly. When two entities share the same
+    /// <typeparamref name="TState"/> but need distinct, permission-gated definitions, use the
+    /// keyed overload <see cref="AddWorkflow{TState}(IServiceCollection, string, IWorkflowDefinition{TState})"/>
+    /// and resolve via <see cref="IWorkflowManagerFactory"/>.
+    /// </para>
+    /// <para>
+    /// The definition is also registered under a default key (<c>typeof(TState).FullName</c>)
+    /// so it is reachable through <see cref="IWorkflowManagerFactory"/> alongside keyed workflows.
+    /// </para>
+    /// </remarks>
     /// <typeparam name="TState">Enum type representing the workflow states.</typeparam>
     /// <param name="services">The service collection.</param>
     /// <param name="definition">The immutable workflow definition.</param>
@@ -60,8 +75,61 @@ public static class WorkflowServiceCollectionExtensions
         IWorkflowDefinition<TState> definition)
         where TState : struct, Enum
     {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        // Non-keyed registrations preserve the single-entity ergonomics:
+        // inject IWorkflowDefinition<TState> / IWorkflowManager<TState> directly.
         services.AddSingleton(definition);
         services.AddScoped<IWorkflowManager<TState>, WorkflowManager<TState>>();
+
+        // Also expose it through the keyed seam under a default key so the factory can
+        // resolve single-entity workflows uniformly with keyed ones.
+        return services.AddWorkflow(DefaultWorkflowKey<TState>(), definition);
+    }
+
+    /// <summary>
+    /// Registers a workflow definition and its <see cref="IWorkflowManager{TState}"/>
+    /// keyed by <paramref name="workflowEntityType"/>, allowing several entities to share the same
+    /// <typeparamref name="TState"/> enum with distinct definitions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Resolve the resulting manager through <see cref="IWorkflowManagerFactory.GetManager{TState}(string)"/>
+    /// (or <see cref="IWorkflowManagerFactory.GetManager{TEntity, TState}()"/>), or by injecting
+    /// <c>[FromKeyedServices(workflowEntityType)] IWorkflowManager&lt;TState&gt;</c>.
+    /// </para>
+    /// <para>
+    /// <paramref name="workflowEntityType"/> should match the entity's
+    /// <see cref="Domain.IWorkflowStateful.WorkflowEntityType"/> (e.g. <c>"BlogPost"</c>).
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TState">Enum type representing the workflow states.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="workflowEntityType">The logical entity type key.</param>
+    /// <param name="definition">The immutable workflow definition.</param>
+    /// <exception cref="ArgumentException"><paramref name="workflowEntityType"/> is null or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="definition"/> is null.</exception>
+    public static IServiceCollection AddWorkflow<TState>(
+        this IServiceCollection services,
+        string workflowEntityType,
+        IWorkflowDefinition<TState> definition)
+        where TState : struct, Enum
+    {
+        ArgumentException.ThrowIfNullOrEmpty(workflowEntityType);
+        ArgumentNullException.ThrowIfNull(definition);
+
+        services.AddKeyedSingleton(workflowEntityType, definition);
+        services.AddKeyedScoped<IWorkflowManager<TState>>(workflowEntityType, static (sp, key) =>
+            ActivatorUtilities.CreateInstance<WorkflowManager<TState>>(
+                sp, sp.GetRequiredKeyedService<IWorkflowDefinition<TState>>(key)));
         return services;
     }
+
+    /// <summary>
+    /// The default key under which a non-keyed workflow definition is also registered,
+    /// so it remains reachable through <see cref="IWorkflowManagerFactory"/>.
+    /// </summary>
+    private static string DefaultWorkflowKey<TState>()
+        where TState : struct, Enum
+        => typeof(TState).FullName!;
 }

--- a/src/Granit.Workflow/IWorkflowManagerFactory.cs
+++ b/src/Granit.Workflow/IWorkflowManagerFactory.cs
@@ -1,0 +1,58 @@
+using Granit.Workflow.Domain;
+
+namespace Granit.Workflow;
+
+/// <summary>
+/// Resolves the <see cref="IWorkflowManager{TState}"/> for a specific workflow entity type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this when several entities share the same state enum but require distinct,
+/// permission-gated <see cref="IWorkflowDefinition{TState}"/> instances (registered via the keyed
+/// <c>AddWorkflow&lt;TState&gt;(string workflowEntityType, …)</c> overload). Each keyed definition
+/// is served by its own manager, keyed on the entity's
+/// <see cref="IWorkflowStateful.WorkflowEntityType"/>.
+/// </para>
+/// <para>
+/// For single-entity modules that register a workflow through the non-keyed
+/// <c>AddWorkflow&lt;TState&gt;(definition)</c> overload, inject
+/// <see cref="IWorkflowManager{TState}"/> directly — the factory remains available for those too,
+/// keyed on <c>typeof(TState).FullName</c>.
+/// </para>
+/// </remarks>
+public interface IWorkflowManagerFactory
+{
+    /// <summary>
+    /// Resolves the <see cref="IWorkflowManager{TState}"/> registered for the given
+    /// <paramref name="workflowEntityType"/>.
+    /// </summary>
+    /// <typeparam name="TState">Enum type representing the workflow states.</typeparam>
+    /// <param name="workflowEntityType">
+    /// The logical entity type key, matching <see cref="IWorkflowStateful.WorkflowEntityType"/>
+    /// (e.g. <c>"BlogPost"</c>) used at registration time.
+    /// </param>
+    /// <returns>The manager backed by the definition keyed under <paramref name="workflowEntityType"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="workflowEntityType"/> is null or empty.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// No workflow was registered for <paramref name="workflowEntityType"/> and
+    /// <typeparamref name="TState"/>.
+    /// </exception>
+    IWorkflowManager<TState> GetManager<TState>(string workflowEntityType)
+        where TState : struct, Enum;
+
+    /// <summary>
+    /// Resolves the <see cref="IWorkflowManager{TState}"/> for the entity type
+    /// <typeparamref name="TEntity"/>, using its static
+    /// <see cref="IWorkflowStateful.WorkflowEntityType"/> as the key.
+    /// </summary>
+    /// <typeparam name="TEntity">The workflow-stateful entity type.</typeparam>
+    /// <typeparam name="TState">Enum type representing the workflow states.</typeparam>
+    /// <returns>The manager backed by the definition keyed for <typeparamref name="TEntity"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// No workflow was registered for <typeparamref name="TEntity"/> and
+    /// <typeparamref name="TState"/>.
+    /// </exception>
+    IWorkflowManager<TState> GetManager<TEntity, TState>()
+        where TEntity : IWorkflowStateful
+        where TState : struct, Enum;
+}

--- a/src/Granit.Workflow/Internal/WorkflowManagerFactory.cs
+++ b/src/Granit.Workflow/Internal/WorkflowManagerFactory.cs
@@ -1,0 +1,30 @@
+using Granit.Workflow.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Workflow.Internal;
+
+/// <summary>
+/// Default <see cref="IWorkflowManagerFactory"/> that resolves keyed
+/// <see cref="IWorkflowManager{TState}"/> instances from the current scope.
+/// </summary>
+/// <remarks>
+/// Registered as scoped so the injected <see cref="IServiceProvider"/> is the request scope:
+/// the resolved managers and their scoped dependencies (<see cref="IWorkflowPermissionChecker"/>,
+/// <c>ICurrentTenant</c>) stay within the caller's scope.
+/// </remarks>
+internal sealed class WorkflowManagerFactory(IServiceProvider serviceProvider) : IWorkflowManagerFactory
+{
+    /// <inheritdoc/>
+    public IWorkflowManager<TState> GetManager<TState>(string workflowEntityType)
+        where TState : struct, Enum
+    {
+        ArgumentException.ThrowIfNullOrEmpty(workflowEntityType);
+        return serviceProvider.GetRequiredKeyedService<IWorkflowManager<TState>>(workflowEntityType);
+    }
+
+    /// <inheritdoc/>
+    public IWorkflowManager<TState> GetManager<TEntity, TState>()
+        where TEntity : IWorkflowStateful
+        where TState : struct, Enum
+        => GetManager<TState>(TEntity.WorkflowEntityType);
+}

--- a/src/Granit.Workflow/README.md
+++ b/src/Granit.Workflow/README.md
@@ -36,6 +36,32 @@ services.AddWorkflow<MyState>(definition);
 `WorkflowDefinitionBuilder<TState>` from `Granit.Workflow.Abstractions`. Without
 `AddWorkflow<TState>()`, no concrete state machine is available at runtime.
 
+## Several entities sharing one state enum
+
+When two entities share the same `TState` enum but need distinct,
+permission-gated definitions (e.g. `BlogPost` and `CmsPage` both on
+`WorkflowLifecycleStatus`), register each definition **keyed** by its
+`IWorkflowStateful.WorkflowEntityType`:
+
+```csharp
+services.AddWorkflow("BlogPost", blogDefinition);
+services.AddWorkflow("CmsPage", pageDefinition);
+```
+
+Resolve the right manager per entity through `IWorkflowManagerFactory`:
+
+```csharp
+IWorkflowManager<WorkflowLifecycleStatus> manager =
+    factory.GetManager<WorkflowLifecycleStatus>("BlogPost");
+// or, by entity type:
+IWorkflowManager<WorkflowLifecycleStatus> byEntity =
+    factory.GetManager<BlogPost, WorkflowLifecycleStatus>();
+```
+
+or by injecting `[FromKeyedServices("BlogPost")] IWorkflowManager<TState>`. The
+non-keyed `AddWorkflow<TState>(definition)` overload keeps working unchanged and
+is also reachable via the factory under `typeof(TState).FullName`.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/tests/Granit.Workflow.Tests/WorkflowManagerFactoryTests.cs
+++ b/tests/Granit.Workflow.Tests/WorkflowManagerFactoryTests.cs
@@ -1,0 +1,180 @@
+using Granit.MultiTenancy;
+using Granit.Workflow.Domain;
+using Granit.Workflow.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workflow.Tests;
+
+/// <summary>
+/// Tests for keyed workflow registration and <see cref="IWorkflowManagerFactory"/> — the core
+/// scenario where two entities share the same <see cref="WorkflowLifecycleStatus"/> enum but
+/// require distinct, permission-gated definitions.
+/// </summary>
+public sealed class WorkflowManagerFactoryTests
+{
+    private const string BlogPostType = "BlogPost";
+    private const string CmsPageType = "CmsPage";
+
+    // Two distinct definitions on the SAME TState, gating on different permissions.
+    private static readonly WorkflowDefinition<WorkflowLifecycleStatus> BlogDefinition =
+        WorkflowDefinition<WorkflowLifecycleStatus>.Create(b => b
+            .InitialState(WorkflowLifecycleStatus.Draft)
+            .Transition(WorkflowLifecycleStatus.Draft, WorkflowLifecycleStatus.Published, t => t
+                .Named("Publish")
+                .RequiresPermission("Blog.Posts.Publish")));
+
+    private static readonly WorkflowDefinition<WorkflowLifecycleStatus> PageDefinition =
+        WorkflowDefinition<WorkflowLifecycleStatus>.Create(b => b
+            .InitialState(WorkflowLifecycleStatus.Draft)
+            .Transition(WorkflowLifecycleStatus.Draft, WorkflowLifecycleStatus.Published, t => t
+                .Named("Publish")
+                .RequiresPermission("Cms.Pages.Publish")));
+
+    private static ServiceProvider BuildProvider()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        services.AddSingleton(Substitute.For<ICurrentTenant>());
+        services.AddGranitWorkflow();
+        services.AddWorkflow(BlogPostType, BlogDefinition);
+        services.AddWorkflow(CmsPageType, PageDefinition);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void For_SameTState_DifferentKeys_ShouldResolveIndependentDefinitions()
+    {
+        using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IWorkflowManagerFactory factory =
+            scope.ServiceProvider.GetRequiredService<IWorkflowManagerFactory>();
+
+        IWorkflowManager<WorkflowLifecycleStatus> blog = factory.GetManager<WorkflowLifecycleStatus>(BlogPostType);
+        IWorkflowManager<WorkflowLifecycleStatus> page = factory.GetManager<WorkflowLifecycleStatus>(CmsPageType);
+
+        blog.ShouldNotBeSameAs(page);
+    }
+
+    [Fact]
+    public async Task For_SameTState_ShouldGateOnEachDefinitionsOwnPermission()
+    {
+        // A permission checker granting ONLY the blog permission proves the two managers
+        // consult different definitions: blog completes, page is denied.
+        ServiceCollection services = new();
+        services.AddMetrics();
+        services.AddSingleton(Substitute.For<ICurrentTenant>());
+        IWorkflowPermissionChecker checker = Substitute.For<IWorkflowPermissionChecker>();
+        checker.IsGrantedAsync("Blog.Posts.Publish", Arg.Any<CancellationToken>()).Returns(true);
+        checker.IsGrantedAsync("Cms.Pages.Publish", Arg.Any<CancellationToken>()).Returns(false);
+        services.AddScoped(_ => checker);
+        services.AddGranitWorkflow();
+        services.AddWorkflow(BlogPostType, BlogDefinition);
+        services.AddWorkflow(CmsPageType, PageDefinition);
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IWorkflowManagerFactory factory =
+            scope.ServiceProvider.GetRequiredService<IWorkflowManagerFactory>();
+
+        TransitionResult<WorkflowLifecycleStatus> blogResult =
+            await factory.GetManager<WorkflowLifecycleStatus>(BlogPostType).TransitionAsync(
+                WorkflowLifecycleStatus.Draft,
+                WorkflowLifecycleStatus.Published,
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        TransitionResult<WorkflowLifecycleStatus> pageResult =
+            await factory.GetManager<WorkflowLifecycleStatus>(CmsPageType).TransitionAsync(
+                WorkflowLifecycleStatus.Draft,
+                WorkflowLifecycleStatus.Published,
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        blogResult.Outcome.ShouldBe(TransitionOutcome.Completed);
+        pageResult.Outcome.ShouldBe(TransitionOutcome.Denied);
+    }
+
+    [Fact]
+    public void ForTEntity_ShouldResolveByStaticWorkflowEntityType()
+    {
+        using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IWorkflowManagerFactory factory =
+            scope.ServiceProvider.GetRequiredService<IWorkflowManagerFactory>();
+
+        IWorkflowManager<WorkflowLifecycleStatus> byKey = factory.GetManager<WorkflowLifecycleStatus>(BlogPostType);
+        IWorkflowManager<WorkflowLifecycleStatus> byEntity =
+            factory.GetManager<BlogPostVersion, WorkflowLifecycleStatus>();
+
+        // Both resolve against the same keyed registration (scoped → same scope instance).
+        byEntity.ShouldBeSameAs(byKey);
+    }
+
+    [Fact]
+    public void FromKeyedServices_ShouldResolveKeyedManager()
+    {
+        using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+
+        IWorkflowManager<WorkflowLifecycleStatus> manager =
+            scope.ServiceProvider.GetRequiredKeyedService<IWorkflowManager<WorkflowLifecycleStatus>>(BlogPostType);
+
+        manager.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void For_UnregisteredKey_ShouldThrow()
+    {
+        using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IWorkflowManagerFactory factory =
+            scope.ServiceProvider.GetRequiredService<IWorkflowManagerFactory>();
+
+        Should.Throw<InvalidOperationException>(() =>
+            factory.GetManager<WorkflowLifecycleStatus>("Unknown"));
+    }
+
+    [Fact]
+    public void For_NullOrEmptyKey_ShouldThrow()
+    {
+        using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IWorkflowManagerFactory factory =
+            scope.ServiceProvider.GetRequiredService<IWorkflowManagerFactory>();
+
+        Should.Throw<ArgumentException>(() => factory.GetManager<WorkflowLifecycleStatus>(string.Empty));
+    }
+
+    [Fact]
+    public void NonKeyedRegistration_ShouldBeReachableViaFactoryDefaultKey()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        services.AddSingleton(Substitute.For<ICurrentTenant>());
+        services.AddGranitWorkflow();
+        services.AddWorkflow(BlogDefinition); // non-keyed
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IWorkflowManagerFactory factory =
+            scope.ServiceProvider.GetRequiredService<IWorkflowManagerFactory>();
+
+        IWorkflowManager<WorkflowLifecycleStatus> manager =
+            factory.GetManager<WorkflowLifecycleStatus>(typeof(WorkflowLifecycleStatus).FullName!);
+
+        manager.ShouldNotBeNull();
+    }
+
+    /// <summary>Minimal <see cref="IWorkflowStateful"/> stub keyed as <c>"BlogPost"</c>.</summary>
+    private sealed class BlogPostVersion : IWorkflowStateful
+    {
+        public static string StatusPropertyName => "LifecycleStatus";
+        public static string WorkflowEntityType => BlogPostType;
+        public string GetWorkflowEntityId() => Guid.Empty.ToString();
+        public void RaiseWorkflowStateChangedEvent(
+            string entityType, string previousState, string newState, string transitionedBy)
+        {
+        }
+    }
+}

--- a/tests/Granit.Workflow.Tests/WorkflowServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Workflow.Tests/WorkflowServiceCollectionExtensionsTests.cs
@@ -135,4 +135,61 @@ public sealed class WorkflowServiceCollectionExtensionsTests
         // Assert
         result.ShouldBeSameAs(services);
     }
+
+    // ========================================================================
+    // AddWorkflow<TState>(key, definition) — keyed
+    // ========================================================================
+
+    [Fact]
+    public void AddWorkflowKeyed_ShouldRegisterKeyedDefinition()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        services.AddGranitWorkflow();
+        var definition =
+            WorkflowDefinition<WorkflowLifecycleStatus>.Create(b => b
+                .InitialState(WorkflowLifecycleStatus.Draft)
+                .Transition(WorkflowLifecycleStatus.Draft, WorkflowLifecycleStatus.Published));
+
+        // Act
+        services.AddWorkflow("BlogPost", definition);
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        // Assert
+        IWorkflowDefinition<WorkflowLifecycleStatus> resolved =
+            sp.GetRequiredKeyedService<IWorkflowDefinition<WorkflowLifecycleStatus>>("BlogPost");
+        resolved.ShouldBeSameAs(definition);
+    }
+
+    [Fact]
+    public void AddWorkflowKeyed_NullOrEmptyKey_ShouldThrow()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        var definition =
+            WorkflowDefinition<WorkflowLifecycleStatus>.Create(b => b
+                .InitialState(WorkflowLifecycleStatus.Draft)
+                .Transition(WorkflowLifecycleStatus.Draft, WorkflowLifecycleStatus.Published));
+
+        // Act / Assert
+        Should.Throw<ArgumentException>(() => services.AddWorkflow(string.Empty, definition));
+    }
+
+    [Fact]
+    public void AddWorkflowKeyed_ShouldReturnSameServiceCollection()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        var definition =
+            WorkflowDefinition<WorkflowLifecycleStatus>.Create(b => b
+                .InitialState(WorkflowLifecycleStatus.Draft)
+                .Transition(WorkflowLifecycleStatus.Draft, WorkflowLifecycleStatus.Published));
+
+        // Act
+        IServiceCollection result = services.AddWorkflow("BlogPost", definition);
+
+        // Assert
+        result.ShouldBeSameAs(services);
+    }
 }


### PR DESCRIPTION
Closes #2924.

## Problem

`AddWorkflow<TState>(definition)` registered a **single** `IWorkflowDefinition<TState>`, and `WorkflowManager<TState>` injected a single one. Two entities sharing the same `TState` enum but needing **different** permission-gated transitions couldn't coexist — the second registration overwrote the first.

Real case (`granit-website`): `Granit.Cms.Pages` (`PageVersion`) and the new `Granit.Blog` (`BlogPostVersion`) both derive from `VersionedWorkflowEntity` → both use `WorkflowLifecycleStatus`, but gate on different permissions → DI collision.

## Change

- **Keyed overload** `AddWorkflow<TState>(string workflowEntityType, IWorkflowDefinition<TState> definition)` → `AddKeyedSingleton` (definition) + `AddKeyedScoped` (`IWorkflowManager<TState>`).
- **`IWorkflowManagerFactory`** — `GetManager<TState>(string workflowEntityType)` and `GetManager<TEntity, TState>()` (uses `TEntity.WorkflowEntityType`) resolve the keyed manager from the current scope. `[FromKeyedServices(key)] IWorkflowManager<TState>` also works.
- **Strict back-compat**: non-keyed `AddWorkflow<TState>(definition)` is unchanged (direct `IWorkflowDefinition<TState>` / `IWorkflowManager<TState>` injection intact) and additionally registered under a default key (`typeof(TState).FullName`) so the factory reaches single-entity workflows uniformly.
- `WorkflowManager<TState>` untouched (already takes a definition in its ctor); the audit interceptor is already generic per entity type.

> `IWorkflowManagerFactory.GetManager` rather than `.For` — `For` trips CA1716 (reserved keyword).

## Tests

- Two definitions keyed on the same `WorkflowLifecycleStatus` resolve independently and gate on their **own** permission (blog completes / page denied with a checker granting only the blog permission).
- `GetManager<TEntity, TState>()` resolves by static `WorkflowEntityType`.
- `[FromKeyedServices]` resolution; unknown/empty key throw; non-keyed reachable via default key.
- Keyed-overload registration + guards in the extension tests.

## Verification

- `Granit.Workflow.Tests`: 130 passed · `Granit.Templating.Workflow.Tests` (existing non-keyed consumer): 9 passed.
- `Granit.ArchitectureTests`: 244 passed.
- `dotnet format --verify-no-changes` clean · markdownlint clean.

## Downstream (separate, granit-website)

Once published: Pages migrates to the keyed variant (`"CmsPage"`), `Granit.Blog` registers `BlogPostPublicationWorkflow.Default` keyed `"BlogPost"`.