### PR TITLE
feat(query-engine): per-query permissions, naming guard-rail, unsigned-cursor warning

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -48989,10 +48989,16 @@
       "line": 7,
       "members": [
         {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
           "name": "ModuleOf",
           "kind": "method",
           "signature": "ModuleOf(Type entityType)",
-          "returnType": "string Name { get; } Type EntityType { get; } string ModuleName { get; } string"
+          "returnType": "string"
         }
       ]
     },
@@ -49248,6 +49254,12 @@
           "kind": "property",
           "signature": "Type? LocalizationResourceType",
           "returnType": "Type?"
+        },
+        {
+          "name": "RequiredPermission",
+          "kind": "property",
+          "signature": "string? RequiredPermission",
+          "returnType": "string?"
         },
         {
           "name": "GetFilterGroups",

--- a/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/IQueryDefinitionDescriptor.cs
@@ -25,6 +25,15 @@ public interface IQueryDefinitionDescriptor
     string ModuleName { get; }
 
     /// <summary>
+    /// Optional permission the caller must hold to execute this query over HTTP and to see it in
+    /// the query catalogue. Three-segment format <c>[Group].[Resource].[Action]</c> — must resolve
+    /// to a declared <c>PermissionDefinition</c>. When <see langword="null"/> (the default), the
+    /// query is gated by authentication only. Enforced by <c>MapGranitQuery</c> (403 when the
+    /// caller lacks the permission) and used to filter the query catalogue per caller.
+    /// </summary>
+    string? RequiredPermission => null;
+
+    /// <summary>
     /// Derives the owning module name from an entity type: its assembly's simple name with the
     /// framework <c>Granit.</c> prefix stripped (so <c>Granit.Auditing</c> → <c>Auditing</c> and
     /// <c>Granit.Identity.Local</c> → <c>Identity.Local</c>). A non-framework assembly name is

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinition.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinition.cs
@@ -63,6 +63,15 @@ public abstract class QueryDefinition<TEntity> : IQueryDefinitionDescriptor wher
     public virtual Type? LocalizationResourceType => null;
 
     /// <summary>
+    /// Optional permission the caller must hold to execute this query over HTTP and to see it in
+    /// the query catalogue. Three-segment format <c>[Group].[Resource].[Action]</c> — must resolve
+    /// to a declared <c>PermissionDefinition</c>. When <c>null</c> (the default), the query is
+    /// gated by authentication only. Override to require a permission (least privilege, ISO 27001
+    /// A.9.4).
+    /// </summary>
+    public virtual string? RequiredPermission => null;
+
+    /// <summary>
     /// Configures the query definition using the fluent builder.
     /// Called once at startup.
     /// </summary>

--- a/src/Granit.QueryEngine.Endpoints/Endpoints/QueryCatalogEndpoints.cs
+++ b/src/Granit.QueryEngine.Endpoints/Endpoints/QueryCatalogEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization;
 using Granit.Entities;
 using Granit.QueryEngine.Endpoints.Dtos;
 using Granit.QueryEngine.Endpoints.Internal;
@@ -31,9 +32,9 @@ internal static class QueryCatalogEndpoints
     {
         group.MapGet("/catalog", ListCatalog)
             .WithName("ListQueryCatalog")
-            .WithSummary("Lists every registered QueryDefinition.")
+            .WithSummary("Lists every registered QueryDefinition the caller may see.")
             .WithDescription(
-                "Returns the full query catalogue surfaced by IQueryDefinitionRegistry so a "
+                "Returns the query catalogue surfaced by IQueryDefinitionRegistry so a "
                 + "dashboard editor can offer a dropdown of queries instead of a free-text "
                 + "queryName. Entries are ordered by owning module, then by name, so the editor "
                 + "can group them under module headings. Each entry carries the wire identifier, "
@@ -41,18 +42,21 @@ internal static class QueryCatalogEndpoints
                 + "display key when registered, else Query:{Name}), and "
                 + "— when a MapGranitQuery route exposes it — the resolved base path of its list "
                 + "endpoint. Registration and routing are decoupled: a query registered without a "
-                + "mapped route is returned with a null base path rather than a forged URL.")
+                + "mapped route is returned with a null base path rather than a forged URL. "
+                + "Queries that declare a RequiredPermission are omitted for callers who lack it.")
             .Produces<IReadOnlyList<QueryCatalogEntryResponse>>();
 
         return group;
     }
 
