### PR TITLE
style(analyzers): promote 15 more Roslynator rules to warning in src

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -108,6 +108,35 @@ dotnet_diagnostic.RCS1077.severity = warning
 dotnet_diagnostic.RCS1197.severity = warning
 # RCS1123: add parentheses when necessary (explicit *-in-+ grouping; precedence unchanged)
 dotnet_diagnostic.RCS1123.severity = warning
+# RCS1205: order named arguments to match the parameter declaration order
+dotnet_diagnostic.RCS1205.severity = warning
+# RCS1021: use expression-bodied lambda (block with a single statement → =>)
+dotnet_diagnostic.RCS1021.severity = warning
+# RCS1251: remove unnecessary braces (empty type body → ;)
+dotnet_diagnostic.RCS1251.severity = warning
+# RCS1073: convert redundant if to a return statement
+dotnet_diagnostic.RCS1073.severity = warning
+# RCS1221: use pattern matching instead of 'as' + null check
+dotnet_diagnostic.RCS1221.severity = warning
+# RCS1235: optimize dictionary 'Add' call
+dotnet_diagnostic.RCS1235.severity = warning
+# RCS1249: remove unnecessary null-forgiving operator (!)
+dotnet_diagnostic.RCS1249.severity = warning
+# RCS1212: remove redundant assignment
+dotnet_diagnostic.RCS1212.severity = warning
+# RCS1206: use conditional access instead of conditional expression
+dotnet_diagnostic.RCS1206.severity = warning
+# RCS1084: use coalesce expression (??) instead of conditional expression
+dotnet_diagnostic.RCS1084.severity = warning
+# RCS1173: use coalesce expression instead of 'if'
+dotnet_diagnostic.RCS1173.severity = warning
+# RCS1006: merge 'else' with nested 'if' (→ else if)
+dotnet_diagnostic.RCS1006.severity = warning
+# RCS1196: call extension method as an instance method
+dotnet_diagnostic.RCS1196.severity = warning
+#
+# RCS1243 (duplicate word in comment) deliberately NOT promoted: it corrupts legitimate
+# repeated format placeholders (e.g. "XXX XXX XXX" SIN masks → "XXX XXX") — a silent doc bug.
 #
 # RCS1124 (inline single-use local) was evaluated and deliberately left at the suggestion
 # baseline: its auto-fix removes named `snapshot` locals that document volatile-read

--- a/.editorconfig
+++ b/.editorconfig
@@ -140,6 +140,10 @@ dotnet_diagnostic.RCS1006.severity = warning
 dotnet_diagnostic.RCS1196.severity = warning
 # RCS1267: use string interpolation instead of string.Concat
 dotnet_diagnostic.RCS1267.severity = warning
+# RCS1261: resource can be disposed asynchronously (using → await using in async methods).
+# Note: the implicit DisposeAsync await carries no ConfigureAwait(false), but that is moot
+# under ASP.NET Core (no sync context) and no analyzer flags it.
+dotnet_diagnostic.RCS1261.severity = warning
 #
 # RCS1243 (duplicate word in comment) deliberately NOT promoted: it corrupts legitimate
 # repeated format placeholders (e.g. "XXX XXX XXX" SIN masks → "XXX XXX") — a silent doc bug.

--- a/.editorconfig
+++ b/.editorconfig
@@ -55,6 +55,10 @@ dotnet_diagnostic.RCS1142.severity = none
 # RCS1181: convert comment to documentation comment
 dotnet_diagnostic.RCS1181.severity = none
 
+# RCS1217 — "convert interpolated string to concatenation": the exact opposite of the
+# promoted RCS1267 (interpolation preferred). Disabled to avoid a contradictory pair.
+dotnet_diagnostic.RCS1217.severity = none
+
 # RCS1090 (add ConfigureAwait) is kept at suggestion: correct for library code but noise
 # in .Endpoints and test projects — do NOT promote globally. Tests silence it below.
 csharp_new_line_before_open_brace = all
@@ -134,6 +138,8 @@ dotnet_diagnostic.RCS1173.severity = warning
 dotnet_diagnostic.RCS1006.severity = warning
 # RCS1196: call extension method as an instance method
 dotnet_diagnostic.RCS1196.severity = warning
+# RCS1267: use string interpolation instead of string.Concat
+dotnet_diagnostic.RCS1267.severity = warning
 #
 # RCS1243 (duplicate word in comment) deliberately NOT promoted: it corrupts legitimate
 # repeated format placeholders (e.g. "XXX XXX XXX" SIN masks → "XXX XXX") — a silent doc bug.

--- a/src/Granit.AI.Anthropic/Extensions/AIAnthropicHostApplicationBuilderExtensions.cs
+++ b/src/Granit.AI.Anthropic/Extensions/AIAnthropicHostApplicationBuilderExtensions.cs
@@ -46,10 +46,7 @@ public static class AIAnthropicHostApplicationBuilderExtensions
         // AllowAutoRedirect = false closes the redirect-to-metadata SSRF path (anthropic.com does
         // not legitimately 3xx).
         builder.Services
