### PR TITLE
style(sonar): resolve async-await, naming, and readability smells

### DIFF
--- a/src/Granit.DataExchange.Excel/Internal/Import/SylvanExcelFileParser.cs
+++ b/src/Granit.DataExchange.Excel/Internal/Import/SylvanExcelFileParser.cs
@@ -48,9 +48,8 @@ internal sealed class SylvanExcelFileParser : IFileParser
         int fieldCount = reader.FieldCount;
 
         List<string[]> rows = [];
-        int count = 0;
 
-        while (count < maxRows && await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        for (int count = 0; count < maxRows && await reader.ReadAsync(cancellationToken).ConfigureAwait(false); count++)
         {
             int cellCount = Math.Min(fieldCount, reader.RowFieldCount);
             string[] values = new string[fieldCount];
@@ -66,7 +65,6 @@ internal sealed class SylvanExcelFileParser : IFileParser
             }
 
             rows.Add(values);
-            count++;
         }
 
         return rows.AsReadOnly();

--- a/src/Granit.DataExchange/Internal/InMemoryDataExchangeFileProvider.cs
+++ b/src/Granit.DataExchange/Internal/InMemoryDataExchangeFileProvider.cs
@@ -38,12 +38,12 @@ internal sealed class InMemoryDataExchangeFileProvider : IDataExchangeFileProvid
         ArgumentNullException.ThrowIfNull(content);
 
         await using MemoryStream buffer = new();
-        content.CopyTo(buffer);
+        await content.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
 
         string reference = $"mem-{Interlocked.Increment(ref _counter)}";
         _store[reference] = buffer.ToArray();
 
-        return await Task.FromResult(BlobReference.Create(reference));
+        return BlobReference.Create(reference);
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
@@ -146,7 +146,7 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
 
         ImageFormat outputFormat = _targetFormat ?? SourceFormat;
         await using MemoryStream ms = new();
-        _image.Write(ms, MagickFormatMapper.ToMagickFormat(outputFormat));
+        await _image.WriteAsync(ms, MagickFormatMapper.ToMagickFormat(outputFormat), cancellationToken).ConfigureAwait(false);
 
         RecordMetrics(outputFormat);
 
@@ -156,22 +156,20 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
             (int)_image.Width,
             (int)_image.Height);
 
-        return await Task.FromResult(result);
+        return result;
     }
 
     /// <inheritdoc/>
