### PR TITLE
test(domain): keep reverse-operand null coverage, satisfy Sonar constant-placement

### DIFF
--- a/tests/Granit.Tests/Domain/ValueObjectTests.cs
+++ b/tests/Granit.Tests/Domain/ValueObjectTests.cs
@@ -42,8 +42,10 @@ public sealed class ValueObjectTests
 
         money.Equals(null).ShouldBeFalse();
         (money == null).ShouldBeFalse();
-        // Reverse operand order exercises the null-on-left path of operator ==(Money, Money).
-        (null == money).ShouldBeFalse();
+        // Reverse operand order exercises the null-on-left path of operator ==(Money, Money);
+        // a typed local keeps that coverage without a constant on the left.
+        Money? nullMoney = null;
+        (nullMoney == money).ShouldBeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #2937. That PR restored `(null == money)` in `Equals_Null_ReturnsFalse` to keep coverage of the null-on-left path of `operator ==(Money, Money)`, which re-tripped the Sonar "constant values should be placed on right side" Info smell.

This replaces the literal with a typed `Money? nullMoney = null;` local, so the reverse-operand path stays covered **and** the smell disappears — no code left on the left-hand side is a constant.

Builds clean (`tests/Granit.Tests`, 0 errors).