### PR TITLE
ci(sonar): exclude Playwright/Puppeteer browser-driver internals from coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
             /d:sonar.token="${SONAR_TOKEN}" \
             /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" \
             /d:sonar.exclusions=".nuget/**,scripts/**" \
-            /d:sonar.coverage.exclusions="**/Tests/**,**/test/**,**/bundles/**,**/*HostApplicationBuilderExtensions.cs,**/Granit*Module.cs,**/Granit.OpenApi.Generator/**,**/OpenApiContractGenerator.cs" \
+            /d:sonar.coverage.exclusions="**/Tests/**,**/test/**,**/bundles/**,**/*HostApplicationBuilderExtensions.cs,**/Granit*Module.cs,**/Granit.OpenApi.Generator/**,**/OpenApiContractGenerator.cs,**/Granit.Browsing.Playwright/Internal/**,**/Granit.Browsing.PuppeteerSharp/Internal/**" \
             /d:sonar.issue.ignore.multicriteria="e1,e2,e3,e4" \
             /d:sonar.issue.ignore.multicriteria.e1.ruleKey="csharpsquid:S6608" \
             /d:sonar.issue.ignore.multicriteria.e1.resourceKey="**/*" \


### PR DESCRIPTION
## What

Adds `**/Granit.Browsing.Playwright/Internal/**` and `**/Granit.Browsing.PuppeteerSharp/Internal/**` to `sonar.coverage.exclusions` in the CI Sonar scan.

## Why

The `Internal/` classes of both browser providers (`BrowserPage`, `HeadlessBrowser`, `ProvisionService`, `RequestRouter`, and the engine capability wrappers) are thin adapters over a **live Chromium engine**. The unit-test shards never launch a browser, so these classes sit at ~10% coverage and can only be exercised by real-browser integration testing. They drag the whole-project coverage down **~1.5 points** without representing a genuine unit-testing gap — the same rationale under which we already exclude DI glue (`*HostApplicationBuilderExtensions.cs`, `Granit*Module.cs`).

Scope is limited to `Internal/` so the genuinely unit-tested parts (Options, Extensions, HealthChecks, InstallGuard, capability registration) **stay counted**.

## Measured impact (SonarCloud API)

| | Coverage |
|---|---|
| Before | 77.07% |
| After | **~78.55%** (+1.48 pt) |

These drivers remain the responsibility of real-browser integration tests. Reaching the 80% gate still needs ~1,495 covered units of real tests on the large testable endpoint assemblies (e.g. `Identity.Local.Endpoints` @ 28.7%).