-    public Task SaveToStreamAsync(Stream destination, CancellationToken cancellationToken = default)
+    public async Task SaveToStreamAsync(Stream destination, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         ApplyOutputSettings();
 
         ImageFormat outputFormat = _targetFormat ?? SourceFormat;
-        _image.Write(destination, MagickFormatMapper.ToMagickFormat(outputFormat));
+        await _image.WriteAsync(destination, MagickFormatMapper.ToMagickFormat(outputFormat), cancellationToken).ConfigureAwait(false);
 
         RecordMetrics(outputFormat);
-
-        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Vault/Internal/CachedSecretStore.cs
+++ b/src/Granit.Vault/Internal/CachedSecretStore.cs
@@ -86,10 +86,8 @@ internal sealed partial class CachedSecretStore(
         return descriptor;
     }
 
-    private bool ShouldCache(SecretDescriptor descriptor)
-    {
-        return !(descriptor.BinaryValue is { } binary) || binary.Length <= _options.MaxCachedBinarySizeBytes;
-    }
+    private bool ShouldCache(SecretDescriptor descriptor) =>
+        !(descriptor.BinaryValue is { } binary) || binary.Length <= _options.MaxCachedBinarySizeBytes;
 
     private string BuildCacheKey(SecretRequest request) =>
         $"vault:secret:{providerName}:{request.Name}:{request.Version?.Identifier ?? "latest"}";

--- a/tests/Granit.AI.Tests/DefaultAIWorkspaceCapabilityResolverTests.cs
+++ b/tests/Granit.AI.Tests/DefaultAIWorkspaceCapabilityResolverTests.cs
@@ -107,11 +107,11 @@ public sealed class DefaultAIWorkspaceCapabilityResolverTests
     {
         public string ProviderName => "Stub";
 
-        public ValueTask<IChatClient> CreateChatClientAsync(AIWorkspace workspace, CancellationToken ct = default)
+        public ValueTask<IChatClient> CreateChatClientAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public ValueTask<IEmbeddingGenerator<string, Embedding<float>>?> CreateEmbeddingGeneratorAsync(
-            AIWorkspace workspace, CancellationToken ct = default)
+            AIWorkspace workspace, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 
@@ -122,11 +122,11 @@ public sealed class DefaultAIWorkspaceCapabilityResolverTests
     {
         public string ProviderName => providerName;
 
-        public ValueTask<IChatClient> CreateChatClientAsync(AIWorkspace workspace, CancellationToken ct = default)
+        public ValueTask<IChatClient> CreateChatClientAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public ValueTask<IEmbeddingGenerator<string, Embedding<float>>?> CreateEmbeddingGeneratorAsync(
-            AIWorkspace workspace, CancellationToken ct = default)
+            AIWorkspace workspace, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task<IReadOnlyList<AIModelInfo>> GetAvailableModelsAsync(CancellationToken cancellationToken = default)

--- a/tests/Granit.BlobStorage.S3.Tests/BlobTenantIsolationTests.cs
+++ b/tests/Granit.BlobStorage.S3.Tests/BlobTenantIsolationTests.cs
@@ -6,10 +6,10 @@ namespace Granit.BlobStorage.S3.Tests;
 public sealed class BlobTenantIsolationTests
 {
     [Fact]
-    public void Prefix_HasExpectedValue() => BlobTenantIsolation.Prefix.ShouldBe((BlobTenantIsolation)0);
+    public void Prefix_HasExpectedValue() => ((int)BlobTenantIsolation.Prefix).ShouldBe(0);
 
     [Fact]
-    public void Bucket_HasExpectedValue() => BlobTenantIsolation.Bucket.ShouldBe((BlobTenantIsolation)1);
+    public void Bucket_HasExpectedValue() => ((int)BlobTenantIsolation.Bucket).ShouldBe(1);
 
     [Fact]
     public void EnumValues_HasTwoMembers() => Enum.GetValues<BlobTenantIsolation>().Length.ShouldBe(2);

--- a/tests/Granit.Browsing.Tests/Pool/PrivilegedFlagGuardTests.cs
+++ b/tests/Granit.Browsing.Tests/Pool/PrivilegedFlagGuardTests.cs
@@ -116,8 +116,15 @@ public sealed class PrivilegedFlagGuardTests
 
     private sealed class FakeProbe(bool optIn, bool container, bool root) : IEnvironmentProbe
     {
-        public string? GetEnvironmentVariable(string name) =>
-            name == PrivilegedFlagGuard.OptInEnvVar ? (optIn ? "1" : null) : null;
+        public string? GetEnvironmentVariable(string name)
+        {
+            if (name != PrivilegedFlagGuard.OptInEnvVar)
+            {
+                return null;
+            }
+
+            return optIn ? "1" : null;
+        }
 
         public bool IsRunningInContainer() => container;
 

--- a/tests/Granit.DataExchange.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.DataExchange.Tests/ServiceCollectionExtensionsTests.cs
@@ -269,7 +269,7 @@ public sealed class ServiceCollectionExtensionsTests
         public bool IsAvailable => true;
 
         public Task<IReadOnlyList<SemanticMappingSuggestion>> SuggestSemanticMappingsAsync(
-            IReadOnlyList<string> unmappedHeaders,
+            IReadOnlyList<string> headers,
             IReadOnlyList<ImportFieldMetadata> targetFields,
             CancellationToken cancellationToken = default) =>
             Task.FromResult<IReadOnlyList<SemanticMappingSuggestion>>([]);

--- a/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineAdditionalTests.cs
+++ b/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineAdditionalTests.cs
@@ -10,7 +10,7 @@ namespace Granit.DocumentGeneration.Excel.Tests;
 
 public sealed class ClosedXmlTemplateEngineAdditionalTests
 {
-    private static readonly string ExcelMimeType =
+    private const string ExcelMimeType =
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
     private static string CreateBase64Template(Action<IXLWorksheet> configure)

--- a/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineTests.cs
+++ b/tests/Granit.DocumentGeneration.Excel.Tests/ClosedXmlTemplateEngineTests.cs
@@ -10,7 +10,7 @@ namespace Granit.DocumentGeneration.Excel.Tests;
 
 public sealed class ClosedXmlTemplateEngineTests
 {
-    private static readonly string ExcelMimeType =
+    private const string ExcelMimeType =
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Entities.Abstractions.Tests/Activities/ActivitiesOptionsBuilderTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Activities/ActivitiesOptionsBuilderTests.cs
@@ -67,10 +67,10 @@ public sealed class ActivitiesOptionsBuilderTests
     {
         public override string Name => "Test.SampleEntity";
 
-        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b)
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder)
         {
-            b.PermissionGroup("Test.Samples");
-            apply(b);
+            builder.PermissionGroup("Test.Samples");
+            apply(builder);
         }
     }
 }

--- a/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
@@ -242,22 +242,22 @@ public sealed class EntityDefinitionTests
     {
         public override string Name => "Granit.Sample.SampleEntity";
 
-        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b)
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder)
         {
-            b.DisplayKey("Entity:SampleEntity")
+            builder.DisplayKey("Entity:SampleEntity")
              .Icon("box")
              .PermissionGroup("Sample.SampleEntities")
              .DisplayProperty(s => s.Title)
              .SubtitleProperty(s => s.Status);
 
-            b.Query<SampleQueryDefinition>();
-            b.Export<SampleExportDefinition>();
-            b.Workflow<SampleWorkflowDefinition>();
-            b.Metric<SampleMetricA>();
-            b.Metric<SampleMetricB>();
-            b.Dashboard<SampleDashboard>();
+            builder.Query<SampleQueryDefinition>();
+            builder.Export<SampleExportDefinition>();
+            builder.Workflow<SampleWorkflowDefinition>();
+            builder.Metric<SampleMetricA>();
+            builder.Metric<SampleMetricB>();
+            builder.Dashboard<SampleDashboard>();
 
-            b.Form("default", f => f
+            builder.Form("default", f => f
                 .Section("general", s => s
                     .Field(x => x.Title)
                     .Field(x => x.Amount, fld => fld
@@ -270,12 +270,12 @@ public sealed class EntityDefinitionTests
                     .Field(x => x.Notes, fld => fld.VisibleIf("Status", FieldOp.Eq, "Draft")))
                 .Customizable());
 
-            b.Form("quick", f => f
+            builder.Form("quick", f => f
                 .Section("essentials", s => s
                     .Field(x => x.Title)
                     .Field(x => x.Amount)));
 
-            b.Detail("default", d => d
+            builder.Detail("default", d => d
                 .SectionsFromForm()
                 .SidePanel.Audit().Timeline());
         }
@@ -285,18 +285,18 @@ public sealed class EntityDefinitionTests
     {
         public override string Name => "Granit.Sample.Minimal";
 
-        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b) =>
-            b.DisplayProperty(s => s.Title);
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder.DisplayProperty(s => s.Title);
     }
 
     private sealed class DuplicateFormDefinition : EntityDefinition<SampleEntity>
     {
         public override string Name => "Granit.Sample.Dup";
 
-        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b)
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder)
         {
-            b.Form("default", f => f.Section("a", s => s.Field(x => x.Title)));
-            b.Form("default", f => f.Section("b", s => s.Field(x => x.Title)));
+            builder.Form("default", f => f.Section("a", s => s.Field(x => x.Title)));
+            builder.Form("default", f => f.Section("b", s => s.Field(x => x.Title)));
         }
     }
 
@@ -304,9 +304,9 @@ public sealed class EntityDefinitionTests
     {
         public override string Name => "Granit.Sample.Mixed";
 
-        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b)
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder)
         {
-            b.Detail("default", d => d.Section("mix", s => s
+            builder.Detail("default", d => d.Section("mix", s => s
                 .InheritsFromForm("default")
                 .Field(x => x.Title)));
         }

--- a/tests/Granit.Entities.Abstractions.Tests/FieldLookupTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/FieldLookupTests.cs
@@ -62,8 +62,8 @@ public sealed class FieldLookupTests
     {
         public override string Name => "Granit.Sample.LookupEntity";
 
-        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b) =>
-            b.Form("default", f => f
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder.Form("default", f => f
                 .Section("general", s => s
                     .Field(x => x.Title)
                     .Field(x => x.TenantId, fld => fld

--- a/tests/Granit.Entities.Abstractions.Tests/FieldValueKindTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/FieldValueKindTests.cs
@@ -48,8 +48,8 @@ public sealed class FieldValueKindTests
     {
         public override string Name => "Granit.Sample.ValueKindEntity";
 
-        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b) =>
-            b.Form("default", f => f
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder.Form("default", f => f
                 .Section("general", s => s
                     .Field(x => x.Title)
                     .Field(x => x.Homepage, fld => fld.Component("url").ValueKind(ValueKind.Url))));

--- a/tests/Granit.Entities.Abstractions.Tests/RegistrationTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/RegistrationTests.cs
@@ -54,7 +54,7 @@ public sealed class RegistrationTests
     {
         public override string Name => "Granit.Test.TestEntity";
 
-        protected override void Configure(EntityDefinitionBuilder<TestEntity> b) =>
-            b.Form("default", f => f.Section("a", s => s.Field(x => x.Title)));
+        protected override void Configure(EntityDefinitionBuilder<TestEntity> builder) =>
+            builder.Form("default", f => f.Section("a", s => s.Field(x => x.Title)));
     }
 }

--- a/tests/Granit.Entities.Abstractions.Tests/RelationBuilderTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/RelationBuilderTests.cs
@@ -28,8 +28,8 @@ public sealed class RelationBuilderTests
     private sealed class PartyDefinition : EntityDefinition<Party>
     {
         public override string Name => "Test.Party";
-        protected override void Configure(EntityDefinitionBuilder<Party> b) =>
-            b
+        protected override void Configure(EntityDefinitionBuilder<Party> builder) =>
+            builder
                 .HasMany<Address>(p => p.Addresses, r => r
                     .DisplayAs(RelationDisplay.Tab)
                     .DisplayKey("Relation:Party.Addresses")
@@ -98,8 +98,8 @@ public sealed class RelationBuilderTests
     private sealed class AggregateDef : EntityDefinition<Party>
     {
         public override string Name => "Test.Party.Aggregates";
-        protected override void Configure(EntityDefinitionBuilder<Party> b) =>
-            b.HasMany<Invoice>(p => p.Invoices,
+        protected override void Configure(EntityDefinitionBuilder<Party> builder) =>
+            builder.HasMany<Invoice>(p => p.Invoices,
                 r => r.DisplayAs(RelationDisplay.SmartButton)
                     .Aggregate(a => a.Count().Sum(i => i.Amount)));
     }
@@ -107,8 +107,8 @@ public sealed class RelationBuilderTests
     private sealed class InvalidNonPropertySelectorDef : EntityDefinition<Party>
     {
         public override string Name => "Test.Party.Bad";
-        protected override void Configure(EntityDefinitionBuilder<Party> b) =>
-            b.HasMany<Address>(p => p.Addresses.Where(a => a.City == "Paris"));
+        protected override void Configure(EntityDefinitionBuilder<Party> builder) =>
+            builder.HasMany<Address>(p => p.Addresses.Where(a => a.City == "Paris"));
     }
 
     [Fact]
@@ -126,8 +126,8 @@ public sealed class RelationBuilderTests
     private sealed class KanbanPinnedDefinition : EntityDefinition<Party>
     {
         public override string Name => "Test.Party.KanbanPinned";
-        protected override void Configure(EntityDefinitionBuilder<Party> b) =>
-            b
+        protected override void Configure(EntityDefinitionBuilder<Party> builder) =>
+            builder
                 .HasMany<Address>(p => p.Addresses, r => r
                     .DisplayAs(RelationDisplay.SmartButton)
                     .OnKanbanCard())

--- a/tests/Granit.EntityMerge.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
+++ b/tests/Granit.EntityMerge.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
@@ -379,22 +379,22 @@ public sealed class EfMergeServiceTests
             return Task.FromResult<FakeAggregate?>(null);
         }
 
-        public Task PersistMergedPairAsync(FakeAggregate s, FakeAggregate l, CancellationToken ct)
+        public Task PersistMergedPairAsync(FakeAggregate survivor, FakeAggregate loser, CancellationToken cancellationToken)
         {
             PersistCalls++;
             return Task.CompletedTask;
         }
 
-        public void ApplyTombstone(FakeAggregate l, Guid survivorId, DateTimeOffset mergedAt)
+        public void ApplyTombstone(FakeAggregate loser, Guid survivorId, DateTimeOffset mergedAt)
         {
             TombstoneCalls++;
             AppliedTombstoneSurvivorId = survivorId;
             AppliedTombstoneAt = mergedAt;
-            l.MergedIntoId = survivorId;
-            l.MergedAt = mergedAt;
+            loser.MergedIntoId = survivorId;
+            loser.MergedAt = mergedAt;
         }
 
-        public Task<int> CollapseChainTombstonesAsync(Guid newSurvivor, Guid oldSurvivor, CancellationToken ct)
+        public Task<int> CollapseChainTombstonesAsync(Guid newSurvivorId, Guid oldSurvivorId, CancellationToken cancellationToken)
         {
             ChainCollapseCalls++;
             return Task.FromResult(0);
@@ -423,16 +423,16 @@ public sealed class EfMergeServiceTests
 
     private sealed class TenantedAdapter(TenantedAggregate? s, TenantedAggregate? l) : IMergeableAggregateAdapter<TenantedAggregate>
     {
-        public Task<TenantedAggregate?> LoadAsync(Guid id, CancellationToken ct)
+        public Task<TenantedAggregate?> LoadAsync(Guid id, CancellationToken cancellationToken)
         {
             if (id == s?.Id) { return Task.FromResult<TenantedAggregate?>(s); }
             if (id == l?.Id) { return Task.FromResult<TenantedAggregate?>(l); }
             return Task.FromResult<TenantedAggregate?>(null);
         }
 
-        public Task PersistMergedPairAsync(TenantedAggregate survivor, TenantedAggregate loser, CancellationToken ct) => Task.CompletedTask;
+        public Task PersistMergedPairAsync(TenantedAggregate survivor, TenantedAggregate loser, CancellationToken cancellationToken) => Task.CompletedTask;
         public void ApplyTombstone(TenantedAggregate loser, Guid survivorId, DateTimeOffset mergedAt) { }
-        public Task<int> CollapseChainTombstonesAsync(Guid newS, Guid oldS, CancellationToken ct) => Task.FromResult(0);
+        public Task<int> CollapseChainTombstonesAsync(Guid newSurvivorId, Guid oldSurvivorId, CancellationToken cancellationToken) => Task.FromResult(0);
     }
 
     private sealed class FakeRewriter(
@@ -445,14 +445,14 @@ public sealed class EfMergeServiceTests
         public int RewriteCalls { get; private set; }
         public int CountCalls { get; private set; }
 
-        public Task<int> RewriteAsync(Guid s, Guid l, CancellationToken ct)
+        public Task<int> RewriteAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
         {
             RewriteCalls++;
             executionLog?.Add(Description);
             return Task.FromResult(rewriteCount);
         }
 
-        public Task<int> CountAsync(Guid s, Guid l, CancellationToken ct)
+        public Task<int> CountAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
         {
             CountCalls++;
             return Task.FromResult(countCount);

--- a/tests/Granit.EntityMerge.Tests/Extensions/EntityMergeServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.EntityMerge.Tests/Extensions/EntityMergeServiceCollectionExtensionsTests.cs
@@ -43,14 +43,14 @@ public sealed class EntityMergeServiceCollectionExtensionsTests
     private sealed class FakeRewriter : IReferenceRewriter<FakeAggregate>
     {
         public string Description => "fake.RefId";
-        public Task<int> RewriteAsync(Guid s, Guid l, CancellationToken ct) => Task.FromResult(0);
-        public Task<int> CountAsync(Guid s, Guid l, CancellationToken ct) => Task.FromResult(0);
+        public Task<int> RewriteAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken) => Task.FromResult(0);
+        public Task<int> CountAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken) => Task.FromResult(0);
     }
 
     private sealed class AnotherFakeRewriter : IReferenceRewriter<FakeAggregate>
     {
         public string Description => "another.RefId";
-        public Task<int> RewriteAsync(Guid s, Guid l, CancellationToken ct) => Task.FromResult(0);
-        public Task<int> CountAsync(Guid s, Guid l, CancellationToken ct) => Task.FromResult(0);
+        public Task<int> RewriteAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken) => Task.FromResult(0);
+        public Task<int> CountAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken) => Task.FromResult(0);
     }
 }

--- a/tests/Granit.Http.Features.Tests/AspNetCore/FeatureEndpointConventionBuilderExtensionsTests.cs
+++ b/tests/Granit.Http.Features.Tests/AspNetCore/FeatureEndpointConventionBuilderExtensionsTests.cs
@@ -16,7 +16,7 @@ public sealed class FeatureEndpointConventionBuilderExtensionsTests
 
         public void Add(Action<EndpointBuilder> convention) => Conventions.Add(convention);
 
-        public void Finally(Action<EndpointBuilder> convention) { }
+        public void Finally(Action<EndpointBuilder> finallyConvention) { }
     }
 
     [Fact]

--- a/tests/Granit.Identity.Abstractions.Tests/UserSessionProviderPrecedenceTests.cs
+++ b/tests/Granit.Identity.Abstractions.Tests/UserSessionProviderPrecedenceTests.cs
@@ -15,26 +15,26 @@ public sealed class UserSessionProviderPrecedenceTests
     // Fake backends — resolvable with no external dependencies, so we can assert the resolved instance type.
     private sealed class LowProvider : IUserSessionProvider, IUserDeviceProvider
     {
-        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string u, string? c, CancellationToken t = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
-        public Task<bool> RevokeAsync(string u, string s, CancellationToken t = default) => Task.FromResult(false);
-        public Task<int> RevokeOthersAsync(string u, string c, CancellationToken t = default) => Task.FromResult(0);
-        Task<IReadOnlyList<UserDevice>> IUserDeviceProvider.ListAsync(string u, CancellationToken t) => Task.FromResult<IReadOnlyList<UserDevice>>([]);
+        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string userId, string? currentSessionId, CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
+        public Task<bool> RevokeAsync(string userId, string sessionId, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<int> RevokeOthersAsync(string userId, string currentSessionId, CancellationToken cancellationToken = default) => Task.FromResult(0);
+        Task<IReadOnlyList<UserDevice>> IUserDeviceProvider.ListAsync(string userId, CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<UserDevice>>([]);
     }
 
     private sealed class HighProvider : IUserSessionProvider, IUserDeviceProvider
     {
-        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string u, string? c, CancellationToken t = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
-        public Task<bool> RevokeAsync(string u, string s, CancellationToken t = default) => Task.FromResult(false);
-        public Task<int> RevokeOthersAsync(string u, string c, CancellationToken t = default) => Task.FromResult(0);
-        Task<IReadOnlyList<UserDevice>> IUserDeviceProvider.ListAsync(string u, CancellationToken t) => Task.FromResult<IReadOnlyList<UserDevice>>([]);
+        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string userId, string? currentSessionId, CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
+        public Task<bool> RevokeAsync(string userId, string sessionId, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<int> RevokeOthersAsync(string userId, string currentSessionId, CancellationToken cancellationToken = default) => Task.FromResult(0);
+        Task<IReadOnlyList<UserDevice>> IUserDeviceProvider.ListAsync(string userId, CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<UserDevice>>([]);
     }
 
     // Session-only backend (like BFF): does not implement IUserDeviceProvider.
     private sealed class SessionOnlyProvider : IUserSessionProvider
     {
-        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string u, string? c, CancellationToken t = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
-        public Task<bool> RevokeAsync(string u, string s, CancellationToken t = default) => Task.FromResult(false);
-        public Task<int> RevokeOthersAsync(string u, string c, CancellationToken t = default) => Task.FromResult(0);
+        public Task<IReadOnlyList<UserSessionDescriptor>> ListAsync(string userId, string? currentSessionId, CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<UserSessionDescriptor>>([]);
+        public Task<bool> RevokeAsync(string userId, string sessionId, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<int> RevokeOthersAsync(string userId, string currentSessionId, CancellationToken cancellationToken = default) => Task.FromResult(0);
     }
 
     private const UserSessionProviderPrecedence Low = UserSessionProviderPrecedence.Federated;

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests/SqliteHarness.cs
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests/SqliteHarness.cs
@@ -71,6 +71,6 @@ internal sealed class SqliteHarness : IAsyncDisposable
 
 internal sealed class NoopLocalEventBus : Granit.Events.ILocalEventBus
 {
-    public Task PublishAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default) where TEvent : class =>
+    public Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default) where TEvent : class =>
         Task.CompletedTask;
 }

--- a/tests/Granit.Localization.Endpoints.Tests/LocalizationEndpointTests.cs
+++ b/tests/Granit.Localization.Endpoints.Tests/LocalizationEndpointTests.cs
@@ -13,7 +13,7 @@ namespace Granit.Localization.Endpoints.Tests;
 
 public sealed class LocalizationEndpointTests : IAsyncDisposable
 {
-    private static readonly string TestResourcePrefix =
+    private const string TestResourcePrefix =
         "Granit.Localization.Endpoints.Tests.TestResources.Localization.Test";
 
     private readonly WebApplication _app;

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
@@ -1014,4 +1014,4 @@ internal sealed class TestDbContextWithMergeable(DbContextOptions<TestDbContextW
         modelBuilder.ApplyGranitConventions();
 }
 
-#endregion
+#endregion Test entities

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslatableQueryExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslatableQueryExtensionsTests.cs
@@ -197,4 +197,4 @@ internal sealed class TestQueryDbContext(DbContextOptions<TestQueryDbContext> op
         modelBuilder.ApplyGranitConventions();
 }
 
-#endregion
+#endregion Test entities for query extensions

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslationConventionTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/TranslationConventionTests.cs
@@ -520,4 +520,4 @@ internal sealed class TranslationTestDataFilter : IDataFilter
     }
 }
 
-#endregion
+#endregion Test entities

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexColumnTests.cs
@@ -259,8 +259,8 @@ public sealed class NestedComplexColumnTests : IDisposable
     {
         public DbSet<PartyAddress> Addresses => Set<PartyAddress>();
 
-        protected override void OnModelCreating(ModelBuilder b) =>
-            b.Entity<PartyAddress>(e =>
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<PartyAddress>(e =>
             {
                 e.HasKey(p => p.Id);
                 e.ComplexProperty(p => p.Value, v => v.ComplexProperty(a => a.Region));

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexGroupByTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/NestedComplexGroupByTests.cs
@@ -210,8 +210,8 @@ public sealed class NestedComplexGroupByTests : IDisposable
     {
         public DbSet<PartyAddress> Addresses => Set<PartyAddress>();
 
-        protected override void OnModelCreating(ModelBuilder b) =>
-            b.Entity<PartyAddress>(e =>
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<PartyAddress>(e =>
             {
                 e.HasKey(p => p.Id);
                 e.ComplexProperty(p => p.Value, v => v.ComplexProperty(a => a.Region));

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableValueObjectJsonStorageTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableValueObjectJsonStorageTests.cs
@@ -85,6 +85,6 @@ public sealed class QueryableValueObjectJsonStorageTests : IDisposable
     private sealed class PageCtx(DbContextOptions<PageCtx> options) : DbContext(options)
     {
         public DbSet<Page> Pages => Set<Page>();
-        protected override void OnModelCreating(ModelBuilder b) => b.ApplyGranitConventions();
+        protected override void OnModelCreating(ModelBuilder modelBuilder) => modelBuilder.ApplyGranitConventions();
     }
 }

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableValueObjectNullableComplexTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableValueObjectNullableComplexTests.cs
@@ -71,6 +71,6 @@ public sealed class QueryableValueObjectNullableComplexTests : IDisposable
     private sealed class Ctx(DbContextOptions<Ctx> options) : DbContext(options)
     {
         public DbSet<Thing> Things => Set<Thing>();
-        protected override void OnModelCreating(ModelBuilder b) => b.ApplyGranitConventions();
+        protected override void OnModelCreating(ModelBuilder modelBuilder) => modelBuilder.ApplyGranitConventions();
     }
 }

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableValueObjectPrototypeTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableValueObjectPrototypeTests.cs
@@ -124,9 +124,9 @@ public sealed class QueryableValueObjectPrototypeTests : IDisposable
     {
         public DbSet<Site> Sites => Set<Site>();
 
-        protected override void OnModelCreating(ModelBuilder b)
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
             // The [QueryableValueObject] attribute alone drives the ComplexProperty mapping
             // (inner Value as the "Slug" column) — ApplyGranitConventions does it, no manual config.
-            => b.ApplyGranitConventions();
+            => modelBuilder.ApplyGranitConventions();
     }
 }

--- a/tests/Granit.Templating.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Templating.Tests/ServiceCollectionExtensionsTests.cs
@@ -181,16 +181,16 @@ public sealed class ServiceCollectionExtensionsTests
     {
         public int Order => 100;
         public bool CanTransform(Granit.Templating.Keys.DocumentFormat format) => true;
-        public Task<string> TransformAsync(string content, Granit.Templating.Keys.DocumentFormat format, CancellationToken ct) =>
+        public Task<string> TransformAsync(string content, Granit.Templating.Keys.DocumentFormat format, CancellationToken cancellationToken) =>
             Task.FromResult(content);
     }
 
     private sealed class FakeTransitionHook : ITemplateTransitionHook
     {
         public bool IsWorkflowEnabled => true;
-        public Task<bool> CanTransitionAsync(WorkflowLifecycleStatus from, WorkflowLifecycleStatus to, CancellationToken cancellationToken) =>
+        public Task<bool> CanTransitionAsync(WorkflowLifecycleStatus from, WorkflowLifecycleStatus target, CancellationToken cancellationToken) =>
             Task.FromResult(true);
-        public Task OnTransitionedAsync(Guid revisionId, WorkflowLifecycleStatus from, WorkflowLifecycleStatus to, string userId, CancellationToken cancellationToken) =>
+        public Task OnTransitionedAsync(Guid revisionId, WorkflowLifecycleStatus from, WorkflowLifecycleStatus target, string userId, CancellationToken cancellationToken) =>
             Task.CompletedTask;
     }
 }

--- a/tests/Granit.Tests/Domain/ValueObjectTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjectTests.cs
@@ -42,6 +42,7 @@ public sealed class ValueObjectTests
 
         money.Equals(null).ShouldBeFalse();
         (money == null).ShouldBeFalse();
+        // Reverse operand order exercises the null-on-left path of operator ==(Money, Money).
         (null == money).ShouldBeFalse();
     }
 

--- a/tests/Granit.Timeline.Tests/InMemoryAnchorTests.cs
+++ b/tests/Granit.Timeline.Tests/InMemoryAnchorTests.cs
@@ -109,10 +109,10 @@ public sealed class InMemoryAnchorTests
         public string SourceKey { get; } = key;
         public TimelineStreamEntry? Projection { get; set; }
 
-        public Task<IReadOnlyList<TimelineStreamEntry>> GetEntriesAsync(string _, string __, int ___, CancellationToken ____) =>
+        public Task<IReadOnlyList<TimelineStreamEntry>> GetEntriesAsync(string entityType, string entityId, int limit, CancellationToken cancellationToken) =>
             Task.FromResult<IReadOnlyList<TimelineStreamEntry>>([]);
 
-        public Task<TimelineStreamEntry?> GetEntryAsync(string _, string __, string ___, CancellationToken ____) =>
+        public Task<TimelineStreamEntry?> GetEntryAsync(string entityType, string entityId, string sourceId, CancellationToken cancellationToken) =>
             Task.FromResult(Projection);
     }
 }

--- a/tests/Granit.Timeline.Tests/TimelineStreamMergerTests.cs
+++ b/tests/Granit.Timeline.Tests/TimelineStreamMergerTests.cs
@@ -163,18 +163,18 @@ public sealed class TimelineStreamMergerTests
     private sealed class StubSource(string key, IReadOnlyList<TimelineStreamEntry> entries) : ITimelineSource
     {
         public string SourceKey => key;
-        public Task<IReadOnlyList<TimelineStreamEntry>> GetEntriesAsync(string _, string __, int ___, CancellationToken ____) =>
+        public Task<IReadOnlyList<TimelineStreamEntry>> GetEntriesAsync(string entityType, string entityId, int limit, CancellationToken cancellationToken) =>
             Task.FromResult(entries);
-        public Task<TimelineStreamEntry?> GetEntryAsync(string _, string __, string ___, CancellationToken ____) =>
+        public Task<TimelineStreamEntry?> GetEntryAsync(string entityType, string entityId, string sourceId, CancellationToken cancellationToken) =>
             Task.FromResult<TimelineStreamEntry?>(null);
     }
 
     private sealed class FailingSource(string key) : ITimelineSource
     {
         public string SourceKey => key;
-        public Task<IReadOnlyList<TimelineStreamEntry>> GetEntriesAsync(string _, string __, int ___, CancellationToken ____) =>
+        public Task<IReadOnlyList<TimelineStreamEntry>> GetEntriesAsync(string entityType, string entityId, int limit, CancellationToken cancellationToken) =>
             throw new InvalidOperationException("boom");
-        public Task<TimelineStreamEntry?> GetEntryAsync(string _, string __, string ___, CancellationToken ____) =>
+        public Task<TimelineStreamEntry?> GetEntryAsync(string entityType, string entityId, string sourceId, CancellationToken cancellationToken) =>
             Task.FromResult<TimelineStreamEntry?>(null);
     }
 }

--- a/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
+++ b/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
@@ -34,7 +34,7 @@ public sealed class JsonSchemaWriterTests
     [Fact]
     public void Write_NoValidatorRegistered_ReturnsNull()
     {
-        JsonSchemaWriter writer = CreateWriter<NoValidatorRequest>(registerValidator: false);
+        JsonSchemaWriter writer = CreateWriter(registerValidator: false);
 
         JsonObject? schema = writer.Write(typeof(NoValidatorRequest));
 
@@ -238,7 +238,7 @@ public sealed class JsonSchemaWriterTests
     [Fact]
     public void Write_NullType_Throws()
     {
-        JsonSchemaWriter writer = CreateWriter<NoValidatorRequest>(registerValidator: false);
+        JsonSchemaWriter writer = CreateWriter(registerValidator: false);
 
         Should.Throw<ArgumentNullException>(() => writer.Write(null!));
     }
@@ -262,7 +262,7 @@ public sealed class JsonSchemaWriterTests
         return new JsonSchemaWriter(provider.GetRequiredService<IServiceScopeFactory>());
     }
 
-    private static JsonSchemaWriter CreateWriter<TRequest>(bool registerValidator)
+    private static JsonSchemaWriter CreateWriter(bool registerValidator)
     {
         ServiceCollection services = new();
         ServiceProvider provider = services.BuildServiceProvider();

--- a/tests/Granit.Workflow.Scheduling.Tests/WorkflowTransitionApplierBaseTests.cs
+++ b/tests/Granit.Workflow.Scheduling.Tests/WorkflowTransitionApplierBaseTests.cs
@@ -22,13 +22,13 @@ public sealed class WorkflowTransitionApplierBaseTests
         protected override Task<FakeEntity?> LoadAsync(Guid entityId, CancellationToken cancellationToken) =>
             Task.FromResult(entity);
 
-        protected override TestState GetCurrentState(FakeEntity e) => e.State;
+        protected override TestState GetCurrentState(FakeEntity entity) => entity.State;
 
-        protected override void SetState(FakeEntity e, TestState target) => e.SetState(target);
+        protected override void SetState(FakeEntity entity, TestState target) => entity.SetState(target);
 
-        protected override Task SaveAsync(FakeEntity e, CancellationToken cancellationToken)
+        protected override Task SaveAsync(FakeEntity entity, CancellationToken cancellationToken)
         {
-            Saved = e;
+            Saved = entity;
             return Task.CompletedTask;
         }
     }

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceBuilderTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceBuilderTests.cs
@@ -68,8 +68,8 @@ public sealed class WorkspaceBuilderTests
     {
         public override string Name => "Sample";
 
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.DisplayKey("Workspace:Sample")
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.DisplayKey("Workspace:Sample")
                 .Icon("layout-grid")
                 .Order(10)
                 .RequiresPermission("Workspace.Sample.Read")
@@ -85,30 +85,30 @@ public sealed class WorkspaceBuilderTests
     {
         public override string Name => "Dup";
 
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("a", _ => { }).Section("a", _ => { });
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("a", _ => { }).Section("a", _ => { });
     }
 
     private sealed class ShellDefinition : WorkspaceDefinition
     {
         public override string Name => "Granit.Framework.Data";
-        protected override void Configure(WorkspaceBuilder b) => b.Shell();
+        protected override void Configure(WorkspaceBuilder builder) => builder.Shell();
     }
 
     private sealed class InvalidViewOnLink : WorkspaceDefinition
     {
         public override string Name => "Invalid";
 
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Link("/x", i => i.View("any")));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Link("/x", i => i.View("any")));
     }
 
     private sealed class FeatureDefinition : WorkspaceDefinition
     {
         public override string Name => "Showcase.Erp";
 
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("billing", s => s
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("billing", s => s
                 .Feature("invoicing.invoices.list", i => i
                     .DisplayKey("Showcase:Workspace.Erp.InvoiceList")
                     .Icon("chart-bar")
@@ -119,8 +119,8 @@ public sealed class WorkspaceBuilderTests
     {
         public override string Name => "Invalid";
 
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Link("/x", i => i.RouteName("any.route")));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Link("/x", i => i.RouteName("any.route")));
     }
 }
 

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceDefinitionTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceDefinitionTests.cs
@@ -55,34 +55,34 @@ public sealed class WorkspaceDefinitionTests
         public int ConfigureCallCount { get; private set; }
         public override string Name => "Counted";
 
-        protected override void Configure(WorkspaceBuilder b)
+        protected override void Configure(WorkspaceBuilder builder)
         {
             ConfigureCallCount++;
-            b.Order(3);
+            builder.Order(3);
         }
     }
 
     private sealed class BareDefinition : WorkspaceDefinition
     {
         public override string Name => "Bare";
-        protected override void Configure(WorkspaceBuilder b) { }
+        protected override void Configure(WorkspaceBuilder builder) { }
     }
 
     private sealed class BlankDisplayKey : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) => b.DisplayKey("  ");
+        protected override void Configure(WorkspaceBuilder builder) => builder.DisplayKey("  ");
     }
 
     private sealed class BlankIcon : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) => b.Icon(" ");
+        protected override void Configure(WorkspaceBuilder builder) => builder.Icon(" ");
     }
 
     private sealed class BlankPermission : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) => b.RequiresPermission("");
+        protected override void Configure(WorkspaceBuilder builder) => builder.RequiresPermission("");
     }
 }

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceItemBuilderTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceItemBuilderTests.cs
@@ -91,8 +91,8 @@ public sealed class WorkspaceItemBuilderTests
     private sealed class EntityItemDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Entity("Mod.Customer", i => i
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Entity("Mod.Customer", i => i
                 .View("open")
                 .DisplayKey("Customer:Label")
                 .Icon("user")
@@ -104,51 +104,51 @@ public sealed class WorkspaceItemBuilderTests
     private sealed class TypedEntityDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Entity<SampleEntityMarker>());
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Entity<SampleEntityMarker>());
     }
 
     private sealed class DashboardItemDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Dashboard("Mod.SalesDashboard"));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Dashboard("Mod.SalesDashboard"));
     }
 
     private sealed class LinkItemDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Link("https://example.test"));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Link("https://example.test"));
     }
 
     private sealed class SubWorkspaceItemDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.SubWorkspace("Mod.Child"));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.SubWorkspace("Mod.Child"));
     }
 
     private sealed class InvalidPresetOnLink : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Link("/x", i =>
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Link("/x", i =>
                 i.Preset(new Dictionary<string, object?> { ["k"] = 1 })));
     }
 
     private sealed class BlankDisplayKey(string key) : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Entity("E", i => i.DisplayKey(key)));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Entity("E", i => i.DisplayKey(key)));
     }
 
     private sealed class OrderingDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s
                 .Entity("A", i => i.Order(10))
                 .Entity("B", i => i.Order(1))
                 .Entity("C", i => i.Order(5)));
