### PR TITLE
style(analyzers): extend Roslynator promotions repo-wide + triage batch 3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,6 +41,32 @@ dotnet_diagnostic.RCS1213.severity = none
 #   RCS1161 — "enum should declare explicit values": directly contradicts the Granit
 #             GRENUM001 analyzer, which BANS redundant sequential explicit enum values.
 dotnet_diagnostic.RCS1161.severity = none
+#   RCS1194 — "implement exception constructors": Granit domain exceptions are sealed and
+#             single-shape by design (a ConversationNotFoundException without its id is
+#             meaningless). The three-ctor CA1032 pattern is legacy (serialization-era).
+dotnet_diagnostic.RCS1194.severity = none
+#   RCS1201 — "use method chaining": subjective; forces e.g. activity.SetTag().SetTag()
+#             chains that read worse than one call per line. A net readability loss.
+dotnet_diagnostic.RCS1201.severity = none
+#   RCS1158 — "static member in generic type should use a type parameter": fires on internal
+#             `const` backend identifiers (EfIndexer<TKey>.BackendName). The CA1000 rationale
+#             (per-instantiation static state) does not apply to consts — they are inlined.
+dotnet_diagnostic.RCS1158.severity = none
+#   RCS1043 — "remove 'partial' from single-part type": source-generator hazard. [LoggerMessage]
+#             and [GeneratedRegex] (both mandated by CLAUDE.md) require partial; the analyzer
+#             may not see the generated part and would strip a required modifier.
+dotnet_diagnostic.RCS1043.severity = none
+#   RCS1124 — "inline local variable": removes named `snapshot` locals that document
+#             volatile-read semantics and emits `(MemoryStream)new()`-style casts — a net
+#             readability loss for a subjective gain.
+dotnet_diagnostic.RCS1124.severity = none
+#   RCS1237 — deprecated by Roslynator itself ("use RCS1254 instead").
+dotnet_diagnostic.RCS1237.severity = none
+#   RCS1241 — "implement IEqualityComparer alongside IEqualityComparer<T>": its fixer bolts a
+#             non-generic System.Collections.IEqualityComparer onto ValueObject (a core domain
+#             base type) with `new public bool Equals(object, object)` + empty-message throws —
+#             an API/semantic change. Same rationale as the ValueObject interface-impl Won't-Fix.
+dotnet_diagnostic.RCS1241.severity = none
 
 # XML-documentation-comment completeness family — disabled to stay consistent with the
 # existing `NoWarn CS1591` (missing XML comment): the framework does not require full
@@ -54,6 +80,13 @@ dotnet_diagnostic.RCS1141.severity = none
 dotnet_diagnostic.RCS1142.severity = none
 # RCS1181: convert comment to documentation comment
 dotnet_diagnostic.RCS1181.severity = none
+# RCS1139: add summary element to documentation comment
+dotnet_diagnostic.RCS1139.severity = none
+# RCS1226: add paragraph to documentation comment
+dotnet_diagnostic.RCS1226.severity = none
+# RCS1243: duplicate word in a comment — corrupts legitimate repeated tokens, e.g. the
+# "XXX XXX XXX" SIN mask collapses to "XXX XXX". A silent documentation bug, not doc-completeness.
+dotnet_diagnostic.RCS1243.severity = none
 
 # RCS1217 — "convert interpolated string to concatenation": the exact opposite of the
 # promoted RCS1267 (interpolation preferred). Disabled to avoid a contradictory pair.