-            .AddHttpClient(AnthropicProviderFactory.HttpClientName, client =>
-            {
-                client.Timeout = Timeout.InfiniteTimeSpan;
-            })
+            .AddHttpClient(AnthropicProviderFactory.HttpClientName, client => client.Timeout = Timeout.InfiniteTimeSpan)
             .ConfigurePrimaryHttpMessageHandler(static () => new SocketsHttpHandler
             {
                 AllowAutoRedirect = false,

--- a/src/Granit.AI.AzureOpenAI/Extensions/AIAzureOpenAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.AI.AzureOpenAI/Extensions/AIAzureOpenAIHostApplicationBuilderExtensions.cs
@@ -41,10 +41,7 @@ public static class AIAzureOpenAIHostApplicationBuilderExtensions
         builder.Services.AddSingleton<IValidateOptions<AzureOpenAIProviderOptions>, AzureOpenAIProviderOptionsValidator>();
 
         builder.Services
-            .AddHttpClient(AzureOpenAIProviderFactory.HttpClientName, client =>
-            {
-                client.Timeout = Timeout.InfiniteTimeSpan;
-            })
+            .AddHttpClient(AzureOpenAIProviderFactory.HttpClientName, client => client.Timeout = Timeout.InfiniteTimeSpan)
             .ConfigurePrimaryHttpMessageHandler(static () => new SocketsHttpHandler
             {
                 AllowAutoRedirect = false,

--- a/src/Granit.AI.Chat.Endpoints/Validators/SetConversationFavoriteRequestValidator.cs
+++ b/src/Granit.AI.Chat.Endpoints/Validators/SetConversationFavoriteRequestValidator.cs
@@ -8,6 +8,4 @@ namespace Granit.AI.Chat.Endpoints.Validators;
 /// unconstrained (both states are valid), so the validator carries no rules; it exists to satisfy
 /// the framework's "every <c>*Request</c> has a <see cref="GranitValidator{T}"/>" convention.
 /// </summary>
-internal sealed class SetConversationFavoriteRequestValidator : GranitValidator<SetConversationFavoriteRequest>
-{
-}
+internal sealed class SetConversationFavoriteRequestValidator : GranitValidator<SetConversationFavoriteRequest>;

--- a/src/Granit.AI.Chat/Internal/AIAttachmentTextResolver.cs
+++ b/src/Granit.AI.Chat/Internal/AIAttachmentTextResolver.cs
@@ -51,7 +51,7 @@ internal sealed class AIAttachmentTextResolver(
                 continue;
             }
 
-            using var stream = new MemoryStream(data.Bytes.ToArray(), writable: false);
+            await using var stream = new MemoryStream(data.Bytes.ToArray(), writable: false);
             TextExtractionResult result = await extractionPipeline
                 .ExtractAsync(stream, data.ContentType, cancellationToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(result.Content))

--- a/src/Granit.AI.Ollama/Internal/OllamaClientCache.cs
+++ b/src/Granit.AI.Ollama/Internal/OllamaClientCache.cs
@@ -42,7 +42,7 @@ internal sealed class OllamaClientCache(
         ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
 
-        string key = string.Concat(endpoint, "|", model, "|", scope.ToString());
+        string key = $"{endpoint}|{model}|{scope.ToString()}";
         if (_cache.TryGetValue(key, out object? cached) && cached is OllamaApiClient existing)
         {
             return existing;

--- a/src/Granit.AI.OpenAI/Extensions/AIOpenAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.AI.OpenAI/Extensions/AIOpenAIHostApplicationBuilderExtensions.cs
@@ -46,10 +46,7 @@ public static class AIOpenAIHostApplicationBuilderExtensions
         builder.Services.TryAddSingleton(TimeProvider.System);
 
         builder.Services
-            .AddHttpClient(OpenAIProviderFactory.HttpClientName, client =>
-            {
-                client.Timeout = Timeout.InfiniteTimeSpan;
-            })
+            .AddHttpClient(OpenAIProviderFactory.HttpClientName, client => client.Timeout = Timeout.InfiniteTimeSpan)
             .ConfigurePrimaryHttpMessageHandler(static () => new SocketsHttpHandler
             {
                 AllowAutoRedirect = false,

--- a/src/Granit.AI/Tenancy/AIEndpointValidator.cs
+++ b/src/Granit.AI/Tenancy/AIEndpointValidator.cs
@@ -80,12 +80,7 @@ public static partial class AIEndpointValidator
 
         string host = uri.Host;
         AIEndpointValidationResult? hostViolation = ValidateHost(uri, host, policy);
-        if (hostViolation is not null)
-        {
-            return hostViolation;
-        }
-
-        return AIEndpointValidationResult.Ok(resolvedHost: host);
+        return hostViolation ?? AIEndpointValidationResult.Ok(resolvedHost: host);
     }
 
     /// <summary>Validates the URI's RFC 3986 shape: userinfo/fragment, scheme, and port allow-lists.</summary>

--- a/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
+++ b/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
@@ -77,8 +77,8 @@ internal static partial class PermissionGrantEndpoints
             .ConfigureAwait(false))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status404NotFound,
-                detail: $"Role '{roleName}' not found.");
+                detail: $"Role '{roleName}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
@@ -114,8 +114,8 @@ internal static partial class PermissionGrantEndpoints
             .ConfigureAwait(false))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status404NotFound,
-                detail: $"Role '{roleName}' not found.");
+                detail: $"Role '{roleName}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         if (!definitionManager.Exists(permissionName))
@@ -173,8 +173,8 @@ internal static partial class PermissionGrantEndpoints
             .ConfigureAwait(false))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status404NotFound,
-                detail: $"Role '{roleName}' not found.");
+                detail: $"Role '{roleName}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         if (!definitionManager.Exists(permissionName))

--- a/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
@@ -62,15 +62,9 @@ public static class AuthorizationEndpointRouteBuilderExtensions
         // sees only the host partition. For ISO 27001 cross-tenant authorization review, mark these
         // groups .AllowHostAccess(); a platform admin holding each group's read permission at global
         // scope then reads across tenants, while the filter stays enforced for tenant-scoped callers.
-        group.MapGranitGroup("grants").MapGranitQuery<PermissionGrant>(configure: opts =>
-        {
-            opts.AuthorizationPolicy = AuthorizationEndpointsPermissions.Grants.Manage;
-        });
+        group.MapGranitGroup("grants").MapGranitQuery<PermissionGrant>(configure: opts => opts.AuthorizationPolicy = AuthorizationEndpointsPermissions.Grants.Manage);
 
-        group.MapGranitGroup("role-metadata").MapGranitQuery<RoleMetadata>(configure: opts =>
-        {
-            opts.AuthorizationPolicy = AuthorizationEndpointsPermissions.Definitions.Read;
-        });
+        group.MapGranitGroup("role-metadata").MapGranitQuery<RoleMetadata>(configure: opts => opts.AuthorizationPolicy = AuthorizationEndpointsPermissions.Definitions.Read);
 
         return group;
     }

--- a/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
+++ b/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
@@ -137,7 +137,7 @@ public sealed class BackgroundJobDefinition : AggregateRoot
     {
         ConsecutiveFailureCount++;
         LastErrorMessage = errorMessage?.Length > MaxErrorMessageLength
-            ? string.Concat(errorMessage.AsSpan(0, MaxErrorMessageLength), "… [truncated]")
+            ? $"{errorMessage.AsSpan(0, MaxErrorMessageLength)}… [truncated]"
             : errorMessage;
 
         if (ConsecutiveFailureCount >= 3)

--- a/src/Granit.BackgroundJobs/Internal/RecurringJobRegistrationCollection.cs
+++ b/src/Granit.BackgroundJobs/Internal/RecurringJobRegistrationCollection.cs
@@ -16,11 +16,8 @@ internal sealed class RecurringJobRegistrationCollection
     {
         lock (_lock)
         {
-            foreach (RecurringJobRegistration? registration in registrations
-                .Where(r => !_registrations.Exists(existing => existing.JobName == r.JobName)))
-            {
-                _registrations.Add(registration);
-            }
+            _registrations.AddRange(registrations
+                .Where(r => !_registrations.Exists(existing => existing.JobName == r.JobName)));
         }
     }
 

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -443,7 +443,7 @@ internal static partial class BffLoginEndpoints
                 dpopNonce = successNonce.FirstOrDefault() ?? dpopNonce;
             }
 
-            using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken)
+            await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             JsonElement tokenResponse = await JsonSerializer.DeserializeAsync<JsonElement>(stream, cancellationToken: cancellationToken)
@@ -526,7 +526,7 @@ internal static partial class BffLoginEndpoints
                 return null;
             }
 
