### PR TITLE
feat(wolverine): SQL Server provider parity, live metrics, encryption via IWolverineExtension

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
+  }
+
+  readonly hook_name="$(basename -- "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  readonly husky_skip_init=1
+  export husky_skip_init
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+  fi
+
+  if [ $exitCode = 127 ]; then
+    echo "husky - command not found in PATH=$PATH"
+  fi
+
+  exit $exitCode
+fi

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2922,10 +2922,7 @@
       "name": "Granit.Wolverine",
       "deps": [
         "Granit",
-        "Granit",
-        "Granit",
-        "Granit.Validation",
-        "Granit"
+        "Granit.Validation"
       ],
       "framework": "net10.0"
     },
@@ -2950,7 +2947,8 @@
       "name": "Granit.Wolverine.SqlServer",
       "deps": [
         "Granit.Wolverine",
-        "Granit.Persistence.EntityFrameworkCore"
+        "Granit.Persistence.EntityFrameworkCore",
+        "Granit.Persistence.EntityFrameworkCore.Hosting"
       ],
       "framework": "net10.0"
     },
@@ -58315,30 +58313,12 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Diagnostics/WolverineMetrics.cs",
-      "line": 10,
+      "line": 16,
       "members": [
         {
           "name": "RecordMessageHandled",
           "kind": "method",
           "signature": "RecordMessageHandled(string? tenantId, string messageType)",
-          "returnType": "void"
-        },
-        {
-          "name": "RecordRetriesExhausted",
-          "kind": "method",
-          "signature": "RecordRetriesExhausted(string? tenantId, string messageType)",
-          "returnType": "void"
-        },
-        {
-          "name": "RecordClaimCheckStored",
-          "kind": "method",
-          "signature": "RecordClaimCheckStored(string? tenantId)",
-          "returnType": "void"
-        },
-        {
-          "name": "RecordClaimCheckRetrieved",
-          "kind": "method",
-          "signature": "RecordClaimCheckRetrieved(string? tenantId)",
           "returnType": "void"
         },
         {
@@ -58371,7 +58351,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.Encryption",
       "file": "src/Granit.Wolverine.Encryption/GranitWolverineEncryptionModule.cs",
-      "line": 26,
+      "line": 24,
       "members": [
         {
           "name": "ConfigureServices",
@@ -58387,7 +58367,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs",
-      "line": 27,
+      "line": 28,
       "members": [
         {
           "name": "AddGranitWolverine",
@@ -58511,7 +58491,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.Postgresql",
       "file": "src/Granit.Wolverine.Postgresql/GranitWolverinePostgresqlModule.cs",
-      "line": 25,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -58543,7 +58523,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.SqlServer",
       "file": "src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 23,
       "members": [
         {
           "name": "AddGranitWolverineWithSqlServer",
@@ -58559,7 +58539,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.SqlServer",
       "file": "src/Granit.Wolverine.SqlServer/GranitWolverineSqlServerModule.cs",
-      "line": 25,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -58575,19 +58555,13 @@
       "kind": "class",
       "project": "Granit.Wolverine.SqlServer",
       "file": "src/Granit.Wolverine.SqlServer/Options/WolverineSqlServerOptions.cs",
-      "line": 21,
+      "line": 20,
       "members": [
         {
-          "name": "TransportConnectionString",
+          "name": "TransportConnectionStringName",
           "kind": "property",
-          "signature": "string TransportConnectionString",
-          "returnType": "string"
-        },
-        {
-          "name": "TransactionMode",
-          "kind": "property",
-          "signature": "TransactionMiddlewareMode TransactionMode",
-          "returnType": "TransactionMiddlewareMode"
+          "signature": "string? TransportConnectionStringName",
+          "returnType": "string?"
         }
       ]
     },
@@ -58597,7 +58571,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/WolverineScopedSender.cs",
-      "line": 13,
+      "line": 17,
       "members": []
     },
     {

--- a/src/Granit.Wolverine.Encryption/GranitWolverineEncryptionModule.cs
+++ b/src/Granit.Wolverine.Encryption/GranitWolverineEncryptionModule.cs
@@ -1,8 +1,8 @@
 using Granit.Encryption;
 using Granit.Modularity;
-using Granit.Wolverine.Encryption.Extensions;
+using Granit.Wolverine.Encryption.Internal;
 using Granit.Wolverine.Internal;
-using Microsoft.Extensions.DependencyInjection;
+using Wolverine;
 
 namespace Granit.Wolverine.Encryption;
 
@@ -12,17 +12,15 @@ namespace Granit.Wolverine.Encryption;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Resolves the registered <see cref="IStringEncryptionService"/> and the
-/// <c>WolverineOptionsHolder</c> placed by
-/// <see cref="GranitWolverineModule"/>, then calls
-/// <see cref="WolverineEncryptionOptionsExtensions.UseEncryptedSensitiveData"/>
-/// once the host has finished registering services. From that point on, every
-/// saga state, command and integration event Wolverine serializes through
-/// System.Text.Json has its <see cref="EncryptedAttribute"/>-marked properties
-/// transparently encrypted on the wire.
+/// Registers <see cref="WolverineEncryptionExtension"/>, applied by Wolverine at
+/// bootstrap with the host-resolved <see cref="IStringEncryptionService"/>. From
+/// that point on, every saga state, command and integration event Wolverine
+/// serializes through System.Text.Json has its
+/// <see cref="EncryptedAttribute"/>-marked properties transparently encrypted
+/// on the wire.
 /// </para>
 /// </remarks>
-[DependsOn(typeof(GranitWolverineModule), typeof(GranitEncryptionModule))]
+[DependsOn(typeof(GranitEncryptionModule), typeof(GranitWolverineModule))]
 public sealed class GranitWolverineEncryptionModule : GranitModule
 {
     /// <inheritdoc/>
@@ -30,10 +28,12 @@ public sealed class GranitWolverineEncryptionModule : GranitModule
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        // The holder is registered as ImplementationInstance by
-        // GranitWolverineModule's UseWolverine() — readable from the descriptor
-        // list without building a provider.
-        WolverineOptionsHolder holder = context.Services
+        // Fail fast on mis-ordering: the holder is registered as
+        // ImplementationInstance by GranitWolverineModule's UseWolverine() —
+        // readable from the descriptor list without building a provider. Without
+        // AddGranitWolverine() the extension below would silently never apply
+        // and PII would reach the outbox in plaintext.
+        _ = context.Services
             .Select(d => d.ImplementationInstance)
             .OfType<WolverineOptionsHolder>()
             .FirstOrDefault()
@@ -42,14 +42,6 @@ public sealed class GranitWolverineEncryptionModule : GranitModule
                 + "GranitWolverineEncryptionModule. Ensure the [DependsOn] chain "
                 + "is preserved.");
 
-        // IStringEncryptionService is a stateless delegator to
-        // IStringEncryptionProvider (key + algorithm captured from options).
-        // Build a transient provider once, resolve the singleton, then dispose.
-        // Cipher round-trip is identical with the eventual host-resolved
-        // instance because both share the same configuration-derived provider.
-        using ServiceProvider sp = context.Services.BuildServiceProvider();
-        IStringEncryptionService encryption = sp.GetRequiredService<IStringEncryptionService>();
-
-        holder.Options.UseEncryptedSensitiveData(encryption);
+        context.Services.AddWolverineExtension<WolverineEncryptionExtension>();
     }
 }

--- a/src/Granit.Wolverine.Encryption/Internal/WolverineEncryptionExtension.cs
+++ b/src/Granit.Wolverine.Encryption/Internal/WolverineEncryptionExtension.cs
@@ -1,0 +1,29 @@
+using Granit.Encryption;
+using Granit.Wolverine.Encryption.Extensions;
+using Wolverine;
+
+namespace Granit.Wolverine.Encryption.Internal;
+
+/// <summary>
+/// Wolverine extension that activates
+/// <see cref="WolverineEncryptionOptionsExtensions.UseEncryptedSensitiveData"/> at
+/// bootstrap time, with the <see cref="IStringEncryptionService"/> resolved from
+/// the host's container.
+/// </summary>
+/// <remarks>
+/// Registered via <c>services.AddWolverineExtension&lt;T&gt;()</c> by
+/// <see cref="GranitWolverineEncryptionModule"/>. Wolverine applies registered
+/// <see cref="IWolverineExtension"/> instances when the runtime is constructed,
+/// so the extension observes the exact singleton the rest of the application
+/// uses — no throwaway service provider, no risk of divergent key material if
+/// the encryption graph ever becomes stateful (Vault-backed rotation, key
+/// caches). Unlike the persistence providers, this extension only mutates
+/// serializer settings and never registers services, so the Wolverine 3.0
+/// read-only-IServiceCollection restriction does not apply.
+/// </remarks>
+internal sealed class WolverineEncryptionExtension(IStringEncryptionService encryption)
+    : IWolverineExtension
+{
+    public void Configure(WolverineOptions options) =>
+        options.UseEncryptedSensitiveData(encryption);
+}

--- a/src/Granit.Wolverine.Postgresql/GranitWolverinePostgresqlModule.cs
+++ b/src/Granit.Wolverine.Postgresql/GranitWolverinePostgresqlModule.cs
@@ -1,5 +1,6 @@
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Hosting;
 using Granit.Wolverine.Postgresql.Extensions;
 using Granit.Wolverine.Postgresql.Options;
 
@@ -21,7 +22,10 @@ namespace Granit.Wolverine.Postgresql;
 /// instead of the standard <c>services.AddDbContext&lt;TContext&gt;()</c>.
 /// </para>
 /// </remarks>
-[DependsOn(typeof(GranitWolverineModule), typeof(GranitPersistenceEntityFrameworkCoreModule))]
+[DependsOn(
+    typeof(GranitPersistenceEntityFrameworkCoreHostingModule),
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitWolverineModule))]
 public sealed class GranitWolverinePostgresqlModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
@@ -1,8 +1,11 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.Hosting;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.Wolverine.Internal;
 using Granit.Wolverine.SqlServer.Internal;
 using Granit.Wolverine.SqlServer.Options;
+using JasperFx;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -99,7 +102,7 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
     }
 
     /// <summary>
-    /// Shared core setup: options binding, connection string validation, and SQL Server Wolverine configuration.
+    /// Shared core setup: options binding, connection string resolution, and SQL Server Wolverine configuration.
     /// </summary>
     private static IHostApplicationBuilder AddGranitWolverineWithSqlServerCore(
         IHostApplicationBuilder builder,
@@ -120,6 +123,8 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
             .GetSection(WolverineSqlServerOptions.SectionName)
             .Bind(options);
 
+        string connectionString = ResolveConnectionString(builder.Configuration, options);
+
         // Resolve the WolverineOptions instance captured by AddGranitWolverine().
         // We apply SQL Server configuration directly on this instance instead of using
         // ConfigureWolverine(), which registers a deferred LambdaWolverineExtension in
@@ -136,11 +141,51 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
                 "AddGranitWolverine() must be called before AddGranitWolverineWithSqlServer(). " +
                 "Ensure GranitWolverineModule is declared in the [DependsOn] chain.");
 
-        wolverineOptions.PersistMessagesWithSqlServer(options.TransportConnectionString);
+        // Resolve Wolverine envelope schema: explicit option → HostDbSchema fallback → Wolverine default
+        string? wolverineSchema = options.SchemaName
+            ?? GranitDbDefaults.HostDbSchema;
+
+        if (wolverineSchema is not null)
+        {
+            wolverineOptions.PersistMessagesWithSqlServer(connectionString, wolverineSchema);
+        }
+        else
+        {
+            wolverineOptions.PersistMessagesWithSqlServer(connectionString);
+        }
+
+        // Disable auto-provisioning at startup — table creation is handled
+        // by IExternalStoreMigrator during --migrate mode only.
+        wolverineOptions.AutoBuildMessageStorageOnStartup = AutoCreate.None;
+
         wolverineOptions.UseEntityFrameworkCoreTransactions(options.TransactionMode);
         wolverineOptions.Policies.AutoApplyTransactions();
         configure?.Invoke(wolverineOptions);
 
+        // Register the Wolverine storage migrator for the --migrate pipeline
+        builder.Services.AddSingleton<IExternalStoreMigrator, WolverineStoreMigrator>();
+
         return builder;
+    }
+
+    /// <summary>
+    /// Resolves the transport connection string from explicit value or <c>ConnectionStrings:{name}</c> fallback.
+    /// </summary>
+    private static string ResolveConnectionString(IConfiguration configuration, WolverineSqlServerOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.TransportConnectionString))
+        {
+            return options.TransportConnectionString;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.TransportConnectionStringName))
+        {
+            return configuration.GetConnectionString(options.TransportConnectionStringName)
+                ?? throw new InvalidOperationException(
+                    $"Connection string '{options.TransportConnectionStringName}' not found in ConnectionStrings configuration. " +
+                    "Ensure the Aspire resource name matches TransportConnectionStringName.");
+        }
+
+        return string.Empty;
     }
 }

