### PR TITLE
test: cover Oidc.TokenManagement, Webhooks & Vault.Aws pure-logic gaps

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -49904,7 +49904,7 @@
       "kind": "record",
       "project": "Granit.Scheduling.Endpoints",
       "file": "src/Granit.Scheduling.Endpoints/Dtos/ScheduledActionResponse.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {

--- a/tests/Granit.Oidc.TokenManagement.Tests/ClientCredentialsTokenCacheFailureTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/ClientCredentialsTokenCacheFailureTests.cs
@@ -1,0 +1,102 @@
+using Granit.Oidc.TokenManagement.Cache.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+#pragma warning disable CA2012 // NSubstitute setup pattern — the faulted ValueTask is configured for replay, not consumed directly
+
+namespace Granit.Oidc.TokenManagement.Tests;
+
+/// <summary>
+/// Verifies fail-open behaviour (cache outages must not fail the outbound request) and
+/// argument validation for <see cref="ClientCredentialsTokenCache"/>.
+/// </summary>
+public sealed class ClientCredentialsTokenCacheFailureTests
+{
+    private readonly IFusionCache _cache = Substitute.For<IFusionCache>();
+    private readonly ClientCredentialsTokenCache _sut;
+
+    public ClientCredentialsTokenCacheFailureTests() =>
+        _sut = new ClientCredentialsTokenCache(_cache, NullLogger<ClientCredentialsTokenCache>.Instance);
+
+    // ──── Fail-open on cache outage ────
+
+    [Fact]
+    public async Task GetTokenAsync_CacheThrows_ReturnsNull()
+    {
+        _cache.TryGetAsync<string?>(Arg.Any<string>(), Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<MaybeValue<string?>>(new InvalidOperationException("cache down")));
+
+        string? result = await _sut.GetTokenAsync("client", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetTokenAsync_CacheThrows_DoesNotThrow()
+    {
+        _cache.SetAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<FusionCacheEntryOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException(new InvalidOperationException("cache down")));
+
+        await Should.NotThrowAsync(() =>
+            _sut.SetTokenAsync("client", "token", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RemoveTokenAsync_CacheThrows_DoesNotThrow()
+    {
+        _cache.RemoveAsync(Arg.Any<string>(), Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException(new InvalidOperationException("cache down")));
+
+        await Should.NotThrowAsync(() =>
+            _sut.RemoveTokenAsync("client", TestContext.Current.CancellationToken));
+    }
+
+    // ──── Cancellation propagates (not swallowed by fail-open) ────
+
+    [Fact]
+    public async Task GetTokenAsync_Cancelled_Propagates()
+    {
+        _cache.TryGetAsync<string?>(Arg.Any<string>(), Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<MaybeValue<string?>>(new OperationCanceledException()));
+
+        await Should.ThrowAsync<OperationCanceledException>(() =>
+            _sut.GetTokenAsync("client", TestContext.Current.CancellationToken));
+    }
+
+    // ──── Argument validation ────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task GetTokenAsync_NullOrEmptyClient_Throws(string? clientName) =>
+        await Should.ThrowAsync<ArgumentException>(() => _sut.GetTokenAsync(clientName!));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task SetTokenAsync_NullOrEmptyClient_Throws(string? clientName) =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.SetTokenAsync(clientName!, "token", TimeSpan.FromMinutes(1)));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task SetTokenAsync_NullOrEmptyToken_Throws(string? accessToken) =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.SetTokenAsync("client", accessToken!, TimeSpan.FromMinutes(1)));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task RemoveTokenAsync_NullOrEmptyClient_Throws(string? clientName) =>
+        await Should.ThrowAsync<ArgumentException>(() => _sut.RemoveTokenAsync(clientName!));
+}
+
+#pragma warning restore CA2012

--- a/tests/Granit.Oidc.TokenManagement.Tests/ClientCredentialsTokenHandlerTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/ClientCredentialsTokenHandlerTests.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using Granit.Oidc.DPoP;
+using Granit.Oidc.Requests;
+using Granit.Oidc.Responses;
+using Granit.Oidc.TokenManagement.Cache;
+using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.DPoP;
+using Granit.Oidc.TokenManagement.Handlers;
+using Granit.Oidc.TokenManagement.Options;
+using Granit.Oidc.TokenManagement.Services;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests;
+
+public sealed class ClientCredentialsTokenHandlerTests : IDisposable
+{
+    private const string ClientName = "svc-client";
+    private const string Authority = "https://auth.example.com";
+    private const string ResourceUri = "https://api.example.com/resource";
+
+    private readonly ITokenEndpointService _tokenEndpoint = Substitute.For<ITokenEndpointService>();
+    private readonly IClientCredentialsTokenCache _cache = Substitute.For<IClientCredentialsTokenCache>();
+    private readonly IDPoPProofService _dpopProof = Substitute.For<IDPoPProofService>();
+    private readonly IDPoPKeyStore _dpopKeyStore = Substitute.For<IDPoPKeyStore>();
+    private readonly IOptionsMonitor<ClientCredentialsOptions> _optionsMonitor =
+        Substitute.For<IOptionsMonitor<ClientCredentialsOptions>>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly TestMeterFactory _meterFactory = new();
+    private readonly TokenManagementMetrics _metrics;
+
+    public ClientCredentialsTokenHandlerTests()
+    {
+        _metrics = new TokenManagementMetrics(_meterFactory);
+        _dpopKeyStore.GetOrCreateKey(ClientName).Returns("private-key-jwk");
+    }
+
+    public void Dispose() => _meterFactory.Dispose();
+
+    // ──── Cached token attached as Bearer, no endpoint round-trip ────
+
+    [Fact]
+    public async Task SendAsync_CachedToken_AttachesBearerWithoutFetching()
+    {
+        _cache.GetTokenAsync(ClientName, Arg.Any<CancellationToken>()).Returns("cached-token");
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await SendThroughHandler(inner, Options());
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        inner.LastRequest!.Headers.Authorization!.Scheme.ShouldBe("Bearer");
+        inner.LastRequest.Headers.Authorization.Parameter.ShouldBe("cached-token");
+        await _tokenEndpoint.DidNotReceive().RequestTokenAsync(
+            Arg.Any<string>(), Arg.Any<ClientCredentialsTokenRequest>(),
+            Arg.Any<Granit.Oidc.ClientAuthentication.IClientAuthenticationStrategy?>(),
+            Arg.Any<DPoPOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ──── Cache miss → acquires and caches token ────
+
+    [Fact]
+    public async Task SendAsync_CacheMiss_AcquiresAndCachesToken()
+    {
+        _cache.GetTokenAsync(ClientName, Arg.Any<CancellationToken>()).Returns((string?)null);
+        _tokenEndpoint.RequestTokenAsync(
+                Authority, Arg.Any<ClientCredentialsTokenRequest>(),
+                Arg.Any<Granit.Oidc.ClientAuthentication.IClientAuthenticationStrategy?>(),
+                Arg.Any<DPoPOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(new TokenResponse { AccessToken = "fresh-token", ExpiresIn = 3600 });
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await SendThroughHandler(inner, Options());
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        inner.LastRequest!.Headers.Authorization!.Parameter.ShouldBe("fresh-token");
+        await _cache.Received(1).SetTokenAsync(
+            ClientName, "fresh-token", Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    // ──── Acquisition failure → request sent without Authorization ────
+
+    [Fact]
+    public async Task SendAsync_TokenAcquisitionFails_SendsWithoutAuthorization()
+    {
+        _cache.GetTokenAsync(ClientName, Arg.Any<CancellationToken>()).Returns((string?)null);
+        _tokenEndpoint.RequestTokenAsync(
+                Authority, Arg.Any<ClientCredentialsTokenRequest>(),
+                Arg.Any<Granit.Oidc.ClientAuthentication.IClientAuthenticationStrategy?>(),
+                Arg.Any<DPoPOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(TokenResponse.FromError("invalid_client", "bad secret"));
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await SendThroughHandler(inner, Options());
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    // ──── 401 → invalidate cache, re-acquire, retry once ────
+
+    [Fact]
+    public async Task SendAsync_Unauthorized_InvalidatesCacheAndRetries()
+    {
+        _cache.GetTokenAsync(ClientName, Arg.Any<CancellationToken>()).Returns("stale-token", "renewed-token");
+        int calls = 0;
+        RecordingHandler inner = new(_ =>
+        {
+            calls++;
+            return new HttpResponseMessage(calls == 1 ? HttpStatusCode.Unauthorized : HttpStatusCode.OK);
+        });
+
+        HttpResponseMessage response = await SendThroughHandler(inner, Options());
+
+        calls.ShouldBe(2);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await _cache.Received(1).RemoveTokenAsync(ClientName, Arg.Any<CancellationToken>());
+        inner.LastRequest!.Headers.Authorization!.Parameter.ShouldBe("renewed-token");
+    }
+
+    // ──── DPoP path attaches DPoP scheme + proof header ────
+
+    [Fact]
+    public async Task SendAsync_DPoPEnabled_AttachesDPoPSchemeAndProof()
+    {
+        _cache.GetTokenAsync(ClientName, Arg.Any<CancellationToken>()).Returns("dpop-token");
+        _dpopProof.CreateProof("private-key-jwk", "GET", ResourceUri, Arg.Any<string?>())
+            .Returns("dpop-proof");
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        ClientCredentialsOptions options = Options();
+        options.UseDPoP = true;
+
+        HttpResponseMessage response = await SendThroughHandler(inner, options);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        inner.LastRequest!.Headers.Authorization!.Scheme.ShouldBe("DPoP");
+        inner.LastRequest.Headers.TryGetValues("DPoP", out IEnumerable<string>? proof).ShouldBeTrue();
+        proof!.Single().ShouldBe("dpop-proof");
+    }
+
+    // ──── Helpers ────
+
+    private ClientCredentialsOptions Options()
+    {
+        ClientCredentialsOptions options = new()
+        {
+            Authority = Authority,
+            ClientId = "client-id",
+            ClientSecret = "secret",
+            Scope = "api",
+        };
+        _optionsMonitor.Get(ClientName).Returns(options);
+        return options;
+    }
+
+    private async Task<HttpResponseMessage> SendThroughHandler(RecordingHandler inner, ClientCredentialsOptions options)
+    {
+        _optionsMonitor.Get(ClientName).Returns(options);
+        ClientCredentialsTokenHandler handler = new(
+            _tokenEndpoint,
+            _cache,
+            _dpopProof,
+            _dpopKeyStore,
+            _optionsMonitor,
+            Microsoft.Extensions.Options.Options.Create(new TokenManagementOptions()),
+            _clock,
+            _metrics,
+            NullLogger<ClientCredentialsTokenHandler>.Instance)
+        {
+            ClientName = ClientName,
+            InnerHandler = inner,
+        };
+
+        using HttpMessageInvoker invoker = new(handler);
+        return await invoker.SendAsync(
+            new HttpRequestMessage(HttpMethod.Get, ResourceUri),
+            TestContext.Current.CancellationToken);
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> factory) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(factory(request));
+        }
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        private readonly List<Meter> _meters = [];
+
+        public Meter Create(MeterOptions options)
+        {
+            Meter meter = new(options);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (Meter meter in _meters)
+            {
+                meter.Dispose();
+            }
+
+            _meters.Clear();
+        }
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/Granit.Oidc.TokenManagement.Tests.csproj
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Granit.Oidc.TokenManagement.Tests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/Granit.Oidc.TokenManagement.Tests/OnBehalfOfOptionsValidatorTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/OnBehalfOfOptionsValidatorTests.cs
@@ -1,0 +1,136 @@
+using Granit.Oidc.ClientAuthentication;
+using Granit.Oidc.TokenManagement.Options;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests;
+
+public sealed class OnBehalfOfOptionsValidatorTests
+{
+    private readonly IHostEnvironment _environment = Substitute.For<IHostEnvironment>();
+
+    private OnBehalfOfOptionsValidator CreateValidator(string environmentName = "Production")
+    {
+        _environment.EnvironmentName = environmentName;
+        return new OnBehalfOfOptionsValidator(_environment);
+    }
+
+    private static OnBehalfOfOptions ValidOptions() => new()
+    {
+        Authority = "https://auth.example.com",
+        ClientId = "client-id",
+        ClientSecret = "secret",
+        Audience = "https://api.example.com",
+        AllowedHosts = ["api.example.com"],
+        ClientAuthenticationMethod = ClientAuthenticationMethod.ClientSecretPost,
+    };
+
+    [Fact]
+    public void Validate_ValidOptions_Succeeds() =>
+        CreateValidator().Validate(null, ValidOptions()).Succeeded.ShouldBeTrue();
+
+    [Fact]
+    public void Validate_MissingAuthority_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.Authority = "";
+
+        CreateValidator().Validate("client", options).Failed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_NonHttpsAuthorityInProduction_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.Authority = "http://auth.example.com";
+
+        ValidateOptionsResultAssert(CreateValidator("Production").Validate(null, options), "must be https");
+    }
+
+    [Fact]
+    public void Validate_NonHttpsAuthorityInDevelopment_Succeeds()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.Authority = "http://localhost:5000";
+
+        CreateValidator("Development").Validate(null, options).Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_MissingClientId_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.ClientId = "";
+
+        CreateValidator().Validate(null, options).Failed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_MissingAudience_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.Audience = "";
+
+        ValidateOptionsResultAssert(CreateValidator().Validate(null, options), "Audience");
+    }
+
+    [Fact]
+    public void Validate_EmptyAllowedHosts_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.AllowedHosts = [];
+
+        ValidateOptionsResultAssert(CreateValidator().Validate(null, options), "AllowedHosts");
+    }
+
+    [Fact]
+    public void Validate_ClientSecretPostWithoutSecret_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.ClientSecret = null;
+        options.ClientAuthenticationMethod = ClientAuthenticationMethod.ClientSecretPost;
+
+        ValidateOptionsResultAssert(CreateValidator().Validate(null, options), "ClientSecret");
+    }
+
+    [Fact]
+    public void Validate_PrivateKeyJwtWithoutSigningKey_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.ClientSecret = null;
+        options.ClientSigningKeyJwk = null;
+        options.ClientAuthenticationMethod = ClientAuthenticationMethod.PrivateKeyJwt;
+
+        ValidateOptionsResultAssert(CreateValidator().Validate(null, options), "ClientSigningKeyJwk");
+    }
+
+    [Fact]
+    public void Validate_PrivateKeyJwtWithSigningKey_Succeeds()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.ClientSecret = null;
+        options.ClientSigningKeyJwk = "signing-key-jwk";
+        options.ClientAuthenticationMethod = ClientAuthenticationMethod.PrivateKeyJwt;
+
+        CreateValidator().Validate(null, options).Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_NegativeSafetyMargin_Fails()
+    {
+        OnBehalfOfOptions options = ValidOptions();
+        options.TokenLifetimeSafetyMargin = TimeSpan.FromSeconds(-1);
+
+        ValidateOptionsResultAssert(CreateValidator().Validate(null, options), "TokenLifetimeSafetyMargin");
+    }
+
+    private static void ValidateOptionsResultAssert(
+        Microsoft.Extensions.Options.ValidateOptionsResult result,
+        string expectedFragment)
+    {
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(expectedFragment);
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/OnBehalfOfTokenHandlerTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/OnBehalfOfTokenHandlerTests.cs
@@ -1,0 +1,312 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using Granit.Caching;
+using Granit.MultiTenancy;
+using Granit.Oidc.ClientAuthentication;
+using Granit.Oidc.DPoP;
+using Granit.Oidc.Requests;
+using Granit.Oidc.Responses;
+using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.DPoP;
+using Granit.Oidc.TokenManagement.Handlers;
+using Granit.Oidc.TokenManagement.Options;
+using Granit.Oidc.TokenManagement.Services;
+using Granit.Timing;
+using Granit.Users;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests;
+
+public sealed class OnBehalfOfTokenHandlerTests : IDisposable
+{
+    private const string ClientName = "downstream-api";
+    private const string Authority = "https://auth.example.com";
+    private const string AllowedHost = "api.example.com";
+    private const string AllowedUri = "https://api.example.com/resource";
+
+    private readonly ITokenEndpointService _tokenEndpoint = Substitute.For<ITokenEndpointService>();
+    private readonly IConditionalCache _cache = Substitute.For<IConditionalCache>();
+    private readonly IDPoPProofService _dpopProof = Substitute.For<IDPoPProofService>();
+    private readonly IDPoPKeyStore _dpopKeyStore = Substitute.For<IDPoPKeyStore>();
+    private readonly IHttpContextAccessor _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IOptionsMonitor<OnBehalfOfOptions> _optionsMonitor =
+        Substitute.For<IOptionsMonitor<OnBehalfOfOptions>>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly TestMeterFactory _meterFactory = new();
+    private readonly TokenManagementMetrics _metrics;
+
+    public OnBehalfOfTokenHandlerTests()
+    {
+        _metrics = new TokenManagementMetrics(_meterFactory);
+        _dpopKeyStore.GetOrCreateKey(ClientName).Returns("obo-private-key");
+        _currentUser.UserId.Returns("user-123");
+        _currentTenant.IsAvailable.Returns(false);
+        WithInboundToken("Bearer inbound-caller-token");
+    }
+
+    public void Dispose() => _meterFactory.Dispose();
+
+    // ──── Target not allow-listed → unauthenticated passthrough ────
+
+    [Fact]
+    public async Task SendAsync_HostNotAllowed_SendsUnauthenticated()
+    {
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, Options(), "https://evil.example.com/x");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+        await _tokenEndpoint.DidNotReceiveWithAnyArgs().RequestTokenAsync(
+            "", null!, null, null, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task SendAsync_NonHttpsWhenRequireHttps_SendsUnauthenticated()
+    {
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        OnBehalfOfOptions options = Options();
+        options.AllowedHosts = ["api.example.com"];
+
+        HttpResponseMessage response = await Send(inner, options, "http://api.example.com/x");
+
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    // ──── No ambient HttpContext (background job) → unauthenticated ────
+
+    [Fact]
+    public async Task SendAsync_NoHttpContext_SendsUnauthenticated()
+    {
+        _httpContextAccessor.HttpContext.Returns((HttpContext?)null);
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, Options(), AllowedUri);
+
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_NoInboundAuthorizationHeader_SendsUnauthenticated()
+    {
+        WithInboundToken(null);
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, Options(), AllowedUri);
+
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    // ──── Successful exchange → Bearer attached + write-through cache ────
+
+    [Fact]
+    public async Task SendAsync_SuccessfulExchange_AttachesBearerAndCaches()
+    {
+        _cache.GetAsync<string>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((string?)null);
+        SetupExchange(new TokenResponse { AccessToken = "exchanged-token", ExpiresIn = 3600 });
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, NonDPoPOptions(), AllowedUri);
+
+        inner.LastRequest!.Headers.Authorization!.Scheme.ShouldBe("Bearer");
+        inner.LastRequest.Headers.Authorization.Parameter.ShouldBe("exchanged-token");
+        await _cache.Received(1).SetIfAbsentAsync(
+            Arg.Any<string>(), "exchanged-token", Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    // ──── Cache hit → no exchange ────
+
+    [Fact]
+    public async Task SendAsync_CacheHit_UsesCachedTokenWithoutExchange()
+    {
+        _cache.GetAsync<string>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns("cached-token");
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, NonDPoPOptions(), AllowedUri);
+
+        inner.LastRequest!.Headers.Authorization!.Parameter.ShouldBe("cached-token");
+        await _tokenEndpoint.DidNotReceiveWithAnyArgs().RequestTokenAsync(
+            "", null!, null, null, TestContext.Current.CancellationToken);
+    }
+
+    // ──── Exchange failure (fail-closed) → unauthenticated ────
+
+    [Fact]
+    public async Task SendAsync_ExchangeFails_SendsUnauthenticated()
+    {
+        _cache.GetAsync<string>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((string?)null);
+        SetupExchange(TokenResponse.FromError("access_denied"));
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, NonDPoPOptions(), AllowedUri);
+
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    // ──── Exchange throws → fail-closed, unauthenticated ────
+
+    [Fact]
+    public async Task SendAsync_ExchangeThrows_SendsUnauthenticated()
+    {
+        _cache.GetAsync<string>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((string?)null);
+        _tokenEndpoint.RequestTokenAsync(
+                Authority, Arg.Any<TokenExchangeTokenRequest>(),
+                Arg.Any<IClientAuthenticationStrategy?>(), Arg.Any<DPoPOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsyncForAnyArgs(new HttpRequestException("idp down"));
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, NonDPoPOptions(), AllowedUri);
+
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    // ──── Cache read outage → fail-open, proceeds to exchange ────
+
+    [Fact]
+    public async Task SendAsync_CacheGetThrows_FailsOpenAndExchanges()
+    {
+        _cache.GetAsync<string>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsyncForAnyArgs(new InvalidOperationException("redis down"));
+        SetupExchange(new TokenResponse { AccessToken = "exchanged-token", ExpiresIn = 3600 });
+        RecordingHandler inner = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        HttpResponseMessage response = await Send(inner, NonDPoPOptions(), AllowedUri);
+
+        inner.LastRequest!.Headers.Authorization!.Parameter.ShouldBe("exchanged-token");
+    }
+
+    // ──── DPoP: 401 nonce challenge triggers a single retry ────
+
+    [Fact]
+    public async Task SendAsync_DPoPNonceChallenge_RetriesOnce()
+    {
+        _cache.GetAsync<string>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns("dpop-token");
+        _dpopProof.CreateProof("obo-private-key", "GET", AllowedUri, Arg.Any<string?>()).Returns("proof");
+
+        int calls = 0;
+        RecordingHandler inner = new(_ =>
+        {
+            calls++;
+            if (calls == 1)
+            {
+                HttpResponseMessage challenge = new(HttpStatusCode.Unauthorized);
+                challenge.Headers.Add("DPoP-Nonce", "server-nonce");
+                return challenge;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        HttpResponseMessage response = await Send(inner, Options(), AllowedUri);
+
+        calls.ShouldBe(2);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        inner.LastRequest!.Headers.Authorization!.Scheme.ShouldBe("DPoP");
+    }
+
+    // ──── Helpers ────
+
+    private void WithInboundToken(string? authorizationHeader)
+    {
+        DefaultHttpContext ctx = new();
+        if (authorizationHeader is not null)
+        {
+            ctx.Request.Headers.Authorization = authorizationHeader;
+        }
+
+        _httpContextAccessor.HttpContext.Returns(ctx);
+    }
+
+    private void SetupExchange(TokenResponse response) =>
+        _tokenEndpoint.RequestTokenAsync(
+                Authority, Arg.Any<TokenExchangeTokenRequest>(),
+                Arg.Any<IClientAuthenticationStrategy?>(), Arg.Any<DPoPOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+    private static OnBehalfOfOptions Options() => new()
+    {
+        Authority = Authority,
+        ClientId = "client-id",
+        ClientSecret = "secret",
+        Audience = "https://api.example.com",
+        AllowedHosts = [AllowedHost],
+        RequireHttps = true,
+        RequireDPoP = true,
+    };
+
+    private static OnBehalfOfOptions NonDPoPOptions()
+    {
+        OnBehalfOfOptions options = Options();
+        options.RequireDPoP = false;
+        return options;
+    }
+
+    private async Task<HttpResponseMessage> Send(RecordingHandler inner, OnBehalfOfOptions options, string uri)
+    {
+        _optionsMonitor.Get(ClientName).Returns(options);
+        OnBehalfOfTokenHandler handler = new(
+            _tokenEndpoint,
+            _cache,
+            _dpopProof,
+            _dpopKeyStore,
+            _httpContextAccessor,
+            _currentTenant,
+            _currentUser,
+            _optionsMonitor,
+            _clock,
+            _metrics,
+            NullLogger<OnBehalfOfTokenHandler>.Instance)
+        {
+            ClientName = ClientName,
+            InnerHandler = inner,
+        };
+
+        using HttpMessageInvoker invoker = new(handler);
+        return await invoker.SendAsync(
+            new HttpRequestMessage(HttpMethod.Get, uri),
+            TestContext.Current.CancellationToken);
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> factory) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(factory(request));
+        }
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        private readonly List<Meter> _meters = [];
+
+        public Meter Create(MeterOptions options)
+        {
+            Meter meter = new(options);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (Meter meter in _meters)
+            {
+                meter.Dispose();
+            }
+
+            _meters.Clear();
+        }
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/TokenRevocationServiceTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/TokenRevocationServiceTests.cs
@@ -1,0 +1,210 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using Granit.Oidc.ClientAuthentication;
+using Granit.Oidc.Discovery;
+using Granit.Oidc.DPoP;
+using Granit.Oidc.Requests;
+using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.Services;
+using Granit.Oidc.TokenManagement.Services.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests;
+
+public sealed class TokenRevocationServiceTests : IDisposable
+{
+    private const string Authority = "https://auth.example.com";
+    private const string RevocationEndpoint = "https://auth.example.com/connect/revocation";
+
+    private readonly IDiscoveryDocumentService _discoveryService = Substitute.For<IDiscoveryDocumentService>();
+    private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+    private readonly IDPoPProofService _dpopProofService = Substitute.For<IDPoPProofService>();
+    private readonly TestMeterFactory _meterFactory = new();
+    private readonly TokenManagementMetrics _metrics;
+    private readonly TokenRevocationService _sut;
+
+    public TokenRevocationServiceTests()
+    {
+        _metrics = new TokenManagementMetrics(_meterFactory);
+        _sut = new TokenRevocationService(
+            _discoveryService,
+            _httpClientFactory,
+            _dpopProofService,
+            _metrics,
+            NullLogger<TokenRevocationService>.Instance);
+
+        _discoveryService.GetAsync(Authority, Arg.Any<CancellationToken>())
+            .Returns(CreateDisco(RevocationEndpoint));
+    }
+
+    public void Dispose() => _meterFactory.Dispose();
+
+    [Fact]
+    public void TokenRevocationService_ImplementsInterface() =>
+        _sut.ShouldBeAssignableTo<ITokenRevocationService>();
+
+    // ──── Argument validation ────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task RevokeTokenAsync_NullOrEmptyAuthority_Throws(string? authority) =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.RevokeTokenAsync(authority!, CreateRequest()));
+
+    [Fact]
+    public async Task RevokeTokenAsync_NullRequest_Throws() =>
+        await Should.ThrowAsync<ArgumentNullException>(() =>
+            _sut.RevokeTokenAsync(Authority, null!));
+
+    // ──── No revocation endpoint advertised ────
+
+    [Fact]
+    public async Task RevokeTokenAsync_NoRevocationEndpoint_ReturnsFalse()
+    {
+        _discoveryService.GetAsync(Authority, Arg.Any<CancellationToken>())
+            .Returns(CreateDisco(revocationEndpoint: null));
+
+        bool result = await _sut.RevokeTokenAsync(
+            Authority, CreateRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeFalse();
+    }
+
+    // ──── Successful revocation ────
+
+    [Fact]
+    public async Task RevokeTokenAsync_SuccessResponse_ReturnsTrue()
+    {
+        SetupHttpClient(new HttpResponseMessage(HttpStatusCode.OK));
+
+        bool result = await _sut.RevokeTokenAsync(
+            Authority, CreateRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+    }
+
+    // ──── Non-success status ────
+
+    [Fact]
+    public async Task RevokeTokenAsync_ErrorStatus_ReturnsFalse()
+    {
+        SetupHttpClient(new HttpResponseMessage(HttpStatusCode.BadRequest));
+
+        bool result = await _sut.RevokeTokenAsync(
+            Authority, CreateRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeFalse();
+    }
+
+    // ──── Network failure ────
+
+    [Fact]
+    public async Task RevokeTokenAsync_HttpRequestException_ReturnsFalse()
+    {
+        FakeHttpMessageHandler handler = new(_ => throw new HttpRequestException("Connection refused"));
+        _httpClientFactory.CreateClient("Granit.TokenManagement").Returns(new HttpClient(handler));
+
+        bool result = await _sut.RevokeTokenAsync(
+            Authority, CreateRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeFalse();
+    }
+
+    // ──── Client authentication strategy applied ────
+
+    [Fact]
+    public async Task RevokeTokenAsync_WithClientAuth_AppliesStrategy()
+    {
+        SetupHttpClient(new HttpResponseMessage(HttpStatusCode.OK));
+        IClientAuthenticationStrategy clientAuth = Substitute.For<IClientAuthenticationStrategy>();
+
+        bool result = await _sut.RevokeTokenAsync(
+            Authority, CreateRequest(), clientAuth, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+        clientAuth.Received(1).Apply(
+            Arg.Any<Dictionary<string, string>>(),
+            "test-client",
+            RevocationEndpoint);
+    }
+
+    // ──── DPoP proof injection ────
+
+    [Fact]
+    public async Task RevokeTokenAsync_WithDPoP_AttachesDPoPHeader()
+    {
+        HttpRequestMessage? captured = null;
+        FakeHttpMessageHandler handler = new(req =>
+        {
+            captured = req;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        _httpClientFactory.CreateClient("Granit.TokenManagement").Returns(new HttpClient(handler));
+        _dpopProofService.CreateProof("key-jwk", "POST", RevocationEndpoint, "nonce-1")
+            .Returns("dpop-proof-xyz");
+
+        DPoPOptions dpop = new("key-jwk", "nonce-1");
+
+        bool result = await _sut.RevokeTokenAsync(
+            Authority, CreateRequest(), dpop: dpop, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured.Headers.TryGetValues("DPoP", out IEnumerable<string>? values).ShouldBeTrue();
+        values!.Single().ShouldBe("dpop-proof-xyz");
+    }
+
+    // ──── Helpers ────
+
+    private static OidcDiscoveryDocument CreateDisco(string? revocationEndpoint) => new()
+    {
+        Issuer = Authority,
+        AuthorizationEndpoint = $"{Authority}/connect/authorize",
+        TokenEndpoint = $"{Authority}/connect/token",
+        RevocationEndpoint = revocationEndpoint,
+    };
+
+    private static RevocationRequest CreateRequest() =>
+        new() { Token = "token-to-revoke", ClientId = "test-client", TokenTypeHint = "access_token" };
+
+    private void SetupHttpClient(HttpResponseMessage response)
+    {
+        FakeHttpMessageHandler handler = new(_ => response);
+        _httpClientFactory.CreateClient("Granit.TokenManagement").Returns(new HttpClient(handler));
+    }
+
+    private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(responseFactory(request));
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        private readonly List<Meter> _meters = [];
+
+        public Meter Create(MeterOptions options)
+        {
+            Meter meter = new(options);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (Meter meter in _meters)
+            {
+                meter.Dispose();
+            }
+
+            _meters.Clear();
+        }
+    }
+}

--- a/tests/Granit.Vault.Aws.Tests/AwsSecretsCredentialProviderTests.cs
+++ b/tests/Granit.Vault.Aws.Tests/AwsSecretsCredentialProviderTests.cs
@@ -1,0 +1,70 @@
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using Granit.Vault.Aws.Options;
+using Granit.Vault.Aws.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Vault.Aws.Tests;
+
+public sealed class AwsSecretsCredentialProviderTests
+{
+    private readonly IAmazonSecretsManager _secretsManager = Substitute.For<IAmazonSecretsManager>();
+
+    [Fact]
+    public async Task ExecuteAsync_ValidSecret_ObtainsCredentials()
+    {
+        _secretsManager.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new GetSecretValueResponse
+            {
+                SecretString = """{"username":"db_user","password":"s3cr3t"}""",
+                VersionId = "0123456789abcdef0123456789abcdef",
+            }));
+
+        using AwsSecretsCredentialProvider provider = CreateProvider("arn:aws:secretsmanager:eu-west-1:0:secret:db");
+
+        await provider.StartAsync(TestContext.Current.CancellationToken);
+        await WaitUntilReadyAsync(provider);
+        await provider.StopAsync(TestContext.Current.CancellationToken);
+
+        provider.IsReady.ShouldBeTrue();
+        provider.Username.ShouldBe("db_user");
+        provider.Password.ShouldBe("s3cr3t");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoSecretArnConfigured_StaysNotReady()
+    {
+        using AwsSecretsCredentialProvider provider = CreateProvider(databaseSecretArn: null);
+
+        await provider.StartAsync(TestContext.Current.CancellationToken);
+        await provider.StopAsync(TestContext.Current.CancellationToken);
+
+        provider.IsReady.ShouldBeFalse();
+        await _secretsManager.DidNotReceiveWithAnyArgs()
+            .GetSecretValueAsync(null!, TestContext.Current.CancellationToken);
+    }
+
+    private AwsSecretsCredentialProvider CreateProvider(string? databaseSecretArn)
+    {
+        AwsVaultOptions options = new()
+        {
+            DatabaseSecretArn = databaseSecretArn,
+            RotationCheckIntervalMinutes = 60,
+        };
+        return new AwsSecretsCredentialProvider(
+            _secretsManager,
+            Microsoft.Extensions.Options.Options.Create(options),
+            NullLogger<AwsSecretsCredentialProvider>.Instance);
+    }
+
+    private static async Task WaitUntilReadyAsync(AwsSecretsCredentialProvider provider)
+    {
+        for (int i = 0; i < 50 && !provider.IsReady; i++)
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/tests/Granit.Webhooks.Tests/SendWebhookHandlerTests.cs
+++ b/tests/Granit.Webhooks.Tests/SendWebhookHandlerTests.cs
@@ -194,6 +194,44 @@ public sealed class SendWebhookHandlerTests : IDisposable
     }
 
     // -------------------------------------------------------------------------
+    // Subscription gone at delivery time (resolved just-in-time)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task HandleAsync_SubscriptionNotFound_RecordsFailureWithoutSending()
+    {
+        _subscriptionReader.FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((WebhookSubscription?)null);
+        SendWebhookHandler handler = BuildHandler(HttpStatusCode.OK);
+        SendWebhookCommand command = BuildCommand();
+
+        await Should.NotThrowAsync(() => handler.HandleAsync(command, TestContext.Current.CancellationToken));
+
+        await _deliveryWriter.Received(1).RecordFailureAsync(
+            command, null, 0, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await _deliveryWriter.DidNotReceive().RecordSuccessAsync(
+            Arg.Any<SendWebhookCommand>(), Arg.Any<int>(), Arg.Any<long>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_SubscriptionDeactivated_RecordsFailureWithoutSending()
+    {
+        var deactivated = WebhookSubscription.Create(
+            Guid.NewGuid(), "https://example.com/webhook", "test.event",
+            signingKeyId: Guid.NewGuid(), protectedSecret: "test-secret", createdAt: DateTimeOffset.UtcNow);
+        deactivated.Deactivate("test cleanup");
+        _subscriptionReader.FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(deactivated);
+        SendWebhookHandler handler = BuildHandler(HttpStatusCode.OK);
+        SendWebhookCommand command = BuildCommand();
+
+        await Should.NotThrowAsync(() => handler.HandleAsync(command, TestContext.Current.CancellationToken));
+
+        await _deliveryWriter.Received(1).RecordFailureAsync(
+            command, null, 0, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    // -------------------------------------------------------------------------
     // StorePayload
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Raises unit-test coverage on genuinely-undertested pure-logic classes identified by a full 9-shard local coverage sweep. Test-only change — no production code touched.

Targets were chosen to actually move the SonarCloud number: modules that are **not** already covered by the `integration` shard (which Sonar counts). Assembly-level gap numbers overcount unit-testable code, so this focuses on the pure-logic pockets that integration tests don't exercise.

## Changes

**`Granit.Oidc.TokenManagement` — real coverage 40.0% → 55.6% (47 tests)**
- `TokenRevocationService`: success / failure status / no revocation endpoint / HTTP error / client-auth strategy / DPoP proof paths
- `ClientCredentialsTokenCache`: fail-open on cache outage + argument validation
- `ClientCredentialsTokenHandler`: cache hit, acquire+cache, 401 retry, DPoP
- `OnBehalfOfTokenHandler`: host allow-list, no HttpContext, exchange success/failure/throw, cache hit, cache fail-open, DPoP nonce retry (RFC 8693)
- `OnBehalfOfOptionsValidator`: full confused-deputy guard matrix
- Adds a `Microsoft.AspNetCore.App` framework reference to the test project for `DefaultHttpContext`

**`Granit.Webhooks` (2 tests)**
- `SendWebhookHandler`: subscription-not-found and deactivated-at-delivery branches (records failure without an HTTP send)

**`Granit.Vault.Aws` (2 tests)**
- `AwsSecretsCredentialProvider`: obtains + parses credentials from Secrets Manager; stays not-ready when no `DatabaseSecretArn` is configured

## Verification

- Build ✅, `dotnet format --verify-no-changes` ✅ on each touched project
- Tests ✅ — Oidc.TokenManagement 114/114, Webhooks 22, Vault.Aws provider 2/2

## Notes

The bulk of the remaining local unit/Sonar delta (~4.5 pts) is the `integration` shard (Testcontainers: Keycloak/Postgres/MsSql/Elasticsearch), which Sonar already counts — adding unit tests to those modules would not move the gate. Highest-impact follow-up is to confirm the `integration` shard's coverage upload is complete in CI.
