### PR TITLE
test(presence): cover FusionCachePresenceTracker and complete options validator

### DIFF
--- a/tests/Granit.Presence.Tests/Internal/FusionCachePresenceTrackerTests.cs
+++ b/tests/Granit.Presence.Tests/Internal/FusionCachePresenceTrackerTests.cs
@@ -1,0 +1,143 @@
+using Granit.Presence.Domain;
+using Granit.Presence.Internal;
+using Granit.Presence.Options;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Presence.Tests.Internal;
+
+/// <summary>
+/// Behavioural tests for the user-heartbeat tracker. Drives a real <see cref="IFusionCache"/>
+/// so the cache-key shape, the idle clamp, the multi-tab MAX(LastActivity) merge rule and the
+/// get/get-many/remove round-trips are all observed end-to-end inside the test process.
+/// </summary>
+public sealed class FusionCachePresenceTrackerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 28, 12, 0, 0, TimeSpan.Zero);
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static FusionCachePresenceTracker CreateTracker(PresenceOptions? options = null)
+    {
+        ServiceCollection services = [];
+        services.AddFusionCache();
+        ServiceProvider sp = services.BuildServiceProvider();
+        IFusionCache cache = sp.GetRequiredService<IFusionCache>();
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Now);
+
+        IOptionsMonitor<PresenceOptions> optionsMonitor = Substitute.For<IOptionsMonitor<PresenceOptions>>();
+        optionsMonitor.CurrentValue.Returns(options ?? new PresenceOptions());
+
+        return new FusionCachePresenceTracker(cache, clock, optionsMonitor);
+    }
+
+    [Fact]
+    public async Task RecordPollAsync_FirstPoll_DerivesActivityFromNowMinusIdle()
+    {
+        FusionCachePresenceTracker tracker = CreateTracker();
+        var userId = Guid.NewGuid();
+
+        PresenceHeartbeat merged = await tracker.RecordPollAsync(userId, TimeSpan.FromSeconds(10), Ct);
+
+        merged.LastPollUtc.ShouldBe(Now);
+        merged.LastActivityUtc.ShouldBe(Now - TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task RecordPollAsync_NegativeIdle_Throws()
+    {
+        FusionCachePresenceTracker tracker = CreateTracker();
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            tracker.RecordPollAsync(Guid.NewGuid(), TimeSpan.FromSeconds(-1), Ct));
+    }
+
+    [Fact]
+    public async Task RecordPollAsync_IdleBeyondTwiceOfflineThreshold_IsClamped()
+    {
+        // Default OfflineThreshold = 90s, so the clamp ceiling is 180s. An 10-minute idle must
+        // be treated as 180s, i.e. activity = Now - 180s (not Now - 600s).
+        FusionCachePresenceTracker tracker = CreateTracker();
+
+        PresenceHeartbeat merged = await tracker.RecordPollAsync(Guid.NewGuid(), TimeSpan.FromMinutes(10), Ct);
+
+        merged.LastActivityUtc.ShouldBe(Now - TimeSpan.FromSeconds(180));
+    }
+
+    [Fact]
+    public async Task RecordPollAsync_SecondPollWithOlderActivity_KeepsMostRecentActivity()
+    {
+        // Multi-tab dedup: an active tab (small idle) followed by a stale tab (large idle) must not
+        // regress LastActivityUtc — the MAX rule keeps the more recent activity instant.
+        FusionCachePresenceTracker tracker = CreateTracker();
+        var userId = Guid.NewGuid();
+
+        await tracker.RecordPollAsync(userId, TimeSpan.FromSeconds(5), Ct);   // activity = Now - 5s
+        PresenceHeartbeat merged = await tracker.RecordPollAsync(userId, TimeSpan.FromSeconds(60), Ct); // computed = Now - 60s
+
+        merged.LastActivityUtc.ShouldBe(Now - TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task RecordPollAsync_PersistsHeartbeatRetrievableByGet()
+    {
+        FusionCachePresenceTracker tracker = CreateTracker();
+        var userId = Guid.NewGuid();
+
+        PresenceHeartbeat recorded = await tracker.RecordPollAsync(userId, TimeSpan.FromSeconds(3), Ct);
+
+        PresenceHeartbeat? fetched = await tracker.GetAsync(userId, Ct);
+        fetched.ShouldBe(recorded);
+    }
+
+    [Fact]
+    public async Task GetAsync_UnknownUser_ReturnsNull()
+    {
+        FusionCachePresenceTracker tracker = CreateTracker();
+
+        (await tracker.GetAsync(Guid.NewGuid(), Ct)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetManyAsync_ReturnsOnlyPresentEntries()
+    {
+        FusionCachePresenceTracker tracker = CreateTracker();
+        var present = Guid.NewGuid();
+        var absent = Guid.NewGuid();
+        await tracker.RecordPollAsync(present, TimeSpan.FromSeconds(1), Ct);
+
+        IReadOnlyDictionary<Guid, PresenceHeartbeat> result =
+            await tracker.GetManyAsync([present, absent], Ct);
+
+        result.Count.ShouldBe(1);
+        result.ShouldContainKey(present);
+        result.ShouldNotContainKey(absent);
+    }
+
+    [Fact]
+    public async Task GetManyAsync_NullUserIds_Throws()
+    {
+        FusionCachePresenceTracker tracker = CreateTracker();
+
+        await Should.ThrowAsync<ArgumentNullException>(() => tracker.GetManyAsync(null!, Ct));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_EvictsHeartbeat()
+    {
+        FusionCachePresenceTracker tracker = CreateTracker();
+        var userId = Guid.NewGuid();
+        await tracker.RecordPollAsync(userId, TimeSpan.FromSeconds(1), Ct);
+
+        await tracker.RemoveAsync(userId, Ct);
+
+        (await tracker.GetAsync(userId, Ct)).ShouldBeNull();
+    }
+}

--- a/tests/Granit.Presence.Tests/Options/PresenceOptionsValidatorTests.cs
+++ b/tests/Granit.Presence.Tests/Options/PresenceOptionsValidatorTests.cs
@@ -50,4 +50,63 @@ public sealed class PresenceOptionsValidatorTests
 
         result.Failed.ShouldBeTrue();
     }
+
+    [Fact]
+    public void Validate_fails_when_offline_threshold_exceeds_thirty_minutes()
+    {
+        PresenceOptions options = new()
+        {
+            OfflineThreshold = TimeSpan.FromMinutes(31),
+            HeartbeatCacheTtl = TimeSpan.FromMinutes(31),
+        };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(PresenceOptions.OfflineThreshold));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(60 * 60 * 3)] // 3 hours, exceeds the 2-hour ceiling
+    public void Validate_fails_when_away_threshold_out_of_range(int seconds)
+    {
+        PresenceOptions options = new() { AwayThreshold = TimeSpan.FromSeconds(seconds) };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(PresenceOptions.AwayThreshold));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(31)] // 31 days, exceeds the 30-day ceiling
+    public void Validate_fails_when_max_override_duration_out_of_range(int days)
+    {
+        PresenceOptions options = new() { MaxOverrideDuration = TimeSpan.FromDays(days) };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(PresenceOptions.MaxOverrideDuration));
+    }
+
+    [Fact]
+    public void Validate_aggregates_every_failure()
+    {
+        PresenceOptions options = new()
+        {
+            OfflineThreshold = TimeSpan.Zero,
+            AwayThreshold = TimeSpan.Zero,
+            HeartbeatCacheTtl = TimeSpan.FromSeconds(-1),
+            MaxBatchSize = 0,
+            MaxOverrideDuration = TimeSpan.Zero,
+        };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.Count().ShouldBeGreaterThanOrEqualTo(4);
+    }
 }