@@ -157,7 +157,7 @@ public sealed class WorkspaceItemBuilderTests
     private sealed class NullPresetDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Entity("E", i => i.Preset(null!)));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Entity("E", i => i.Preset(null!)));
     }
 }

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceSectionBuilderTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceSectionBuilderTests.cs
@@ -50,8 +50,8 @@ public sealed class WorkspaceSectionBuilderTests
     private sealed class ConfiguredSectionDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("reports", s => s
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("reports", s => s
                 .DisplayKey("Section:Reports")
                 .Order(7)
                 .CollapsedByDefault(true));
@@ -60,32 +60,32 @@ public sealed class WorkspaceSectionBuilderTests
     private sealed class DefaultCollapsedDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.CollapsedByDefault());
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.CollapsedByDefault());
     }
 
     private sealed class EmptySectionDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) => b.Section("s", _ => { });
+        protected override void Configure(WorkspaceBuilder builder) => builder.Section("s", _ => { });
     }
 
     private sealed class BlankSectionKey(string key) : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) => b.Section(key, _ => { });
+        protected override void Configure(WorkspaceBuilder builder) => builder.Section(key, _ => { });
     }
 
     private sealed class BlankEntityName(string n) : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) =>
-            b.Section("s", s => s.Entity(n));
+        protected override void Configure(WorkspaceBuilder builder) =>
+            builder.Section("s", s => s.Entity(n));
     }
 
     private sealed class NullConfigureDefinition : WorkspaceDefinition
     {
         public override string Name => "X";
-        protected override void Configure(WorkspaceBuilder b) => b.Section("s", null!);
+        protected override void Configure(WorkspaceBuilder builder) => builder.Section("s", null!);
     }
 }

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceServiceCollectionExtensionsTests.cs
@@ -49,7 +49,7 @@ public sealed class WorkspaceServiceCollectionExtensionsTests
     private sealed class DummyWorkspace : WorkspaceDefinition
     {
         public override string Name => "Dummy";
-        protected override void Configure(WorkspaceBuilder b) { }
+        protected override void Configure(WorkspaceBuilder builder) { }
     }
 
     private sealed class DummyFeatureProvider : IFeatureProvider


