### PR TITLE
chore(multitenancy): remove dead ICurrentTenant breadcrumb + promote RCS1093

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -189,6 +189,8 @@ dotnet_diagnostic.RCS1199.severity = warning
 dotnet_diagnostic.RCS1247.severity = warning
 # RCS1135: declare a zero-value member on a [Flags] enum (compatible with GRENUM001)
 dotnet_diagnostic.RCS1135.severity = warning
+# RCS1093: file contains no code (empty/comment-only compilation unit)
+dotnet_diagnostic.RCS1093.severity = warning
 # RCS1015: use the nameof operator
 dotnet_diagnostic.RCS1015.severity = warning
 # RCS1033: remove redundant '== true' in a boolean comparison

--- a/src/Granit.MultiTenancy/ICurrentTenant.cs
+++ b/src/Granit.MultiTenancy/ICurrentTenant.cs
@@ -1,2 +1,0 @@
-// ICurrentTenant has moved to Granit.MultiTenancy.
-// This assembly-wide alias maintains internal compatibility within Granit.MultiTenancy.


### PR DESCRIPTION
Follow-up to #2932.

`src/Granit.MultiTenancy/ICurrentTenant.cs` was a **comment-only file** (two lines, no code) left behind when the interface moved to the base `Granit` assembly (`src/Granit/MultiTenancy/ICurrentTenant.cs`, namespace `Granit.MultiTenancy`). Its comment claimed an "assembly-wide alias" that no longer exists.

`RCS1093` (*file contains no code*) correctly flagged it — the only hit repo-wide. #2932 left the rule at `suggestion` pending this deletion rather than block on a destructive change.

- Deletes the dead file.
- Promotes **RCS1093 → warning** (now zero hits repo-wide).

**Verified:** `security` shard (compiles `Granit.MultiTenancy`) builds clean under `TreatWarningsAsErrors`; real `ICurrentTenant` interface intact in the base assembly.