--- a/src/Granit.Wolverine.SqlServer/Granit.Wolverine.SqlServer.csproj
+++ b/src/Granit.Wolverine.SqlServer/Granit.Wolverine.SqlServer.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Wolverine\Granit.Wolverine.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore.Hosting\Granit.Persistence.EntityFrameworkCore.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Wolverine.SqlServer/GranitWolverineSqlServerModule.cs
+++ b/src/Granit.Wolverine.SqlServer/GranitWolverineSqlServerModule.cs
@@ -1,5 +1,6 @@
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Hosting;
 using Granit.Wolverine.SqlServer.Extensions;
 using Granit.Wolverine.SqlServer.Options;
 
@@ -21,7 +22,10 @@ namespace Granit.Wolverine.SqlServer;
 /// instead of the standard <c>services.AddDbContext&lt;TContext&gt;()</c>.
 /// </para>
 /// </remarks>
-[DependsOn(typeof(GranitWolverineModule), typeof(GranitPersistenceEntityFrameworkCoreModule))]
+[DependsOn(
+    typeof(GranitPersistenceEntityFrameworkCoreHostingModule),
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitWolverineModule))]
 public sealed class GranitWolverineSqlServerModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Wolverine.SqlServer/Internal/WolverineSqlServerOptionsValidator.cs