### PR DESCRIPTION
## Summary

Raises **real** line coverage of `Granit.Presence` from **61.5% → 70.9%** (+61 Sonar-counted lines) by testing genuinely-uncovered pure logic — no complaisance, no production changes.

- **`FusionCachePresenceTracker`** (was ~0% on its async logic): idle clamp to `2 × OfflineThreshold`, the `MAX(LastActivityUtc)` multi-tab merge rule, the negative-idle guard, and `Get` / `GetMany` / `Remove` round-trips — driven against a real `IFusionCache`.
- **`PresenceOptionsValidator`**: the previously-uncovered `AwayThreshold`, `MaxOverrideDuration`, and `OfflineThreshold` upper-bound branches, plus the aggregated-failure path.

77 tests pass in `Granit.Presence.Tests`.

## Why this module (and a note on the coverage numbers)

Most modules that *look* low-coverage in raw reports aren't. The raw per-assembly numbers are inflated by **source-generated code that SonarCloud already excludes** — `[LoggerMessage]` partials and OpenAPI helpers emitted to `obj/**/*.g.cs`. Measured file-aware (excluding `obj/` generated code but **keeping** async state machines, which Sonar counts):

| Module | Raw | **Real** |
|---|---|---|
| `Oidc.TokenManagement` | 51% | **89.7%** — already well-covered (#2941); not a target |
| `Bff` | ~59% | **78.8%** |
| `JwtBearer` | — | **77.6%** |
| **`Presence`** | ~59% | **61.5% → 70.9%** ← this PR |

So `Presence` was a genuine gap; the others were illusions of generated code.

## Honest scope

This is **one increment**. Reaching the 80% overall gate is a many-module grind of genuinely-uncovered pockets (each nets a fraction of a percent globally). `Presence` still has pure-logic classes worth covering in a follow-up (`PresenceStartupChecks`, `PresenceHeartbeatRecorder`, `PresenceOverrideService`, `LoggingPresenceReadAuditSink`).