### PR DESCRIPTION
## Summary

Resolves a batch of open SonarQube findings — a few real async fixes plus a large sweep of Info/Major maintainability smells. No behavior change except the two `Write` calls that are now genuinely async.

## Source code

| File | Finding | Fix |
|---|---|---|
| `InMemoryDataExchangeFileProvider` | Await `CopyToAsync` | sync `CopyTo` → `await CopyToAsync(buffer, ct)`; dropped redundant `await Task.FromResult` |
| `MagickNetImagePipeline` | Await `WriteAsync` | `_image.Write` → `await _image.WriteAsync(...)` in `ToResultAsync`; `SaveToStreamAsync` promoted to genuinely async |
| `SylvanExcelFileParser` | Use `for` not `while` | counted read loop converted to `for` |
| `CachedSecretStore` | Use expression body | `ShouldCache` → expression-bodied |

## Tests (41 files total)

Mostly **S927** "parameter name differs from base name" — stub/lambda/override parameters renamed to match their interface signatures across Entities, Workspaces, EntityMerge, QueryEngine/Persistence EFCore, Timeline, AI, Identity, Http.Features and misc projects. Plus: named `#endregion` directives, const-instead-of-field, explicit enum values, denested ternary, and one unused type parameter removed.

## Deliberately not changed (recommend Won't Fix / architecture-model update)

- **`ScheduledWorkflowTransitionHandler`** (S1118) — documented Wolverine false positive; handlers must stay `public class` with a public ctor.
- **`GeneratorEndpoints` / `LegalDocumentAdminEndpoints`** (architecture-deviation to `Query*`) — canonical archi-tested `MapGranitQuery`/`MapGranitQueryCatalog` pattern; the constraint belongs in the Sonar architecture model, not the code.
- **`BlobBackedExportSource`** (S4457) — already implements eager-validation + iterator split; stale finding.
- **`ValueObjectTests`** ("constant on right") — kept `null == money` to preserve reverse-operand-order coverage of `operator ==`.

## Verification

- All touched projects build with 0 warnings / 0 errors (single-project builds).
- `dotnet format --verify-no-changes` clean on the four source projects.