+++ b/src/Granit.Wolverine.SqlServer/Internal/WolverineSqlServerOptionsValidator.cs
@@ -11,11 +11,13 @@ internal sealed class WolverineSqlServerOptionsValidator : IValidateOptions<Wolv
     /// <inheritdoc/>
     public ValidateOptionsResult Validate(string? name, WolverineSqlServerOptions options)
     {
-        if (string.IsNullOrWhiteSpace(options.TransportConnectionString))
+        if (string.IsNullOrWhiteSpace(options.TransportConnectionString) &&
+            string.IsNullOrWhiteSpace(options.TransportConnectionStringName))
         {
             return ValidateOptionsResult.Fail(
-                $"{nameof(options.TransportConnectionString)} must be non-empty. " +
-                "A valid SQL Server connection string is required for the Wolverine Outbox (ISO 27001 compliance).");
+                $"Either {nameof(options.TransportConnectionString)} or {nameof(options.TransportConnectionStringName)} " +
+                "must be configured. A valid SQL Server connection string is required for the Wolverine Outbox (ISO 27001 compliance). " +
+                "Use TransportConnectionStringName for Aspire integration (e.g., \"catalog-db\").");
         }
 
         return ValidateOptionsResult.Success;

--- a/src/Granit.Wolverine.SqlServer/Internal/WolverineStoreMigrator.cs
+++ b/src/Granit.Wolverine.SqlServer/Internal/WolverineStoreMigrator.cs
@@ -1,0 +1,15 @@
+using Granit.Persistence.EntityFrameworkCore.Hosting;
+using Wolverine.Persistence.Durability;
+
+namespace Granit.Wolverine.SqlServer.Internal;
+
+/// <summary>
+/// Migrates Wolverine envelope tables (incoming, outgoing, dead-letter) during <c>--migrate</c> mode.
+/// </summary>
+internal sealed class WolverineStoreMigrator(IMessageStore messageStore) : IExternalStoreMigrator
+{
+    public string Name => "Wolverine message storage";
+
+    public async Task MigrateAsync(CancellationToken cancellationToken = default) =>
+        await messageStore.Admin.MigrateAsync().ConfigureAwait(false);
+}

--- a/src/Granit.Wolverine.SqlServer/Options/WolverineSqlServerOptions.cs
+++ b/src/Granit.Wolverine.SqlServer/Options/WolverineSqlServerOptions.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using Wolverine.Persistence;
 
 namespace Granit.Wolverine.SqlServer.Options;
@@ -24,15 +23,46 @@ public sealed class WolverineSqlServerOptions
     public const string SectionName = "Wolverine:SqlServer";
 
     /// <summary>
-    /// SQL Server connection string for the Wolverine Outbox tables.
-    /// Must be non-empty. Required for ISO 27001-compliant durable messaging.
+    /// Explicit SQL Server connection string for the Wolverine Outbox tables.
+    /// Takes priority over <see cref="TransportConnectionStringName"/>.
+    /// Required (either this or <see cref="TransportConnectionStringName"/>) for ISO 27001-compliant durable messaging.
     /// </summary>
-    [Required]
-    public string TransportConnectionString { get; set; } = string.Empty;
+    public string? TransportConnectionString { get; set; }
+
+    /// <summary>
+    /// Name of the connection string in the <c>ConnectionStrings</c> configuration section.
+    /// Used as fallback when <see cref="TransportConnectionString"/> is null or empty.
+    /// Enables seamless integration with .NET Aspire service discovery.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // appsettings.json
+    /// {
+    ///   "Wolverine:SqlServer": {
+    ///     "TransportConnectionStringName": "catalog-db"
+    ///   }
+    /// }
+    /// // Aspire injects ConnectionStrings:catalog-db → Wolverine reads it automatically.
+    /// </code>
+    /// </example>
+    public string? TransportConnectionStringName { get; set; }
 
     /// <summary>
     /// EF Core transaction wrapping mode for Wolverine handlers.
     /// Default: <see cref="TransactionMiddlewareMode.Eager"/> (ISO 27001-recommended).
     /// </summary>
     public TransactionMiddlewareMode TransactionMode { get; set; } = TransactionMiddlewareMode.Eager;
+
+    /// <summary>
+    /// SQL Server schema for Wolverine envelope tables (inbox, outbox, dead letter).
+    /// Default: <c>null</c> — falls back to <see cref="Granit.Persistence.EntityFrameworkCore.GranitDbDefaults.HostDbSchema"/>,
+    /// then Wolverine's built-in default (<c>"dbo"</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>SharedDatabase</b>: leave <c>null</c> — Wolverine uses its default schema.</para>
+    /// <para><b>SchemaPerTenant</b>: automatically uses <c>HostDbSchema</c> (e.g. <c>"host"</c>) so
+    /// Wolverine tables live alongside other host infrastructure.</para>
+    /// <para><b>DatabasePerTenant</b>: leave <c>null</c> — Wolverine uses the host database.</para>
+    /// </remarks>
+    public string? SchemaName { get; set; }
 }

--- a/src/Granit.Wolverine.SqlServer/README.md
+++ b/src/Granit.Wolverine.SqlServer/README.md
@@ -16,6 +16,34 @@ dotnet add package Granit.Wolverine.SqlServer
 - `Granit.Persistence`
 - `Granit.Wolverine`
 
+## Configuration
+
+`AddGranitWolverineWithSqlServer()` binds the `Wolverine:SqlServer` section and
+validates it on startup. At least **one** connection-string source must be set, or
+startup fails with `OptionsValidationException`:
+
+```json
+{
+  "Wolverine": {
+    "SqlServer": {
+      "TransportConnectionStringName": "DefaultConnection"
+    }
+  }
+}
+```
+
+| Key | Notes |
+| --- | ----- |
+| `TransportConnectionString` | Explicit connection string. Takes priority over the name. |
+| `TransportConnectionStringName` | Key into `ConnectionStrings` (Aspire-friendly). |
+| `SchemaName` | Optional. Defaults to the Granit host schema (`GranitDbDefaults.HostDbSchema`), then Wolverine's built-in default schema. Set only to override the envelope-table schema. |
+
+Envelope tables are created by the `--migrate` pipeline (`IExternalStoreMigrator`),
+never at application startup — the runtime database user does not need DDL grants.
+
+`AddGranitWolverine()` must run before `AddGranitWolverineWithSqlServer()` —
+`GranitWolverineSqlServerModule` handles this ordering automatically via `[DependsOn]`.
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Wolverine.SqlServer/packages.lock.json
+++ b/src/Granit.Wolverine.SqlServer/packages.lock.json
@@ -884,6 +884,21 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.persistence.entityframeworkcore.hosting": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore.Migrations": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore.migrations": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs
+++ b/src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs
@@ -50,15 +50,6 @@ public sealed class TenantContextBehavior(
             return;
         }
 
-        if (envelope.Headers.TryGetValue(
-                Middleware.OutgoingContextMiddleware.TenantIdHeader, out string? tenantIdStr)
-            && Guid.TryParse(tenantIdStr, out Guid tenantId))
-        {
-            _scope = _currentTenant.Change(tenantId);
-            return;
-        }
-
-        // Envelope without tenant header — observability only.
         // Prefer the runtime CLR type when available; Wolverine's `envelope.MessageType`
         // uses a wire-format identifier that is not always resolvable across assemblies.
         Type? messageType = envelope.Message?.GetType()