-    private static Ok<IReadOnlyList<QueryCatalogEntryResponse>> ListCatalog(
+    private static async Task<Ok<IReadOnlyList<QueryCatalogEntryResponse>>> ListCatalog(
         [FromServices] IQueryDefinitionRegistry registry,
         [FromServices] EndpointDataSource endpointDataSource,
         [FromServices] LinkGenerator linkGenerator,
         [FromServices] IEnumerable<IEntityDefinitionDescriptor> entityDescriptors,
-        HttpContext httpContext)
+        HttpContext httpContext,
+        CancellationToken cancellationToken,
+        [FromServices] IPermissionChecker? permissionChecker = null)
     {
         // Resolve each List-tagged endpoint's URL via LinkGenerator so route parameters
         // (e.g. /api/v{version:apiVersion}/patients) are substituted into the path.
@@ -84,10 +88,45 @@ internal static class QueryCatalogEndpoints
 
         Dictionary<Type, string> entityDisplayKeys = BuildEntityDisplayKeyIndex(entityDescriptors);
 
+        IReadOnlyList<IQueryDefinitionDescriptor> visible = await FilterByPermissionAsync(
+            registry.GetAll(), permissionChecker, cancellationToken).ConfigureAwait(false);
+
         return TypedResults.Ok(QueryCatalogProjection.Project(
-            registry.GetAll(),
+            visible,
             routeIndex,
             descriptor => ResolveLabelKey(descriptor, entityDisplayKeys)));
+    }
+
+    /// <summary>
+    /// Drops catalogue entries whose <see cref="IQueryDefinitionDescriptor.RequiredPermission"/>
+    /// the caller does not hold. Queries with no declared permission are always visible. When no
+    /// <see cref="IPermissionChecker"/> is registered (authorization not wired), every query is
+    /// returned — matching the authenticated-only default of the catalogue gate. The distinct
+    /// required permissions are resolved in a single batched <see cref="IPermissionChecker.GetGrantedAsync"/>
+    /// call rather than one check per entry.
+    /// </summary>
+    private static async Task<IReadOnlyList<IQueryDefinitionDescriptor>> FilterByPermissionAsync(
+        IEnumerable<IQueryDefinitionDescriptor> descriptors,
+        IPermissionChecker? permissionChecker,
+        CancellationToken cancellationToken)
+    {
+        List<IQueryDefinitionDescriptor> all = [.. descriptors];
+
+        List<string> required =
+            [.. all.Select(d => d.RequiredPermission).OfType<string>().Distinct(StringComparer.Ordinal)];
+
+        if (required.Count == 0 || permissionChecker is null)
+        {
+            return all;
+        }
+
+        IReadOnlyList<string> granted = await permissionChecker
+            .GetGrantedAsync(required, cancellationToken)
+            .ConfigureAwait(false);
+        HashSet<string> grantedSet = [.. granted];
+
+        return [.. all.Where(d =>
+            d.RequiredPermission is null || grantedSet.Contains(d.RequiredPermission))];
     }
 
     /// <summary>

--- a/src/Granit.QueryEngine.Endpoints/Extensions/QueryCatalogEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.Endpoints/Extensions/QueryCatalogEndpointRouteBuilderExtensions.cs
@@ -31,9 +31,10 @@ public static class QueryCatalogEndpointRouteBuilderExtensions
         RouteGroupBuilder group = endpoints.MapGranitGroup(prefix)
             .WithTags("Query Engine");
 
-        // Authenticated-only gate: the catalogue exposes query identifiers and base paths
-        // (metadata, not row data), mirroring the per-query list endpoints' default. The
-        // descriptors carry no PermissionGroup, so there is nothing to filter per-item on.
+        // Authenticated-only gate on the endpoint: the catalogue exposes query identifiers and
+        // base paths (metadata, not row data), mirroring the per-query list endpoints' default.
+        // Per-item authorization is applied inside the handler — a query that declares a
+        // RequiredPermission is omitted for callers who lack it (see ListCatalog).
         group.RequireAuthorization();
 
         group.MapQueryCatalogEndpoints();