-            using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken)
+            await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             JsonElement parResponse = await JsonSerializer.DeserializeAsync<JsonElement>(
@@ -583,7 +583,7 @@ internal static partial class BffLoginEndpoints
     {
         try
         {
-            using Stream errorStream = await response.Content.ReadAsStreamAsync(cancellationToken)
+            await using Stream errorStream = await response.Content.ReadAsStreamAsync(cancellationToken)
                 .ConfigureAwait(false);
             JsonElement errorBody = await JsonSerializer.DeserializeAsync<JsonElement>(
                 errorStream, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
@@ -347,7 +347,7 @@ public sealed partial class BffTokenInjectionMiddleware
                 dpopNonce = nonceValues.FirstOrDefault() ?? dpopNonce;
             }
 
-            using Stream stream = await response.Content.ReadAsStreamAsync(context.RequestAborted)
+            await using Stream stream = await response.Content.ReadAsStreamAsync(context.RequestAborted)
                 .ConfigureAwait(false);
 
             JsonElement tokenResponse = await JsonSerializer.DeserializeAsync<JsonElement>(

--- a/src/Granit.Bff.Yarp/Internal/BffTokenInjectionTransform.cs
+++ b/src/Granit.Bff.Yarp/Internal/BffTokenInjectionTransform.cs
@@ -251,7 +251,7 @@ internal sealed partial class BffTokenInjectionTransform(
                 dpopNonce = nonceValues.FirstOrDefault() ?? dpopNonce;
             }
 
-            using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken)
+            await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             JsonElement tokenResponse = await JsonSerializer.DeserializeAsync<JsonElement>(

--- a/src/Granit.Bff/Internal/LogoutTokenValidator.cs
+++ b/src/Granit.Bff/Internal/LogoutTokenValidator.cs
@@ -166,7 +166,7 @@ internal sealed partial class LogoutTokenValidator(
             .GetAsync(discoveryUrl, ct).ConfigureAwait(false);
         discoveryResponse.EnsureSuccessStatusCode();
 
-        using Stream discoveryStream = await discoveryResponse.Content
+        await using Stream discoveryStream = await discoveryResponse.Content
             .ReadAsStreamAsync(ct).ConfigureAwait(false);
         using JsonDocument discoveryDoc = await JsonDocument
             .ParseAsync(discoveryStream, cancellationToken: ct).ConfigureAwait(false);
@@ -185,7 +185,7 @@ internal sealed partial class LogoutTokenValidator(
             .GetAsync(jwksUri, ct).ConfigureAwait(false);
         jwksResponse.EnsureSuccessStatusCode();
 
-        using Stream jwksStream = await jwksResponse.Content
+        await using Stream jwksStream = await jwksResponse.Content
             .ReadAsStreamAsync(ct).ConfigureAwait(false);
         using JsonDocument jwksDoc = await JsonDocument
             .ParseAsync(jwksStream, cancellationToken: ct).ConfigureAwait(false);

--- a/src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptionsValidator.cs
+++ b/src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptionsValidator.cs
@@ -24,14 +24,11 @@ internal sealed class AzureBlobOptionsValidator : IValidateOptions<AzureBlobOpti
                     $"{nameof(options.ServiceUri)} must use HTTPS.");
             }
         }
-        else
+        else if (string.IsNullOrWhiteSpace(options.ConnectionString))
         {
-            if (string.IsNullOrWhiteSpace(options.ConnectionString))
-            {
-                return ValidateOptionsResult.Fail(
-                    $"{nameof(options.ConnectionString)} must be non-empty when {nameof(options.UseManagedIdentity)} is false. " +
-                    "Inject from Granit.Vault.");
-            }
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.ConnectionString)} must be non-empty when {nameof(options.UseManagedIdentity)} is false. " +
+                "Inject from Granit.Vault.");
         }
 
         if (string.IsNullOrWhiteSpace(options.DefaultContainer))

--- a/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
+++ b/src/Granit.BlobStorage.Database/Internal/DatabaseBlobClient.cs
@@ -48,7 +48,7 @@ internal sealed class DatabaseBlobClient(
 
         // EF Core maps the column as `byte[]`, which requires full materialization before SaveChanges;
         // we still cap the read at MaxBlobSizeBytes + 1 to fail fast on oversize unseekable streams.
-        using MemoryStream ms = new();
+        await using MemoryStream ms = new();
         byte[] buffer = new byte[81920];
         long totalRead = 0;
         int read;

--- a/src/Granit.BlobStorage/Internal/DefaultBlobContentReader.cs
+++ b/src/Granit.BlobStorage/Internal/DefaultBlobContentReader.cs
@@ -19,7 +19,7 @@ internal sealed class DefaultBlobContentReader(
         Stream stream = await storeProvider.OpenReadAsync(bucket, descriptor.ObjectKey, cancellationToken).ConfigureAwait(false);
         await using (stream.ConfigureAwait(false))
         {
-            using var ms = new MemoryStream();
+            await using var ms = new MemoryStream();
             await stream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
             return new BlobContent(ms.ToArray(), descriptor.VerifiedContentType!, descriptor.OriginalFileName);
         }

--- a/src/Granit.Browsing.Playwright/Internal/PlaywrightBrowserPage.cs
+++ b/src/Granit.Browsing.Playwright/Internal/PlaywrightBrowserPage.cs
@@ -278,10 +278,7 @@ internal sealed partial class PlaywrightBrowserPage : IBrowserPage
         ArgumentException.ThrowIfNullOrEmpty(css);
         PublishScriptInjected("style", css);
         return BrowsingTimeout.RunAsync(
-            async ct =>
-            {
-                await _page.AddStyleTagAsync(new PageAddStyleTagOptions { Content = css }).ConfigureAwait(false);
-            },
+            async ct => await _page.AddStyleTagAsync(new PageAddStyleTagOptions { Content = css }).ConfigureAwait(false),
             _maxRenderDuration,
             cancellationToken);
     }
@@ -292,10 +289,7 @@ internal sealed partial class PlaywrightBrowserPage : IBrowserPage
         ArgumentException.ThrowIfNullOrEmpty(js);
         PublishScriptInjected("script", js);
         return BrowsingTimeout.RunAsync(
-            async ct =>
-            {
-                await _page.AddScriptTagAsync(new PageAddScriptTagOptions { Content = js }).ConfigureAwait(false);
-            },
+            async ct => await _page.AddScriptTagAsync(new PageAddScriptTagOptions { Content = js }).ConfigureAwait(false),
             _maxRenderDuration,
             cancellationToken);
     }

--- a/src/Granit.Browsing.Playwright/Internal/PlaywrightPdfViewerCapability.cs
+++ b/src/Granit.Browsing.Playwright/Internal/PlaywrightPdfViewerCapability.cs
@@ -82,7 +82,7 @@ internal sealed partial class PlaywrightPdfViewerCapability : IPdfViewerCapabili
 
         using Activity? activity = BrowsingActivitySource.Source.StartActivity(BrowsingActivitySource.PdfViewerOpen);
 
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await pdf.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         byte[] bytes = buffer.ToArray();
 

--- a/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerBrowserPage.cs
+++ b/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerBrowserPage.cs
@@ -274,10 +274,7 @@ internal sealed partial class PuppeteerBrowserPage : IBrowserPage
         ArgumentException.ThrowIfNullOrEmpty(css);
         PublishScriptInjected("style", css);
         return BrowsingTimeout.RunAsync(
-            async ct =>
-            {
-                await _page.AddStyleTagAsync(new AddTagOptions { Content = css }).ConfigureAwait(false);
-            },
+            async ct => await _page.AddStyleTagAsync(new AddTagOptions { Content = css }).ConfigureAwait(false),
             _maxRenderDuration,
             cancellationToken);
     }
@@ -288,10 +285,7 @@ internal sealed partial class PuppeteerBrowserPage : IBrowserPage
         ArgumentException.ThrowIfNullOrEmpty(js);
         PublishScriptInjected("script", js);
         return BrowsingTimeout.RunAsync(
-            async ct =>
-            {
-                await _page.AddScriptTagAsync(new AddTagOptions { Content = js }).ConfigureAwait(false);
-            },
+            async ct => await _page.AddScriptTagAsync(new AddTagOptions { Content = js }).ConfigureAwait(false),
             _maxRenderDuration,
             cancellationToken);
     }

--- a/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerPdfViewerCapability.cs
+++ b/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerPdfViewerCapability.cs
@@ -78,7 +78,7 @@ internal sealed partial class PuppeteerPdfViewerCapability : IPdfViewerCapabilit
 
         using Activity? activity = BrowsingActivitySource.Source.StartActivity(BrowsingActivitySource.PdfViewerOpen);
 
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await pdf.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         byte[] bytes = buffer.ToArray();
 

--- a/src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs
+++ b/src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs
@@ -147,10 +147,7 @@ public static partial class RedisCachingServiceCollectionExtensions
         // Deferred backplane configuration via options
         services.AddOptions<ZiggyCreatures.Caching.Fusion.Backplane.StackExchangeRedis.RedisBackplaneOptions>()
             .Configure<IConnectionMultiplexer>(
-                (backplane, mux) =>
-                {
-                    backplane.ConnectionMultiplexerFactory = () => Task.FromResult(mux);
-                });
+                (backplane, mux) => backplane.ConnectionMultiplexerFactory = () => Task.FromResult(mux));
 
         return services;
     }

