### PR TITLE
feat(scheduling): record AttemptCount on ScheduledAction terminal transitions

### DIFF
--- a/src/Granit.Scheduling.Endpoints/Dtos/ScheduledActionResponse.cs
+++ b/src/Granit.Scheduling.Endpoints/Dtos/ScheduledActionResponse.cs
@@ -13,6 +13,7 @@ namespace Granit.Scheduling.Endpoints.Dtos;
 /// <param name="ExecutedAt">The UTC timestamp when the action was executed (null if not yet).</param>
 /// <param name="CancelledBy">The user who cancelled the action (null if not cancelled).</param>
 /// <param name="FailureReason">Error message if the action failed.</param>
+/// <param name="AttemptCount">Number of execution attempts recorded at the terminal status (0 while Pending/Processing).</param>
 /// <param name="CreatedAt">The UTC timestamp when the action was created.</param>
 /// <param name="ModifiedAt">The UTC timestamp of the last state change (reschedule, cancellation, execution); <c>null</c> if the action was never modified.</param>
 public sealed record ScheduledActionResponse(
@@ -24,5 +25,6 @@ public sealed record ScheduledActionResponse(
     DateTimeOffset? ExecutedAt,
     string? CancelledBy,
     string? FailureReason,
+    int AttemptCount,
     DateTimeOffset CreatedAt,
     DateTimeOffset? ModifiedAt);

--- a/src/Granit.Scheduling.Endpoints/Endpoints/SchedulingReadEndpoints.cs
+++ b/src/Granit.Scheduling.Endpoints/Endpoints/SchedulingReadEndpoints.cs
@@ -55,6 +55,7 @@ internal static class SchedulingReadEndpoints
             action.ExecutedAt,
             action.CancelledBy,
             action.FailureReason,
+            action.AttemptCount,
             action.CreatedAt,
             action.ModifiedAt);
 }

--- a/src/Granit.Scheduling.EntityFrameworkCore/Internal/ScheduledActionConfiguration.cs
+++ b/src/Granit.Scheduling.EntityFrameworkCore/Internal/ScheduledActionConfiguration.cs
@@ -44,6 +44,9 @@ internal sealed class ScheduledActionConfiguration
         builder.Property(e => e.FailureReason)
             .HasMaxLength(500);
 
+        builder.Property(e => e.AttemptCount)
+            .IsRequired();
+
         builder.HasIndex(e => new { e.Status, e.ExecuteAt })
             .HasDatabaseName($"ix_{GranitSchedulingDbProperties.DbTablePrefix}scheduled_actions_status_execute_at");
 

--- a/src/Granit.Scheduling.Wolverine/ScheduledActionStatusMiddleware.cs
+++ b/src/Granit.Scheduling.Wolverine/ScheduledActionStatusMiddleware.cs
@@ -68,7 +68,7 @@ public sealed class ScheduledActionStatusMiddleware(
             return;
         }
 
-        action.MarkExecuted(clock.Now);
+        action.MarkExecuted(clock.Now, envelope.Attempts);
         await actionWriter.UpdateAsync(action, cancellationToken).ConfigureAwait(false);
 
         string? tenantId = currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null;
@@ -91,7 +91,7 @@ public sealed class ScheduledActionStatusMiddleware(
             return;
         }
 
-        action.MarkFailed(exception.Message, clock.Now);
+        action.MarkFailed(exception.Message, clock.Now, envelope.Attempts);
         await actionWriter.UpdateAsync(action, cancellationToken).ConfigureAwait(false);
 
         string? tenantId = currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null;

--- a/src/Granit.Scheduling/Domain/ScheduledAction.cs
+++ b/src/Granit.Scheduling/Domain/ScheduledAction.cs
@@ -85,6 +85,14 @@ public sealed class ScheduledAction : AuditedAggregateRoot, IMultiTenant
     /// <summary>Truncated error message if the action failed (max 500 characters).</summary>
     public string? FailureReason { get; private set; }
 
+    /// <summary>
+    /// Number of execution attempts recorded when the action reached its terminal status
+    /// (<see cref="ScheduledActionStatus.Executed"/> or <see cref="ScheduledActionStatus.Failed"/>).
+    /// <c>0</c> while the action is still Pending / Processing. A value greater than <c>1</c>
+    /// means the payload handler was retried before settling.
+    /// </summary>
+    public int AttemptCount { get; private set; }
+
     /// <inheritdoc />
     public Guid? TenantId { get; private set; }
 
@@ -123,11 +131,13 @@ public sealed class ScheduledAction : AuditedAggregateRoot, IMultiTenant
     /// Marks the action as successfully executed.
     /// </summary>
     /// <param name="executedAt">The UTC timestamp of execution.</param>
-    internal void MarkExecuted(DateTimeOffset executedAt)
+    /// <param name="attempts">The number of execution attempts (1 on first-try success).</param>
+    internal void MarkExecuted(DateTimeOffset executedAt, int attempts = 1)
     {
         EnsureProcessing();
         Status = ScheduledActionStatus.Executed;
         ExecutedAt = executedAt;
+        AttemptCount = attempts;
         AddDistributedEvent(new ScheduledActionExecutedEto(
             Id, PayloadType, CorrelationId, executedAt));
     }
@@ -137,7 +147,8 @@ public sealed class ScheduledAction : AuditedAggregateRoot, IMultiTenant
     /// </summary>
     /// <param name="failureReason">The error message (truncated to 500 characters).</param>
     /// <param name="failedAt">The UTC timestamp of failure.</param>