@@ -67,6 +58,16 @@ public sealed class TenantContextBehavior(
             ?? envelope.MessageType
             ?? "(unknown)";
 
+        if (envelope.Headers.TryGetValue(
+                Middleware.OutgoingContextMiddleware.TenantIdHeader, out string? tenantIdStr)
+            && Guid.TryParse(tenantIdStr, out Guid tenantId))
+        {
+            _scope = _currentTenant.Change(tenantId);
+            _metrics.RecordMessageHandled(tenantIdStr, messageTypeName);
+            return;
+        }
+
+        // Envelope without tenant header — observability only.
         bool isCrossTenant = messageType is not null
             && Attribute.IsDefined(messageType, typeof(CrossTenantMessageAttribute), inherit: false);
 

--- a/src/Granit.Wolverine/ClaimCheck/Internal/InMemoryClaimCheckStore.cs
+++ b/src/Granit.Wolverine/ClaimCheck/Internal/InMemoryClaimCheckStore.cs
@@ -27,7 +27,7 @@ internal sealed class InMemoryClaimCheckStore : IClaimCheckStore
         TimeSpan? expiry = null,
         CancellationToken cancellationToken = default)
     {
-#pragma warning disable GRSEC002
+#pragma warning disable GRSEC002 // dev/test-only store: references are opaque and unordered, no UUIDv7/IGuidGenerator need
         var id = Guid.NewGuid();
 #pragma warning restore GRSEC002
         _store[id] = data.ToArray();

--- a/src/Granit.Wolverine/Diagnostics/WolverineMetrics.cs
+++ b/src/Granit.Wolverine/Diagnostics/WolverineMetrics.cs
@@ -7,6 +7,12 @@ namespace Granit.Wolverine.Diagnostics;
 /// OpenTelemetry metrics for the Wolverine messaging module.
 /// Meter: <c>Granit.Wolverine</c>.
 /// </summary>
+/// <remarks>
+/// These counters complement Wolverine's native <c>Wolverine</c> meter (execution
+/// time, dead-letter, retry counters) with Granit-specific signals: tenant-tagged
+/// dispatch/handling volume and untenanted-envelope observability. Failure and
+/// retry observability is intentionally left to the native Wolverine meter.
+/// </remarks>
 public sealed class WolverineMetrics
 {
     public const string MeterName = "Granit.Wolverine";
@@ -16,9 +22,6 @@ public sealed class WolverineMetrics
 
     private readonly Counter<long> _messagesDispatched;
     private readonly Counter<long> _messagesHandled;
-    private readonly Counter<long> _retriesExhausted;
-    private readonly Counter<long> _claimCheckStored;
-    private readonly Counter<long> _claimCheckRetrieved;
     private readonly Counter<long> _envelopeNoTenant;
 
     public WolverineMetrics(IMeterFactory meterFactory)
@@ -27,23 +30,12 @@ public sealed class WolverineMetrics
 
         _messagesDispatched = meter.CreateCounter<long>(
             "granit.wolverine.messages.dispatched",
-            description: "Number of messages dispatched via the scoped sender.");
+            description: "Number of messages dispatched via the Granit command senders "
+                + "(ICommandSender / WolverineScopedSender).");
 
         _messagesHandled = meter.CreateCounter<long>(
             "granit.wolverine.messages.handled",
-            description: "Number of messages handled with restored context (tenant + user).");
-
-        _retriesExhausted = meter.CreateCounter<long>(
-            "granit.wolverine.retries.exhausted",
-            description: "Number of messages that exhausted all retry attempts.");
-
-        _claimCheckStored = meter.CreateCounter<long>(
-            "granit.wolverine.claimcheck.stored",
-            description: "Number of payloads stored via the claim check pattern.");
-
-        _claimCheckRetrieved = meter.CreateCounter<long>(
-            "granit.wolverine.claimcheck.retrieved",
-            description: "Number of payloads retrieved via the claim check pattern.");
+            description: "Number of messages entering handler execution with a restored tenant context.");
 
         _envelopeNoTenant = meter.CreateCounter<long>(
             "granit.wolverine.envelope.no_tenant",
@@ -67,25 +59,6 @@ public sealed class WolverineMetrics
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { "message_type", messageType },
-        });
-
-    public void RecordRetriesExhausted(string? tenantId, string messageType) =>
-        _retriesExhausted.Add(1, new TagList
-        {
-            { TagTenantId, tenantId ?? DefaultTenant },
-            { "message_type", messageType },
-        });
-
-    public void RecordClaimCheckStored(string? tenantId) =>
-        _claimCheckStored.Add(1, new TagList
-        {
-            { TagTenantId, tenantId ?? DefaultTenant },
-        });
-
-    public void RecordClaimCheckRetrieved(string? tenantId) =>
-        _claimCheckRetrieved.Add(1, new TagList
-        {
-            { TagTenantId, tenantId ?? DefaultTenant },
         });
 
     /// <summary>

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using FluentValidation;
 using Granit.Commands;
 using Granit.Diagnostics;
+using Granit.MultiTenancy;
 using Granit.Users;
 using Granit.Wolverine.Behaviors;
 using Granit.Wolverine.Diagnostics;
@@ -62,8 +63,15 @@ public static class WolverineHostApplicationBuilderExtensions
         // only exposes the bridge spans).
         GranitActivitySourceRegistry.Register("Wolverine");
 
-        // Metrics: IMeterFactory-backed counters for message throughput, retries, claim checks.
+        // Metrics: IMeterFactory-backed counters for message dispatch/handling volume
+        // and untenanted-envelope observability. Failure/retry counters come from
+        // Wolverine's native "Wolverine" meter (registered above for tracing; metrics
+        // are exposed by the OTel meter provider).
         builder.Services.TryAddSingleton<WolverineMetrics>();
+
+        // Tenant context fallback so the senders and behaviors resolve outside a
+        // full Granit host bootstrap (AddGranit* registers the same default).
+        builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
 
         // Shared helper for Singleton services that need to dispatch via scoped IMessageBus.
         builder.Services.TryAddSingleton<WolverineScopedSender>();

--- a/src/Granit.Wolverine/Granit.Wolverine.csproj
+++ b/src/Granit.Wolverine/Granit.Wolverine.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <ProjectReference Include="..\..\src\Granit\Granit.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,7 +17,6 @@
     <InternalsVisibleTo Include="Granit.Wolverine.Tests" />
     <InternalsVisibleTo Include="WolverineHandlers" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-    <ProjectReference Include="..\..\src\Granit\Granit.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,12 +25,11 @@
     <!-- v6 split Roslyn runtime codegen out of core WolverineFx; the host needs this for the
          default TypeLoadMode.Dynamic. Auto-registers via [WolverineModule] (Automatic discovery). -->
     <PackageReference Include="WolverineFx.RuntimeCompilation" />
-    <ProjectReference Include="..\..\src\Granit\Granit.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
     <ProjectReference Include="..\..\src\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Wolverine/Internal/WolverineCommandSender.cs
+++ b/src/Granit.Wolverine/Internal/WolverineCommandSender.cs
@@ -1,4 +1,6 @@
 using Granit.Commands;
+using Granit.MultiTenancy;
+using Granit.Wolverine.Diagnostics;
 using Wolverine;
 
 namespace Granit.Wolverine.Internal;
@@ -19,13 +21,22 @@ namespace Granit.Wolverine.Internal;
 /// a DI scope themselves via <c>IServiceScopeFactory.CreateAsyncScope()</c> and resolve
 /// <see cref="ICommandSender"/> inside it.
 /// </para>
+/// <para>
+/// Each dispatch is recorded on the <c>granit.wolverine.messages.dispatched</c> counter,
+/// tagged with the current tenant (or <c>global</c>).
+/// </para>
 /// </remarks>
