### PR TITLE
fix(settings): restore user culture application in SettingsCultureMiddleware

### DIFF
--- a/src/Granit.Settings.Endpoints/Middleware/SettingsCultureMiddleware.cs
+++ b/src/Granit.Settings.Endpoints/Middleware/SettingsCultureMiddleware.cs
@@ -28,7 +28,17 @@ public sealed class SettingsCultureMiddleware(RequestDelegate next)
         {
             ISettingProvider settingProvider = context.RequestServices.GetRequiredService<ISettingProvider>();
 
-            await ApplyCultureAsync(context, settingProvider).ConfigureAwait(false);
+            // The culture MUST be assigned in this method's async context, not inside a nested
+            // async helper: CultureInfo.Current(UI)Culture is backed by an AsyncLocal, and a value
+            // set inside a callee does not flow back to the caller. Setting it here — the same
+            // async frame that awaits _next — is what makes it visible to downstream handlers.
+            CultureInfo? culture = await ResolveCultureAsync(context, settingProvider).ConfigureAwait(false);
+            if (culture is not null)
+            {
+                CultureInfo.CurrentCulture = culture;
+                CultureInfo.CurrentUICulture = culture;
+            }
+
             await ApplyTimezoneAsync(context, settingProvider).ConfigureAwait(false);
             await ApplyFirstDayOfWeekAsync(context, settingProvider).ConfigureAwait(false);
         }
@@ -36,18 +46,15 @@ public sealed class SettingsCultureMiddleware(RequestDelegate next)
         await _next(context).ConfigureAwait(false);
     }
 
-    private static async Task ApplyCultureAsync(HttpContext context, ISettingProvider settingProvider)
+    private static async Task<CultureInfo?> ResolveCultureAsync(HttpContext context, ISettingProvider settingProvider)
     {
         string? locale = await settingProvider
             .GetOrNullAsync(WellKnownSettingNames.PreferredCulture, context.RequestAborted)
             .ConfigureAwait(false);
 
-        if (locale is not null && IsKnownCulture(locale))
-        {
-            var culture = CultureInfo.GetCultureInfo(locale);
-            CultureInfo.CurrentCulture = culture;
-            CultureInfo.CurrentUICulture = culture;
-        }
+        return locale is not null && IsKnownCulture(locale)
+            ? CultureInfo.GetCultureInfo(locale)
+            : null;
     }
 
     private static async Task ApplyTimezoneAsync(HttpContext context, ISettingProvider settingProvider)


### PR DESCRIPTION
Closes #2926.

## Problem

`SettingsCultureMiddleware` stopped applying the authenticated user's `PreferredCulture` — downstream handlers ran under the ambient (invariant) culture. This turned the `test (Infrastructure)` CI shard red from #2923 onward (`SettingsCultureMiddlewareTests`, 3 tests).

## Root cause

The #2923 cognitive-complexity refactor extracted the culture assignment into a nested async helper:

```csharp
await ApplyCultureAsync(context, settingProvider); // sets CultureInfo.CurrentCulture *inside* the callee
...
await _next(context);                              // runs with the ORIGINAL culture
```

`CultureInfo.CurrentCulture` / `CurrentUICulture` are backed by an `AsyncLocal`. A value written in a **callee** async method does not flow **back** to the caller when it returns, so the assignment was unwound before `_next` ran. Timezone and first-day-of-week kept working because they mutate an **injected service property**, not an `AsyncLocal` — that asymmetry is the tell.

## Fix

Resolve the culture in the helper (`ResolveCultureAsync` → `CultureInfo?`) but perform the `CurrentCulture`/`CurrentUICulture` assignment in `InvokeAsync` — the same async frame that awaits `_next` — so the value flows downstream. Restores the pre-#2923 behaviour with the complexity split intact.

## Verification

- `Granit.Settings.Endpoints.Tests`: **117 passed** (the 3 previously-failing `SettingsCultureMiddlewareTests` now green).
- `dotnet format --verify-no-changes` clean.
- No new test needed — the existing tests already covered this and correctly caught the regression.

## Note

Unrelated to and independent of #2925 (workflow keyed definitions); this is a pre-existing regression on `develop` that was surfacing on that PR's CI.