@@ -90,12 +123,12 @@ dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case_style
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-# ── Roslynator: rules promoted to warning in framework source only ────────────
-# These have been cleaned across all src/ projects and are now enforced (a warning ==
-# a build error under TreatWarningsAsErrors). Test projects stay at the advisory
-# `suggestion` baseline. Promote a rule here only after `dotnet format analyzers
-# --diagnostics RCSxxxx` reports zero remaining hits on src-only.slnf.
-[src/**.cs]
+# ── Roslynator: rules promoted to warning across the whole repository ─────────
+# These have been cleaned across all src/ AND tests/ projects and are now enforced (a
+# warning == a build error under TreatWarningsAsErrors). Promote a rule here only after
+# `dotnet format analyzers <shard>.slnf --diagnostics RCSxxxx` reports zero remaining hits
+# on every shard (unit layers + integration + architecture), tests included.
+[*.{cs,csx}]
 # RCS1214: unnecessary interpolated string ($"literal" with no holes → "literal")
 dotnet_diagnostic.RCS1214.severity = warning
 # RCS1192: unnecessary verbatim string literal (@"no-escapes" → "no-escapes")
@@ -144,14 +177,26 @@ dotnet_diagnostic.RCS1267.severity = warning
 # Note: the implicit DisposeAsync await carries no ConfigureAwait(false), but that is moot
 # under ASP.NET Core (no sync context) and no analyzer flags it.
 dotnet_diagnostic.RCS1261.severity = warning
-#
-# RCS1243 (duplicate word in comment) deliberately NOT promoted: it corrupts legitimate
-# repeated format placeholders (e.g. "XXX XXX XXX" SIN masks → "XXX XXX") — a silent doc bug.
-#
-# RCS1124 (inline single-use local) was evaluated and deliberately left at the suggestion
-# baseline: its auto-fix removes named `snapshot` locals that document volatile-read
-# semantics, emits `(MemoryStream)new()`-style casts, and left non-fixable cases — a
-# net readability loss for a subjective gain. Do not promote without hand-curation.
+# RCS1047: remove suffix 'Async' from a non-asynchronous method (sync handlers/helpers)
+dotnet_diagnostic.RCS1047.severity = warning
+# RCS1151: remove redundant cast
+dotnet_diagnostic.RCS1151.severity = warning
+# RCS1112: combine 'Enumerable.Where' method chain into a single predicate
+dotnet_diagnostic.RCS1112.severity = warning
+# RCS1199: remove unnecessary null check (already guaranteed non-null)
+dotnet_diagnostic.RCS1199.severity = warning
+# RCS1247: fix a malformed documentation-comment tag (distinct from doc-completeness rules)
+dotnet_diagnostic.RCS1247.severity = warning
+# RCS1135: declare a zero-value member on a [Flags] enum (compatible with GRENUM001)
+dotnet_diagnostic.RCS1135.severity = warning
+# RCS1015: use the nameof operator
+dotnet_diagnostic.RCS1015.severity = warning
+# RCS1033: remove redundant '== true' in a boolean comparison
+dotnet_diagnostic.RCS1033.severity = warning
+# RCS1049: simplify a boolean comparison ('x == false' → '!x')
+dotnet_diagnostic.RCS1049.severity = warning
+# RCS1097: remove redundant 'ToString' call
+dotnet_diagnostic.RCS1097.severity = warning
 
 [*.{csproj,props,targets}]
 indent_size = 2

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20589,7 +20589,7 @@
       "kind": "class",
       "project": "Granit",
       "file": "src/Granit/Endpoints/ModuleConfigEndpointExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": []
     },
     {

--- a/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
+++ b/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
@@ -89,7 +89,7 @@ internal sealed partial class ApiKeyAuthenticationHandler(
             return AuthenticateResult.Fail("API key has been revoked.");
         }
 
-        if (apiKey.ExpiresAt.HasValue && apiKey.ExpiresAt.Value <= now)
+        if (apiKey.ExpiresAt <= now)
         {
             LogApiKeyExpired(Logger, apiKey.Id);
             await TryWriteFailureAuditAsync("api_key_expired", apiKey.Id, apiKey.Name, apiKey.TenantId)

--- a/src/Granit.BackgroundJobs.Wolverine/Internal/CronSchedulerAgent.cs
+++ b/src/Granit.BackgroundJobs.Wolverine/Internal/CronSchedulerAgent.cs
@@ -38,7 +38,7 @@ internal sealed partial class CronSchedulerAgent(
 
         foreach (BackgroundJobDefinition job in jobs)
         {
-            if (job.NextExecutionAt.HasValue && job.NextExecutionAt.Value > clock.Now)
+            if (job.NextExecutionAt > clock.Now)
             {
                 LogJobAlreadyScheduled(logger, job.JobName, job.NextExecutionAt.Value);
                 continue;

--- a/src/Granit.BackgroundJobs/Internal/ChannelCronSchedulerService.cs
+++ b/src/Granit.BackgroundJobs/Internal/ChannelCronSchedulerService.cs
@@ -53,7 +53,7 @@ internal sealed partial class ChannelCronSchedulerService(
 
         foreach (BackgroundJobDefinition job in jobs)
         {
-            if (job.NextExecutionAt.HasValue && job.NextExecutionAt.Value > clock.Now)
+            if (job.NextExecutionAt > clock.Now)
             {
                 LogJobAlreadyScheduled(job.JobName, job.NextExecutionAt.Value);
                 continue;

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportDefinitionEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportDefinitionEndpoints.cs
@@ -19,13 +19,13 @@ internal static class ExportDefinitionEndpoints
     /// </summary>
     internal static RouteGroupBuilder MapExportDefinitionEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/definitions", ListDefinitionsAsync)
+        group.MapGet("/definitions", ListDefinitions)
             .WithName("ListExportDefinitions")
             .WithSummary("Lists all registered export definitions.")
             .WithDescription("Returns all export definitions registered by application modules. Each definition describes an exportable dataset, its supported output formats, and metadata. Use the fields endpoint to discover selectable columns for a specific definition.")
             .Produces<IReadOnlyList<ExportDefinitionResponse>>();
 
-        group.MapGet("/definitions/{name}/fields", GetFieldsAsync)
+        group.MapGet("/definitions/{name}/fields", GetFields)
             .WithName("GetExportDefinitionFields")
             .WithSummary("Returns the available fields for a given export definition.")
             .WithDescription("Returns the list of selectable fields for the named export definition — each with its property name, display label, and data type. Use this to populate a field picker UI before creating an export job. Returns 404 if the definition name is not registered.")
@@ -35,7 +35,7 @@ internal static class ExportDefinitionEndpoints
         return group;
     }
 
-    private static Ok<IReadOnlyList<ExportDefinitionResponse>> ListDefinitionsAsync(
+    private static Ok<IReadOnlyList<ExportDefinitionResponse>> ListDefinitions(
         [FromServices] IServiceProvider serviceProvider,
         [FromServices] IEnumerable<IExportWriter> writers)
     {
@@ -52,7 +52,7 @@ internal static class ExportDefinitionEndpoints
         return TypedResults.Ok(response);
     }
 
-    private static Results<Ok<IReadOnlyList<ExportFieldResponse>>, ProblemHttpResult> GetFieldsAsync(
+    private static Results<Ok<IReadOnlyList<ExportFieldResponse>>, ProblemHttpResult> GetFields(
         string name,
         [FromServices] IServiceProvider serviceProvider)
     {

--- a/src/Granit.Features.Endpoints/Endpoints/FeaturesReadEndpoints.cs
+++ b/src/Granit.Features.Endpoints/Endpoints/FeaturesReadEndpoints.cs
@@ -18,7 +18,7 @@ internal static class FeaturesReadEndpoints
     /// <summary>Maps all feature read endpoints to the given route group.</summary>
     public static RouteGroupBuilder MapFeaturesReadEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/definitions", HandleGetDefinitionsAsync)
+        group.MapGet("/definitions", HandleGetDefinitions)
              .RequireAuthorization(FeaturesPermissions.Flags.Read)
              .WithName("GetFeatureDefinitions")
              .WithSummary("Returns all feature definitions grouped by name prefix.")
@@ -41,7 +41,7 @@ internal static class FeaturesReadEndpoints
         return group;
     }
 
-    private static Ok<IReadOnlyList<FeatureGroupResponse>> HandleGetDefinitionsAsync(
+    private static Ok<IReadOnlyList<FeatureGroupResponse>> HandleGetDefinitions(
         [FromServices] IFeatureDefinitionStore definitionStore)
     {
         IReadOnlyList<FeatureDefinition> all = definitionStore.GetAll();

--- a/src/Granit.Features/Definitions/FeatureDefinitionProvider.cs
+++ b/src/Granit.Features/Definitions/FeatureDefinitionProvider.cs
@@ -5,7 +5,7 @@ namespace Granit.Features.Definitions;
 /// </summary>
 /// <remarks>
 /// Implement this interface and register the implementation with:
-/// <code>services.AddFeatureDefinitions&lt;MyFeatureDefinitionProvider&gt;();</code>
+/// <c>services.AddFeatureDefinitions&lt;MyFeatureDefinitionProvider&gt;();</c>
 /// </remarks>
 /// <example>
 /// <code>

--- a/src/Granit.Features/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Features/Extensions/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceCollectionExtensions
     /// </para>
     /// <para>
     /// To declare features, register a <see cref="IFeatureDefinitionProvider"/>:
-    /// <code>services.AddFeatureDefinitions&lt;MyFeatureDefinitionProvider&gt;();</code>
+    /// <c>services.AddFeatureDefinitions&lt;MyFeatureDefinitionProvider&gt;();</c>
     /// </para>
     /// </remarks>
     /// <param name="services">The service collection.</param>

--- a/src/Granit.Features/Plans/IPlanFeatureStore.cs
+++ b/src/Granit.Features/Plans/IPlanFeatureStore.cs
@@ -9,7 +9,7 @@ namespace Granit.Features.Plans;
 /// plan-level values then take precedence over defaults but yield to tenant overrides.
 /// <para>
 /// Registration:
-/// <code>services.AddScoped&lt;IPlanFeatureStore, YourPlanFeatureStore&gt;();</code>
+/// <c>services.AddScoped&lt;IPlanFeatureStore, YourPlanFeatureStore&gt;();</c>
 /// </para>
 /// </remarks>
 public interface IPlanFeatureStore

--- a/src/Granit.Features/Plans/IPlanIdProvider.cs
+++ b/src/Granit.Features/Plans/IPlanIdProvider.cs
@@ -9,7 +9,7 @@ namespace Granit.Features.Plans;
 /// (e.g., via Stripe or your billing service).
 /// <para>
 /// Registration:
-/// <code>services.AddScoped&lt;IPlanIdProvider, YourPlanIdProvider&gt;();</code>
+/// <c>services.AddScoped&lt;IPlanIdProvider, YourPlanIdProvider&gt;();</c>
 /// </para>
 /// </remarks>
 public interface IPlanIdProvider

--- a/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
+++ b/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
@@ -20,7 +20,7 @@ public sealed class GranitCorsOptions
     /// Wildcard (<c>*</c>) is forbidden in non-development environments (ISO 27001 compliance).
     /// </summary>
     /// <example>
-    /// <code>["https://app.example.com", "https://admin.example.com"]</code>
+    /// <c>["https://app.example.com", "https://admin.example.com"]</c>
     /// </example>
     [Required]
     [MinLength(1)]

--- a/src/Granit.Imaging.AI/Extensions/ExtractTextFromImageToolRegistrationExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ExtractTextFromImageToolRegistrationExtensions.cs
@@ -17,7 +17,7 @@ public static class ExtractTextFromImageToolRegistrationExtensions
     /// <param name="tools">The AI tool registration builder.</param>
     /// <returns>The builder, for chaining.</returns>
     /// <example>
-    /// <code>services.AddGranitAITools(tools => tools.AddImageTextExtractionTool());</code>
+    /// <c>services.AddGranitAITools(tools => tools.AddImageTextExtractionTool());</c>
     /// </example>
     public static AIToolRegistrationBuilder AddImageTextExtractionTool(this AIToolRegistrationBuilder tools)
     {

--- a/src/Granit.Indexing.Embeddings/Options/GranitIndexingEmbeddingsOptions.cs
+++ b/src/Granit.Indexing.Embeddings/Options/GranitIndexingEmbeddingsOptions.cs
@@ -71,8 +71,8 @@ public sealed class GranitIndexingEmbeddingsOptions
 
     /// <summary>
     /// Informational hint emitted at startup to remind operators that HNSW indices
-    /// retain stale vector pointers after <c>DELETE</c> until a <c>REINDEX
-    /// CONCURRENTLY</c> (Postgres) or <c>forcemerge</c> (Elasticsearch) runs.
+    /// retain stale vector pointers after <c>DELETE</c> until a <code>REINDEX
+    /// CONCURRENTLY</code> (Postgres) or <c>forcemerge</c> (Elasticsearch) runs.
     /// Default <c>7</c> days — a reasonable cadence for typical GDPR Art. 17
     /// audit windows. The framework does NOT schedule the reindex itself.
     /// </summary>

--- a/src/Granit.Localization.AI/Extensions/TranslateToolRegistrationExtensions.cs
+++ b/src/Granit.Localization.AI/Extensions/TranslateToolRegistrationExtensions.cs
@@ -17,7 +17,7 @@ public static class TranslateToolRegistrationExtensions
     /// <param name="tools">The AI tool registration builder.</param>
     /// <returns>The builder, for chaining.</returns>
     /// <example>
-    /// <code>services.AddGranitAITools(tools => tools.AddTranslateTool());</code>
+    /// <c>services.AddGranitAITools(tools => tools.AddTranslateTool());</c>
     /// </example>
     public static AIToolRegistrationBuilder AddTranslateTool(this AIToolRegistrationBuilder tools)
     {

--- a/src/Granit.MultiTenancy.Auditing/AuditingHostImpersonationAuditWriter.cs
+++ b/src/Granit.MultiTenancy.Auditing/AuditingHostImpersonationAuditWriter.cs
@@ -15,8 +15,8 @@ namespace Granit.MultiTenancy.Auditing;
 /// </summary>
 /// <remarks>
 /// Decision details (allowed flag, deny reason, resolver) are persisted as a
-/// synthetic <see cref="AuditEntityChange"/> with <c>EntityType =
-/// "HostImpersonation"</c> so investigators get a self-contained audit row
+/// synthetic <see cref="AuditEntityChange"/> with <code>EntityType =
+/// "HostImpersonation"</code> so investigators get a self-contained audit row
 /// without needing to correlate with logs or metrics. The <c>CorrelationId</c>
 /// still carries the request's trace id for cross-store lookups.
 /// </remarks>

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/TranslatableQueryExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/TranslatableQueryExtensions.cs
@@ -104,8 +104,8 @@ public static class TranslatableQueryExtensions
     /// Entities without a translation in the requested culture sort last.
     /// </summary>
     /// <remarks>
-    /// Translates to SQL: <c>ORDER BY (SELECT t.Column FROM Translations t
-    /// WHERE t.ParentId = e.Id AND t.Culture = @c LIMIT 1)</c>
+    /// Translates to SQL: <code>ORDER BY (SELECT t.Column FROM Translations t
+    /// WHERE t.ParentId = e.Id AND t.Culture = @c LIMIT 1)</code>
     /// </remarks>
     /// <example>
     /// <code>

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyAgreementEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyAgreementEndpoints.cs
@@ -17,7 +17,7 @@ internal static class PrivacyAgreementEndpoints
 {
     internal static RouteGroupBuilder MapPrivacyAgreementEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/agreements/documents", HandleGetDocumentsAsync)
+        group.MapGet("/agreements/documents", HandleGetDocuments)
              .RequireAuthorization(PrivacyPermissions.Agreements.Read)
              .WithName("ListPrivacyLegalDocuments")
              .WithSummary("Returns all registered legal documents.")
@@ -66,7 +66,7 @@ internal static class PrivacyAgreementEndpoints
         return group;
     }
 
-    private static Ok<IReadOnlyList<PrivacyLegalDocumentResponse>> HandleGetDocumentsAsync(
+    private static Ok<IReadOnlyList<PrivacyLegalDocumentResponse>> HandleGetDocuments(
         [FromServices] ILegalDocumentRegistry registry)
     {
         IReadOnlyList<PrivacyLegalDocumentResponse> result = registry

--- a/src/Granit.Privacy.Endpoints/Options/PrivacyEndpointsOptions.cs
+++ b/src/Granit.Privacy.Endpoints/Options/PrivacyEndpointsOptions.cs
@@ -32,8 +32,8 @@ public sealed class PrivacyEndpointsOptions
     /// Whether the privacy-export download endpoints require a recent re-authentication
     /// (step-up auth). When <see langword="true"/> (default), the OIDC <c>auth_time</c>
     /// claim must be within <see cref="DownloadStepUpMaxAge"/> of the current time;
-    /// otherwise the endpoint returns <c>401</c> with a <c>WWW-Authenticate: Bearer
-    /// error="step_up"</c> header so an OIDC-aware BFF can refresh the session
+    /// otherwise the endpoint returns <c>401</c> with a <code>WWW-Authenticate: Bearer
+    /// error="step_up"</code> header so an OIDC-aware BFF can refresh the session
     /// transparently before retrying.
     /// </summary>
     /// <remarks>

--- a/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Endpoints/QueryCatalogEndpoints.cs
@@ -29,7 +29,7 @@ internal static class QueryCatalogEndpoints
     /// </summary>
     public static RouteGroupBuilder MapQueryCatalogEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/catalog", ListCatalogAsync)
+        group.MapGet("/catalog", ListCatalog)
             .WithName("ListQueryCatalog")
             .WithSummary("Lists every registered QueryDefinition.")
             .WithDescription(
@@ -47,7 +47,7 @@ internal static class QueryCatalogEndpoints
         return group;
     }
 
-    private static Ok<IReadOnlyList<QueryCatalogEntryResponse>> ListCatalogAsync(
+    private static Ok<IReadOnlyList<QueryCatalogEntryResponse>> ListCatalog(
         [FromServices] IQueryDefinitionRegistry registry,
         [FromServices] EndpointDataSource endpointDataSource,
         [FromServices] LinkGenerator linkGenerator,

--- a/src/Granit.Templating.Scriban/Internal/FormatBytesFunction.cs
+++ b/src/Granit.Templating.Scriban/Internal/FormatBytesFunction.cs
@@ -11,8 +11,8 @@ namespace Granit.Templating.Scriban.Internal;
 /// </summary>
 /// <remarks>
 /// <para>Usage in templates:</para>
-/// <code>{{ model.usage_bytes | format_bytes }}</code>
-/// <code>Storage: {{ model.usage_bytes | format_bytes }} of {{ model.limit_bytes | format_bytes }}</code>
+/// <c>{{ model.usage_bytes | format_bytes }}</c>
+/// <c>Storage: {{ model.usage_bytes | format_bytes }} of {{ model.limit_bytes | format_bytes }}</c>
 /// <para>
 /// Uses 1024-based ("binary") units so 1 KB = 1024 bytes, matching the convention
 /// used elsewhere in Granit (<c>BlobUploadRequest.MaxAllowedBytes</c>,

--- a/src/Granit.Templating.Scriban/Internal/UserTimeFunction.cs
+++ b/src/Granit.Templating.Scriban/Internal/UserTimeFunction.cs
@@ -12,8 +12,8 @@ namespace Granit.Templating.Scriban.Internal;
 /// </summary>
 /// <remarks>
 /// Usage in templates:
-/// <code>{{ model.trial_ends_at | to_user_time }}</code>
-/// <code>{{ model.trial_ends_at | to_user_time | date.to_string "%B %d, %Y at %H:%M" }}</code>
+/// <c>{{ model.trial_ends_at | to_user_time }}</c>
+/// <c>{{ model.trial_ends_at | to_user_time | date.to_string "%B %d, %Y at %H:%M" }}</c>
 ///
 /// When no user timezone is set (via <see cref="ICurrentTimezoneProvider"/>),
 /// the date is returned unchanged (UTC).

--- a/src/Granit/Endpoints/ModuleConfigEndpointExtensions.cs
+++ b/src/Granit/Endpoints/ModuleConfigEndpointExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Modularity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -72,6 +73,10 @@ public static class ModuleConfigEndpointExtensions
     /// (e.g., <c>.AllowAnonymous()</c>, cache headers).
     /// </param>
     /// <returns>The endpoint route builder for chaining.</returns>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'",
+        Justification = "The 'Async' suffix disambiguates this IAsyncModuleConfigProvider overload from the "
+            + "synchronous MapGranitModuleConfig above; the two differ only by generic constraint (not part of "
+            + "the signature), so they cannot share a name.")]
     public static IEndpointRouteBuilder MapGranitModuleConfigAsync<TProvider, TResponse>(
         this IEndpointRouteBuilder endpoints,
         string routePrefix,

--- a/src/Granit/MultiTenancy/MultiTenancySides.cs
+++ b/src/Granit/MultiTenancy/MultiTenancySides.cs
@@ -23,6 +23,9 @@ namespace Granit.MultiTenancy;
 [Flags]
 public enum MultiTenancySides
 {
+    /// <summary>Applicable in no context. Represents the absence of any side (the zero value of the flags set).</summary>
+    None = 0,
+
     /// <summary>Applicable only when no tenant context is active (host-level admin, cross-tenant operations).</summary>
     Host = 1 << 0,
 

--- a/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationDataManagerTests.cs
+++ b/tests/Granit.AI.Chat.EntityFrameworkCore.Tests/EfConversationDataManagerTests.cs
@@ -50,7 +50,7 @@ public sealed class EfConversationDataStoreTests : IDisposable
         IReadOnlyList<Conversation> result = await _sut.GetAllForOwnerAsync(UserA, TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(2);
-        result.SelectMany(c => c.Messages).Count().ShouldBe(3);
+        result.Sum(c => c.Messages.Count).ShouldBe(3);
     }
 
     [Fact]

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/ApiConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/ApiConventionRules.cs
@@ -201,7 +201,7 @@ public static partial class ApiConventionRules
         }
 
         violations.ShouldBeEmpty(
-            $"Public Map* extension methods on IEndpointRouteBuilder must follow " +
+            "Public Map* extension methods on IEndpointRouteBuilder must follow " +
             $"the Map{requiredPrefix}{{Feature}}() naming convention. " +
             $"Violators: {string.Join("; ", violations)}");
     }
@@ -254,8 +254,8 @@ public static partial class ApiConventionRules
     /// Minimal API handlers bound to bodyless HTTP verbs (<c>DELETE</c>, <c>GET</c>, <c>HEAD</c>)
     /// must carry an explicit <c>[FromBody]</c> (or another explicit <c>[From*]</c>) on any complex
     /// <c>*Request</c> DTO parameter. ASP.NET Core 10 rejects an inferred body parameter on these
-    /// verbs at endpoint construction (<c>InvalidOperationException: Body was inferred but the
-    /// method does not allow inferred body parameters</c>), failing app startup — a regression that
+    /// verbs at endpoint construction (<code>InvalidOperationException: Body was inferred but the
+    /// method does not allow inferred body parameters</code>), failing app startup — a regression that
     /// escapes compile-time checks.
     /// </summary>
     /// <param name="srcDir">Path to the <c>src/</c> directory.</param>

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/BackgroundJobConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/BackgroundJobConventionRules.cs
@@ -22,8 +22,7 @@ public static class BackgroundJobConventionRules
         var violations = architecture.Classes
             .Where(c => c.FullName.StartsWith(typePrefix, StringComparison.Ordinal)
                 && !c.IsAbstract.GetValueOrDefault()
-                && ImplementsInterface(c, "Granit.BackgroundJobs.IBackgroundJob"))
-            .Where(c => !StripGenericArity(c.Name).EndsWith("Job", StringComparison.Ordinal))
+                && ImplementsInterface(c, "Granit.BackgroundJobs.IBackgroundJob") && !StripGenericArity(c.Name).EndsWith("Job", StringComparison.Ordinal))
             .Select(c => $"{c.FullName} (IBackgroundJob must end with 'Job')")
             .ToList();
 
@@ -42,8 +41,7 @@ public static class BackgroundJobConventionRules
         var violations = architecture.Classes
             .Where(c => c.FullName.StartsWith(typePrefix, StringComparison.Ordinal)
                 && !c.IsAbstract.GetValueOrDefault()
-                && HasAttribute(c, "Granit.BackgroundJobs.RecurringJobAttribute"))
-            .Where(c => !ImplementsInterface(c, "Granit.BackgroundJobs.IBackgroundJob"))
+                && HasAttribute(c, "Granit.BackgroundJobs.RecurringJobAttribute") && !ImplementsInterface(c, "Granit.BackgroundJobs.IBackgroundJob"))
             .Select(c => $"{c.FullName} (has [RecurringJob] but does not implement IBackgroundJob)")
             .ToList();
 

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/FileOrganizationRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/FileOrganizationRules.cs
@@ -47,7 +47,7 @@ public static partial class FileOrganizationRules
         }
 
         violations.ShouldBeEmpty(
-            $"Module classes (*Module.cs) must be at the module root directory. " +
+            "Module classes (*Module.cs) must be at the module root directory. " +
             $"Violators: {string.Join(", ", violations)}");
     }
 
@@ -384,12 +384,9 @@ public static partial class FileOrganizationRules
                     violations.Add($"[EfCore] {Path.GetRelativePath(srcDir, csFile)} → must be in Entities/ or Internal/");
                 }
             }
-            else
+            else if (!IsInFolder(csFile, "Domain") && InheritsFromDomainBaseClass(csFile))
             {
-                if (!IsInFolder(csFile, "Domain") && InheritsFromDomainBaseClass(csFile))
-                {
-                    violations.Add($"[Base] {Path.GetRelativePath(srcDir, csFile)} → must be in Domain/");
-                }
+                violations.Add($"[Base] {Path.GetRelativePath(srcDir, csFile)} → must be in Domain/");
             }
         }
 

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
@@ -92,8 +92,8 @@ public static class LayerDependencyRules
             .Where(c => (c.Namespace.FullName.EndsWith(".Endpoints", StringComparison.Ordinal) ||
                          c.Namespace.FullName.Contains(".Endpoints.", StringComparison.Ordinal))
                 && c.Dependencies
-                    .Where(d => d is ArchUnitNET.Domain.Dependencies.InheritsBaseClassDependency)
-                    .Any(d => domainBaseClasses.Contains(d.Target.FullName)));
+                    .Any(d => d is ArchUnitNET.Domain.Dependencies.InheritsBaseClassDependency && domainBaseClasses.Contains(d.Target.FullName))
+);
 
         violations.ShouldBeEmpty(
             "Endpoint types must not inherit from domain entity base classes — use standalone Request/Response DTOs. " +
@@ -157,12 +157,7 @@ public static class LayerDependencyRules
 
         IEnumerable<IType> violators = architecture.Types
             .Where(t => !allowedNamespaceFragments.Any(ns =>
-                t.Namespace.FullName.Contains(ns, StringComparison.Ordinal)))
-            .Where(t => !t.Name.EndsWith("QueryableSource", StringComparison.Ordinal))
-            .Where(t => !t.Name.EndsWith("EndpointRouteBuilderExtensions", StringComparison.Ordinal))
-            .Where(t => !t.Name.EndsWith("DataSource", StringComparison.Ordinal))
-            .Where(t => !t.Name.EndsWith("MetricDefinition", StringComparison.Ordinal))
-            .Where(t => t.Dependencies
+                t.Namespace.FullName.Contains(ns, StringComparison.Ordinal)) && !t.Name.EndsWith("QueryableSource", StringComparison.Ordinal) && !t.Name.EndsWith("EndpointRouteBuilderExtensions", StringComparison.Ordinal) && !t.Name.EndsWith("DataSource", StringComparison.Ordinal) && !t.Name.EndsWith("MetricDefinition", StringComparison.Ordinal) && t.Dependencies
                 .Any(d => d.Target.FullName.StartsWith("System.Linq.IQueryable", StringComparison.Ordinal)));
 
         violators.ShouldBeEmpty(
@@ -189,8 +184,7 @@ public static class LayerDependencyRules
         ];
 
         IEnumerable<IType> nonEndpointTypes = architecture.Types
-            .Where(t => t.Namespace.FullName.StartsWith(namespacePrefix, StringComparison.Ordinal))
-            .Where(t => !t.Namespace.FullName.EndsWith(".Endpoints", StringComparison.Ordinal)
+            .Where(t => t.Namespace.FullName.StartsWith(namespacePrefix, StringComparison.Ordinal) && !t.Namespace.FullName.EndsWith(".Endpoints", StringComparison.Ordinal)
                 && !t.Namespace.FullName.Contains(".Endpoints.", StringComparison.Ordinal));
 
         IEnumerable<IType> violators = nonEndpointTypes

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/QueryDefinitionCatalogRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/QueryDefinitionCatalogRules.cs
@@ -98,8 +98,7 @@ public static class QueryDefinitionCatalogRules
         List<string> violations =
         [
             .. candidateTypes
-                .Where(t => IsConcreteDefinition(t, queryDefinitionOpenType))
-                .Where(t => !HasPublicParameterlessConstructor(t))
+                .Where(t => IsConcreteDefinition(t, queryDefinitionOpenType) && !HasPublicParameterlessConstructor(t))
                 .Select(t => t.FullName!)
                 .Where(name => !exemptDefinitions.Contains(name)),
         ];

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/SourceCodeAntiPatternRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/SourceCodeAntiPatternRules.cs
@@ -241,8 +241,7 @@ public static partial class SourceCodeAntiPatternRules
         List<string> violations = [];
 
         foreach (string validatorFile in Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories)
-            .Where(f => !IsInBuildOutput(f))
-            .Where(f => f.Contains(Path.DirectorySeparatorChar + "Validators" + Path.DirectorySeparatorChar,
+            .Where(f => !IsInBuildOutput(f) && f.Contains(Path.DirectorySeparatorChar + "Validators" + Path.DirectorySeparatorChar,
                 StringComparison.OrdinalIgnoreCase)))
         {
             string content = File.ReadAllText(validatorFile);

--- a/tests/Granit.ArchitectureTests/BodylessVerbBodyBindingTests.cs
+++ b/tests/Granit.ArchitectureTests/BodylessVerbBodyBindingTests.cs
@@ -10,8 +10,8 @@ namespace Granit.ArchitectureTests;
 /// </summary>
 /// <remarks>
 /// ASP.NET Core 10 rejects an inferred body parameter on these verbs at endpoint construction
-/// (<c>InvalidOperationException: Body was inferred but the method does not allow inferred body
-/// parameters</c>), so a missing <c>[FromBody]</c> is a deployment-time regression that escapes
+/// (<code>InvalidOperationException: Body was inferred but the method does not allow inferred body
+/// parameters</code>), so a missing <c>[FromBody]</c> is a deployment-time regression that escapes
 /// compile-time checks. The scan logic lives in
 /// <see cref="ApiConventionRules.BodylessVerbHandlersShouldAnnotateRequestDtoParameters"/>
 /// (Granit.ArchitectureTests.Abstractions) so downstream repos can reuse it.

--- a/tests/Granit.ArchitectureTests/BrowsingArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/BrowsingArchitectureTests.cs
@@ -144,7 +144,7 @@ public sealed class BrowsingArchitectureTests
 
         violators.ShouldBeEmpty(
             $"Only {string.Join(" / ", allowedProjects)} may reference the {packageId} NuGet directly. " +
-            $"Other consumers must route through Granit.Browsing's IHeadlessBrowser + capability interfaces. " +
+            "Other consumers must route through Granit.Browsing's IHeadlessBrowser + capability interfaces. " +
             $"Violators: {string.Join(", ", violators)}");
     }
 

--- a/tests/Granit.ArchitectureTests/EndpointModuleLocalizationRegistrationTests.cs
+++ b/tests/Granit.ArchitectureTests/EndpointModuleLocalizationRegistrationTests.cs
@@ -101,8 +101,7 @@ public sealed class EndpointModuleLocalizationRegistrationTests
         foreach (Assembly assembly in assemblies)
         {
             string? name = assembly.GetName().Name;
-            if (name is null
-                || !name.StartsWith("Granit.", StringComparison.Ordinal)
+            if (name?.StartsWith("Granit.", StringComparison.Ordinal) != true
                 || !name.EndsWith(".Endpoints", StringComparison.Ordinal))
             {
                 continue;

--- a/tests/Granit.ArchitectureTests/NotificationDefinitionProviderCoverageTests.cs
+++ b/tests/Granit.ArchitectureTests/NotificationDefinitionProviderCoverageTests.cs
@@ -57,9 +57,9 @@ public sealed class NotificationDefinitionProviderCoverageTests
                 failures.Add(
                     $"Assembly '{assembly.GetName().Name}' declares {missing.Length} NotificationType(s) " +
                     $"without a matching NotificationDefinition: [{string.Join(", ", missing)}]. " +
-                    $"Add an INotificationDefinitionProvider in the assembly's Internal/ folder and register it " +
-                    $"via context.Services.AddSingleton<INotificationDefinitionProvider, …>() — pattern: " +
-                    $"IdentityNotificationDefinitionProvider in Granit.Identity.Local.Notifications.");
+                    "Add an INotificationDefinitionProvider in the assembly's Internal/ folder and register it " +
+                    "via context.Services.AddSingleton<INotificationDefinitionProvider, …>() — pattern: " +
+                    "IdentityNotificationDefinitionProvider in Granit.Identity.Local.Notifications.");
             }
         }
 

--- a/tests/Granit.ArchitectureTests/OpenApiGeneratorCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/OpenApiGeneratorCompletenessTests.cs
@@ -89,7 +89,7 @@ public sealed partial class OpenApiGeneratorCompletenessTests
         int expected = EndpointsProjectNames.Count + NonEndpointsDocumentSlugs.Count;
 
         entries.ShouldBe(expected,
-            $"GeneratorEndpoints.All must declare one document per endpoints module plus the " +
+            "GeneratorEndpoints.All must declare one document per endpoints module plus the " +
             $"{NonEndpointsDocumentSlugs.Count} non-.Endpoints surface(s) [{string.Join(", ", NonEndpointsDocumentSlugs)}] " +
             $"({expected} expected, found {entries}). Every module's routes must be mounted.");
 

--- a/tests/Granit.ArchitectureTests/OutboundHttpSafetyTests.cs
+++ b/tests/Granit.ArchitectureTests/OutboundHttpSafetyTests.cs
@@ -50,7 +50,7 @@ public sealed class OutboundHttpSafetyTests
 
         referenced.ShouldBeTrue(
             $"{projectName} emits outbound user-controlled URLs and must reference Granit.Http.Security " +
-            $"so it can use IUrlSafetyValidator / PrivateNetworkClassifier instead of inventing local rules.");
+            "so it can use IUrlSafetyValidator / PrivateNetworkClassifier instead of inventing local rules.");
     }
 
     /// <summary>

--- a/tests/Granit.ArchitectureTests/PermissionLocalizationCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/PermissionLocalizationCompletenessTests.cs
@@ -76,7 +76,7 @@ public sealed partial class PermissionLocalizationCompletenessTests
         }
 
         missing.ShouldBeEmpty(
-            $"Every permission constant must have a 'Permission:{{Value}}' key in all 15 base cultures " +
+            "Every permission constant must have a 'Permission:{Value}' key in all 15 base cultures " +
             $"of its owning module. {missing.Count} key(s) missing:" + Environment.NewLine +
             string.Join(Environment.NewLine, missing.Order(StringComparer.Ordinal)));
     }

--- a/tests/Granit.ArchitectureTests/PrivacyDataProviderConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/PrivacyDataProviderConventionTests.cs
@@ -39,8 +39,7 @@ public sealed class PrivacyDataProviderConventionTests
             try
             {
                 providers = [.. assembly.GetTypes()
-                    .Where(t => !t.IsAbstract && !t.IsInterface)
-                    .Where(t => typeof(IPrivacyDataProvider).IsAssignableFrom(t))];
+                    .Where(t => !t.IsAbstract && !t.IsInterface && typeof(IPrivacyDataProvider).IsAssignableFrom(t))];
             }
             catch (ReflectionTypeLoadException)
             {
@@ -50,8 +49,7 @@ public sealed class PrivacyDataProviderConventionTests
             foreach (Type provider in providers)
             {
                 Type[] candidateHandlers = [.. assembly.GetTypes()
-                    .Where(t => !t.IsAbstract && !t.IsInterface && t.IsPublic)
-                    .Where(t => t.Name.EndsWith("PersonalDataExportHandler", StringComparison.Ordinal))];
+                    .Where(t => !t.IsAbstract && !t.IsInterface && t.IsPublic && t.Name.EndsWith("PersonalDataExportHandler", StringComparison.Ordinal))];
 
                 bool hasMatchingHandler = candidateHandlers.Any(h => HandlerReferencesProvider(h, provider));
                 if (!hasMatchingHandler)

--- a/tests/Granit.ArchitectureTests/TestProjectConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/TestProjectConventionTests.cs
@@ -21,10 +21,7 @@ public sealed class TestProjectConventionTests
         // (IsPackable=false) — not shipped packages; covered by dedicated tests elsewhere.
         IEnumerable<string> srcPackages = Directory.GetDirectories(srcDir)
             .Select(Path.GetFileName)
-            .Where(name => name!.StartsWith("Granit.", StringComparison.Ordinal))
-            .Where(name => File.Exists(Path.Join(srcDir, name!, $"{name}.csproj")))
-            .Where(name => !TargetsNetStandard(Path.Join(srcDir, name!, $"{name}.csproj")))
-            .Where(name => !IsBuildOnly(Path.Join(srcDir, name!, $"{name}.csproj")))
+            .Where(name => name!.StartsWith("Granit.", StringComparison.Ordinal) && File.Exists(Path.Join(srcDir, name, $"{name}.csproj")) && !TargetsNetStandard(Path.Join(srcDir, name, $"{name}.csproj")) && !IsBuildOnly(Path.Join(srcDir, name, $"{name}.csproj")))
             .Cast<string>();
 
         List<string> missing = [];
@@ -51,8 +48,7 @@ public sealed class TestProjectConventionTests
 
         IEnumerable<string> srcPackages = Directory.GetDirectories(srcDir)
             .Select(Path.GetFileName)
-            .Where(name => name!.StartsWith("Granit.", StringComparison.Ordinal))
-            .Where(name => File.Exists(Path.Join(srcDir, name!, $"{name}.csproj")))
+            .Where(name => name!.StartsWith("Granit.", StringComparison.Ordinal) && File.Exists(Path.Join(srcDir, name, $"{name}.csproj")))
             .Cast<string>();
 
         List<string> missing = [];

--- a/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/TextExtractionArchitectureTests.cs
@@ -80,9 +80,8 @@ public sealed partial class TextExtractionArchitectureTests
         {
             bool packageReferencesLimitedStream = Directory
                 .EnumerateFiles(packageDir, "*.cs", SearchOption.AllDirectories)
-                .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-                .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-                .Any(p => File.ReadAllText(p).Contains("LimitedStream", StringComparison.Ordinal));
+                .Any(p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) && !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) && File.ReadAllText(p).Contains("LimitedStream", StringComparison.Ordinal))
+;
 
             if (!packageReferencesLimitedStream)
             {
@@ -193,8 +192,7 @@ public sealed partial class TextExtractionArchitectureTests
 
         foreach (string csFile in Directory
             .EnumerateFiles(officeDir, "*.cs", SearchOption.AllDirectories)
-            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)))
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) && !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)))
         {
             string code = StripCommentsAndStrings(File.ReadAllText(csFile));
             string relativePath = Path.GetRelativePath(SrcRoot, csFile);

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Diagnostics/AuditingMetricsTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Diagnostics/AuditingMetricsTests.cs
@@ -22,10 +22,7 @@ public sealed class AuditingMetricsTests : IDisposable
                 listener.EnableMeasurementEvents(instrument);
             }
         };
-        _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-        {
-            _recordings.Add((instrument.Name, measurement, tags.ToArray()));
-        });
+        _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) => _recordings.Add((instrument.Name, measurement, tags.ToArray())));
         _listener.Start();
     }
 

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/GranitAuditingEntityFrameworkCoreModuleTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/GranitAuditingEntityFrameworkCoreModuleTests.cs
@@ -74,6 +74,6 @@ public sealed class GranitAuditingEntityFrameworkCoreModuleTests
             .OfType<DependsOnAttribute>()
             .ToArray();
 
-        attributes.SelectMany(a => a.DependedTypes).Count().ShouldBe(3);
+        attributes.Sum(a => a.DependedTypes.Length).ShouldBe(3);
     }
 }

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/ChangeTrackingCaptureServiceTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/ChangeTrackingCaptureServiceTests.cs
@@ -588,7 +588,7 @@ public sealed class ChangeTrackingCaptureServiceTests : IDisposable
         await service.PublishAsync(TestContext.Current.CancellationToken);
 
         // Second capture with a fresh DbContext entry
-        using DbContext secondContext = CreateInMemoryDbContext();
+        await using DbContext secondContext = CreateInMemoryDbContext();
         secondContext.Add(new PropertyIgnoredEntity { Id = 2, Name = "Second", InternalNotes = "Secret2" });
         service.Capture(secondContext);
         await service.PublishAsync(TestContext.Current.CancellationToken);

--- a/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -16,15 +16,14 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests;
 internal sealed class TestDbContextFactory : IDbContextFactory<AuthenticationApiKeysDbContext>, IDisposable
 {
     private readonly SqliteConnection _connection;
-    private readonly DbContextOptions<AuthenticationApiKeysDbContext> _options;
 
     private TestDbContextFactory(SqliteConnection connection, DbContextOptions<AuthenticationApiKeysDbContext> options)
     {
         _connection = connection;
-        _options = options;
+        Options = options;
     }
 
-    public DbContextOptions<AuthenticationApiKeysDbContext> Options => _options;
+    public DbContextOptions<AuthenticationApiKeysDbContext> Options { get; }
 
     public static TestDbContextFactory Create()
     {
@@ -46,7 +45,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<AuthenticationApi
         return new TestDbContextFactory(connection, options);
     }
 
-    public AuthenticationApiKeysDbContext CreateDbContext() => new(_options, GranitDesignTime.CurrentTenant);
+    public AuthenticationApiKeysDbContext CreateDbContext() => new(Options, GranitDesignTime.CurrentTenant);
 
     public void Dispose() => _connection.Dispose();
 }

--- a/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyAuthenticationHandlerTests.cs
@@ -335,7 +335,7 @@ public sealed class ApiKeyAuthenticationHandlerTests
         // ApiKey-specific claims
         principal.FindFirstValue(ApiKeyClaimTypes.ActorKind).ShouldBe(nameof(Users.ActorKind.ExternalSystem));
         principal.FindFirstValue(ApiKeyClaimTypes.ApiKeyId).ShouldBe(apiKey.Id.ToString());
-        principal.FindFirstValue(ApiKeyClaimTypes.ApiKeyType).ShouldBe(ApiKeyType.Secret.ToString());
+        principal.FindFirstValue(ApiKeyClaimTypes.ApiKeyType).ShouldBe(nameof(ApiKeyType.Secret));
         principal.FindFirstValue(ApiKeyClaimTypes.Environment).ShouldBe("live");
 
         // Permissions

--- a/tests/Granit.Authentication.DPoP.Tests/Validation/DPoPProofValidatorTests.cs
+++ b/tests/Granit.Authentication.DPoP.Tests/Validation/DPoPProofValidatorTests.cs
@@ -80,7 +80,7 @@ public sealed class DPoPProofValidatorTests : IDisposable
     [Fact]
     public async Task ValidateAsync_InvalidHeaderEncoding_ReturnsFailure()
     {
-        string jwt = "!!!invalid-base64!!!.eyJ0ZXN0IjoxfQ.signature";
+        const string jwt = "!!!invalid-base64!!!.eyJ0ZXN0IjoxfQ.signature";
 
         DPoPValidationResult result = await _validator.ValidateAsync(
             jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);

--- a/tests/Granit.Authentication.DPoP.Tests/Validation/JwkThumbprintCalculatorTests.cs
+++ b/tests/Granit.Authentication.DPoP.Tests/Validation/JwkThumbprintCalculatorTests.cs
@@ -22,7 +22,7 @@ public sealed class JwkThumbprintCalculatorTests
     {
         // RFC 7638 §3.1 example RSA key (required members only)
         // Expected thumbprint: NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs
-        string jwkJson = """
+        const string jwkJson = """
         {
             "kty": "RSA",
             "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
@@ -105,7 +105,7 @@ public sealed class JwkThumbprintCalculatorTests
     [Fact]
     public void ComputeThumbprint_UnsupportedKeyType_Throws()
     {
-        string jwkJson = """{"kty":"oct","k":"AyM32w"}""";
+        const string jwkJson = """{"kty":"oct","k":"AyM32w"}""";
 
         using var doc = JsonDocument.Parse(jwkJson);
         Should.Throw<NotSupportedException>(() =>

--- a/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakClaimsTransformationAdditionalTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakClaimsTransformationAdditionalTests.cs
@@ -22,7 +22,7 @@ public sealed class KeycloakClaimsTransformationAdditionalTests
     public async Task TransformAsync_ResourceAccess_MissingClientId_ReturnsUnmodified()
     {
         // Arrange — resource_access with a different client ID than configured
-        string resourceAccess = """{"other-client":{"roles":["admin"]}}""";
+        const string resourceAccess = """{"other-client":{"roles":["admin"]}}""";
         ClaimsIdentity identity = new(
             [
                 new Claim("sub", "user-123"),
@@ -42,7 +42,7 @@ public sealed class KeycloakClaimsTransformationAdditionalTests
     public async Task TransformAsync_RealmAccess_NoRolesProperty_ReturnsUnmodified()
     {
         // Arrange — realm_access without "roles" key
-        string realmAccess = """{"something_else":["admin"]}""";
+        const string realmAccess = """{"something_else":["admin"]}""";
         ClaimsIdentity identity = new(
             [
                 new Claim("sub", "user-123"),
@@ -62,7 +62,7 @@ public sealed class KeycloakClaimsTransformationAdditionalTests
     public async Task TransformAsync_ResourceAccess_WithEmptyClientId_ReturnsUnmodified()
     {
         // Arrange — resource_access with empty ClientId configured
-        string resourceAccess = """{"test-client":{"roles":["admin"]}}""";
+        const string resourceAccess = """{"test-client":{"roles":["admin"]}}""";
         ClaimsIdentity identity = new(
             [
                 new Claim("sub", "user-123"),
@@ -82,7 +82,7 @@ public sealed class KeycloakClaimsTransformationAdditionalTests
     public async Task TransformAsync_NullRoleValue_IsSkipped()
     {
         // Arrange — roles array contains a null entry (unusual but possible)
-        string realmAccess = """{"roles":["admin",null,"editor"]}""";
+        const string realmAccess = """{"roles":["admin",null,"editor"]}""";
         ClaimsIdentity identity = new(
             [
                 new Claim("sub", "user-123"),

--- a/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakClaimsTransformationTests.cs
+++ b/tests/Granit.Authentication.JwtBearer.Keycloak.Tests/KeycloakClaimsTransformationTests.cs
@@ -29,7 +29,7 @@ public sealed class KeycloakClaimsTransformationTests
     public async Task TransformAsync_WithRealmAccessRoles_AddsRoleClaims()
     {
         // Arrange
-        string realmAccess = """{"roles":["admin","practitioner"]}""";
+        const string realmAccess = """{"roles":["admin","practitioner"]}""";
         var identity = new ClaimsIdentity(
             [
                 new Claim("sub", "user-123"),
@@ -51,7 +51,7 @@ public sealed class KeycloakClaimsTransformationTests
     public async Task TransformAsync_WithResourceAccessRoles_AddsRoleClaims()
     {
         // Arrange
-        string resourceAccess = """{"test-client":{"roles":["admin"]}}""";
+        const string resourceAccess = """{"test-client":{"roles":["admin"]}}""";
         var identity = new ClaimsIdentity(
             [
                 new Claim("sub", "user-123"),
@@ -103,7 +103,7 @@ public sealed class KeycloakClaimsTransformationTests
     public async Task TransformAsync_WithEmptyRoles_AddsNoClaims()
     {
         // Arrange
-        string realmAccess = """{"roles":[]}""";
+        const string realmAccess = """{"roles":[]}""";
         var identity = new ClaimsIdentity(
             [
                 new Claim("sub", "user-123"),
@@ -123,7 +123,7 @@ public sealed class KeycloakClaimsTransformationTests
     public async Task TransformAsync_DoesNotDuplicateExistingRoles()
     {
         // Arrange
-        string realmAccess = """{"roles":["admin"]}""";
+        const string realmAccess = """{"roles":["admin"]}""";
         var identity = new ClaimsIdentity(
             [
                 new Claim("sub", "user-123"),

--- a/tests/Granit.Authorization.Tests/Exports/RoleMetadataExportDefinitionTests.cs
+++ b/tests/Granit.Authorization.Tests/Exports/RoleMetadataExportDefinitionTests.cs
@@ -9,7 +9,7 @@ public sealed class RoleMetadataExportDefinitionTests
 {
     private static readonly RoleMetadataExportDefinition Sut = new();
     private static IReadOnlyList<ExportFieldDescriptor> Fields =>
-        ((IExportDefinitionDescriptor)Sut).GetFields();
+        Sut.GetFields();
 
     [Fact]
     public void Name_is_stable() =>

--- a/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
@@ -43,8 +43,8 @@ public sealed class PermissionCheckerTests
         PermissionChecker checker = BuildChecker(
             alwaysAllow: true,
             isAuthenticated: true,
-            cache: cache,
-            store: store);
+            store: store,
+            cache: cache);
 
         // Act
         bool result = await checker.IsGrantedAsync(DefinedPermission, TestContext.Current.CancellationToken);
@@ -81,8 +81,8 @@ public sealed class PermissionCheckerTests
         PermissionChecker checker = BuildChecker(
             isAuthenticated: true,
             roles: [AdminRoleName],
-            cache: cache,
-            store: store);
+            store: store,
+            cache: cache);
 
         // Act
         bool result = await checker.IsGrantedAsync(DefinedPermission, TestContext.Current.CancellationToken);
@@ -244,8 +244,8 @@ public sealed class PermissionCheckerTests
         PermissionChecker checker = BuildChecker(
             isAuthenticated: true,
             roles: [roleCasing],
-            cache: cache,
-            store: store);
+            store: store,
+            cache: cache);
 
         // Act
         bool result = await checker.IsGrantedAsync(DefinedPermission, TestContext.Current.CancellationToken);

--- a/tests/Granit.Authorization.Tests/PermissionDefinitionRegistryTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionDefinitionRegistryTests.cs
@@ -107,7 +107,7 @@ public sealed class PermissionDefinitionRegistryTests
         PermissionDefinitionRegistry manager = new(providers);
 
         // Assert — le groupe "Administration" n'est présent qu'une fois
-        manager.GetGroups().Where(g => g.Name == "Administration").Count().ShouldBe(1);
+        manager.GetGroups().Count(g => g.Name == "Administration").ShouldBe(1);
     }
 
     // =========================================================================
@@ -224,7 +224,7 @@ public sealed class PermissionDefinitionRegistryTests
         manager.Exists("Administration.Users.Read").ShouldBeTrue();
         manager.Exists("Administration.Reports.Export").ShouldBeTrue();
         manager.Exists("Administration.Settings.Manage").ShouldBeTrue();
-        manager.GetGroups().Where(g => g.Name == "Administration").Count().ShouldBe(1);
+        manager.GetGroups().Count(g => g.Name == "Administration").ShouldBe(1);
     }
 
     // --- Test doubles ---

--- a/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
@@ -173,7 +173,7 @@ public sealed class BackgroundJobDefinitionTests
     public void RecordFailure_ShortErrorMessage_ShouldNotTruncate()
     {
         BackgroundJobDefinition job = BuildJob();
-        string shortMessage = "timeout";
+        const string shortMessage = "timeout";
 
         job.RecordFailure(shortMessage);
 

--- a/tests/Granit.BackgroundJobs.Tests/ChannelCronSchedulerServiceTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/ChannelCronSchedulerServiceTests.cs
@@ -214,7 +214,7 @@ public sealed class ChannelCronSchedulerServiceTests
     public async Task StopAsync_DoesNotThrow()
     {
         Func<Task> act = () =>
-            ((IHostedService)CreateService())
+            CreateService()
                 .StopAsync(TestContext.Current.CancellationToken);
 
         await Should.NotThrowAsync(act);

--- a/tests/Granit.BackgroundJobs.Tests/Internal/BackgroundJobEnvelopeTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/Internal/BackgroundJobEnvelopeTests.cs
@@ -43,7 +43,7 @@ public sealed class BackgroundJobEnvelopeTests
     [Fact]
     public void RecordEquality_SameValues_AreEqual()
     {
-        string message = "same-message";
+        const string message = "same-message";
         BackgroundJobEnvelope a = new(message);
         BackgroundJobEnvelope b = new(message);
 

--- a/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
@@ -532,8 +532,8 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetCallback_ValidCodeAndState_ExchangesTokensAndRedirects()
     {
-        string testState = "test-state-123";
-        string testCode = "authorization-code-456";
+        const string testState = "test-state-123";
+        const string testCode = "authorization-code-456";
 
         // Pre-populate cache with PkceState
         BffLoginEndpoints.PkceState pkceState = new("test-verifier", testState, BffEndpointsTestServer.TestFrontendName);
@@ -557,7 +557,7 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetCallback_TokenExchangeFails_RedirectsToErrorPage()
     {
-        string testState = "test-state-fail";
+        const string testState = "test-state-fail";
 
         BffLoginEndpoints.PkceState pkceState = new("test-verifier", testState, BffEndpointsTestServer.TestFrontendName);
         _server.Cache.TryGetAsync<BffLoginEndpoints.PkceState>(default!, default, CancellationToken.None)
@@ -642,7 +642,7 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetCallback_ValidResponse_ConsumesStateFromCache()
     {
-        string testState = "consumed-state";
+        const string testState = "consumed-state";
 
         BffLoginEndpoints.PkceState pkceState = new("verifier", testState, BffEndpointsTestServer.TestFrontendName);
         _server.Cache.TryGetAsync<BffLoginEndpoints.PkceState>(default!, default, CancellationToken.None)

--- a/tests/Granit.Bff.Tests/Internal/LogoutTokenValidatorTests.cs
+++ b/tests/Granit.Bff.Tests/Internal/LogoutTokenValidatorTests.cs
@@ -93,7 +93,7 @@ public sealed class LogoutTokenValidatorTests : IDisposable
     [Fact]
     public async Task ValidateAsync_InvalidBase64Header_ReturnsNull()
     {
-        string token = "!!!invalid-base64!!!.payload.signature";
+        const string token = "!!!invalid-base64!!!.payload.signature";
 
         ValidatedLogoutToken? result = await _validator.ValidateAsync(
             token, ClientId, TestContext.Current.CancellationToken);

--- a/tests/Granit.BlobStorage.GoogleCloud.Tests/Internal/GcsResumableMultipartWriteStreamTests.cs
+++ b/tests/Granit.BlobStorage.GoogleCloud.Tests/Internal/GcsResumableMultipartWriteStreamTests.cs
@@ -145,7 +145,7 @@ public sealed class GcsResumableMultipartWriteStreamTests
         await sut.WriteAsync(new byte[500], TestContext.Current.CancellationToken);
         await sut.CompleteAsync(TestContext.Current.CancellationToken);
 
-        totalSizes.ShouldBe([null, null, 2L * ChunkSize + 500]);
+        totalSizes.ShouldBe([null, null, (2L * ChunkSize) + 500]);
     }
 
     [Fact]

--- a/tests/Granit.BlobStorage.S3.Tests/S3PresignedUrlRewriterTests.cs
+++ b/tests/Granit.BlobStorage.S3.Tests/S3PresignedUrlRewriterTests.cs
@@ -14,7 +14,7 @@ public sealed class S3PresignedUrlRewriterTests
     [Fact]
     public void ForceScheme_HttpsServiceUrl_ReturnsInputUnchanged()
     {
-        string presigned = "https://s3.eu-west-1.amazonaws.com/bucket/key?X-Amz-Signature=abc";
+        const string presigned = "https://s3.eu-west-1.amazonaws.com/bucket/key?X-Amz-Signature=abc";
 
         string result = S3PresignedUrlRewriter.ForceScheme(presigned, httpServiceUrl: null);
 
@@ -24,7 +24,7 @@ public sealed class S3PresignedUrlRewriterTests
     [Fact]
     public void ForceScheme_HttpServiceUrl_RewritesHttpsToHttpAndPreservesPort()
     {
-        string presigned = "https://localhost/showcase/2026/05/blob?X-Amz-Signature=abc";
+        const string presigned = "https://localhost/showcase/2026/05/blob?X-Amz-Signature=abc";
         Uri serviceUrl = new("http://localhost:9000");
 
         string result = S3PresignedUrlRewriter.ForceScheme(presigned, serviceUrl);
@@ -41,7 +41,7 @@ public sealed class S3PresignedUrlRewriterTests
     public void ForceScheme_HttpServiceUrlAlreadyHttp_PreservesPortFromServiceUrl()
     {
         // AWSSDK could emit either scheme; this case proves the rewriter is idempotent on http.
-        string presigned = "http://localhost:9000/bucket/key?X-Amz-Signature=abc";
+        const string presigned = "http://localhost:9000/bucket/key?X-Amz-Signature=abc";
         Uri serviceUrl = new("http://localhost:9000");
 
         string result = S3PresignedUrlRewriter.ForceScheme(presigned, serviceUrl);
@@ -56,7 +56,7 @@ public sealed class S3PresignedUrlRewriterTests
     {
         // AWS SDK may emit port 443 with https; rewriting to http must restore the service port,
         // not fall back to 80 (UriBuilder's default for the http scheme).
-        string presigned = "https://localhost:443/bucket/key?X-Amz-Signature=abc";
+        const string presigned = "https://localhost:443/bucket/key?X-Amz-Signature=abc";
         Uri serviceUrl = new("http://localhost:9123");
 
         string result = S3PresignedUrlRewriter.ForceScheme(presigned, serviceUrl);
@@ -71,7 +71,7 @@ public sealed class S3PresignedUrlRewriterTests
     {
         // Signature must remain bit-identical — host (not scheme) is in SignedHeaders, but the
         // signed query parameters (X-Amz-Signature, X-Amz-SignedHeaders, ...) must not be touched.
-        string query =
+        const string query =
             "?X-Amz-Expires=900&X-Amz-Algorithm=AWS4-HMAC-SHA256" +
             "&X-Amz-Credential=minioadmin%2F20260523%2Fus-east-1%2Fs3%2Faws4_request" +
             "&X-Amz-Date=20260523T175245Z&X-Amz-SignedHeaders=content-type%3Bhost" +

--- a/tests/Granit.BlobStorage.Tests/Internal/BufferedMultipartWriteStreamTests.cs
+++ b/tests/Granit.BlobStorage.Tests/Internal/BufferedMultipartWriteStreamTests.cs
@@ -170,13 +170,13 @@ public sealed class BufferedMultipartWriteStreamTests
         CapturedBytes captured = new();
         provider.SaveAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
+            .Returns(async callInfo =>
             {
                 Stream s = callInfo.Arg<Stream>();
-                using MemoryStream ms = new();
+                await using MemoryStream ms = new();
                 s.CopyTo(ms);
                 captured.Value = ms.ToArray();
-                return Task.CompletedTask;
+                await Task.CompletedTask;
             });
         return captured;
     }

--- a/tests/Granit.Browsing.Tests/BrowsingPermissionAdvisoryServiceTests.cs
+++ b/tests/Granit.Browsing.Tests/BrowsingPermissionAdvisoryServiceTests.cs
@@ -30,7 +30,7 @@ public sealed class BrowsingPermissionAdvisoryServiceTests
         ServiceConfigurationContext context = new(services, configuration, hostBuilder);
         new GranitBrowsingModule().ConfigureServices(context);
 
-        using ServiceProvider provider = services.BuildServiceProvider(
+        await using ServiceProvider provider = services.BuildServiceProvider(
             new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true });
 
         IEnumerable<IHostedService> hostedServices = provider.GetServices<IHostedService>();

--- a/tests/Granit.Browsing.Tests/Diagnostics/ConsoleRedactorTests.cs
+++ b/tests/Granit.Browsing.Tests/Diagnostics/ConsoleRedactorTests.cs
@@ -18,7 +18,7 @@ public sealed class ConsoleRedactorTests
     [Fact]
     public void JWT_shape_should_be_redacted_under_bearer_prefix()
     {
-        string jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2Q";
+        const string jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2Q";
         string output = ConsoleRedactor.Redact($"Bearer {jwt}");
 
         output.ShouldNotContain(jwt);

--- a/tests/Granit.Caching.Tests/CacheEncryptionResolutionTests.cs
+++ b/tests/Granit.Caching.Tests/CacheEncryptionResolutionTests.cs
@@ -70,10 +70,10 @@ public sealed class CacheEncryptionResolutionTests
 
     // Types de test
     [CacheEncrypted]
-    private sealed class AlwaysEncryptedItem { }
+    private sealed class AlwaysEncryptedItem;
 
     [CacheEncrypted(false)]
-    private sealed class NeverEncryptedItem { }
+    private sealed class NeverEncryptedItem;
 
-    private sealed class UnattributedItem { }
+    private sealed class UnattributedItem;
 }

--- a/tests/Granit.Caching.Tests/CachingServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Caching.Tests/CachingServiceCollectionExtensionsTests.cs
@@ -76,10 +76,7 @@ public sealed class CachingServiceCollectionExtensionsTests
     [Fact]
     public void AddGranitCaching_FusionCacheOptions_UsesCustomDuration()
     {
-        using ServiceProvider sp = BuildServiceProvider(builder =>
-        {
-            builder.Configuration["Cache:DefaultAbsoluteExpirationRelativeToNow"] = "00:30:00";
-        });
+        using ServiceProvider sp = BuildServiceProvider(builder => builder.Configuration["Cache:DefaultAbsoluteExpirationRelativeToNow"] = "00:30:00");
 
         FusionCacheOptions fcOptions = sp.GetRequiredService<IOptions<FusionCacheOptions>>().Value;
 
@@ -132,10 +129,7 @@ public sealed class CachingServiceCollectionExtensionsTests
     [Fact]
     public void AddGranitCaching_FusionCacheOptions_SetsCustomKeyPrefix()
     {
-        using ServiceProvider sp = BuildServiceProvider(builder =>
-        {
-            builder.Configuration["Cache:KeyPrefix"] = "myapp";
-        });
+        using ServiceProvider sp = BuildServiceProvider(builder => builder.Configuration["Cache:KeyPrefix"] = "myapp");
 
         FusionCacheOptions fcOptions = sp.GetRequiredService<IOptions<FusionCacheOptions>>().Value;
 

--- a/tests/Granit.DataExchange.BlobStorage.Tests/BlobStorageFileProviderTests.cs
+++ b/tests/Granit.DataExchange.BlobStorage.Tests/BlobStorageFileProviderTests.cs
@@ -51,7 +51,7 @@ public sealed class BlobStorageFileProviderTests
         _guidGenerator.Create().Returns(blobId);
         _keyStrategy.BuildObjectKey("test-container", blobId).Returns("tenant/test-container/2026/04/blob-id");
 
-        using var content = new MemoryStream([4, 5, 6]);
+        await using var content = new MemoryStream([4, 5, 6]);
         string reference = await _sut.SaveAsync("report.csv", content, TestContext.Current.CancellationToken);
 
         reference.ShouldBe("tenant/test-container/2026/04/blob-id");

--- a/tests/Granit.DataExchange.Csv.Tests/CsvExportWriterTests.cs
+++ b/tests/Granit.DataExchange.Csv.Tests/CsvExportWriterTests.cs
@@ -54,7 +54,7 @@ public sealed class CsvExportWriterTests
             new Dictionary<string, object?> { ["Name"] = "Bob", ["Email"] = "bob@test.com" },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -77,7 +77,7 @@ public sealed class CsvExportWriterTests
             new("Name", "String", "Nom", null, 0, false),
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields,
@@ -105,7 +105,7 @@ public sealed class CsvExportWriterTests
             new Dictionary<string, object?> { ["Name"] = "Smith; John" },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -129,7 +129,7 @@ public sealed class CsvExportWriterTests
             new Dictionary<string, object?> { ["Name"] = "John \"Jack\" Doe" },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -154,7 +154,7 @@ public sealed class CsvExportWriterTests
             new Dictionary<string, object?> { ["Name"] = "Alice", ["Email"] = null },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -179,7 +179,7 @@ public sealed class CsvExportWriterTests
             new Dictionary<string, object?> { ["Date"] = new DateOnly(2026, 3, 3) },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -198,7 +198,7 @@ public sealed class CsvExportWriterTests
             new("Name", "String", null, null, 0, false),
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields,
@@ -221,7 +221,7 @@ public sealed class CsvExportWriterTests
             new("Company.Name", "String", null, null, 0, true),
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields,

--- a/tests/Granit.DataExchange.Csv.Tests/CsvRoundtripTests.cs
+++ b/tests/Granit.DataExchange.Csv.Tests/CsvRoundtripTests.cs
@@ -34,7 +34,7 @@ public sealed class CsvRoundtripTests
             new("Company.Name", "String", "Société", null, 2, true),
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act — export
         await Writer.WriteAsync(stream, fields,
@@ -191,7 +191,7 @@ public sealed class CsvRoundtripTests
         List<ExportFieldDescriptor> fields,
         List<IReadOnlyDictionary<string, object?>> rows)
     {
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Export
         await Writer.WriteAsync(stream, fields, ToAsyncEnumerable(rows),

--- a/tests/Granit.DataExchange.Csv.Tests/SepCsvFileParserTests.cs
+++ b/tests/Granit.DataExchange.Csv.Tests/SepCsvFileParserTests.cs
@@ -35,7 +35,7 @@ public sealed class SepCsvFileParserTests
     public async Task ExtractHeadersAsync_returns_column_names()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("simple.csv");
+        await using FileStream stream = OpenTestFile("simple.csv");
 
         // Act
         IReadOnlyList<string> headers = await Sut.ExtractHeadersAsync(
@@ -49,7 +49,7 @@ public sealed class SepCsvFileParserTests
     public async Task ExtractHeadersAsync_with_semicolon_separator()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("semicolon.csv");
+        await using FileStream stream = OpenTestFile("semicolon.csv");
         FileParsingOptions options = new() { Separator = ";" };
 
         // Act
@@ -66,7 +66,7 @@ public sealed class SepCsvFileParserTests
     public async Task ReadPreviewAsync_returns_limited_rows()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("simple.csv");
+        await using FileStream stream = OpenTestFile("simple.csv");
 
         // Act
         IReadOnlyList<string[]> rows = await Sut.ReadPreviewAsync(
@@ -82,7 +82,7 @@ public sealed class SepCsvFileParserTests
     public async Task ReadPreviewAsync_returns_all_when_fewer_than_max()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("semicolon.csv");
+        await using FileStream stream = OpenTestFile("semicolon.csv");
         FileParsingOptions options = new() { Separator = ";" };
 
         // Act
@@ -99,7 +99,7 @@ public sealed class SepCsvFileParserTests
     public async Task ParseAsync_streams_all_rows()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("simple.csv");
+        await using FileStream stream = OpenTestFile("simple.csv");
         List<RawImportRow> rows = [];
 
         // Act
@@ -121,7 +121,7 @@ public sealed class SepCsvFileParserTests
     public async Task ParseAsync_row_numbers_are_one_based()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("simple.csv");
+        await using FileStream stream = OpenTestFile("simple.csv");
         List<RawImportRow> rows = [];
 
         // Act
@@ -141,7 +141,7 @@ public sealed class SepCsvFileParserTests
     public async Task ParseAsync_handles_quoted_values()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("quoted.csv");
+        await using FileStream stream = OpenTestFile("quoted.csv");
         List<RawImportRow> rows = [];
 
         // Act
@@ -161,7 +161,7 @@ public sealed class SepCsvFileParserTests
     public async Task ParseAsync_empty_values_are_null()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("empty-values.csv");
+        await using FileStream stream = OpenTestFile("empty-values.csv");
         List<RawImportRow> rows = [];
 
         // Act
@@ -180,7 +180,7 @@ public sealed class SepCsvFileParserTests
     public async Task ParseAsync_utf8_bom_is_handled()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("utf8-bom.csv");
+        await using FileStream stream = OpenTestFile("utf8-bom.csv");
         List<RawImportRow> rows = [];
 
         // Act
@@ -201,7 +201,7 @@ public sealed class SepCsvFileParserTests
     public async Task ParseAsync_with_semicolon_separator()
     {
         // Arrange
-        using FileStream stream = OpenTestFile("semicolon.csv");
+        await using FileStream stream = OpenTestFile("semicolon.csv");
         FileParsingOptions options = new() { Separator = ";" };
         List<RawImportRow> rows = [];
 

--- a/tests/Granit.DataExchange.Excel.Tests/ClosedXmlExportWriterTests.cs
+++ b/tests/Granit.DataExchange.Excel.Tests/ClosedXmlExportWriterTests.cs
@@ -55,7 +55,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Name"] = "Bob", ["Email"] = "bob@test.com", ["Age"] = 25 },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -88,7 +88,7 @@ public sealed class ClosedXmlExportWriterTests
             new("Name", "String", "Nom", null, 0, false),
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields,
@@ -118,7 +118,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Company.Name"] = "Acme" },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -143,7 +143,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Name"] = null },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -168,7 +168,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["BirthDate"] = new DateOnly(1990, 6, 15) },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -197,7 +197,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["CreatedAt"] = dt },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -225,7 +225,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["CreatedAt"] = dt },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -254,7 +254,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Timestamp"] = dto },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -282,7 +282,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Timestamp"] = dto },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -310,7 +310,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["BirthDate"] = new DateOnly(1990, 6, 15) },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -339,7 +339,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Amount"] = 123.45m },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -365,7 +365,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Amount"] = 1234.56m },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -394,7 +394,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Rate"] = 3.14 },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -420,7 +420,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Rate"] = 3.14159 },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -449,7 +449,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["BigId"] = 9_876_543_210L },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -479,7 +479,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Activated"] = value },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -508,7 +508,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Id"] = guid },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
@@ -537,7 +537,7 @@ public sealed class ClosedXmlExportWriterTests
             new Dictionary<string, object?> { ["Name"] = "Alice" },
         ];
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
 
         // Act
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);

--- a/tests/Granit.DataExchange.Excel.Tests/SylvanExcelFileParserTests.cs
+++ b/tests/Granit.DataExchange.Excel.Tests/SylvanExcelFileParserTests.cs
@@ -39,7 +39,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ExtractHeadersAsync_returns_column_names()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
+        await using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
 
         // Act
         IReadOnlyList<string> headers = await Sut.ExtractHeadersAsync(
@@ -55,7 +55,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ReadPreviewAsync_returns_limited_rows()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
+        await using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
 
         // Act
         IReadOnlyList<string[]> rows = await Sut.ReadPreviewAsync(
@@ -71,7 +71,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ReadPreviewAsync_returns_all_when_fewer_than_max()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
+        await using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
 
         // Act
         IReadOnlyList<string[]> rows = await Sut.ReadPreviewAsync(
@@ -87,7 +87,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ParseAsync_streams_all_rows()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
+        await using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
         List<RawImportRow> rows = [];
 
         // Act
@@ -109,7 +109,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ParseAsync_row_numbers_are_one_based()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
+        await using MemoryStream stream = TestExcelHelper.CreateSimpleXlsx();
         List<RawImportRow> rows = [];
 
         // Act
@@ -129,7 +129,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ParseAsync_empty_cells_are_null()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateXlsxWithEmptyCells();
+        await using MemoryStream stream = TestExcelHelper.CreateXlsxWithEmptyCells();
         List<RawImportRow> rows = [];
 
         // Act
@@ -148,7 +148,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ParseAsync_with_sheet_name_selects_correct_sheet()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateMultiSheetXlsx();
+        await using MemoryStream stream = TestExcelHelper.CreateMultiSheetXlsx();
         FileParsingOptions options = new() { MimeType = XlsxOptions.MimeType, SheetName = "Lookup" };
         List<RawImportRow> rows = [];
 
@@ -171,7 +171,7 @@ public sealed class SylvanExcelFileParserTests
     public async Task ExtractHeadersAsync_with_sheet_name()
     {
         // Arrange
-        using MemoryStream stream = TestExcelHelper.CreateMultiSheetXlsx();
+        await using MemoryStream stream = TestExcelHelper.CreateMultiSheetXlsx();
         FileParsingOptions options = new() { MimeType = XlsxOptions.MimeType, SheetName = "Lookup" };
 
         // Act

--- a/tests/Granit.DataExchange.Json.Tests/JsonExportWriterTests.cs
+++ b/tests/Granit.DataExchange.Json.Tests/JsonExportWriterTests.cs
@@ -59,7 +59,7 @@ public sealed class JsonExportWriterTests
             new Dictionary<string, object?> { ["Name"] = "Bob", ["Email"] = "bob@test.com" },
         ];
 
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
 
         stream.Position = 0;
@@ -76,7 +76,7 @@ public sealed class JsonExportWriterTests
     {
         List<ExportFieldDescriptor> fields = [new("Name", "String", null, null, 0, false)];
 
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable([]), TestContext.Current.CancellationToken);
 
         stream.Position = 0;
@@ -92,7 +92,7 @@ public sealed class JsonExportWriterTests
         List<IReadOnlyDictionary<string, object?>> rows =
             [new Dictionary<string, object?> { ["Name"] = null }];
 
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
 
         stream.Position = 0;
@@ -108,7 +108,7 @@ public sealed class JsonExportWriterTests
         List<IReadOnlyDictionary<string, object?>> rows =
             [new Dictionary<string, object?> { ["Email"] = "test@test.com" }];
 
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
 
         stream.Position = 0;
@@ -143,7 +143,7 @@ public sealed class JsonExportWriterTests
             },
         ];
 
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
 
         stream.Position = 0;
@@ -172,7 +172,7 @@ public sealed class JsonExportWriterTests
         List<IReadOnlyDictionary<string, object?>> rows =
             [new Dictionary<string, object?> { ["Pet"] = cat }];
 
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
 
         stream.Position = 0;
@@ -201,7 +201,7 @@ public sealed class JsonExportWriterTests
         List<IReadOnlyDictionary<string, object?>> rows =
             [new Dictionary<string, object?> { ["Node"] = node }];
 
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
 
         // Should NOT throw — IgnoreCycles breaks the cycle
         await Should.NotThrowAsync(

--- a/tests/Granit.DataExchange.Tests/Import/ImportUploadServiceTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/ImportUploadServiceTests.cs
@@ -50,7 +50,7 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_WithValidFile_ReturnsSuccess()
     {
         // Arrange
-        using var stream = new MemoryStream("Name,Email\nAlice,alice@test.com"u8.ToArray());
+        await using var stream = new MemoryStream("Name,Email\nAlice,alice@test.com"u8.ToArray());
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -71,7 +71,7 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_UnknownDefinition_ReturnsFailure()
     {
         // Arrange
-        using var stream = new MemoryStream([1, 2, 3]);
+        await using var stream = new MemoryStream([1, 2, 3]);
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -88,7 +88,7 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_EmptyFile_ReturnsFailure()
     {
         // Arrange
-        using var stream = new MemoryStream();
+        await using var stream = new MemoryStream();
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -104,8 +104,8 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_FileTooLarge_ReturnsFailure()
     {
         // Arrange
-        long size = 11 * 1024 * 1024; // 11 MB, limit is 10
-        using var stream = new MemoryStream([1]);
+        const long size = 11 * 1024 * 1024; // 11 MB, limit is 10
+        await using var stream = new MemoryStream([1]);
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -121,8 +121,8 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_ExactlyAtMaxSize_Succeeds()
     {
         // Arrange — exactly 10 MB
-        long size = 10 * 1024 * 1024;
-        using var stream = new MemoryStream([1]);
+        const long size = 10 * 1024 * 1024;
+        await using var stream = new MemoryStream([1]);
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -137,7 +137,7 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_DisallowedMimeType_ReturnsFailure()
     {
         // Arrange
-        using var stream = new MemoryStream([1, 2, 3]);
+        await using var stream = new MemoryStream([1, 2, 3]);
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -154,7 +154,7 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_StripsPathFromFileName()
     {
         // Arrange — simulate a path traversal attempt
-        using var stream = new MemoryStream("data"u8.ToArray());
+        await using var stream = new MemoryStream("data"u8.ToArray());
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -173,7 +173,7 @@ public sealed class ImportUploadServiceTests
         // Arrange
         var expectedTime = new DateTimeOffset(2026, 1, 15, 8, 30, 0, TimeSpan.Zero);
         _clock.Now.Returns(expectedTime);
-        using var stream = new MemoryStream("data"u8.ToArray());
+        await using var stream = new MemoryStream("data"u8.ToArray());
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(
@@ -188,7 +188,7 @@ public sealed class ImportUploadServiceTests
     public async Task UploadAsync_CaseInsensitiveDefinitionName()
     {
         // Arrange
-        using var stream = new MemoryStream("data"u8.ToArray());
+        await using var stream = new MemoryStream("data"u8.ToArray());
 
         // Act
         ImportUploadResult result = await _sut.UploadAsync(

--- a/tests/Granit.DataExchange.Tests/Import/InMemoryDataExchangeFileProviderTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/InMemoryDataExchangeFileProviderTests.cs
@@ -11,7 +11,7 @@ public sealed class InMemoryDataExchangeFileProviderTests
     [Fact]
     public async Task SaveAsync_ReturnsNonEmptyReference()
     {
-        using MemoryStream content = new([1, 2, 3]);
+        await using MemoryStream content = new([1, 2, 3]);
 
         string reference = await _provider.SaveAsync("file.csv", content, TestContext.Current.CancellationToken);
 
@@ -22,11 +22,11 @@ public sealed class InMemoryDataExchangeFileProviderTests
     public async Task OpenAsync_ReturnsStoredContent()
     {
         byte[] expected = [10, 20, 30];
-        using MemoryStream content = new(expected);
+        await using MemoryStream content = new(expected);
         string reference = await _provider.SaveAsync("file.csv", content, TestContext.Current.CancellationToken);
 
         await using Stream result = await _provider.OpenAsync(reference, TestContext.Current.CancellationToken);
-        using MemoryStream resultBuffer = new();
+        await using MemoryStream resultBuffer = new();
         await result.CopyToAsync(resultBuffer, TestContext.Current.CancellationToken);
 
         resultBuffer.ToArray().ShouldBe(expected);
@@ -42,7 +42,7 @@ public sealed class InMemoryDataExchangeFileProviderTests
     [Fact]
     public async Task DeleteAsync_RemovesFile()
     {
-        using MemoryStream content = new([1, 2, 3]);
+        await using MemoryStream content = new([1, 2, 3]);
         string reference = await _provider.SaveAsync("file.csv", content, TestContext.Current.CancellationToken);
 
         await _provider.DeleteAsync(reference, TestContext.Current.CancellationToken);
@@ -59,8 +59,8 @@ public sealed class InMemoryDataExchangeFileProviderTests
     [Fact]
     public async Task SaveAsync_GeneratesUniqueReferences()
     {
-        using MemoryStream content1 = new([1]);
-        using MemoryStream content2 = new([2]);
+        await using MemoryStream content1 = new([1]);
+        await using MemoryStream content2 = new([2]);
 
         string ref1 = await _provider.SaveAsync("a.csv", content1, TestContext.Current.CancellationToken);
         string ref2 = await _provider.SaveAsync("b.csv", content2, TestContext.Current.CancellationToken);

--- a/tests/Granit.DataExchange.Tests/Mapping/ChildCollectionBuilderTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/ChildCollectionBuilderTests.cs
@@ -90,7 +90,7 @@ public sealed class ChildCollectionBuilderTests
 
         // Act & Assert — method call is not a MemberExpression
         Should.Throw<ArgumentException>(() =>
-            builder.Property(l => l.ProductName.ToString()));
+            builder.Property(l => l.ProductName));
     }
 
     [Fact]

--- a/tests/Granit.DataExchange.Tests/Mapping/MappingSuggestionServiceTests.cs
+++ b/tests/Granit.DataExchange.Tests/Mapping/MappingSuggestionServiceTests.cs
@@ -197,6 +197,6 @@ public sealed class MappingSuggestionServiceTests
             headers, TestContext.Current.CancellationToken);
 
         // Assert — only one mapping to "Email" target
-        result.Where(m => m.TargetProperty == "Email").Count().ShouldBe(1);
+        result.Count(m => m.TargetProperty == "Email").ShouldBe(1);
     }
 }

--- a/tests/Granit.DataExchange.Xml.Tests/XmlExportWriterTests.cs
+++ b/tests/Granit.DataExchange.Xml.Tests/XmlExportWriterTests.cs
@@ -163,7 +163,7 @@ public sealed class XmlExportWriterTests
         List<ExportFieldDescriptor> fields,
         List<IReadOnlyDictionary<string, object?>> rows)
     {
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
         await Sut.WriteAsync(stream, fields, ToAsyncEnumerable(rows), TestContext.Current.CancellationToken);
         stream.Position = 0;
         return XDocument.Load(stream);

--- a/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryDefinitionLookupSourceTests.cs
+++ b/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryDefinitionLookupSourceTests.cs
@@ -80,7 +80,7 @@ public sealed class QueryDefinitionLookupSourceTests : IDisposable
             .Returns(Task.FromResult(new PagedResult<Tenant>([], TotalCount: null, HasMore: true, NextCursor: "next-cursor")));
 
         LookupResult result = await source.SearchAsync(
-            new LookupQuery(ContinuationToken: "cur-1", Page: 5),
+            new LookupQuery(Page: 5, ContinuationToken: "cur-1"),
             TestContext.Current.CancellationToken);
 
         captured!.Cursor.ShouldBe("cur-1");

--- a/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineAdditionalTests.cs
+++ b/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineAdditionalTests.cs
@@ -48,7 +48,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
             TestContext.Current.CancellationToken);
 
         BinaryRenderedContent binary = result.ShouldBeOfType<BinaryRenderedContent>();
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         IXLWorksheet ws = wb.Worksheet(1);
         ws.Cell("A1").GetValue<string>().ShouldBe("Item: Alpha");
@@ -78,7 +78,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
             TestContext.Current.CancellationToken);
 
         BinaryRenderedContent binary = result.ShouldBeOfType<BinaryRenderedContent>();
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         IXLWorksheet ws = wb.Worksheet(1);
         ws.Cell("A1").GetValue<int>().ShouldBe(42);
@@ -101,7 +101,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
         IXLWorksheet ws2 = templateWb.AddWorksheet("Sheet2");
         ws2.Cell("A1").SetValue("Goodbye {{model.name}}");
 
-        using MemoryStream templateMs = new();
+        await using MemoryStream templateMs = new();
         templateWb.SaveAs(templateMs);
         string base64 = Convert.ToBase64String(templateMs.ToArray());
 
@@ -115,7 +115,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
             TestContext.Current.CancellationToken);
 
         BinaryRenderedContent binary = result.ShouldBeOfType<BinaryRenderedContent>();
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         wb.Worksheet("Sheet1").Cell("A1").GetValue<string>().ShouldBe("Hello World");
         wb.Worksheet("Sheet2").Cell("A1").GetValue<string>().ShouldBe("Goodbye World");
@@ -129,10 +129,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
     public async Task RenderAsync_NoPlaceholders_ReturnsCellsUnchanged()
     {
         ClosedXmlTemplateEngine sut = CreateSut();
-        string base64 = CreateBase64Template(ws =>
-        {
-            ws.Cell("A1").SetValue("Static text");
-        });
+        string base64 = CreateBase64Template(ws => ws.Cell("A1").SetValue("Static text"));
         TemplateDescriptor descriptor = new() { Content = base64, MimeType = ExcelMimeType };
 
         RenderedContent result = await sut.RenderAsync(
@@ -143,7 +140,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
             TestContext.Current.CancellationToken);
 
         BinaryRenderedContent binary = result.ShouldBeOfType<BinaryRenderedContent>();
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         wb.Worksheet(1).Cell("A1").GetValue<string>().ShouldBe("Static text");
     }
@@ -172,10 +169,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
     public async Task RenderAsync_MultiplePlaceholdersInSameCell_ReplacesAll()
     {
         ClosedXmlTemplateEngine sut = CreateSut();
-        string base64 = CreateBase64Template(ws =>
-        {
-            ws.Cell("A1").SetValue("{{model.first_name}} {{model.last_name}} ({{model.age}})");
-        });
+        string base64 = CreateBase64Template(ws => ws.Cell("A1").SetValue("{{model.first_name}} {{model.last_name}} ({{model.age}})"));
         TemplateDescriptor descriptor = new() { Content = base64, MimeType = ExcelMimeType };
 
         RenderedContent result = await sut.RenderAsync(
@@ -186,7 +180,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
             TestContext.Current.CancellationToken);
 
         BinaryRenderedContent binary = result.ShouldBeOfType<BinaryRenderedContent>();
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         wb.Worksheet(1).Cell("A1").GetValue<string>().ShouldBe("Jean Dupont (42)");
     }
@@ -199,10 +193,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
     public async Task RenderAsync_BooleanValue_ReplacesCorrectly()
     {
         ClosedXmlTemplateEngine sut = CreateSut();
-        string base64 = CreateBase64Template(ws =>
-        {
-            ws.Cell("A1").SetValue("Active: {{model.is_active}}");
-        });
+        string base64 = CreateBase64Template(ws => ws.Cell("A1").SetValue("Active: {{model.is_active}}"));
         TemplateDescriptor descriptor = new() { Content = base64, MimeType = ExcelMimeType };
 
         RenderedContent result = await sut.RenderAsync(
@@ -213,7 +204,7 @@ public sealed class ClosedXmlTemplateEngineAdditionalTests
             TestContext.Current.CancellationToken);
 
         BinaryRenderedContent binary = result.ShouldBeOfType<BinaryRenderedContent>();
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         string cellValue = wb.Worksheet(1).Cell("A1").GetValue<string>();
         cellValue.ShouldBe("Active: True");

--- a/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineTests.cs
+++ b/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineTests.cs
@@ -92,7 +92,7 @@ public sealed class ClosedXmlTemplateEngineTests
         binary.Bytes.IsEmpty.ShouldBeFalse("must produce non-empty bytes");
 
         // Verify the output is a valid XLSX (readable by ClosedXML)
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         wb.Worksheets.Count.ShouldBe(1);
     }
@@ -101,10 +101,7 @@ public sealed class ClosedXmlTemplateEngineTests
     public async Task RenderAsync_ReplacesPlaceholders()
     {
         ClosedXmlTemplateEngine sut = CreateSut();
-        string base64 = CreateBase64Template(ws =>
-        {
-            ws.Cell("A1").SetValue("Hello {{model.first_name}} {{model.last_name}}");
-        });
+        string base64 = CreateBase64Template(ws => ws.Cell("A1").SetValue("Hello {{model.first_name}} {{model.last_name}}"));
         TemplateDescriptor descriptor = new() { Content = base64, MimeType = ExcelMimeType };
 
         RenderedContent result = await sut.RenderAsync(
@@ -115,7 +112,7 @@ public sealed class ClosedXmlTemplateEngineTests
             TestContext.Current.CancellationToken);
 
         var binary = (BinaryRenderedContent)result;
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         string cellValue = wb.Worksheet(1).Cell("A1").GetValue<string>();
         cellValue.ShouldBe("Hello Jean Dupont");
@@ -125,10 +122,7 @@ public sealed class ClosedXmlTemplateEngineTests
     public async Task RenderAsync_NestedProperty_ReplacesPlaceholder()
     {
         ClosedXmlTemplateEngine sut = CreateSut();
-        string base64 = CreateBase64Template(ws =>
-        {
-            ws.Cell("A1").SetValue("City: {{model.address.city}}");
-        });
+        string base64 = CreateBase64Template(ws => ws.Cell("A1").SetValue("City: {{model.address.city}}"));
         TemplateDescriptor descriptor = new() { Content = base64, MimeType = ExcelMimeType };
 
         RenderedContent result = await sut.RenderAsync(
@@ -139,7 +133,7 @@ public sealed class ClosedXmlTemplateEngineTests
             TestContext.Current.CancellationToken);
 
         var binary = (BinaryRenderedContent)result;
-        using MemoryStream ms = new(binary.Bytes.ToArray());
+        await using MemoryStream ms = new(binary.Bytes.ToArray());
         using XLWorkbook wb = new(ms);
         string cellValue = wb.Worksheet(1).Cell("A1").GetValue<string>();
         cellValue.ShouldBe("City: Bruxelles");

--- a/tests/Granit.DocumentGeneration.Tests/Pipeline/DocumentGeneratorTests.cs
+++ b/tests/Granit.DocumentGeneration.Tests/Pipeline/DocumentGeneratorTests.cs
@@ -184,7 +184,7 @@ public sealed class DocumentGeneratorTests
     {
         // Arrange — verifies the rendered HTML is forwarded as-is to the document renderer
         InvoiceData data = new("Dupont", 999m);
-        string expectedHtml = "<h1>Invoice</h1><p>Total: 999</p>";
+        const string expectedHtml = "<h1>Invoice</h1><p>Total: 999</p>";
         string? capturedHtml = null;
 
         ITextTemplateRenderer textRenderer = Substitute.For<ITextTemplateRenderer>();

--- a/tests/Granit.Encryption.EntityFrameworkCore.Tests/DefaultReEncryptionServiceTests.cs
+++ b/tests/Granit.Encryption.EntityFrameworkCore.Tests/DefaultReEncryptionServiceTests.cs
@@ -25,7 +25,7 @@ public sealed class DefaultReEncryptionServiceTests
     [Fact]
     public async Task ReEncryptAsync_MarksEncryptedProperties_AsModified_AndSaves()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
@@ -33,7 +33,7 @@ public sealed class DefaultReEncryptionServiceTests
             .Options;
 
         // Seed one row
-        using (TestDbContext ctx = new(options, _encryption))
+        await using (TestDbContext ctx = new(options, _encryption))
         {
             ctx.Database.EnsureCreated();
             ctx.Patients.Add(new PatientEntity { Id = 1, Ssn = "123-45-6789", Name = "Alice" });
@@ -41,7 +41,7 @@ public sealed class DefaultReEncryptionServiceTests
         }
 
         // Verify the raw value is encrypted after initial save
-        using SqliteCommand cmd = connection.CreateCommand();
+        await using SqliteCommand cmd = connection.CreateCommand();
         cmd.CommandText = "SELECT Ssn FROM Patients WHERE Id = 1";
         string? initialRaw = cmd.ExecuteScalar() as string;
         initialRaw.ShouldBe("ENC:123-45-6789");
@@ -61,14 +61,14 @@ public sealed class DefaultReEncryptionServiceTests
     [Fact]
     public async Task ReEncryptAsync_DoesNotTouch_NonAnnotatedProperties()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
             .UseSqlite(connection)
             .Options;
 
-        using (TestDbContext ctx = new(options, _encryption))
+        await using (TestDbContext ctx = new(options, _encryption))
         {
             ctx.Database.EnsureCreated();
             ctx.Patients.Add(new PatientEntity { Id = 1, Ssn = "123-45-6789", Name = "Alice" });
@@ -89,14 +89,14 @@ public sealed class DefaultReEncryptionServiceTests
     [Fact]
     public async Task ReEncryptAsync_SkipsEntities_WhenNoEncryptedProperties()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
             .UseSqlite(connection)
             .Options;
 
-        using (TestDbContext ctx = new(options, _encryption))
+        await using (TestDbContext ctx = new(options, _encryption))
         {
             ctx.Database.EnsureCreated();
         }
@@ -115,14 +115,14 @@ public sealed class DefaultReEncryptionServiceTests
     [Fact]
     public async Task ReEncryptAsync_ProcessesMultipleBatches_AllEntitiesReadable()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
             .UseSqlite(connection)
             .Options;
 
-        using (TestDbContext ctx = new(options, _encryption))
+        await using (TestDbContext ctx = new(options, _encryption))
         {
             ctx.Database.EnsureCreated();
             for (int i = 1; i <= 5; i++)
@@ -140,7 +140,7 @@ public sealed class DefaultReEncryptionServiceTests
         await sut.ReEncryptAsync<PatientEntity>(batchSize: 2, cancellationToken: TestContext.Current.CancellationToken);
 
         // After re-encryption, all entities must still be readable with their original SSNs
-        using TestDbContext verify = new(options, _encryption);
+        await using TestDbContext verify = new(options, _encryption);
         var all = verify.Patients.OrderBy(p => p.Id).ToList();
 
         all.Count.ShouldBe(5);
@@ -153,14 +153,14 @@ public sealed class DefaultReEncryptionServiceTests
     [Fact]
     public async Task ReEncryptAsync_EmptyTable_CompletesWithoutError()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
             .UseSqlite(connection)
             .Options;
 
-        using (TestDbContext ctx = new(options, _encryption))
+        await using (TestDbContext ctx = new(options, _encryption))
         {
             ctx.Database.EnsureCreated();
         }
@@ -179,14 +179,14 @@ public sealed class DefaultReEncryptionServiceTests
     [Fact]
     public async Task ReEncryptAsync_SingleBatch_ProcessesAllEntities()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
             .UseSqlite(connection)
             .Options;
 
-        using (TestDbContext ctx = new(options, _encryption))
+        await using (TestDbContext ctx = new(options, _encryption))
         {
             ctx.Database.EnsureCreated();
             for (int i = 1; i <= 3; i++)
@@ -203,7 +203,7 @@ public sealed class DefaultReEncryptionServiceTests
         // batchSize=500 (default) > 3 rows — single batch
         await sut.ReEncryptAsync<PatientEntity>(cancellationToken: TestContext.Current.CancellationToken);
 
-        using TestDbContext verify = new(options, _encryption);
+        await using TestDbContext verify = new(options, _encryption);
         var all = verify.Patients.OrderBy(p => p.Id).ToList();
         all.Count.ShouldBe(3);
         all[0].Ssn.ShouldBe("SSN-1");
@@ -214,14 +214,14 @@ public sealed class DefaultReEncryptionServiceTests
     [Fact]
     public async Task ReEncryptAsync_ExactBatchSize_ProcessesCorrectly()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         connection.Open();
 
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
             .UseSqlite(connection)
             .Options;
 
-        using (TestDbContext ctx = new(options, _encryption))
+        await using (TestDbContext ctx = new(options, _encryption))
         {
             ctx.Database.EnsureCreated();
             // Exactly 3 entities with batchSize=3 — boundary case
@@ -239,7 +239,7 @@ public sealed class DefaultReEncryptionServiceTests
         // batchSize == row count — triggers the do-while boundary condition
         await sut.ReEncryptAsync<PatientEntity>(batchSize: 3, cancellationToken: TestContext.Current.CancellationToken);
 
-        using TestDbContext verify = new(options, _encryption);
+        await using TestDbContext verify = new(options, _encryption);
         var all = verify.Patients.OrderBy(p => p.Id).ToList();
         all.Count.ShouldBe(3);
     }

--- a/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptionIsolationSaveChangesInterceptorTests.cs
+++ b/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptionIsolationSaveChangesInterceptorTests.cs
@@ -50,7 +50,7 @@ public sealed class EncryptionIsolationSaveChangesInterceptorTests : IDisposable
             "PatientEntity", Arg.Any<string>(), Arg.Any<CancellationToken>());
 
         // Verify raw DB value is encrypted (not plaintext)
-        using SqliteCommand cmd = _connection.CreateCommand();
+        await using SqliteCommand cmd = _connection.CreateCommand();
         cmd.CommandText = "SELECT Ssn FROM Patients WHERE Name = 'Alice'";
         string? rawValue = cmd.ExecuteScalar() as string;
 
@@ -74,7 +74,7 @@ public sealed class EncryptionIsolationSaveChangesInterceptorTests : IDisposable
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Name is not annotated with [Encrypted] — should be stored as-is
-        using SqliteCommand cmd = _connection.CreateCommand();
+        await using SqliteCommand cmd = _connection.CreateCommand();
         cmd.CommandText = "SELECT Name FROM Patients WHERE Name = 'Bob'";
         string? rawName = cmd.ExecuteScalar() as string;
 
@@ -96,7 +96,7 @@ public sealed class EncryptionIsolationSaveChangesInterceptorTests : IDisposable
 
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        using SqliteCommand cmd = _connection.CreateCommand();
+        await using SqliteCommand cmd = _connection.CreateCommand();
         cmd.CommandText = "SELECT Ssn FROM Patients WHERE Name = 'Charlie'";
         object? rawValue = cmd.ExecuteScalar();
 

--- a/tests/Granit.Encryption.Tests/AesStringEncryptionProviderTests.cs
+++ b/tests/Granit.Encryption.Tests/AesStringEncryptionProviderTests.cs
@@ -67,7 +67,7 @@ public sealed class AesStringEncryptionProviderTests
     {
         // CWE-329 : chaque chiffrement doit produire un IV différent.
         AesStringEncryptionProvider provider = CreateProvider();
-        string plainText = "texte identique";
+        const string plainText = "texte identique";
 
         string cipher1 = provider.Encrypt(plainText);
         string cipher2 = provider.Encrypt(plainText);

--- a/tests/Granit.Entities.Abstractions.Tests/Layouts/CalendarRangeFilterBuilderTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Layouts/CalendarRangeFilterBuilderTests.cs
@@ -136,7 +136,7 @@ public sealed class CalendarRangeFilterBuilderTests
             .BuildOverlapFilter<Meeting>(layout, new CalendarFilterRange(Anchor, Anchor.AddDays(7)))
             .Compile();
 
-        meetings.Where(filter).Count().ShouldBe(1);
+        meetings.Count(filter).ShouldBe(1);
     }
 
     private sealed class PointInTimeEvent

--- a/tests/Granit.Entities.Abstractions.Tests/Layouts/GalleryLayoutTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Layouts/GalleryLayoutTests.cs
@@ -128,7 +128,7 @@ public sealed class GalleryLayoutTests
     {
         public override string Name => "Granit.Sample.BadImageLambda";
         protected override void Configure(EntityDefinitionBuilder<SamplePhoto> builder) =>
-            builder.GalleryView(g => g.ImageField(p => p.Thumbnail == null ? null : p.Thumbnail));
+            builder.GalleryView(g => g.ImageField(p => p.CapturedAt == default ? null : p.Thumbnail));
     }
 
     private sealed class BadTitleLambdaDefinition : EntityDefinition<SamplePhoto>

--- a/tests/Granit.Events.Wolverine.Tests/WolverineDomainEventDispatcherTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineDomainEventDispatcherTests.cs
@@ -39,7 +39,7 @@ public sealed class WolverineDomainEventDispatcherTests
     public async Task DispatchAsync_WhenReady_PublishesEachEventViaMessageBus()
     {
         ServiceCollection services = [];
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
         TestDomainEvent evt1 = new();
@@ -55,7 +55,7 @@ public sealed class WolverineDomainEventDispatcherTests
     public async Task DispatchAsync_WhenReady_EmptyList_DoesNotCallPublish()
     {
         ServiceCollection services = [];
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
 
@@ -68,7 +68,7 @@ public sealed class WolverineDomainEventDispatcherTests
     public async Task DispatchAsync_WhenReady_PublishesExpectedCount()
     {
         ServiceCollection services = [];
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
         IReadOnlyList<IDomainEvent> events = [new TestDomainEvent(), new TestDomainEvent(), new TestDomainEvent()];
@@ -84,7 +84,7 @@ public sealed class WolverineDomainEventDispatcherTests
         TestDomainEventHandler handler = new();
         ServiceCollection services = [];
         services.AddSingleton<ILocalEventHandler<TestDomainEvent>>(handler);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
         TestDomainEvent evt = new();
@@ -99,7 +99,7 @@ public sealed class WolverineDomainEventDispatcherTests
     public async Task DispatchAsync_WhenNotReady_NoHandlers_CompletesSuccessfully()
     {
         ServiceCollection services = [];
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
 

--- a/tests/Granit.Events.Wolverine.Tests/WolverineLocalEventBusTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineLocalEventBusTests.cs
@@ -57,7 +57,7 @@ public sealed class WolverineLocalEventBusTests
     {
         IMessageBus bus = Substitute.For<IMessageBus>();
         ServiceCollection services = [];
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
         TestEvent evt = new("test");
@@ -74,7 +74,7 @@ public sealed class WolverineLocalEventBusTests
         TestEventHandler handler = new();
         ServiceCollection services = [];
         services.AddSingleton<ILocalEventHandler<TestEvent>>(handler);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
         TestEvent evt = new("test");
@@ -91,7 +91,7 @@ public sealed class WolverineLocalEventBusTests
         IMessageBus bus = Substitute.For<IMessageBus>();
         ServiceCollection services = [];
         services.AddSingleton<ILocalEventHandler<TestEvent>, FailingTestEventHandler>();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
         TestEvent evt = new("test");
@@ -105,7 +105,7 @@ public sealed class WolverineLocalEventBusTests
     {
         IMessageBus bus = Substitute.For<IMessageBus>();
         ServiceCollection services = [];
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
 

--- a/tests/Granit.Features.Tests/Definitions/FeatureGroupDefinitionTests.cs
+++ b/tests/Granit.Features.Tests/Definitions/FeatureGroupDefinitionTests.cs
@@ -12,10 +12,7 @@ public sealed class FeatureGroupDefinitionTests
         // FeatureGroupDefinition constructor is internal — use IFeatureDefinitionContext
         // AddGroup returns the group directly, so capture it via a closure.
         FeatureGroupDefinition? group = null;
-        FakeContextProvider provider = new(ctx =>
-        {
-            group = ctx.AddGroup(name, displayName);
-        });
+        FakeContextProvider provider = new(ctx => group = ctx.AddGroup(name, displayName));
         FeatureDefinitionContext context = new();
         provider.Define(context);
         return group!;

--- a/tests/Granit.Geocoding.Tests/DefaultGeocodingServiceTests.cs
+++ b/tests/Granit.Geocoding.Tests/DefaultGeocodingServiceTests.cs
@@ -171,7 +171,7 @@ public sealed class DefaultGeocodingServiceTests
     [Fact]
     public void BuildCacheKey_HashesKey_NeverEmbedsRawAddress()
     {
-        string normalized = "rue de la loi 16|1000|brussels|be";
+        const string normalized = "rue de la loi 16|1000|brussels|be";
 
         string key = DefaultGeocodingService.BuildCacheKey(normalized);
 

--- a/tests/Granit.Guids.Tests/SequentialGuidGeneratorTests.cs
+++ b/tests/Granit.Guids.Tests/SequentialGuidGeneratorTests.cs
@@ -270,9 +270,8 @@ public sealed class SequentialGuidGeneratorTests
         }
 
         // Assert — last 6 bytes should be non-decreasing (timestamp at end)
-        var lastSixBytesList = guids
-            .Select(g => g.ToByteArray()[10..16])
-            .ToList();
+        List<byte[]> lastSixBytesList = guids
+            .ConvertAll(g => g.ToByteArray()[10..16]);
 
         for (int i = 1; i < lastSixBytesList.Count; i++)
         {

--- a/tests/Granit.Hostnames.Endpoints.Tests/Validators/CreateManagedHostnameRequestValidatorTests.cs
+++ b/tests/Granit.Hostnames.Endpoints.Tests/Validators/CreateManagedHostnameRequestValidatorTests.cs
@@ -37,7 +37,7 @@ public sealed class CreateManagedHostnameRequestValidatorTests
     [Fact]
     public void HostExceedingMaxLength_Fails()
     {
-        string tooLong = string.Concat(new string('a', 127), ".", new string('b', 126));
+        string tooLong = $"{new string('a', 127)}.{new string('b', 126)}";
         tooLong.Length.ShouldBeGreaterThan(CreateManagedHostnameRequestValidator.MaxHostLength);
 
         ValidationResult result = Validate(new(tooLong, "cms.site", OwnerId));

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfHostnameResolverTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfHostnameResolverTests.cs
@@ -31,7 +31,7 @@ public sealed class EfHostnameResolverTests
     [Fact]
     public async Task ResolveAsync_ignores_hostnames_that_are_not_active()
     {
-        string db = nameof(ResolveAsync_ignores_hostnames_that_are_not_active);
+        const string db = nameof(ResolveAsync_ignores_hostnames_that_are_not_active);
         await HostnamesEf.SeedAsync(HostnamesEf.Factory(db, HostnamesEf.NoTenant()), HostnamesEf.Pending("pending.example", HostnamesEf.TenantA));
         EfHostnameResolver resolver = Create(db, HostnamesEf.NoTenant());
 
@@ -43,7 +43,7 @@ public sealed class EfHostnameResolverTests
     [Fact]
     public async Task ResolveAsync_resolves_an_active_hostname_across_tenants()
     {
-        string db = nameof(ResolveAsync_resolves_an_active_hostname_across_tenants);
+        const string db = nameof(ResolveAsync_resolves_an_active_hostname_across_tenants);
         // Resolution is tenant-agnostic: a TenantB hostname resolves with no ambient tenant.
         await HostnamesEf.SeedAsync(HostnamesEf.Factory(db, HostnamesEf.NoTenant()), HostnamesEf.Active("acme.com", HostnamesEf.TenantB, isPrimary: true));
         EfHostnameResolver resolver = Create(db, HostnamesEf.NoTenant());

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameQueryableSourceTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameQueryableSourceTests.cs
@@ -12,7 +12,7 @@ public sealed class EfManagedHostnameQueryableSourceTests
     [Fact]
     public async Task GetQueryable_scopes_to_the_active_tenant()
     {
-        string db = nameof(GetQueryable_scopes_to_the_active_tenant);
+        const string db = nameof(GetQueryable_scopes_to_the_active_tenant);
         await SeedBothTenants(db);
         ICurrentTenant tenant = HostnamesEf.Tenant(HostnamesEf.TenantA);
         await using var source = new EfManagedHostnameQueryableSource(
@@ -28,7 +28,7 @@ public sealed class EfManagedHostnameQueryableSourceTests
     public async Task GetQueryable_bypasses_the_tenant_filter_for_signaled_host_access()
     {
         // VULN-001: cross-tenant visibility requires a signaled .AllowHostAccess() request.
-        string db = nameof(GetQueryable_bypasses_the_tenant_filter_for_signaled_host_access);
+        const string db = nameof(GetQueryable_bypasses_the_tenant_filter_for_signaled_host_access);
         await SeedBothTenants(db);
         await using var source = new EfManagedHostnameQueryableSource(
             HostnamesEf.Factory(db, HostnamesEf.NoTenant()),
@@ -45,7 +45,7 @@ public sealed class EfManagedHostnameQueryableSourceTests
     {
         // VULN-001: an unsignaled absent tenant must NOT leak foreign-tenant rows — only the host
         // partition (TenantId == null) is visible. Both seeded rows carry a tenant, so none show.
-        string db = nameof(GetQueryable_fails_closed_to_host_partition_without_host_signal);
+        const string db = nameof(GetQueryable_fails_closed_to_host_partition_without_host_signal);
         await SeedBothTenants(db);
         await using var source = new EfManagedHostnameQueryableSource(
             HostnamesEf.Factory(db, HostnamesEf.NoTenant()),
@@ -59,7 +59,7 @@ public sealed class EfManagedHostnameQueryableSourceTests
     [Fact]
     public async Task GetQueryable_reuses_a_single_context_across_calls()
     {
-        string db = nameof(GetQueryable_reuses_a_single_context_across_calls);
+        const string db = nameof(GetQueryable_reuses_a_single_context_across_calls);
         await SeedBothTenants(db);
         await using var source = new EfManagedHostnameQueryableSource(
             HostnamesEf.Factory(db, HostnamesEf.NoTenant()), HostnamesEf.Scope(HostnamesEf.NoTenant()));
@@ -82,7 +82,7 @@ public sealed class EfManagedHostnameQueryableSourceTests
     [Fact]
     public async Task DisposeAsync_disposes_the_materialised_context()
     {
-        string db = nameof(DisposeAsync_disposes_the_materialised_context);
+        const string db = nameof(DisposeAsync_disposes_the_materialised_context);
         await SeedBothTenants(db);
         var source = new EfManagedHostnameQueryableSource(
             HostnamesEf.Factory(db, HostnamesEf.NoTenant()), HostnamesEf.Scope(HostnamesEf.NoTenant()));

--- a/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreTests.cs
+++ b/tests/Granit.Hostnames.EntityFrameworkCore.Tests/EfManagedHostnameStoreTests.cs
@@ -198,7 +198,7 @@ public sealed class EfManagedHostnameStoreTests
     [Fact]
     public async Task ListDueForVerificationAsync_returns_due_hostnames_across_tenants()
     {
-        string db = nameof(ListDueForVerificationAsync_returns_due_hostnames_across_tenants);
+        const string db = nameof(ListDueForVerificationAsync_returns_due_hostnames_across_tenants);
         EfManagedHostnameStore store = CreateStore(db, TenantA);
 
         // Errored with NextCheckAt in the past → due. Owned by TenantB: the poller is system-wide.
@@ -219,7 +219,7 @@ public sealed class EfManagedHostnameStoreTests
     [Fact]
     public async Task ListDueForVerificationAsync_excludes_hostnames_not_yet_due()
     {
-        string db = nameof(ListDueForVerificationAsync_excludes_hostnames_not_yet_due);
+        const string db = nameof(ListDueForVerificationAsync_excludes_hostnames_not_yet_due);
         EfManagedHostnameStore store = CreateStore(db);
 
         ManagedHostname errored = MakeHostname("future.com");

--- a/tests/Granit.Html.AngleSharp.Tests/AngleSharpHtmlToPlainTextConverterTests.cs
+++ b/tests/Granit.Html.AngleSharp.Tests/AngleSharpHtmlToPlainTextConverterTests.cs
@@ -243,7 +243,7 @@ public sealed class AngleSharpHtmlToPlainTextConverterTests
     [Fact]
     public async Task FullEmailLayout_ProducesCleanText()
     {
-        string html = """
+        const string html = """
             <html>
             <head><title>Test Email</title></head>
             <body style="margin: 0; padding: 0; background-color: #f4f5f7;">

--- a/tests/Granit.Http.ApiDocumentation.Tests/ApiDocumentationServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Http.ApiDocumentation.Tests/ApiDocumentationServiceCollectionExtensionsTests.cs
@@ -138,7 +138,7 @@ public sealed class ApiDocumentationServiceCollectionExtensionsTests
 
         builder.AddGranitApiDocumentation();
 
-        using ServiceProvider sp = builder.Services.BuildServiceProvider();
+        await using ServiceProvider sp = builder.Services.BuildServiceProvider();
 
         // IOptionsMonitor.Get("v1") triggers the outer openApiOptions => lambda,
         // which registers the document transformers on the OpenApiOptions instance.
@@ -174,7 +174,7 @@ public sealed class ApiDocumentationServiceCollectionExtensionsTests
 
         builder.AddGranitApiDocumentation();
 
-        using ServiceProvider sp = builder.Services.BuildServiceProvider();
+        await using ServiceProvider sp = builder.Services.BuildServiceProvider();
         IOptionsMonitor<OpenApiOptions> monitor = sp.GetRequiredService<IOptionsMonitor<OpenApiOptions>>();
         OpenApiOptions openApiOpts = monitor.Get("v2");
 

--- a/tests/Granit.Http.Bulkhead.Tests/BulkheadServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Http.Bulkhead.Tests/BulkheadServiceCollectionExtensionsTests.cs
@@ -70,10 +70,7 @@ public sealed class BulkheadServiceCollectionExtensionsTests
         services.AddSingleton(configuration);
         services.AddSingleton<IConfiguration>(configuration);
 
-        services.AddGranitBulkhead(opts =>
-        {
-            opts.Enabled = false;
-        });
+        services.AddGranitBulkhead(opts => opts.Enabled = false);
 
         ServiceProvider provider = services.BuildServiceProvider();
         provider.GetService<ConcurrencyLimiterRegistry>().ShouldNotBeNull();

--- a/tests/Granit.Http.Cookies.Tests/CookieDefinitionContributorTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookieDefinitionContributorTests.cs
@@ -26,10 +26,7 @@ public sealed class CookieDefinitionContributorTests
     {
         ServiceCollection services = new();
         services.AddSingleton<ICookieDefinitionContributor, TestContributor>();
-        services.AddGranitCookies(cookies =>
-        {
-            cookies.RegisterCookie(new("builder_cookie", CookieCategory.Analytics, 365, false, "From builder"));
-        });
+        services.AddGranitCookies(cookies => cookies.RegisterCookie(new("builder_cookie", CookieCategory.Analytics, 365, false, "From builder")));
 
         ServiceProvider provider = services.BuildServiceProvider();
         ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
@@ -58,14 +55,8 @@ public sealed class CookieDefinitionContributorTests
     public void AddGranitCookies_MultipleCalls_AccumulateDefinitions()
     {
         ServiceCollection services = new();
-        services.AddGranitCookies(cookies =>
-        {
-            cookies.RegisterCookie(new("first", CookieCategory.StrictlyNecessary, 1, true, "First"));
-        });
-        services.AddGranitCookies(cookies =>
-        {
-            cookies.RegisterCookie(new("second", CookieCategory.Analytics, 365, false, "Second"));
-        });
+        services.AddGranitCookies(cookies => cookies.RegisterCookie(new("first", CookieCategory.StrictlyNecessary, 1, true, "First")));
+        services.AddGranitCookies(cookies => cookies.RegisterCookie(new("second", CookieCategory.Analytics, 365, false, "Second")));
 
         ServiceProvider provider = services.BuildServiceProvider();
         ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
@@ -94,10 +85,7 @@ public sealed class CookieDefinitionContributorTests
 
         ServiceCollection services = new();
         services.AddSingleton<ICookieDefinitionContributor>(new StaticContributor(shared));
-        services.AddGranitCookies(cookies =>
-        {
-            cookies.RegisterCookie(shared);
-        });
+        services.AddGranitCookies(cookies => cookies.RegisterCookie(shared));
 
         ServiceProvider provider = services.BuildServiceProvider();
         ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();

--- a/tests/Granit.Http.Cookies.Tests/CookiesServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookiesServiceCollectionExtensionsTests.cs
@@ -17,10 +17,7 @@ public sealed class CookiesServiceCollectionExtensionsTests
         IHostEnvironment environment = Substitute.For<IHostEnvironment>();
         environment.EnvironmentName.Returns(Environments.Production);
         services.AddSingleton(environment);
-        services.AddGranitCookies(cookies =>
-        {
-            cookies.UseConsentResolver<FakeConsentResolver>();
-        });
+        services.AddGranitCookies(cookies => cookies.UseConsentResolver<FakeConsentResolver>());
 
         ServiceProvider provider = services.BuildServiceProvider();
 
@@ -52,10 +49,7 @@ public sealed class CookiesServiceCollectionExtensionsTests
     public void AddGranitCookies_WithConsentResolver_RegistersResolver()
     {
         ServiceCollection services = new();
-        services.AddGranitCookies(cookies =>
-        {
-            cookies.UseConsentResolver<FakeConsentResolver>();
-        });
+        services.AddGranitCookies(cookies => cookies.UseConsentResolver<FakeConsentResolver>());
 
         ServiceProvider provider = services.BuildServiceProvider();
         IConsentResolver? resolver = provider.GetService<IConsentResolver>();

--- a/tests/Granit.Http.ExceptionHandling.Tests/GranitExceptionHandlerTests.cs
+++ b/tests/Granit.Http.ExceptionHandling.Tests/GranitExceptionHandlerTests.cs
@@ -82,7 +82,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_OperationCanceled_ReturnsTrueWithoutWritingResponse()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
         var handler = (GranitExceptionHandler)sp
             .GetRequiredService<Microsoft.AspNetCore.Diagnostics.IExceptionHandler>();
 
@@ -99,7 +99,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_TaskCanceledException_ReturnsTrueWithoutWritingResponse()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
         var handler = (GranitExceptionHandler)sp
             .GetRequiredService<Microsoft.AspNetCore.Diagnostics.IExceptionHandler>();
 
@@ -121,7 +121,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_EntityNotFoundException_ReturnsStatus404()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new EntityNotFoundException(typeof(object), 1));
@@ -132,7 +132,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_NotFoundException_ReturnsStatus404()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new NotFoundException("Resource not found"));
@@ -143,7 +143,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_BusinessException_ReturnsStatus400()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new BusinessException("Test:Error", "Business rule violated."));
@@ -154,7 +154,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_ValidationException_ReturnsStatus422()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
         Dictionary<string, string[]> errors = new() { ["Email"] = ["Required"] };
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
@@ -166,7 +166,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_ForbiddenException_ReturnsStatus403()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new ForbiddenException("Access denied"));
@@ -177,7 +177,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_UnauthorizedAccessException_ReturnsStatus403()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new UnauthorizedAccessException("Not authorized"));
@@ -188,7 +188,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_ConflictException_ReturnsStatus409()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new ConflictException("Test:Conflict"));
@@ -199,7 +199,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_NotImplementedException_ReturnsStatus501()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new NotImplementedException("Feature not implemented"));
@@ -210,7 +210,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_TimeoutException_ReturnsStatus408()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new TimeoutException("Request timed out"));
@@ -221,7 +221,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_UnknownException_ReturnsStatus500()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new InvalidOperationException("Something went wrong"));
@@ -242,7 +242,7 @@ public sealed class GranitExceptionHandlerTests
         // so it's tried first in the chain
         services.AddSingleton<IExceptionStatusCodeMapper, ArgumentExceptionMapper>();
         services.AddGranitExceptionHandling();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new ArgumentException("Bad argument"));
@@ -258,7 +258,7 @@ public sealed class GranitExceptionHandlerTests
         services.AddLogging();
         services.AddSingleton<IExceptionStatusCodeMapper, NullReturningMapper>();
         services.AddGranitExceptionHandling();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new InvalidOperationException("generic error"));
@@ -274,7 +274,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_AnyException_TraceIdPresentInExtensions()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, IDictionary<string, object?> extensions, _, _) = await InvokeHandlerAsync(
             sp, new BusinessException("Test:Error"));
@@ -286,7 +286,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_WithActivityCurrent_UsesActivityTraceId()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
         using ActivitySource source = new("TestSource");
         using ActivityListener listener = new()
         {
@@ -310,7 +310,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_WithoutActivityCurrent_UsesHttpContextTraceIdentifier()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
         var handler = (GranitExceptionHandler)sp
             .GetRequiredService<Microsoft.AspNetCore.Diagnostics.IExceptionHandler>();
 
@@ -338,7 +338,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_BusinessException_ErrorCodeInExtensions()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, IDictionary<string, object?> extensions, _, _) = await InvokeHandlerAsync(
             sp, new BusinessException("Appointment:SlotUnavailable", "Slot unavailable."));
@@ -349,7 +349,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_EntityNotFoundException_NoErrorCodeInExtensions()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, IDictionary<string, object?> extensions, _, _) = await InvokeHandlerAsync(
             sp, new EntityNotFoundException(typeof(object), 99));
@@ -364,7 +364,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_ValidationException_ErrorsInExtensions()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
         Dictionary<string, string[]> errors = new()
         {
             ["Email"] = ["Email is required."],
@@ -381,7 +381,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_NonValidationException_NoErrorsInExtensions()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, IDictionary<string, object?> extensions, _, _) = await InvokeHandlerAsync(
             sp, new BusinessException("Test:Error", "Some error"));
@@ -397,7 +397,7 @@ public sealed class GranitExceptionHandlerTests
     public async Task TryHandleAsync_InternalException_Production_TitleIsMasked()
     {
         // ExposeInternalErrorDetails = false (default = production behaviour)
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new InvalidOperationException("Patient#12345 caused NullRef"));
@@ -411,7 +411,7 @@ public sealed class GranitExceptionHandlerTests
     public async Task TryHandleAsync_InternalException_Development_TitleExposesMessage()
     {
         // ExposeInternalErrorDetails = true (development/staging)
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = true);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = true);
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new InvalidOperationException("Detailed dev error"));
@@ -422,7 +422,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_InternalException_Production_DetailIsNull()
     {
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
 
         (_, _, _, string? detail) = await InvokeHandlerAsync(
             sp, new InvalidOperationException("Sensitive SQL query here"));
@@ -433,7 +433,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_InternalException_Development_DetailExposesStackTrace()
     {
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = true);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = true);
 
         (_, _, _, string? detail) = await InvokeHandlerAsync(
             sp, new InvalidOperationException("Dev mode exception"));
@@ -449,7 +449,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_BusinessException_TitleEqualsMessage()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new BusinessException("Test:Error", "The business rule was violated."));
@@ -460,7 +460,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_UserFriendlyException_DetailIsNull()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, _, _, string? detail) = await InvokeHandlerAsync(
             sp, new BusinessException("Test:Error", "User-friendly message"));
@@ -481,7 +481,7 @@ public sealed class GranitExceptionHandlerTests
     public async Task TryHandleAsync_4xxNonUserFriendly_Production_TitleIsGeneric()
     {
         // UnauthorizedAccessException is not IUserFriendlyException but maps to 403
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new UnauthorizedAccessException("User 'alice@x.com' denied tenant 'acme'"));
@@ -497,7 +497,7 @@ public sealed class GranitExceptionHandlerTests
         // TimeoutException (.NET built-in) is NOT IUserFriendlyException — its
         // message may reference internal service URLs, SQL fragments, etc.
         // Maps to 408 via DefaultExceptionStatusCodeMapper.
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new TimeoutException("SQL query to 'internal-db-01' timed out after 30s"));
@@ -509,7 +509,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_4xxNonUserFriendly_Development_TitleExposesMessage()
     {
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = true);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = true);
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new UnauthorizedAccessException("Access denied to resource X"));
@@ -520,7 +520,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_4xxNonUserFriendly_DetailIsNull()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, _, _, string? detail) = await InvokeHandlerAsync(
             sp, new UnauthorizedAccessException("Access denied"));
@@ -533,7 +533,7 @@ public sealed class GranitExceptionHandlerTests
     {
         // IUserFriendlyException is deliberately exposed even in production — the
         // opt-in contract for messages that are safe to show to the client.
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new BusinessException("Appointment:SlotUnavailable", "Slot already booked."));
@@ -558,7 +558,7 @@ public sealed class GranitExceptionHandlerTests
         services.AddLogging();
         services.AddSingleton(mockLocalizerFactory);
         services.AddGranitExceptionHandling();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         (_, _, string? title, _) = await InvokeHandlerAsync(sp, new DomainException("Domain:ErrorCode"));
 
@@ -578,7 +578,7 @@ public sealed class GranitExceptionHandlerTests
         services.AddLogging();
         services.AddSingleton(mockLocalizerFactory);
         services.AddGranitExceptionHandling();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new UserFriendlyDomainException("Domain:MissingCode", "Friendly fallback message"));
@@ -591,7 +591,7 @@ public sealed class GranitExceptionHandlerTests
     public async Task TryHandleAsync_IHasErrorCode_NoLocalizerFactory_FallsBackToExceptionMessage()
     {
         // No IStringLocalizerFactory registered
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new UserFriendlyDomainException("Test:Code", "User-friendly message"));
@@ -613,7 +613,7 @@ public sealed class GranitExceptionHandlerTests
         services.AddLogging();
         services.AddSingleton(mockLocalizerFactory);
         services.AddGranitExceptionHandling();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new DomainException("SimpleErrorCode"));
@@ -635,7 +635,7 @@ public sealed class GranitExceptionHandlerTests
         services.AddLogging();
         services.AddSingleton(mockLocalizerFactory);
         services.AddGranitExceptionHandling();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new DomainException("Module:Sub:Detail"));
@@ -654,7 +654,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_BadHttpRequestException_ReturnsStatus400()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, CreateMalformedBodyException("$.definition.chartType"));
@@ -665,7 +665,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_BadHttpRequestException_ExposesErrorCodeAndJsonPath()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (_, IDictionary<string, object?> extensions, _, _) = await InvokeHandlerAsync(
             sp, CreateMalformedBodyException("$.definition.chartType"));
@@ -681,7 +681,7 @@ public sealed class GranitExceptionHandlerTests
     {
         // ExposeInternalErrorDetails = false (production). The raw JSON parsing
         // message may echo the offending value — it must never reach the client.
-        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+        await using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
 
         BadHttpRequestException exception = CreateMalformedBodyException(
             "$.definition.chartType",
@@ -702,7 +702,7 @@ public sealed class GranitExceptionHandlerTests
     [Fact]
     public async Task TryHandleAsync_BusinessRuleViolationException_ReturnsStatus422()
     {
-        using ServiceProvider sp = BuildServiceProvider();
+        await using ServiceProvider sp = BuildServiceProvider();
 
         (int statusCode, _, _, _) = await InvokeHandlerAsync(
             sp, new BusinessRuleViolationException("Rule:Violated"));

--- a/tests/Granit.Http.Idempotency.Tests/IdempotencyMiddlewareTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotencyMiddlewareTests.cs
@@ -216,10 +216,7 @@ public sealed class IdempotencyMiddlewareTests
              .Returns(Task.CompletedTask);
 
         // Endpoint that blocks until the token is cancelled (simulates a hung operation)
-        RequestDelegate slowHandler = async ctx =>
-        {
-            await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestAborted);
-        };
+        RequestDelegate slowHandler = async ctx => await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestAborted);
 
         (HttpClient client, IHost host) = await BuildTestHostAsync(
             store,

--- a/tests/Granit.Http.Idempotency.Tests/IdempotentAttributeTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotentAttributeTests.cs
@@ -64,7 +64,7 @@ public sealed class IdempotentAttributeTests
     {
         IdempotentAttribute attribute = new() { Required = false, CompletedTtlSeconds = 7200 };
 
-        ((IIdempotencyMetadata)attribute).Required.ShouldBeFalse();
+        attribute.Required.ShouldBeFalse();
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public sealed class IdempotentAttributeTests
     {
         IdempotentAttribute attribute = new() { Required = false, CompletedTtlSeconds = 7200 };
 
-        ((IIdempotencyMetadata)attribute).CompletedTtlSeconds.ShouldBe(7200);
+        attribute.CompletedTtlSeconds.ShouldBe(7200);
     }
 
     // =========================================================================

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/TenantIsolationTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/TenantIsolationTests.cs
@@ -110,7 +110,7 @@ public sealed class TenantIsolationTests(PostgresFixture postgres)
         // EF Core's translator emits the model's HasQueryFilter clauses first
         // (compose-FIRST guarantee); we confirm the actual SQL.
         _app.SqlCapture.Clear();
-        await GetAsync(TenantA, $"Invoices?$filter=Amount gt 100");
+        await GetAsync(TenantA, "Invoices?$filter=Amount gt 100");
 
         string? selectCommand = _app.SqlCapture.Commands
             .FirstOrDefault(c => c.Contains(@"FROM ""Invoices""", StringComparison.Ordinal));

--- a/tests/Granit.Http.ODataExposure.Tests/EntityDefinitionStrictConfigTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/EntityDefinitionStrictConfigTests.cs
@@ -53,10 +53,10 @@ public sealed class EntityDefinitionStrictConfigTests
             CallMap(
                 registerEntityDefinitions: true,
                 registerExports: true,
-                useExportlessEntityDefinition: true,
                 configure: opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
                     .RequirePermission("OData.Test.Invoices.Read")
-                    .DisableExpand()));
+                    .DisableExpand(),
+                useExportlessEntityDefinition: true));
 
         ex.Message.ShouldContain("Invoices");
         ex.Message.ShouldContain("does not declare a b.Export<T>() reference");

--- a/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
+++ b/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
@@ -104,7 +104,7 @@ public sealed class DefaultUrlSafetyValidatorTests
     public async Task SchemeMatchIsCaseInsensitive()
     {
         UrlSafetyOptions opts = new() { AllowedSchemes = ["HTTPS"] };
-        DefaultUrlSafetyValidator v = Create(options: opts, resolver: FakeDnsResolver.Returning("8.8.8.8"));
+        DefaultUrlSafetyValidator v = Create(resolver: FakeDnsResolver.Returning("8.8.8.8"), options: opts);
 
         UrlSafetyResult result = await v.ValidateAsync(new Uri("https://example.com/"), TestContext.Current.CancellationToken);
 

--- a/tests/Granit.IO.Tests/LimitedStreamTests.cs
+++ b/tests/Granit.IO.Tests/LimitedStreamTests.cs
@@ -38,8 +38,8 @@ public sealed class LimitedStreamTests
     [Fact]
     public async Task WriteAsync_BeyondCap_Throws()
     {
-        using MemoryStream inner = new();
-        using LimitedStream stream = new(inner, 100);
+        await using MemoryStream inner = new();
+        await using LimitedStream stream = new(inner, 100);
 
         await Should.ThrowAsync<IOException>(async () =>
             await stream.WriteAsync(new byte[101]));
@@ -169,8 +169,8 @@ public sealed class LimitedStreamTests
     [Fact]
     public async Task FlushAsync_PassesThrough()
     {
-        using MemoryStream inner = new();
-        using LimitedStream stream = new(inner, 100);
+        await using MemoryStream inner = new();
+        await using LimitedStream stream = new(inner, 100);
 
         await Should.NotThrowAsync(() => stream.FlushAsync(CancellationToken.None));
     }
@@ -193,8 +193,8 @@ public sealed class LimitedStreamTests
     public async Task ReadAsync_Array_PassesThrough()
     {
         byte[] payload = [1, 2, 3];
-        using MemoryStream inner = new(payload);
-        using LimitedStream stream = new(inner, 100);
+        await using MemoryStream inner = new(payload);
+        await using LimitedStream stream = new(inner, 100);
 
         byte[] buffer = new byte[3];
 #pragma warning disable CA1835 // Intentionally exercises the byte[] overload for coverage.
@@ -208,8 +208,8 @@ public sealed class LimitedStreamTests
     public async Task ReadAsync_Memory_PassesThrough()
     {
         byte[] payload = [1, 2, 3];
-        using MemoryStream inner = new(payload);
-        using LimitedStream stream = new(inner, 100);
+        await using MemoryStream inner = new(payload);
+        await using LimitedStream stream = new(inner, 100);
 
         byte[] buffer = new byte[3];
         int read = await stream.ReadAsync(buffer.AsMemory());

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
@@ -64,10 +64,7 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
         builder.Services.Replace(ServiceDescriptor.Singleton<TimeProvider>(_clock));
 
         // Configure webhook with a secret
-        builder.Services.Configure<IdentityWebhookOptions>(o =>
-        {
-            o.Secret = WebhookSecret;
-        });
+        builder.Services.Configure<IdentityWebhookOptions>(o => o.Secret = WebhookSecret);
 
         _app = builder.Build();
         _app.MapGranitIdentityUserCache();
@@ -197,7 +194,7 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
     [Fact]
     public async Task Webhook_invalid_json_returns_400()
     {
-        string invalidJson = "{ not valid json }}}";
+        const string invalidJson = "{ not valid json }}}";
         byte[] body = Encoding.UTF8.GetBytes(invalidJson);
         string signature = ComputeSignature(body, _clock.GetUtcNow());
 

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -19,15 +19,14 @@ namespace Granit.Identity.EntityFrameworkCore.Tests;
 internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext>, IDisposable
 {
     private readonly SqliteConnection _connection;
-    private readonly DbContextOptions<IdentityDbContext> _options;
 
     private TestDbContextFactory(SqliteConnection connection, DbContextOptions<IdentityDbContext> options)
     {
         _connection = connection;
-        _options = options;
+        Options = options;
     }
 
-    public DbContextOptions<IdentityDbContext> Options => _options;
+    public DbContextOptions<IdentityDbContext> Options { get; }
 
     public static TestDbContextFactory Create()
     {
@@ -49,7 +48,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext
         return new TestDbContextFactory(connection, options);
     }
 
-    public IdentityDbContext CreateDbContext() => new(_options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant);
+    public IdentityDbContext CreateDbContext() => new(Options, new PassthroughEncryption(), GranitDesignTime.CurrentTenant);
 
     public void Dispose() => _connection.Dispose();
 

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/CognitoClientRoleSyncTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/CognitoClientRoleSyncTests.cs
@@ -117,7 +117,7 @@ public sealed class CognitoClientRoleSyncTests : IClassFixture<CognitoWireMockFi
 
         sut.Store.All.Count.ShouldBe(3, "only the 3 clientA-prefixed groups should be synced");
         sut.Store.All.ShouldAllBe(r => r.ClientId == CognitoWireMockFixture.AppClientIdA);
-        sut.Store.All.Select(r => r.Name).OrderBy(x => x).ShouldBe(["admin", "editor", "viewer"]);
+        sut.Store.All.Select(r => r.Name).Order().ShouldBe(["admin", "editor", "viewer"]);
         sut.Store.All.First(r => r.Name == "editor").Description.ShouldBe("Edit showcase documents");
     }
 
@@ -131,11 +131,11 @@ public sealed class CognitoClientRoleSyncTests : IClassFixture<CognitoWireMockFi
         using SutContext sut = BuildSut(trackedAppClientIds: CognitoWireMockFixture.AppClientIdA);
 
         await sut.Sync.SyncAsync(TestContext.Current.CancellationToken);
-        IReadOnlyList<Guid> firstRun = sut.Store.All.Select(r => r.Id).OrderBy(g => g).ToList();
+        IReadOnlyList<Guid> firstRun = sut.Store.All.Select(r => r.Id).Order().ToList();
 
         await sut.Sync.SyncAsync(TestContext.Current.CancellationToken);
 
-        sut.Store.All.Select(r => r.Id).OrderBy(g => g).ShouldBe(firstRun);
+        sut.Store.All.Select(r => r.Id).Order().ShouldBe(firstRun);
         sut.Store.All.Count.ShouldBe(2);
     }
 
@@ -193,6 +193,6 @@ public sealed class CognitoClientRoleSyncTests : IClassFixture<CognitoWireMockFi
 
         roles.Count.ShouldBe(2);
         roles.ShouldAllBe(r => r.ClientId == CognitoWireMockFixture.AppClientIdA);
-        roles.Select(r => r.Name).OrderBy(x => x).ShouldBe(["admin", "editor"]);
+        roles.Select(r => r.Name).Order().ShouldBe(["admin", "editor"]);
     }
 }

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/EntraIdClientRoleSyncTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/EntraIdClientRoleSyncTests.cs
@@ -125,7 +125,7 @@ public sealed class EntraIdClientRoleSyncTests : IClassFixture<EntraIdWireMockFi
 
         store.All.Count.ShouldBe(3, "the isEnabled=false role must be filtered out");
         store.All.ShouldAllBe(r => r.ClientId == EntraIdWireMockFixture.TrackedAppId);
-        store.All.Select(r => r.Name).OrderBy(x => x).ShouldBe(["Admin", "Editor", "Viewer"]);
+        store.All.Select(r => r.Name).Order().ShouldBe(["Admin", "Editor", "Viewer"]);
     }
 
     [Fact]
@@ -140,11 +140,11 @@ public sealed class EntraIdClientRoleSyncTests : IClassFixture<EntraIdWireMockFi
         (EntraIdClientRoleSyncService sync, _, InMemoryRoleMetadataStore store) = BuildSut(EntraIdWireMockFixture.TrackedAppId);
 
         await sync.SyncAsync(TestContext.Current.CancellationToken);
-        IReadOnlyList<Guid> firstRun = store.All.Select(r => r.Id).OrderBy(g => g).ToList();
+        IReadOnlyList<Guid> firstRun = store.All.Select(r => r.Id).Order().ToList();
 
         await sync.SyncAsync(TestContext.Current.CancellationToken);
 
-        store.All.Select(r => r.Id).OrderBy(g => g).ShouldBe(firstRun);
+        store.All.Select(r => r.Id).Order().ShouldBe(firstRun);
         store.All.Count.ShouldBe(3);
     }
 
@@ -231,6 +231,6 @@ public sealed class EntraIdClientRoleSyncTests : IClassFixture<EntraIdWireMockFi
 
         roles.Count.ShouldBe(2);
         roles.ShouldAllBe(r => r.ClientId == EntraIdWireMockFixture.TrackedAppId);
-        roles.Select(r => r.Name).OrderBy(x => x).ShouldBe(["Admin", "Editor"]);
+        roles.Select(r => r.Name).Order().ShouldBe(["Admin", "Editor"]);
     }
 }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
@@ -81,7 +81,7 @@ public sealed class EntraIdAdminOptionsTests
     [Fact]
     public void GetGroupsEndpoint_ReturnsStaticUrl()
     {
-        string endpoint = EntraIdAdminOptions.GroupsEndpoint;
+        const string endpoint = EntraIdAdminOptions.GroupsEndpoint;
 
         endpoint.ShouldBe("/v1.0/groups?$select=id,displayName,description");
     }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
@@ -221,7 +221,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
             }
             """;
 
-        IReadOnlyList<UserDevice> result = await ((IUserDeviceProvider)_provider).ListAsync(
+        IReadOnlyList<UserDevice> result = await _provider.ListAsync(
             "user-1", TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(2);
@@ -294,7 +294,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
     [Fact]
     public async Task GetUserRolesAsync_CrossReferencesAssignmentsWithRoleDefinitions()
     {
-        string assignmentsResponse = """
+        const string assignmentsResponse = """
             {
                 "value": [
                     { "id": "a1", "appRoleId": "role-id-1", "principalId": "user-1", "resourceId": "sp-object-id" },
@@ -303,7 +303,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
             }
             """;
 
-        string servicePrincipalResponse = """
+        const string servicePrincipalResponse = """
             {
                 "id": "sp-object-id",
                 "appRoles": [
@@ -358,7 +358,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
     [Fact]
     public async Task RevokeOthersAsync_SendsPostToRevokeEndpoint_AndCountsOthers()
     {
-        string signInsResponse = """
+        const string signInsResponse = """
             {
                 "value": [
                     { "id": "s1", "ipAddress": "10.0.0.1", "createdDateTime": "2026-01-01T10:00:00Z", "status": { "errorCode": 0 } },

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -240,10 +240,7 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
             tag.Key.ShouldNotContain("email");
             tag.Key.ShouldNotContain("name");
             string? value = tag.Value;
-            if (value is not null)
-            {
-                value.ShouldNotContain("alice");
-            }
+            value?.ShouldNotContain("alice");
         }
     }
 

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
@@ -115,7 +115,7 @@ public sealed class GoogleCloudIdentityProviderTests
             Arg.Is<UserRecordArgs>(a =>
                 a.Email == "new@example.com" &&
                 a.DisplayName == "New User" &&
-                a.Disabled == false &&
+                !a.Disabled &&
                 a.Password == "TempPass123!"),
             Arg.Any<CancellationToken>());
         await _distributedEventBus.Received(1).PublishAsync(

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/KeycloakClientRoleSyncTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/KeycloakClientRoleSyncTests.cs
@@ -75,7 +75,7 @@ public sealed class KeycloakClientRoleSyncTests(KeycloakFixture keycloak)
 
         store.All.Count.ShouldBe(3);
         store.All.ShouldAllBe(r => r.ClientId == KeycloakFixture.TrackedClientId);
-        store.All.Select(r => r.Name).OrderBy(x => x).ShouldBe(["admin", "editor", "viewer"]);
+        store.All.Select(r => r.Name).Order().ShouldBe(["admin", "editor", "viewer"]);
         store.All.First(r => r.Name == "editor").Description.ShouldBe("Edit showcase documents");
     }
 
@@ -88,12 +88,12 @@ public sealed class KeycloakClientRoleSyncTests(KeycloakFixture keycloak)
 
         await sut.SyncAsync(TestContext.Current.CancellationToken);
         int firstRunCount = store.All.Count;
-        IReadOnlyList<Guid> firstRunIds = store.All.Select(r => r.Id).OrderBy(x => x).ToList();
+        IReadOnlyList<Guid> firstRunIds = store.All.Select(r => r.Id).Order().ToList();
 
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         store.All.Count.ShouldBe(firstRunCount);
-        store.All.Select(r => r.Id).OrderBy(x => x).ShouldBe(firstRunIds);
+        store.All.Select(r => r.Id).Order().ShouldBe(firstRunIds);
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public sealed class KeycloakClientRoleSyncTests(KeycloakFixture keycloak)
 
         roles.Count.ShouldBe(2);
         roles.ShouldAllBe(r => r.ClientId == KeycloakFixture.TrackedClientId);
-        roles.Select(r => r.Name).OrderBy(x => x).ShouldBe(["admin", "editor"]);
+        roles.Select(r => r.Name).Order().ShouldBe(["admin", "editor"]);
     }
 
     [Fact]
@@ -205,7 +205,7 @@ public sealed class KeycloakClientRoleSyncTests(KeycloakFixture keycloak)
             // from Keycloak, but 'viewer' stays in the store until an explicit cleanup job
             // (tracked separately in Phase 3, #1118).
             store.All.Count.ShouldBe(3);
-            store.All.Select(r => r.Name).OrderBy(x => x).ShouldBe(["admin", "editor", "viewer"]);
+            store.All.Select(r => r.Name).Order().ShouldBe(["admin", "editor", "viewer"]);
         }
         finally
         {

--- a/tests/Granit.Identity.Federated.Tests/Exports/FederatedIdentityExportDefinitionTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Exports/FederatedIdentityExportDefinitionTests.cs
@@ -9,7 +9,7 @@ public sealed class FederatedIdentityExportDefinitionTests
 {
     private static readonly FederatedIdentityExportDefinition Sut = new();
     private static IReadOnlyList<ExportFieldDescriptor> Fields =>
-        ((IExportDefinitionDescriptor)Sut).GetFields();
+        Sut.GetFields();
 
     [Fact]
     public void Name_is_stable() =>

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/TotpServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/TotpServiceTests.cs
@@ -47,7 +47,7 @@ public sealed class TotpServiceTests
     public void GetQrCodeUri_FormatsOtpauthUri()
     {
         _identityOptions.Tokens.AuthenticatorIssuer = "TestApp";
-        string key = "JBSWY3DPEHPK3PXP";
+        const string key = "JBSWY3DPEHPK3PXP";
 
         string uri = _sut.GetQrCodeUri("user@example.com", key);
 

--- a/tests/Granit.Identity.Local.Notifications.Tests/Handlers/HandlerTests.cs
+++ b/tests/Granit.Identity.Local.Notifications.Tests/Handlers/HandlerTests.cs
@@ -266,7 +266,7 @@ public sealed class HandlerTests
 
         await _publisher.Received(1).PublishAsync(
             TwoFactorChangedNotificationType.Instance,
-            Arg.Is<TwoFactorChangedNotificationData>(d => d.Enabled == true),
+            Arg.Is<TwoFactorChangedNotificationData>(d => d.Enabled),
             Arg.Is<IReadOnlyList<string>>(r => r.Count == 1),
             Arg.Any<CancellationToken>());
     }

--- a/tests/Granit.Identity.Local.Tests/Entities/EntityTests.cs
+++ b/tests/Granit.Identity.Local.Tests/Entities/EntityTests.cs
@@ -72,7 +72,7 @@ public sealed class EntityTests
         var tenantId = Guid.NewGuid();
         LocalIdentity user = new() { TenantId = tenantId };
 
-        ((IMultiTenant)user).TenantId.ShouldBe(tenantId);
+        user.TenantId.ShouldBe(tenantId);
     }
 
     [Fact]

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineFormatConversionTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineFormatConversionTests.cs
@@ -86,7 +86,7 @@ public sealed class MagickNetImagePipelineFormatConversionTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
         MagickNetImagePipeline pipeline = CreatePipeline();
-        using MemoryStream output = new();
+        await using MemoryStream output = new();
 
         Func<Task> act = () => pipeline.SaveToStreamAsync(output, cts.Token);
         await Should.ThrowAsync<OperationCanceledException>(act);
@@ -103,7 +103,7 @@ public sealed class MagickNetImagePipelineFormatConversionTests
             .Compress(80)
             .ToResultAsync(TestContext.Current.CancellationToken);
 
-        using MemoryStream stream = new();
+        await using MemoryStream stream = new();
         await pipeline2
             .ConvertTo(ImageFormat.Jpeg)
             .Compress(80)

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineTests.cs
@@ -196,7 +196,7 @@ public sealed class MagickNetImagePipelineTests
     {
         // Arrange
         await using MagickNetImagePipeline pipeline = CreatePipeline();
-        using MemoryStream output = new();
+        await using MemoryStream output = new();
 
         // Act
         await pipeline.SaveToStreamAsync(output, TestContext.Current.CancellationToken);

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineWatermarkTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineWatermarkTests.cs
@@ -88,7 +88,7 @@ public sealed class MagickNetImagePipelineWatermarkTests
     public async Task Watermark_FromStream_ProducesValidOutput()
     {
         await using MagickNetImagePipeline pipeline = CreatePipeline();
-        using MemoryStream watermarkStream = CreateWatermarkStream();
+        await using MemoryStream watermarkStream = CreateWatermarkStream();
 
         ImageResult result = await pipeline
             .Watermark(watermarkStream, WatermarkPosition.BottomRight, 0.5f)

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
@@ -89,7 +89,7 @@ public sealed class MagickNetImageProcessorTests
     public async Task Load_FromStream_PipelineIsDisposable()
     {
         // Arrange
-        using Stream stream = GetTestImageStream();
+        await using Stream stream = GetTestImageStream();
 
         // Act
         IImagePipeline pipeline = _processor.Load(stream);

--- a/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
+++ b/tests/Granit.Localization.AI.Tests/TranslateToolTests.cs
@@ -19,7 +19,7 @@ public sealed class TranslateToolTests
 
         tool.Name.ShouldBe("translate");
         tool.ShouldBeAssignableTo<IGatedAITool>();
-        ((IGatedAITool)tool).RequiredPermission.ShouldBe(LocalizationAIPermissions.ChatTools.Translate);
+        tool.RequiredPermission.ShouldBe(LocalizationAIPermissions.ChatTools.Translate);
     }
 
     [Fact]

--- a/tests/Granit.Localization.AI.Tests/TranslationContextTests.cs
+++ b/tests/Granit.Localization.AI.Tests/TranslationContextTests.cs
@@ -7,35 +7,35 @@ public sealed class TranslationContextTests
     [Fact]
     public void UiLabel_HasExpectedValue()
     {
-        TranslationContext context = TranslationContext.UiLabel;
+        const TranslationContext context = TranslationContext.UiLabel;
         context.ShouldBe(TranslationContext.UiLabel);
     }
 
     [Fact]
     public void ErrorMessage_HasExpectedValue()
     {
-        TranslationContext context = TranslationContext.ErrorMessage;
+        const TranslationContext context = TranslationContext.ErrorMessage;
         context.ShouldBe(TranslationContext.ErrorMessage);
     }
 
     [Fact]
     public void Notification_HasExpectedValue()
     {
-        TranslationContext context = TranslationContext.Notification;
+        const TranslationContext context = TranslationContext.Notification;
         context.ShouldBe(TranslationContext.Notification);
     }
 
     [Fact]
     public void Description_HasExpectedValue()
     {
-        TranslationContext context = TranslationContext.Description;
+        const TranslationContext context = TranslationContext.Description;
         context.ShouldBe(TranslationContext.Description);
     }
 
     [Fact]
     public void Placeholder_HasExpectedValue()
     {
-        TranslationContext context = TranslationContext.Placeholder;
+        const TranslationContext context = TranslationContext.Placeholder;
         context.ShouldBe(TranslationContext.Placeholder);
     }
 

--- a/tests/Granit.Localization.Tests/JsonLocalizationDictionaryBuilderTests.cs
+++ b/tests/Granit.Localization.Tests/JsonLocalizationDictionaryBuilderTests.cs
@@ -11,7 +11,7 @@ public sealed class JsonLocalizationDictionaryBuilderTests
     {
         // Arrange — les fichiers Test/fr.json et Test/en.json sont embarqués dans l'assembly de test
         System.Reflection.Assembly assembly = typeof(JsonLocalizationDictionaryBuilderTests).Assembly;
-        string prefix = "Granit.Localization.Tests.TestResources.Localization.Test";
+        const string prefix = "Granit.Localization.Tests.TestResources.Localization.Test";
 
         // Act
         Dictionary<string, Dictionary<string, string>> result =
@@ -44,7 +44,7 @@ public sealed class JsonLocalizationDictionaryBuilderTests
     {
         // Arrange
         System.Reflection.Assembly assembly = typeof(JsonLocalizationDictionaryBuilderTests).Assembly;
-        string prefix = "Granit.Localization.Tests.TestResources.Localization.Test";
+        const string prefix = "Granit.Localization.Tests.TestResources.Localization.Test";
 
         // Act
         Dictionary<string, Dictionary<string, string>> result =
@@ -60,7 +60,7 @@ public sealed class JsonLocalizationDictionaryBuilderTests
     {
         // Arrange
         System.Reflection.Assembly assembly = typeof(JsonLocalizationDictionaryBuilderTests).Assembly;
-        string prefix = "Granit.Localization.Tests.TestResources.Localization.Parent";
+        const string prefix = "Granit.Localization.Tests.TestResources.Localization.Parent";
 
         // Act
         Dictionary<string, Dictionary<string, string>> result =

--- a/tests/Granit.Localization.Tests/LocalizationServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Localization.Tests/LocalizationServiceCollectionExtensionsTests.cs
@@ -109,10 +109,7 @@ public sealed class LocalizationServiceCollectionExtensionsTests
         ServiceCollection services = CreateServices();
         services.AddGranitLocalization();
 
-        services.ConfigureLocalizationOverridesCache(options =>
-        {
-            options.CacheTtl = TimeSpan.FromMinutes(10);
-        });
+        services.ConfigureLocalizationOverridesCache(options => options.CacheTtl = TimeSpan.FromMinutes(10));
 
         using ServiceProvider sp = services.BuildServiceProvider();
         LocalizationOverridesCacheOptions cacheOptions =
@@ -126,10 +123,7 @@ public sealed class LocalizationServiceCollectionExtensionsTests
     {
         ServiceCollection services = new();
 
-        IServiceCollection result = services.ConfigureLocalizationOverridesCache(options =>
-        {
-            options.CacheTtl = TimeSpan.FromMinutes(1);
-        });
+        IServiceCollection result = services.ConfigureLocalizationOverridesCache(options => options.CacheTtl = TimeSpan.FromMinutes(1));
 
         result.ShouldBeSameAs(services);
     }

--- a/tests/Granit.Mcp.Server.Tests/CallToolAuthorizationFilterTests.cs
+++ b/tests/Granit.Mcp.Server.Tests/CallToolAuthorizationFilterTests.cs
@@ -25,7 +25,7 @@ public sealed class CallToolAuthorizationFilterTests
     [Fact]
     public async Task EvaluateAsync_UnresolvedTool_IsDenied()
     {
-        using ServiceProvider sp = BuildServices();
+        await using ServiceProvider sp = BuildServices();
 
         CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
             sp, "ghost-tool", matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
@@ -41,7 +41,7 @@ public sealed class CallToolAuthorizationFilterTests
         checker.IsGrantedAsync(McpPermissions.Tools.Execute, Arg.Any<CancellationToken>())
             .Returns(false);
 
-        using ServiceProvider sp = BuildServices(permissionChecker: checker);
+        await using ServiceProvider sp = BuildServices(permissionChecker: checker);
 
         CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
             sp, PlainToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
@@ -53,7 +53,7 @@ public sealed class CallToolAuthorizationFilterTests
     [Fact]
     public async Task EvaluateAsync_UnannotatedTool_WithNoPermissionChecker_IsDenied()
     {
-        using ServiceProvider sp = BuildServices(permissionChecker: null);
+        await using ServiceProvider sp = BuildServices(permissionChecker: null);
 
         CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
             sp, PlainToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
@@ -69,7 +69,7 @@ public sealed class CallToolAuthorizationFilterTests
         checker.IsGrantedAsync(McpPermissions.Tools.Execute, Arg.Any<CancellationToken>())
             .Returns(true);
 
-        using ServiceProvider sp = BuildServices(permissionChecker: checker);
+        await using ServiceProvider sp = BuildServices(permissionChecker: checker);
 
         CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
             sp, PlainToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
@@ -82,7 +82,7 @@ public sealed class CallToolAuthorizationFilterTests
     {
         // No IPermissionChecker registered: the tool must pass through purely because it
         // carries explicit authorization metadata (enforced downstream by the SDK filter).
-        using ServiceProvider sp = BuildServices(permissionChecker: null);
+        await using ServiceProvider sp = BuildServices(permissionChecker: null);
 
         object[] metadata = [new PermissionAttribute("Some.Resource.Action")];
 
@@ -102,7 +102,7 @@ public sealed class CallToolAuthorizationFilterTests
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
         tenant.IsAvailable.Returns(false);
 
-        using ServiceProvider sp = BuildServices(permissionChecker: checker, currentTenant: tenant);
+        await using ServiceProvider sp = BuildServices(permissionChecker: checker, currentTenant: tenant);
 
         CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
             sp, TenantScopedToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);
@@ -121,7 +121,7 @@ public sealed class CallToolAuthorizationFilterTests
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
         tenant.IsAvailable.Returns(true);
 
-        using ServiceProvider sp = BuildServices(permissionChecker: checker, currentTenant: tenant);
+        await using ServiceProvider sp = BuildServices(permissionChecker: checker, currentTenant: tenant);
 
         CallToolResult? result = await CallToolAuthorizationFilter.EvaluateAsync(
             sp, TenantScopedToolName, matchedPrimitiveMetadata: null, TestContext.Current.CancellationToken);

--- a/tests/Granit.Mcp.Server.Tests/TenantAwareVisibilityFilterTests.cs
+++ b/tests/Granit.Mcp.Server.Tests/TenantAwareVisibilityFilterTests.cs
@@ -47,7 +47,7 @@ public sealed class TenantAwareVisibilityFilterTests
 
         ServiceCollection services = new();
         services.AddSingleton(tenant);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         bool result = await sut.IsVisibleAsync("tool", typeof(TenantScopedClass), sp, TestContext.Current.CancellationToken);
 
@@ -62,7 +62,7 @@ public sealed class TenantAwareVisibilityFilterTests
 
         // No ICurrentTenant registered
         ServiceCollection services = new();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         bool result = await sut.IsVisibleAsync("tool", typeof(TenantScopedClass), sp, TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
+++ b/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
@@ -88,7 +88,7 @@ public sealed class PropertyRedactionSanitizerTests
     public async Task SanitizeAsync_NestedObject_RedactsNestedWellKnownNames()
     {
         PropertyRedactionSanitizer sut = CreateSanitizer();
-        string json = """{"user":{"name":"Alice","password":"s3cr3t"}}""";
+        const string json = """{"user":{"name":"Alice","password":"s3cr3t"}}""";
         CallToolResult result = new() { Content = [new TextContentBlock { Text = json }] };
 
         CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);
@@ -104,7 +104,7 @@ public sealed class PropertyRedactionSanitizerTests
     public async Task SanitizeAsync_ArrayOfObjects_RedactsWellKnownNames()
     {
         PropertyRedactionSanitizer sut = CreateSanitizer();
-        string json = """[{"name":"Alice","token":"abc"},{"name":"Bob","token":"xyz"}]""";
+        const string json = """[{"name":"Alice","token":"abc"},{"name":"Bob","token":"xyz"}]""";
         CallToolResult result = new() { Content = [new TextContentBlock { Text = json }] };
 
         CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
@@ -11,7 +11,7 @@ public sealed class UpdateTenantRequestTests
     [Fact]
     public void Constructor_MapsAllFields()
     {
-        UpdateTenantRequest request = new(Name: "Updated Name", ContactEmail: "updated@acme.com", Jurisdiction: "FR", ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: "Updated Name", ConcurrencyStamp: AnyStamp, ContactEmail: "updated@acme.com", Jurisdiction: "FR");
 
         request.Name.ShouldBe("Updated Name");
         request.ContactEmail.ShouldBe("updated@acme.com");
@@ -21,7 +21,7 @@ public sealed class UpdateTenantRequestTests
     [Fact]
     public void Constructor_NullContactEmail_IsValid()
     {
-        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: null, Jurisdiction: null, ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ConcurrencyStamp: AnyStamp, ContactEmail: null, Jurisdiction: null);
 
         request.ContactEmail.ShouldBeNull();
     }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
@@ -14,7 +14,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void ValidRequest_Succeeds()
     {
-        UpdateTenantRequest request = new(Name: "Updated Name", ContactEmail: "admin@acme.com", Jurisdiction: null, ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: "Updated Name", ConcurrencyStamp: AnyStamp, ContactEmail: "admin@acme.com", Jurisdiction: null);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -24,7 +24,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void EmptyName_Fails()
     {
-        UpdateTenantRequest request = new(Name: "", ContactEmail: "admin@acme.com", Jurisdiction: null, ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: "", ConcurrencyStamp: AnyStamp, ContactEmail: "admin@acme.com", Jurisdiction: null);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -35,7 +35,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void NameTooLong_Fails()
     {
-        UpdateTenantRequest request = new(Name: new string('A', 257), ContactEmail: null, Jurisdiction: null, ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: new string('A', 257), ConcurrencyStamp: AnyStamp, ContactEmail: null, Jurisdiction: null);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -46,7 +46,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void InvalidEmail_Fails()
     {
-        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: "not-an-email", Jurisdiction: null, ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ConcurrencyStamp: AnyStamp, ContactEmail: "not-an-email", Jurisdiction: null);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -57,7 +57,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void NullEmail_Succeeds()
     {
-        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: null, Jurisdiction: null, ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ConcurrencyStamp: AnyStamp, ContactEmail: null, Jurisdiction: null);
 
         ValidationResult result = _validator.Validate(request);
 
@@ -67,7 +67,7 @@ public sealed class UpdateTenantRequestValidatorTests
     [Fact]
     public void JurisdictionTooLong_Fails()
     {
-        UpdateTenantRequest request = new(Name: "Acme", ContactEmail: null, Jurisdiction: new string('A', 17), ConcurrencyStamp: AnyStamp);
+        UpdateTenantRequest request = new(Name: "Acme", ConcurrencyStamp: AnyStamp, ContactEmail: null, Jurisdiction: new string('A', 17));
 
         ValidationResult result = _validator.Validate(request);
 

--- a/tests/Granit.MultiTenancy.Tests/TenantInfoTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantInfoTests.cs
@@ -46,8 +46,8 @@ public sealed class TenantInfoTests
         var info = new TenantInfo(Guid.NewGuid(), "Test");
 
         info.ShouldBeAssignableTo<ITenantInfo>();
-        ((ITenantInfo)info).Id.ShouldBe(info.Id);
-        ((ITenantInfo)info).Name.ShouldBe(info.Name);
+        info.Id.ShouldBe(info.Id);
+        info.Name.ShouldBe(info.Name);
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Email.Smtp.Tests/MailKitEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.Smtp.Tests/MailKitEmailSenderTests.cs
@@ -274,7 +274,7 @@ public sealed class MailKitEmailSenderTests
         await sender.SendAsync(SimpleMessage(), TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
-        ((MailboxAddress)captured.From[0]).Name.ShouldBe("noreply@localhost");
+        captured.From[0].Name.ShouldBe("noreply@localhost");
         ((MailboxAddress)captured.From[0]).Address.ShouldBe("noreply@localhost");
     }
 
@@ -376,7 +376,7 @@ public sealed class MailKitEmailSenderTests
         await sender.SendAsync(message, TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
-        ((MailboxAddress)captured.To[0]).Name.ShouldBe("John Doe");
+        captured.To[0].Name.ShouldBe("John Doe");
     }
 
     // -------------------------------------------------------------------------
@@ -402,7 +402,7 @@ public sealed class MailKitEmailSenderTests
         await sender.SendAsync(SimpleMessage(), TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
-        ((MailboxAddress)captured.From[0]).Name.ShouldBe("My App");
+        captured.From[0].Name.ShouldBe("My App");
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationDeliveryStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationDeliveryStoreTests.cs
@@ -95,8 +95,8 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
             .ToListAsync(TestContext.Current.CancellationToken);
 
         all.Count.ShouldBe(3);
-        all.Where(a => a.ChannelName == "email").Count().ShouldBe(2);
-        all.Where(a => a.IsSuccess == true).Count().ShouldBe(2);
+        all.Count(a => a.ChannelName == "email").ShouldBe(2);
+        all.Count(a => a.IsSuccess == true).ShouldBe(2);
         all.Single(a => a.IsSuccess == false).ErrorMessage.ShouldBe("SMTP timeout");
     }
 
@@ -114,9 +114,9 @@ public sealed class EfCoreNotificationDeliveryStoreTests : IDisposable
             TestContext.Current.CancellationToken);
 
         NotificationDeliveryAttempt second = BuildClaim(
-            deliveryId: first.DeliveryId,
             notificationId: first.NotificationId,
             channelName: first.ChannelName,
+            deliveryId: first.DeliveryId,
             isSuccess: null);
 
         (await _store.TryAcquireDeliveryAttemptAsync(second, TestContext.Current.CancellationToken)).ShouldBeTrue();

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationPreferenceStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationPreferenceStoreTests.cs
@@ -29,7 +29,7 @@ public sealed class EfCoreNotificationPreferenceStoreTests : IDisposable
     [Fact]
     public async Task GetListAsync_ReturnsUserPreferences()
     {
-        string userId = "user-prefs";
+        const string userId = "user-prefs";
         var tenantId = Guid.NewGuid();
 
         NotificationPreference pref1 = BuildPreference(userId: userId, tenantId: tenantId, notificationTypeName: "type-a", channelName: "email");
@@ -49,7 +49,7 @@ public sealed class EfCoreNotificationPreferenceStoreTests : IDisposable
     [Fact]
     public async Task SetAsync_InsertsNewPreference()
     {
-        string userId = "user-insert";
+        const string userId = "user-insert";
         var tenantId = Guid.NewGuid();
         NotificationPreference preference = BuildPreference(userId: userId, tenantId: tenantId, isEnabled: false);
 
@@ -64,10 +64,10 @@ public sealed class EfCoreNotificationPreferenceStoreTests : IDisposable
     [Fact]
     public async Task SetAsync_UpdatesExistingPreference()
     {
-        string userId = "user-update";
+        const string userId = "user-update";
         var tenantId = Guid.NewGuid();
-        string typeName = "order.created";
-        string channelName = "email";
+        const string typeName = "order.created";
+        const string channelName = "email";
 
         // Insert initial preference (enabled)
         NotificationPreference initial = BuildPreference(userId: userId, tenantId: tenantId, notificationTypeName: typeName, channelName: channelName, isEnabled: true);
@@ -95,10 +95,10 @@ public sealed class EfCoreNotificationPreferenceStoreTests : IDisposable
     [Fact]
     public async Task IsChannelEnabledAsync_WithPreference_ReturnsStoredValue()
     {
-        string userId = "user-channel-check";
+        const string userId = "user-channel-check";
         var tenantId = Guid.NewGuid();
-        string typeName = "alert.critical";
-        string channelName = "sms";
+        const string typeName = "alert.critical";
+        const string channelName = "sms";
 
         NotificationPreference preference = BuildPreference(userId: userId, tenantId: tenantId, notificationTypeName: typeName, channelName: channelName, isEnabled: false);
         await _store.SetAsync(preference, TestContext.Current.CancellationToken);

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationSubscriptionStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationSubscriptionStoreTests.cs
@@ -30,8 +30,8 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
     [Fact]
     public async Task SubscribeAsync_InsertsSubscription()
     {
-        string userId = "user-sub";
-        string typeName = "order.created";
+        const string userId = "user-sub";
+        const string typeName = "order.created";
         var tenantId = Guid.NewGuid();
 
         await _store.SubscribeAsync(userId, typeName, tenantId, TestContext.Current.CancellationToken);
@@ -43,22 +43,22 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
     [Fact]
     public async Task SubscribeAsync_DuplicateSubscription_DoesNotInsertTwice()
     {
-        string userId = "user-dup";
-        string typeName = "order.created";
+        const string userId = "user-dup";
+        const string typeName = "order.created";
         var tenantId = Guid.NewGuid();
 
         await _store.SubscribeAsync(userId, typeName, tenantId, TestContext.Current.CancellationToken);
         await _store.SubscribeAsync(userId, typeName, tenantId, TestContext.Current.CancellationToken);
 
         IReadOnlyList<NotificationSubscription> subscriptions = await _store.GetUserSubscriptionsAsync(userId, tenantId, TestContext.Current.CancellationToken);
-        subscriptions.Where(s => s.NotificationTypeName == typeName && s.EntityType == null).Count().ShouldBe(1);
+        subscriptions.Count(s => s.NotificationTypeName == typeName && s.EntityType == null).ShouldBe(1);
     }
 
     [Fact]
     public async Task UnsubscribeAsync_RemovesSubscription()
     {
-        string userId = "user-unsub";
-        string typeName = "order.created";
+        const string userId = "user-unsub";
+        const string typeName = "order.created";
         var tenantId = Guid.NewGuid();
 
         await _store.SubscribeAsync(userId, typeName, tenantId, TestContext.Current.CancellationToken);
@@ -71,7 +71,7 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
     [Fact]
     public async Task GetSubscriberIdsAsync_ReturnsSubscribers()
     {
-        string typeName = "invoice.paid";
+        const string typeName = "invoice.paid";
         var tenantId = Guid.NewGuid();
 
         await _store.SubscribeAsync("user-a", typeName, tenantId, TestContext.Current.CancellationToken);
@@ -88,9 +88,9 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
     [Fact]
     public async Task FollowEntityAsync_InsertsEntitySubscription()
     {
-        string userId = "user-follow";
-        string entityType = "Order";
-        string entityId = "order-42";
+        const string userId = "user-follow";
+        const string entityType = "Order";
+        const string entityId = "order-42";
         var tenantId = Guid.NewGuid();
 
         await _store.FollowEntityAsync(userId, entityType, entityId, tenantId, TestContext.Current.CancellationToken);
@@ -102,24 +102,24 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
     [Fact]
     public async Task FollowEntityAsync_DuplicateFollow_DoesNotInsertTwice()
     {
-        string userId = "user-dup-follow";
-        string entityType = "Order";
-        string entityId = "order-42";
+        const string userId = "user-dup-follow";
+        const string entityType = "Order";
+        const string entityId = "order-42";
         var tenantId = Guid.NewGuid();
 
         await _store.FollowEntityAsync(userId, entityType, entityId, tenantId, TestContext.Current.CancellationToken);
         await _store.FollowEntityAsync(userId, entityType, entityId, tenantId, TestContext.Current.CancellationToken);
 
         IReadOnlyList<NotificationSubscription> followers = await _store.GetEntityFollowersAsync(entityType, entityId, tenantId, TestContext.Current.CancellationToken);
-        followers.Where(s => s.UserId == userId).Count().ShouldBe(1);
+        followers.Count(s => s.UserId == userId).ShouldBe(1);
     }
 
     [Fact]
     public async Task UnfollowEntityAsync_RemovesEntitySubscription()
     {
-        string userId = "user-unfollow";
-        string entityType = "Order";
-        string entityId = "order-42";
+        const string userId = "user-unfollow";
+        const string entityType = "Order";
+        const string entityId = "order-42";
         var tenantId = Guid.NewGuid();
 
         await _store.FollowEntityAsync(userId, entityType, entityId, tenantId, TestContext.Current.CancellationToken);
@@ -132,8 +132,8 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
     [Fact]
     public async Task GetEntityFollowerIdsAsync_ReturnsFollowers()
     {
-        string entityType = "Project";
-        string entityId = "proj-10";
+        const string entityType = "Project";
+        const string entityId = "proj-10";
         var tenantId = Guid.NewGuid();
 
         await _store.FollowEntityAsync("user-x", entityType, entityId, tenantId, TestContext.Current.CancellationToken);
@@ -150,8 +150,8 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
     [Fact]
     public async Task GetEntityFollowersAsync_FiltersByEntityTypeAndId()
     {
-        string entityType = "Task";
-        string entityId = "task-5";
+        const string entityType = "Task";
+        const string entityId = "task-5";
         var tenantId = Guid.NewGuid();
 
         await _store.FollowEntityAsync("user-1", entityType, entityId, tenantId, TestContext.Current.CancellationToken);

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreUserNotificationStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreUserNotificationStoreTests.cs
@@ -46,7 +46,7 @@ public sealed class EfCoreUserNotificationStoreTests : IDisposable
     [Fact]
     public async Task GetListAsync_ReturnsPaginatedResults_SortedByDate()
     {
-        string userId = "user-paginated";
+        const string userId = "user-paginated";
         var tenantId = Guid.NewGuid();
         DateTimeOffset baseTime = DateTimeOffset.UtcNow;
 
@@ -87,7 +87,7 @@ public sealed class EfCoreUserNotificationStoreTests : IDisposable
     [Fact]
     public async Task GetUnreadCountAsync_ReturnsCorrectCount()
     {
-        string userId = "user-unread-count";
+        const string userId = "user-unread-count";
         var tenantId = Guid.NewGuid();
 
         // Insert 3 unread notifications
@@ -124,7 +124,7 @@ public sealed class EfCoreUserNotificationStoreTests : IDisposable
     [Fact]
     public async Task MarkAllAsReadAsync_MarksAllUnreadAsRead()
     {
-        string userId = "user-mark-all";
+        const string userId = "user-mark-all";
         var tenantId = Guid.NewGuid();
 
         // Insert 3 unread notifications
@@ -147,8 +147,8 @@ public sealed class EfCoreUserNotificationStoreTests : IDisposable
     public async Task GetByEntityAsync_FiltersCorrectly()
     {
         var tenantId = Guid.NewGuid();
-        string entityType = "Order";
-        string entityId = "order-42";
+        const string entityType = "Order";
+        const string entityId = "order-42";
 
         await _store.InsertAsync(BuildNotification(tenantId: tenantId, relatedEntityType: entityType, relatedEntityId: entityId), TestContext.Current.CancellationToken);
         await _store.InsertAsync(BuildNotification(tenantId: tenantId, relatedEntityType: entityType, relatedEntityId: entityId), TestContext.Current.CancellationToken);

--- a/tests/Granit.Notifications.MobilePush.Tests/MobilePushNotificationsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.MobilePush.Tests/MobilePushNotificationsServiceCollectionExtensionsTests.cs
@@ -27,7 +27,7 @@ public sealed class MobilePushNotificationsServiceCollectionExtensionsTests
     [Fact]
     public async Task AddGranitNotificationsMobilePush_TokenWrittenViaWriter_IsVisibleViaReader()
     {
-        using ServiceProvider sp = BuildProvider();
+        await using ServiceProvider sp = BuildProvider();
 
         IMobilePushTokenReader reader = sp.GetRequiredService<IMobilePushTokenReader>();
         IMobilePushTokenWriter writer = sp.GetRequiredService<IMobilePushTokenWriter>();

--- a/tests/Granit.Notifications.SignalR.Tests/SignalRNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.SignalR.Tests/SignalRNotificationChannelTests.cs
@@ -51,7 +51,7 @@ public sealed class SignalRNotificationChannelTests
         SignalRNotificationMessage? captured = null;
         _clientProxy.SendCoreAsync(
             "ReceiveNotification",
-            Arg.Do<object?[]>(args => { captured = args[0] as SignalRNotificationMessage; }),
+            Arg.Do<object?[]>(args => captured = args[0] as SignalRNotificationMessage),
             Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
@@ -72,7 +72,7 @@ public sealed class SignalRNotificationChannelTests
         SignalRNotificationMessage? captured = null;
         _clientProxy.SendCoreAsync(
             "ReceiveNotification",
-            Arg.Do<object?[]>(args => { captured = args[0] as SignalRNotificationMessage; }),
+            Arg.Do<object?[]>(args => captured = args[0] as SignalRNotificationMessage),
             Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
@@ -90,7 +90,7 @@ public sealed class SignalRNotificationChannelTests
         SignalRNotificationMessage? captured = null;
         _clientProxy.SendCoreAsync(
             "ReceiveNotification",
-            Arg.Do<object?[]>(args => { captured = args[0] as SignalRNotificationMessage; }),
+            Arg.Do<object?[]>(args => captured = args[0] as SignalRNotificationMessage),
             Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 

--- a/tests/Granit.Notifications.SignalR.Tests/SignalRNotificationsServiceCollectionExtensionsAdditionalTests.cs
+++ b/tests/Granit.Notifications.SignalR.Tests/SignalRNotificationsServiceCollectionExtensionsAdditionalTests.cs
@@ -40,10 +40,7 @@ public sealed class SignalRNotificationsServiceCollectionExtensionsAdditionalTes
     {
         ServiceCollection services = new();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddGranitNotificationsSignalR(opts =>
-        {
-            opts.RedisConnectionString = "localhost:6379";
-        });
+        services.AddGranitNotificationsSignalR(opts => opts.RedisConnectionString = "localhost:6379");
 
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<SignalRChannelOptions> options = sp.GetRequiredService<IOptions<SignalRChannelOptions>>();

--- a/tests/Granit.Notifications.SignalR.Tests/SignalRNotificationsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.SignalR.Tests/SignalRNotificationsServiceCollectionExtensionsTests.cs
@@ -39,10 +39,7 @@ public sealed class SignalRNotificationsServiceCollectionExtensionsTests
     {
         ServiceCollection services = new();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddGranitNotificationsSignalR(opts =>
-        {
-            opts.RedisConnectionString = "localhost:6379";
-        });
+        services.AddGranitNotificationsSignalR(opts => opts.RedisConnectionString = "localhost:6379");
 
         ServiceProvider sp = services.BuildServiceProvider();
         SignalRChannelOptions options = sp.GetRequiredService<IOptions<SignalRChannelOptions>>().Value;

--- a/tests/Granit.Notifications.Sse.Tests/SseNotificationsServiceCollectionExtensionsAdditionalTests.cs
+++ b/tests/Granit.Notifications.Sse.Tests/SseNotificationsServiceCollectionExtensionsAdditionalTests.cs
@@ -58,10 +58,7 @@ public sealed class SseNotificationsServiceCollectionExtensionsAdditionalTests
     {
         ServiceCollection services = new();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddGranitNotificationsSse(opts =>
-        {
-            opts.HeartbeatIntervalSeconds = 60;
-        });
+        services.AddGranitNotificationsSse(opts => opts.HeartbeatIntervalSeconds = 60);
 
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<SseChannelOptions> options = sp.GetRequiredService<IOptions<SseChannelOptions>>();

--- a/tests/Granit.Notifications.Sse.Tests/SseNotificationsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.Sse.Tests/SseNotificationsServiceCollectionExtensionsTests.cs
@@ -51,10 +51,7 @@ public sealed class SseNotificationsServiceCollectionExtensionsTests
     {
         ServiceCollection services = new();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddGranitNotificationsSse(opts =>
-        {
-            opts.HeartbeatIntervalSeconds = 15;
-        });
+        services.AddGranitNotificationsSse(opts => opts.HeartbeatIntervalSeconds = 15);
 
         ServiceProvider sp = services.BuildServiceProvider();
         SseChannelOptions options = sp.GetRequiredService<IOptions<SseChannelOptions>>().Value;

--- a/tests/Granit.Notifications.Tests/Exports/UserNotificationExportDefinitionTests.cs
+++ b/tests/Granit.Notifications.Tests/Exports/UserNotificationExportDefinitionTests.cs
@@ -11,7 +11,7 @@ public sealed class UserNotificationExportDefinitionTests
 {
     private static readonly UserNotificationExportDefinition Sut = new();
     private static IReadOnlyList<ExportFieldDescriptor> Fields =>
-        ((IExportDefinitionDescriptor)Sut).GetFields();
+        Sut.GetFields();
 
     [Fact]
     public void Name_is_stable() =>

--- a/tests/Granit.Notifications.Tests/InMemoryNotificationPreferenceStoreTests.cs
+++ b/tests/Granit.Notifications.Tests/InMemoryNotificationPreferenceStoreTests.cs
@@ -165,8 +165,8 @@ public sealed class InMemoryNotificationPreferenceStoreTests
         var tenantA = Guid.NewGuid();
         var tenantB = Guid.NewGuid();
 
-        NotificationPreference prefTenantA = BuildPreference("user-1", "order.created", "email", tenantId: tenantA, isEnabled: false);
-        NotificationPreference prefTenantB = BuildPreference("user-1", "order.created", "email", tenantId: tenantB, isEnabled: true);
+        NotificationPreference prefTenantA = BuildPreference("user-1", "order.created", "email", isEnabled: false, tenantId: tenantA);
+        NotificationPreference prefTenantB = BuildPreference("user-1", "order.created", "email", isEnabled: true, tenantId: tenantB);
 
         await _store.SetAsync(prefTenantA, TestContext.Current.CancellationToken);
         await _store.SetAsync(prefTenantB, TestContext.Current.CancellationToken);
@@ -188,7 +188,7 @@ public sealed class InMemoryNotificationPreferenceStoreTests
         var tenantA = Guid.NewGuid();
         var tenantB = Guid.NewGuid();
 
-        NotificationPreference prefTenantA = BuildPreference("user-1", "order.created", "email", tenantId: tenantA, isEnabled: false);
+        NotificationPreference prefTenantA = BuildPreference("user-1", "order.created", "email", isEnabled: false, tenantId: tenantA);
         await _store.SetAsync(prefTenantA, TestContext.Current.CancellationToken);
 
         bool enabledForA = await _store.IsChannelEnabledAsync(

--- a/tests/Granit.Notifications.Tests/NotificationDispatchWorkerTests.cs
+++ b/tests/Granit.Notifications.Tests/NotificationDispatchWorkerTests.cs
@@ -37,7 +37,7 @@ public sealed class NotificationDispatchWorkerTests
     {
         var tenantId = Guid.NewGuid();
         var harness = Harness.Build();
-        using ServiceProvider sp = harness.ServiceProvider;
+        await using ServiceProvider sp = harness.ServiceProvider;
 
         await harness.Worker.StartAsync(Ct);
         await harness.Channel.Writer.WriteAsync(
@@ -59,7 +59,7 @@ public sealed class NotificationDispatchWorkerTests
     public async Task Dispatch_HostScopedTrigger_RunsInHostContext()
     {
         var harness = Harness.Build();
-        using ServiceProvider sp = harness.ServiceProvider;
+        await using ServiceProvider sp = harness.ServiceProvider;
 
         await harness.Worker.StartAsync(Ct);
         await harness.Channel.Writer.WriteAsync(

--- a/tests/Granit.Notifications.WebPush.Tests/WebPushNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.WebPush.Tests/WebPushNotificationChannelTests.cs
@@ -151,7 +151,7 @@ public sealed class WebPushNotificationChannelTests
         MockHttpMessageHandler handler = new() { ResponseStatusCode = HttpStatusCode.Gone };
         WebPushNotificationChannel channel = BuildChannel(handler);
         NotificationDeliveryContext context = BuildContext();
-        string expiredEndpoint = "https://push.example.com/expired";
+        const string expiredEndpoint = "https://push.example.com/expired";
         SetupSubscriptions(context.RecipientUserId, context.TenantId,
             [BuildSubscription(expiredEndpoint)]);
 
@@ -178,7 +178,7 @@ public sealed class WebPushNotificationChannelTests
             OccurredAt = DateTimeOffset.UtcNow,
             TenantId = tenantId,
         };
-        string expiredEndpoint = "https://push.example.com/expired-tenant";
+        const string expiredEndpoint = "https://push.example.com/expired-tenant";
         SetupSubscriptions(context.RecipientUserId, tenantId,
             [BuildSubscription(expiredEndpoint)]);
 

--- a/tests/Granit.Oidc.TokenManagement.Tests/TokenManagementMetricsTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/TokenManagementMetricsTests.cs
@@ -58,10 +58,7 @@ public sealed class TokenManagementMetricsTests : IDisposable
             }
         };
 
-        collector.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
-        {
-            count += measurement;
-        });
+        collector.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) => count += measurement);
 
         collector.Start();
 

--- a/tests/Granit.OpenIddict.Server.Tests/Extensions/RoleClaimNormalizationRegistrationTests.cs
+++ b/tests/Granit.OpenIddict.Server.Tests/Extensions/RoleClaimNormalizationRegistrationTests.cs
@@ -46,7 +46,7 @@ public sealed class RoleClaimNormalizationRegistrationTests
         HostApplicationBuilder builder = BuildMinimalBuilder();
         builder.AddGranitOpenIddictServer();
 
-        using ServiceProvider provider = builder.Services.BuildServiceProvider();
+        await using ServiceProvider provider = builder.Services.BuildServiceProvider();
         using IServiceScope scope = provider.CreateScope();
 
         RoleClaimNormalizationTransformation transformation = scope.ServiceProvider

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -140,7 +140,7 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
 
         // OIDC protocol handler — OpenIddict validates requests via UseAuthentication(),
         // then passes through to ASP.NET Core for token issuance (client_credentials).
-        _app.MapPost("/connect/token", HandleTokenAsync);
+        _app.MapPost("/connect/token", HandleToken);
 
         _app.MapGranitOpenIddict();
         _app.MapGranitAccount();
@@ -183,7 +183,7 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
     /// builds a ClaimsPrincipal and signs in to issue the access token.
     /// </summary>
 #pragma warning disable GRAPI001 // Test code — SignIn/Forbid have no TypedResults equivalent
-    private static IResult HandleTokenAsync(HttpContext context)
+    private static IResult HandleToken(HttpContext context)
     {
         OpenIddictRequest request = context.GetOpenIddictServerRequest()
             ?? throw new InvalidOperationException("OpenIddict server request not available.");

--- a/tests/Granit.OpenIddict.Tests/Entities/EntityTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Entities/EntityTests.cs
@@ -74,7 +74,7 @@ public sealed class EntityTests
         var tenantId = Guid.NewGuid();
         LocalIdentity user = new() { TenantId = tenantId };
 
-        ((IMultiTenant)user).TenantId.ShouldBe(tenantId);
+        user.TenantId.ShouldBe(tenantId);
     }
 
     [Fact]

--- a/tests/Granit.OpenIddict.Tests/Exports/OpenIddictExportDefinitionTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Exports/OpenIddictExportDefinitionTests.cs
@@ -12,7 +12,7 @@ public sealed class OpenIddictExportDefinitionTests
 
     private static readonly OpenIddictApplicationExportDefinition AppSut = new();
     private static IReadOnlyList<ExportFieldDescriptor> AppFields =>
-        ((IExportDefinitionDescriptor)AppSut).GetFields();
+        AppSut.GetFields();
 
     [Fact]
     public void Application_Name_is_stable() =>
@@ -82,7 +82,7 @@ public sealed class OpenIddictExportDefinitionTests
 
     private static readonly OpenIddictScopeExportDefinition ScopeSut = new();
     private static IReadOnlyList<ExportFieldDescriptor> ScopeFields =>
-        ((IExportDefinitionDescriptor)ScopeSut).GetFields();
+        ScopeSut.GetFields();
 
     [Fact]
     public void Scope_Name_is_stable() =>

--- a/tests/Granit.OpenIddict.Tests/Extensions/ClaimsPrincipalDestinationExtensionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Extensions/ClaimsPrincipalDestinationExtensionsTests.cs
@@ -24,7 +24,7 @@ public sealed class ClaimsPrincipalDestinationExtensionsTests
         provider.GetDestinations(Arg.Any<Claim>(), Arg.Any<ClaimsPrincipal>())
             .Returns([ClaimsDestinations.AccessToken]);
 
-        ClaimsPrincipal result = ClaimsPrincipalDestinationExtensions.SetDestinations(principal, provider);
+        ClaimsPrincipal result = principal.SetDestinations(provider);
 
         result.ShouldBeSameAs(principal);
         provider.Received(2).GetDestinations(Arg.Any<Claim>(), principal);
@@ -59,7 +59,7 @@ public sealed class ClaimsPrincipalDestinationExtensionsTests
         ClaimsPrincipal principal = new(new ClaimsIdentity([], "Test"));
         IClaimsDestinationProvider provider = Substitute.For<IClaimsDestinationProvider>();
 
-        ClaimsPrincipal result = ClaimsPrincipalDestinationExtensions.SetDestinations(principal, provider);
+        ClaimsPrincipal result = principal.SetDestinations(provider);
 
         result.ShouldBeSameAs(principal);
     }
@@ -70,7 +70,7 @@ public sealed class ClaimsPrincipalDestinationExtensionsTests
         ClaimsPrincipal principal = new(new ClaimsIdentity([], "Test"));
         IClaimsDestinationProvider provider = Substitute.For<IClaimsDestinationProvider>();
 
-        Should.NotThrow(() => ClaimsPrincipalDestinationExtensions.SetDestinations(principal, provider));
+        Should.NotThrow(() => principal.SetDestinations(provider));
 
         provider.DidNotReceive().GetDestinations(Arg.Any<Claim>(), Arg.Any<ClaimsPrincipal>());
     }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/AutoTenantProvisionerTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/AutoTenantProvisionerTests.cs
@@ -36,7 +36,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddSingleton<ITenantDbIsolator>(Substitute.For<ITenantDbIsolator>());
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
@@ -50,7 +50,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
     {
         // Arrange
         ServiceCollection services = BuildServicesWithTestContext();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
@@ -72,7 +72,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
         ServiceCollection services = BuildServicesWithTestContext();
         IDataSeeder seeder = Substitute.For<IDataSeeder>();
         services.AddSingleton(seeder);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
@@ -88,7 +88,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
     {
         // Arrange — no IDataSeeder registered
         ServiceCollection services = BuildServicesWithTestContext();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
@@ -111,7 +111,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
                 return Substitute.For<IDisposable>();
             });
         services.AddScoped(_ => currentTenant);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
@@ -134,7 +134,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
 #pragma warning restore CA2012
         services.AddSingleton(schemaProvider);
 
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
@@ -155,7 +155,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
     {
         // Arrange — no ITenantSchemaProvider registered
         ServiceCollection services = BuildServicesWithTestContext();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 

--- a/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationBatchExecutorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationBatchExecutorTests.cs
@@ -95,7 +95,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_AlreadyCompleted_ReturnsNull()
     {
-        string cycleId = "completed-cycle";
+        const string cycleId = "completed-cycle";
         StubDbContext stubContext = CreateStubContext();
         IMigrationCycleRegistry registry = RegistryWith(
             cycleId, typeof(StubDbContext),
@@ -126,7 +126,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_LastBatch_ReturnsNullAndMarksCompleted()
     {
-        string cycleId = "last-batch";
+        const string cycleId = "last-batch";
         StubDbContext stubContext = CreateStubContext();
         DateTimeOffset completedAt = DateTimeOffset.UtcNow;
         _clock.Now.Returns(completedAt);
@@ -157,7 +157,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_MidBatch_ReturnsNextCommand()
     {
-        string cycleId = "mid-batch";
+        const string cycleId = "mid-batch";
         StubDbContext stubContext = CreateStubContext();
         IMigrationCycleRegistry registry = RegistryWith(
             cycleId, typeof(StubDbContext),
@@ -182,7 +182,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_AccumulatesProcessedRows_AcrossBatches()
     {
-        string cycleId = "accumulate";
+        const string cycleId = "accumulate";
         StubDbContext stubContext = CreateStubContext();
         int callCount = 0;
 
@@ -219,7 +219,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_NonEmptyTenantId_CallsIsolator()
     {
-        string cycleId = "tenant-isolation";
+        const string cycleId = "tenant-isolation";
         var tenantId = Guid.NewGuid();
         StubDbContext stubContext = CreateStubContext();
         IMigrationCycleRegistry registry = RegistryWith(
@@ -238,7 +238,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_EmptyTenantId_DoesNotCallIsolator()
     {
-        string cycleId = "no-tenant";
+        const string cycleId = "no-tenant";
         StubDbContext stubContext = CreateStubContext();
         IMigrationCycleRegistry registry = RegistryWith(
             cycleId, typeof(StubDbContext),
@@ -260,7 +260,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_EmptyTenantId_StoresNullTenantIdInProgress()
     {
-        string cycleId = "null-tenant";
+        const string cycleId = "null-tenant";
         StubDbContext stubContext = CreateStubContext();
         IMigrationCycleRegistry registry = RegistryWith(
             cycleId, typeof(StubDbContext),
@@ -284,7 +284,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_BatchThrows_MarksFailedAndRethrows()
     {
-        string cycleId = "failing-batch";
+        const string cycleId = "failing-batch";
         StubDbContext stubContext = CreateStubContext();
         IMigrationCycleRegistry registry = RegistryWith(
             cycleId, typeof(StubDbContext),
@@ -307,7 +307,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_BatchThrowsOperationCanceled_PropagatesWithoutMarkingFailed()
     {
-        string cycleId = "cancel-batch";
+        const string cycleId = "cancel-batch";
         StubDbContext stubContext = CreateStubContext();
         using CancellationTokenSource cts = new();
         await cts.CancelAsync();
@@ -340,7 +340,7 @@ public sealed class MigrationBatchExecutorTests : IDisposable
     [Fact]
     public async Task ExecuteBatchAsync_LongErrorMessage_TruncatesTo4000Chars()
     {
-        string cycleId = "long-error";
+        const string cycleId = "long-error";
         StubDbContext stubContext = CreateStubContext();
         string longMessage = new('x', 5000);
         IMigrationCycleRegistry registry = RegistryWith(

--- a/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationPhaseTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationPhaseTests.cs
@@ -16,7 +16,7 @@ public sealed class MigrationPhaseTests
     [Fact]
     public void Expand_IsDefaultValue()
     {
-        MigrationPhase defaultValue = default;
+        const MigrationPhase defaultValue = default;
 
         defaultValue.ShouldBe(MigrationPhase.Expand);
     }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationStatusTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationStatusTests.cs
@@ -16,7 +16,7 @@ public sealed class MigrationStatusTests
     [Fact]
     public void Pending_IsDefaultValue()
     {
-        MigrationStatus defaultValue = default;
+        const MigrationStatus defaultValue = default;
 
         defaultValue.ShouldBe(MigrationStatus.Pending);
     }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Internal/NpgsqlTenantDbIsolatorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Postgres.Tests/Internal/NpgsqlTenantDbIsolatorTests.cs
@@ -21,7 +21,7 @@ public sealed class NpgsqlTenantDbIsolatorTests
     [Fact]
     public async Task IsolateAsync_resolves_schema_and_activates_it_on_an_opened_connection()
     {
-        using SqliteConnection connection = new("DataSource=:memory:");
+        await using SqliteConnection connection = new("DataSource=:memory:");
         DbContextOptionsBuilder<IsolatorTestDbContext> optionsBuilder = new();
         optionsBuilder.UseSqlite(connection);
         await using var context = new IsolatorTestDbContext(optionsBuilder.Options);

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ConcurrencyStampInterceptorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ConcurrencyStampInterceptorTests.cs
@@ -26,7 +26,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
     public async Task SaveChangesAsync_NewEntity_SetsInitialConcurrencyStamp()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestConcurrencyEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -50,7 +50,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
     public async Task SaveChangesAsync_ModifiedEntity_RegeneratesStamp()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestConcurrencyEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -101,7 +101,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
     public async Task SaveChangesAsync_NonConcurrencyAwareEntity_IsIgnored()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestPlainEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -125,7 +125,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
     {
         // Arrange — create entity via context1
         var entityId = Guid.NewGuid();
-        using TestDbContext context1 = CreateContext();
+        await using TestDbContext context1 = CreateContext();
         TestConcurrencyEntity entity1 = new()
         {
             Id = entityId,
@@ -135,7 +135,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
         await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Load the same entity in context2 (EF tracks OriginalValue automatically)
-        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        await using TestDbContext context2 = CreateContext(ensureCreated: false);
         TestConcurrencyEntity entity2 = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
         entity2.ShouldNotBeNull();
 
@@ -160,7 +160,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
     {
         // Arrange — create entity and capture its initial stamp
         var entityId = Guid.NewGuid();
-        using TestDbContext context1 = CreateContext();
+        await using TestDbContext context1 = CreateContext();
         TestConcurrencyEntity entity = new()
         {
             Id = entityId,
@@ -177,7 +177,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
         entity.ConcurrencyStamp.ShouldNotBe(staleStamp, "stamp must have rotated");
 
         // Simulate a disconnected update: load entity in context2, set stale OriginalValue
-        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        await using TestDbContext context2 = CreateContext(ensureCreated: false);
         TestConcurrencyEntity disconnected = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
 
         // Force the OriginalValue to the stale stamp (simulating a frontend sending an old stamp)
@@ -200,7 +200,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
     {
         // Arrange — create entity, rotate its stamp so the captured one is stale
         var entityId = Guid.NewGuid();
-        using TestDbContext context1 = CreateContext();
+        await using TestDbContext context1 = CreateContext();
         TestConcurrencyEntity entity = new()
         {
             Id = entityId,
@@ -216,7 +216,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
         entity.ConcurrencyStamp.ShouldNotBe(staleStamp, "stamp must have rotated");
 
         // Disconnected update via the helper instead of the raw Entry(...).OriginalValue expression
-        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        await using TestDbContext context2 = CreateContext(ensureCreated: false);
         TestConcurrencyEntity disconnected = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
 
         context2.SetConcurrencyStampOriginalValue(disconnected, staleStamp);
@@ -234,7 +234,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
     {
         // Arrange
         var entityId = Guid.NewGuid();
-        using TestDbContext context1 = CreateContext();
+        await using TestDbContext context1 = CreateContext();
         TestConcurrencyEntity entity = new()
         {
             Id = entityId,
@@ -246,7 +246,7 @@ public sealed class ConcurrencyStampInterceptorTests : IDisposable
         string currentStamp = entity.ConcurrencyStamp;
 
         // Disconnected update carrying the up-to-date stamp
-        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        await using TestDbContext context2 = CreateContext(ensureCreated: false);
         TestConcurrencyEntity disconnected = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
 
         context2.SetConcurrencyStampOriginalValue(disconnected, currentStamp);

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeederTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeederTests.cs
@@ -35,7 +35,7 @@ public sealed class DataSeederTests
     {
         // Arrange
         ServiceCollection services = new();
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
         DataSeedContext context = new();
 
@@ -54,7 +54,7 @@ public sealed class DataSeederTests
         IDataSeedContributor contributor = Substitute.For<IDataSeedContributor>();
         ServiceCollection services = new();
         services.AddTransient(_ => contributor);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
         DataSeedContext context = new();
 
@@ -74,7 +74,7 @@ public sealed class DataSeederTests
         ServiceCollection services = new();
         services.AddTransient(_ => hostContributor);
         services.AddTransient(_ => tenantContributor);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
         DataSeedContext context = new();
 
@@ -99,7 +99,7 @@ public sealed class DataSeederTests
         ServiceCollection services = new();
         services.AddTransient(_ => contributor1);
         services.AddTransient(_ => contributor2);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -126,7 +126,7 @@ public sealed class DataSeederTests
 
         ServiceCollection services = new();
         services.AddTransient(_ => legacy);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -152,7 +152,7 @@ public sealed class DataSeederTests
         ServiceCollection services = new();
         services.AddTransient(_ => failing);
         services.AddTransient(_ => success);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -173,7 +173,7 @@ public sealed class DataSeederTests
 
         ServiceCollection services = new();
         services.AddTransient(_ => contributor);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act & Assert
@@ -202,7 +202,7 @@ public sealed class DataSeederTests
 
         ServiceCollection services = new();
         services.AddTransient(_ => legacy);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -221,7 +221,7 @@ public sealed class DataSeederTests
         ITenantDataSeedContributor contributor = Substitute.For<ITenantDataSeedContributor>();
         ServiceCollection services = new();
         services.AddTransient(_ => contributor);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -251,7 +251,7 @@ public sealed class DataSeederTests
         services.AddTransient(_ => contributor);
         services.AddSingleton(tenantProvider);
         services.AddScoped(_ => currentTenant);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -290,7 +290,7 @@ public sealed class DataSeederTests
         services.AddTransient(_ => contributor);
         services.AddSingleton(tenantProvider);
         services.AddScoped(_ => currentTenant);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -314,7 +314,7 @@ public sealed class DataSeederTests
         ServiceCollection services = new();
         services.AddTransient(_ => failing);
         services.AddTransient(_ => success);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
@@ -335,7 +335,7 @@ public sealed class DataSeederTests
 
         ServiceCollection services = new();
         services.AddTransient(_ => contributor);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act & Assert
@@ -371,7 +371,7 @@ public sealed class DataSeederTests
         services.AddTransient(_ => contributor);
         services.AddSingleton(tenantProvider);
         services.AddScoped(_ => currentTenant);
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         DataSeedContext context = new();

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
@@ -639,7 +639,7 @@ public sealed class ModelBuilderExtensionsTests
     [Fact]
     public async Task ApplyGranitConventions_Mergeable_FiltersTombstonedEntities()
     {
-        using TestDbContextWithMergeable context = CreateMergeableContext();
+        await using TestDbContextWithMergeable context = CreateMergeableContext();
 
         var alive = new TestMergeableEntity { Name = "alive" };
         var tombstoned = new TestMergeableEntity

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/SharedDatabaseDbContextFactoryTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/SharedDatabaseDbContextFactoryTests.cs
@@ -38,7 +38,7 @@ public sealed class SharedDatabaseDbContextFactoryTests
     public async Task CreateDbContextAsync_ReturnsNonNullContext()
     {
         ServiceCollection services = [];
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
 
         SharedDatabaseDbContextOptions<StubSharedDbContext> opts = new()
         {

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantIsolationStrategyTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantIsolationStrategyTests.cs
@@ -17,7 +17,7 @@ public sealed class TenantIsolationStrategyTests
     [Fact]
     public void SharedDatabase_IsDefaultValue()
     {
-        TenantIsolationStrategy defaultValue = default;
+        const TenantIsolationStrategy defaultValue = default;
 
         defaultValue.ShouldBe(TenantIsolationStrategy.SharedDatabase);
     }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/TenantQueryScopeTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/TenantQueryScopeTests.cs
@@ -75,7 +75,7 @@ public sealed class TenantQueryScopeTests
         // The core VULN-001 guard: an unsignaled tenant-context loss must NOT widen the query to
         // every tenant. Pre-fix, each IQueryableSource called IgnoreQueryFilters and leaked all rows.
         (ITenantQueryScope scope, _, ServiceProvider sp) = BuildScope(tenantAvailable: false);
-        using ServiceProvider provider = sp;
+        await using ServiceProvider provider = sp;
         var foreignTenant = Guid.NewGuid();
         FilteredTenantDbContextFactory factory = new();
         await SeedAsync(factory, ("host-row", null), ("tenant-row", foreignTenant));
@@ -93,7 +93,7 @@ public sealed class TenantQueryScopeTests
     public async Task Restrict_HostSignalled_BypassesFilter_ReturnsAllTenants()
     {
         (ITenantQueryScope scope, _, ServiceProvider sp) = BuildScope(tenantAvailable: false, hostAccess: true);
-        using ServiceProvider provider = sp;
+        await using ServiceProvider provider = sp;
         var foreignTenant = Guid.NewGuid();
         FilteredTenantDbContextFactory factory = new();
         await SeedAsync(factory, ("host-row", null), ("tenant-row", foreignTenant));

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslatableQueryExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslatableQueryExtensionsTests.cs
@@ -29,7 +29,7 @@ public sealed class TranslatableQueryExtensionsTests
             .ToListAsync(TestContext.Current.CancellationToken);
 
         results.Count.ShouldBe(2);
-        results.SelectMany(d => d.Translations).Count().ShouldBe(4,
+        results.Sum(d => d.Translations.Count).ShouldBe(4,
             "all translations for all documents must be loaded");
     }
 

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/VersioningInterceptorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/VersioningInterceptorTests.cs
@@ -33,7 +33,7 @@ public sealed class VersioningInterceptorTests
     public async Task SaveChanges_WhenVersionIdIsEmpty_ShouldAssignNewVersionId()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -53,7 +53,7 @@ public sealed class VersioningInterceptorTests
     {
         // Arrange
         var existingVersionId = Guid.NewGuid();
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -77,7 +77,7 @@ public sealed class VersioningInterceptorTests
     public async Task SaveChanges_FirstVersion_ShouldSetVersionTo1()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -97,7 +97,7 @@ public sealed class VersioningInterceptorTests
     {
         // Arrange
         var businessId = Guid.NewGuid();
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
 
         // Add first version
         TestVersionedEntity v1 = new()
@@ -131,7 +131,7 @@ public sealed class VersioningInterceptorTests
     {
         // Arrange — two entities added in the same SaveChanges batch
         var businessId = Guid.NewGuid();
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
 
         TestVersionedEntity v1 = new()
         {
@@ -165,7 +165,7 @@ public sealed class VersioningInterceptorTests
     public async Task SaveChanges_WhenModified_ShouldNotChangeVersion()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -192,7 +192,7 @@ public sealed class VersioningInterceptorTests
     public async Task SaveChanges_NonVersionedEntity_ShouldBeIgnored()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestPlainEntity entity = new()
         {
             Id = Guid.NewGuid(),

--- a/tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceScopeValidationTests.cs
+++ b/tests/Granit.Presence.EntityFrameworkCore.Tests/PresenceScopeValidationTests.cs
@@ -32,7 +32,7 @@ public sealed class PresenceScopeValidationTests
 
         storeDescriptor.Lifetime.ShouldBe(
             ServiceLifetime.Scoped,
-            $"IPresenceStore must be Scoped because EfPresenceStore consumes the Scoped " +
+            "IPresenceStore must be Scoped because EfPresenceStore consumes the Scoped " +
             $"IDbContextFactory<PresenceDbContext>. Got {storeDescriptor.Lifetime}.");
 
         ServiceDescriptor concreteDescriptor = builder.Services

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/BlobBackedPrivacyExportDownloadResolverTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/BlobBackedPrivacyExportDownloadResolverTests.cs
@@ -159,7 +159,7 @@ public sealed class BlobBackedPrivacyExportDownloadResolverTests : IDisposable
             id: ManifestBlobId,
             tenantId: null,
             containerName: "gdpr-exports",
-            objectKey: $"personal-data-export/abc-manifest.json",
+            objectKey: "personal-data-export/abc-manifest.json",
             request: new BlobUploadRequest(
                 FileName: $"personal-data-export-{RequestId}-manifest.json",
                 ContentType: "application/json",

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/CountingStreamTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/CountingStreamTests.cs
@@ -37,7 +37,7 @@ public sealed class CountingStreamTests
     [Fact]
     public async Task WriteAsync_ExceedingLimit_ThrowsSizeLimitExceededException()
     {
-        using MemoryStream inner = new();
+        await using MemoryStream inner = new();
         await using CountingStream sut = new(inner, maxBytes: 4);
 
         await sut.WriteAsync(new byte[] { 1, 2, 3 }, TestContext.Current.CancellationToken);

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/Sha256ComputingStreamTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/Sha256ComputingStreamTests.cs
@@ -13,7 +13,7 @@ public sealed class Sha256ComputingStreamTests
         byte[] payload = [.. Enumerable.Range(0, 1024).Select(i => (byte)(i % 256))];
         byte[] expected = SHA256.HashData(payload);
 
-        using MemoryStream inner = new();
+        await using MemoryStream inner = new();
         await using (Sha256ComputingStream sut = new(inner, leaveOpen: true))
         {
             // Write in three uneven chunks to exercise the memory + span + offset overloads.
@@ -33,7 +33,7 @@ public sealed class Sha256ComputingStreamTests
     {
         byte[] expected = SHA256.HashData([0xAB]);
 
-        using MemoryStream inner = new();
+        await using MemoryStream inner = new();
         await using Sha256ComputingStream sut = new(inner, leaveOpen: true);
         sut.WriteByte(0xAB);
 

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
@@ -88,8 +88,8 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         byte[] shardBytes = _blobStoreProvider.SavedBlobs.First(kvp => kvp.Key.EndsWith(".zip", StringComparison.Ordinal)).Value;
 
         // Shard contains the two fragments at their declared entry paths.
-        using MemoryStream zipStream = new(shardBytes);
-        using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
+        await using MemoryStream zipStream = new(shardBytes);
+        await using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
         zip.Entries.Select(e => e.FullName).ShouldBe(["identity.json", "audit.json"], ignoreOrder: true);
 
         await _tracker.Received(1).MarkCompletedAsync(
@@ -319,8 +319,8 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         // Exactly one shard with the non-empty fragment.
         byte[] shardBytes = _blobStoreProvider.SavedBlobs.First(kvp => kvp.Key.EndsWith(".zip", StringComparison.Ordinal)).Value;
-        using MemoryStream zipStream = new(shardBytes);
-        using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
+        await using MemoryStream zipStream = new(shardBytes);
+        await using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
         zip.Entries.Select(e => e.FullName).ShouldBe(["identity.json"]);
 
         // Empty provider name surfaces in the manifest blob upload's payload — best
@@ -463,8 +463,8 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         // The new shard contains only the third fragment.
         byte[] shardBytes = _blobStoreProvider.SavedBlobs[$"personal-data-export/{requestId}-001.zip"];
-        using MemoryStream zipStream = new(shardBytes);
-        using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
+        await using MemoryStream zipStream = new(shardBytes);
+        await using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
         zip.Entries.Select(e => e.FullName).ShouldBe(["p2.json"]);
 
         // Fragments 0 and 1 were re-fetched only for descriptor lookup, NOT for
@@ -601,7 +601,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         public async Task SaveAsync(string bucket, string objectKey, Stream content, string contentType, CancellationToken cancellationToken)
         {
-            using MemoryStream ms = new();
+            await using MemoryStream ms = new();
             await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
             SavedBlobs[objectKey] = ms.ToArray();
         }

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/ShardingArchiveWriterTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/ShardingArchiveWriterTests.cs
@@ -33,13 +33,13 @@ public sealed class ShardingArchiveWriterTests
         provider.SavedBlobs.Count.ShouldBe(1);
         byte[] zipBytes = provider.SavedBlobs[$"{KeyPrefix}-000.zip"];
 
-        using MemoryStream zipStream = new(zipBytes);
-        using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
+        await using MemoryStream zipStream = new(zipBytes);
+        await using ZipArchive zip = new(zipStream, ZipArchiveMode.Read);
         zip.Entries.Count.ShouldBe(1);
         zip.Entries[0].FullName.ShouldBe("identity-local.json");
 
-        using Stream entry = zip.Entries[0].Open();
-        using MemoryStream copied = new();
+        await using Stream entry = zip.Entries[0].Open();
+        await using MemoryStream copied = new();
         entry.CopyTo(copied);
         copied.ToArray().ShouldBe(payload);
     }
@@ -192,7 +192,7 @@ public sealed class ShardingArchiveWriterTests
 
         public async Task SaveAsync(string bucket, string objectKey, Stream content, string contentType, CancellationToken cancellationToken)
         {
-            using MemoryStream ms = new();
+            await using MemoryStream ms = new();
             await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
             SavedBlobs[objectKey] = ms.ToArray();
         }

--- a/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
@@ -310,8 +310,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         await context.Received(1).PublishAsync(
             Arg.Any<ExportTimedOutEvent>(),
             Arg.Is<DeliveryOptions>(o =>
-                o.ScheduleDelay.HasValue &&
-                o.ScheduleDelay.Value == TimeSpan.FromMinutes(10)));
+                o.ScheduleDelay == TimeSpan.FromMinutes(10)));
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
+++ b/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
@@ -105,10 +105,7 @@ public sealed class PrivacySagaWolverineCodegenTests
                 services.AddSingleton<PrivacyMetrics>();
                 services.Configure<GranitPrivacyOptions>(_ => { });
             })
-            .UseWolverine(opts =>
-            {
-                opts.ApplicationAssembly = typeof(PersonalDataExportSaga).Assembly;
-            })
+            .UseWolverine(opts => opts.ApplicationAssembly = typeof(PersonalDataExportSaga).Assembly)
             .StartAsync();
 
     private static SagaChain GetSagaChain(IHost host, Type messageType)

--- a/tests/Granit.Privacy.Tests/PrivacyServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Privacy.Tests/PrivacyServiceCollectionExtensionsTests.cs
@@ -79,10 +79,7 @@ public sealed class PrivacyServiceCollectionExtensionsTests
     public void AddGranitPrivacy_WithoutLegalAgreementStore_DoesNotRegisterChecker()
     {
         ServiceCollection services = new();
-        services.AddGranitPrivacy(privacy =>
-        {
-            privacy.RegisterDocument("privacy-policy", "1.0.0", "Privacy Policy");
-        });
+        services.AddGranitPrivacy(privacy => privacy.RegisterDocument("privacy-policy", "1.0.0", "Privacy Policy"));
 
         ServiceProvider provider = services.BuildServiceProvider();
 

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointOpenApiSchemaTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointOpenApiSchemaTests.cs
@@ -134,7 +134,7 @@ public sealed class QueryEndpointOpenApiSchemaTests
                     if (prop.NameEquals("$ref") && prop.Value.ValueKind == JsonValueKind.String)
                     {
                         string? value = prop.Value.GetString();
-                        if (value is not null && value.StartsWith("#/components/schemas/", StringComparison.Ordinal))
+                        if (value?.StartsWith("#/components/schemas/", StringComparison.Ordinal) == true)
                         {
                             string id = value["#/components/schemas/".Length..];
                             if (!declared.Contains(id) && !orphans.Contains(id))

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
@@ -74,7 +74,7 @@ public sealed class NestedComplexColumnTests : IDisposable
 
         // Brussels, Ghent, New York contain 'e' (case-sensitive LIKE on SQLite collation-dependent —
         // seed values chosen so the ASCII 'e' is unambiguous).
-        result.Items.Select(a => a.Value.City).OrderBy(c => c)
+        result.Items.Select(a => a.Value.City).Order()
             .ShouldBe(["Brussels", "Ghent", "New York"]);
     }
 

--- a/tests/Granit.RateLimiting.Tests/RateLimitingMetricsTests.cs
+++ b/tests/Granit.RateLimiting.Tests/RateLimitingMetricsTests.cs
@@ -60,10 +60,7 @@ public sealed class RateLimitingMetricsTests : IDisposable
             }
         };
 
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
-        {
-            count += measurement;
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) => count += measurement);
 
         listener.Start();
 
@@ -96,10 +93,7 @@ public sealed class RateLimitingMetricsTests : IDisposable
             }
         };
 
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
-        {
-            count += measurement;
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) => count += measurement);
 
         listener.Start();
 

--- a/tests/Granit.RateLimiting.Tests/RateLimitingServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.RateLimiting.Tests/RateLimitingServiceCollectionExtensionsTests.cs
@@ -100,10 +100,7 @@ public sealed class RateLimitingServiceCollectionExtensionsTests
         ServiceCollection services = CreateServices();
         services.AddLogging();
 
-        services.AddGranitRateLimiting(opts =>
-        {
-            opts.KeyPrefix = "test";
-        });
+        services.AddGranitRateLimiting(opts => opts.KeyPrefix = "test");
 
         ServiceProvider sp = services.BuildServiceProvider();
 
@@ -124,10 +121,7 @@ public sealed class RateLimitingServiceCollectionExtensionsTests
         services.AddSingleton(NSubstitute.Substitute.For<Granit.MultiTenancy.ICurrentTenant>());
         services.AddSingleton(NSubstitute.Substitute.For<Granit.Users.ICurrentUserService>());
 
-        services.AddGranitRateLimiting(opts =>
-        {
-            opts.KeyPrefix = "test";
-        });
+        services.AddGranitRateLimiting(opts => opts.KeyPrefix = "test");
 
         ServiceProvider sp = services.BuildServiceProvider();
 

--- a/tests/Granit.Scheduling.Tests/Exports/ScheduledActionExportDefinitionTests.cs
+++ b/tests/Granit.Scheduling.Tests/Exports/ScheduledActionExportDefinitionTests.cs
@@ -9,7 +9,7 @@ public sealed class ScheduledActionExportDefinitionTests
 {
     private static readonly ScheduledActionExportDefinition Sut = new();
     private static IReadOnlyList<ExportFieldDescriptor> Fields =>
-        ((IExportDefinitionDescriptor)Sut).GetFields();
+        Sut.GetFields();
 
     [Fact]
     public void Name_is_stable() =>

--- a/tests/Granit.Settings.EntityFrameworkCore.Tests/EfCoreSettingStoreTests.cs
+++ b/tests/Granit.Settings.EntityFrameworkCore.Tests/EfCoreSettingStoreTests.cs
@@ -203,7 +203,7 @@ public sealed class EfCoreSettingStoreTests
         IReadOnlyList<SettingValue> all = await store.GetListAsync(
             "G", null, TestContext.Current.CancellationToken);
 
-        all.Where(v => v.Name == "App.Theme").Count().ShouldBe(1,
+        all.Count(v => v.Name == "App.Theme").ShouldBe(1,
             "upsert must not create duplicate records");
     }
 

--- a/tests/Granit.Settings.Tests/GranitSettingsModuleTests.cs
+++ b/tests/Granit.Settings.Tests/GranitSettingsModuleTests.cs
@@ -156,7 +156,7 @@ public sealed class GranitSettingsModuleTests
     [Fact]
     public async Task SetGlobal_Then_GetOrNull_Returns_StoredValue()
     {
-        using WebApplication app = BuildApp();
+        await using WebApplication app = BuildApp();
         using IServiceScope scope = app.Services.CreateScope();
 
         // Déclarer le paramètre via un provider enregistré dans le DI

--- a/tests/Granit.Settings.Tests/SettingDefinitionRegistryTests.cs
+++ b/tests/Granit.Settings.Tests/SettingDefinitionRegistryTests.cs
@@ -97,10 +97,7 @@ public sealed class SettingDefinitionRegistryTests
 
         // On utilise un provider qui consulte le contexte pendant Define()
         SettingDefinitionRegistry manager = new([
-            new InspectingProvider(added, ctx =>
-            {
-                capturedFromContext = ctx.GetOrNull("App.Theme");
-            })
+            new InspectingProvider(added, ctx => capturedFromContext = ctx.GetOrNull("App.Theme"))
         ]);
 
         capturedFromContext.ShouldBeSameAs(added,

--- a/tests/Granit.Templating.AI.Tests/LlmTemplateAssistantTests.cs
+++ b/tests/Granit.Templating.AI.Tests/LlmTemplateAssistantTests.cs
@@ -113,9 +113,9 @@ public sealed class LlmTemplateAssistantTests
         // Verify the prompt sent to the LLM contains property names from the data type
         await _chatClient.Received(1).GetResponseAsync(
             Arg.Is<IEnumerable<ChatMessage>>(msgs =>
-                string.Join("", msgs.Select(m => m.Text)).Contains("Supplier") &&
-                string.Join("", msgs.Select(m => m.Text)).Contains("Amount") &&
-                string.Join("", msgs.Select(m => m.Text)).Contains("InvoiceDate")),
+                string.Concat(msgs.Select(m => m.Text)).Contains("Supplier") &&
+                string.Concat(msgs.Select(m => m.Text)).Contains("Amount") &&
+                string.Concat(msgs.Select(m => m.Text)).Contains("InvoiceDate")),
             Arg.Any<ChatOptions?>(),
             Arg.Any<CancellationToken>());
     }

--- a/tests/Granit.Templating.Endpoints.Tests/Dtos/TemplatingDtoTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/Dtos/TemplatingDtoTests.cs
@@ -13,7 +13,7 @@ public sealed class TemplatingDtoTests
     [Fact]
     public void SaveTemplateRequest_DefaultMimeType_IsTextHtml()
     {
-        SaveTemplateRequest request = new(Name: "Test.Template", Culture: null, Content: "<p>Hello</p>");
+        SaveTemplateRequest request = new(Content: "<p>Hello</p>", Name: "Test.Template", Culture: null);
 
         request.MimeType.ShouldBe("text/html");
     }
@@ -21,7 +21,7 @@ public sealed class TemplatingDtoTests
     [Fact]
     public void SaveTemplateRequest_AllProperties_SetCorrectly()
     {
-        SaveTemplateRequest request = new(Name: "Billing.Invoice", Culture: "fr-BE", Content: "<p>Facture</p>", MimeType: "text/plain");
+        SaveTemplateRequest request = new(Content: "<p>Facture</p>", Name: "Billing.Invoice", Culture: "fr-BE", MimeType: "text/plain");
 
         request.Name.ShouldBe("Billing.Invoice");
         request.Culture.ShouldBe("fr-BE");

--- a/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
@@ -257,7 +257,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await client.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: null, Content: "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Hello</h1>", Name: "Billing.Invoice", Culture: null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotImplemented);
@@ -284,7 +284,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: "fr", Content: "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Hello</h1>", Name: "Billing.Invoice", Culture: "fr"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
@@ -309,7 +309,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest(Name: null, Culture: null, Content: "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Hello</h1>", Name: null, Culture: null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -320,7 +320,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest(Name: "invalid", Culture: null, Content: "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Hello</h1>", Name: "invalid", Culture: null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
@@ -331,7 +331,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: null, Content: ""),
+            new SaveTemplateRequest(Content: "", Name: "Billing.Invoice", Culture: null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
@@ -349,7 +349,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await client.PutAsJsonAsync(
             $"{Prefix}/Billing.Invoice",
-            new SaveTemplateRequest(Name: null, Culture: null, Content: "<h1>Updated</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Updated</h1>", Name: null, Culture: null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotImplemented);
@@ -376,7 +376,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
 
         HttpResponseMessage response = await _adminClient.PutAsJsonAsync(
             $"{Prefix}/Billing.Invoice",
-            new SaveTemplateRequest(Name: null, Culture: "fr", Content: "<h1>Updated</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Updated</h1>", Name: null, Culture: "fr"),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -401,7 +401,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _adminClient.PutAsJsonAsync(
             $"{Prefix}/bad",
-            new SaveTemplateRequest(Name: null, Culture: null, Content: "<h1>Updated</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Updated</h1>", Name: null, Culture: null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -953,7 +953,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         HttpResponseMessage response = await _anonClient.PostAsJsonAsync(
             Prefix,
-            new SaveTemplateRequest(Name: "Billing.Invoice", Culture: null, Content: "<h1>Hello</h1>"),
+            new SaveTemplateRequest(Content: "<h1>Hello</h1>", Name: "Billing.Invoice", Culture: null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -997,10 +997,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(CreateTestUserService());
 
         await using WebApplication app = builder.Build();
-        app.MapGranitTemplating(opts =>
-        {
-            opts.RoutePrefix = "custom-templates";
-        });
+        app.MapGranitTemplating(opts => opts.RoutePrefix = "custom-templates");
         await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = BuildClient(app, AllPermissions);

--- a/tests/Granit.Templating.Mjml.Tests/MjmlTransformerTests.cs
+++ b/tests/Granit.Templating.Mjml.Tests/MjmlTransformerTests.cs
@@ -30,7 +30,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task PlainHtml_PassesThrough()
     {
-        string html = "<p>Hello world</p>";
+        const string html = "<p>Hello world</p>";
 
         string result = await _sut.TransformAsync(html, DocumentFormat.Html, CancellationToken);
 
@@ -40,7 +40,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task PlainHtml_WithWhitespace_PassesThrough()
     {
-        string html = "  \n  <html><body><p>Hello</p></body></html>";
+        const string html = "  \n  <html><body><p>Hello</p></body></html>";
 
         string result = await _sut.TransformAsync(html, DocumentFormat.Html, CancellationToken);
 
@@ -50,7 +50,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task Mjml_ProducesTableBasedHtml()
     {
-        string mjml = """
+        const string mjml = """
             <mjml>
               <mj-body>
                 <mj-section>
@@ -74,7 +74,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task Mjml_ProducesInlineCss()
     {
-        string mjml = """
+        const string mjml = """
             <mjml>
               <mj-body>
                 <mj-section background-color="#ff0000">
@@ -95,7 +95,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task Mjml_ProducesMsoConditionals()
     {
-        string mjml = """
+        const string mjml = """
             <mjml>
               <mj-body>
                 <mj-section>
@@ -115,7 +115,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task Mjml_PreservesScribanVariables()
     {
-        string mjml = """
+        const string mjml = """
             <mjml>
               <mj-body>
                 <mj-section>
@@ -135,7 +135,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task Mjml_WithButton_ProducesAccessibleLink()
     {
-        string mjml = """
+        const string mjml = """
             <mjml>
               <mj-body>
                 <mj-section>
@@ -156,7 +156,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task Mjml_WithTable_RendersRows()
     {
-        string mjml = """
+        const string mjml = """
             <mjml>
               <mj-body>
                 <mj-section>
@@ -181,7 +181,7 @@ public sealed class MjmlTransformerTests
     [Fact]
     public async Task Mjml_CaseInsensitive_DetectsMjmlTag()
     {
-        string mjml = """
+        const string mjml = """
             <MJML>
               <mj-body>
                 <mj-section>

--- a/tests/Granit.Testing.EntityFrameworkCore.Tests/InMemoryDbContextFactoryAdditionalTests.cs
+++ b/tests/Granit.Testing.EntityFrameworkCore.Tests/InMemoryDbContextFactoryAdditionalTests.cs
@@ -47,7 +47,7 @@ public sealed class InMemoryDbContextFactoryAdditionalTests
 
         InMemoryDbContextFactory<TestDbContext> factory = new(guidGenerator: guidGenerator);
 
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
         TestAuditedEntity entity = new() { Name = "GuidTest" };
         context.AuditedEntities.Add(entity);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -64,7 +64,7 @@ public sealed class InMemoryDbContextFactoryAdditionalTests
 
         InMemoryDbContextFactory<TestDbContext> factory = new(tenant: tenant);
 
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
         context.ShouldNotBeNull();
 
         // Verify we can still add entities (proves the context is functional)
@@ -91,11 +91,11 @@ public sealed class InMemoryDbContextFactoryAdditionalTests
         InMemoryDbContextFactory<TestDbContext> factory1 = new();
         InMemoryDbContextFactory<TestDbContext> factory2 = new();
 
-        using TestDbContext ctx1 = factory1.CreateContext();
+        await using TestDbContext ctx1 = factory1.CreateContext();
         ctx1.AuditedEntities.Add(new TestAuditedEntity { Name = "Factory1" });
         await ctx1.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        using TestDbContext ctx2 = factory2.CreateContext();
+        await using TestDbContext ctx2 = factory2.CreateContext();
         int count = await ctx2.AuditedEntities.CountAsync(TestContext.Current.CancellationToken);
 
         count.ShouldBe(0); // different database

--- a/tests/Granit.Testing.EntityFrameworkCore.Tests/InMemoryDbContextFactoryTests.cs
+++ b/tests/Granit.Testing.EntityFrameworkCore.Tests/InMemoryDbContextFactoryTests.cs
@@ -23,9 +23,9 @@ public sealed class InMemoryDbContextFactoryTests
     {
         FakeClock clock = new();
         FakeCurrentUser user = new();
-        InMemoryDbContextFactory<TestDbContext> factory = new(clock: clock, user: user);
+        InMemoryDbContextFactory<TestDbContext> factory = new(user: user, clock: clock);
 
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
         TestAuditedEntity entity = new() { Name = "Test" };
         context.AuditedEntities.Add(entity);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -40,9 +40,9 @@ public sealed class InMemoryDbContextFactoryTests
     {
         FakeClock clock = new();
         FakeCurrentUser user = new();
-        InMemoryDbContextFactory<TestDbContext> factory = new(clock: clock, user: user);
+        InMemoryDbContextFactory<TestDbContext> factory = new(user: user, clock: clock);
 
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
         TestFullAuditedEntity entity = new() { Name = "ToDelete" };
         context.FullAuditedEntities.Add(entity);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -60,11 +60,11 @@ public sealed class InMemoryDbContextFactoryTests
     {
         InMemoryDbContextFactory<TestDbContext> factory = new();
 
-        using TestDbContext ctx1 = factory.CreateContext();
+        await using TestDbContext ctx1 = factory.CreateContext();
         ctx1.AuditedEntities.Add(new TestAuditedEntity { Name = "Shared" });
         await ctx1.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        using TestDbContext ctx2 = factory.CreateContext();
+        await using TestDbContext ctx2 = factory.CreateContext();
         (await ctx2.AuditedEntities.CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
     }
 }

--- a/tests/Granit.Testing.EntityFrameworkCore.Tests/SqliteDbContextFactoryAdditionalTests.cs
+++ b/tests/Granit.Testing.EntityFrameworkCore.Tests/SqliteDbContextFactoryAdditionalTests.cs
@@ -58,7 +58,7 @@ public sealed class SqliteDbContextFactoryAdditionalTests
         clock.Now = customTime;
 
         using SqliteDbContextFactory<TestDbContext> factory = new(clock: clock);
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
 
         TestAuditedEntity entity = new() { Name = "ClockTest" };
         context.AuditedEntities.Add(entity);
@@ -74,7 +74,7 @@ public sealed class SqliteDbContextFactoryAdditionalTests
         user.UserId = "custom-user-id";
 
         using SqliteDbContextFactory<TestDbContext> factory = new(user: user);
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
 
         TestAuditedEntity entity = new() { Name = "UserTest" };
         context.AuditedEntities.Add(entity);
@@ -99,7 +99,7 @@ public sealed class SqliteDbContextFactoryAdditionalTests
         FakeGuidGenerator guidGenerator = new(expectedId);
 
         using SqliteDbContextFactory<TestDbContext> factory = new(guidGenerator: guidGenerator);
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
 
         TestAuditedEntity entity = new() { Name = "GuidTest" };
         context.AuditedEntities.Add(entity);

--- a/tests/Granit.Testing.EntityFrameworkCore.Tests/SqliteDbContextFactoryTests.cs
+++ b/tests/Granit.Testing.EntityFrameworkCore.Tests/SqliteDbContextFactoryTests.cs
@@ -24,7 +24,7 @@ public sealed class SqliteDbContextFactoryTests : IDisposable
     [Fact]
     public async Task Schema_Is_Created_By_Default()
     {
-        using TestDbContext context = _factory.CreateContext();
+        await using TestDbContext context = _factory.CreateContext();
 
         (await context.AuditedEntities.CountAsync(TestContext.Current.CancellationToken)).ShouldBe(0);
     }
@@ -34,9 +34,9 @@ public sealed class SqliteDbContextFactoryTests : IDisposable
     {
         FakeClock clock = new();
         FakeCurrentUser user = new();
-        using SqliteDbContextFactory<TestDbContext> factory = new(clock: clock, user: user);
+        using SqliteDbContextFactory<TestDbContext> factory = new(user: user, clock: clock);
 
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
         TestAuditedEntity entity = new() { Name = "SqliteTest" };
         context.AuditedEntities.Add(entity);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -51,9 +51,9 @@ public sealed class SqliteDbContextFactoryTests : IDisposable
     {
         FakeClock clock = new();
         FakeCurrentUser user = new();
-        using SqliteDbContextFactory<TestDbContext> factory = new(clock: clock, user: user);
+        using SqliteDbContextFactory<TestDbContext> factory = new(user: user, clock: clock);
 
-        using TestDbContext context = factory.CreateContext();
+        await using TestDbContext context = factory.CreateContext();
         TestFullAuditedEntity entity = new() { Name = "ToDelete" };
         context.FullAuditedEntities.Add(entity);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -69,11 +69,11 @@ public sealed class SqliteDbContextFactoryTests : IDisposable
     [Fact]
     public async Task Contexts_Share_Same_Database()
     {
-        using TestDbContext ctx1 = _factory.CreateContext();
+        await using TestDbContext ctx1 = _factory.CreateContext();
         ctx1.AuditedEntities.Add(new TestAuditedEntity { Name = "Shared" });
         await ctx1.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        using TestDbContext ctx2 = _factory.CreateContext(ensureCreated: false);
+        await using TestDbContext ctx2 = _factory.CreateContext(ensureCreated: false);
         (await ctx2.AuditedEntities.CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
     }
 

--- a/tests/Granit.Testing.EntityFrameworkCore.Tests/TestDbContextServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Testing.EntityFrameworkCore.Tests/TestDbContextServiceCollectionExtensionsTests.cs
@@ -52,7 +52,7 @@ public sealed class TestDbContextServiceCollectionExtensionsTests
         services.AddGranitTestDbContext<TestDbContext>();
 
         ServiceProvider provider = services.BuildServiceProvider();
-        using TestDbContext context = provider.GetRequiredService<TestDbContext>();
+        await using TestDbContext context = provider.GetRequiredService<TestDbContext>();
 
         TestAuditedEntity entity = new() { Name = "ExtensionTest" };
         context.AuditedEntities.Add(entity);

--- a/tests/Granit.Tests/Exceptions/BusinessExceptionTests.cs
+++ b/tests/Granit.Tests/Exceptions/BusinessExceptionTests.cs
@@ -63,7 +63,7 @@ public sealed class BusinessExceptionTests
         BusinessException exception = new("Vault:CredentialsFailed");
 
         exception.ShouldBeAssignableTo<IHasErrorCode>();
-        ((IHasErrorCode)exception).ErrorCode.ShouldBe("Vault:CredentialsFailed");
+        exception.ErrorCode.ShouldBe("Vault:CredentialsFailed");
     }
 
     [Fact]

--- a/tests/Granit.Tests/Exceptions/BusinessRuleViolationExceptionTests.cs
+++ b/tests/Granit.Tests/Exceptions/BusinessRuleViolationExceptionTests.cs
@@ -84,7 +84,7 @@ public sealed class BusinessRuleViolationExceptionTests
         BusinessRuleViolationException exception = new("Appointment:SlotUnavailable");
 
         exception.ShouldBeAssignableTo<IHasErrorCode>();
-        ((IHasErrorCode)exception).ErrorCode.ShouldBe("Appointment:SlotUnavailable");
+        exception.ErrorCode.ShouldBe("Appointment:SlotUnavailable");
     }
 
     [Fact]

--- a/tests/Granit.Tests/Json/SingleValueObjectJsonConverterFactoryTests.cs
+++ b/tests/Granit.Tests/Json/SingleValueObjectJsonConverterFactoryTests.cs
@@ -94,7 +94,7 @@ public sealed class SingleValueObjectJsonConverterFactoryTests
     public void Deserialize_ContentType_ReadsFromRawString()
     {
         JsonSerializerOptions options = CreateOptions();
-        string json = "\"text/html\"";
+        const string json = "\"text/html\"";
 
         ContentType? result = JsonSerializer.Deserialize<ContentType>(json, options);
 
@@ -106,7 +106,7 @@ public sealed class SingleValueObjectJsonConverterFactoryTests
     public void Deserialize_FileName_ReadsFromRawString()
     {
         JsonSerializerOptions options = CreateOptions();
-        string json = "\"image.png\"";
+        const string json = "\"image.png\"";
 
         FileName? result = JsonSerializer.Deserialize<FileName>(json, options);
 
@@ -118,7 +118,7 @@ public sealed class SingleValueObjectJsonConverterFactoryTests
     public void Deserialize_Null_ReturnsNull()
     {
         JsonSerializerOptions options = CreateOptions();
-        string json = "null";
+        const string json = "null";
 
         ContentType? result = JsonSerializer.Deserialize<ContentType>(json, options);
 

--- a/tests/Granit.Tests/ModuleLoaderTests.cs
+++ b/tests/Granit.Tests/ModuleLoaderTests.cs
@@ -94,7 +94,7 @@ public sealed class ModuleLoaderTests
         modules.Count.ShouldBe(4);
 
         // Shared must appear exactly once
-        modules.Where(m => m.ModuleType == typeof(SharedModule)).Count().ShouldBe(1);
+        modules.Count(m => m.ModuleType == typeof(SharedModule)).ShouldBe(1);
 
         // Shared must come before Left and Right
         var types = modules.Select(m => m.ModuleType).ToList();
@@ -128,7 +128,7 @@ public sealed class ModuleLoaderTests
         IReadOnlyList<ModuleDescriptor> modules = ModuleLoader.LoadModules<DuplicateDepsModule>();
 
         modules.Count.ShouldBe(2);
-        modules.Where(m => m.ModuleType == typeof(StandaloneModule)).Count().ShouldBe(1);
+        modules.Count(m => m.ModuleType == typeof(StandaloneModule)).ShouldBe(1);
     }
 
     [Fact]

--- a/tests/Granit.TextExtraction.Email.Tests/EmailTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Email.Tests/EmailTextExtractorTests.cs
@@ -34,7 +34,7 @@ public sealed class EmailTextExtractorTests
     public async Task Extracts_envelope_and_plain_body_from_text_only_message()
     {
         byte[] eml = EmlFixtures.PlainTextOnly(subject: "Quarterly figures");
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -54,7 +54,7 @@ public sealed class EmailTextExtractorTests
         byte[] eml = EmlFixtures.MultipartAlternative(
             plainBody: "PLAIN-MARKER body",
             htmlBody: "<p>HTML-MARKER body</p>");
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -67,7 +67,7 @@ public sealed class EmailTextExtractorTests
     public async Task Falls_back_to_html_body_when_no_plain_alternative()
     {
         byte[] eml = EmlFixtures.HtmlOnly("<html><body><h1>Hello</h1><p>HTML-MARKER content</p></body></html>");
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -82,7 +82,7 @@ public sealed class EmailTextExtractorTests
     public async Task Includes_Cc_header_when_present()
     {
         byte[] eml = EmlFixtures.WithCc();
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -95,7 +95,7 @@ public sealed class EmailTextExtractorTests
     public async Task Omits_Cc_header_when_absent()
     {
         byte[] eml = EmlFixtures.PlainTextOnly();
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -107,7 +107,7 @@ public sealed class EmailTextExtractorTests
     public async Task Walks_nested_multipart_to_find_the_body()
     {
         byte[] eml = EmlFixtures.NestedMultipart();
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -119,7 +119,7 @@ public sealed class EmailTextExtractorTests
     public async Task Decodes_rfc2047_encoded_headers()
     {
         byte[] eml = EmlFixtures.EncodedHeaders();
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -132,7 +132,7 @@ public sealed class EmailTextExtractorTests
     public async Task Ignores_attachments_but_keeps_envelope_and_body()
     {
         byte[] eml = EmlFixtures.WithAttachment();
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -148,7 +148,7 @@ public sealed class EmailTextExtractorTests
     public async Task Encrypted_multipart_degrades_to_placeholder()
     {
         byte[] eml = EmlFixtures.EncryptedMultipart();
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -163,7 +163,7 @@ public sealed class EmailTextExtractorTests
     public async Task Malformed_eml_is_soft_skipped()
     {
         byte[] eml = EmlFixtures.Malformed();
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -179,7 +179,7 @@ public sealed class EmailTextExtractorTests
         byte[] eml = EmlFixtures.PlainTextOnly(
             subject: "abc",
             body: new string('x', 4000));
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 64, cancellationToken: TestContext.Current.CancellationToken);
@@ -194,7 +194,7 @@ public sealed class EmailTextExtractorTests
     {
         ExtractionOptions options = new() { MaxBodySizeBytes = 32 };
         byte[] eml = EmlFixtures.PlainTextOnly(body: "some body that is well above 32 bytes once headers are added");
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionException tex = await Should.ThrowAsync<TextExtractionException>(
             async () => await CreateExtractor(options).ExtractAsync(
@@ -208,7 +208,7 @@ public sealed class EmailTextExtractorTests
     {
         // Construct a raw message with an embedded LF+colon in the subject — a
         // header-injection attempt that should be neutralised on emit.
-        string raw =
+        const string raw =
             "From: sender@example.com\r\n" +
             "To: rec@example.com\r\n" +
             "Subject: cleansubject\r\n" +
@@ -217,7 +217,7 @@ public sealed class EmailTextExtractorTests
             "\r\n" +
             "body\r\n";
         byte[] eml = System.Text.Encoding.ASCII.GetBytes(raw);
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -235,7 +235,7 @@ public sealed class EmailTextExtractorTests
         // consumer would see a spliced fake header.
         //
         // =?utf-8?B?Z29vZApGcm9tOiBhdHRhY2tlckBldmls?= decodes to "good\nFrom: attacker@evil".
-        string raw =
+        const string raw =
             "From: sender@example.com\r\n" +
             "To: rec@example.com\r\n" +
             "Subject: =?utf-8?B?Z29vZApGcm9tOiBhdHRhY2tlckBldmls?=\r\n" +
@@ -244,7 +244,7 @@ public sealed class EmailTextExtractorTests
             "\r\n" +
             "body\r\n";
         byte[] eml = System.Text.Encoding.ASCII.GetBytes(raw);
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);
@@ -261,7 +261,7 @@ public sealed class EmailTextExtractorTests
     public async Task Strips_carriage_returns_too()
     {
         // Belt-and-braces: \r alone (no \n) is also a structured-log threat.
-        string raw =
+        const string raw =
             "From: sender@example.com\r\n" +
             "To: rec@example.com\r\n" +
             "Subject: =?utf-8?Q?carriage=0Dreturn?=\r\n" +
@@ -270,7 +270,7 @@ public sealed class EmailTextExtractorTests
             "\r\n" +
             "body\r\n";
         byte[] eml = System.Text.Encoding.ASCII.GetBytes(raw);
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "message/rfc822", maxCharLength: 4096, cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Email.Tests/GranitTextExtractionEmailModuleTests.cs
+++ b/tests/Granit.TextExtraction.Email.Tests/GranitTextExtractionEmailModuleTests.cs
@@ -39,11 +39,11 @@ public sealed class GranitTextExtractionEmailModuleTests
         services.AddLogging();
         services.AddGranitTextExtractionEmail();
 
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         ITextExtractionPipeline pipeline = sp.GetRequiredService<ITextExtractionPipeline>();
 
         byte[] eml = EmlFixtures.PlainTextOnly(subject: "DI smoke", body: "DI smoke body");
-        using MemoryStream stream = new(eml);
+        await using MemoryStream stream = new(eml);
 
         TextExtractionResult result =
             await pipeline.ExtractAsync(stream, "message/rfc822", TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.AI.Tests/AIVisionOcrExtractorTests.cs
@@ -76,7 +76,7 @@ public sealed class AIVisionOcrExtractorTests
             });
 
         byte[] imageBytes = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]; // PNG magic
-        using MemoryStream input = new(imageBytes);
+        await using MemoryStream input = new(imageBytes);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -102,7 +102,7 @@ public sealed class AIVisionOcrExtractorTests
             Messages = [new ChatMessage(ChatRole.Assistant, new string('x', 5_000))],
         };
         (AIVisionOcrExtractor extractor, _, _) = CreateExtractor(big);
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -116,7 +116,7 @@ public sealed class AIVisionOcrExtractorTests
     {
         ExtractionOptions extraction = new() { MaxBodySizeBytes = 16 };
         (AIVisionOcrExtractor extractor, _, _) = CreateExtractor(extractionOptions: extraction);
-        using MemoryStream input = Bytes(4096);
+        await using MemoryStream input = Bytes(4096);
 
         TextExtraction.Exceptions.TextExtractionException tex =
             await Should.ThrowAsync<TextExtraction.Exceptions.TextExtractionException>(
@@ -140,7 +140,7 @@ public sealed class AIVisionOcrExtractorTests
             MEOptions.Create(new ExtractionOptions()),
             MEOptions.Create(new AIVisionOcrOptions()),
             NullLogger<AIVisionOcrExtractor>.Instance);
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -171,7 +171,7 @@ public sealed class AIVisionOcrExtractorTests
             MEOptions.Create(new ExtractionOptions()),
             MEOptions.Create(new AIVisionOcrOptions()),
             NullLogger<AIVisionOcrExtractor>.Instance);
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -185,7 +185,7 @@ public sealed class AIVisionOcrExtractorTests
     {
         AIVisionOcrOptions opts = new() { WorkspaceName = "vision-ocr-fr" };
         (AIVisionOcrExtractor extractor, _, IAIChatClientFactory factory) = CreateExtractor(ocrOptions: opts);
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -201,7 +201,7 @@ public sealed class AIVisionOcrExtractorTests
 
         (AIVisionOcrExtractor extractor, IChatClient chatClient, _) =
             CreateExtractor(promptBuilder: customPrompt);
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         await extractor.ExtractAsync(
             input, Png, maxCharLength: 512, cancellationToken: TestContext.Current.CancellationToken);
@@ -226,7 +226,7 @@ public sealed class AIVisionOcrExtractorTests
         {
             Messages = [new ChatMessage(ChatRole.Assistant, modelEcho)],
         });
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -243,7 +243,7 @@ public sealed class AIVisionOcrExtractorTests
         {
             Messages = [new ChatMessage(ChatRole.Assistant, "<granit-vlm-ocr>body</granit-vlm-ocr>")],
         });
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -261,7 +261,7 @@ public sealed class AIVisionOcrExtractorTests
         {
             Messages = [new ChatMessage(ChatRole.Assistant, "   plain transcription   ")],
         });
-        using MemoryStream input = Bytes(8);
+        await using MemoryStream input = Bytes(8);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
@@ -55,7 +55,7 @@ public sealed class LiveTesseractRecognizerTests
             .OfType<TesseractOcrExtractor>()
             .Single();
 
-        using MemoryStream stream = new(png);
+        await using MemoryStream stream = new(png);
         TextExtractionResult result = await extractor.ExtractAsync(
             stream,
             contentType: "image/png",

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/TesseractOcrExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests/TesseractOcrExtractorTests.cs
@@ -71,7 +71,7 @@ public sealed class TesseractOcrExtractorTests
             CreateExtractor("Hello, OCR!");
 
         byte[] imageBytes = SampleImageBytes();
-        using MemoryStream input = new(imageBytes);
+        await using MemoryStream input = new(imageBytes);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024,
@@ -90,7 +90,7 @@ public sealed class TesseractOcrExtractorTests
     public async Task Truncates_when_recognition_exceeds_max_char_length()
     {
         (TesseractOcrExtractor extractor, _) = CreateExtractor(new string('x', 5_000));
-        using MemoryStream input = new(SampleImageBytes());
+        await using MemoryStream input = new(SampleImageBytes());
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 100,
@@ -112,7 +112,7 @@ public sealed class TesseractOcrExtractorTests
         (TesseractOcrExtractor extractor, ITesseractRecognizer recognizer) =
             CreateExtractor(ocrOptions: tight, imageProcessor: ImageProcessorReturning(32, 32));
 
-        using MemoryStream input = new(SampleImageBytes());
+        await using MemoryStream input = new(SampleImageBytes());
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024,
@@ -137,7 +137,7 @@ public sealed class TesseractOcrExtractorTests
 
         // No PNG/JPEG/etc header → the imaging provider rejects it as an unsupported format.
         byte[] junk = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
-        using MemoryStream input = new(junk);
+        await using MemoryStream input = new(junk);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024,
@@ -163,7 +163,7 @@ public sealed class TesseractOcrExtractorTests
             MEOptions.Create(new TesseractOcrOptions { DataPath = "/tmp/tessdata" }),
             NullLogger<TesseractOcrExtractor>.Instance);
 
-        using MemoryStream input = new(SampleImageBytes());
+        await using MemoryStream input = new(SampleImageBytes());
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Png, maxCharLength: 1024,
@@ -180,7 +180,7 @@ public sealed class TesseractOcrExtractorTests
         (TesseractOcrExtractor extractor, _) = CreateExtractor(extractionOptions: extraction);
 
         // 64-byte payload exceeds the 16-byte body cap, which trips before the image is identified.
-        using MemoryStream input = new(SampleImageBytes());
+        await using MemoryStream input = new(SampleImageBytes());
 
         TextExtraction.Exceptions.TextExtractionException tex =
             await Should.ThrowAsync<TextExtraction.Exceptions.TextExtractionException>(

--- a/tests/Granit.TextExtraction.Office.Tests/ExcelTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Office.Tests/ExcelTextExtractorTests.cs
@@ -33,7 +33,7 @@ public sealed class ExcelTextExtractorTests
             { "Gamma", "Delta" },
         };
         byte[] xlsx = OfficeFixtures.Xlsx(("Sheet1", sheet1));
-        using MemoryStream stream = new(xlsx);
+        await using MemoryStream stream = new(xlsx);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Xlsx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -50,7 +50,7 @@ public sealed class ExcelTextExtractorTests
         byte[] xlsx = OfficeFixtures.Xlsx(
             ("Sheet1", new[,] { { "First sheet content" } }),
             ("Sheet2", new[,] { { "Second sheet content" } }));
-        using MemoryStream stream = new(xlsx);
+        await using MemoryStream stream = new(xlsx);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Xlsx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -66,7 +66,7 @@ public sealed class ExcelTextExtractorTests
         // content into one position.
         string[,] big = { { new string('x', 5_000) } };
         byte[] xlsx = OfficeFixtures.Xlsx(("Sheet1", big));
-        using MemoryStream stream = new(xlsx);
+        await using MemoryStream stream = new(xlsx);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Xlsx, maxCharLength: 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -80,7 +80,7 @@ public sealed class ExcelTextExtractorTests
     {
         ExtractionOptions options = new() { MaxZipEntries = 5 };
         byte[] adversarial = OfficeFixtures.ZipWithEntryCount(entries: 10);
-        using MemoryStream stream = new(adversarial);
+        await using MemoryStream stream = new(adversarial);
 
         TextExtractionResult result = await CreateExtractor(options).ExtractAsync(
             stream, Xlsx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Office.Tests/GranitTextExtractionOfficeModuleTests.cs
+++ b/tests/Granit.TextExtraction.Office.Tests/GranitTextExtractionOfficeModuleTests.cs
@@ -42,11 +42,11 @@ public sealed class GranitTextExtractionOfficeModuleTests
         services.AddLogging();
         services.AddGranitTextExtractionOffice();
 
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         ITextExtractionPipeline pipeline = sp.GetRequiredService<ITextExtractionPipeline>();
 
         byte[] docx = OfficeFixtures.Docx("DI smoke");
-        using MemoryStream stream = new(docx);
+        await using MemoryStream stream = new(docx);
 
         TextExtractionResult result =
             await pipeline.ExtractAsync(stream, Docx, TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Office.Tests/PowerPointTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Office.Tests/PowerPointTextExtractorTests.cs
@@ -27,7 +27,7 @@ public sealed class PowerPointTextExtractorTests
     public async Task Extracts_text_from_each_slide()
     {
         byte[] pptx = OfficeFixtures.Pptx("First slide", "Second slide", "Third slide");
-        using MemoryStream stream = new(pptx);
+        await using MemoryStream stream = new(pptx);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Pptx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -43,7 +43,7 @@ public sealed class PowerPointTextExtractorTests
     public async Task Truncates_when_slides_exceed_cap()
     {
         byte[] pptx = OfficeFixtures.Pptx(Enumerable.Range(1, 50).Select(i => $"Slide {i}").ToArray());
-        using MemoryStream stream = new(pptx);
+        await using MemoryStream stream = new(pptx);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Pptx, maxCharLength: 50, cancellationToken: TestContext.Current.CancellationToken);
@@ -57,7 +57,7 @@ public sealed class PowerPointTextExtractorTests
     {
         ExtractionOptions options = new() { MaxDecompressedBytes = 1024 };
         byte[] adversarial = OfficeFixtures.ZipWithAdvertisedSize(advertisedBytes: 64 * 1024);
-        using MemoryStream stream = new(adversarial);
+        await using MemoryStream stream = new(adversarial);
 
         TextExtractionResult result = await CreateExtractor(options).ExtractAsync(
             stream, Pptx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Office.Tests/WordTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Office.Tests/WordTextExtractorTests.cs
@@ -27,7 +27,7 @@ public sealed class WordTextExtractorTests
     public async Task Extracts_paragraph_text()
     {
         byte[] doc = OfficeFixtures.Docx("Hello world", "Second paragraph");
-        using MemoryStream stream = new(doc);
+        await using MemoryStream stream = new(doc);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Docx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -41,7 +41,7 @@ public sealed class WordTextExtractorTests
     public async Task Truncates_to_max_char_length_and_flags()
     {
         byte[] doc = OfficeFixtures.Docx(new string('x', 5_000));
-        using MemoryStream stream = new(doc);
+        await using MemoryStream stream = new(doc);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Docx, maxCharLength: 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -55,7 +55,7 @@ public sealed class WordTextExtractorTests
     {
         ExtractionOptions options = new() { MaxZipEntries = 5 };
         byte[] adversarial = OfficeFixtures.ZipWithEntryCount(entries: 10);
-        using MemoryStream stream = new(adversarial);
+        await using MemoryStream stream = new(adversarial);
 
         TextExtractionResult result = await CreateExtractor(options).ExtractAsync(
             stream, Docx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -69,7 +69,7 @@ public sealed class WordTextExtractorTests
     {
         ExtractionOptions options = new() { MaxDecompressedBytes = 1024 };
         byte[] adversarial = OfficeFixtures.ZipWithAdvertisedSize(advertisedBytes: 64 * 1024);
-        using MemoryStream stream = new(adversarial);
+        await using MemoryStream stream = new(adversarial);
 
         TextExtractionResult result = await CreateExtractor(options).ExtractAsync(
             stream, Docx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -82,7 +82,7 @@ public sealed class WordTextExtractorTests
     public async Task Malformed_zip_returns_skipped_result()
     {
         byte[] bytes = OfficeFixtures.InvalidZip();
-        using MemoryStream stream = new(bytes);
+        await using MemoryStream stream = new(bytes);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, Docx, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Pdf.Ocr.Tests/PdfOcrTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Pdf.Ocr.Tests/PdfOcrTextExtractorTests.cs
@@ -29,7 +29,7 @@ public sealed class PdfOcrTextExtractorTests
         (PdfOcrTextExtractor extractor, IPdfRasterizer rasterizer, ITextExtractor ocr) = BuildExtractor();
 
         byte[] pdf = PdfFixtures.TextPage("hello native text extraction this should easily exceed the threshold");
-        using MemoryStream src = new(pdf);
+        await using MemoryStream src = new(pdf);
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 
@@ -62,7 +62,7 @@ public sealed class PdfOcrTextExtractorTests
                 Confidence: ExtractionConfidence.Heuristic));
 
         byte[] pdf = PdfFixtures.EmptyPage();
-        using MemoryStream src = new(pdf);
+        await using MemoryStream src = new(pdf);
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 
@@ -93,7 +93,7 @@ public sealed class PdfOcrTextExtractorTests
 
         byte[] pdf = PdfFixtures.MixedTextThenScanned(
             "page one with enough native text to clear the threshold here");
-        using MemoryStream src = new(pdf);
+        await using MemoryStream src = new(pdf);
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 
@@ -117,7 +117,7 @@ public sealed class PdfOcrTextExtractorTests
         (PdfOcrTextExtractor extractor, IPdfRasterizer rasterizer, _) = BuildExtractor(includeOcr: false);
 
         byte[] pdf = PdfFixtures.EmptyPage();
-        using MemoryStream src = new(pdf);
+        await using MemoryStream src = new(pdf);
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 
@@ -136,7 +136,7 @@ public sealed class PdfOcrTextExtractorTests
         ocr.CanHandle(ImagePng).Returns(true);
 
         byte[] pdf = PdfFixtures.EmptyPage();
-        using MemoryStream src = new(pdf);
+        await using MemoryStream src = new(pdf);
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 
@@ -165,7 +165,7 @@ public sealed class PdfOcrTextExtractorTests
             .ReturnsForAnyArgs(new TextExtractionResult("page", null, false, 4, "fake.ocr", ExtractionConfidence.Heuristic));
 
         byte[] pdf = PdfFixtures.EmptyPages(5);
-        using MemoryStream src = new(pdf);
+        await using MemoryStream src = new(pdf);
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 
@@ -179,7 +179,7 @@ public sealed class PdfOcrTextExtractorTests
     {
         (PdfOcrTextExtractor extractor, _, _) = BuildExtractor();
 
-        using MemoryStream src = new(PdfFixtures.Malformed());
+        await using MemoryStream src = new(PdfFixtures.Malformed());
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 
@@ -199,7 +199,7 @@ public sealed class PdfOcrTextExtractorTests
         ocr.CanHandle(ImagePng).Returns(true);
 
         byte[] pdf = PdfFixtures.EmptyPage();
-        using MemoryStream src = new(pdf);
+        await using MemoryStream src = new(pdf);
 
         TextExtractionResult result = await extractor.ExtractAsync(src, Pdf, 4096, TestContext.Current.CancellationToken);
 

--- a/tests/Granit.TextExtraction.Pdf.Tests/GranitTextExtractionPdfModuleTests.cs
+++ b/tests/Granit.TextExtraction.Pdf.Tests/GranitTextExtractionPdfModuleTests.cs
@@ -39,11 +39,11 @@ public sealed class GranitTextExtractionPdfModuleTests
         services.AddLogging();
         services.AddGranitTextExtractionPdf();
 
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         ITextExtractionPipeline pipeline = sp.GetRequiredService<ITextExtractionPipeline>();
 
         byte[] pdf = PdfFixtures.TextOnly("DI smoke");
-        using MemoryStream stream = new(pdf);
+        await using MemoryStream stream = new(pdf);
 
         TextExtractionResult result =
             await pipeline.ExtractAsync(stream, "application/pdf", TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Pdf.Tests/PdfTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Pdf.Tests/PdfTextExtractorTests.cs
@@ -26,7 +26,7 @@ public sealed class PdfTextExtractorTests
     public async Task Extracts_text_from_single_page()
     {
         byte[] pdf = PdfFixtures.TextOnly("Hello world", "Second line");
-        using MemoryStream stream = new(pdf);
+        await using MemoryStream stream = new(pdf);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "application/pdf", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -41,7 +41,7 @@ public sealed class PdfTextExtractorTests
     public async Task Joins_pages_with_blank_lines()
     {
         byte[] pdf = PdfFixtures.MultiPage(3);
-        using MemoryStream stream = new(pdf);
+        await using MemoryStream stream = new(pdf);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "application/pdf", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -59,7 +59,7 @@ public sealed class PdfTextExtractorTests
         // Each page contains a long string — capping at a small char count should
         // truncate after the first or second page, not walk all 20.
         byte[] pdf = PdfFixtures.MultiPage(20, textPrefix: new string('x', 200));
-        using MemoryStream stream = new(pdf);
+        await using MemoryStream stream = new(pdf);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "application/pdf", maxCharLength: 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -73,7 +73,7 @@ public sealed class PdfTextExtractorTests
     public async Task Empty_pdf_returns_empty_content()
     {
         byte[] pdf = PdfFixtures.Empty();
-        using MemoryStream stream = new(pdf);
+        await using MemoryStream stream = new(pdf);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "application/pdf", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -86,7 +86,7 @@ public sealed class PdfTextExtractorTests
     public async Task Malformed_pdf_is_soft_skipped()
     {
         byte[] pdf = PdfFixtures.Malformed();
-        using MemoryStream stream = new(pdf);
+        await using MemoryStream stream = new(pdf);
 
         TextExtractionResult result = await CreateExtractor().ExtractAsync(
             stream, "application/pdf", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -103,7 +103,7 @@ public sealed class PdfTextExtractorTests
         // Generate a real PDF that exceeds the configured cap (Empty PDF is ~700 bytes).
         ExtractionOptions options = new() { MaxBodySizeBytes = 32 };
         byte[] pdf = PdfFixtures.TextOnly("Some text");
-        using MemoryStream stream = new(pdf);
+        await using MemoryStream stream = new(pdf);
 
         TextExtractionException tex = await Should.ThrowAsync<TextExtractionException>(
             async () => await CreateExtractor(options).ExtractAsync(

--- a/tests/Granit.TextExtraction.Tests/LimitedStreamTests.cs
+++ b/tests/Granit.TextExtraction.Tests/LimitedStreamTests.cs
@@ -41,8 +41,8 @@ public sealed class LimitedStreamTests
     public async Task ReadAsync_exceeding_cap_throws_input_too_large()
     {
         byte[] payload = new byte[2048];
-        using MemoryStream source = new(payload);
-        using LimitedStream limited = new(source, maxBytes: 512);
+        await using MemoryStream source = new(payload);
+        await using LimitedStream limited = new(source, maxBytes: 512);
 
         byte[] buffer = new byte[2048];
 

--- a/tests/Granit.TextExtraction.Tests/PlainTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Tests/PlainTextExtractorTests.cs
@@ -21,7 +21,7 @@ public sealed class PlainTextExtractorTests
     public async Task Extracts_full_text_when_under_cap()
     {
         PlainTextExtractor extractor = CreateExtractor();
-        using MemoryStream stream = Utf8("hello world");
+        await using MemoryStream stream = Utf8("hello world");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream,
@@ -42,7 +42,7 @@ public sealed class PlainTextExtractorTests
         byte[] bom = [0xEF, 0xBB, 0xBF];
         byte[] payload = Encoding.UTF8.GetBytes("café");
         byte[] full = [.. bom, .. payload];
-        using MemoryStream stream = new(full);
+        await using MemoryStream stream = new(full);
 
         PlainTextExtractor extractor = CreateExtractor();
         TextExtractionResult result = await extractor.ExtractAsync(
@@ -60,7 +60,7 @@ public sealed class PlainTextExtractorTests
     {
         PlainTextExtractor extractor = CreateExtractor();
         string payload = new('x', 1024);
-        using MemoryStream stream = Utf8(payload);
+        await using MemoryStream stream = Utf8(payload);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream,
@@ -78,7 +78,7 @@ public sealed class PlainTextExtractorTests
     {
         ExtractionOptions options = new() { MaxBodySizeBytes = 8 };
         PlainTextExtractor extractor = CreateExtractor(options);
-        using MemoryStream stream = Utf8(new string('a', 1024));
+        await using MemoryStream stream = Utf8(new string('a', 1024));
 
         TextExtractionException tex = await Should.ThrowAsync<TextExtractionException>(
             async () => await extractor.ExtractAsync(

--- a/tests/Granit.TextExtraction.Tests/TextExtractionPipelineTests.cs
+++ b/tests/Granit.TextExtraction.Tests/TextExtractionPipelineTests.cs
@@ -33,9 +33,9 @@ public sealed class TextExtractionPipelineTests
     public async Task Falls_back_to_plain_text_when_no_extractor_claims_content_type()
     {
         (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline();
-        using ServiceProvider _ = sp;
+        await using ServiceProvider _ = sp;
 
-        using MemoryStream stream = Utf8("plain body");
+        await using MemoryStream stream = Utf8("plain body");
         TextExtractionResult result = await pipeline.ExtractAsync(
             stream,
             "application/x-unknown",
@@ -53,16 +53,16 @@ public sealed class TextExtractionPipelineTests
             s.AddTextExtractor<FakeHtmlExtractor>();
             s.AddTextExtractor<FakeMarkdownExtractor>();
         });
-        using ServiceProvider _ = sp;
+        await using ServiceProvider _ = sp;
 
-        using MemoryStream stream = Utf8("ignored");
+        await using MemoryStream stream = Utf8("ignored");
         TextExtractionResult htmlResult = await pipeline.ExtractAsync(
             stream,
             "text/html",
             TestContext.Current.CancellationToken);
         htmlResult.ExtractorName.ShouldBe(FakeHtmlExtractor.Id);
 
-        using MemoryStream stream2 = Utf8("ignored");
+        await using MemoryStream stream2 = Utf8("ignored");
         TextExtractionResult mdResult = await pipeline.ExtractAsync(
             stream2,
             "text/markdown",
@@ -79,9 +79,9 @@ public sealed class TextExtractionPipelineTests
             s.AddTextExtractor<FakeHtmlExtractor>();
             s.AddTextExtractor<FakeCatchAllExtractor>();
         });
-        using ServiceProvider _ = sp;
+        await using ServiceProvider _ = sp;
 
-        using MemoryStream stream = Utf8("body");
+        await using MemoryStream stream = Utf8("body");
         TextExtractionResult result = await pipeline.ExtractAsync(
             stream,
             "text/html",
@@ -95,9 +95,9 @@ public sealed class TextExtractionPipelineTests
     {
         ExtractionOptions options = new() { MaxExtractedCharLength = 5 };
         (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline(options: options);
-        using ServiceProvider _ = sp;
+        await using ServiceProvider _ = sp;
 
-        using MemoryStream stream = Utf8("hello world");
+        await using MemoryStream stream = Utf8("hello world");
         TextExtractionResult result = await pipeline.ExtractAsync(
             stream,
             "text/plain",
@@ -110,13 +110,10 @@ public sealed class TextExtractionPipelineTests
     [Fact]
     public async Task Propagates_text_extraction_exception_from_extractor()
     {
-        (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline(s =>
-        {
-            s.AddTextExtractor<ThrowingExtractor>();
-        });
-        using ServiceProvider _ = sp;
+        (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline(s => s.AddTextExtractor<ThrowingExtractor>());
+        await using ServiceProvider _ = sp;
 
-        using MemoryStream stream = Utf8("anything");
+        await using MemoryStream stream = Utf8("anything");
         TextExtractionException tex = await Should.ThrowAsync<TextExtractionException>(
             async () => await pipeline.ExtractAsync(
                 stream,
@@ -134,9 +131,9 @@ public sealed class TextExtractionPipelineTests
         (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline(
             s => s.AddTextExtractor<SlowExtractor>(),
             options);
-        using ServiceProvider _ = sp;
+        await using ServiceProvider _ = sp;
 
-        using MemoryStream stream = Utf8("ignored");
+        await using MemoryStream stream = Utf8("ignored");
 
         TextExtractionException tex = await Should.ThrowAsync<TextExtractionException>(
             async () => await pipeline.ExtractAsync(
@@ -155,9 +152,9 @@ public sealed class TextExtractionPipelineTests
         (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline(
             s => s.AddTextExtractor<FakeHtmlExtractor>(),
             options);
-        using ServiceProvider _ = sp;
+        await using ServiceProvider _ = sp;
 
-        using MemoryStream stream = Utf8("ignored");
+        await using MemoryStream stream = Utf8("ignored");
         TextExtractionResult result = await pipeline.ExtractAsync(
             stream, "text/html", TestContext.Current.CancellationToken);
 
@@ -176,7 +173,7 @@ public sealed class TextExtractionPipelineTests
         (ITextExtractionPipeline pipeline, ServiceProvider sp) = BuildPipeline(
             s => s.AddTextExtractor<GateableExtractor>(),
             options);
-        using ServiceProvider _ = sp;
+        await using ServiceProvider _ = sp;
 
         // 3 concurrent calls; only 2 should be in-flight at any moment.
         Task<TextExtractionResult>[] inFlight =

--- a/tests/Granit.TextExtraction.Text.Tests/GranitTextExtractionTextModuleTests.cs
+++ b/tests/Granit.TextExtraction.Text.Tests/GranitTextExtractionTextModuleTests.cs
@@ -39,15 +39,15 @@ public sealed class GranitTextExtractionTextModuleTests
         services.AddSingleton(MEOptions.Create(new ExtractionOptions()));
         services.AddGranitTextExtractionText();
 
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         ITextExtractionPipeline pipeline = sp.GetRequiredService<ITextExtractionPipeline>();
 
-        using MemoryStream html = new(Encoding.UTF8.GetBytes("<p>Hello</p>"));
+        await using MemoryStream html = new(Encoding.UTF8.GetBytes("<p>Hello</p>"));
         TextExtractionResult htmlResult =
             await pipeline.ExtractAsync(html, "text/html", TestContext.Current.CancellationToken);
         htmlResult.ExtractorName.ShouldBe(HtmlTextExtractor.ExtractorName);
 
-        using MemoryStream md = new(Encoding.UTF8.GetBytes("**Bold**"));
+        await using MemoryStream md = new(Encoding.UTF8.GetBytes("**Bold**"));
         TextExtractionResult mdResult =
             await pipeline.ExtractAsync(md, "text/markdown", TestContext.Current.CancellationToken);
         mdResult.ExtractorName.ShouldBe(MarkdownTextExtractor.ExtractorName);

--- a/tests/Granit.TextExtraction.Text.Tests/HtmlTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Text.Tests/HtmlTextExtractorTests.cs
@@ -32,7 +32,7 @@ public sealed class HtmlTextExtractorTests
     public async Task Extracts_plain_text_from_paragraph()
     {
         HtmlTextExtractor extractor = CreateExtractor();
-        using MemoryStream stream = Utf8("<html><body><p>Hello world</p></body></html>");
+        await using MemoryStream stream = Utf8("<html><body><p>Hello world</p></body></html>");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream, "text/html", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -47,7 +47,7 @@ public sealed class HtmlTextExtractorTests
     public async Task Strips_script_and_style_tags()
     {
         HtmlTextExtractor extractor = CreateExtractor();
-        using MemoryStream stream = Utf8(
+        await using MemoryStream stream = Utf8(
             "<html><head><style>body{color:red}</style></head>" +
             "<body><script>alert('x')</script><p>Visible</p></body></html>");
 
@@ -64,7 +64,7 @@ public sealed class HtmlTextExtractorTests
     {
         HtmlTextExtractor extractor = CreateExtractor();
         string body = new('x', 5_000);
-        using MemoryStream stream = Utf8($"<p>{body}</p>");
+        await using MemoryStream stream = Utf8($"<p>{body}</p>");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream, "text/html", maxCharLength: 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -79,7 +79,7 @@ public sealed class HtmlTextExtractorTests
     {
         ExtractionOptions options = new() { MaxBodySizeBytes = 16 };
         HtmlTextExtractor extractor = CreateExtractor(options);
-        using MemoryStream stream = Utf8("<p>" + new string('a', 4096) + "</p>");
+        await using MemoryStream stream = Utf8("<p>" + new string('a', 4096) + "</p>");
 
         TextExtractionException tex = await Should.ThrowAsync<TextExtractionException>(
             async () => await extractor.ExtractAsync(
@@ -92,7 +92,7 @@ public sealed class HtmlTextExtractorTests
     public async Task Heading_followed_by_paragraph_renders_readable_text()
     {
         HtmlTextExtractor extractor = CreateExtractor();
-        using MemoryStream stream = Utf8("<h1>Welcome</h1><p>Body</p>");
+        await using MemoryStream stream = Utf8("<h1>Welcome</h1><p>Body</p>");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream, "text/html", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/Granit.TextExtraction.Text.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Text.Tests/MarkdownTextExtractorTests.cs
@@ -27,7 +27,7 @@ public sealed class MarkdownTextExtractorTests
     public async Task Strips_inline_formatting()
     {
         MarkdownTextExtractor extractor = CreateExtractor();
-        using MemoryStream stream = Utf8("This is **bold** and _italic_ text.");
+        await using MemoryStream stream = Utf8("This is **bold** and _italic_ text.");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream, "text/markdown", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -43,7 +43,7 @@ public sealed class MarkdownTextExtractorTests
     public async Task Strips_link_syntax()
     {
         MarkdownTextExtractor extractor = CreateExtractor();
-        using MemoryStream stream = Utf8("See [the docs](https://example.com) for details.");
+        await using MemoryStream stream = Utf8("See [the docs](https://example.com) for details.");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream, "text/markdown", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -63,7 +63,7 @@ public sealed class MarkdownTextExtractorTests
             | ----- | ----- |
             | Alpha | Beta  |
             """;
-        using MemoryStream stream = Utf8(md);
+        await using MemoryStream stream = Utf8(md);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream, "text/markdown", maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -79,7 +79,7 @@ public sealed class MarkdownTextExtractorTests
     {
         MarkdownTextExtractor extractor = CreateExtractor();
         string body = new('x', 5_000);
-        using MemoryStream stream = Utf8(body);
+        await using MemoryStream stream = Utf8(body);
 
         TextExtractionResult result = await extractor.ExtractAsync(
             stream, "text/markdown", maxCharLength: 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -94,7 +94,7 @@ public sealed class MarkdownTextExtractorTests
     {
         ExtractionOptions options = new() { MaxBodySizeBytes = 16 };
         MarkdownTextExtractor extractor = CreateExtractor(options);
-        using MemoryStream stream = Utf8(new string('a', 4096));
+        await using MemoryStream stream = Utf8(new string('a', 4096));
 
         TextExtractionException tex = await Should.ThrowAsync<TextExtractionException>(
             async () => await extractor.ExtractAsync(

--- a/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarTextExtractorTests.cs
+++ b/tests/Granit.TextExtraction.Tika.Tests/TikaSidecarTextExtractorTests.cs
@@ -66,7 +66,7 @@ public sealed class TikaSidecarTextExtractorTests
     {
         (TikaSidecarTextExtractor extractor, StubHttpMessageHandler handler) = CreateExtractor(
             StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "Hello from Tika."));
-        using MemoryStream input = Utf8("{rtf body}");
+        await using MemoryStream input = Utf8("{rtf body}");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Rtf, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -91,7 +91,7 @@ public sealed class TikaSidecarTextExtractorTests
         string payload = new('x', 5_000);
         (TikaSidecarTextExtractor extractor, _) = CreateExtractor(
             StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, payload));
-        using MemoryStream input = Utf8("any");
+        await using MemoryStream input = Utf8("any");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Rtf, maxCharLength: 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -105,7 +105,7 @@ public sealed class TikaSidecarTextExtractorTests
     {
         ExtractionOptions extraction = new() { MaxBodySizeBytes = 16 };
         (TikaSidecarTextExtractor extractor, _) = CreateExtractor(extractionOptions: extraction);
-        using MemoryStream input = Utf8(new string('a', 4096));
+        await using MemoryStream input = Utf8(new string('a', 4096));
 
         TextExtraction.Exceptions.TextExtractionException tex =
             await Should.ThrowAsync<TextExtraction.Exceptions.TextExtractionException>(
@@ -123,7 +123,7 @@ public sealed class TikaSidecarTextExtractorTests
     {
         (TikaSidecarTextExtractor extractor, _) = CreateExtractor(
             StubHttpMessageHandler.RespondWith(status, "ignored body"));
-        using MemoryStream input = Utf8("body");
+        await using MemoryStream input = Utf8("body");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Rtf, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -137,7 +137,7 @@ public sealed class TikaSidecarTextExtractorTests
     {
         (TikaSidecarTextExtractor extractor, _) = CreateExtractor(
             StubHttpMessageHandler.Throws(new HttpRequestException("DNS down")));
-        using MemoryStream input = Utf8("body");
+        await using MemoryStream input = Utf8("body");
 
         TextExtractionResult result = await extractor.ExtractAsync(
             input, Rtf, maxCharLength: 1024, cancellationToken: TestContext.Current.CancellationToken);
@@ -151,7 +151,7 @@ public sealed class TikaSidecarTextExtractorTests
     {
         // Defence against Tika SSRF/fetch-recursion CVEs via embedded parsing.
         (TikaSidecarTextExtractor extractor, StubHttpMessageHandler handler) = CreateExtractor();
-        using MemoryStream input = Utf8("body");
+        await using MemoryStream input = Utf8("body");
 
         _ = await extractor.ExtractAsync(input, Rtf, 1024, TestContext.Current.CancellationToken);
 
@@ -170,7 +170,7 @@ public sealed class TikaSidecarTextExtractorTests
             SkipEmbeddedResources = false,
         };
         (TikaSidecarTextExtractor extractor, StubHttpMessageHandler handler) = CreateExtractor(tikaOptions: opts);
-        using MemoryStream input = Utf8("body");
+        await using MemoryStream input = Utf8("body");
 
         _ = await extractor.ExtractAsync(input, Rtf, 1024, TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Timeline.Tests/Exports/TimelineEntryExportDefinitionTests.cs
+++ b/tests/Granit.Timeline.Tests/Exports/TimelineEntryExportDefinitionTests.cs
@@ -9,7 +9,7 @@ public sealed class TimelineEntryExportDefinitionTests
 {
     private static readonly TimelineEntryExportDefinition Sut = new();
     private static IReadOnlyList<ExportFieldDescriptor> Fields =>
-        ((IExportDefinitionDescriptor)Sut).GetFields();
+        Sut.GetFields();
 
     [Fact]
     public void Name_is_stable() =>

--- a/tests/Granit.Timeline.Tests/MentionParserTests.cs
+++ b/tests/Granit.Timeline.Tests/MentionParserTests.cs
@@ -15,7 +15,7 @@ public sealed class MentionParserTests
     [Fact]
     public void ExtractMentionedUserIds_WithValidMention_ReturnsUserId()
     {
-        string body = "Hello @[Dr. Martin](user:550e8400-e29b-41d4-a716-446655440000), please review.";
+        const string body = "Hello @[Dr. Martin](user:550e8400-e29b-41d4-a716-446655440000), please review.";
 
         IReadOnlyList<string> result = MentionParser.ExtractMentionedUserIds(body);
 
@@ -26,7 +26,7 @@ public sealed class MentionParserTests
     [Fact]
     public void ExtractMentionedUserIds_WithMultipleMentions_ReturnsDistinctUserIds()
     {
-        string body = "@[Alice](user:aaaaaaaa-0000-0000-0000-000000000001) and @[Bob](user:bbbbbbbb-0000-0000-0000-000000000002) are assigned.";
+        const string body = "@[Alice](user:aaaaaaaa-0000-0000-0000-000000000001) and @[Bob](user:bbbbbbbb-0000-0000-0000-000000000002) are assigned.";
 
         IReadOnlyList<string> result = MentionParser.ExtractMentionedUserIds(body);
 
@@ -38,7 +38,7 @@ public sealed class MentionParserTests
     [Fact]
     public void ExtractMentionedUserIds_WithDuplicateMention_ReturnsDistinct()
     {
-        string body = "@[Dr. Martin](user:550e8400-e29b-41d4-a716-446655440000) said hi. @[Dr. Martin](user:550e8400-e29b-41d4-a716-446655440000) confirmed.";
+        const string body = "@[Dr. Martin](user:550e8400-e29b-41d4-a716-446655440000) said hi. @[Dr. Martin](user:550e8400-e29b-41d4-a716-446655440000) confirmed.";
 
         IReadOnlyList<string> result = MentionParser.ExtractMentionedUserIds(body);
 
@@ -48,7 +48,7 @@ public sealed class MentionParserTests
     [Fact]
     public void ExtractMentionedUserIds_WithInvalidFormat_ReturnsEmpty()
     {
-        string body = "Hello @invalid and @[Name](wrong:123) are not valid mentions.";
+        const string body = "Hello @invalid and @[Name](wrong:123) are not valid mentions.";
 
         IReadOnlyList<string> result = MentionParser.ExtractMentionedUserIds(body);
 
@@ -74,7 +74,7 @@ public sealed class MentionParserTests
     [Fact]
     public void ExtractMentionedUserIds_WithMixedValidAndInvalid_ReturnsOnlyValid()
     {
-        string body = "@[Valid](user:12345678-1234-1234-1234-123456789012) and @[Invalid](user:not-a-guid) and @plain.";
+        const string body = "@[Valid](user:12345678-1234-1234-1234-123456789012) and @[Invalid](user:not-a-guid) and @plain.";
 
         IReadOnlyList<string> result = MentionParser.ExtractMentionedUserIds(body);
 

--- a/tests/Granit.Timeline.Tests/ReactionTests.cs
+++ b/tests/Granit.Timeline.Tests/ReactionTests.cs
@@ -129,7 +129,7 @@ public sealed class EmojiValidatorTests
     public void IsValid_rejects_tag_sequence_without_cancel_tag()
     {
         // 🏴 + 'g' 'b' 'e' 'n' 'g' tag chars, no U+E007F terminator.
-        string truncated = "🏴\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067";
+        const string truncated = "🏴\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067";
         EmojiValidator.IsValid(truncated).ShouldBeFalse();
     }
 
@@ -137,7 +137,7 @@ public sealed class EmojiValidatorTests
     public void IsValid_rejects_cancel_tag_with_no_tag_chars_between()
     {
         // 🏴 immediately followed by U+E007F, no tag chars in between.
-        string immediateCancel = "🏴\U000E007F";
+        const string immediateCancel = "🏴\U000E007F";
         EmojiValidator.IsValid(immediateCancel).ShouldBeFalse();
     }
 
@@ -149,7 +149,7 @@ public sealed class EmojiValidatorTests
     public void IsValid_rejects_tag_char_after_zwj()
     {
         // 👨 ZWJ tag char — not a defined sequence.
-        string bad = "👨‍\U000E0067";
+        const string bad = "👨‍\U000E0067";
         EmojiValidator.IsValid(bad).ShouldBeFalse();
     }
 

--- a/tests/Granit.Timing.Tests/TimingServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Timing.Tests/TimingServiceCollectionExtensionsTests.cs
@@ -118,10 +118,7 @@ public sealed class TimingServiceCollectionExtensionsTests
         ServiceCollection services = new();
 
         // Act
-        services.AddGranitTiming(opts =>
-        {
-            opts.DefaultTimezone = "America/New_York";
-        });
+        services.AddGranitTiming(opts => opts.DefaultTimezone = "America/New_York");
 
         using ServiceProvider sp = services.BuildServiceProvider();
 

--- a/tests/Granit.Validation.Endpoints.Tests/ValidationFieldStatusTests.cs
+++ b/tests/Granit.Validation.Endpoints.Tests/ValidationFieldStatusTests.cs
@@ -9,7 +9,7 @@ public sealed class ValidationFieldStatusTests
     [Fact]
     public void Valid_HasExpectedValue()
     {
-        ValidationFieldStatus status = ValidationFieldStatus.Valid;
+        const ValidationFieldStatus status = ValidationFieldStatus.Valid;
 
         ((int)status).ShouldBe(0);
     }
@@ -17,7 +17,7 @@ public sealed class ValidationFieldStatusTests
     [Fact]
     public void Invalid_HasExpectedValue()
     {
-        ValidationFieldStatus status = ValidationFieldStatus.Invalid;
+        const ValidationFieldStatus status = ValidationFieldStatus.Invalid;
 
         ((int)status).ShouldBe(1);
     }
@@ -25,7 +25,7 @@ public sealed class ValidationFieldStatusTests
     [Fact]
     public void ValidatorNotFound_HasExpectedValue()
     {
-        ValidationFieldStatus status = ValidationFieldStatus.ValidatorNotFound;
+        const ValidationFieldStatus status = ValidationFieldStatus.ValidatorNotFound;
 
         ((int)status).ShouldBe(2);
     }

--- a/tests/Granit.Validation.Europe.Tests/FrenchRibAlgorithmTests.cs
+++ b/tests/Granit.Validation.Europe.Tests/FrenchRibAlgorithmTests.cs
@@ -96,7 +96,7 @@ public sealed class FrenchRibAlgorithmTests
     public void IsValid_LowercaseInput_NormalizedCorrectly()
     {
         // Same as uppercase variant — Normalize converts to upper
-        string lower = "30004 00001 00000004045 29";
+        const string lower = "30004 00001 00000004045 29";
         FrenchRibAlgorithm.IsValid(lower).ShouldBeTrue();
     }
 }

--- a/tests/Granit.Validation.Tests/FluentValidationSchemaTransformerTests.cs
+++ b/tests/Granit.Validation.Tests/FluentValidationSchemaTransformerTests.cs
@@ -108,7 +108,7 @@ public sealed class FluentValidationSchemaTransformerTests
         OpenApiSchema schema = await TransformAsync<PatternRequest, PatternRequestValidator>();
 
         OpenApiSchema codeSchema = GetProperty(schema, "code");
-        codeSchema.Pattern.ShouldBe(@"^[A-Z]{3}$");
+        codeSchema.Pattern.ShouldBe("^[A-Z]{3}$");
     }
 
     // -------------------------------------------------------------------------
@@ -121,7 +121,7 @@ public sealed class FluentValidationSchemaTransformerTests
         OpenApiSchema schema = await TransformAsync<PatternHintRequest, PatternHintRequestValidator>();
 
         OpenApiSchema codeSchema = GetProperty(schema, "code");
-        codeSchema.Pattern.ShouldBe(@"^[A-Z]{2}$");
+        codeSchema.Pattern.ShouldBe("^[A-Z]{2}$");
         codeSchema.Extensions.ShouldNotBeNull();
         codeSchema.Extensions.ShouldContainKey("x-granit-pattern-hint");
     }
@@ -132,11 +132,8 @@ public sealed class FluentValidationSchemaTransformerTests
         OpenApiSchema schema = await TransformAsync<PatternRequest, PatternRequestValidator>();
 
         OpenApiSchema codeSchema = GetProperty(schema, "code");
-        codeSchema.Pattern.ShouldBe(@"^[A-Z]{3}$");
-        if (codeSchema.Extensions is not null)
-        {
-            codeSchema.Extensions.ShouldNotContainKey("x-granit-pattern-hint");
-        }
+        codeSchema.Pattern.ShouldBe("^[A-Z]{3}$");
+        codeSchema.Extensions?.ShouldNotContainKey("x-granit-pattern-hint");
     }
 
     // -------------------------------------------------------------------------
@@ -286,7 +283,7 @@ public sealed class FluentValidationSchemaTransformerTests
 
     private sealed class PatternRequestValidator : GranitValidator<PatternRequest>
     {
-        public PatternRequestValidator() => RuleFor(x => x.Code).Matches(@"^[A-Z]{3}$");
+        public PatternRequestValidator() => RuleFor(x => x.Code).Matches("^[A-Z]{3}$");
     }
 
     private sealed record PatternHintRequest(string Code);
@@ -295,7 +292,7 @@ public sealed class FluentValidationSchemaTransformerTests
     {
         public PatternHintRequestValidator() =>
             RuleFor(x => x.Code)
-                .Matches(@"^[A-Z]{2}$")
+                .Matches("^[A-Z]{2}$")
                 .WithPatternHint("Validation:Hint:Alpha2Code");
     }
 

--- a/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
+++ b/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
@@ -159,7 +159,7 @@ public sealed class JsonSchemaWriterTests
 
         JsonObject schema = writer.Write(typeof(PatternRequest))!;
 
-        schema["properties"]!["code"]!["pattern"]!.GetValue<string>().ShouldBe(@"^[A-Z]{3}$");
+        schema["properties"]!["code"]!["pattern"]!.GetValue<string>().ShouldBe("^[A-Z]{3}$");
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public sealed class JsonSchemaWriterTests
         JsonObject schema = writer.Write(typeof(PatternHintRequest))!;
 
         JsonNode prop = schema["properties"]!["code"]!;
-        prop["pattern"]!.GetValue<string>().ShouldBe(@"^[A-Z]{2}$");
+        prop["pattern"]!.GetValue<string>().ShouldBe("^[A-Z]{2}$");
         prop["x-granit-pattern-hint"]!.GetValue<string>().ShouldBe("Validation:Hint:Alpha2Code");
     }
 
@@ -217,7 +217,7 @@ public sealed class JsonSchemaWriterTests
         JsonNode prop = schema["properties"]!["code"]!;
         prop["minLength"]!.GetValue<int>().ShouldBe(2);
         prop["maxLength"]!.GetValue<int>().ShouldBe(8);
-        prop["pattern"]!.GetValue<string>().ShouldBe(@"^[A-Z]+$");
+        prop["pattern"]!.GetValue<string>().ShouldBe("^[A-Z]+$");
         schema["required"]!.AsArray().Select(n => n!.GetValue<string>()).ShouldContain("code");
     }
 
@@ -353,7 +353,7 @@ public sealed class JsonSchemaWriterTests
 
     private sealed class PatternRequestValidator : GranitValidator<PatternRequest>
     {
-        public PatternRequestValidator() => RuleFor(x => x.Code).Matches(@"^[A-Z]{3}$");
+        public PatternRequestValidator() => RuleFor(x => x.Code).Matches("^[A-Z]{3}$");
     }
 
     private sealed record EmailRequest(string Email);
@@ -369,7 +369,7 @@ public sealed class JsonSchemaWriterTests
     {
         public PatternHintRequestValidator() =>
             RuleFor(x => x.Code)
-                .Matches(@"^[A-Z]{2}$")
+                .Matches("^[A-Z]{2}$")
                 .WithPatternHint("Validation:Hint:Alpha2Code");
     }
 
@@ -391,7 +391,7 @@ public sealed class JsonSchemaWriterTests
             RuleFor(x => x.Code)
                 .NotEmpty()
                 .Length(2, 8)
-                .Matches(@"^[A-Z]+$");
+                .Matches("^[A-Z]+$");
     }
 
     private sealed record TwoFieldsRequest(string Name, int Age);

--- a/tests/Granit.Validation.Tests/Mod97AlgorithmTests.cs
+++ b/tests/Granit.Validation.Tests/Mod97AlgorithmTests.cs
@@ -38,7 +38,7 @@ public sealed class Mod97AlgorithmTests
     public void Compute_LargeNumber_DoesNotOverflow()
     {
         // A very large number that would overflow long arithmetic
-        string largeNumber = "111111111111111111111111111111111111111111111";
+        const string largeNumber = "111111111111111111111111111111111111111111111";
 
         int result = Mod97Algorithm.Compute(largeNumber);
 

--- a/tests/Granit.Validation.Tests/RuleBuilderExtensionsTests.cs
+++ b/tests/Granit.Validation.Tests/RuleBuilderExtensionsTests.cs
@@ -49,7 +49,7 @@ public sealed class RuleBuilderExtensionsTests
     {
         InlineValidator<TestModel> validator = [];
         validator.RuleFor(x => x.Value)
-            .Matches(@"^[A-Z]{2}$")
+            .Matches("^[A-Z]{2}$")
             .WithPatternHint("Validation:Hint:Alpha2Code");
 
         ValidationResult validResult = validator.Validate(new TestModel("BE"));

--- a/tests/Granit.Vault.Azure.Tests/AzureManagedHsmMacServiceTests.cs
+++ b/tests/Granit.Vault.Azure.Tests/AzureManagedHsmMacServiceTests.cs
@@ -72,8 +72,8 @@ public sealed class AzureManagedHsmMacServiceTests : IDisposable
                 Arg.Any<byte[]>(),
                 Arg.Any<CancellationToken>())
             .Returns(CryptographyModelFactory.VerifyResult(
-                isValid: true,
                 keyId: "https://hsm.example.managedhsm.azure.net/keys/granit-mac/abc",
+                isValid: true,
                 algorithm: SignatureAlgorithm.HS256));
         AzureManagedHsmMacService sut = BuildSut(_ => client);
 

--- a/tests/Granit.Vault.HashiCorp.Tests/HashiCorpTransitEncryptionServiceTests.cs
+++ b/tests/Granit.Vault.HashiCorp.Tests/HashiCorpTransitEncryptionServiceTests.cs
@@ -46,9 +46,9 @@ public sealed class HashiCorpTransitEncryptionServiceTests : IDisposable
     [Fact]
     public async Task EncryptAsync_CallsVaultTransitWithBase64Plaintext()
     {
-        string plaintext = "donnée de santé sensible";
+        const string plaintext = "donnée de santé sensible";
         string expectedBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(plaintext));
-        string ciphertext = "vault:v1:abc123encrypted";
+        const string ciphertext = "vault:v1:abc123encrypted";
 
         ITransitSecretsEngine transitEngine = Substitute.For<ITransitSecretsEngine>();
         ISecretsEngine secretsEngine = Substitute.For<ISecretsEngine>();
@@ -73,9 +73,9 @@ public sealed class HashiCorpTransitEncryptionServiceTests : IDisposable
     [Fact]
     public async Task DecryptAsync_ReturnsDecodedPlaintext()
     {
-        string originalText = "donnée personnelle sensible";
+        const string originalText = "donnée personnelle sensible";
         string base64Plaintext = Convert.ToBase64String(Encoding.UTF8.GetBytes(originalText));
-        string ciphertext = "vault:v1:abc123encrypted";
+        const string ciphertext = "vault:v1:abc123encrypted";
 
         ITransitSecretsEngine transitEngine = Substitute.For<ITransitSecretsEngine>();
         ISecretsEngine secretsEngine = Substitute.For<ISecretsEngine>();
@@ -100,8 +100,8 @@ public sealed class HashiCorpTransitEncryptionServiceTests : IDisposable
     [Fact]
     public async Task RewrapAsync_CallsVaultTransitRewrap_AndReturnsNewCiphertext()
     {
-        string oldCiphertext = "vault:v1:abc123encrypted";
-        string newCiphertext = "vault:v3:xyz789rewrapped";
+        const string oldCiphertext = "vault:v1:abc123encrypted";
+        const string newCiphertext = "vault:v3:xyz789rewrapped";
 
         ITransitSecretsEngine transitEngine = Substitute.For<ITransitSecretsEngine>();
         ISecretsEngine secretsEngine = Substitute.For<ISecretsEngine>();

--- a/tests/Granit.Vault.HashiCorp.Tests/HashiCorpVaultConfigurationExceptionTests.cs
+++ b/tests/Granit.Vault.HashiCorp.Tests/HashiCorpVaultConfigurationExceptionTests.cs
@@ -44,6 +44,6 @@ public sealed class HashiCorpVaultConfigurationExceptionTests
     {
         HashiCorpVaultConfigurationException exception = new("Vault:Test", "test");
 
-        ((IHasErrorCode)exception).ErrorCode.ShouldBe("Vault:Test");
+        exception.ErrorCode.ShouldBe("Vault:Test");
     }
 }

--- a/tests/Granit.Webhooks.Endpoints.Tests/Dtos/WebhookSubscriptionResponseTests.cs
+++ b/tests/Granit.Webhooks.Endpoints.Tests/Dtos/WebhookSubscriptionResponseTests.cs
@@ -11,14 +11,14 @@ public sealed class WebhookSubscriptionResponseTests
     public void Constructor_SetsAllProperties()
     {
         var id = Guid.NewGuid();
-        string targetUrl = "https://example.com/webhook";
-        string eventType = "order.created";
-        WebhookSubscriptionStatus status = WebhookSubscriptionStatus.Active;
-        int failureCount = 3;
+        const string targetUrl = "https://example.com/webhook";
+        const string eventType = "order.created";
+        const WebhookSubscriptionStatus status = WebhookSubscriptionStatus.Active;
+        const int failureCount = 3;
         DateTimeOffset lastSuccessAt = DateTimeOffset.UtcNow.AddHours(-1);
         DateTimeOffset createdAt = DateTimeOffset.UtcNow.AddDays(-7);
         DateTimeOffset modifiedAt = DateTimeOffset.UtcNow;
-        string hint = "whsec_b46a****************5182";
+        const string hint = "whsec_b46a****************5182";
 
         var response = new WebhookSubscriptionResponse(
             id,

--- a/tests/Granit.Webhooks.Tests/Definitions/WebhookSubscriptionExportDefinitionTests.cs
+++ b/tests/Granit.Webhooks.Tests/Definitions/WebhookSubscriptionExportDefinitionTests.cs
@@ -25,7 +25,7 @@ public sealed class WebhookSubscriptionExportDefinitionTests
     [Fact]
     public void SigningKeys_field_has_RequiresHierarchy()
     {
-        ExportFieldDescriptor field = ((IExportDefinitionDescriptor)Sut).GetFields()
+        ExportFieldDescriptor field = Sut.GetFields()
             .Single(f => f.PropertyPath == "SigningKeys");
 
         field.RequiresHierarchy.ShouldBeTrue();
@@ -36,7 +36,7 @@ public sealed class WebhookSubscriptionExportDefinitionTests
     [Fact]
     public void SigningKeys_selector_maps_lifecycle_metadata_only()
     {
-        ExportFieldDescriptor field = ((IExportDefinitionDescriptor)Sut).GetFields()
+        ExportFieldDescriptor field = Sut.GetFields()
             .Single(f => f.PropertyPath == "SigningKeys");
 
         WebhookSubscription subscription = BuildSubscriptionWithRotation();
@@ -57,7 +57,7 @@ public sealed class WebhookSubscriptionExportDefinitionTests
     [Fact]
     public void SigningSecretHint_is_exported_as_scalar()
     {
-        IReadOnlyList<ExportFieldDescriptor> fields = ((IExportDefinitionDescriptor)Sut).GetFields();
+        IReadOnlyList<ExportFieldDescriptor> fields = Sut.GetFields();
         ExportFieldDescriptor? hint = fields.FirstOrDefault(f => f.PropertyPath == "SigningSecretHint");
 
         hint.ShouldNotBeNull();
@@ -67,11 +67,11 @@ public sealed class WebhookSubscriptionExportDefinitionTests
     [Fact]
     public void ProtectedSecret_is_not_exported()
     {
-        IReadOnlyList<ExportFieldDescriptor> fields = ((IExportDefinitionDescriptor)Sut).GetFields();
+        IReadOnlyList<ExportFieldDescriptor> fields = Sut.GetFields();
 
         fields.ShouldNotContain(f =>
             f.PropertyPath.Contains("ProtectedSecret", StringComparison.OrdinalIgnoreCase) ||
-            f.PropertyPath.Contains("Secret", StringComparison.OrdinalIgnoreCase) && !f.PropertyPath.Contains("Hint"));
+            (f.PropertyPath.Contains("Secret", StringComparison.OrdinalIgnoreCase) && !f.PropertyPath.Contains("Hint")));
     }
 
     // ---- Helpers -----------------------------------------------------------

--- a/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
@@ -160,7 +160,7 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
             "https://example.com/hook", "test.event", null, TestContext.Current.CancellationToken);
         string initialHint = created.Subscription.SigningSecretHint!;
 
-        WebhookSigningKeyRotatedResult rotated = await ((IWebhookSigningKeyWriter)_store)
+        WebhookSigningKeyRotatedResult rotated = await _store
             .RotateSigningKeyAsync(created.Subscription.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
 
         WebhookSubscription? updated = await _store.FindByIdAsync(created.Subscription.Id, TestContext.Current.CancellationToken);
@@ -322,10 +322,10 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
         _store.Add(sub);
 
-        WebhookSigningKeyRotatedResult first = await ((IWebhookSigningKeyWriter)_store)
+        WebhookSigningKeyRotatedResult first = await _store
             .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
 
-        await ((IWebhookSigningKeyWriter)_store)
+        await _store
             .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
 
         // Initial seeded key + 2 rotation keys = 3 total. Exactly one is Active;
@@ -344,10 +344,10 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
         _store.Add(sub);
 
-        WebhookSigningKeyRotatedResult result = await ((IWebhookSigningKeyWriter)_store)
+        WebhookSigningKeyRotatedResult result = await _store
             .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
 
-        Func<Task> act = () => ((IWebhookSigningKeyWriter)_store)
+        Func<Task> act = () => _store
             .RevokeSigningKeyAsync(sub.Id, result.KeyId, TestContext.Current.CancellationToken);
 
         await Should.ThrowAsync<InvalidOperationException>(act);
@@ -359,12 +359,12 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
         _store.Add(sub);
 
-        await ((IWebhookSigningKeyWriter)_store)
+        await _store
             .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
-        await ((IWebhookSigningKeyWriter)_store)
+        await _store
             .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
 
-        IReadOnlyList<WebhookSigningKey> keys = await ((IWebhookSigningKeyReader)_store)
+        IReadOnlyList<WebhookSigningKey> keys = await _store
             .GetForSubscriptionAsync(sub.Id, TestContext.Current.CancellationToken);
 
         // Initial seeded key + 2 rotation keys.

--- a/tests/Granit.Webhooks.Tests/NoOpWebhookSecretProtectorTests.cs
+++ b/tests/Granit.Webhooks.Tests/NoOpWebhookSecretProtectorTests.cs
@@ -17,7 +17,7 @@ public sealed class NoOpWebhookSecretProtectorTests
     [Fact]
     public async Task ProtectAsync_ReturnsPlainSecretUnchanged()
     {
-        string secret = "test-webhook-value-256";
+        const string secret = "test-webhook-value-256";
 
         string result = await _protector.ProtectAsync(secret, TestContext.Current.CancellationToken);
 
@@ -27,7 +27,7 @@ public sealed class NoOpWebhookSecretProtectorTests
     [Fact]
     public async Task UnprotectAsync_ReturnsProtectedSecretUnchanged()
     {
-        string secret = "my-protected-secret";
+        const string secret = "my-protected-secret";
 
         string result = await _protector.UnprotectAsync(secret, TestContext.Current.CancellationToken);
 
@@ -53,7 +53,7 @@ public sealed class NoOpWebhookSecretProtectorTests
     [Fact]
     public async Task RoundTrip_ProtectThenUnprotect_ReturnsSameValue()
     {
-        string original = "round-trip-secret";
+        const string original = "round-trip-secret";
 
         string protectedValue = await _protector.ProtectAsync(original, TestContext.Current.CancellationToken);
         string unprotected = await _protector.UnprotectAsync(protectedValue, TestContext.Current.CancellationToken);

--- a/tests/Granit.Webhooks.Tests/WebhookSecretHintTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSecretHintTests.cs
@@ -10,7 +10,7 @@ public sealed class WebhookSecretHintTests
     public void From_PreservesKnownPrefix_AndMasksBody()
     {
         // 64 hex chars after the prefix → standard whsec_ output.
-        string plaintext = "whsec_b46a0123456789abcdef0123456789abcdef0123456789abcdef0123455182";
+        const string plaintext = "whsec_b46a0123456789abcdef0123456789abcdef0123456789abcdef0123455182";
 
         string hint = WebhookSecretHint.From(plaintext);
 
@@ -34,7 +34,7 @@ public sealed class WebhookSecretHintTests
     [Fact]
     public void From_WithoutKnownPrefix_DoesNotInventOne()
     {
-        string plaintext = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        const string plaintext = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
         string hint = WebhookSecretHint.From(plaintext);
 

--- a/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
+++ b/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
@@ -123,7 +123,7 @@ public sealed class GranitWolverineModuleTests
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
         bool callbackInvoked = false;
 
-        builder.AddGranitWolverine(configure: opts => { callbackInvoked = true; });
+        builder.AddGranitWolverine(configure: opts => callbackInvoked = true);
 
         callbackInvoked.ShouldBeTrue();
     }

--- a/tests/Granit.Wolverine.Tests/OutgoingContextMiddlewareTests.cs
+++ b/tests/Granit.Wolverine.Tests/OutgoingContextMiddlewareTests.cs
@@ -235,7 +235,7 @@ public sealed class OutgoingContextMiddlewareTests : IDisposable
 
         string? traceParent = envelope.Headers[OutgoingContextMiddleware.TraceParentHeader];
         // W3C format: 00-{32 hex}-{16 hex}-{2 hex}
-        traceParent!.ShouldMatch(@"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$");
+        traceParent!.ShouldMatch("^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$");
     }
 
     [Fact]

--- a/tests/Granit.Workflow.Endpoints.Tests/WorkflowEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/Granit.Workflow.Endpoints.Tests/WorkflowEndpointRouteBuilderExtensionsTests.cs
@@ -28,10 +28,7 @@ public sealed class WorkflowEndpointRouteBuilderExtensionsTests
         historyQuery.GetHistoryAsync("Order", "1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new PagedResult<WorkflowTransitionHistoryResponse>([], 0, HasMore: false));
 
-        await using WebApplication app = BuildApp(historyQuery, opts =>
-        {
-            opts.RoutePrefix = "admin/wf";
-        });
+        await using WebApplication app = BuildApp(historyQuery, opts => opts.RoutePrefix = "admin/wf");
 
         HttpClient client = BuildAuthorizedClient(app);
 

--- a/tests/Granit.Workflow.EntityFrameworkCore.Tests/WorkflowTransitionInterceptorTests.cs
+++ b/tests/Granit.Workflow.EntityFrameworkCore.Tests/WorkflowTransitionInterceptorTests.cs
@@ -41,7 +41,7 @@ public sealed class WorkflowTransitionInterceptorTests
     public async Task SaveChanges_WhenStatusChanges_ShouldCreateTransitionRecord()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestWorkflowEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -82,7 +82,7 @@ public sealed class WorkflowTransitionInterceptorTests
     public async Task SaveChanges_WhenStatusUnchanged_ShouldNotCreateRecord()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestWorkflowEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -108,7 +108,7 @@ public sealed class WorkflowTransitionInterceptorTests
         // Arrange
         _currentTenant.IsAvailable.Returns(false);
 
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestWorkflowEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -134,7 +134,7 @@ public sealed class WorkflowTransitionInterceptorTests
         // Arrange
         _currentUserService.UserId.Returns((string?)null);
 
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestWorkflowEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -164,7 +164,7 @@ public sealed class WorkflowTransitionInterceptorTests
         // Arrange
         using IDisposable scope = WorkflowTransitionContext.SetComment("Validated by Dr. Martin");
 
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestWorkflowEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -192,7 +192,7 @@ public sealed class WorkflowTransitionInterceptorTests
     public async Task SaveChanges_WhenPublished_ShouldSyncIsPublishedToTrue()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -214,7 +214,7 @@ public sealed class WorkflowTransitionInterceptorTests
     public async Task SaveChanges_WhenDraft_ShouldSyncIsPublishedToFalse()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -240,7 +240,7 @@ public sealed class WorkflowTransitionInterceptorTests
     public async Task SaveChanges_ExplicitInterfaceImpl_ShouldSyncIsPublished()
     {
         // Arrange — entity uses explicit IWorkflowStateful implementation (like VersionedWorkflowEntity)
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestExplicitEntity entity = new()
         {
             Id = Guid.NewGuid(),
@@ -260,7 +260,7 @@ public sealed class WorkflowTransitionInterceptorTests
     public async Task SaveChanges_ExplicitInterfaceImpl_ShouldCreateTransitionRecord()
     {
         // Arrange
-        using TestDbContext context = CreateContext();
+        await using TestDbContext context = CreateContext();
         TestExplicitEntity entity = new()
         {
             Id = Guid.NewGuid(),

--- a/tests/Granit.Workflow.Tests/WorkflowManagerFactoryTests.cs
+++ b/tests/Granit.Workflow.Tests/WorkflowManagerFactoryTests.cs
@@ -74,7 +74,7 @@ public sealed class WorkflowManagerFactoryTests
         services.AddWorkflow(BlogPostType, BlogDefinition);
         services.AddWorkflow(CmsPageType, PageDefinition);
 
-        using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = services.BuildServiceProvider();
         using IServiceScope scope = sp.CreateScope();
         IWorkflowManagerFactory factory =
             scope.ServiceProvider.GetRequiredService<IWorkflowManagerFactory>();


### PR DESCRIPTION
## Why

Integrating Roslynator (#2928) at an advisory `suggestion` baseline flooded SonarCloud to **1221 MAINTAINABILITY issues**. Root cause: SonarCloud's .NET scanner imports **external Roslyn diagnostics at Info severity**, not just warnings, as `external_roslyn:RCS*` external issues. Breakdown:

- **1215 / 1221** are Roslynator (`RCS*`); only **6** are Sonar-native → the pre-Roslynator baseline was ~6.
- **~81%** are in **test projects**, because the earlier promotions were scoped `[src/**.cs]` while the `suggestion` baseline covers the whole repo and Sonar imports test-file issues.
- They *look* pre-existing only because SonarCloud **backdates** issues from a newly-activated analyzer to each line's last SCM commit.

## What

**Promotions → repo-wide** (`[*.{cs,csx}]`, tests included) + **11 new safe rules** promoted (RCS1047, RCS1077, RCS1112, RCS1135, RCS1199, RCS1247, RCS1015, RCS1033, RCS1049, RCS1097). Auto-fixed across all 11 shards — mostly `using` → `await using` and `.Where(p).Count()` → `.Count(p)`.

**Disabled** (fight deliberate Granit patterns, each justified inline in `.editorconfig`):

| Rule | Reason |
|---|---|
| RCS1194 | sealed single-shape domain exceptions |
| RCS1201 | method-chaining readability loss (`activity.SetTag` chains) |
| RCS1158 | `const` identifiers on generic backend types (CA1000 moot for consts) |
| RCS1043 | source-generator `partial` hazard (`[LoggerMessage]`/`[GeneratedRegex]`) |
| RCS1124 / RCS1243 | inline-local readability loss / SIN-mask comment corruption |
| RCS1237 | deprecated by Roslynator |
| RCS1241 | its fixer mangles `ValueObject`'s `IEqualityComparer` into an API change |
| RCS1139 / RCS1226 | XML-doc completeness (consistent with `NoWarn CS1591`) |

**Hand-fixes** for non-Fix-All stragglers: 6 sync-handler `Async`-suffix renames (1 RCS1047 suppressed as a false positive on the `MapGranitModuleConfig`/`-Async` overload pair — they differ only by generic constraint and cannot share a name); `None = 0` on the `MultiTenancySides` `[Flags]` enum; 7 LINQ optimizations. Reverted 3 broken fixer outputs (RCS1084 invalid `(T??)` cast, RCS1077 `var`/IDE0008 + dangling `;`).

`RCS1093` left at `suggestion`: its only hit is the comment-only `ICurrentTenant.cs` breadcrumb (candidate for a separate deletion PR).

## Verification

- ✅ All 11 CI shards build clean under `TreatWarningsAsErrors`
- ✅ All 11 shards pass `dotnet format --verify-no-changes`
- 239 files, +841/-928 (net negative)

Expected effect: the `external_roslyn:RCS*` Sonar backlog drops sharply as promoted rules are enforced-and-fixed and convention-hostile rules are disabled.