-internal sealed class WolverineCommandSender(IMessageBus bus) : ICommandSender
+internal sealed class WolverineCommandSender(
+    IMessageBus bus,
+    WolverineMetrics metrics,
+    ICurrentTenant currentTenant) : ICommandSender
 {
     public async Task SendAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
         where TCommand : class
     {
         ArgumentNullException.ThrowIfNull(command);
+        cancellationToken.ThrowIfCancellationRequested();
         await bus.SendAsync(command).ConfigureAwait(false);
+        metrics.RecordMessageDispatched(currentTenant.Id?.ToString());
     }
 }

--- a/src/Granit.Wolverine/WolverineScopedSender.cs
+++ b/src/Granit.Wolverine/WolverineScopedSender.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+using Granit.Wolverine.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Wolverine;
 
@@ -9,8 +11,12 @@ namespace Granit.Wolverine;
 /// <remarks>
 /// <see cref="IMessageBus"/> is Scoped, so Singleton services cannot inject it directly.
 /// This helper creates a short-lived scope per dispatch, resolves the bus, and sends.
+/// Each dispatch is recorded on the <c>granit.wolverine.messages.dispatched</c> counter,
+/// tagged with the tenant active in the created scope (or <c>global</c>).
 /// </remarks>
-public sealed class WolverineScopedSender(IServiceScopeFactory scopeFactory)
+public sealed class WolverineScopedSender(
+    IServiceScopeFactory scopeFactory,
+    WolverineMetrics metrics)
 {
     /// <summary>
     /// Sends a command through a scoped <see cref="IMessageBus"/>.
@@ -25,5 +31,8 @@ public sealed class WolverineScopedSender(IServiceScopeFactory scopeFactory)
         await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
         IMessageBus bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
         await bus.SendAsync(command).ConfigureAwait(false);
+
+        ICurrentTenant? currentTenant = scope.ServiceProvider.GetService<ICurrentTenant>();
+        metrics.RecordMessageDispatched(currentTenant?.Id?.ToString());
     }
 }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -4326,6 +4326,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore.Hosting": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.*, )",
           "WolverineFx.EntityFrameworkCore": "[6.*, )",
@@ -4397,8 +4398,8 @@
       "AngleSharp": {
         "type": "CentralTransitive",
         "requested": "[1.*, )",
-        "resolved": "1.5.1",
-        "contentHash": "jFG0tKwFMNzIdv0rX3qvyiKyxAzUIvDyTLTJo2ORKtv/hiJC8juZTknc4b9DQmBFbrky+0twr58QQWt6DR48Og=="
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "Anthropic": {
         "type": "CentralTransitive",
@@ -4649,8 +4650,8 @@
       "Google.Cloud.Kms.V1": {
         "type": "CentralTransitive",
         "requested": "[3.*, )",
-        "resolved": "3.24.0",
-        "contentHash": "ZKiL+HWnCM49uiUxnotE2M83LXGSBDEDzeA7tWBxQ6HugSb4th/KvlmSfebhwecJ6BgzF9zS2a1DPBteiC77YQ==",
+        "resolved": "3.25.0",
+        "contentHash": "tlRxgVAJHBx3pfhKytbpdlEASePFJTeU1oS3ZR/9VtXLgSysaVPFHgo+OKEkz21X47sxCVqXlK1flx+xfofqXw==",
         "dependencies": {
           "Google.Api.Gax.Grpc": "[4.13.1, 5.0.0)",
           "Google.Cloud.Iam.V1": "[3.5.0, 4.0.0)",
@@ -5335,8 +5336,8 @@
       "Sylvan.Data.Excel": {
         "type": "CentralTransitive",
         "requested": "[0.5.*, )",
-        "resolved": "0.5.6",
-        "contentHash": "6OcGGQRT0dfg1bBEl0AIakNUfuAQCMRclq7ZJEeWejRuIypp0zxzLB52/8FTgw7wFYdLcikI8fK7oLpMA4F7Lw=="
+        "resolved": "0.5.7",
+        "contentHash": "3Rv5cxSyk6O3xzuSdYja1IxL+39AzJMeF4u0qzsKnxPvYMTHJ6L3AQ0HbTfhOIVOcu64pbwkW2cm/FbQ+QXc+Q=="
       },
       "System.Composition.AttributedModel": {
         "type": "CentralTransitive",

--- a/tests/Granit.Wolverine.Encryption.Tests/GranitWolverineEncryptionModuleTests.cs
+++ b/tests/Granit.Wolverine.Encryption.Tests/GranitWolverineEncryptionModuleTests.cs
@@ -1,0 +1,70 @@
+// =============================================================================
+// Tests - GranitWolverineEncryptionModule
+// =============================================================================
+// Verifies module inheritance, DependsOn declarations, that ConfigureServices
+// registers the IWolverineExtension applied at Wolverine bootstrap, and that
+// mis-ordering (no AddGranitWolverine first) fails fast instead of silently
+// shipping plaintext PII to the outbox.
+// =============================================================================
+
+using Granit.Encryption;
+using Granit.Modularity;
+using Granit.Wolverine.Encryption.Internal;
+using Granit.Wolverine.Extensions;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace Granit.Wolverine.Encryption.Tests;
+
+public sealed class GranitWolverineEncryptionModuleTests
+{
+    [Fact]
+    public void GranitWolverineEncryptionModule_IsGranitModule() =>
+        typeof(GranitWolverineEncryptionModule).IsAssignableTo(typeof(GranitModule)).ShouldBeTrue();
+
+    [Fact]
+    public void GranitWolverineEncryptionModule_IsSealed() =>
+        typeof(GranitWolverineEncryptionModule).IsSealed.ShouldBeTrue();
+
+    [Fact]
+    public void GranitWolverineEncryptionModule_DependsOn_WolverineAndEncryptionModules()
+    {
+        var attributes = (DependsOnAttribute[])
+            typeof(GranitWolverineEncryptionModule).GetCustomAttributes(typeof(DependsOnAttribute), inherit: false);
+
+        attributes.ShouldContain(a => a.DependedTypes.Contains(typeof(GranitWolverineModule)));
+        attributes.ShouldContain(a => a.DependedTypes.Contains(typeof(GranitEncryptionModule)));
+    }
+
+    [Fact]
+    public void ConfigureServices_RegistersWolverineEncryptionExtension()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.AddGranitWolverine();
+        GranitWolverineEncryptionModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+
+        module.ConfigureServices(context);
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IWolverineExtension)
+            && d.ImplementationType == typeof(WolverineEncryptionExtension));
+    }
+
+    [Fact]
+    public void ConfigureServices_WithoutWolverineModule_ThrowsInvalidOperationException()
+    {
+        // Without AddGranitWolverine() the extension would never be applied and
+        // [Encrypted] properties would reach the outbox in plaintext — fail fast.
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        GranitWolverineEncryptionModule module = new();
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+
+        Action act = () => module.ConfigureServices(context);
+
+        InvalidOperationException exception = Should.Throw<InvalidOperationException>(act);
+        exception.Message.ShouldContain("GranitWolverineModule");
+    }
+}

--- a/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
@@ -7,6 +7,7 @@
 
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Hosting;
 using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Postgresql.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -42,6 +43,16 @@ public sealed class GranitWolverinePostgresqlModuleTests
             typeof(GranitWolverinePostgresqlModule).GetCustomAttributes(typeof(DependsOnAttribute), inherit: false);
 
         attributes.ShouldContain(a => a.DependedTypes.Contains(typeof(GranitPersistenceEntityFrameworkCoreModule)));
+    }
+
+    [Fact]
+    public void GranitWolverinePostgresqlModule_DependsOn_PersistenceHostingModule()
+    {
+        // Direct project reference (IExternalStoreMigrator) → must be declared.
+        var attributes = (DependsOnAttribute[])
+            typeof(GranitWolverinePostgresqlModule).GetCustomAttributes(typeof(DependsOnAttribute), inherit: false);
+
+        attributes.ShouldContain(a => a.DependedTypes.Contains(typeof(GranitPersistenceEntityFrameworkCoreHostingModule)));
     }
 
     [Fact]

--- a/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerTests.cs
@@ -5,6 +5,7 @@
 // value for both single-tenant and per-tenant extension methods.
 // =============================================================================
 
+using Granit.Persistence.EntityFrameworkCore.Hosting;
 using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Granit.Wolverine.SqlServer.Options;
@@ -21,19 +22,26 @@ public sealed class AddGranitWolverineWithSqlServerTests
     private const string ValidTransportConnStr =
         "Server=localhost;Database=wolverine_transport;User Id=sa;Password=test;TrustServerCertificate=True";
 
-    private static HostApplicationBuilder CreateBuilder()
+    private static HostApplicationBuilder CreateBuilder(
+        Dictionary<string, string?>? config = null,
+        bool withWolverine = true)
     {
         HostApplicationBuilderSettings settings = new()
         {
             Configuration = new ConfigurationManager(),
         };
-        settings.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        settings.Configuration.AddInMemoryCollection(config ?? new Dictionary<string, string?>
         {
             [$"{WolverineSqlServerOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
         HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
-        builder.AddGranitWolverine();
+
+        if (withWolverine)
+        {
+            builder.AddGranitWolverine();
+        }
+
         return builder;
     }
 
@@ -67,6 +75,63 @@ public sealed class AddGranitWolverineWithSqlServerTests
 
         builder.Services.ShouldContain(d =>
             d.ServiceType == typeof(IValidateOptions<WolverineSqlServerOptions>));
+    }
+
+    // -----------------------------------------------------------------------
+    // Connection string name — resolved from ConnectionStrings section (Aspire)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AddGranitWolverineWithSqlServer_WithConnectionStringName_DoesNotThrow()
+    {
+        HostApplicationBuilder builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            [$"{WolverineSqlServerOptions.SectionName}:TransportConnectionStringName"] = "catalog-db",
+            ["ConnectionStrings:catalog-db"] = ValidTransportConnStr,
+        });
+
+        Action act = () => builder.AddGranitWolverineWithSqlServer();
+
+        Should.NotThrow(act);
+    }
+
+    // -----------------------------------------------------------------------
+    // Missing connection string name — throws
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AddGranitWolverineWithSqlServer_WithMissingConnectionStringName_ThrowsInvalidOperationException()
+    {
+        // Throws before WolverineOptionsHolder lookup, so AddGranitWolverine() is not needed.
+        HostApplicationBuilder builder = CreateBuilder(
+            config: new Dictionary<string, string?>
+            {
+                [$"{WolverineSqlServerOptions.SectionName}:TransportConnectionStringName"] = "non-existent-db",
+            },
+            withWolverine: false);
+
+        Action act = () => builder.AddGranitWolverineWithSqlServer();
+
+        InvalidOperationException exception = Should.Throw<InvalidOperationException>(act);
+        exception.Message.ShouldContain("non-existent-db");
+    }
+
+    // -----------------------------------------------------------------------
+    // Migrate pipeline — no auto-DDL at boot, migrator registered instead
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AddGranitWolverineWithSqlServer_RegistersWolverineStoreMigrator()
+    {
+        // Table creation must go through --migrate mode (IExternalStoreMigrator),
+        // never through startup auto-provisioning: concurrent DDL between replicas
+        // during a rolling update, and the runtime DB user must not need DDL grants.
+        HostApplicationBuilder builder = CreateBuilder();
+
+        builder.AddGranitWolverineWithSqlServer();
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IExternalStoreMigrator));
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
@@ -7,6 +7,7 @@
 
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Hosting;
 using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -42,6 +43,16 @@ public sealed class GranitWolverineSqlServerModuleTests
             typeof(GranitWolverineSqlServerModule).GetCustomAttributes(typeof(DependsOnAttribute), inherit: false);
 
         attributes.ShouldContain(a => a.DependedTypes.Contains(typeof(GranitPersistenceEntityFrameworkCoreModule)));