--- a/src/Granit.QueryEngine.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -92,9 +92,21 @@ public static class QueryEndpointRouteBuilderExtensions
             group.WithTags(options.TagName);
         }
 
+        // Resolve the definition once at setup time (also consulted below for projection).
+        QueryDefinition<TEntity>? definition = endpoints.ServiceProvider
+            .GetService<QueryDefinition<TEntity>>();
+
+        // Authorization precedence: an explicit host-supplied AuthorizationPolicy wins; otherwise
+        // the definition's declared RequiredPermission gates the group via the dynamic permission
+        // policy (403 when the caller lacks it); otherwise the default authentication gate applies
+        // unless the host opted into anonymous access.
         if (options.AuthorizationPolicy is not null)
         {
             group.RequireAuthorization(options.AuthorizationPolicy);
+        }
+        else if (definition?.RequiredPermission is { } requiredPermission)
+        {
+            group.RequireAuthorization(requiredPermission);
         }
         else if (!options.AllowAnonymous)
         {
@@ -103,11 +115,10 @@ public static class QueryEndpointRouteBuilderExtensions
 
         if (options.IncludeListEndpoint)
         {
-            // Resolve the query definition once at setup time. When it declares a projection,
-            // dispatch to a generic helper that wires GET / to the typed ExecuteAsync<TDto>
-            // overload. Reflection is used exclusively here (setup) — never per request.
-            QueryDefinition<TEntity>? definitionForProjection = endpoints.ServiceProvider
-                .GetService<QueryDefinition<TEntity>>();
+            // When the definition declares a projection, dispatch to a generic helper that wires
+            // GET / to the typed ExecuteAsync<TDto> overload. Reflection is used exclusively here
+            // (setup) — never per request.
+            QueryDefinition<TEntity>? definitionForProjection = definition;
 
             Type? projectionType = definitionForProjection?.GetProjectionType();
             LambdaExpression? projectionExpression = definitionForProjection?.GetProjectionExpression();

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Diagnostics/QueryEngineEfCoreLog.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Diagnostics/QueryEngineEfCoreLog.cs
@@ -44,4 +44,10 @@ internal static partial class QueryEngineEfCoreLog
         Message = "Substring filter (contains/startsWith/endsWith) on field '{Field}' of non-string type {ColumnType} is ignored — EF Core cannot translate LIKE over a value-object/non-string column. See issue #2767.")]
     public static partial void SubstringFilterOnNonStringColumnIgnored(
         ILogger logger, string field, string columnType);