--- a/src/Granit.DataExchange.Abstractions/GranitDataExchangeAbstractionsModule.cs
+++ b/src/Granit.DataExchange.Abstractions/GranitDataExchangeAbstractionsModule.cs
@@ -13,6 +13,4 @@ namespace Granit.DataExchange;
 /// export or import pipelines depend on <c>GranitDataExchangeModule</c> instead, which
 /// transitively depends on this module.
 /// </remarks>
-public sealed class GranitDataExchangeAbstractionsModule : GranitModule
-{
-}
+public sealed class GranitDataExchangeAbstractionsModule : GranitModule;

--- a/src/Granit.DataExchange.Excel/Internal/Import/SylvanExcelFileParser.cs
+++ b/src/Granit.DataExchange.Excel/Internal/Import/SylvanExcelFileParser.cs
@@ -26,7 +26,7 @@ internal sealed class SylvanExcelFileParser : IFileParser
         FileParsingOptions options,
         CancellationToken cancellationToken = default)
     {
-        using ExcelDataReader reader = await CreateReaderAsync(stream, options, cancellationToken).ConfigureAwait(false);
+        await using ExcelDataReader reader = await CreateReaderAsync(stream, options, cancellationToken).ConfigureAwait(false);
 
         List<string> headers = new(reader.FieldCount);
         for (int i = 0; i < reader.FieldCount; i++)
@@ -44,7 +44,7 @@ internal sealed class SylvanExcelFileParser : IFileParser
         int maxRows = 10,
         CancellationToken cancellationToken = default)
     {
-        using ExcelDataReader reader = await CreateReaderAsync(stream, options, cancellationToken).ConfigureAwait(false);
+        await using ExcelDataReader reader = await CreateReaderAsync(stream, options, cancellationToken).ConfigureAwait(false);
         int fieldCount = reader.FieldCount;
 
         List<string[]> rows = [];
@@ -78,7 +78,7 @@ internal sealed class SylvanExcelFileParser : IFileParser
         FileParsingOptions options,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        using ExcelDataReader reader = await CreateReaderAsync(stream, options, cancellationToken).ConfigureAwait(false);
+        await using ExcelDataReader reader = await CreateReaderAsync(stream, options, cancellationToken).ConfigureAwait(false);
 
         List<string> headers = new(reader.FieldCount);
         for (int i = 0; i < reader.FieldCount; i++)

--- a/src/Granit.DataExchange.Xml/Internal/Export/XmlExportWriter.cs
+++ b/src/Granit.DataExchange.Xml/Internal/Export/XmlExportWriter.cs
@@ -63,7 +63,7 @@ internal sealed class XmlExportWriter : IExportWriter
             GetOrCreateSerializer(field.SelectorType!);
         }
 
-        using var xmlWriter = XmlWriter.Create(output, WriterSettings);
+        await using var xmlWriter = XmlWriter.Create(output, WriterSettings);
 
         await xmlWriter.WriteStartDocumentAsync().ConfigureAwait(false);
         await xmlWriter.WriteStartElementAsync(null, "Export", null).ConfigureAwait(false);

--- a/src/Granit.DataExchange/Export/ExportOrchestrator.cs
+++ b/src/Granit.DataExchange/Export/ExportOrchestrator.cs
@@ -136,7 +136,7 @@ public sealed partial class ExportOrchestrator(
         {
             stopwatch.Stop();
             string sanitizedError = ex.Message.Length > 500
-                ? string.Concat(ex.Message.AsSpan(0, 500), "… [truncated]")
+                ? $"{ex.Message.AsSpan(0, 500)}… [truncated]"
                 : ex.Message;
             job.Fail(sanitizedError, clock.Now);
             await jobWriter.UpdateAsync(job, cancellationToken).ConfigureAwait(false);

--- a/src/Granit.DataExchange/Import/Internal/ImportOrchestrator.cs
+++ b/src/Granit.DataExchange/Import/Internal/ImportOrchestrator.cs
@@ -85,7 +85,7 @@ internal sealed class ImportOrchestrator(
                 RowErrors =
                 [
                     new ImportRowError(0, ImportRowErrorKind.Persistence, ["Granit:DataExchange:PipelineError"],
-                        ex.Message.Length > 500 ? string.Concat(ex.Message.AsSpan(0, 500), "... [truncated]") : ex.Message),
+                        ex.Message.Length > 500 ? $"{ex.Message.AsSpan(0, 500)}... [truncated]" : ex.Message),
                 ],
             };
 

--- a/src/Granit.DataExchange/Internal/InMemoryDataExchangeFileProvider.cs
+++ b/src/Granit.DataExchange/Internal/InMemoryDataExchangeFileProvider.cs
@@ -33,17 +33,17 @@ internal sealed class InMemoryDataExchangeFileProvider : IDataExchangeFileProvid
     }
 
     /// <inheritdoc/>
-    public Task<BlobReference> SaveAsync(string fileName, Stream content, CancellationToken cancellationToken = default)
+    public async Task<BlobReference> SaveAsync(string fileName, Stream content, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(content);
 
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         content.CopyTo(buffer);
 
         string reference = $"mem-{Interlocked.Increment(ref _counter)}";
         _store[reference] = buffer.ToArray();
 
-        return Task.FromResult(BlobReference.Create(reference));
+        return await Task.FromResult(BlobReference.Create(reference));
     }
 
     /// <inheritdoc/>

