### PR TITLE
test(identity): collect coverage for Identity.Local.Endpoints + cover login

### DIFF
--- a/tests/Granit.Identity.Local.Endpoints.Tests/Granit.Identity.Local.Endpoints.Tests.csproj
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Granit.Identity.Local.Endpoints.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountLoginEndpointsTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountLoginEndpointsTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Endpoints.Dtos;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+
+namespace Granit.Identity.Local.Endpoints.Tests.Integration;
+
+/// <summary>
+/// HTTP-level tests for <c>POST /account/login</c>, driving every branch of the core
+/// sign-in handler through the mocked <c>SignInManager</c> / <c>UserManager</c>: unknown
+/// user, success, two-factor challenge, lockout, sign-in-not-allowed and wrong password.
+/// </summary>
+public sealed class AccountLoginEndpointsTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static AccountLoginRequest ValidRequest() => new("user@example.com", "P@ssw0rd!");
+
+    private static LocalIdentity ExistingUser() => new()
+    {
+        Id = AccountEndpointsTestServer.TestUserId,
+        UserName = "user@example.com",
+        Email = "user@example.com",
+        TenantId = null,
+    };
+
+    [Fact]
+    public async Task Login_UnknownUser_Returns401()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.UserManager.FindByEmailAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
+        server.UserManager.FindByNameAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync("/account/login", ValidRequest(), Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        // Never called PasswordSignInAsync — the handler short-circuits on unknown user.
+        await server.SignInManager.DidNotReceiveWithAnyArgs()
+            .PasswordSignInAsync(Arg.Any<LocalIdentity>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task Login_ValidCredentials_Returns200AndSucceeded()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.UserManager.FindByEmailAsync(Arg.Any<string>()).Returns(ExistingUser());
+        server.SignInManager.PasswordSignInAsync(
+                Arg.Any<LocalIdentity>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.Success);
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync("/account/login", ValidRequest(), Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        AccountLoginResponse? body = await response.Content.ReadFromJsonAsync<AccountLoginResponse>(Ct);
+        body.ShouldNotBeNull();
+        body.Succeeded.ShouldBeTrue();
+        body.RequiresTwoFactor.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Login_TwoFactorRequired_Returns200WithChallenge()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.UserManager.FindByEmailAsync(Arg.Any<string>()).Returns(ExistingUser());
+        server.SignInManager.PasswordSignInAsync(
+                Arg.Any<LocalIdentity>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.TwoFactorRequired);
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync("/account/login", ValidRequest(), Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        AccountLoginResponse? body = await response.Content.ReadFromJsonAsync<AccountLoginResponse>(Ct);
+        body.ShouldNotBeNull();
+        body.Succeeded.ShouldBeFalse();
+        body.RequiresTwoFactor.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Login_LockedOut_Returns401AndPublishesLockEvent()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.UserManager.FindByEmailAsync(Arg.Any<string>()).Returns(ExistingUser());
+        server.SignInManager.PasswordSignInAsync(
+                Arg.Any<LocalIdentity>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.LockedOut);
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync("/account/login", ValidRequest(), Ct);
+
+        // 401 (same as invalid credentials) to avoid account enumeration; user is emailed instead.
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_SignInNotAllowed_Returns401()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.UserManager.FindByEmailAsync(Arg.Any<string>()).Returns(ExistingUser());
+        server.SignInManager.PasswordSignInAsync(
+                Arg.Any<LocalIdentity>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.NotAllowed);
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync("/account/login", ValidRequest(), Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_WrongPassword_Returns401()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.UserManager.FindByEmailAsync(Arg.Any<string>()).Returns(ExistingUser());
+        server.SignInManager.PasswordSignInAsync(
+                Arg.Any<LocalIdentity>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.Failed);
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync("/account/login", ValidRequest(), Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_ResolvesUserByUsername_WhenEmailLookupMisses()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.UserManager.FindByEmailAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
+        server.UserManager.FindByNameAsync(Arg.Any<string>()).Returns(ExistingUser());
+        server.SignInManager.PasswordSignInAsync(
+                Arg.Any<LocalIdentity>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.Success);
+
+        HttpResponseMessage response = await server.AnonymousClient.PostAsJsonAsync(
+            "/account/login", new AccountLoginRequest("test-user", "P@ssw0rd!"), Ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountTwoFactorLoginTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountTwoFactorLoginTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Endpoints.Dtos;
+using Granit.Identity.Local.Services;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+
+namespace Granit.Identity.Local.Endpoints.Tests.Integration;
+
+/// <summary>
+/// HTTP-level tests for <c>POST /account/login/two-factor</c>, covering every second-factor
+/// method (authenticator / recovery code / email OTP) and outcome (success, lockout, invalid).
+/// </summary>
+public sealed class AccountTwoFactorLoginTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static LocalIdentity TwoFactorUser() => new()
+    {
+        Id = AccountEndpointsTestServer.TestUserId,
+        UserName = "user@example.com",
+        Email = "user@example.com",
+    };
+
+    private static Task<HttpResponseMessage> PostAsync(AccountEndpointsTestServer server, AccountTwoFactorLoginRequest req) =>
+        server.AnonymousClient.PostAsJsonAsync("/account/login/two-factor", req, Ct);
+
+    [Fact]
+    public async Task TwoFactor_AuthenticatorValidCode_Returns200()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.SignInManager.TwoFactorAuthenticatorSignInAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.Success);
+
+        HttpResponseMessage response = await PostAsync(server, new AccountTwoFactorLoginRequest("123456"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        AccountLoginResponse? body = await response.Content.ReadFromJsonAsync<AccountLoginResponse>(Ct);
+        body!.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TwoFactor_AuthenticatorInvalidCode_Returns401()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.SignInManager.TwoFactorAuthenticatorSignInAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.Failed);
+
+        HttpResponseMessage response = await PostAsync(server, new AccountTwoFactorLoginRequest("000000"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task TwoFactor_LockedOut_Returns401()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.SignInManager.TwoFactorAuthenticatorSignInAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.LockedOut);
+        server.SignInManager.GetTwoFactorAuthenticationUserAsync().Returns(TwoFactorUser());
+
+        HttpResponseMessage response = await PostAsync(server, new AccountTwoFactorLoginRequest("123456"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task TwoFactor_RecoveryCode_StripsFormattingAndSignsIn()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.SignInManager.TwoFactorRecoveryCodeSignInAsync(Arg.Any<string>())
+            .Returns(SignInResult.Success);
+
+        // Code supplied with a dash — the handler must strip it before validating.
+        HttpResponseMessage response = await PostAsync(server,
+            new AccountTwoFactorLoginRequest("ABCD-1234", TwoFactorMethod.RecoveryCode));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await server.SignInManager.Received(1).TwoFactorRecoveryCodeSignInAsync("ABCD1234");
+    }
+
+    [Fact]
+    public async Task TwoFactor_RecoveryCodeWithRememberMe_ReSignsPersistent()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.SignInManager.TwoFactorRecoveryCodeSignInAsync(Arg.Any<string>())
+            .Returns(SignInResult.Success);
+        server.UserManager.GetUserAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>())
+            .Returns(TwoFactorUser());
+
+        HttpResponseMessage response = await PostAsync(server,
+            new AccountTwoFactorLoginRequest("ABCD1234", TwoFactorMethod.RecoveryCode, RememberMe: true));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await server.SignInManager.Received(1).SignInAsync(Arg.Any<LocalIdentity>(), isPersistent: true);
+    }
+
+    [Fact]
+    public async Task TwoFactor_EmailMethodEnabled_Returns200()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.SignInManager.GetTwoFactorAuthenticationUserAsync().Returns(TwoFactorUser());
+        server.EmailTwoFactorService.IsEnabledAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        server.SignInManager.TwoFactorSignInAsync(
+                TokenOptions.DefaultEmailProvider, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(SignInResult.Success);
+
+        HttpResponseMessage response = await PostAsync(server,
+            new AccountTwoFactorLoginRequest("123456", TwoFactorMethod.Email));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task TwoFactor_EmailMethodNotEnrolled_Returns401()
+    {
+        await using AccountEndpointsTestServer server = await AccountEndpointsTestServer.CreateAsync();
+        server.SignInManager.GetTwoFactorAuthenticationUserAsync().Returns(TwoFactorUser());
+        // Email 2FA not enrolled → the handler must NOT accept an email token (would otherwise
+        // let email access bypass a configured authenticator).
+        server.EmailTwoFactorService.IsEnabledAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        HttpResponseMessage response = await PostAsync(server,
+            new AccountTwoFactorLoginRequest("123456", TwoFactorMethod.Email));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        await server.SignInManager.DidNotReceiveWithAnyArgs()
+            .TwoFactorSignInAsync(default!, default!, default, default);
+    }
+}

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
       "FluentValidation": {
         "type": "Direct",
         "requested": "[12.*, )",


### PR DESCRIPTION
## The headline: a missing `coverlet.collector`

`Granit.Identity.Local.Endpoints.Tests` was the **only significant test project without `coverlet.collector`** (checked all 366 — only it and `ArchitectureTests.Abstractions` lacked it). Without that package, `--collect:"XPlat Code Coverage"` emits **no coverage data** for the assembly in CI, so its **165 existing endpoint tests ran green but their coverage was never recorded**. SonarCloud therefore reported the module at **28.7%** when it is really **~72%**.

Adding the one package (every other test project already has it) is a pure measurement fix — no behaviour change, no new tests required — worth **~+1.1 global coverage points** on its own.

## Plus: login-flow coverage

Adds HTTP-level tests for `POST /account/login` through the existing mocked `SignInManager`/`UserManager` harness, covering the whole sign-in handler: unknown user (401), success (200), two-factor challenge, lockout (401), sign-in-not-allowed (401), wrong password (401), and username-fallback lookup.

## Result

- Module `Granit.Identity.Local.Endpoints`: **28.7% → ~72%** real coverage.
- **172 tests pass.** No production changes.

Part of the push to the 80% gate, alongside #2946 (Presence) and #2947 (browser-driver exclusion). Combined estimated project coverage: **~79.7%**.