+
+    [LoggerMessage(
+        EventId = 8205,
+        Level = LogLevel.Warning,
+        Message = "A query definition enables cursor pagination but QueryEngineOptions.CursorHmacKey is not configured — cursors are unsigned and forgeable (CWE-565). Configure a Base64 256-bit key in production. This warning is emitted once per process.")]
+    public static partial void UnsignedCursorPagination(ILogger logger);
 }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -43,9 +43,8 @@ internal sealed class QueryEngine<TEntity>(
         ResolveSearchStrategy(definition, searchStrategy, serviceProvider);
     private readonly QueryEngineMetrics? _metrics = metrics;
     private readonly ICurrentTenant? _currentTenant = currentTenant;
-    private readonly byte[]? _cursorHmacKey = !string.IsNullOrEmpty(engineOptions.Value.CursorHmacKey)
-        ? Convert.FromBase64String(engineOptions.Value.CursorHmacKey)
-        : null;
+    private readonly byte[]? _cursorHmacKey =
+        ResolveCursorHmacKey(engineOptions.Value, definition.GetBuilder(), logger);
 
     /// <inheritdoc/>
     public async Task<PagedResult<TEntity>> ExecuteAsync(
@@ -373,6 +372,35 @@ internal sealed class QueryEngine<TEntity>(
     }
 
     /// <summary>
+    /// Decodes the configured HMAC key for cursor signing, or returns <see langword="null"/>
+    /// (unsigned cursors) when none is configured. When a definition enables cursor pagination
+    /// but no key is set, emits a single process-wide warning: unsigned cursors are forgeable
+    /// (CWE-565), so production hosts should configure <c>QueryEngineOptions.CursorHmacKey</c>.
+    /// A per-process random default is deliberately NOT used — it would break keyset pagination
+    /// across replicas and restarts (a cursor signed by one replica must verify on another).
+    /// </summary>
+    private static byte[]? ResolveCursorHmacKey(
+        QueryEngineOptions options,
+        QueryDefinitionBuilder<TEntity> builder,
+        ILogger logger)
+    {
+        if (!string.IsNullOrEmpty(options.CursorHmacKey))
+        {
+            return Convert.FromBase64String(options.CursorHmacKey);
+        }
+
+        if (builder.CursorPropertyName is not null && !CursorSigningWarning.Emitted)
+        {
+            // Volatile check-then-set: at worst two threads both log once during a startup
+            // race — acceptable for a one-time advisory, and never per-request steady state.
+            CursorSigningWarning.Emitted = true;
+            QueryEngineEfCoreLog.UnsignedCursorPagination(logger);
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Resolves the effective global search strategy. A type declared via
     /// <c>QueryDefinitionBuilder.UseSearchStrategy&lt;T&gt;()</c> wins: it is resolved from DI
     /// when registered, otherwise activated with constructor injection. Without a declared
@@ -561,4 +589,14 @@ internal sealed class QueryEngine<TEntity>(
         _metrics.RecordQueryExecuted(tenantId, EntityTypeName, mode);
         _metrics.RecordQueryDuration(tenantId, EntityTypeName, mode, elapsed);
     }
+}
+
+/// <summary>
+/// Process-wide latch so the "unsigned cursor pagination" advisory is logged at most once,
+/// regardless of how many closed <c>QueryEngine&lt;TEntity&gt;</c> types exist (a static field in
+/// a generic type is per-closed-type, hence this non-generic holder).
+/// </summary>
+file static class CursorSigningWarning
+{
+    internal static volatile bool Emitted;
 }

--- a/tests/Granit.ArchitectureTests/NamingHomogeneityTests.cs
+++ b/tests/Granit.ArchitectureTests/NamingHomogeneityTests.cs
@@ -124,6 +124,31 @@ public sealed partial class NamingHomogeneityTests
     }
 
     /// <summary>
+    /// No src <b>package</b> (project directory) may carry the <c>.AspNetCore</c> suffix: the
+    /// framework's HTTP-integration surface convention is <c>.Endpoints</c>. This closes the gap
+    /// that let <c>Granit.QueryEngine.AspNetCore</c> live for a while as the sole outlier among
+    /// ~35 <c>.Endpoints</c> modules (#2952). Sub-namespaces / folders named <c>AspNetCore</c>
+    /// inside a base package (e.g. <c>Granit.Validation/AspNetCore/</c>) are a deliberate
+    /// convention for ASP.NET-touching helpers and are unaffected — this rule targets the
+    /// package name only.
+    /// </summary>
+    [Fact]
+    public void No_src_package_should_use_the_AspNetCore_suffix()
+    {
+        List<string> violations =
+            [.. Directory.EnumerateDirectories(SrcRoot)
+                .Select(Path.GetFileName)
+                .OfType<string>()
+                .Where(name => name.StartsWith("Granit.", StringComparison.Ordinal)
+                    && name.EndsWith(".AspNetCore", StringComparison.Ordinal))];
+
+        violations.ShouldBeEmpty(
+            "HTTP-integration packages use the '.Endpoints' suffix, never '.AspNetCore'. " +
+            "Rename the package (folder, .csproj, PackageId, module class, namespaces) to " +
+            "'.Endpoints'. Violators: " + string.Join(", ", violations));
+    }
+
+    /// <summary>
     /// Extracts the file-scoped or first block-scoped namespace from a C# file.
     /// Returns <c>null</c> if no namespace declaration is found.
     /// </summary>

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionAggregateGuardTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryDefinitionAggregateGuardTests.cs
@@ -96,4 +96,38 @@ public sealed class QueryDefinitionAggregateGuardTests
         Should.Throw<ArgumentException>(() =>
             builder.Aggregate(o => o.Amount, AggregateFunction.Sum, " "));
     }
+
+    private sealed class OrderQuery : QueryDefinition<Order>
+    {
+        public override string Name => "Test.Orders";
+
+        protected override void Configure(QueryDefinitionBuilder<Order> builder) =>
+            builder.Column(o => o.Reference);
+    }
+
+    private sealed class PermissionedOrderQuery : QueryDefinition<Order>
+    {
+        public override string Name => "Test.PermissionedOrders";
+
+        public override string? RequiredPermission => "Orders.Orders.Read";
+
+        protected override void Configure(QueryDefinitionBuilder<Order> builder) =>
+            builder.Column(o => o.Reference);
+    }
+
+    [Fact]
+    public void RequiredPermission_defaults_to_null()
+    {
+        IQueryDefinitionDescriptor query = new OrderQuery();
+
+        query.RequiredPermission.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RequiredPermission_override_is_surfaced_through_the_descriptor()
+    {
+        IQueryDefinitionDescriptor query = new PermissionedOrderQuery();
+
+        query.RequiredPermission.ShouldBe("Orders.Orders.Read");
+    }
 }

--- a/tests/Granit.QueryEngine.Endpoints.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
+++ b/tests/Granit.QueryEngine.Endpoints.Tests/Endpoints/QueryCatalogEndpointsHttpTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Granit.Authorization;
 using Granit.Entities;
 using Granit.QueryEngine.Endpoints.Dtos;
 using Granit.QueryEngine.Endpoints.Extensions;
@@ -129,6 +130,63 @@ public sealed class QueryCatalogEndpointsHttpTests
             .GetAsync("/catalog", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private static Task<GranitEndpointTestHost> StartWithPermissionedQueryAsync(
+        IReadOnlyList<string> grantedPermissions) =>
+        GranitEndpointTestHost.StartAsync(
+            configureServices: services =>
+            {
+                services.AddAuthorizationBuilder();
+                services.AddQueryDefinition<RoutedEntity, RoutedQueryDefinition>();
+                services.AddQueryDefinition<UnroutedEntity, PermissionedQueryDefinition>();
+                services.TryAddSingleton<IQueryDefinitionRegistry, QueryDefinitionRegistry>();
+                services.AddSingleton<IPermissionChecker>(new StubPermissionChecker(grantedPermissions));
+            },
+            configureEndpoints: app => app.MapGranitQueryCatalog());
+
+    [Fact]
+    public async Task Catalog_omits_a_permissioned_query_the_caller_cannot_access()
+    {
+        await using GranitEndpointTestHost host = await StartWithPermissionedQueryAsync(grantedPermissions: []);
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        body!.Select(e => e.Name).ShouldBe(["Test.Routed"]);
+    }
+
+    [Fact]
+    public async Task Catalog_includes_a_permissioned_query_when_the_caller_is_granted()
+    {
+        await using GranitEndpointTestHost host =
+            await StartWithPermissionedQueryAsync(grantedPermissions: ["Test.Things.Read"]);
+
+        List<QueryCatalogEntryResponse>? body = await host.CreateAuthenticatedClient()
+            .GetFromJsonAsync<List<QueryCatalogEntryResponse>>("/catalog", TestContext.Current.CancellationToken);
+
+        body!.Select(e => e.Name).ShouldBe(["Test.Permissioned", "Test.Routed"]);
+    }
+
+    private sealed class PermissionedQueryDefinition : QueryDefinition<UnroutedEntity>
+    {
+        public override string Name => "Test.Permissioned";
+
+        public override string? RequiredPermission => "Test.Things.Read";
+
+        protected override void Configure(QueryDefinitionBuilder<UnroutedEntity> builder) =>
+            builder.Column(e => e.Name);
+    }
+
+    private sealed class StubPermissionChecker(IReadOnlyList<string> granted) : IPermissionChecker
+    {
+        public Task<bool> IsGrantedAsync(string permissionName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(granted.Contains(permissionName));
+
+        public Task<IReadOnlyList<string>> GetGrantedAsync(
+            IReadOnlyList<string> permissionNames, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>(
+                [.. permissionNames.Where(granted.Contains)]);
     }
 
     private sealed class RoutedEntity


### PR DESCRIPTION
## Summary

Follow-up to #2952 completing the "clean-slate" hardening items from the QueryEngine `/audit`. Adds a per-query permission model, closes the naming guard-rail gap, and makes unsigned cursor pagination visible — the three items that carried real security or convention value. Two remaining items are deliberately **not** implemented, with rationale below.

## What changed

**Per-query permission model** (`[5b]` — the main security win)
- `QueryDefinition` may now declare a `RequiredPermission` (three-segment `[Group].[Resource].[Action]`), surfaced on `IQueryDefinitionDescriptor` as a default interface member (`null` by default, so existing implementers — including test fakes — are unaffected).
- `MapGranitQuery` gates the group via `RequireAuthorization(permission)` (dynamic permission policy → 403 when the caller lacks it). Precedence: explicit host `AuthorizationPolicy` > definition `RequiredPermission` > default authentication gate.
- `GET /catalog` omits entries whose `RequiredPermission` the caller does not hold — resolved in a single batched `IPermissionChecker.GetGrantedAsync` call. Queries with no permission stay visible; when authorization is not wired, every query is returned (prior authenticated-only default preserved).
- Mirrors the established `Granit.Http.ODataExposure` permission pattern. Closes the audit gap where any authenticated principal could invoke any mapped query and enumerate the whole catalogue.

**Naming guard-rail** (`[6]`)
- New `NamingHomogeneityTests` rule: no src **package** may use the `.AspNetCore` suffix (HTTP surfaces are `.Endpoints`). This is the guard that was missing when `Granit.QueryEngine.AspNetCore` lived as the sole outlier. Scoped to package names — the deliberate `.AspNetCore` sub-namespace convention inside base packages (`Granit.Validation/AspNetCore`, …) is untouched.

**Unsigned cursor visibility** (`[5a]`)
- A definition that enables cursor pagination without a configured `CursorHmacKey` now emits a single process-wide warning (EventId 8205): unsigned cursors are forgeable (CWE-565).
- A per-process random default is **not** used on purpose — it would break keyset pagination across replicas and restarts (a cursor signed by one replica must verify on another), which is worse than a visible-but-unsigned status quo. Configuring an explicit Base64 256-bit key remains the way to sign.

## Deliberately not done (with rationale)

- **`[3]` migrate the ~11 `ClampPagination` call sites to the options-aware overload** — declined. Those sites are hand-rolled paginated endpoints/stores in unrelated modules (Notifications, BackgroundJobs, Workflow, …) that borrow `QueryEngineDefaults.ClampPagination` as a convenience; none is driven by a `QueryDefinition` and none has `QueryEngineOptions` in scope. The actual QueryEngine execution path already respects configured limits (`_builder.MaxPageSizeValue`). Migrating would inject `IOptions<QueryEngineOptions>` into ~11 classes across ~7 modules for a conservative fixed cap of 100 — cross-module churn with no security value. The options-aware overload (shipped in #2952) remains available for callers that legitimately have options in scope.
- **`[2]` route the HTTP binder path through `QueryRequestSanitizer`** — declined. The engine already whitelists at execution (`FilterExpressionBuilder` drops unknown fields/operators, `ApplySort`/`ApplyGroupBy` check the whitelist) and clamps `pageSize`. Adding the sanitizer at the endpoint would require an `engine.GetMetadata()` call per request for redundant protection — net-negative on performance. The sanitizer keeps its value for the LLM paths (model output inspected + `ignoredFilters` reported before execution).

## Verification
- **519 family tests** green (Abstractions 173 / EFCore 230 / Endpoints 65 / Integration 14 / AI 30 / AI.Tools 7), including new coverage: per-query permission default + override, and catalogue filtering (granted vs denied caller).
- **Architecture suite 245/245** green (+1 = the new naming rule).
- `dotnet format --verify-no-changes` clean on all touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