--- a/src/Granit.DocumentGeneration.Excel/Internal/ClosedXmlTemplateEngine.cs
+++ b/src/Granit.DocumentGeneration.Excel/Internal/ClosedXmlTemplateEngine.cs
@@ -43,7 +43,7 @@ internal sealed class ClosedXmlTemplateEngine : ITemplateEngine
         string.Equals(descriptor.MimeType, ExcelMimeType, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
-    public Task<RenderedContent> RenderAsync<TData>(
+    public async Task<RenderedContent> RenderAsync<TData>(
         TemplateDescriptor descriptor,
         TData data,
         TemplatingDocFormat targetFormat,
@@ -53,8 +53,8 @@ internal sealed class ClosedXmlTemplateEngine : ITemplateEngine
         byte[] templateBytes = Convert.FromBase64String(descriptor.Content);
         Dictionary<string, string> substitutions = BuildSubstitutions(data);
 
-        using MemoryStream outputStream = new();
-        using (MemoryStream inputStream = new(templateBytes))
+        await using MemoryStream outputStream = new();
+        await using (MemoryStream inputStream = new(templateBytes))
         using (XLWorkbook workbook = new(inputStream))
         {
             ApplySubstitutions(workbook, substitutions);
@@ -67,7 +67,7 @@ internal sealed class ClosedXmlTemplateEngine : ITemplateEngine
             RevisionId = descriptor.RevisionId,
         };
 
-        return Task.FromResult(result);
+        return await Task.FromResult(result);
     }
 
     private static Dictionary<string, string> BuildSubstitutions<TData>(TData data)

--- a/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationMaterializationInterceptor.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationMaterializationInterceptor.cs
@@ -67,8 +67,7 @@ public sealed partial class EncryptionIsolationMaterializationInterceptor(
 
         foreach (PropertyInfo property in isolatedProperties)
         {
-            string? cipherText = property.GetValue(entity) as string;
-            if (cipherText is null)
+            if (!(property.GetValue(entity) is string cipherText))
             {
                 continue;
             }

--- a/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationSaveChangesInterceptor.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationSaveChangesInterceptor.cs
@@ -93,8 +93,7 @@ public sealed partial class EncryptionIsolationSaveChangesInterceptor(
     {
         foreach (PropertyInfo property in properties)
         {
-            string? plainText = property.GetValue(entry.Entity) as string;
-            if (plainText is null)
+            if (!(property.GetValue(entry.Entity) is string plainText))
             {
                 continue;
             }

--- a/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
+++ b/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
@@ -116,7 +116,7 @@ public static partial class ApiDocumentationApplicationBuilderExtensions
     private static void ConfigureOAuth2Flow(AuthorizationCodeFlow flow, Options.OAuth2Options oauth2)
     {
         flow
-            .WithClientId(oauth2.ClientId!)
+            .WithClientId(oauth2.ClientId)
             .WithSelectedScopes(oauth2.Scopes);
 
         if (oauth2.EnablePkce)

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
@@ -213,7 +213,7 @@ internal sealed partial class IdempotencyMiddleware(
         Stream originalBody = context.Response.Body;
         CancellationToken originalAborted = context.RequestAborted;
 
-        using RecyclableMemoryStream captureStream = _streamManager.GetStream("idempotency");
+        await using RecyclableMemoryStream captureStream = _streamManager.GetStream("idempotency");
         context.Response.Body = captureStream;
 
         using CancellationTokenSource timeoutCts = new(_opts.ExecutionTimeout);

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
@@ -63,7 +63,7 @@ internal static class IdentityWebhookEndpoints
     {
         // Read raw body for signature validation (server-verified size check)
         request.EnableBuffering();
-        using var ms = new MemoryStream(capacity: 1024);
+        await using var ms = new MemoryStream(capacity: 1024);
         await request.Body.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
 
         if (ms.Length > MaxWebhookBodySize)

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -111,9 +111,9 @@ internal static class GranitRoleEndpoints
         if (role is null || !IsVisible(role, currentTenant))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status404NotFound,
                 detail: AccountEndpointMessages.Localize(
-                    httpContext, "Granit:Identity:Role:NotFound", "Role not found."));
+                    httpContext, "Granit:Identity:Role:NotFound", "Role not found."),
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         return TypedResults.Ok(Map(role));
@@ -132,10 +132,10 @@ internal static class GranitRoleEndpoints
         if (request.MultiTenancySides == MultiTenancySides.Tenant && !opts.AllowTenantRoles)
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status403Forbidden,
                 detail: AccountEndpointMessages.Localize(
                     httpContext, "Granit:Identity:Role:TenantRolesDisabled",
-                    "Tenant-scoped role creation is disabled."));
+                    "Tenant-scoped role creation is disabled."),
+                statusCode: StatusCodes.Status403Forbidden);
         }
 
         // Tenant admins may only create roles in their own tenant.
@@ -143,20 +143,20 @@ internal static class GranitRoleEndpoints
             && request.TenantId != currentTenant.Id)
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status403Forbidden,
                 detail: AccountEndpointMessages.Localize(
                     httpContext, "Granit:Identity:Role:CrossTenantForbidden",
-                    "Tenant admins can only create roles within their own tenant."));
+                    "Tenant admins can only create roles within their own tenant."),
+                statusCode: StatusCodes.Status403Forbidden);
         }
 
         // Tenant admins cannot create Host or Both roles (platform-level scope).
         if (currentTenant.IsAvailable && request.MultiTenancySides != MultiTenancySides.Tenant)
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status403Forbidden,
                 detail: AccountEndpointMessages.Localize(
                     httpContext, "Granit:Identity:Role:HostManagedElsewhere",
-                    "Host and Both roles are managed from the host admin context."));
+                    "Host and Both roles are managed from the host admin context."),
+                statusCode: StatusCodes.Status403Forbidden);
         }
 
         RoleMetadata created;
@@ -174,11 +174,11 @@ internal static class GranitRoleEndpoints
         }
         catch (ArgumentException ex)
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status400BadRequest, detail: ex.Message);
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
         }
         catch (InvalidOperationException ex)
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status409Conflict, detail: ex.Message);
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
 
         string basePath = httpContext.Request.Path.Value!.TrimEnd('/');
@@ -198,18 +198,18 @@ internal static class GranitRoleEndpoints
         if (role is null || !IsVisible(role, currentTenant))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status404NotFound,
                 detail: AccountEndpointMessages.Localize(
-                    httpContext, "Granit:Identity:Role:NotFound", "Role not found."));
+                    httpContext, "Granit:Identity:Role:NotFound", "Role not found."),
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         if (!CanMutate(role, currentTenant))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status403Forbidden,
                 detail: AccountEndpointMessages.Localize(
                     httpContext, "Granit:Identity:Role:ModifyForbidden",
-                    "You do not have permission to modify this role."));
+                    "You do not have permission to modify this role."),
+                statusCode: StatusCodes.Status403Forbidden);
         }
 
         try
@@ -221,11 +221,11 @@ internal static class GranitRoleEndpoints
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("system role", StringComparison.OrdinalIgnoreCase))
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden, detail: ex.Message);
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status403Forbidden);
         }
         catch (InvalidOperationException ex)
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status409Conflict, detail: ex.Message);
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
     }
 
@@ -241,18 +241,18 @@ internal static class GranitRoleEndpoints
         if (role is null || !IsVisible(role, currentTenant))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status404NotFound,
                 detail: AccountEndpointMessages.Localize(
-                    httpContext, "Granit:Identity:Role:NotFound", "Role not found."));
+                    httpContext, "Granit:Identity:Role:NotFound", "Role not found."),
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         if (!CanMutate(role, currentTenant))
         {
             return TypedResults.Problem(
-                statusCode: StatusCodes.Status403Forbidden,
                 detail: AccountEndpointMessages.Localize(
                     httpContext, "Granit:Identity:Role:DeleteForbidden",
-                    "You do not have permission to delete this role."));
+                    "You do not have permission to delete this role."),
+                statusCode: StatusCodes.Status403Forbidden);
         }
 
         try
@@ -262,11 +262,11 @@ internal static class GranitRoleEndpoints
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("system role", StringComparison.OrdinalIgnoreCase))
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden, detail: ex.Message);
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status403Forbidden);
         }
         catch (InvalidOperationException ex)
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status409Conflict, detail: ex.Message);
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
     }
 

--- a/src/Granit.Identity/IIdentityProvider.cs
+++ b/src/Granit.Identity/IIdentityProvider.cs
@@ -30,6 +30,4 @@ public interface IIdentityProvider :
     IIdentityRoleManager,
     IIdentityGroupManager,
     IIdentityPasswordManager,
-    IIdentityCredentialVerifier
-{
-}
+    IIdentityCredentialVerifier;

--- a/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
@@ -138,14 +138,14 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
     }
 
     /// <inheritdoc/>
-    public Task<ImageResult> ToResultAsync(CancellationToken cancellationToken = default)
+    public async Task<ImageResult> ToResultAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         ApplyOutputSettings();
 
         ImageFormat outputFormat = _targetFormat ?? SourceFormat;
-        using MemoryStream ms = new();
+        await using MemoryStream ms = new();
         _image.Write(ms, MagickFormatMapper.ToMagickFormat(outputFormat));
 
         RecordMetrics(outputFormat);
@@ -156,7 +156,7 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
             (int)_image.Width,
             (int)_image.Height);
 
-        return Task.FromResult(result);
+        return await Task.FromResult(result);
     }
 
     /// <inheritdoc/>

