### PR TITLE
fix(notifications): phase 0 blocking fixes — FCM auth, GDPR counts, culture fallback, credential hygiene

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1967,7 +1967,8 @@
       "name": "Granit.Notifications.MobilePush.GoogleFcm",
       "deps": [
         "Granit.Http.Resilience",
-        "Granit.Notifications.MobilePush"
+        "Granit.Notifications.MobilePush",
+        "Granit.Timing"
       ],
       "framework": "net10.0"
     },
@@ -37572,7 +37573,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AI",
       "file": "src/Granit.Notifications.AI/Options/NotificationsAIOptions.cs",
-      "line": 9,
+      "line": 11,
       "members": [
         {
           "name": "WorkspaceName",
@@ -37895,7 +37896,7 @@
           "name": "EraseUserDataAsync",
           "kind": "method",
           "signature": "EraseUserDataAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
+          "returnType": "Task<int>"
         }
       ]
     },
@@ -39154,6 +39155,15 @@
       "members": []
     },
     {
+      "name": "MobilePushTokenRemoveRequest",
+      "fqn": "Granit.Notifications.MobilePush.Endpoints.Dtos.MobilePushTokenRemoveRequest",
+      "kind": "record",
+      "project": "Granit.Notifications.MobilePush.Endpoints",
+      "file": "src/Granit.Notifications.MobilePush.Endpoints/Dtos/MobilePushTokenRemoveRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "MobilePushTokenResponse",
       "fqn": "Granit.Notifications.MobilePush.Endpoints.Dtos.MobilePushTokenResponse",
       "kind": "record",
@@ -39272,7 +39282,7 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush.GoogleFcm",
       "file": "src/Granit.Notifications.MobilePush.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitNotificationsMobilePushGoogleFcm",
@@ -39288,7 +39298,7 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush.GoogleFcm",
       "file": "src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs",
-      "line": 16,
+      "line": 18,
       "members": []
     },
     {
@@ -39707,7 +39717,7 @@
       "kind": "class",
       "project": "Granit.Notifications.SignalR",
       "file": "src/Granit.Notifications.SignalR/Extensions/SignalRNotificationsServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitNotificationsSignalR",
@@ -40377,7 +40387,7 @@
         {
           "name": "RemoveSubscriptionAsync",
           "kind": "method",
-          "signature": "RemoveSubscriptionAsync(string endpoint, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "RemoveSubscriptionAsync(string userId, string endpoint, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -167,6 +167,8 @@
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.*" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.*" />
     <PackageVersion Include="Azure.Communication.Sms" Version="1.*" />
+    <!-- OAuth2 service-account token minting for the FCM HTTP v1 API (Granit.Notifications.MobilePush.GoogleFcm). -->
+    <PackageVersion Include="Google.Apis.Auth" Version="1.*" />
     <PackageVersion Include="Microsoft.Azure.NotificationHubs" Version="4.*" />
     <PackageVersion Include="MailKit" Version="4.*" />
     <PackageVersion Include="MimeKit" Version="4.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,10 @@ Only **direct dependencies** are listed here. Transitive dependencies are
 covered by their own license notices, restored from NuGet by the consumer
 (Granit packages do not redistribute their binaries).
 
-Last updated: 2026-07-04 (added Roslynator.Analyzers 4.15.0, Apache-2.0 — dev-time
+Last updated: 2026-07-12 (added Google.Apis.Auth 1.75.0, Apache-2.0 — OAuth 2.0
+service-account token minting for FCM HTTP v1 in `Granit.Notifications.MobilePush.GoogleFcm`;
+corrected the stale FirebaseAdmin consumer reference to `Granit.Identity.Federated.GoogleCloud`).
+Prior: 2026-07-04 (added Roslynator.Analyzers 4.15.0, Apache-2.0 — dev-time
 code-quality analyzer, `PrivateAssets="all"`, not redistributed). Prior: 2026-06-30 (global NuGet version refresh via `dotnet restore --force-evaluate`; aligned the OpenTelemetry instrumentation packages on 1.16.*; added three previously unlisted direct dependencies — DnsClient, Microsoft.Extensions.ApiDescription.Server, Npgsql.OpenTelemetry; removed dead central entries (packages referenced by no project, including modules migrated to granit-business); recomputed the license summary; notable bumps: WolverineFx 6.16.0, DocumentFormat.OpenXml 3.5.1, Scalar.AspNetCore 2.16.6, Anthropic 12.32.0, AWSSDK 4.0.100, Microsoft.\* 10.0.9 / 10.7.0, MailKit / MimeKit 4.17.0)
 
 ---
@@ -18,7 +21,7 @@ code-quality analyzer, `PrivateAssets="all"`, not redistributed). Prior: 2026-06
 | License      | Package count |
 | ------------ | ------------- |
 | MIT          | 102           |
-| Apache-2.0   | 47            |
+| Apache-2.0   | 48            |
 | BSD-3-Clause | 3             |
 | BSD-2-Clause | 2             |
 | PostgreSQL   | 2             |
@@ -133,6 +136,7 @@ code-quality analyzer, `PrivateAssets="all"`, not redistributed). Prior: 2026-06
 | FirebaseAdmin | 3.5.0 | Copyright (c) 2018 Google Inc. |
 | FluentValidation | 12.1.1 | Copyright (c) Jeremy Skinner, .NET Foundation 2008-2025 |
 | FluentValidation.DependencyInjectionExtensions | 12.1.1 | Copyright (c) Jeremy Skinner, .NET Foundation 2008-2025 |
+| Google.Apis.Auth | 1.75.0 | Copyright (c) Google LLC |
 | Google.Cloud.Kms.V1 | 3.24.0 | Copyright (c) Google LLC |
 | Google.Cloud.SecretManager.V1 | 2.7.0 | Copyright (c) Google LLC |
 | Google.Cloud.Storage.V1 | 4.15.0 | Copyright (c) Google LLC |
@@ -353,9 +357,14 @@ and SMS via Azure Communication Services.
 
 ### FirebaseAdmin
 
-This SDK is used by the `Granit.Identity.Firebase` (Firebase Authentication user
-administration) and `Granit.Notifications.Push.Firebase` (push notification
-delivery via Firebase Cloud Messaging) packages.
+This SDK is used by the `Granit.Identity.Federated.GoogleCloud` package for
+Firebase Authentication user administration.
+
+### Google.Apis.Auth
+
+This library is used by the `Granit.Notifications.MobilePush.GoogleFcm` package to
+mint OAuth 2.0 service-account access tokens for the FCM HTTP v1 API
+(scope `firebase.messaging`). License: Apache-2.0.
 
 ### Google.Cloud.Kms.V1 / Google.Cloud.SecretManager.V1
 

--- a/src/Granit.AI.Chat.Privacy/packages.lock.json
+++ b/src/Granit.AI.Chat.Privacy/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -767,12 +767,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.AI.Prompts.Privacy/packages.lock.json
+++ b/src/Granit.AI.Prompts.Privacy/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -658,12 +658,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Auditing.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Auditing.BackgroundJobs/packages.lock.json
@@ -97,7 +97,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Auditing.ConfigurationChanges/packages.lock.json
+++ b/src/Granit.Auditing.ConfigurationChanges/packages.lock.json
@@ -69,7 +69,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Auditing.Endpoints/packages.lock.json
+++ b/src/Granit.Auditing.Endpoints/packages.lock.json
@@ -42,8 +42,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Auditing.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Auditing.EntityFrameworkCore/packages.lock.json
@@ -43,8 +43,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Auditing.Notifications/packages.lock.json
+++ b/src/Granit.Auditing.Notifications/packages.lock.json
@@ -30,7 +30,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Auditing.Privacy/packages.lock.json
+++ b/src/Granit.Auditing.Privacy/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -331,7 +331,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -669,12 +668,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
+++ b/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -52,8 +52,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -68,10 +68,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -88,8 +88,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -787,21 +787,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Bff.Endpoints/packages.lock.json
+++ b/src/Granit.Bff.Endpoints/packages.lock.json
@@ -120,8 +120,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.BlobStorage.GoogleCloud/packages.lock.json
+++ b/src/Granit.BlobStorage.GoogleCloud/packages.lock.json
@@ -99,16 +99,6 @@
           "Google.Apis.Core": "1.74.0"
         }
       },
-      "Google.Apis.Auth": {
-        "type": "Transitive",
-        "resolved": "1.74.0",
-        "contentHash": "43H4foh3zfWgboK8QnJjIfPQuBiS794TxqQLDfeE3erQSluKmEN0qeDuwxLTpSr9Mtwj76S4LWxPneuSbC6fNg==",
-        "dependencies": {
-          "Google.Apis": "1.74.0",
-          "Google.Apis.Core": "1.74.0",
-          "System.Management": "7.0.2"
-        }
-      },
       "Google.Apis.Core": {
         "type": "Transitive",
         "resolved": "1.74.0",
@@ -247,6 +237,17 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.74.0",
+        "contentHash": "43H4foh3zfWgboK8QnJjIfPQuBiS794TxqQLDfeE3erQSluKmEN0qeDuwxLTpSr9Mtwj76S4LWxPneuSbC6fNg==",
+        "dependencies": {
+          "Google.Apis": "1.74.0",
+          "Google.Apis.Core": "1.74.0",
+          "System.Management": "7.0.2"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/src/Granit.Events.Wolverine/packages.lock.json
+++ b/src/Granit.Events.Wolverine/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -52,8 +52,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -68,10 +68,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -88,8 +88,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -767,21 +767,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Identity.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Endpoints/packages.lock.json
@@ -42,8 +42,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
@@ -126,7 +126,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -107,7 +107,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -129,7 +129,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
@@ -49,8 +49,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
@@ -241,7 +241,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.EntraId/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId/packages.lock.json
@@ -280,7 +280,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
+++ b/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
@@ -64,16 +64,6 @@
           "Google.Apis.Core": "1.73.0"
         }
       },