-    internal void MarkFailed(string failureReason, DateTimeOffset failedAt)
+    /// <param name="attempts">The number of execution attempts made before failing.</param>
+    internal void MarkFailed(string failureReason, DateTimeOffset failedAt, int attempts = 1)
     {
         EnsureProcessing();
         Status = ScheduledActionStatus.Failed;
@@ -145,6 +156,7 @@ public sealed class ScheduledAction : AuditedAggregateRoot, IMultiTenant
             ? failureReason[..MaxFailureReasonLength]
             : failureReason;
         ExecutedAt = failedAt;
+        AttemptCount = attempts;
         AddDistributedEvent(new ScheduledActionFailedEto(
             Id, PayloadType, CorrelationId, FailureReason, failedAt));
     }

--- a/src/Granit.Scheduling/Exports/ScheduledActionExportDefinition.cs
+++ b/src/Granit.Scheduling/Exports/ScheduledActionExportDefinition.cs
@@ -19,6 +19,7 @@ public sealed class ScheduledActionExportDefinition : ExportDefinition<Scheduled
             .Field(e => e.ExecutedAt, f => f.Format("O"))
             .Field(e => e.CancelledBy)
             .Field(e => e.FailureReason)
+            .Field(e => e.AttemptCount)
             .Field(e => e.TenantId)
             .IncludeAuditFields();
     }

--- a/tests/Granit.Scheduling.Wolverine.Tests/ScheduledActionStatusMiddlewareTests.cs
+++ b/tests/Granit.Scheduling.Wolverine.Tests/ScheduledActionStatusMiddlewareTests.cs
@@ -45,9 +45,9 @@ public sealed class ScheduledActionStatusMiddlewareTests : IDisposable
     private ScheduledActionStatusMiddleware CreateSut() =>
         new(_reader, _writer, _clock, _metrics, _currentTenant);
 
-    private static Envelope CreateEnvelope(Guid? actionId = null)
+    private static Envelope CreateEnvelope(Guid? actionId = null, int attempts = 1)
     {
-        Envelope envelope = new();
+        Envelope envelope = new() { Attempts = attempts };
         if (actionId is not null)
         {
             envelope.Headers[ScheduledActionStatusMiddleware.ActionIdHeader] = actionId.Value.ToString();
@@ -192,10 +192,11 @@ public sealed class ScheduledActionStatusMiddlewareTests : IDisposable
         using MetricCollector<long> collector = new(
             _meterFactory, SchedulingMetrics.MeterName, "granit.scheduling.action.executed");
 
-        await CreateSut().AfterAsync(CreateEnvelope(actionId), TestContext.Current.CancellationToken);
+        await CreateSut().AfterAsync(CreateEnvelope(actionId, attempts: 2), TestContext.Current.CancellationToken);
 
         action.Status.ShouldBe(ScheduledActionStatus.Executed);
         action.ExecutedAt.ShouldBe(NowFixture);
+        action.AttemptCount.ShouldBe(2);
         await _writer.Received(1).UpdateAsync(action, Arg.Any<CancellationToken>());
 
         IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
@@ -279,11 +280,12 @@ public sealed class ScheduledActionStatusMiddlewareTests : IDisposable
 
         var exception = new InvalidOperationException("payload handler exploded");
         await CreateSut().PostProcessAsync(
-            CreateEnvelope(actionId), exception, TestContext.Current.CancellationToken);
+            CreateEnvelope(actionId, attempts: 3), exception, TestContext.Current.CancellationToken);
 
         action.Status.ShouldBe(ScheduledActionStatus.Failed);
         action.FailureReason.ShouldBe("payload handler exploded");
         action.ExecutedAt.ShouldBe(NowFixture);
+        action.AttemptCount.ShouldBe(3);
         await _writer.Received(1).UpdateAsync(action, Arg.Any<CancellationToken>());
 
         IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();


### PR DESCRIPTION
## What

Persist the number of execution attempts on `ScheduledAction` when it reaches a terminal status (`Executed` / `Failed`), so ops and analytics can see how often scheduled work is retried before settling.

## Why

Enables an average-attempts / retry-rate KPI in the new `Granit.Scheduling.Analytics` satellite (granit-business). Today the entity records `Status`, `ExecuteAt`, `ExecutedAt` and `FailureReason` but nothing about retries — retries are handled globally by Wolverine and were invisible on the aggregate.

## How

- **`ScheduledAction.AttemptCount`** (`int`) — `0` while `Pending` / `Processing`; a value `> 1` means the payload handler was retried before settling.
- `MarkExecuted` / `MarkFailed` now take the attempt count. `ScheduledActionStatusMiddleware` passes `envelope.Attempts` at the terminal step — the entity is already loaded and saved there, so **no extra DB round-trip** and no change to the hot claim path.
- Surfaced end-to-end: EF `ScheduledActionConfiguration` (required column), `ScheduledActionResponse` DTO + mapping, `ScheduledActionExportDefinition`.
- The grid `QueryDefinition` column is intentionally **not** added (would require a `Scheduling.Columns.AttemptCount` label across all 18 culture files for no functional need on the metric side) — trivial follow-up if desired.

## Tests

- `ScheduledActionStatusMiddlewareTests`: executed path asserts `AttemptCount == 2`, failed path asserts `AttemptCount == 3` (via `envelope.Attempts`).
- Full Scheduling suite green: `Tests` (11), `Wolverine.Tests` (15), `EntityFrameworkCore.Tests` (2), `Endpoints.Tests` (6). `dotnet format` clean.

## Migrations

Framework ships **no** migrations. Hosts owning the scheduling `DbContext` (showcase, microservice-template) add an EF migration for the new non-null `attempt_count` column (defaults to `0`).

## Follow-up

Once this publishes to the dev feed, `Granit.Scheduling.Analytics` in granit-business gains an `AverageScheduledActionAttemptsMetric` over `AttemptCount`.