+    }
+
+    [Fact]
+    public void GranitWolverineSqlServerModule_DependsOn_PersistenceHostingModule()
+    {
+        // Direct project reference (IExternalStoreMigrator) → must be declared.
+        var attributes = (DependsOnAttribute[])
+            typeof(GranitWolverineSqlServerModule).GetCustomAttributes(typeof(DependsOnAttribute), inherit: false);
+
+        attributes.ShouldContain(a => a.DependedTypes.Contains(typeof(GranitPersistenceEntityFrameworkCoreHostingModule)));
     }
 
     [Fact]

--- a/tests/Granit.Wolverine.SqlServer.Tests/WolverineSqlServerOptionsAdditionalTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/WolverineSqlServerOptionsAdditionalTests.cs
@@ -33,7 +33,11 @@ public sealed class WolverineSqlServerOptionsAdditionalTests
     public void Validate_FailureMessage_ContainsISO27001Reference()
     {
         WolverineSqlServerOptionsValidator validator = new();
-        WolverineSqlServerOptions options = new() { TransportConnectionString = string.Empty };
+        WolverineSqlServerOptions options = new()
+        {
+            TransportConnectionString = string.Empty,
+            TransportConnectionStringName = string.Empty,
+        };
 
         ValidateOptionsResult result = validator.Validate(null, options);
 

--- a/tests/Granit.Wolverine.SqlServer.Tests/WolverineSqlServerOptionsTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/WolverineSqlServerOptionsTests.cs
@@ -24,15 +24,23 @@ public sealed class WolverineSqlServerOptionsTests
         WolverineSqlServerOptions.SectionName.ShouldBe("Wolverine:SqlServer");
 
     [Fact]
-    public void DefaultTransportConnectionString_IsEmpty() =>
-        new WolverineSqlServerOptions().TransportConnectionString.ShouldBeEmpty();
+    public void DefaultTransportConnectionString_IsNull() =>
+        new WolverineSqlServerOptions().TransportConnectionString.ShouldBeNull();
+
+    [Fact]
+    public void DefaultTransportConnectionStringName_IsNull() =>
+        new WolverineSqlServerOptions().TransportConnectionStringName.ShouldBeNull();
+
+    [Fact]
+    public void DefaultSchemaName_IsNull() =>
+        new WolverineSqlServerOptions().SchemaName.ShouldBeNull();
 
     [Fact]
     public void DefaultTransactionMode_IsEager() =>
         new WolverineSqlServerOptions().TransactionMode.ShouldBe(TransactionMiddlewareMode.Eager);
 
     // -----------------------------------------------------------------------
-    // WolverineSqlServerOptionsValidator — happy path
+    // WolverineSqlServerOptionsValidator — happy paths
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -42,6 +50,21 @@ public sealed class WolverineSqlServerOptionsTests
         WolverineSqlServerOptions options = new()
         {
             TransportConnectionString = "Server=localhost;Database=test;User Id=sa;Password=pass;TrustServerCertificate=True",
+        };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ConnectionStringNameOnly_Succeeds()
+    {
+        // Aspire integration: the actual value is resolved from ConnectionStrings:{name}.
+        WolverineSqlServerOptionsValidator validator = new();
+        WolverineSqlServerOptions options = new()
+        {
+            TransportConnectionStringName = "catalog-db",
         };
 
         ValidateOptionsResult result = validator.Validate(null, options);
@@ -65,14 +88,31 @@ public sealed class WolverineSqlServerOptionsTests
     }
 
     // -----------------------------------------------------------------------
-    // WolverineSqlServerOptionsValidator — TransportConnectionString failures
+    // WolverineSqlServerOptionsValidator — failures (neither value configured)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void Validate_NullConnectionString_Fails()
+    public void Validate_NullConnectionStringAndName_Fails()
     {
         WolverineSqlServerOptionsValidator validator = new();
-        WolverineSqlServerOptions options = new() { TransportConnectionString = null! };
+        WolverineSqlServerOptions options = new();
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldContain(x => x.Contains("TransportConnectionString"));
+        result.Failures.ShouldContain(x => x.Contains("TransportConnectionStringName"));
+    }
+
+    [Fact]
+    public void Validate_EmptyConnectionStringAndName_Fails()
+    {
+        WolverineSqlServerOptionsValidator validator = new();
+        WolverineSqlServerOptions options = new()
+        {
+            TransportConnectionString = string.Empty,
+            TransportConnectionStringName = string.Empty,
+        };
 
         ValidateOptionsResult result = validator.Validate(null, options);
 
@@ -81,22 +121,14 @@ public sealed class WolverineSqlServerOptionsTests
     }
 
     [Fact]
-    public void Validate_EmptyConnectionString_Fails()
+    public void Validate_WhitespaceConnectionStringAndName_Fails()
     {
         WolverineSqlServerOptionsValidator validator = new();
-        WolverineSqlServerOptions options = new() { TransportConnectionString = string.Empty };
-
-        ValidateOptionsResult result = validator.Validate(null, options);
-
-        result.Failed.ShouldBeTrue();
-        result.Failures.ShouldContain(x => x.Contains("TransportConnectionString"));
-    }
-
-    [Fact]
-    public void Validate_WhitespaceConnectionString_Fails()
-    {
-        WolverineSqlServerOptionsValidator validator = new();
-        WolverineSqlServerOptions options = new() { TransportConnectionString = "   " };
+        WolverineSqlServerOptions options = new()
+        {
+            TransportConnectionString = "   ",
+            TransportConnectionStringName = "   ",
+        };
 
         ValidateOptionsResult result = validator.Validate(null, options);
 

--- a/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
@@ -1024,6 +1024,21 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.persistence.entityframeworkcore.hosting": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore.Migrations": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore.migrations": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -1064,6 +1079,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore.Hosting": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",

--- a/tests/Granit.Wolverine.Tests/TenantContextBehaviorTests.cs
+++ b/tests/Granit.Wolverine.Tests/TenantContextBehaviorTests.cs
@@ -44,6 +44,9 @@ public sealed class TenantContextBehaviorTests : IDisposable
     private MetricCollector<long> NoTenantCollector() =>
         new(_meterFactory, WolverineMetrics.MeterName, "granit.wolverine.envelope.no_tenant");
 
+    private MetricCollector<long> HandledCollector() =>
+        new(_meterFactory, WolverineMetrics.MeterName, "granit.wolverine.messages.handled");
+
     [Fact]
     public void Before_WithValidTenantHeader_CallsChange()
     {
@@ -58,6 +61,38 @@ public sealed class TenantContextBehaviorTests : IDisposable
         behavior.Before(envelope);
 
         tenant.Received(1).Change(tenantId);
+        collector.GetMeasurementSnapshot().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Before_WithValidTenantHeader_RecordsMessageHandled()
+    {
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.Change(tenantId).Returns(Substitute.For<IDisposable>());
+        TenantContextBehavior behavior = CreateBehavior(tenant);
+        using MetricCollector<long> collector = HandledCollector();
+        Envelope envelope = new() { Message = new TenantScopedMessage() };
+        envelope.Headers[OutgoingContextMiddleware.TenantIdHeader] = tenantId.ToString();
+
+        behavior.Before(envelope);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["tenant_id"].ShouldBe(tenantId.ToString());
+        snapshot[0].Tags["message_type"].ShouldBe(nameof(TenantScopedMessage));
+    }
+
+    [Fact]
+    public void Before_WithMissingHeader_DoesNotRecordMessageHandled()
+    {
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        TenantContextBehavior behavior = CreateBehavior(tenant);
+        using MetricCollector<long> collector = HandledCollector();
+        Envelope envelope = new() { Message = new TenantScopedMessage() };
+
+        behavior.Before(envelope);
+
         collector.GetMeasurementSnapshot().ShouldBeEmpty();
     }
 

--- a/tests/Granit.Wolverine.Tests/WolverineCommandSenderTests.cs
+++ b/tests/Granit.Wolverine.Tests/WolverineCommandSenderTests.cs
@@ -1,11 +1,17 @@
 // =============================================================================
 // Tests - WolverineCommandSender
 // =============================================================================
-// Verifies that ICommandSender forwards commands to IMessageBus.SendAsync and
-// validates its null-argument contract.
+// Verifies that ICommandSender forwards commands to IMessageBus.SendAsync,
+// validates its null-argument contract, honors cancellation, and records the
+// granit.wolverine.messages.dispatched counter tagged with the current tenant.
 // =============================================================================
 
+using System.Diagnostics.Metrics;
+using Granit.MultiTenancy;
+using Granit.Wolverine.Diagnostics;
 using Granit.Wolverine.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using NSubstitute;
 using Shouldly;
 using Wolverine;
@@ -13,15 +19,33 @@ using Xunit;
 
 namespace Granit.Wolverine.Tests;
 
-public sealed class WolverineCommandSenderTests
+public sealed class WolverineCommandSenderTests : IDisposable
 {
     private sealed record TestCommand(string Payload);
+
+    private readonly ServiceProvider _sp;
+    private readonly IMeterFactory _meterFactory;
+    private readonly WolverineMetrics _metrics;
+
+    public WolverineCommandSenderTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _meterFactory = _sp.GetRequiredService<IMeterFactory>();
+        _metrics = new WolverineMetrics(_meterFactory);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private MetricCollector<long> DispatchedCollector() =>
+        new(_meterFactory, WolverineMetrics.MeterName, "granit.wolverine.messages.dispatched");
 
     [Fact]
     public async Task SendAsync_forwards_command_to_IMessageBus()
     {
         IMessageBus bus = Substitute.For<IMessageBus>();
-        WolverineCommandSender sut = new(bus);
+        WolverineCommandSender sut = new(bus, _metrics, NullTenantContext.Instance);
         TestCommand command = new("hello");
 
         await sut.SendAsync(command, TestContext.Current.CancellationToken);
@@ -33,11 +57,56 @@ public sealed class WolverineCommandSenderTests
     public async Task SendAsync_throws_when_command_is_null()
     {
         IMessageBus bus = Substitute.For<IMessageBus>();
-        WolverineCommandSender sut = new(bus);
+        WolverineCommandSender sut = new(bus, _metrics, NullTenantContext.Instance);
 
         await Should.ThrowAsync<ArgumentNullException>(
             () => sut.SendAsync<TestCommand>(null!, TestContext.Current.CancellationToken));
 
         await bus.DidNotReceiveWithAnyArgs().SendAsync<TestCommand>(default!);
+    }
+
+    [Fact]
+    public async Task SendAsync_throws_when_token_already_canceled()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        WolverineCommandSender sut = new(bus, _metrics, NullTenantContext.Instance);
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => sut.SendAsync(new TestCommand("late"), cts.Token));
+
+        await bus.DidNotReceiveWithAnyArgs().SendAsync<TestCommand>(default!);
+    }
+
+    [Fact]
+    public async Task SendAsync_records_dispatched_metric_with_global_tenant()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        WolverineCommandSender sut = new(bus, _metrics, NullTenantContext.Instance);
+        using MetricCollector<long> collector = DispatchedCollector();
+
+        await sut.SendAsync(new TestCommand("hello"), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["tenant_id"].ShouldBe("global");
+    }
+
+    [Fact]
+    public async Task SendAsync_records_dispatched_metric_with_current_tenant()
+    {
+        var tenantId = Guid.NewGuid();
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.Id.Returns(tenantId);
+        WolverineCommandSender sut = new(bus, _metrics, tenant);
+        using MetricCollector<long> collector = DispatchedCollector();
+
+        await sut.SendAsync(new TestCommand("hello"), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["tenant_id"].ShouldBe(tenantId.ToString());
     }
 }

--- a/tests/Granit.Wolverine.Tests/WolverineScopedSenderTests.cs
+++ b/tests/Granit.Wolverine.Tests/WolverineScopedSenderTests.cs
@@ -1,0 +1,107 @@
+// =============================================================================
+// Tests - WolverineScopedSender
+// =============================================================================
+// Verifies that the singleton-friendly sender creates a DI scope per dispatch,
+// resolves the scoped IMessageBus, honors cancellation, and records the
+// granit.wolverine.messages.dispatched counter tagged with the scope's tenant.
+// =============================================================================
+
+using System.Diagnostics.Metrics;
+using Granit.MultiTenancy;
+using Granit.Wolverine.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace Granit.Wolverine.Tests;
+
+public sealed class WolverineScopedSenderTests
+{
+    private sealed record TestCommand(string Payload);
+
+    private static ServiceProvider BuildProvider(IMessageBus bus, ICurrentTenant? tenant = null)
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        services.AddScoped(_ => bus);
+        if (tenant is not null)
+        {
+            services.AddSingleton(tenant);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static WolverineScopedSender CreateSender(ServiceProvider sp) =>
+        new(sp.GetRequiredService<IServiceScopeFactory>(),
+            new WolverineMetrics(sp.GetRequiredService<IMeterFactory>()));
+
+    private static MetricCollector<long> DispatchedCollector(ServiceProvider sp) =>
+        new(sp.GetRequiredService<IMeterFactory>(),
+            WolverineMetrics.MeterName,
+            "granit.wolverine.messages.dispatched");
+
+    [Fact]
+    public async Task SendAsync_resolves_scoped_bus_and_forwards_command()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        await using ServiceProvider sp = BuildProvider(bus);
+        WolverineScopedSender sender = CreateSender(sp);
+        TestCommand command = new("hello");
+
+        await sender.SendAsync(command, TestContext.Current.CancellationToken);
+
+        await bus.Received(1).SendAsync(command);
+    }
+
+    [Fact]
+    public async Task SendAsync_throws_when_token_already_canceled()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        await using ServiceProvider sp = BuildProvider(bus);
+        WolverineScopedSender sender = CreateSender(sp);
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => sender.SendAsync(new TestCommand("late"), cts.Token));
+
+        await bus.DidNotReceiveWithAnyArgs().SendAsync<TestCommand>(default!);
+    }
+
+    [Fact]
+    public async Task SendAsync_records_dispatched_metric_with_global_tenant_when_none_registered()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        await using ServiceProvider sp = BuildProvider(bus);
+        WolverineScopedSender sender = CreateSender(sp);
+        using MetricCollector<long> collector = DispatchedCollector(sp);
+
+        await sender.SendAsync(new TestCommand("hello"), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["tenant_id"].ShouldBe("global");
+    }
+
+    [Fact]
+    public async Task SendAsync_records_dispatched_metric_with_scope_tenant()
+    {
+        var tenantId = Guid.NewGuid();
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.Id.Returns(tenantId);
+        await using ServiceProvider sp = BuildProvider(bus, tenant);
+        WolverineScopedSender sender = CreateSender(sp);
+        using MetricCollector<long> collector = DispatchedCollector(sp);
+
+        await sender.SendAsync(new TestCommand("hello"), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["tenant_id"].ShouldBe(tenantId.ToString());
+    }
+}


### PR DESCRIPTION
## Summary

Applies all findings from the \`/audit Granit.Wolverine*\` framework audit (1 ARCHITECTURE, 3 CONVENTION, 3 CLEANUP, 2 IMPROVEMENT).

### SQL Server provider parity (ARCHITECTURE)
- **No more DDL at boot**: \`AutoBuildMessageStorageOnStartup = AutoCreate.None\` + \`WolverineStoreMigrator\` registered as \`IExternalStoreMigrator\` — envelope tables are created by the \`--migrate\` pipeline like the PostgreSQL provider (#957). Eliminates the multi-replica DDL race on rolling updates and the DDL-grant requirement on the runtime DB user (ISO 27001 least-privilege).
- **Option parity with PostgreSQL**: \`TransportConnectionStringName\` (Aspire \`ConnectionStrings:{name}\` fallback) and \`SchemaName\` (explicit → \`HostDbSchema\` → Wolverine default); either/or startup validation.

### Metrics (CONVENTION)
- 5 of 6 \`WolverineMetrics\` counters were declared but never recorded. Now: \`messages.dispatched\` emitted by both senders, \`messages.handled\` by \`TenantContextBehavior\` on context restore; \`retries.exhausted\` + the 2 claim-check counters removed (no reliable hook; Wolverine's native meter covers failure/DLQ).

### Encryption module (IMPROVEMENT)
- \`BuildServiceProvider()\` in \`ConfigureServices\` (ASP0000) replaced by a \`WolverineEncryptionExtension : IWolverineExtension\` resolved from the real container at bootstrap. Safe because the serializer config never registers services (the Wolverine 3.0 read-only-collection restriction that motivated the holder pattern does not apply here). Fail-fast ordering guard preserved.

### Conventions & cleanups
- Both provider modules declare \`GranitPersistenceEntityFrameworkCoreHostingModule\` (direct ref) and list \`[DependsOn]\` alphabetically.
- \`Granit.csproj\` reference deduplicated (was 4× in \`Granit.Wolverine.csproj\`); \`WolverineCommandSender\` honors its \`CancellationToken\`; GRSEC002 suppression justified inline; \`NullTenantContext\` TryAdd fallback in \`AddGranitWolverine\`.

## Verification
- \`infrastructure\` shard: build + tests green (only failure: \`Granit.Geocoding.Nominatim.Tests\` ×1, flaky, passes on rerun, unrelated)
- \`architecture\` shard: 263 tests green (covers the \`[DependsOn]\` changes)
- \`dotnet format --verify-no-changes\` on the shard: clean
- 4 Wolverine test suites: 249 → 262 tests, all green (new coverage: scoped sender, dispatched/handled metrics, SqlServer Aspire fallback + migrator registration, encryption module wiring & fail-fast)

Docs PR (package table, dependency graph, configuration keys) follows separately in granit-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)