--- a/src/Granit.LanguageDetection/ILanguageDetectorProvider.cs
+++ b/src/Granit.LanguageDetection/ILanguageDetectorProvider.cs
@@ -24,6 +24,4 @@ namespace Granit.LanguageDetection;
 /// register it with <c>TryAddEnumerable</c>.
 /// </para>
 /// </remarks>
-public interface ILanguageDetectorProvider : ILanguageDetector
-{
-}
+public interface ILanguageDetectorProvider : ILanguageDetector;

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
@@ -104,10 +104,7 @@ internal sealed partial class EfCoreTenantStore(
     {
         var tenant = Tenant.Create(id, name, identifier, contactEmail, jurisdiction);
 
-        await WriteAsync(async db =>
-        {
-            db.Tenants.Add(tenant);
-        }, cancellationToken).ConfigureAwait(false);
+        await WriteAsync(async db => db.Tenants.Add(tenant), cancellationToken).ConfigureAwait(false);
 
         LogTenantCreated(id, identifier);
     }

--- a/src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ public static class BrevoNotificationsServiceCollectionExtensions
         services.AddGranitHttpClient(ProviderKey, (sp, client) =>
         {
             BrevoOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<BrevoOptions>>().Value;
-            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            client.BaseAddress = new Uri($"{opts.BaseUrl.TrimEnd('/')}/");
             client.DefaultRequestHeaders.Add("api-key", opts.ApiKey);
             client.DefaultRequestHeaders.Add("Accept", "application/json");
             client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);

--- a/src/Granit.Notifications.Email.Scaleway/Internal/ScalewayEmailSender.cs
+++ b/src/Granit.Notifications.Email.Scaleway/Internal/ScalewayEmailSender.cs
@@ -36,9 +36,7 @@ internal sealed partial class ScalewayEmailSender(
         string fromEmail = message.FromEmailOverride ?? opts.DefaultSenderEmail;
         string fromName = message.FromNameOverride ?? opts.DefaultSenderName;
 
-        object? textField = message.PlainTextBody is not null
-            ? message.PlainTextBody
-            : null;
+        object? textField = message.PlainTextBody;
 
         var to = new { email = message.To, name = message.ToName };
 

--- a/src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ public static class SendGridEmailServiceCollectionExtensions
         {
             SendGridEmailOptions opts = sp
                 .GetRequiredService<Microsoft.Extensions.Options.IOptions<SendGridEmailOptions>>().Value;
-            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            client.BaseAddress = new Uri($"{opts.BaseUrl.TrimEnd('/')}/");
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {opts.ApiKey}");
             client.DefaultRequestHeaders.Add("Accept", "application/json");
             client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);

--- a/src/Granit.Notifications.MobilePush.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
+++ b/src/Granit.Notifications.MobilePush.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
@@ -116,5 +116,5 @@ internal static class MobilePushTokenEndpoints
     private static string MaskDeviceToken(string deviceToken) =>
         deviceToken.Length <= 4
             ? "…"
-            : string.Concat("…", deviceToken.AsSpan(deviceToken.Length - 4));
+            : $"…{deviceToken.AsSpan(deviceToken.Length - 4)}";
 }

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
@@ -74,9 +74,7 @@ internal sealed partial class GoogleFcmMobilePushSender(
                     Title = message.Title,
                     Body = message.Body,
                 },
-                Data = message.Data.HasValue
-                    ? JsonSerializer.Deserialize<Dictionary<string, string>>(message.Data.Value)
-                    : null,
+                Data = message.Data?.Deserialize<Dictionary<string, string>>(),
             },
         };
 

--- a/src/Granit.Notifications.SignalR/Extensions/SignalRNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.SignalR/Extensions/SignalRNotificationsServiceCollectionExtensions.cs
@@ -48,10 +48,7 @@ public static class SignalRNotificationsServiceCollectionExtensions
         services.AddSingleton<INotificationChannel, SignalRNotificationChannel>();
 
         services.AddSignalR()
-            .AddStackExchangeRedis(redisConnectionString, options =>
-            {
-                options.Configuration.ChannelPrefix = RedisChannel.Literal("granit-notifications");
-            });
+            .AddStackExchangeRedis(redisConnectionString, options => options.Configuration.ChannelPrefix = RedisChannel.Literal("granit-notifications"));
 
         return services;
     }

--- a/src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ public static class TwilioNotificationsServiceCollectionExtensions
         services.AddGranitHttpClient(ProviderKey, (sp, client) =>
         {
             TwilioOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<TwilioOptions>>().Value;
-            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            client.BaseAddress = new Uri($"{opts.BaseUrl.TrimEnd('/')}/");
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{opts.AccountSid}:{opts.AuthToken}"));
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
             client.DefaultRequestHeaders.Add("Accept", "application/json");

--- a/src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class ZulipNotificationsServiceCollectionExtensions
         services.AddGranitHttpClient(ZulipBotSender.HttpClientName, (sp, client) =>
         {
             ZulipBotOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ZulipBotOptions>>().Value;
-            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            client.BaseAddress = new Uri($"{opts.BaseUrl.TrimEnd('/')}/");
             client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
         });
 

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -126,8 +126,8 @@ public static class ObservabilityServiceCollectionExtensions
         builder.Services.AddOpenTelemetry()
             .ConfigureResource(r => r.AddService(
                 serviceName: options.ServiceName,
-                serviceVersion: options.ServiceVersion,
-                serviceNamespace: options.ServiceNamespace))
+                serviceNamespace: options.ServiceNamespace,
+                serviceVersion: options.ServiceVersion))
             .WithTracing(tracing => ConfigureTracing(tracing, options, deferOtlpToHost))
             .WithMetrics(metrics => ConfigureMetrics(metrics, options, deferOtlpToHost));
     }

--- a/src/Granit.Oidc.TokenManagement/Services/Internal/TokenEndpointService.cs
+++ b/src/Granit.Oidc.TokenManagement/Services/Internal/TokenEndpointService.cs
@@ -121,7 +121,7 @@ internal sealed partial class TokenEndpointService(
             ? nonces.FirstOrDefault()
             : null;
 
-        using Stream responseStream = await httpResponse.Content.ReadAsStreamAsync(cancellationToken)
+        await using Stream responseStream = await httpResponse.Content.ReadAsStreamAsync(cancellationToken)
             .ConfigureAwait(false);
 
         using JsonDocument doc = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken)

--- a/src/Granit.Oidc/Discovery/Internal/DiscoveryDocumentService.cs
+++ b/src/Granit.Oidc/Discovery/Internal/DiscoveryDocumentService.cs
@@ -41,7 +41,7 @@ internal sealed partial class DiscoveryDocumentService(
                 using HttpResponseMessage response = await httpClient.GetAsync(discoveryUrl, ct).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
 
-                using Stream stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+                await using Stream stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
                 using JsonDocument doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
 
                 var discoveryDocument = OidcDiscoveryDocument.FromJson(doc.RootElement);

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -138,10 +138,7 @@ public static class OpenIddictModelBuilderExtensions
                 .WithMany()
                 .HasForeignKey(p => p.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
-            b.OwnsOne(p => p.Data, data =>
-            {
-                data.ToJson();
-            });
+            b.OwnsOne(p => p.Data, data => data.ToJson());
         });
 
         // ──── OpenIddict conventions + table remapping ────

--- a/src/Granit.Privacy.BlobStorage/DataExport/BlobBackedPrivacyExportDownloadResolver.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/BlobBackedPrivacyExportDownloadResolver.cs
@@ -121,7 +121,7 @@ internal sealed class BlobBackedPrivacyExportDownloadResolver(
             .OpenReadAsync(PrivacyExportContainerNames.FragmentContainer, descriptor.ObjectKey, cancellationToken)
             .ConfigureAwait(false);
 
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await ciphertextStream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
 
         return contentEncryptor.Decrypt(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));