-      "Google.Apis.Auth": {
-        "type": "Transitive",
-        "resolved": "1.73.0",
-        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
-        "dependencies": {
-          "Google.Apis": "1.73.0",
-          "Google.Apis.Core": "1.73.0",
-          "System.Management": "7.0.2"
-        }
-      },
       "Google.Apis.Core": {
         "type": "Transitive",
         "resolved": "1.73.0",
@@ -143,7 +133,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -266,6 +255,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
+        "dependencies": {
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
+          "System.Management": "7.0.2"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
@@ -241,7 +241,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Keycloak/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak/packages.lock.json
@@ -280,7 +280,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Federated.Notifications/packages.lock.json
@@ -52,7 +52,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Federated.Privacy/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -331,7 +331,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -714,12 +713,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Identity.Federated/packages.lock.json
+++ b/src/Granit.Identity.Federated/packages.lock.json
@@ -29,8 +29,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Identity.Local.AspNetIdentity/packages.lock.json
+++ b/src/Granit.Identity.Local.AspNetIdentity/packages.lock.json
@@ -126,8 +126,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -42,8 +42,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Identity.Local.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Local.Notifications/packages.lock.json
@@ -64,7 +64,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity.Local.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Local.Privacy/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -331,7 +331,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -727,12 +726,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Identity.Local/packages.lock.json
+++ b/src/Granit.Identity.Local/packages.lock.json
@@ -24,8 +24,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Identity.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Notifications/packages.lock.json
@@ -30,7 +30,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Identity/packages.lock.json
+++ b/src/Granit.Identity/packages.lock.json
@@ -30,7 +30,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Imaging.MagickNet/packages.lock.json
+++ b/src/Granit.Imaging.MagickNet/packages.lock.json
@@ -5,10 +5,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "Direct",
         "requested": "[14.*, )",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -25,8 +25,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "granit": {
         "type": "Project"

--- a/src/Granit.Indexing.Privacy/packages.lock.json
+++ b/src/Granit.Indexing.Privacy/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -520,12 +520,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.MultiTenancy.Auditing/packages.lock.json
+++ b/src/Granit.MultiTenancy.Auditing/packages.lock.json
@@ -52,7 +52,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.MultiTenancy.Provisioning/packages.lock.json
+++ b/src/Granit.MultiTenancy.Provisioning/packages.lock.json
@@ -31,8 +31,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -47,10 +47,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -67,8 +67,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -848,12 +848,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -869,21 +869,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs
@@ -32,7 +32,9 @@ public static class NotificationsAIHostApplicationBuilderExtensions
     {
         builder.Services
             .AddOptions<NotificationsAIOptions>()
-            .BindConfiguration(NotificationsAIOptions.SectionName);
+            .BindConfiguration(NotificationsAIOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
         // Scoped, not singleton: both depend on the scoped IStructuredCompletion primitive
         // (ADR-064), so a singleton here would capture a stale scope.

--- a/src/Granit.Notifications.AI/Internal/LlmNotificationContentGenerator.cs
+++ b/src/Granit.Notifications.AI/Internal/LlmNotificationContentGenerator.cs
@@ -27,7 +27,11 @@ internal sealed partial class LlmNotificationContentGenerator(
         NotificationsAIOptions config = options.Value;
 
         string culture = context.Culture ?? "en";
-        string dataJson = context.Data.ValueKind != JsonValueKind.Undefined
+
+        // GDPR gate: the Data payload may carry personal data. It only reaches the model
+        // when the host explicitly opted in — otherwise the LLM works from the notification
+        // type, severity and culture alone.
+        string dataJson = config.AllowPersonalDataInPrompts && context.Data.ValueKind != JsonValueKind.Undefined
             ? context.Data.GetRawText()
             : "{}";
 

--- a/src/Granit.Notifications.AI/Options/NotificationsAIOptions.cs
+++ b/src/Granit.Notifications.AI/Options/NotificationsAIOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Granit.Notifications.AI.Options;
 
 /// <summary>
@@ -22,5 +24,14 @@ public sealed class NotificationsAIOptions
     /// <summary>
     /// Timeout in seconds for LLM requests.
     /// </summary>
+    [Range(1, 300)]
     public int TimeoutSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Gates whether the notification's <c>Data</c> payload is forwarded to the LLM when
+    /// generating content. The payload may contain personal data (GDPR), so forwarding is
+    /// opt-in: when <see langword="false"/> (the default) only the notification type,
+    /// severity and culture reach the model.
+    /// </summary>
+    public bool AllowPersonalDataInPrompts { get; set; }
 }

--- a/src/Granit.Notifications.AI/README.md
+++ b/src/Granit.Notifications.AI/README.md
@@ -10,6 +10,26 @@ Part of the [granit](https://granit-fx.dev) framework.
 dotnet add package Granit.Notifications.AI
 ```
 
+## Personal data and the LLM (GDPR)
+
+By default the notification `Data` payload is **not** forwarded to the model — only the
+notification type, severity and culture are. The payload may contain personal data, so
+forwarding it is an explicit opt-in:
+
+```json
+{
+  "Notifications": {
+    "AI": {
+      "AllowPersonalDataInPrompts": true
+    }
+  }
+}
+```
+
+Before enabling, verify your AI provider agreement covers personal-data processing
+(GDPR Art. 28 processor terms) and document the flow in your record of processing
+activities.
+
 ## Dependencies
 
 - `Granit.AI`

--- a/src/Granit.Notifications.Abstractions/Abstractions/INotificationsPersonalDataEraser.cs
+++ b/src/Granit.Notifications.Abstractions/Abstractions/INotificationsPersonalDataEraser.cs
@@ -12,7 +12,11 @@ public interface INotificationsPersonalDataEraser
     /// Permanently deletes every inbox item, preference and subscription owned by the
     /// given user within a tenant scope. A no-op for entities the user has none of.
     /// </summary>
-    Task EraseUserDataAsync(
+    /// <returns>
+    /// The total number of rows physically deleted across all entity sets — carried into
+    /// <c>PersonalDataDeletedEto.AffectedRecords</c> as the ISO 27001 deletion audit evidence.
+    /// </returns>
+    Task<int> EraseUserDataAsync(
         string userId,
         Guid? tenantId,
         CancellationToken cancellationToken = default);

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/HealthChecks/AcsEmailHealthCheck.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/HealthChecks/AcsEmailHealthCheck.cs
@@ -7,57 +7,54 @@ using Microsoft.Extensions.Options;
 namespace Granit.Notifications.Email.AzureCommunicationServices.HealthChecks;
 
 /// <summary>
-/// Health check that verifies Azure Communication Services email connectivity.
+/// Health check that verifies the Azure Communication Services email configuration.
 /// </summary>
 /// <remarks>
+/// <para>
+/// The ACS email API exposes no read-only operation, so this check validates configuration
+/// and client construction only — it MUST NOT send a message: a real send on every readiness
+/// probe generates bounces and cost, and mutates external state (mirrors the config-only
+/// probes of the AwsSns and ACS SMS providers).
+/// </para>
 /// <list type="bullet">
-///   <item>Endpoint reachable → <see cref="HealthCheckResult.Healthy"/></item>
-///   <item>Unreachable or credentials invalid → <see cref="HealthCheckResult.Unhealthy"/></item>
+///   <item>Sender + connection string / endpoint present and well-formed → <see cref="HealthCheckResult.Healthy"/></item>
+///   <item>Missing or malformed configuration → <see cref="HealthCheckResult.Unhealthy"/></item>
 /// </list>
 /// The response never exposes connection strings or endpoint details.
 /// </remarks>
 internal sealed class AcsEmailHealthCheck(IOptions<AcsEmailOptions> options) : IHealthCheck
 {
-    private static readonly TimeSpan s_healthCheckTimeout = TimeSpan.FromSeconds(10);
-
     /// <inheritdoc />
-    public async Task<HealthCheckResult> CheckHealthAsync(
+    public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
+        AcsEmailOptions opts = options.Value;
+
+        if (string.IsNullOrWhiteSpace(opts.DefaultSenderEmail))
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy("ACS Email: DefaultSenderEmail is not configured"));
+        }
+
+        if (string.IsNullOrWhiteSpace(opts.ConnectionString) && string.IsNullOrWhiteSpace(opts.Endpoint))
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy("ACS Email: neither ConnectionString nor Endpoint is configured"));
+        }
+
         try
         {
-            AcsEmailOptions opts = options.Value;
-
-            EmailClient client = opts.ConnectionString is not null
+            // Construction parses the connection string / endpoint URI — catches malformed
+            // configuration without any network call.
+            _ = opts.ConnectionString is not null
                 ? new EmailClient(opts.ConnectionString)
                 : new EmailClient(new Uri(opts.Endpoint!), new DefaultAzureCredential());
 
-            // Attempt a lightweight send with an invalid message to verify connectivity.
-            // The service will reject it, but a successful rejection proves the endpoint is reachable.
-            // We catch the expected RequestFailedException to confirm connectivity.
-            var testMessage = new Azure.Communication.Email.EmailMessage(
-                opts.DefaultSenderEmail,
-                "healthcheck@localhost",
-                new EmailContent("healthcheck"));
-
-            await client
-                .SendAsync(Azure.WaitUntil.Started, testMessage, cancellationToken)
-                .WaitAsync(s_healthCheckTimeout, cancellationToken)
-                .ConfigureAwait(false);
-
-            return HealthCheckResult.Healthy();
+            return Task.FromResult(HealthCheckResult.Healthy());
         }
-        catch (Azure.RequestFailedException)
-        {
-            // A RequestFailedException means the endpoint is reachable but rejected the request,
-            // which is expected for a health check probe.
-            return HealthCheckResult.Healthy();
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is FormatException or ArgumentException or UriFormatException or InvalidOperationException)
         {
             // Sanitize: never expose connection strings, endpoints, or credentials
-            return HealthCheckResult.Unhealthy($"ACS Email unreachable: {ex.GetType().Name}");
+            return Task.FromResult(HealthCheckResult.Unhealthy($"ACS Email configuration invalid: {ex.GetType().Name}"));
         }
     }
 }

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -78,6 +78,12 @@ internal sealed partial class EmailNotificationChannel(
             return;
         }
 
+        // Effective culture: an explicit trigger-level override wins, otherwise the recipient's
+        // preferred culture. Publishers rarely set Culture, so without this fallback the
+        // localized template variants (18 cultures) are never selected — every recipient
+        // silently gets the culture-neutral template.
+        context = context with { Culture = context.Culture ?? recipient.PreferredCulture };
+
         // Resolve notification metadata for opt-out and group info
         INotificationDefinitionStore? defStore = serviceProvider.GetService<INotificationDefinitionStore>();
         NotificationDefinition? definition = defStore?.Get(context.NotificationTypeName);

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationsPersonalDataEraser.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationsPersonalDataEraser.cs
@@ -11,22 +11,24 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 internal sealed class EfCoreNotificationsPersonalDataEraser(
     IDbContextFactory<NotificationsDbContext> contextFactory) : INotificationsPersonalDataEraser
 {
-    public async Task EraseUserDataAsync(
+    public async Task<int> EraseUserDataAsync(
         string userId, Guid? tenantId, CancellationToken cancellationToken = default)
     {
         await using NotificationsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        await db.UserNotifications
+        int affected = await db.UserNotifications
             .Where(n => n.RecipientUserId == userId && n.TenantId == tenantId)
             .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 
-        await db.Preferences
+        affected += await db.Preferences
             .Where(p => p.UserId == userId && p.TenantId == tenantId)
             .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 
-        await db.Subscriptions
+        affected += await db.Subscriptions
             .Where(s => s.UserId == userId && s.TenantId == tenantId)
             .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+
+        return affected;
     }
 }

--- a/src/Granit.Notifications.MobilePush.Endpoints/Dtos/MobilePushTokenRemoveRequest.cs
+++ b/src/Granit.Notifications.MobilePush.Endpoints/Dtos/MobilePushTokenRemoveRequest.cs
@@ -1,0 +1,12 @@
+namespace Granit.Notifications.MobilePush.Endpoints.Dtos;
+
+/// <summary>Request to unregister a mobile push device token.</summary>
+/// <remarks>
+/// The token travels in the request body — it is a sendable push credential, and a route
+/// segment would leak it into access logs, proxy logs and browser history.
+/// </remarks>
+public sealed record MobilePushTokenRemoveRequest
+{
+    /// <summary>Device token (FCM or APNs) to remove.</summary>
+    public required string DeviceToken { get; init; }
+}

--- a/src/Granit.Notifications.MobilePush.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
+++ b/src/Granit.Notifications.MobilePush.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
@@ -29,12 +29,13 @@ internal static class MobilePushTokenEndpoints
             .Produces(StatusCodes.Status200OK)
             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
-        group.MapDelete("/tokens/{deviceToken}", RemoveTokenAsync)
+        group.MapDelete("/tokens", RemoveTokenAsync)
             .RequireAuthorization(NotificationPermissions.UserNotifications.Manage)
             .WithName("RemoveMobilePushToken")
             .WithSummary("Removes a mobile device token.")
-            .WithDescription("Removes the specified device token for the authenticated user in the current tenant. Call this when the user logs out or the token becomes invalid. No-op if the token does not exist.")
-            .Produces(StatusCodes.Status204NoContent);
+            .WithDescription("Removes the device token carried in the request body for the authenticated user in the current tenant. The token is a sendable push credential, so it travels in the body — never in the URL, where it would leak into access and proxy logs. Call this when the user logs out or the token becomes invalid. No-op if the token does not exist.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
         group.MapGet("/tokens", GetTokensAsync)
             .RequireAuthorization(NotificationPermissions.UserNotifications.Read)
@@ -76,7 +77,7 @@ internal static class MobilePushTokenEndpoints
     }
 
     private static async Task<NoContent> RemoveTokenAsync(
-        string deviceToken,
+        [FromBody] MobilePushTokenRemoveRequest request,
         ClaimsPrincipal user,
         [FromServices] IMobilePushTokenWriter tokenWriter,
         [FromServices] ICurrentTenant tenant,
@@ -85,7 +86,7 @@ internal static class MobilePushTokenEndpoints
         string userId = NotificationsResponseMapper.GetUserId(user);
         Guid? tenantId = tenant.IsAvailable ? tenant.Id : null;
 
-        await tokenWriter.RemoveAsync(deviceToken, userId, tenantId, cancellationToken).ConfigureAwait(false);
+        await tokenWriter.RemoveAsync(request.DeviceToken, userId, tenantId, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.NoContent();
     }

--- a/src/Granit.Notifications.MobilePush.Endpoints/Validators/MobilePushTokenRemoveRequestValidator.cs
+++ b/src/Granit.Notifications.MobilePush.Endpoints/Validators/MobilePushTokenRemoveRequestValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using Granit.Notifications.MobilePush.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Notifications.MobilePush.Endpoints.Validators;
+
+/// <summary>
+/// Validates the <see cref="MobilePushTokenRemoveRequest"/> body for mobile push token removal.
+/// </summary>
+internal sealed class MobilePushTokenRemoveRequestValidator : GranitValidator<MobilePushTokenRemoveRequest>
+{
+    public MobilePushTokenRemoveRequestValidator()
+    {
+        RuleFor(x => x.DeviceToken)
+            .NotEmpty()
+            .MaximumLength(MobilePushTokenRegisterRequestValidator.MaxDeviceTokenLength);
+    }
+}

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.MobilePush.GoogleFcm.Internal;
 using Granit.Notifications.MobilePush.GoogleFcm.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Notifications.MobilePush.GoogleFcm.Extensions;
 
@@ -26,12 +27,18 @@ public static class GoogleFcmMobilePushServiceCollectionExtensions
             services.Configure(configure);
         }
 
+        // OAuth 2.0 service-account auth for the FCM HTTP v1 API: cached single-flight
+        // token provider + Bearer handler (401 ⇒ invalidate, mint fresh, retry once).
+        services.TryAddSingleton<IGoogleFcmTokenSource, GoogleApisAuthTokenSource>();
+        services.TryAddSingleton<GoogleFcmTokenProvider>();
+        services.AddTransient<GoogleFcmAuthenticationHandler>();
+
         services.AddGranitHttpClient(HttpClientName, (sp, client) =>
         {
             GoogleFcmOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<GoogleFcmOptions>>().Value;
             client.BaseAddress = new Uri(opts.BaseAddress);
             client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-        });
+        }).AddHttpMessageHandler<GoogleFcmAuthenticationHandler>();
 
         services.AddKeyedSingleton<IMobilePushSender, GoogleFcmMobilePushSender>(ProviderKey);
         return services;

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Granit.Notifications.MobilePush.GoogleFcm.csproj
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Granit.Notifications.MobilePush.GoogleFcm.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
@@ -22,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Http.Resilience\Granit.Http.Resilience.csproj" />
     <ProjectReference Include="..\Granit.Notifications.MobilePush\Granit.Notifications.MobilePush.csproj" />
+    <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs
@@ -1,5 +1,6 @@
 using Granit.Http.Resilience;
 using Granit.Modularity;
+using Granit.Timing;
 
 namespace Granit.Notifications.MobilePush.GoogleFcm;
 
@@ -12,5 +13,6 @@ namespace Granit.Notifications.MobilePush.GoogleFcm;
 /// </remarks>
 [DependsOn(
     typeof(GranitHttpResilienceModule),
-    typeof(GranitNotificationsMobilePushModule))]
+    typeof(GranitNotificationsMobilePushModule),
+    typeof(GranitTimingModule))]
 public sealed class GranitNotificationsMobilePushGoogleFcmModule : GranitModule;

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleApisAuthTokenSource.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleApisAuthTokenSource.cs
@@ -1,0 +1,53 @@
+using Google.Apis.Auth.OAuth2;
+using Granit.Notifications.MobilePush.GoogleFcm.Options;
+using Granit.Timing;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Notifications.MobilePush.GoogleFcm.Internal;
+
+/// <summary>
+/// <see cref="IGoogleFcmTokenSource"/> backed by Google.Apis.Auth: exchanges the
+/// service-account key for an OAuth 2.0 access token scoped to FCM.
+/// </summary>
+/// <remarks>
+/// The credential is rebuilt from <see cref="GoogleFcmOptions.ServiceAccountJson"/> on every
+/// mint — mints happen roughly once per token lifetime (about an hour), and rebuilding keeps
+/// the source coherent with configuration hot-reload.
+/// </remarks>
+internal sealed class GoogleApisAuthTokenSource(
+    IOptionsMonitor<GoogleFcmOptions> options,
+    IClock clock) : IGoogleFcmTokenSource
+{
+    private const string FirebaseMessagingScope = "https://www.googleapis.com/auth/firebase.messaging";
+
+    /// <summary>Fallback lifetime when Google omits expires_in (per RFC 6749 it is optional).</summary>
+    private static readonly TimeSpan DefaultTokenLifetime = TimeSpan.FromHours(1);
+
+    /// <inheritdoc />
+    public async Task<GoogleFcmAccessToken> MintTokenAsync(CancellationToken cancellationToken = default)
+    {
+        // CredentialFactory pins the credential type: JSON that is not a service-account
+        // key is rejected at parse time instead of silently yielding another credential kind.
+        GoogleCredential credential = CredentialFactory
+            .FromJson(options.CurrentValue.ServiceAccountJson, JsonCredentialParameters.ServiceAccountCredentialType)
+            .CreateScoped(FirebaseMessagingScope);
+
+        if (credential.UnderlyingCredential is not ServiceAccountCredential serviceAccount)
+        {
+            throw new InvalidOperationException(
+                "GoogleFcmOptions.ServiceAccountJson is not a service-account key "
+                + $"(parsed credential type: {credential.UnderlyingCredential.GetType().Name}).");
+        }
+
+        if (!await serviceAccount.RequestAccessTokenAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("Google OAuth 2.0 token endpoint refused the FCM service-account token request.");
+        }
+
+        TimeSpan lifetime = serviceAccount.Token.ExpiresInSeconds is { } seconds
+            ? TimeSpan.FromSeconds(seconds)
+            : DefaultTokenLifetime;
+
+        return new GoogleFcmAccessToken(serviceAccount.Token.AccessToken, clock.Now + lifetime);
+    }
+}

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmAccessToken.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmAccessToken.cs
@@ -1,0 +1,4 @@
+namespace Granit.Notifications.MobilePush.GoogleFcm.Internal;
+
+/// <summary>An OAuth 2.0 access token for the FCM HTTP v1 API with its absolute expiry.</summary>
+internal sealed record GoogleFcmAccessToken(string AccessToken, DateTimeOffset ExpiresAt);

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmAuthenticationHandler.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmAuthenticationHandler.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Notifications.MobilePush.GoogleFcm.Internal;
+
+/// <summary>
+/// Attaches the OAuth 2.0 Bearer token to every FCM HTTP v1 request.
+/// On 401 the cached token is invalidated and the request retried once with a fresh token.
+/// </summary>
+internal sealed partial class GoogleFcmAuthenticationHandler(
+    GoogleFcmTokenProvider tokenProvider,
+    ILogger<GoogleFcmAuthenticationHandler> logger) : DelegatingHandler
+{
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        string accessToken = await tokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode is not HttpStatusCode.Unauthorized)
+        {
+            return response;
+        }
+
+        // Token may have been revoked server-side before its local expiry — mint a fresh one and retry once.
+        LogUnauthorizedRetry(request.RequestUri?.AbsolutePath ?? "unknown");
+        tokenProvider.Invalidate();
+        accessToken = await tokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+
+        response.Dispose();
+
+        using HttpRequestMessage retryRequest = await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false);
+        retryRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        return await base.SendAsync(retryRequest, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpRequestMessage> CloneRequestAsync(
+        HttpRequestMessage original,
+        CancellationToken cancellationToken)
+    {
+        HttpRequestMessage clone = new(original.Method, original.RequestUri)
+        {
+            Version = original.Version,
+        };
+
+        foreach (KeyValuePair<string, IEnumerable<string>> header in original.Headers
+            .Where(h => !string.Equals(h.Key, "Authorization", StringComparison.OrdinalIgnoreCase)))
+        {
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        if (original.Content is not null)
+        {
+            byte[] contentBytes = await original.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            clone.Content = new ByteArrayContent(contentBytes);
+
+            if (original.Content.Headers.ContentType is not null)
+            {
+                clone.Content.Headers.ContentType = original.Content.Headers.ContentType;
+            }
+        }
+
+        return clone;
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "FCM returned 401 for {RequestPath}; refreshing the access token and retrying once")]
+    private partial void LogUnauthorizedRetry(string requestPath);
+}

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmTokenProvider.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmTokenProvider.cs
@@ -1,0 +1,57 @@
+using Granit.Timing;
+
+namespace Granit.Notifications.MobilePush.GoogleFcm.Internal;
+
+/// <summary>
+/// Caches the FCM access token and refreshes it with a safety margin before expiry.
+/// Refreshes are single-flight: N concurrent sends holding an expired token trigger
+/// exactly one mint against Google, never a thundering herd.
+/// </summary>
+internal sealed class GoogleFcmTokenProvider(
+    IGoogleFcmTokenSource tokenSource,
+    IClock clock) : IDisposable
+{
+    /// <summary>Refresh this long before actual expiry so in-flight requests never carry a token that dies mid-request.</summary>
+    private static readonly TimeSpan RefreshMargin = TimeSpan.FromMinutes(5);
+
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private GoogleFcmAccessToken? _cached;
+
+    /// <summary>Returns the cached token, minting a fresh one when missing or within the refresh margin.</summary>
+    public async ValueTask<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+    {
+        GoogleFcmAccessToken? cached = Volatile.Read(ref _cached);
+        if (IsUsable(cached))
+        {
+            return cached.AccessToken;
+        }
+
+        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Another caller may have refreshed while this one waited on the semaphore.
+            cached = Volatile.Read(ref _cached);
+            if (IsUsable(cached))
+            {
+                return cached.AccessToken;
+            }
+
+            GoogleFcmAccessToken minted = await tokenSource.MintTokenAsync(cancellationToken).ConfigureAwait(false);
+            Volatile.Write(ref _cached, minted);
+            return minted.AccessToken;
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    /// <summary>Drops the cached token so the next call mints a fresh one (401 recovery).</summary>
+    public void Invalidate() => Volatile.Write(ref _cached, null);
+
+    /// <inheritdoc />
+    public void Dispose() => _refreshLock.Dispose();
+
+    private bool IsUsable([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] GoogleFcmAccessToken? token) =>
+        token is not null && clock.Now < token.ExpiresAt - RefreshMargin;
+}

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/IGoogleFcmTokenSource.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/IGoogleFcmTokenSource.cs
@@ -1,0 +1,11 @@
+namespace Granit.Notifications.MobilePush.GoogleFcm.Internal;
+
+/// <summary>
+/// Mints OAuth 2.0 access tokens for the FCM HTTP v1 API. Seam over the Google
+/// auth library so caching and single-flight logic can be tested without network I/O.
+/// </summary>
+internal interface IGoogleFcmTokenSource
+{
+    /// <summary>Requests a fresh access token from Google (no caching at this layer).</summary>
+    Task<GoogleFcmAccessToken> MintTokenAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/packages.lock.json
@@ -2,6 +2,17 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Google.Apis.Auth": {
+        "type": "Direct",
+        "requested": "[1.*, )",
+        "resolved": "1.75.0",
+        "contentHash": "hzuGwUBIQYdFkChXm62E5Suxe+q5PHt2uE5EunGBco2j01uQJGlUgzNujZvGHMlAIEHaytzhdn3v3v52ZPgv2Q==",
+        "dependencies": {
+          "Google.Apis": "1.75.0",
+          "Google.Apis.Core": "1.75.0",
+          "System.Management": "7.0.2"
+        }
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
@@ -65,6 +76,22 @@
         "requested": "[4.15.*, )",
         "resolved": "4.15.0",
         "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+      },
+      "Google.Apis": {
+        "type": "Transitive",
+        "resolved": "1.75.0",
+        "contentHash": "ZqODi2IvyTBezeGztemXv6U/+VinyqxxPiyoW2CZbzIrUp+a35Rt5tzUjXHPXK9nA1YQi/w8ABpYQpBm31ditw==",
+        "dependencies": {
+          "Google.Apis.Core": "1.75.0"
+        }
+      },
+      "Google.Apis.Core": {
+        "type": "Transitive",
+        "resolved": "1.75.0",
+        "contentHash": "7AuI44XP4LzMFiOjdk4GCtCxJTIWZcjrXLeGjLYYSpTHHbiPkvm76XNym7zPOnD90sIg+zdTulg+I6D5W5spTQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.4"
+        }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -233,6 +260,11 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -255,6 +287,19 @@
         "dependencies": {
           "Polly.Core": "8.4.2",
           "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "/qEUN91mP/MUQmJnM5y5BdT7ZoPuVrtxnFlbJ8a3kBJGhe2wCzBfnPFtK2wTtEEcf3DMGR9J00GZZfg6HRI6yA==",
+        "dependencies": {
+          "System.CodeDom": "7.0.0"
         }
       },
       "System.Threading.RateLimiting": {
@@ -300,6 +345,14 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/src/Granit.Notifications.MobilePush/Options/MobilePushChannelOptions.cs
+++ b/src/Granit.Notifications.MobilePush/Options/MobilePushChannelOptions.cs
@@ -6,6 +6,9 @@ public sealed class MobilePushChannelOptions
     /// <summary>Configuration section name.</summary>
     public const string SectionName = "Notifications:MobilePush";
 
-    /// <summary>Provider key for Keyed Services resolution (e.g. "Fcm").</summary>
-    public string Provider { get; set; } = "Fcm";
+    /// <summary>
+    /// Provider key for Keyed Services resolution. Must match a registered
+    /// <c>IMobilePushSender</c> key: "GoogleFcm", "AwsSns", or "AzureNotificationHubs".
+    /// </summary>
+    public string Provider { get; set; } = "GoogleFcm";
 }

--- a/src/Granit.Notifications.Privacy/DataDeletion/NotificationsPersonalDataDeletionHandler.cs
+++ b/src/Granit.Notifications.Privacy/DataDeletion/NotificationsPersonalDataDeletionHandler.cs
@@ -41,13 +41,14 @@ public class NotificationsPersonalDataDeletionHandler
         ArgumentNullException.ThrowIfNull(currentTenant);
 
         Guid? tenantId = @event.TenantId ?? currentTenant.Id;
-        await eraser.EraseUserDataAsync(@event.UserId.ToString(), tenantId, cancellationToken).ConfigureAwait(false);
+        int affectedRecords = await eraser
+            .EraseUserDataAsync(@event.UserId.ToString(), tenantId, cancellationToken).ConfigureAwait(false);
 
         return new PersonalDataDeletedEto(
             @event.RequestId,
             NotificationsPrivacyDataProvider.ProviderName,
             DeletionAction.PhysicalDelete,
-            AffectedRecords: 0,
+            affectedRecords,
             Details: null,
             @event.TenantId);
     }

--- a/src/Granit.Notifications.Privacy/packages.lock.json
+++ b/src/Granit.Notifications.Privacy/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -672,12 +672,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Notifications.SignalR/Extensions/SignalRNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.SignalR/Extensions/SignalRNotificationsServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.SignalR.Internal;
 using Granit.Notifications.SignalR.Options;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 
@@ -14,6 +16,14 @@ public static class SignalRNotificationsServiceCollectionExtensions
     /// <summary>
     /// Adds the SignalR real-time notification channel with optional Redis backplane.
     /// </summary>
+    /// <remarks>
+    /// The Redis backplane must be wired at registration time, so
+    /// <see cref="SignalRChannelOptions.RedisConnectionString"/> is only honored when supplied
+    /// through the <paramref name="configure"/> delegate here. To source it from
+    /// <c>appsettings.json</c> (<c>Notifications:SignalR:RedisConnectionString</c>), use the
+    /// <see cref="AddGranitNotificationsSignalR(IServiceCollection, IConfiguration, Action{SignalRChannelOptions}?)"/>
+    /// overload instead.
+    /// </remarks>
     public static IServiceCollection AddGranitNotificationsSignalR(
         this IServiceCollection services,
         Action<SignalRChannelOptions>? configure = null)
@@ -29,7 +39,43 @@ public static class SignalRNotificationsServiceCollectionExtensions
 
         services.AddSingleton<INotificationChannel, SignalRNotificationChannel>();
 
-        services.AddSignalR();
+        // Probe the delegate so a connection string supplied through it wires the
+        // backplane instead of being silently ignored (delegates must stay idempotent).
+        SignalRChannelOptions probe = new();
+        configure?.Invoke(probe);
+
+        AddSignalRCore(services, probe.RedisConnectionString);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the SignalR real-time notification channel, wiring the Redis backplane from
+    /// configuration (<c>Notifications:SignalR:RedisConnectionString</c>) when present.
+    /// </summary>
+    public static IServiceCollection AddGranitNotificationsSignalR(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Action<SignalRChannelOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<SignalRChannelOptions>()
+            .BindConfiguration(SignalRChannelOptions.SectionName)
+            .ValidateOnStart();
+
+        if (configure is not null)
+        {
+            services.Configure(configure);
+        }
+
+        services.AddSingleton<INotificationChannel, SignalRNotificationChannel>();
+
+        SignalRChannelOptions probe = new();
+        configuration.GetSection(SignalRChannelOptions.SectionName).Bind(probe);
+        configure?.Invoke(probe);
+
+        AddSignalRCore(services, probe.RedisConnectionString);
 
         return services;
     }
@@ -47,9 +93,20 @@ public static class SignalRNotificationsServiceCollectionExtensions
 
         services.AddSingleton<INotificationChannel, SignalRNotificationChannel>();
 
-        services.AddSignalR()
-            .AddStackExchangeRedis(redisConnectionString, options => options.Configuration.ChannelPrefix = RedisChannel.Literal("granit-notifications"));
+        AddSignalRCore(services, redisConnectionString);
 
         return services;
+    }
+
+    private static void AddSignalRCore(IServiceCollection services, string? redisConnectionString)
+    {
+        ISignalRServerBuilder signalR = services.AddSignalR();
+
+        if (!string.IsNullOrWhiteSpace(redisConnectionString))
+        {
+            signalR.AddStackExchangeRedis(
+                redisConnectionString,
+                options => options.Configuration.ChannelPrefix = RedisChannel.Literal("granit-notifications"));
+        }
     }
 }

--- a/src/Granit.Notifications.Twilio/Internal/TwilioNotificationProvider.cs
+++ b/src/Granit.Notifications.Twilio/Internal/TwilioNotificationProvider.cs
@@ -94,7 +94,7 @@ internal sealed partial class TwilioNotificationProvider(
         {
             errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Best-effort -- do not mask the original HTTP error.
         }

--- a/src/Granit.Notifications.WebPush.Endpoints/Endpoints/WebPushSubscriptionEndpoints.cs
+++ b/src/Granit.Notifications.WebPush.Endpoints/Endpoints/WebPushSubscriptionEndpoints.cs
@@ -73,17 +73,18 @@ internal static class WebPushSubscriptionEndpoints
 
     private static async Task<NoContent> RemoveSubscriptionAsync(
         [FromBody] WebPushSubscriptionRemoveRequest request,
+        ClaimsPrincipal user,
         [FromServices] IWebPushSubscriptionWriter writer,
         [FromServices] ICurrentTenant tenant,
         CancellationToken cancellationToken)
     {
+        string userId = NotificationsResponseMapper.GetUserId(user);
         Guid? tenantId = tenant.IsAvailable ? tenant.Id : null;
 
-        // The removal seam is scoped by (endpoint, tenant), not by user: the push endpoint is a
-        // cryptographically-unguessable secret minted by the browser's push service, so an
-        // attacker cannot target another user's subscription without already knowing it. A
-        // user-scoped overload of IWebPushSubscriptionWriter.RemoveSubscriptionAsync is a follow-up.
-        await writer.RemoveSubscriptionAsync(request.Endpoint, tenantId, cancellationToken).ConfigureAwait(false);
+        // Scoped by (user, endpoint, tenant): even though the push endpoint is an
+        // unguessable secret, least privilege forbids one tenant user deleting
+        // another user's subscription with a leaked endpoint.
+        await writer.RemoveSubscriptionAsync(userId, request.Endpoint, tenantId, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.NoContent();
     }

--- a/src/Granit.Notifications.WebPush.EntityFrameworkCore/Internal/EfCoreWebPushSubscriptionStore.cs
+++ b/src/Granit.Notifications.WebPush.EntityFrameworkCore/Internal/EfCoreWebPushSubscriptionStore.cs
@@ -54,10 +54,10 @@ internal sealed class EfCoreWebPushSubscriptionStore(
         cancellationToken);
 
     /// <inheritdoc />
-    public Task RemoveSubscriptionAsync(string endpoint, Guid? tenantId, CancellationToken cancellationToken = default) =>
+    public Task RemoveSubscriptionAsync(string userId, string endpoint, Guid? tenantId, CancellationToken cancellationToken = default) =>
         WriteAsync(async db =>
             await db.WebPushSubscriptions
-                .Where(s => s.Endpoint == endpoint && s.TenantId == tenantId)
+                .Where(s => s.UserId == userId && s.Endpoint == endpoint && s.TenantId == tenantId)
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false),
             cancellationToken);

--- a/src/Granit.Notifications.WebPush/IWebPushSubscriptionWriter.cs
+++ b/src/Granit.Notifications.WebPush/IWebPushSubscriptionWriter.cs
@@ -7,7 +7,10 @@ public interface IWebPushSubscriptionWriter
     Task SaveSubscriptionAsync(
         string userId, WebPushSubscriptionInfo subscription, Guid? tenantId, CancellationToken cancellationToken = default);
 
-    /// <summary>Removes a push subscription by endpoint.</summary>
+    /// <summary>
+    /// Removes a push subscription by endpoint, scoped to its owning user so one tenant user
+    /// can never delete another user's subscription (least privilege).
+    /// </summary>
     Task RemoveSubscriptionAsync(
-        string endpoint, Guid? tenantId, CancellationToken cancellationToken = default);
+        string userId, string endpoint, Guid? tenantId, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Notifications.WebPush/Internal/InMemoryWebPushSubscriptionStore.cs
+++ b/src/Granit.Notifications.WebPush/Internal/InMemoryWebPushSubscriptionStore.cs
@@ -33,12 +33,13 @@ internal sealed class InMemoryWebPushSubscriptionStore : IWebPushSubscriptionRea
         return Task.CompletedTask;
     }
 
-    public Task RemoveSubscriptionAsync(string endpoint, Guid? tenantId, CancellationToken cancellationToken = default)
+    public Task RemoveSubscriptionAsync(string userId, string endpoint, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        foreach (KeyValuePair<string, List<WebPushSubscriptionInfo>> kvp in _subscriptions)
+        if (_subscriptions.TryGetValue(BuildKey(userId, tenantId), out List<WebPushSubscriptionInfo>? subscriptions))
         {
-            kvp.Value.RemoveAll(s => s.Endpoint == endpoint);
+            subscriptions.RemoveAll(s => s.Endpoint == endpoint);
         }
+
         return Task.CompletedTask;
     }
 

--- a/src/Granit.Notifications.WebPush/Internal/WebPushNotificationChannel.cs
+++ b/src/Granit.Notifications.WebPush/Internal/WebPushNotificationChannel.cs
@@ -68,7 +68,7 @@ internal sealed partial class WebPushNotificationChannel(
             catch (PushServiceClientException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Gone)
             {
                 LogSubscriptionExpired(sub.Endpoint);
-                await subscriptionWriter.RemoveSubscriptionAsync(sub.Endpoint, context.TenantId, cancellationToken).ConfigureAwait(false);
+                await subscriptionWriter.RemoveSubscriptionAsync(context.RecipientUserId, sub.Endpoint, context.TenantId, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/Granit.Notifications.Wolverine/packages.lock.json
+++ b/src/Granit.Notifications.Wolverine/packages.lock.json
@@ -27,12 +27,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -62,8 +62,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -78,10 +78,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -98,8 +98,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -800,21 +800,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Notifications/Messages/NotificationTrigger.cs
+++ b/src/Granit.Notifications/Messages/NotificationTrigger.cs
@@ -18,6 +18,12 @@ public sealed record NotificationTrigger
     public EntityReference? RelatedEntity { get; init; }
     public Guid? TenantId { get; init; }
     public required DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>
+    /// Explicit culture override for content rendering (BCP-47). Leave <see langword="null"/>
+    /// (the default) to let each channel fall back to the recipient's preferred culture —
+    /// stamping a server-ambient culture here would override per-recipient localization.
+    /// </summary>
     public string? Culture { get; init; }
 
     /// <summary>

--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -78,8 +78,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -90,16 +90,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Lib.Net.Http.EncryptedContentEncoding": {
         "type": "Transitive",
@@ -506,8 +506,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {
@@ -1642,12 +1641,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -462,7 +462,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -329,8 +329,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -373,8 +373,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -347,8 +347,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -322,8 +322,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/src/Granit.Presence.Wolverine/packages.lock.json
+++ b/src/Granit.Presence.Wolverine/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -52,8 +52,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -68,10 +68,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -88,8 +88,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -500,7 +500,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -888,21 +887,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Privacy.AI/packages.lock.json
+++ b/src/Granit.Privacy.AI/packages.lock.json
@@ -48,8 +48,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -64,16 +64,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -555,12 +555,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Privacy.Auditing/packages.lock.json
+++ b/src/Granit.Privacy.Auditing/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -326,7 +326,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -535,12 +534,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Privacy.BackgroundJobs.Wolverine/packages.lock.json
+++ b/src/Granit.Privacy.BackgroundJobs.Wolverine/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -52,8 +52,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -68,10 +68,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -88,8 +88,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -849,21 +849,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Privacy.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Privacy.BackgroundJobs/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -535,12 +535,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Privacy.BlobStorage/packages.lock.json
+++ b/src/Granit.Privacy.BlobStorage/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -38,16 +38,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -267,12 +267,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },

--- a/src/Granit.Privacy.Endpoints/packages.lock.json
+++ b/src/Granit.Privacy.Endpoints/packages.lock.json
@@ -39,8 +39,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -51,16 +51,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -392,12 +392,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },

--- a/src/Granit.Privacy.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Privacy.EntityFrameworkCore/packages.lock.json
@@ -51,8 +51,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -67,16 +67,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -608,12 +608,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Privacy.Notifications/packages.lock.json
+++ b/src/Granit.Privacy.Notifications/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -42,16 +42,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -530,12 +530,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Privacy.Vault/packages.lock.json
+++ b/src/Granit.Privacy.Vault/packages.lock.json
@@ -64,8 +64,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -80,16 +80,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -670,12 +670,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/src/Granit.Privacy/packages.lock.json
+++ b/src/Granit.Privacy/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -47,8 +47,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -63,16 +63,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",

--- a/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
@@ -31,8 +31,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -47,10 +47,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -67,8 +67,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -786,12 +786,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -807,21 +807,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Scheduling.Wolverine/packages.lock.json
+++ b/src/Granit.Scheduling.Wolverine/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -52,8 +52,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -68,10 +68,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -88,8 +88,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -779,21 +779,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Timeline.Auditing/packages.lock.json
+++ b/src/Granit.Timeline.Auditing/packages.lock.json
@@ -30,7 +30,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/Granit.Vault.GoogleCloud/packages.lock.json
+++ b/src/Granit.Vault.GoogleCloud/packages.lock.json
@@ -139,16 +139,6 @@
           "Google.Apis.Core": "1.73.0"
         }
       },
-      "Google.Apis.Auth": {
-        "type": "Transitive",
-        "resolved": "1.73.0",
-        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
-        "dependencies": {
-          "Google.Apis": "1.73.0",
-          "Google.Apis.Core": "1.73.0",
-          "System.Management": "7.0.2"
-        }
-      },
       "Google.Apis.Core": {
         "type": "Transitive",
         "resolved": "1.73.0",
@@ -327,6 +317,17 @@
           "Granit.Encryption": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
+        }
+      },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
+        "dependencies": {
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
+          "System.Management": "7.0.2"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/src/Granit.Webhooks.Wolverine/packages.lock.json
+++ b/src/Granit.Webhooks.Wolverine/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -52,8 +52,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -68,10 +68,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -88,8 +88,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -947,21 +947,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.Encryption/packages.lock.json
+++ b/src/Granit.Wolverine.Encryption/packages.lock.json
@@ -17,12 +17,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -52,8 +52,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -68,10 +68,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -88,8 +88,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -769,21 +769,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.Postgresql/packages.lock.json
+++ b/src/Granit.Wolverine.Postgresql/packages.lock.json
@@ -64,24 +64,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "wEz1wTv3q9YKlYqSoH6/WqsSRAeVtV62itPu4nzG+YFjkrYR8HYB6KD4W/moa3feRQYvIJtKHZD8eUWmdI1oFg==",
+        "resolved": "6.17.2",
+        "contentHash": "qYaGRE8J5bkc+uHP8B7eKbTgWtADv+aqwK4yn0VvUK2mHRW4qhN7JBv63HEnqBkavKbchafLEWgiWSpU3I2jpA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "GJGBhzD+2/+bwhC3HlUeTRhGxv2Rrrf3Qm8NDkfV+DGa8L8DHadm2hf5yf2Xq8J1yUETtkFe20O8U9IGanwSSQ==",
+        "resolved": "6.17.2",
+        "contentHash": "/6RRduPHbbEGjY1zqSW3huEqeOAJdrMIRqLQ/+qYapFLDeaQHFH/WQ/OhsdHCHyaaxmKRa3ZVgNoqqRwc+jfUw==",
         "dependencies": {
           "Weasel.Postgresql": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "DistributedLock.Core": {
@@ -115,8 +115,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -131,10 +131,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -151,8 +151,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -685,11 +685,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "6.17.1",
-        "contentHash": "PsjjDe9UsctngMjrvjdZEBS7W+7mF1XDM1e/+PiVM6PtVGJVdYhmBkQvjsvWKeDRm7P/srJgNa1hsrJ2BuhYfw==",
+        "resolved": "6.17.2",
+        "contentHash": "uIo2iBlHhxIe6P99I+47ZfFn85O+pYSKQhq02OP8/Tb/LoNHcVGsYmwjf8MCSvqT3MLb0GWFx/jDnHV0uBMvsg==",
         "dependencies": {
           "Weasel.Core": "9.16.2",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZString": {
@@ -1028,12 +1028,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1049,21 +1049,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.SqlServer/packages.lock.json
+++ b/src/Granit.Wolverine.SqlServer/packages.lock.json
@@ -66,24 +66,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "wEz1wTv3q9YKlYqSoH6/WqsSRAeVtV62itPu4nzG+YFjkrYR8HYB6KD4W/moa3feRQYvIJtKHZD8eUWmdI1oFg==",
+        "resolved": "6.17.2",
+        "contentHash": "qYaGRE8J5bkc+uHP8B7eKbTgWtADv+aqwK4yn0VvUK2mHRW4qhN7JBv63HEnqBkavKbchafLEWgiWSpU3I2jpA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "PvV0ys36J363dD/pBd40B9Hc4KDL90FfFzPPMsA0y/N/Qx+ROifctz+B/bnUWhpg7fgsQjjnTxcTlxs5Te2h2w==",
+        "resolved": "6.17.2",
+        "contentHash": "4aAtteJbtCR1199zs+K1FjQeCUscFCywYr74VQB9QZ6FkvJvhGa47u8D5Ua/6Nc2COavMnkNFmSzYBcswQ2rRg==",
         "dependencies": {
           "Weasel.SqlServer": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "Azure.Core": {
@@ -113,8 +113,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -129,10 +129,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -149,8 +149,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -793,11 +793,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "6.17.1",
-        "contentHash": "PsjjDe9UsctngMjrvjdZEBS7W+7mF1XDM1e/+PiVM6PtVGJVdYhmBkQvjsvWKeDRm7P/srJgNa1hsrJ2BuhYfw==",
+        "resolved": "6.17.2",
+        "contentHash": "uIo2iBlHhxIe6P99I+47ZfFn85O+pYSKQhq02OP8/Tb/LoNHcVGsYmwjf8MCSvqT3MLb0GWFx/jDnHV0uBMvsg==",
         "dependencies": {
           "Weasel.Core": "9.16.2",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZString": {
@@ -1141,12 +1141,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1162,21 +1162,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine/packages.lock.json
+++ b/src/Granit.Wolverine/packages.lock.json
@@ -17,33 +17,33 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "FastExpressionCompiler": {
@@ -63,8 +63,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -75,10 +75,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -94,8 +94,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",

--- a/src/Granit.Workflow.Notifications/packages.lock.json
+++ b/src/Granit.Workflow.Notifications/packages.lock.json
@@ -77,7 +77,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -517,7 +517,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.AI.Chat.Privacy.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1001,12 +1001,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.AI.Prompts.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.AI.Prompts.Privacy.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -892,12 +892,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -291,26 +291,16 @@
       },
       "Google.Apis": {
         "type": "Transitive",
-        "resolved": "1.74.0",
-        "contentHash": "Z6hSkmRD6V8/raSBqn/EsPpNop6suaLaGE9DbSY3yRE5G47l4zYqrJgapcLARk2Z3TsQUDmWz+w/tob3wuVt3g==",
+        "resolved": "1.75.0",
+        "contentHash": "ZqODi2IvyTBezeGztemXv6U/+VinyqxxPiyoW2CZbzIrUp+a35Rt5tzUjXHPXK9nA1YQi/w8ABpYQpBm31ditw==",
         "dependencies": {
-          "Google.Apis.Core": "1.74.0"
-        }
-      },
-      "Google.Apis.Auth": {
-        "type": "Transitive",
-        "resolved": "1.74.0",
-        "contentHash": "43H4foh3zfWgboK8QnJjIfPQuBiS794TxqQLDfeE3erQSluKmEN0qeDuwxLTpSr9Mtwj76S4LWxPneuSbC6fNg==",
-        "dependencies": {
-          "Google.Apis": "1.74.0",
-          "Google.Apis.Core": "1.74.0",
-          "System.Management": "7.0.2"
+          "Google.Apis.Core": "1.75.0"
         }
       },
       "Google.Apis.Core": {
         "type": "Transitive",
-        "resolved": "1.74.0",
-        "contentHash": "gWOIiks6yo2TRliIyy10V18BJOO2BfUSPJFiTW6Tfap4tm3hFj7nvYU3XIfwzAxwoIy6nsBoqVDt9iBDSXrvYQ==",
+        "resolved": "1.75.0",
+        "contentHash": "7AuI44XP4LzMFiOjdk4GCtCxJTIWZcjrXLeGjLYYSpTHHbiPkvm76XNym7zPOnD90sIg+zdTulg+I6D5W5spTQ==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4"
         }
@@ -400,8 +390,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -412,10 +402,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -431,8 +421,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "JetBrains.Annotations": {
         "type": "Transitive",
@@ -451,8 +441,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "MaxMind.Db": {
         "type": "Transitive",
@@ -1425,11 +1415,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "6.17.1",
-        "contentHash": "PsjjDe9UsctngMjrvjdZEBS7W+7mF1XDM1e/+PiVM6PtVGJVdYhmBkQvjsvWKeDRm7P/srJgNa1hsrJ2BuhYfw==",
+        "resolved": "6.17.2",
+        "contentHash": "uIo2iBlHhxIe6P99I+47ZfFn85O+pYSKQhq02OP8/Tb/LoNHcVGsYmwjf8MCSvqT3MLb0GWFx/jDnHV0uBMvsg==",
         "dependencies": {
           "Weasel.Core": "9.16.2",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "xunit.analyzers": {
@@ -1745,8 +1735,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {
@@ -1768,7 +1757,6 @@
         "dependencies": {
           "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Features": "[0.1.0-dev, )",
-          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )"
         }
       },
@@ -3371,8 +3359,10 @@
       "granit.notifications.mobilepush.googlefcm": {
         "type": "Project",
         "dependencies": {
+          "Google.Apis.Auth": "[1.*, )",
           "Granit.Http.Resilience": "[0.1.0-dev, )",
-          "Granit.Notifications.MobilePush": "[0.1.0-dev, )"
+          "Granit.Notifications.MobilePush": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.notifications.privacy": {
@@ -4644,6 +4634,17 @@
           "FluentValidation": "12.1.1"
         }
       },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.75.0",
+        "contentHash": "hzuGwUBIQYdFkChXm62E5Suxe+q5PHt2uE5EunGBco2j01uQJGlUgzNujZvGHMlAIEHaytzhdn3v3v52ZPgv2Q==",
+        "dependencies": {
+          "Google.Apis": "1.75.0",
+          "Google.Apis.Core": "1.75.0",
+          "System.Management": "7.0.2"
+        }
+      },
       "Google.Cloud.Kms.V1": {
         "type": "CentralTransitive",
         "requested": "[3.*, )",
@@ -4689,10 +4690,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
         "requested": "[14.*, )",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "MailKit": {
@@ -5357,66 +5358,66 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "wEz1wTv3q9YKlYqSoH6/WqsSRAeVtV62itPu4nzG+YFjkrYR8HYB6KD4W/moa3feRQYvIJtKHZD8eUWmdI1oFg==",
+        "resolved": "6.17.2",
+        "contentHash": "qYaGRE8J5bkc+uHP8B7eKbTgWtADv+aqwK4yn0VvUK2mHRW4qhN7JBv63HEnqBkavKbchafLEWgiWSpU3I2jpA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "GJGBhzD+2/+bwhC3HlUeTRhGxv2Rrrf3Qm8NDkfV+DGa8L8DHadm2hf5yf2Xq8J1yUETtkFe20O8U9IGanwSSQ==",
+        "resolved": "6.17.2",
+        "contentHash": "/6RRduPHbbEGjY1zqSW3huEqeOAJdrMIRqLQ/+qYapFLDeaQHFH/WQ/OhsdHCHyaaxmKRa3ZVgNoqqRwc+jfUw==",
         "dependencies": {
           "Weasel.Postgresql": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "PvV0ys36J363dD/pBd40B9Hc4KDL90FfFzPPMsA0y/N/Qx+ROifctz+B/bnUWhpg7fgsQjjnTxcTlxs5Te2h2w==",
+        "resolved": "6.17.2",
+        "contentHash": "4aAtteJbtCR1199zs+K1FjQeCUscFCywYr74VQB9QZ6FkvJvhGa47u8D5Ua/6Nc2COavMnkNFmSzYBcswQ2rRg==",
         "dependencies": {
           "Weasel.SqlServer": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "Yarp.ReverseProxy": {

--- a/tests/Granit.Auditing.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.BackgroundJobs.Tests/packages.lock.json
@@ -329,7 +329,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Auditing.ConfigurationChanges.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.ConfigurationChanges.Tests/packages.lock.json
@@ -253,8 +253,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {
@@ -269,7 +268,6 @@
         "dependencies": {
           "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Features": "[0.1.0-dev, )",
-          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Auditing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.Endpoints.Tests/packages.lock.json
@@ -252,8 +252,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/packages.lock.json
@@ -340,8 +340,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.Auditing.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.Notifications.Tests/packages.lock.json
@@ -262,7 +262,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Auditing.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.Privacy.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -558,7 +558,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -903,12 +902,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Auditing.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.Tests/packages.lock.json
@@ -262,7 +262,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
@@ -58,12 +58,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -130,8 +130,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -146,10 +146,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -166,8 +166,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1017,21 +1017,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -145,8 +145,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -996,12 +996,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1017,21 +1017,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
@@ -379,8 +379,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.BlobStorage.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.GoogleCloud.Tests/packages.lock.json
@@ -125,16 +125,6 @@
           "Google.Apis.Core": "1.74.0"
         }
       },
-      "Google.Apis.Auth": {
-        "type": "Transitive",
-        "resolved": "1.74.0",
-        "contentHash": "43H4foh3zfWgboK8QnJjIfPQuBiS794TxqQLDfeE3erQSluKmEN0qeDuwxLTpSr9Mtwj76S4LWxPneuSbC6fNg==",
-        "dependencies": {
-          "Google.Apis": "1.74.0",
-          "Google.Apis.Core": "1.74.0",
-          "System.Management": "7.0.2"
-        }
-      },
       "Google.Apis.Core": {
         "type": "Transitive",
         "resolved": "1.74.0",
@@ -416,6 +406,17 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.74.0",
+        "contentHash": "43H4foh3zfWgboK8QnJjIfPQuBiS794TxqQLDfeE3erQSluKmEN0qeDuwxLTpSr9Mtwj76S4LWxPneuSbC6fNg==",
+        "dependencies": {
+          "Google.Apis": "1.74.0",
+          "Google.Apis.Core": "1.74.0",
+          "System.Management": "7.0.2"
         }
       },
       "Google.Cloud.Storage.V1": {

--- a/tests/Granit.Events.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Events.Wolverine.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -145,8 +145,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -976,12 +976,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -997,21 +997,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
@@ -524,7 +524,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
@@ -413,7 +413,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -339,7 +339,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -1362,7 +1362,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -339,7 +339,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
@@ -523,7 +523,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
@@ -473,7 +473,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
@@ -1467,7 +1467,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
@@ -473,7 +473,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
@@ -119,16 +119,6 @@
           "Google.Apis.Core": "1.73.0"
         }
       },
-      "Google.Apis.Auth": {
-        "type": "Transitive",
-        "resolved": "1.73.0",
-        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
-        "dependencies": {
-          "Google.Apis": "1.73.0",
-          "Google.Apis.Core": "1.73.0",
-          "System.Management": "7.0.2"
-        }
-      },
       "Google.Apis.Core": {
         "type": "Transitive",
         "resolved": "1.73.0",
@@ -329,7 +319,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -470,6 +459,17 @@
         "dependencies": {
           "Google.Api.Gax.Rest": "4.13.1",
           "Google.Apis.Auth": "1.73.0"
+        }
+      },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
+        "dependencies": {
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
+          "System.Management": "7.0.2"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
@@ -473,7 +473,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
@@ -729,7 +729,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
@@ -484,7 +484,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Notifications.Tests/packages.lock.json
@@ -290,7 +290,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -558,7 +558,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -948,12 +947,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Identity.Federated.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Tests/packages.lock.json
@@ -265,8 +265,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -488,8 +488,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/packages.lock.json
@@ -330,8 +330,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -524,7 +524,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
@@ -296,7 +296,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -558,7 +558,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -961,12 +960,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Identity.Local.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Tests/packages.lock.json
@@ -248,8 +248,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.Identity.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Notifications.Tests/packages.lock.json
@@ -262,7 +262,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Identity.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Tests/packages.lock.json
@@ -333,7 +333,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
+++ b/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
@@ -94,8 +94,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -271,10 +271,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
         "requested": "[14.*, )",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {

--- a/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Indexing.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -173,8 +173,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -189,16 +189,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1091,12 +1091,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Indexing.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Indexing.Privacy.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -799,12 +799,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.MultiTenancy.Auditing.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Auditing.Tests/packages.lock.json
@@ -253,8 +253,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -145,8 +145,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1078,12 +1078,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1099,21 +1099,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Notifications.AI.Tests/LlmNotificationContentGeneratorTests.cs
+++ b/tests/Granit.Notifications.AI.Tests/LlmNotificationContentGeneratorTests.cs
@@ -5,7 +5,6 @@ using Granit.Notifications.AI.Options;
 using Granit.Notifications.AI.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -17,10 +16,10 @@ namespace Granit.Notifications.AI.Tests;
 public sealed class LlmNotificationContentGeneratorTests
 {
     private readonly IStructuredCompletion _structured = Substitute.For<IStructuredCompletion>();
-    private readonly IOptions<NotificationsAIOptions> _options = MsOptions.Create(new NotificationsAIOptions());
     private readonly ILogger<LlmNotificationContentGenerator> _logger = NullLogger<LlmNotificationContentGenerator>.Instance;
 
-    private LlmNotificationContentGenerator CreateSut() => new(_structured, _options, _logger);
+    private LlmNotificationContentGenerator CreateSut(NotificationsAIOptions? options = null) =>
+        new(_structured, MsOptions.Create(options ?? new NotificationsAIOptions()), _logger);
 
     private static NotificationDeliveryContext MakeContext(
         string typeName = "order.completed",
@@ -103,7 +102,8 @@ public sealed class LlmNotificationContentGeneratorTests
             .CompleteAsync<NotificationContentResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
             .Returns(Ok("S", "B"));
 
-        await CreateSut().GenerateAsync(
+        // Forwarding the Data payload is an explicit GDPR opt-in.
+        await CreateSut(new NotificationsAIOptions { AllowPersonalDataInPrompts = true }).GenerateAsync(
             MakeContext(typeName: "user.registered", culture: "fr"), TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
@@ -114,5 +114,22 @@ public sealed class LlmNotificationContentGeneratorTests
         // ...and the notification type travels as labelled context.
         captured.Context.ShouldNotBeNull();
         captured.Context.ShouldContain(kv => kv.Value == "user.registered");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ByDefault_DoesNotForwardDataPayloadToTheModel()
+    {
+        StructuredCompletionRequest? captured = null;
+        _structured
+            .CompleteAsync<NotificationContentResponse>(Arg.Do<StructuredCompletionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(Ok("S", "B"));
+
+        await CreateSut().GenerateAsync(MakeContext(), TestContext.Current.CancellationToken);
+
+        // GDPR: the payload may contain personal data — it must never reach the LLM
+        // unless the host explicitly sets AllowPersonalDataInPrompts = true.
+        captured.ShouldNotBeNull();
+        captured.Content.ShouldBe("{}");
+        captured.Content.ShouldNotContain("ORD-001");
     }
 }

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
@@ -117,6 +117,70 @@ public sealed class EmailNotificationChannelTests
     public void Name_ReturnsEmail() =>
         _channel.Name.ShouldBe(NotificationChannels.Email);
 
+    // ──── Culture selection ────
+
+    [Fact]
+    public async Task SendAsync_NoExplicitCulture_ResolvesTemplateWithRecipientPreferredCulture()
+    {
+        NotificationDeliveryContext context = BuildContext(); // Culture is null
+        _recipientResolver.ResolveAsync("user-1", Arg.Any<CancellationToken>())
+            .Returns(new RecipientInfo
+            {
+                UserId = "user-1",
+                Email = "user@test.com",
+                PreferredCulture = "fr",
+            });
+
+        List<Granit.Templating.Keys.TemplateKey> requestedKeys = [];
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                requestedKeys.Add(callInfo.Arg<Granit.Templating.Keys.TemplateKey>());
+                return Task.FromResult<TemplateDescriptor?>(null);
+            });
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        // The recipient's preferred culture must drive template resolution — without the
+        // fallback, the 18 localized template variants are dead code (culture always null).
+        requestedKeys.ShouldNotBeEmpty();
+        requestedKeys.ShouldAllBe(k => k.Culture == "fr");
+    }
+
+    [Fact]
+    public async Task SendAsync_ExplicitCulture_OverridesRecipientPreferredCulture()
+    {
+        NotificationDeliveryContext context = BuildContext() with { Culture = "de" };
+        _recipientResolver.ResolveAsync("user-1", Arg.Any<CancellationToken>())
+            .Returns(new RecipientInfo
+            {
+                UserId = "user-1",
+                Email = "user@test.com",
+                PreferredCulture = "fr",
+            });
+
+        List<Granit.Templating.Keys.TemplateKey> requestedKeys = [];
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                requestedKeys.Add(callInfo.Arg<Granit.Templating.Keys.TemplateKey>());
+                return Task.FromResult<TemplateDescriptor?>(null);
+            });
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        requestedKeys.ShouldNotBeEmpty();
+        requestedKeys.ShouldAllBe(k => k.Culture == "de");
+    }
+
     // ──── Template rendering branch tests ────
 
     [Fact]

--- a/tests/Granit.Notifications.MobilePush.Endpoints.Tests/MobilePushTokenEndpointsTests.cs
+++ b/tests/Granit.Notifications.MobilePush.Endpoints.Tests/MobilePushTokenEndpointsTests.cs
@@ -2,10 +2,12 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using FluentValidation;
 using Granit.MultiTenancy;
 using Granit.Notifications.MobilePush.Domain;
 using Granit.Notifications.MobilePush.Endpoints.Dtos;
 using Granit.Notifications.MobilePush.Endpoints.Extensions;
+using Granit.Notifications.MobilePush.Endpoints.Validators;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -47,6 +49,8 @@ public sealed class MobilePushTokenEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_tokenWriter);
         builder.Services.AddSingleton(_tokenReader);
         builder.Services.AddSingleton(_currentTenant);
+        builder.Services.AddScoped<IValidator<MobilePushTokenRegisterRequest>, MobilePushTokenRegisterRequestValidator>();
+        builder.Services.AddScoped<IValidator<MobilePushTokenRemoveRequest>, MobilePushTokenRemoveRequestValidator>();
 
         _app = builder.Build();
         _app.MapGranitMobilePushTokens();
@@ -115,20 +119,45 @@ public sealed class MobilePushTokenEndpointsTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task RemoveToken_Returns204()
+    public async Task RemoveToken_Returns204_AndBindsTokenFromBody()
     {
-        HttpResponseMessage response = await _authClient.DeleteAsync(
-            $"{Prefix}/my-device-token", TestContext.Current.CancellationToken);
+        // The device token is a sendable push credential — it travels in the JSON body,
+        // never in the URL (access/proxy log leakage).
+        using HttpRequestMessage request = new(HttpMethod.Delete, Prefix)
+        {
+            Content = JsonContent.Create(new MobilePushTokenRemoveRequest { DeviceToken = "my-device-token" }),
+        };
+
+        HttpResponseMessage response = await _authClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         await _tokenWriter.Received(1).RemoveAsync("my-device-token", "user-456", null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
+    public async Task RemoveToken_EmptyToken_Returns422()
+    {
+        using HttpRequestMessage request = new(HttpMethod.Delete, Prefix)
+        {
+            Content = JsonContent.Create(new MobilePushTokenRemoveRequest { DeviceToken = "" }),
+        };
+
+        HttpResponseMessage response = await _authClient.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        await _tokenWriter.DidNotReceive().RemoveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task RemoveToken_Unauthenticated_Returns401()
     {
-        HttpResponseMessage response = await _anonClient.DeleteAsync(
-            $"{Prefix}/my-device-token", TestContext.Current.CancellationToken);
+        using HttpRequestMessage request = new(HttpMethod.Delete, Prefix)
+        {
+            Content = JsonContent.Create(new MobilePushTokenRemoveRequest { DeviceToken = "my-device-token" }),
+        };
+
+        HttpResponseMessage response = await _anonClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
@@ -196,8 +225,12 @@ public sealed class MobilePushTokenEndpointsTests : IAsyncDisposable
         _currentTenant.IsAvailable.Returns(true);
         _currentTenant.Id.Returns(tenantId);
 
-        HttpResponseMessage response = await _authClient.DeleteAsync(
-            $"{Prefix}/my-token", TestContext.Current.CancellationToken);
+        using HttpRequestMessage request = new(HttpMethod.Delete, Prefix)
+        {
+            Content = JsonContent.Create(new MobilePushTokenRemoveRequest { DeviceToken = "my-token" }),
+        };
+
+        HttpResponseMessage response = await _authClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         await _tokenWriter.Received(1).RemoveAsync("my-token", "user-456", tenantId, Arg.Any<CancellationToken>());

--- a/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/GoogleFcmAuthenticationHandlerTests.cs
+++ b/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/GoogleFcmAuthenticationHandlerTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using Granit.Notifications.MobilePush.GoogleFcm.Internal;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.MobilePush.GoogleFcm.Tests;
+
+public sealed class GoogleFcmAuthenticationHandlerTests
+{
+    private static readonly DateTimeOffset Anchor = new(2026, 1, 15, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task SendAsync_AttachesBearerToken()
+    {
+        SequencedTokenSource source = new();
+        RecordingInnerHandler inner = new(HttpStatusCode.OK);
+        using HttpClient client = BuildClient(source, inner);
+
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("https://fcm.googleapis.com/v1/projects/p/messages:send"),
+            new StringContent("{}"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        inner.AuthorizationHeaders.ShouldBe(["Bearer token-1"]);
+    }
+
+    [Fact]
+    public async Task SendAsync_On401_RefreshesTokenAndRetriesOnce()
+    {
+        SequencedTokenSource source = new();
+        RecordingInnerHandler inner = new(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using HttpClient client = BuildClient(source, inner);
+
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("https://fcm.googleapis.com/v1/projects/p/messages:send"),
+            new StringContent("{\"message\":{}}"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        source.MintCount.ShouldBe(2);
+        inner.AuthorizationHeaders.ShouldBe(["Bearer token-1", "Bearer token-2"]);
+        inner.Bodies.ShouldBe(["{\"message\":{}}", "{\"message\":{}}"]);
+    }
+
+    [Fact]
+    public async Task SendAsync_On401Twice_DoesNotRetryASecondTime()
+    {
+        SequencedTokenSource source = new();
+        RecordingInnerHandler inner = new(HttpStatusCode.Unauthorized, HttpStatusCode.Unauthorized);
+        using HttpClient client = BuildClient(source, inner);
+
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("https://fcm.googleapis.com/v1/projects/p/messages:send"),
+            new StringContent("{}"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        inner.AuthorizationHeaders.Count.ShouldBe(2);
+    }
+
+    private static HttpClient BuildClient(SequencedTokenSource source, RecordingInnerHandler inner)
+    {
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Anchor);
+
+        GoogleFcmAuthenticationHandler handler = new(
+            new GoogleFcmTokenProvider(source, clock),
+            NullLogger<GoogleFcmAuthenticationHandler>.Instance)
+        {
+            InnerHandler = inner,
+        };
+
+        return new HttpClient(handler);
+    }
+
+    private sealed class SequencedTokenSource : IGoogleFcmTokenSource
+    {
+        private int _mintCount;
+
+        public int MintCount => Volatile.Read(ref _mintCount);
+
+        public Task<GoogleFcmAccessToken> MintTokenAsync(CancellationToken cancellationToken = default)
+        {
+            int count = Interlocked.Increment(ref _mintCount);
+            return Task.FromResult(new GoogleFcmAccessToken($"token-{count}", Anchor.AddHours(1)));
+        }
+    }
+
+    private sealed class RecordingInnerHandler(params HttpStatusCode[] statusCodes) : HttpMessageHandler
+    {
+        private int _callIndex;
+
+        public List<string?> AuthorizationHeaders { get; } = [];
+
+        public List<string> Bodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            AuthorizationHeaders.Add(request.Headers.Authorization?.ToString());
+            Bodies.Add(request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+
+            HttpStatusCode status = statusCodes[Math.Min(_callIndex++, statusCodes.Length - 1)];
+            return new HttpResponseMessage(status);
+        }
+    }
+}

--- a/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/GoogleFcmMobilePushServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/GoogleFcmMobilePushServiceCollectionExtensionsTests.cs
@@ -22,6 +22,23 @@ public sealed class GoogleFcmMobilePushServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddGranitNotificationsMobilePushGoogleFcm_RegistersOAuthTokenPipeline()
+    {
+        ServiceCollection services = new();
+        services.AddGranitNotificationsMobilePushGoogleFcm();
+
+        services.ShouldContain(d =>
+            d.ServiceType == typeof(Internal.IGoogleFcmTokenSource) &&
+            d.Lifetime == ServiceLifetime.Singleton);
+        services.ShouldContain(d =>
+            d.ServiceType == typeof(Internal.GoogleFcmTokenProvider) &&
+            d.Lifetime == ServiceLifetime.Singleton);
+        services.ShouldContain(d =>
+            d.ServiceType == typeof(Internal.GoogleFcmAuthenticationHandler) &&
+            d.Lifetime == ServiceLifetime.Transient);
+    }
+
+    [Fact]
     public void AddGranitNotificationsMobilePushGoogleFcm_ReturnsServiceCollection()
     {
         ServiceCollection services = new();

--- a/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/GoogleFcmTokenProviderTests.cs
+++ b/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/GoogleFcmTokenProviderTests.cs
@@ -1,0 +1,98 @@
+using Granit.Notifications.MobilePush.GoogleFcm.Internal;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.MobilePush.GoogleFcm.Tests;
+
+public sealed class GoogleFcmTokenProviderTests
+{
+    private static readonly DateTimeOffset Anchor = new(2026, 1, 15, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task GetAccessTokenAsync_ConcurrentCallers_MintExactlyOnce()
+    {
+        CountingTokenSource source = new(Anchor.AddHours(1)) { MintDelay = TimeSpan.FromMilliseconds(50) };
+        using GoogleFcmTokenProvider provider = new(source, FixedClock(Anchor));
+
+        string[] tokens = await Task.WhenAll(Enumerable.Range(0, 25)
+            .Select(_ => provider.GetAccessTokenAsync(TestContext.Current.CancellationToken).AsTask()));
+
+        source.MintCount.ShouldBe(1);
+        tokens.ShouldAllBe(t => t == "token-1");
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_WithinMargin_ReturnsCachedToken()
+    {
+        CountingTokenSource source = new(Anchor.AddHours(1));
+        using GoogleFcmTokenProvider provider = new(source, FixedClock(Anchor));
+
+        string first = await provider.GetAccessTokenAsync(TestContext.Current.CancellationToken);
+        string second = await provider.GetAccessTokenAsync(TestContext.Current.CancellationToken);
+
+        source.MintCount.ShouldBe(1);
+        second.ShouldBe(first);
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_InsideRefreshMargin_MintsFreshToken()
+    {
+        // Token expires at +1h; the provider refreshes 5 minutes early.
+        CountingTokenSource source = new(Anchor.AddHours(1));
+        DateTimeOffset now = Anchor;
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(_ => now);
+        using GoogleFcmTokenProvider provider = new(source, clock);
+
+        await provider.GetAccessTokenAsync(TestContext.Current.CancellationToken);
+        now = Anchor.AddMinutes(56); // 4 min before expiry — inside the 5 min margin
+        string refreshed = await provider.GetAccessTokenAsync(TestContext.Current.CancellationToken);
+
+        source.MintCount.ShouldBe(2);
+        refreshed.ShouldBe("token-2");
+    }
+
+    [Fact]
+    public async Task Invalidate_ForcesMintOnNextCall()
+    {
+        CountingTokenSource source = new(Anchor.AddHours(1));
+        using GoogleFcmTokenProvider provider = new(source, FixedClock(Anchor));
+
+        await provider.GetAccessTokenAsync(TestContext.Current.CancellationToken);
+        provider.Invalidate();
+        string refreshed = await provider.GetAccessTokenAsync(TestContext.Current.CancellationToken);
+
+        source.MintCount.ShouldBe(2);
+        refreshed.ShouldBe("token-2");
+    }
+
+    private static IClock FixedClock(DateTimeOffset now)
+    {
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(now);
+        return clock;
+    }
+
+    /// <summary>Thread-safe fake token source: counts mints and numbers the issued tokens.</summary>
+    private sealed class CountingTokenSource(DateTimeOffset expiresAt) : IGoogleFcmTokenSource
+    {
+        private int _mintCount;
+
+        public TimeSpan MintDelay { get; init; }
+
+        public int MintCount => Volatile.Read(ref _mintCount);
+
+        public async Task<GoogleFcmAccessToken> MintTokenAsync(CancellationToken cancellationToken = default)
+        {
+            int count = Interlocked.Increment(ref _mintCount);
+            if (MintDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(MintDelay, cancellationToken).ConfigureAwait(false);
+            }
+
+            return new GoogleFcmAccessToken($"token-{count}", expiresAt);
+        }
+    }
+}

--- a/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/packages.lock.json
@@ -92,6 +92,22 @@
         "resolved": "4.4.0",
         "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
       },
+      "Google.Apis": {
+        "type": "Transitive",
+        "resolved": "1.75.0",
+        "contentHash": "ZqODi2IvyTBezeGztemXv6U/+VinyqxxPiyoW2CZbzIrUp+a35Rt5tzUjXHPXK9nA1YQi/w8ABpYQpBm31ditw==",
+        "dependencies": {
+          "Google.Apis.Core": "1.75.0"
+        }
+      },
+      "Google.Apis.Core": {
+        "type": "Transitive",
+        "resolved": "1.75.0",
+        "contentHash": "7AuI44XP4LzMFiOjdk4GCtCxJTIWZcjrXLeGjLYYSpTHHbiPkvm76XNym7zPOnD90sIg+zdTulg+I6D5W5spTQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.4"
+        }
+      },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -325,8 +341,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "Polly.Core": {
         "type": "Transitive",
@@ -354,8 +370,8 @@
       },
       "System.CodeDom": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+        "resolved": "7.0.0",
+        "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -364,10 +380,10 @@
       },
       "System.Management": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "resolved": "7.0.2",
+        "contentHash": "/qEUN91mP/MUQmJnM5y5BdT7ZoPuVrtxnFlbJ8a3kBJGhe2wCzBfnPFtK2wTtEEcf3DMGR9J00GZZfg6HRI6yA==",
         "dependencies": {
-          "System.CodeDom": "6.0.0"
+          "System.CodeDom": "7.0.0"
         }
       },
       "System.Threading.RateLimiting": {
@@ -550,8 +566,10 @@
       "granit.notifications.mobilepush.googlefcm": {
         "type": "Project",
         "dependencies": {
+          "Google.Apis.Auth": "[1.*, )",
           "Granit.Http.Resilience": "[0.1.0-dev, )",
           "Granit.Notifications.MobilePush": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Http": "[10.*, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
@@ -572,6 +590,17 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.75.0",
+        "contentHash": "hzuGwUBIQYdFkChXm62E5Suxe+q5PHt2uE5EunGBco2j01uQJGlUgzNujZvGHMlAIEHaytzhdn3v3v52ZPgv2Q==",
+        "dependencies": {
+          "Google.Apis": "1.75.0",
+          "Google.Apis.Core": "1.75.0",
+          "System.Management": "7.0.2"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/tests/Granit.Notifications.Privacy.Tests/DataDeletion/NotificationsPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Notifications.Privacy.Tests/DataDeletion/NotificationsPersonalDataDeletionHandlerTests.cs
@@ -60,12 +60,26 @@ public sealed class NotificationsPersonalDataDeletionHandlerTests
     }
 
     [Fact]
+    public async Task Handle_reports_the_real_erased_row_count_in_the_acknowledgement()
+    {
+        INotificationsPersonalDataEraser eraser = Substitute.For<INotificationsPersonalDataEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        eraser.EraseUserDataAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(42);
+
+        PersonalDataDeletedEto ack = await NotificationsPersonalDataDeletionHandler.Handle(
+            Eto(Tenant), eraser, currentTenant, TestContext.Current.CancellationToken);
+
+        ack.AffectedRecords.ShouldBe(42);
+    }
+
+    [Fact]
     public async Task Handle_does_not_acknowledge_when_the_erasure_fails()
     {
         INotificationsPersonalDataEraser eraser = Substitute.For<INotificationsPersonalDataEraser>();
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         eraser.EraseUserDataAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns<Task>(_ => throw new InvalidOperationException("notifications erase failed"));
+            .Returns<Task<int>>(_ => throw new InvalidOperationException("notifications erase failed"));
 
         await Should.ThrowAsync<InvalidOperationException>(() => NotificationsPersonalDataDeletionHandler.Handle(
             Eto(Tenant), eraser, currentTenant, TestContext.Current.CancellationToken));

--- a/tests/Granit.Notifications.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Privacy.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -906,12 +906,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Notifications.WebPush.Endpoints.Tests/WebPushSubscriptionEndpointsTests.cs
+++ b/tests/Granit.Notifications.WebPush.Endpoints.Tests/WebPushSubscriptionEndpointsTests.cs
@@ -198,7 +198,7 @@ public sealed class WebPushSubscriptionEndpointsTests : IAsyncDisposable
         HttpResponseMessage response = await _authClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
-        await _writer.Received(1).RemoveSubscriptionAsync(SampleEndpoint, null, Arg.Any<CancellationToken>());
+        await _writer.Received(1).RemoveSubscriptionAsync(UserId, SampleEndpoint, null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -214,7 +214,7 @@ public sealed class WebPushSubscriptionEndpointsTests : IAsyncDisposable
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         await _writer.Received(1).RemoveSubscriptionAsync(
-            "https://push.example/unknown", null, Arg.Any<CancellationToken>());
+            UserId, "https://push.example/unknown", null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -242,7 +242,7 @@ public sealed class WebPushSubscriptionEndpointsTests : IAsyncDisposable
 
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
         await _writer.DidNotReceive().RemoveSubscriptionAsync(
-            Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -260,7 +260,7 @@ public sealed class WebPushSubscriptionEndpointsTests : IAsyncDisposable
         HttpResponseMessage response = await _authClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
-        await _writer.Received(1).RemoveSubscriptionAsync(SampleEndpoint, tenantId, Arg.Any<CancellationToken>());
+        await _writer.Received(1).RemoveSubscriptionAsync(UserId, SampleEndpoint, tenantId, Arg.Any<CancellationToken>());
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/tests/Granit.Notifications.WebPush.EntityFrameworkCore.Tests/EfCoreWebPushSubscriptionStoreTests.cs
+++ b/tests/Granit.Notifications.WebPush.EntityFrameworkCore.Tests/EfCoreWebPushSubscriptionStoreTests.cs
@@ -76,10 +76,10 @@ public sealed class EfCoreWebPushSubscriptionStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RemoveSubscriptionAsync_DeletesByEndpoint()
+    public async Task RemoveSubscriptionAsync_DeletesByUserAndEndpoint()
     {
         await _store.SaveSubscriptionAsync("user-1", Sub("https://push/1"), tenantId: null, TestContext.Current.CancellationToken);
-        await _store.RemoveSubscriptionAsync("https://push/1", tenantId: null, TestContext.Current.CancellationToken);
+        await _store.RemoveSubscriptionAsync("user-1", "https://push/1", tenantId: null, TestContext.Current.CancellationToken);
 
         IReadOnlyList<WebPushSubscriptionInfo> subs = await _store
             .GetSubscriptionsAsync("user-1", null, TestContext.Current.CancellationToken);
@@ -91,7 +91,20 @@ public sealed class EfCoreWebPushSubscriptionStoreTests : IDisposable
     public async Task RemoveSubscriptionAsync_OtherEndpoint_DoesNotDelete()
     {
         await _store.SaveSubscriptionAsync("user-1", Sub("https://push/1"), tenantId: null, TestContext.Current.CancellationToken);
-        await _store.RemoveSubscriptionAsync("https://push/other", tenantId: null, TestContext.Current.CancellationToken);
+        await _store.RemoveSubscriptionAsync("user-1", "https://push/other", tenantId: null, TestContext.Current.CancellationToken);
+
+        IReadOnlyList<WebPushSubscriptionInfo> subs = await _store
+            .GetSubscriptionsAsync("user-1", null, TestContext.Current.CancellationToken);
+
+        subs.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task RemoveSubscriptionAsync_AnotherUsersEndpoint_DoesNotDelete()
+    {
+        // Least privilege: knowing another user's endpoint must not allow deleting it.
+        await _store.SaveSubscriptionAsync("user-1", Sub("https://push/1"), tenantId: null, TestContext.Current.CancellationToken);
+        await _store.RemoveSubscriptionAsync("user-2", "https://push/1", tenantId: null, TestContext.Current.CancellationToken);
 
         IReadOnlyList<WebPushSubscriptionInfo> subs = await _store
             .GetSubscriptionsAsync("user-1", null, TestContext.Current.CancellationToken);

--- a/tests/Granit.Notifications.WebPush.Tests/InMemoryWebPushSubscriptionStoreTests.cs
+++ b/tests/Granit.Notifications.WebPush.Tests/InMemoryWebPushSubscriptionStoreTests.cs
@@ -47,7 +47,7 @@ public sealed class InMemoryWebPushSubscriptionStoreTests
         WebPushSubscriptionInfo subscription = BuildSubscription("https://push.example.com/1");
         await _store.SaveSubscriptionAsync("user-1", subscription, null, TestContext.Current.CancellationToken);
 
-        await _store.RemoveSubscriptionAsync("https://push.example.com/1", null, TestContext.Current.CancellationToken);
+        await _store.RemoveSubscriptionAsync("user-1", "https://push.example.com/1", null, TestContext.Current.CancellationToken);
         IReadOnlyList<WebPushSubscriptionInfo> result = await _store.GetSubscriptionsAsync(
             "user-1", null, TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Notifications.WebPush.Tests/WebPushNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.WebPush.Tests/WebPushNotificationChannelTests.cs
@@ -158,7 +158,7 @@ public sealed class WebPushNotificationChannelTests
         await channel.SendAsync(context, TestContext.Current.CancellationToken);
 
         await _subscriptionWriter.Received(1).RemoveSubscriptionAsync(
-            expiredEndpoint, context.TenantId, Arg.Any<CancellationToken>());
+            context.RecipientUserId, expiredEndpoint, context.TenantId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public sealed class WebPushNotificationChannelTests
         await channel.SendAsync(context, TestContext.Current.CancellationToken);
 
         await _subscriptionWriter.Received(1).RemoveSubscriptionAsync(
-            expiredEndpoint, tenantId, Arg.Any<CancellationToken>());
+            context.RecipientUserId, expiredEndpoint, tenantId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -214,11 +214,11 @@ public sealed class WebPushNotificationChannelTests
         handler.Requests.Count.ShouldBe(3);
         // Only the expired endpoint should be removed.
         await _subscriptionWriter.Received(1).RemoveSubscriptionAsync(
-            "https://push.example.com/expired", context.TenantId, Arg.Any<CancellationToken>());
+            context.RecipientUserId, "https://push.example.com/expired", context.TenantId, Arg.Any<CancellationToken>());
         await _subscriptionWriter.DidNotReceive().RemoveSubscriptionAsync(
-            "https://push.example.com/active1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), "https://push.example.com/active1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
         await _subscriptionWriter.DidNotReceive().RemoveSubscriptionAsync(
-            "https://push.example.com/active2", Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), "https://push.example.com/active2", Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -145,8 +145,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1011,12 +1011,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1032,21 +1032,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -676,7 +676,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -600,8 +600,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -540,8 +540,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
@@ -535,8 +535,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -684,8 +684,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -546,8 +546,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {

--- a/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/packages.lock.json
@@ -75,12 +75,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -96,11 +96,11 @@
       "WolverineFx.RuntimeCompilation": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "xunit.runner.visualstudio": {
@@ -157,8 +157,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -173,10 +173,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -193,8 +193,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
@@ -644,7 +644,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Presence.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Presence.Wolverine.Tests/packages.lock.json
@@ -120,8 +120,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -136,10 +136,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -156,8 +156,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -732,7 +732,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
@@ -1129,12 +1128,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1150,21 +1149,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Privacy.AI.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.AI.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -791,12 +791,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Privacy.Auditing.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Auditing.Tests/packages.lock.json
@@ -101,8 +101,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -113,16 +113,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -311,8 +311,7 @@
           "Granit.Auditing.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.auditing.abstractions": {
@@ -421,12 +420,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },

--- a/tests/Granit.Privacy.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.BackgroundJobs.Tests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -137,16 +137,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -806,12 +806,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Privacy.BackgroundJobs.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.BackgroundJobs.Wolverine.Tests/packages.lock.json
@@ -92,8 +92,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -108,10 +108,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -128,8 +128,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1041,12 +1041,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1062,21 +1062,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Privacy.BlobStorage.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.BlobStorage.Tests/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -138,16 +138,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -548,12 +548,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },

--- a/tests/Granit.Privacy.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Endpoints.Tests/packages.lock.json
@@ -131,8 +131,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -147,16 +147,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1025,12 +1025,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/packages.lock.json
@@ -146,8 +146,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -162,16 +162,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -969,12 +969,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Privacy.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Notifications.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -766,12 +766,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Tests/packages.lock.json
@@ -69,12 +69,12 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -90,11 +90,11 @@
       "WolverineFx.RuntimeCompilation": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "xunit.runner.visualstudio": {
@@ -151,8 +151,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -167,10 +167,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -187,8 +187,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",

--- a/tests/Granit.Privacy.Vault.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Vault.Tests/packages.lock.json
@@ -104,8 +104,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -120,16 +120,16 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -909,12 +909,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",

--- a/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
@@ -115,8 +115,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -131,10 +131,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -151,8 +151,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1022,12 +1022,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1043,21 +1043,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -142,10 +142,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -162,8 +162,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1025,12 +1025,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1046,21 +1046,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
@@ -17,10 +17,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "Direct",
         "requested": "[14.*, )",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -86,8 +86,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",

--- a/tests/Granit.Timeline.Auditing.Tests/packages.lock.json
+++ b/tests/Granit.Timeline.Auditing.Tests/packages.lock.json
@@ -268,7 +268,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }

--- a/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
@@ -142,16 +142,6 @@
           "Google.Apis.Core": "1.73.0"
         }
       },
-      "Google.Apis.Auth": {
-        "type": "Transitive",
-        "resolved": "1.73.0",
-        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
-        "dependencies": {
-          "Google.Apis": "1.73.0",
-          "Google.Apis.Core": "1.73.0",
-          "System.Management": "7.0.2"
-        }
-      },
       "Google.Apis.Core": {
         "type": "Transitive",
         "resolved": "1.73.0",
@@ -518,6 +508,17 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "Google.Apis.Auth": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
+        "dependencies": {
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
+          "System.Management": "7.0.2"
         }
       },
       "Google.Cloud.Kms.V1": {

--- a/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -145,8 +145,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -1156,12 +1156,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1177,21 +1177,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Encryption.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Encryption.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -145,8 +145,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -978,12 +978,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -999,21 +999,21 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
@@ -221,8 +221,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -237,10 +237,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -257,8 +257,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -884,11 +884,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "6.17.1",
-        "contentHash": "PsjjDe9UsctngMjrvjdZEBS7W+7mF1XDM1e/+PiVM6PtVGJVdYhmBkQvjsvWKeDRm7P/srJgNa1hsrJ2BuhYfw==",
+        "resolved": "6.17.2",
+        "contentHash": "uIo2iBlHhxIe6P99I+47ZfFn85O+pYSKQhq02OP8/Tb/LoNHcVGsYmwjf8MCSvqT3MLb0GWFx/jDnHV0uBMvsg==",
         "dependencies": {
           "Weasel.Core": "9.16.2",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "xunit.analyzers": {
@@ -1332,12 +1332,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1353,44 +1353,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "wEz1wTv3q9YKlYqSoH6/WqsSRAeVtV62itPu4nzG+YFjkrYR8HYB6KD4W/moa3feRQYvIJtKHZD8eUWmdI1oFg==",
+        "resolved": "6.17.2",
+        "contentHash": "qYaGRE8J5bkc+uHP8B7eKbTgWtADv+aqwK4yn0VvUK2mHRW4qhN7JBv63HEnqBkavKbchafLEWgiWSpU3I2jpA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "GJGBhzD+2/+bwhC3HlUeTRhGxv2Rrrf3Qm8NDkfV+DGa8L8DHadm2hf5yf2Xq8J1yUETtkFe20O8U9IGanwSSQ==",
+        "resolved": "6.17.2",
+        "contentHash": "/6RRduPHbbEGjY1zqSW3huEqeOAJdrMIRqLQ/+qYapFLDeaQHFH/WQ/OhsdHCHyaaxmKRa3ZVgNoqqRwc+jfUw==",
         "dependencies": {
           "Weasel.Postgresql": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
@@ -123,8 +123,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -139,10 +139,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -159,8 +159,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -760,11 +760,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "6.17.1",
-        "contentHash": "PsjjDe9UsctngMjrvjdZEBS7W+7mF1XDM1e/+PiVM6PtVGJVdYhmBkQvjsvWKeDRm7P/srJgNa1hsrJ2BuhYfw==",
+        "resolved": "6.17.2",
+        "contentHash": "uIo2iBlHhxIe6P99I+47ZfFn85O+pYSKQhq02OP8/Tb/LoNHcVGsYmwjf8MCSvqT3MLb0GWFx/jDnHV0uBMvsg==",
         "dependencies": {
           "Weasel.Core": "9.16.2",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "xunit.analyzers": {
@@ -1231,12 +1231,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1252,44 +1252,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "wEz1wTv3q9YKlYqSoH6/WqsSRAeVtV62itPu4nzG+YFjkrYR8HYB6KD4W/moa3feRQYvIJtKHZD8eUWmdI1oFg==",
+        "resolved": "6.17.2",
+        "contentHash": "qYaGRE8J5bkc+uHP8B7eKbTgWtADv+aqwK4yn0VvUK2mHRW4qhN7JBv63HEnqBkavKbchafLEWgiWSpU3I2jpA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "GJGBhzD+2/+bwhC3HlUeTRhGxv2Rrrf3Qm8NDkfV+DGa8L8DHadm2hf5yf2Xq8J1yUETtkFe20O8U9IGanwSSQ==",
+        "resolved": "6.17.2",
+        "contentHash": "/6RRduPHbbEGjY1zqSW3huEqeOAJdrMIRqLQ/+qYapFLDeaQHFH/WQ/OhsdHCHyaaxmKRa3ZVgNoqqRwc+jfUw==",
         "dependencies": {
           "Weasel.Postgresql": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
@@ -219,8 +219,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -235,10 +235,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -255,8 +255,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -997,11 +997,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "6.17.1",
-        "contentHash": "PsjjDe9UsctngMjrvjdZEBS7W+7mF1XDM1e/+PiVM6PtVGJVdYhmBkQvjsvWKeDRm7P/srJgNa1hsrJ2BuhYfw==",
+        "resolved": "6.17.2",
+        "contentHash": "uIo2iBlHhxIe6P99I+47ZfFn85O+pYSKQhq02OP8/Tb/LoNHcVGsYmwjf8MCSvqT3MLb0GWFx/jDnHV0uBMvsg==",
         "dependencies": {
           "Weasel.Core": "9.16.2",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "xunit.analyzers": {
@@ -1477,12 +1477,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1498,44 +1498,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "wEz1wTv3q9YKlYqSoH6/WqsSRAeVtV62itPu4nzG+YFjkrYR8HYB6KD4W/moa3feRQYvIJtKHZD8eUWmdI1oFg==",
+        "resolved": "6.17.2",
+        "contentHash": "qYaGRE8J5bkc+uHP8B7eKbTgWtADv+aqwK4yn0VvUK2mHRW4qhN7JBv63HEnqBkavKbchafLEWgiWSpU3I2jpA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "PvV0ys36J363dD/pBd40B9Hc4KDL90FfFzPPMsA0y/N/Qx+ROifctz+B/bnUWhpg7fgsQjjnTxcTlxs5Te2h2w==",
+        "resolved": "6.17.2",
+        "contentHash": "4aAtteJbtCR1199zs+K1FjQeCUscFCywYr74VQB9QZ6FkvJvhGa47u8D5Ua/6Nc2COavMnkNFmSzYBcswQ2rRg==",
         "dependencies": {
           "Weasel.SqlServer": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
@@ -119,8 +119,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -135,10 +135,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -155,8 +155,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -866,11 +866,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "6.17.1",
-        "contentHash": "PsjjDe9UsctngMjrvjdZEBS7W+7mF1XDM1e/+PiVM6PtVGJVdYhmBkQvjsvWKeDRm7P/srJgNa1hsrJ2BuhYfw==",
+        "resolved": "6.17.2",
+        "contentHash": "uIo2iBlHhxIe6P99I+47ZfFn85O+pYSKQhq02OP8/Tb/LoNHcVGsYmwjf8MCSvqT3MLb0GWFx/jDnHV0uBMvsg==",
         "dependencies": {
           "Weasel.Core": "9.16.2",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "xunit.analyzers": {
@@ -1344,12 +1344,12 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
@@ -1365,44 +1365,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "wEz1wTv3q9YKlYqSoH6/WqsSRAeVtV62itPu4nzG+YFjkrYR8HYB6KD4W/moa3feRQYvIJtKHZD8eUWmdI1oFg==",
+        "resolved": "6.17.2",
+        "contentHash": "qYaGRE8J5bkc+uHP8B7eKbTgWtADv+aqwK4yn0VvUK2mHRW4qhN7JBv63HEnqBkavKbchafLEWgiWSpU3I2jpA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "PvV0ys36J363dD/pBd40B9Hc4KDL90FfFzPPMsA0y/N/Qx+ROifctz+B/bnUWhpg7fgsQjjnTxcTlxs5Te2h2w==",
+        "resolved": "6.17.2",
+        "contentHash": "4aAtteJbtCR1199zs+K1FjQeCUscFCywYr74VQB9QZ6FkvJvhGa47u8D5Ua/6Nc2COavMnkNFmSzYBcswQ2rRg==",
         "dependencies": {
           "Weasel.SqlServer": "9.16.2",
-          "WolverineFx.RDBMS": "6.17.1"
+          "WolverineFx.RDBMS": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Tests/packages.lock.json
@@ -115,8 +115,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "fR2IEkvTDLdBpsaqC4ZnGK8+EbAZ6SY6c0cS8aZrw665uIfOE4CT3z6xKfO1+kCQWBa9p4Jgx66a/dO8a+NCAg==",
+        "resolved": "2.27.0",
+        "contentHash": "bn2W7Rx70sbIUHx0GqJjKQ9cWSeArax3/sZpTRvyRcJ5Vg05filu6qIctLrXLX9wsqPCjcNWGav1C8NyUVq0hw==",
         "dependencies": {
           "FastExpressionCompiler": "5.4.1",
           "ImTools": "4.0.0",
@@ -127,10 +127,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "ZBFGM+aAJZQTMb6j4n7gP4on3s53yY0aywMr4Ll2bAqcuaA4k/4bHEhwKh6EuPr4b1IdSzVut0vlsC7bmMJG7A==",
+        "resolved": "2.27.0",
+        "contentHash": "uzRv0lDYcYqMrndcYsG2eIW2SzMTXhZMHMrg7w2U97hva8svp1GLc8CRAyWBZuKFbDEInBvlj1JDx1wEy/GNuA==",
         "dependencies": {
-          "JasperFx": "2.24.1"
+          "JasperFx": "2.27.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -146,8 +146,8 @@
       },
       "JasperFx.SourceGenerator": {
         "type": "Transitive",
-        "resolved": "2.24.1",
-        "contentHash": "KTx1uOQwFlda/fTvj1cI++546IIroTe04I1bLTvq/i8lXHEGwVTbRdBQgc1aCiZInAWU9rWZoP7g2FiQhbKMDA=="
+        "resolved": "2.27.0",
+        "contentHash": "d8/kEfqPR0EXRWEZS56oiVHsAAsUWNt8VpxVw6/RFVkhMQHPBMYdy7QaTLYuDBfGtj6ubJjFld3tpeMZf5lBeQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -631,33 +631,33 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "ujWv3tTyd8W5GsYiJuOX490387SpYMy8vnm8UB2NnpKXa0EnDTIW+Tk0Fpdf2O1Njk1y5N4Za/jUDfzJMiGj/Q==",
+        "resolved": "6.17.2",
+        "contentHash": "50n1ObhnfCyy2/nJfJSCYFjcs6RsVbtjpT5uzS7ZjnruQo+JRJeLhpsuF5ovR0R53MAS6wGrbJcs0xPWjj3bhA==",
         "dependencies": {
-          "JasperFx": "2.24.1",
-          "JasperFx.Events": "2.24.1",
-          "JasperFx.SourceGenerator": "2.24.1",
+          "JasperFx": "2.27.0",
+          "JasperFx.Events": "2.27.0",
+          "JasperFx.SourceGenerator": "2.27.0",
           "NewId": "4.0.1"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "WKO/wubLDc6HTU6KCWl0tOdP3N+7oioYMqGjJcT1RbySUSdswIJmsVXuvVUIAULEYPEP/xQKRS5EhE0+443e1w==",
+        "resolved": "6.17.2",
+        "contentHash": "xNVZg/LPiA4gfaTirBv8zIH5iUQGx9qcXjFKm+O1JhuAwVD2UNyMKcAlCQQjwpGZqY9bJqIhuYk2SewJkShBPw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "WolverineFx.RuntimeCompilation": {
         "type": "CentralTransitive",
         "requested": "[6.*, )",
-        "resolved": "6.17.1",
-        "contentHash": "hzTYm3+CBV//X3BoSVi0/GyweY2+odax5glThL8x2IdaQAz8GhTuKy0NFDub7xrttIfXFGgKBOkjg/xHMsin/g==",
+        "resolved": "6.17.2",
+        "contentHash": "A58hlYXYpIYkKhNTmkTIiM92brGnq/u93M5/snpkrFE8GDlFPpeEUha8rS9+RuR+XjW3P0aG8fYEZlKGes9Q9Q==",
         "dependencies": {
           "JasperFx.RuntimeCompiler": "5.0.0",
-          "WolverineFx": "6.17.1"
+          "WolverineFx": "6.17.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Workflow.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Workflow.Notifications.Tests/packages.lock.json
@@ -296,7 +296,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }


### PR DESCRIPTION
Closes #2958 (part of epic #2957 — notifications family overhaul, phase 0 of 8).

## What

Ten independent blocking fixes from the 2026-07-12 notifications audit — no restructuring, each independently reviewable:

| # | Fix | Severity |
|---|-----|----------|
| 1 | **GoogleFcm authenticates** — OAuth2 service-account `DelegatingHandler` (Google.Apis.Auth, scope `firebase.messaging`), token cached with 5-min expiry margin (`IClock`), **single-flight refresh** (`SemaphoreSlim`: N concurrent sends ⇒ 1 mint, test-proven with 25 concurrent callers), 401 ⇒ invalidate + retry once. Previously **no Authorization header was ever sent** — the provider could not deliver at all. | BREAKING |
| 2 | `MobilePushChannelOptions.Provider` default `"Fcm"` → `"GoogleFcm"` (phantom keyed-service key threw at first send) | BREAKING |
| 3 | SignalR Redis backplane honored from options: delegate probe + new `IConfiguration` overload (`Notifications:SignalR:RedisConnectionString` was silently ignored) | ARCHITECTURE |
| 4 | ACS email health check rewritten as **non-mutating** config probe — it used to send a real email per readiness probe and report `Healthy` on `RequestFailedException` | ARCHITECTURE |
| 5 | GDPR deletion ack carries the **real** deleted row count (`INotificationsPersonalDataEraser` → `Task<int>`); `AffectedRecords` was hardcoded `0` | ARCHITECTURE |
| 6 | Device token moved from `DELETE /tokens/{deviceToken}` route segment to the request body (push credential leaked into access/proxy logs; mirrors the WebPush pattern) | ARCHITECTURE (security) |
| 7 | **Culture bug**: email channel falls back to `recipient.PreferredCulture` — publishers never set trigger `Culture`, so the 18-culture localized templates were dead code. Explicit trigger `Culture` stays an override (deliberately NOT stamping server-ambient culture into triggers, which would defeat per-recipient localization) | BREAKING (localization) |
| 8 | WebPush unsubscribe scoped by `(user, endpoint, tenant)` — least privilege | LOW (security) |
| 9 | `Notifications.AI`: `Data` payload no longer forwarded to the LLM unless `AllowPersonalDataInPrompts=true` (GDPR opt-in) + README warning + effective options validation (`[Range]`, `ValidateDataAnnotations().ValidateOnStart()`) | ARCHITECTURE (GDPR) |
| 10 | Twilio bare `catch { }` typed | CONVENTION |

## Breaking API changes (pre-1.0, per epic decision)

- `INotificationsPersonalDataEraser.EraseUserDataAsync` returns `Task<int>`
- `IWebPushSubscriptionWriter.RemoveSubscriptionAsync` gains a leading `userId` parameter (compiler-checked: arity change, no silent positional misuse)
- `DELETE /notifications/mobile-push/tokens/{deviceToken}` → `DELETE /notifications/mobile-push/tokens` with JSON body (`MobilePushTokenRemoveRequest`)
- `GoogleFcmOptions.ServiceAccountJson` is now actually consumed (was dead config)

## Dependencies

- New: `Google.Apis.Auth` 1.75.0 (Apache-2.0) — THIRD-PARTY-NOTICES updated (+ fixed the stale FirebaseAdmin consumer reference)

## Verification

- `dotnet restore notifications.slnf --locked-mode` ✓ (CI parity, no NU1004)
- `dotnet build notifications.slnf` — 0 warnings, 0 errors
- `dotnet test notifications.slnf` — all projects green (incl. 8 new FCM auth tests, single-flight concurrency test, culture-fallback tests, `AffectedRecords` propagation test, cross-user WebPush isolation test, 422 body-validation test)
- `dotnet format notifications.slnf --verify-no-changes` ✓ ; markdownlint ✓

Docs-site updates (endpoint route change, FCM configuration) ship separately in granit-docs per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)