--- a/src/Granit.Privacy.Regulations/Extensions/PrivacyRegulationsServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy.Regulations/Extensions/PrivacyRegulationsServiceCollectionExtensions.cs
@@ -65,10 +65,7 @@ public static class PrivacyRegulationsServiceCollectionExtensions
         {
             new BuiltInPrivacyJurisdictionMapProvider(),
         };
-        foreach (IPrivacyJurisdictionMapProvider provider in builder.JurisdictionMapProviders)
-        {
-            jurisdictionMapProviders.Add(provider);
-        }
+        jurisdictionMapProviders.AddRange(builder.JurisdictionMapProviders);
 
         services.TryAddSingleton<IPrivacyJurisdictionResolver>(
             new DefaultPrivacyJurisdictionResolver(jurisdictionMapProviders));

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -236,9 +236,7 @@ internal sealed class QueryEngine<TEntity>(
 
             foreach (GroupEntry<TEntity> group in entityResult.Groups)
             {
-                IReadOnlyList<TItem>? items = itemsByKey is null
-                    ? null
-                    : itemsByKey[group.Value?.ToString() ?? "(null)"].ToList();
+                IReadOnlyList<TItem>? items = itemsByKey?[group.Value?.ToString() ?? "(null)"].ToList();
 
                 groups.Add(new GroupEntry<TItem>
                 {

--- a/src/Granit.Templating.AI/Internal/LlmTemplateAssistant.cs
+++ b/src/Granit.Templating.AI/Internal/LlmTemplateAssistant.cs
@@ -64,9 +64,7 @@ internal sealed partial class LlmTemplateAssistant(
 
             // Strip potentially dangerous HTML elements from LLM output.
             // Full Scriban syntax validation is deferred to the template engine at render time.
-            template = SanitizeHtmlOutput(template);
-
-            return template;
+            return SanitizeHtmlOutput(template);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {

--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -192,11 +192,6 @@ internal sealed class ScribanTemplateEngine(
     private static MemberFilterDelegate MemberFilterDelegate => (member) =>
     {
         // Block regex builtins — user-controlled patterns can cause catastrophic backtracking
-        if (member.DeclaringType?.Name is "RegexFunctions")
-        {
-            return false;
-        }
-
-        return true;
+        return member.DeclaringType?.Name is not "RegexFunctions";
     };
 }

--- a/src/Granit.TextExtraction.Ocr.AI/AIVisionOcrExtractor.cs
+++ b/src/Granit.TextExtraction.Ocr.AI/AIVisionOcrExtractor.cs
@@ -177,7 +177,7 @@ public sealed partial class AIVisionOcrExtractor : ITextExtractor
         Stream source, long maxBytes, CancellationToken cancellationToken)
     {
         LimitedStream limited = new(source, maxBytes);
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await limited.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         return buffer.ToArray();
     }

--- a/src/Granit.TextExtraction.Ocr.Tesseract/TesseractOcrExtractor.cs
+++ b/src/Granit.TextExtraction.Ocr.Tesseract/TesseractOcrExtractor.cs
@@ -134,7 +134,7 @@ public sealed partial class TesseractOcrExtractor : ITextExtractor
         Stream source, long maxBytes, CancellationToken cancellationToken)
     {
         LimitedStream limited = new(source, maxBytes);
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await limited.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         return buffer.ToArray();
     }

--- a/src/Granit.TextExtraction.Office/ExcelTextExtractor.cs
+++ b/src/Granit.TextExtraction.Office/ExcelTextExtractor.cs
@@ -64,7 +64,7 @@ public sealed partial class ExcelTextExtractor : ITextExtractor
 
         try
         {
-            using MemoryStream pkg = new(bytes, writable: false);
+            await using MemoryStream pkg = new(bytes, writable: false);
             using var doc = SpreadsheetDocument.Open(
                 pkg, isEditable: false, OpenXmlExtraction.BuildOpenSettings(_options));
 

--- a/src/Granit.TextExtraction.Office/Internal/OpenXmlExtraction.cs
+++ b/src/Granit.TextExtraction.Office/Internal/OpenXmlExtraction.cs
@@ -47,7 +47,7 @@ internal static class OpenXmlExtraction
         ArgumentNullException.ThrowIfNull(source);
 
         LimitedStream limited = new(source, maxBytes);
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await limited.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         return buffer.ToArray();
     }

--- a/src/Granit.TextExtraction.Office/PowerPointTextExtractor.cs
+++ b/src/Granit.TextExtraction.Office/PowerPointTextExtractor.cs
@@ -65,7 +65,7 @@ public sealed partial class PowerPointTextExtractor : ITextExtractor
 
         try
         {
-            using MemoryStream pkg = new(bytes, writable: false);
+            await using MemoryStream pkg = new(bytes, writable: false);
             using var doc = PresentationDocument.Open(
                 pkg, isEditable: false, OpenXmlExtraction.BuildOpenSettings(_options));
 

--- a/src/Granit.TextExtraction.Office/WordTextExtractor.cs
+++ b/src/Granit.TextExtraction.Office/WordTextExtractor.cs
@@ -61,7 +61,7 @@ public sealed partial class WordTextExtractor : ITextExtractor
 
         try
         {
-            using MemoryStream pkg = new(bytes, writable: false);
+            await using MemoryStream pkg = new(bytes, writable: false);
             using var doc = WordprocessingDocument.Open(
                 pkg, isEditable: false, OpenXmlExtraction.BuildOpenSettings(_options));
 

--- a/src/Granit.TextExtraction.Pdf.Ocr/PdfOcrTextExtractor.cs
+++ b/src/Granit.TextExtraction.Pdf.Ocr/PdfOcrTextExtractor.cs
@@ -241,7 +241,7 @@ public sealed partial class PdfOcrTextExtractor : ITextExtractor
 
         try
         {
-            using MemoryStream pngStream = new(pngBytes);
+            await using MemoryStream pngStream = new(pngBytes);
             TextExtractionResult result = await ocrExtractor.ExtractAsync(
                 pngStream, ImagePng, maxCharLength, cancellationToken).ConfigureAwait(false);
             return result.Content;
@@ -290,7 +290,7 @@ public sealed partial class PdfOcrTextExtractor : ITextExtractor
         Stream source, long maxBytes, CancellationToken cancellationToken)
     {
         LimitedStream limited = new(source, maxBytes);
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await limited.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         return buffer.ToArray();
     }

--- a/src/Granit.TextExtraction.Pdf/PdfTextExtractor.cs
+++ b/src/Granit.TextExtraction.Pdf/PdfTextExtractor.cs
@@ -144,7 +144,7 @@ public sealed partial class PdfTextExtractor : ITextExtractor
         Stream source, long maxBytes, CancellationToken cancellationToken)
     {
         LimitedStream limited = new(source, maxBytes);
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await limited.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         return buffer.ToArray();
     }

--- a/src/Granit.TextExtraction.Tika/TikaSidecarTextExtractor.cs
+++ b/src/Granit.TextExtraction.Tika/TikaSidecarTextExtractor.cs
@@ -145,7 +145,7 @@ public sealed partial class TikaSidecarTextExtractor : ITextExtractor
         Stream source, long maxBytes, CancellationToken cancellationToken)
     {
         LimitedStream limited = new(source, maxBytes);
-        using MemoryStream buffer = new();
+        await using MemoryStream buffer = new();
         await limited.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         return buffer.ToArray();
     }

--- a/src/Granit.Timeline.Notifications/Internal/NotificationBackedNotifier.cs
+++ b/src/Granit.Timeline.Notifications/Internal/NotificationBackedNotifier.cs
@@ -132,6 +132,6 @@ internal sealed class NotificationBackedNotifier(
             return body;
         }
 
-        return string.Concat(body.AsSpan(0, MaxBodyPreviewLength), "...");
+        return $"{body.AsSpan(0, MaxBodyPreviewLength)}...";
     }
 }

--- a/src/Granit.Validation/AspNetCore/FluentValidationAutoEndpointFilter.cs
+++ b/src/Granit.Validation/AspNetCore/FluentValidationAutoEndpointFilter.cs
@@ -91,8 +91,8 @@ internal sealed class FluentValidationAutoEndpointFilter : IEndpointFilter
 #pragma warning disable GRAPI001
                 return Results.ValidationProblem(
                     result.ToDictionary(),
-                    title: ResolveTitle(context.HttpContext),
-                    statusCode: StatusCodes.Status422UnprocessableEntity);
+                    statusCode: StatusCodes.Status422UnprocessableEntity,
+                    title: ResolveTitle(context.HttpContext));
 #pragma warning restore GRAPI001
             }
         }

--- a/src/Granit.Vault/Internal/CachedSecretStore.cs
+++ b/src/Granit.Vault/Internal/CachedSecretStore.cs
@@ -88,12 +88,7 @@ internal sealed partial class CachedSecretStore(
 
     private bool ShouldCache(SecretDescriptor descriptor)
     {
-        if (descriptor.BinaryValue is { } binary && binary.Length > _options.MaxCachedBinarySizeBytes)
-        {
-            return false;
-        }
-
-        return true;
+        return !(descriptor.BinaryValue is { } binary) || binary.Length <= _options.MaxCachedBinarySizeBytes;
     }
 
     private string BuildCacheKey(SecretRequest request) =>

--- a/src/Granit/Diagnostics/LogRedaction.cs
+++ b/src/Granit/Diagnostics/LogRedaction.cs
@@ -51,7 +51,7 @@ public static class LogRedaction
         }
 
         int prefixKeep = Math.Min(4, phone.Length - 2);
-        return string.Concat(phone.AsSpan(0, prefixKeep), "*****", phone.AsSpan(phone.Length - 2));
+        return $"{phone.AsSpan(0, prefixKeep)}*****{phone.AsSpan(phone.Length - 2)}";
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public static class LogRedaction
             return Mask;
         }
 
-        return string.Concat(token.AsSpan(0, 4), "...", token.AsSpan(token.Length - 3));
+        return $"{token.AsSpan(0, 4)}...{token.AsSpan(token.Length - 3)}";
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public static class LogRedaction
 
             if (colonCount == 4)
             {
-                return string.Concat(ip.AsSpan(0, i), ":***");
+                return $"{ip.AsSpan(0, i)}:***";
             }
         }
 

--- a/src/Granit/Domain/IEmitEntityLifecycleEvents.cs
+++ b/src/Granit/Domain/IEmitEntityLifecycleEvents.cs
@@ -15,4 +15,4 @@ namespace Granit.Domain;
 /// <see cref="IHasEntityEto{TEto}"/> instead — it extends this interface automatically.
 /// </para>
 /// </remarks>
-public interface IEmitEntityLifecycleEvents { }
+public interface IEmitEntityLifecycleEvents;

--- a/src/Granit/Events/IDomainEvent.cs
+++ b/src/Granit/Events/IDomainEvent.cs
@@ -19,4 +19,4 @@ namespace Granit.Events;
 /// </para>
 /// <para>Naming convention: <c>*Event</c> suffix (e.g., <c>PatientDischargedEvent</c>).</para>
 /// </remarks>
-public interface IDomainEvent { }
+public interface IDomainEvent;

--- a/src/Granit/Events/IIntegrationEvent.cs
+++ b/src/Granit/Events/IIntegrationEvent.cs
@@ -14,4 +14,4 @@ namespace Granit.Events;
 /// </para>
 /// <para>Naming convention: <c>*Eto</c> suffix — Event Transfer Object (e.g., <c>BedReleasedEto</c>).</para>
 /// </remarks>
-public interface IIntegrationEvent { }
+public interface IIntegrationEvent;


### PR DESCRIPTION
## Summary

Second wave of Roslynator rule promotions (follows #2928 baseline + #2929 first 8 rules). Full-`src` inventory of remaining `suggestion` diagnostics, triaged by confidence, then promoted the safe/valuable ones to `warning` under `[src/**.cs]` (tests stay advisory).

**15 rules promoted, 2 disabled, several deliberately skipped** — each auto-fix reviewed for semantic equivalence, two bad fixer outputs hand-corrected.

## Promoted (3 commits)

**Green batch (13):** RCS1205 (order named args), RCS1021 (expression-bodied lambda), RCS1251 (empty type body → `;`), RCS1073 (redundant `if`→`return`), RCS1221 (pattern matching over `as`+null), RCS1235 (optimize dict `Add`), RCS1249 (drop unnecessary `!`), RCS1212 (redundant assignment), RCS1206 (conditional access), RCS1084 (`??` over `?:`), RCS1173 (`??` over `if`), RCS1006 (merge `else if`), RCS1196 (extension as instance method).

**Interpolation pair:** RCS1267 (`string.Concat` → interpolation, incl. efficient `ReadOnlySpan<char>` handling) promoted; **RCS1217 disabled** (opposite direction — avoids a contradictory pair).

**RCS1261 (async dispose):** `using` → `await using` (28 files). Reviewed: the one `XmlWriter` conversion is safe (`WriterSettings.Async = true` → `DisposeAsync` flushes, doesn't throw); the fixer correctly left the sync sub-writer as `using`. Trade-off documented inline: the implicit `DisposeAsync` await carries no `ConfigureAwait(false)`, but that's moot under ASP.NET Core (no sync context) and no analyzer flags it — **flagged here for your call in review.**

## Hand-corrections of bad fixer output

- **RCS1084** emitted an invalid `(object??)` cast in `ScalewayEmailSender`; the ternary was redundant (`x is not null ? x : null`) → simplified to `object? textField = message.PlainTextBody`.
- **RCS1206** left one non-fixable `JsonElement?` case in `GoogleFcmMobilePushSender` → hand-converted to `message.Data?.Deserialize<...>()`.

## Deliberately NOT promoted (with reasons)

- **RCS1243** (duplicate word in comment) — **corrupts** legitimate repeated format placeholders (`XXX XXX XXX` SIN mask → `XXX XXX`), a silent doc bug. Disabled implicitly by exclusion; rationale recorded in `.editorconfig`.
- **RCS1201** (use method chaining, 158) — subjective/churny, same class as the previously-rejected RCS1124.
- **RCS1194** (implement exception constructors, 116) — imposes boilerplate on deliberately-minimal exceptions; not a clean autofix.
- **RCS1047** (remove `Async` suffix, 12) — renames methods → breaking for public API.
- **RCS1158** (static member → type param, 10) — design-opinionated.
- **RCS1247 / RCS1139** (XML doc-comment family) — consistent with the already-disabled doc rules (`NoWarn CS1591`).

## Verification

- Each rule: `dotnet format analyzers --diagnostics RCSxxxx` → **0 remaining** on `src-only.slnf`, full `src-only` build **0 warning / 0 error** at each step.
- Final gates: `dotnet format --verify-no-changes` on `src-only` → **exit 0**; `notifications` shard (src + tests) build → **0/0**.