### PR TITLE
feat(notifications): phase 1a — shared provider tooling and ProviderConventionTests

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18781,7 +18781,7 @@
       "kind": "class",
       "project": "Granit",
       "file": "src/Granit/Diagnostics/LogRedaction.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "Email",
@@ -22133,6 +22133,15 @@
           "returnType": "Task<IHostApplicationBuilder>"
         }
       ]
+    },
+    {
+      "name": "GranitProviderOptionsServiceCollectionExtensions",
+      "fqn": "Granit.Extensions.GranitProviderOptionsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/Extensions/GranitProviderOptionsServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": []
     },
     {
       "name": "FeatureCacheInvalidationHandler",
@@ -26217,6 +26226,22 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpResponseMessageExtensions",
+      "fqn": "Granit.Http.Resilience.Extensions.GranitHttpResponseMessageExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Resilience",
+      "file": "src/Granit.Http.Resilience/Extensions/GranitHttpResponseMessageExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "EnsureGranitSuccessAsync",
+          "kind": "method",
+          "signature": "EnsureGranitSuccessAsync(this HttpResponseMessage response, ILogger logger, string providerName, string? endpoint = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
         }
       ]
     },

--- a/src/Granit.Http.Resilience/Extensions/GranitHttpResponseMessageExtensions.cs
+++ b/src/Granit.Http.Resilience/Extensions/GranitHttpResponseMessageExtensions.cs
@@ -1,0 +1,68 @@
+using Granit.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Http.Resilience.Extensions;
+
+/// <summary>
+/// Shared success-guard for HTTP-based provider senders (SendGrid, Scaleway, Brevo,
+/// Twilio, Zulip…): reads the error body best-effort, logs it <b>scrubbed</b> (vendor
+/// error payloads routinely echo the recipient or message content back), and throws an
+/// <see cref="HttpRequestException"/> carrying the status code but never the body —
+/// exception messages end up in delivery audit rows and upstream logs.
+/// </summary>
+public static partial class GranitHttpResponseMessageExtensions
+{
+    /// <summary>
+    /// Throws an <see cref="HttpRequestException"/> when <paramref name="response"/> is not
+    /// a success status, after logging the scrubbed error body at Warning.
+    /// </summary>
+    /// <param name="response">The provider HTTP response to check.</param>
+    /// <param name="logger">Logger of the calling sender.</param>
+    /// <param name="providerName">Human-readable provider name for the log/exception ("SendGrid").</param>
+    /// <param name="endpoint">Optional endpoint label to disambiguate multi-endpoint providers.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task EnsureGranitSuccessAsync(
+        this HttpResponseMessage response,
+        ILogger logger,
+        string providerName,
+        string? endpoint = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        string? errorBody = null;
+        try
+        {
+            errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Best-effort — never mask the original HTTP error with a body-read failure.
+        }
+
+        LogProviderApiError(
+            logger,
+            providerName,
+            endpoint ?? "(default)",
+            (int)response.StatusCode,
+            errorBody is null ? "(no body)" : LogRedaction.Scrub(errorBody));
+
+        throw new HttpRequestException(
+            endpoint is null
+                ? $"{providerName} API error {(int)response.StatusCode}"
+                : $"{providerName} API error {(int)response.StatusCode} on {endpoint}",
+            inner: null,
+            response.StatusCode);
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{ProviderName} API error on {Endpoint}: HTTP {StatusCode} — {ScrubbedErrorBody}")]
+    private static partial void LogProviderApiError(
+        ILogger logger, string providerName, string endpoint, int statusCode, string scrubbedErrorBody);
+}

--- a/src/Granit/Diagnostics/LogRedaction.cs
+++ b/src/Granit/Diagnostics/LogRedaction.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Granit.Diagnostics;
 
@@ -8,9 +9,12 @@ namespace Granit.Diagnostics;
 /// Use these methods to prevent sensitive data (email, phone, IP, device tokens)
 /// from reaching observability backends (GDPR Art. 5, ISO 27001 A.5.34).
 /// </summary>
-public static class LogRedaction
+public static partial class LogRedaction
 {
     private const string Mask = "***";
+
+    /// <summary>Ceiling applied by <see cref="Scrub"/> so a huge vendor payload cannot flood a log line.</summary>
+    private const int ScrubMaxLength = 2000;
 
     /// <summary>
     /// Redacts an email address, preserving a prefix and the domain for debugging.
@@ -123,4 +127,29 @@ public static class LogRedaction
         byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
         return Convert.ToHexStringLower(hash.AsSpan(0, 4));
     }
+
+    /// <summary>
+    /// Scrubs free-form text (typically a provider error-response body) before logging:
+    /// email addresses and phone-like digit sequences are masked, and the result is
+    /// truncated to a bounded length. Use for third-party payloads that may echo the
+    /// recipient or message content back on the error path.
+    /// <example><c>{"to":"john@example.com"}</c> → <c>{"to":"joh***@example.com"}</c></example>
+    /// </summary>
+    public static string Scrub(string text)
+    {
+        string scrubbed = EmailPattern().Replace(text, m => Email(m.Value));
+        scrubbed = PhoneLikePattern().Replace(scrubbed, m => Phone(m.Value));
+
+        return scrubbed.Length <= ScrubMaxLength
+            ? scrubbed
+            : $"{scrubbed.AsSpan(0, ScrubMaxLength)}… [truncated {scrubbed.Length - ScrubMaxLength} chars]";
+    }
+
+    [GeneratedRegex(@"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 250)]
+    private static partial Regex EmailPattern();
+
+    // 7+ digit runs, optionally +-prefixed and separated by spaces/dots/dashes/parens —
+    // catches E.164 and most national phone formats without eating short numeric ids.
+    [GeneratedRegex(@"\+?\d(?:[\s().-]?\d){6,}", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 250)]
+    private static partial Regex PhoneLikePattern();
 }

--- a/src/Granit/Extensions/GranitProviderOptionsServiceCollectionExtensions.cs
+++ b/src/Granit/Extensions/GranitProviderOptionsServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Extensions;
+
+/// <summary>
+/// Canonical options registration for Granit provider packages (notification channel
+/// providers, vault backends, storage providers…): one call wires configuration binding,
+/// DataAnnotations validation and fail-fast startup validation identically everywhere.
+/// </summary>
+/// <remarks>
+/// Rule of thumb: express simple constraints as DataAnnotations on the options POCO
+/// (<c>[Required]</c>, <c>[Range]</c>, <c>[Url]</c>…) and reserve a hand-written
+/// <see cref="IValidateOptions{TOptions}"/> for cross-field rules DataAnnotations cannot
+/// express — registered through the two-type-parameter overload so both run at startup.
+/// </remarks>
+public static class GranitProviderOptionsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <typeparamref name="TOptions"/> bound to <paramref name="sectionName"/>,
+    /// with <c>ValidateDataAnnotations()</c> and <c>ValidateOnStart()</c> — the mandatory
+    /// provider triad. Returns the builder for further chaining.
+    /// </summary>
+    public static OptionsBuilder<TOptions> AddGranitProviderOptions<TOptions>(
+        this IServiceCollection services,
+        string sectionName)
+        where TOptions : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sectionName);
+
+        return services.AddOptions<TOptions>()
+            .BindConfiguration(sectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+    }
+
+    /// <summary>
+    /// Same as <see cref="AddGranitProviderOptions{TOptions}"/>, additionally registering
+    /// <typeparamref name="TValidator"/> for cross-field rules that DataAnnotations cannot
+    /// express. The validator participates in <c>ValidateOnStart()</c>.
+    /// </summary>
+    public static OptionsBuilder<TOptions> AddGranitProviderOptions<TOptions, TValidator>(
+        this IServiceCollection services,
+        string sectionName)
+        where TOptions : class
+        where TValidator : class, IValidateOptions<TOptions>
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IValidateOptions<TOptions>, TValidator>();
+        return services.AddGranitProviderOptions<TOptions>(sectionName);
+    }
+}

--- a/tests/Granit.ArchitectureTests/ProviderConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ProviderConventionTests.cs
@@ -1,0 +1,341 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Granit.Modularity;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Locks the canonical notification-provider template (reference implementation:
+/// <c>Granit.Notifications.MobilePush.AwsSns</c>). A provider package — any
+/// <c>Granit.Notifications.*</c> assembly implementing a channel <c>I*Sender</c>
+/// interface — must ship:
+/// <list type="bullet">
+///   <item>an options class with a <c>public const string SectionName</c>;</item>
+///   <item>effective options validation (<c>AddGranitProviderOptions</c>, or
+///         <c>ValidateDataAnnotations()</c>, or an <c>IValidateOptions&lt;&gt;</c>);</item>
+///   <item>a <c>SectionName</c> assertion in its test project (renames must surface in CI);</item>
+///   <item>a registered <c>*ActivitySource</c>;</item>
+///   <item>a health check;</item>
+///   <item>a self-registering module (<c>ConfigureServices</c> override) whose
+///         <c>[DependsOn]</c> covers every direct project reference carrying a module;</item>
+///   <item>a top-level package name — providers never nest under a channel
+///         (<c>Granit.Notifications.Twilio</c>, not <c>Granit.Notifications.Sms.Twilio</c>).</item>
+/// </list>
+/// Grandfathered violations live in <see cref="ProviderExemptions"/> with one justification
+/// per entry; the stale-exemption fact guarantees the list only shrinks.
+/// </summary>
+public sealed partial class ProviderConventionTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    // Lazy: static initializers run in textual order, and discovery depends on
+    // LoadedGranitAssemblies declared further down the file.
+    private static readonly Lazy<List<Assembly>> DiscoveredProviders = new(DiscoverProviderAssemblies);
+
+    private static List<Assembly> ProviderAssemblies => DiscoveredProviders.Value;
+
+    // ── Facts ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Providers_are_discovered() =>
+        // Guards the discovery mechanism itself: if the sender-interface heuristic breaks,
+        // every other fact would silently pass on an empty set.
+        ProviderAssemblies.Count.ShouldBeGreaterThanOrEqualTo(10);
+
+    [Fact]
+    public void Provider_packages_declare_options_with_SectionName() =>
+        AssertCompliant(FailingOptionsDeclaration(), exemptions: EmptyExemptions, "declare an options class with 'public const string SectionName'");
+
+    [Fact]
+    public void Provider_modules_self_register_in_ConfigureServices() =>
+        AssertCompliant(FailingSelfRegistration(), ProviderExemptions.SelfRegistrationPending, "override ConfigureServices in the module to self-register the provider");
+
+    [Fact]
+    public void Provider_packages_register_an_ActivitySource() =>
+        AssertCompliant(FailingActivitySource(), ProviderExemptions.ActivitySourcePending, "ship an 'internal static *ActivitySource' with a Name const, registered via GranitActivitySourceRegistry");
+
+    [Fact]
+    public void Provider_packages_ship_a_health_check() =>
+        AssertCompliant(FailingHealthCheck(), ProviderExemptions.HealthCheckPending, "ship an IHealthCheck implementation (non-mutating probe)");
+
+    [Fact]
+    public void Provider_packages_do_not_nest_under_a_channel() =>
+        AssertCompliant(FailingPlacement(), ProviderExemptions.PlacementPending, "live at the top level (Granit.Notifications.{Provider}) as a capability implementer");
+
+    [Fact]
+    public void Provider_options_validation_is_effective() =>
+        AssertCompliant(FailingValidation(), ProviderExemptions.ValidationPending, "use AddGranitProviderOptions (or ValidateDataAnnotations / IValidateOptions) so ValidateOnStart actually validates");
+
+    [Fact]
+    public void Provider_options_SectionName_is_asserted_in_tests() =>
+        AssertCompliant(FailingSectionNameTest(), ProviderExemptions.SectionNameTestPending, "add an options test asserting SectionName.ShouldBe(\"…\")");
+
+    [Fact]
+    public void Provider_module_DependsOn_covers_direct_module_references() =>
+        AssertCompliant(FailingDependsOn().Keys, ProviderExemptions.DependsOnPending, "declare every direct project reference that carries a *Module in [DependsOn]",
+            details: FailingDependsOn());
+
+    [Fact]
+    public void Exemption_lists_contain_no_stale_entries()
+    {
+        List<string> stale = [];
+
+        CollectStale(stale, nameof(ProviderExemptions.SelfRegistrationPending), ProviderExemptions.SelfRegistrationPending, FailingSelfRegistration());
+        CollectStale(stale, nameof(ProviderExemptions.ActivitySourcePending), ProviderExemptions.ActivitySourcePending, FailingActivitySource());
+        CollectStale(stale, nameof(ProviderExemptions.HealthCheckPending), ProviderExemptions.HealthCheckPending, FailingHealthCheck());
+        CollectStale(stale, nameof(ProviderExemptions.PlacementPending), ProviderExemptions.PlacementPending, FailingPlacement());
+        CollectStale(stale, nameof(ProviderExemptions.ValidationPending), ProviderExemptions.ValidationPending, FailingValidation());
+        CollectStale(stale, nameof(ProviderExemptions.SectionNameTestPending), ProviderExemptions.SectionNameTestPending, FailingSectionNameTest());
+        CollectStale(stale, nameof(ProviderExemptions.DependsOnPending), ProviderExemptions.DependsOnPending, FailingDependsOn().Keys);
+
+        stale.ShouldBeEmpty(
+            "These exemption entries are no longer failing (or no longer providers) — remove them from ProviderExemptions so the backlog stays honest.");
+    }
+
+    // ── Checks ───────────────────────────────────────────────────────────────
+
+    private static List<string> FailingOptionsDeclaration() =>
+        FailingProviders(assembly => GetLoadableTypes(assembly).Any(t =>
+            t.Name.EndsWith("Options", StringComparison.Ordinal)
+            && t.GetField("SectionName", BindingFlags.Public | BindingFlags.Static)?.IsLiteral == true));
+
+    private static List<string> FailingSelfRegistration() =>
+        FailingProviders(assembly =>
+        {
+            Type? module = FindModuleType(assembly);
+            return module?.GetMethod("ConfigureServices", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly) is not null;
+        });
+
+    private static List<string> FailingActivitySource() =>
+        FailingProviders(assembly => GetLoadableTypes(assembly).Any(t =>
+            t.Name.EndsWith("ActivitySource", StringComparison.Ordinal)
+            && t.IsAbstract && t.IsSealed // static class
+            && t.GetField("Name", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)?.IsLiteral == true));
+
+    private static List<string> FailingHealthCheck() =>
+        FailingProviders(assembly => GetLoadableTypes(assembly).Any(t =>
+            !t.IsAbstract && t.GetInterfaces().Any(i =>
+                i.FullName == "Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck")));
+
+    private static List<string> FailingPlacement() =>
+        FailingProviders(assembly =>
+        {
+            // Compliant: Granit.Notifications.{Provider} — exactly one segment after "Notifications".
+            string name = assembly.GetName().Name!;
+            return NestedProviderName().Count(name) == 0;
+        });
+
+    private static List<string> FailingValidation() =>
+        FailingProviders(assembly =>
+        {
+            string srcDir = Path.Join(RepoRoot, "src", assembly.GetName().Name);
+            if (!Directory.Exists(srcDir))
+            {
+                return true; // no source (external?) — nothing to check
+            }
+
+            bool usesHelper = false, usesDataAnnotations = false, hasValidator = false;
+            foreach (string file in EnumerateSourceFiles(srcDir))
+            {
+                string content = File.ReadAllText(file);
+                usesHelper |= content.Contains("AddGranitProviderOptions", StringComparison.Ordinal);
+                usesDataAnnotations |= content.Contains("ValidateDataAnnotations()", StringComparison.Ordinal);
+                hasValidator |= content.Contains("IValidateOptions<", StringComparison.Ordinal);
+            }
+
+            return usesHelper || usesDataAnnotations || hasValidator;
+        });
+
+    private static List<string> FailingSectionNameTest() =>
+        FailingProviders(assembly =>
+        {
+            string testsDir = Path.Join(RepoRoot, "tests", assembly.GetName().Name! + ".Tests");
+            return Directory.Exists(testsDir)
+                && EnumerateSourceFiles(testsDir).Any(file =>
+                    File.ReadLines(file).Any(line =>
+                        line.Contains("SectionName", StringComparison.Ordinal)
+                        && line.Contains("ShouldBe", StringComparison.Ordinal)));
+        });
+
+    private static Dictionary<string, string> FailingDependsOn()
+    {
+        var failures = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (Assembly assembly in ProviderAssemblies)
+        {
+            string name = assembly.GetName().Name!;
+            Type? module = FindModuleType(assembly);
+            if (module is null)
+            {
+                failures[name] = "no GranitModule subclass found";
+                continue;
+            }
+
+            var declared = module
+                .GetCustomAttributes<DependsOnAttribute>()
+                .SelectMany(a => a.DependedTypes)
+                .Select(t => t.Name)
+                .ToHashSet(StringComparer.Ordinal);
+
+            List<string> missing = [];
+            foreach (string referencedProject in ReadDirectProjectReferences(name))
+            {
+                if (referencedProject is "Granit")
+                {
+                    continue; // implicit base — never declared
+                }
+
+                Type? referencedModule = LoadedGranitAssemblies.Value
+                    .FirstOrDefault(a => a.GetName().Name == referencedProject) is { } refAssembly
+                        ? FindModuleType(refAssembly)
+                        : null;
+
+                if (referencedModule is not null && !declared.Contains(referencedModule.Name))
+                {
+                    missing.Add(referencedModule.Name);
+                }
+            }
+
+            if (missing.Count > 0)
+            {
+                failures[name] = $"missing [DependsOn]: {string.Join(", ", missing)}";
+            }
+        }
+
+        return failures;
+    }
+
+    // ── Discovery & plumbing ─────────────────────────────────────────────────
+
+    private static readonly Lazy<List<Assembly>> LoadedGranitAssemblies = new(() =>
+    {
+        string outputDir = Path.GetDirectoryName(typeof(ProviderConventionTests).Assembly.Location)!;
+        List<Assembly> loaded = [];
+        foreach (string path in Directory.GetFiles(outputDir, "Granit.*.dll"))
+        {
+            try
+            {
+                loaded.Add(Assembly.LoadFrom(path));
+            }
+            catch (BadImageFormatException)
+            {
+                // Native/satellite artifacts — not managed Granit assemblies.
+            }
+        }
+
+        return loaded;
+    });
+
+    private static List<Assembly> DiscoverProviderAssemblies()
+    {
+        var notificationAssemblies = LoadedGranitAssemblies.Value
+            .Where(a => a.GetName().Name!.StartsWith("Granit.Notifications", StringComparison.Ordinal))
+            .ToList();
+
+        // Channel sender contracts: interfaces named I{X}Sender defined in the family.
+        var senderInterfaces = notificationAssemblies
+            .SelectMany(GetLoadableTypes)
+            .Where(t => t.IsInterface && SenderInterfaceName().IsMatch(t.Name))
+            .ToHashSet();
+
+        return notificationAssemblies
+            .Where(a => GetLoadableTypes(a).Any(t =>
+                t is { IsClass: true, IsAbstract: false }
+                && t.GetInterfaces().Any(senderInterfaces.Contains)))
+            .OrderBy(a => a.GetName().Name, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static List<string> FailingProviders(Func<Assembly, bool> passes) =>
+        ProviderAssemblies
+            .Where(a => !passes(a))
+            .Select(a => a.GetName().Name!)
+            .ToList();
+
+    private static readonly HashSet<string> EmptyExemptions = new(StringComparer.Ordinal);
+
+    private static void AssertCompliant(
+        IReadOnlyCollection<string> failing,
+        HashSet<string> exemptions,
+        string requirement,
+        Dictionary<string, string>? details = null)
+    {
+        var violations = failing
+            .Where(name => !exemptions.Contains(name))
+            .Select(name => details is not null && details.TryGetValue(name, out string? d) ? $"{name} — {d}" : name)
+            .ToList();
+
+        violations.ShouldBeEmpty(
+            $"Every notification provider package must {requirement}. "
+            + "Fix the provider or add a justified entry to ProviderExemptions (with its removal issue).");
+    }
+
+    private static void CollectStale(
+        List<string> stale, string listName, HashSet<string> exemptions, IReadOnlyCollection<string> currentlyFailing)
+    {
+        foreach (string entry in exemptions.Where(e => !currentlyFailing.Contains(e)))
+        {
+            stale.Add($"{listName}: {entry}");
+        }
+    }
+
+    private static Type? FindModuleType(Assembly assembly) =>
+        GetLoadableTypes(assembly).FirstOrDefault(t =>
+            t is { IsClass: true, IsAbstract: false } && typeof(GranitModule).IsAssignableFrom(t));
+
+    private static List<string> ReadDirectProjectReferences(string projectName)
+    {
+        string csproj = Path.Join(RepoRoot, "src", projectName, projectName + ".csproj");
+        if (!File.Exists(csproj))
+        {
+            return [];
+        }
+
+        return XDocument.Load(csproj)
+            .Descendants("ProjectReference")
+            .Select(e => Path.GetFileNameWithoutExtension(e.Attribute("Include")!.Value.Replace('\\', '/')))
+            .ToList();
+    }
+
+    private static IEnumerable<string> EnumerateSourceFiles(string dir) =>
+        Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static Type[] GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return [.. ex.Types.Where(t => t is not null)!];
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(ProviderConventionTests).Assembly.Location);
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Join(dir, ".git")) || File.Exists(Path.Join(dir, ".git")))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    [GeneratedRegex(@"^I\w+Sender$")]
+    private static partial Regex SenderInterfaceName();
+
+    [GeneratedRegex(@"^Granit\.Notifications\.(Sms|Email|MobilePush|WebPush|WhatsApp)\..+$")]
+    private static partial Regex NestedProviderName();
+}

--- a/tests/Granit.ArchitectureTests/ProviderExemptions.cs
+++ b/tests/Granit.ArchitectureTests/ProviderExemptions.cs
@@ -1,0 +1,77 @@
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Grandfathered violations of the notification-provider template
+/// (<see cref="ProviderConventionTests"/>). Every entry MUST carry an inline justification
+/// and its removal issue. A companion fact fails when an entry stops being necessary, so
+/// this list can only shrink (honest-backlog pattern, cf. ValidationKeyConventionTests).
+/// </summary>
+internal static class ProviderExemptions
+{
+    /// <summary>Provider modules not yet self-registering in <c>ConfigureServices</c> — phase 1b (#2961).</summary>
+    public static readonly HashSet<string> SelfRegistrationPending = new(StringComparer.Ordinal)
+    {
+        "Granit.Notifications.Brevo",                 // empty-bodied module; manual AddGranitNotificationsBrevo() required
+        "Granit.Notifications.Email.Smtp",            // empty-bodied module — trap: EmailChannelOptions.Provider defaults to "Smtp"
+        "Granit.Notifications.MobilePush.GoogleFcm",  // empty-bodied module; manual AddGranitNotificationsMobilePushGoogleFcm() required
+        "Granit.Notifications.Twilio",                // empty-bodied module
+        "Granit.Notifications.Zulip",                 // empty-bodied module
+    };
+
+    /// <summary>Providers without a registered ActivitySource — phase 1b (#2961).</summary>
+    public static readonly HashSet<string> ActivitySourcePending = new(StringComparer.Ordinal)
+    {
+        "Granit.Notifications.Brevo",                 // no OTel spans on send
+        "Granit.Notifications.Email.Smtp",            // no OTel spans on send
+        "Granit.Notifications.MobilePush.GoogleFcm",  // no OTel spans on send
+        "Granit.Notifications.Twilio",                // no OTel spans on send
+        "Granit.Notifications.Zulip",                 // no OTel spans on send
+    };
+
+    /// <summary>Providers without a health check — phase 1b (#2961).</summary>
+    public static readonly HashSet<string> HealthCheckPending = new(StringComparer.Ordinal)
+    {
+        "Granit.Notifications.MobilePush.GoogleFcm",  // only mobile-push provider without one (AwsSns/Anh have config probes)
+    };
+
+    /// <summary>Providers still nested under a channel package — renamed/merged in phase 2 (#2960).</summary>
+    public static readonly HashSet<string> PlacementPending = new(StringComparer.Ordinal)
+    {
+        "Granit.Notifications.Email.AwsSes",                          // → Granit.Notifications.AwsSes
+        "Granit.Notifications.Email.AzureCommunicationServices",      // → merged into Granit.Notifications.AzureCommunicationServices
+        "Granit.Notifications.Email.Scaleway",                        // → Granit.Notifications.Scaleway
+        "Granit.Notifications.Email.SendGrid",                        // → Granit.Notifications.SendGrid
+        "Granit.Notifications.Email.Smtp",                            // → Granit.Notifications.Smtp
+        "Granit.Notifications.MobilePush.AwsSns",                     // → merged into Granit.Notifications.AwsSns
+        "Granit.Notifications.MobilePush.AzureNotificationHubs",      // → Granit.Notifications.AzureNotificationHubs
+        "Granit.Notifications.MobilePush.GoogleFcm",                  // → Granit.Notifications.GoogleFcm
+        "Granit.Notifications.Sms.AwsSns",                            // → merged into Granit.Notifications.AwsSns
+        "Granit.Notifications.Sms.AzureCommunicationServices",        // → merged into Granit.Notifications.AzureCommunicationServices
+    };
+
+    /// <summary>Providers whose options validation is a no-op — phase 1b (#2961).</summary>
+    public static readonly HashSet<string> ValidationPending = new(StringComparer.Ordinal)
+    {
+        "Granit.Notifications.Email.Smtp",  // ValidateOnStart() without ValidateDataAnnotations() and no IValidateOptions
+    };
+
+    /// <summary>Providers without a SectionName assertion test — phase 1b (#2961).</summary>
+    public static readonly HashSet<string> SectionNameTestPending = new(StringComparer.Ordinal)
+    {
+        "Granit.Notifications.Email.AwsSes",                      // only *OptionsValidatorTests exist
+        "Granit.Notifications.Email.AzureCommunicationServices",  // only *OptionsValidatorTests exist
+        "Granit.Notifications.MobilePush.AwsSns",                 // no options test asserting the section path
+        "Granit.Notifications.Sms.AwsSns",                        // no options test asserting the section path
+        "Granit.Notifications.Sms.AzureCommunicationServices",    // no options test asserting the section path
+    };
+
+    /// <summary>Providers whose module [DependsOn] omits direct module references — phase 1b (#2961).</summary>
+    public static readonly HashSet<string> DependsOnPending = new(StringComparer.Ordinal)
+    {
+        "Granit.Notifications.Brevo",           // missing GranitDiagnosticsModule (direct ref via HttpServiceHealthCheckBase)
+        "Granit.Notifications.Email.Scaleway",  // missing GranitDiagnosticsModule
+        "Granit.Notifications.Email.SendGrid",  // missing GranitDiagnosticsModule
+        "Granit.Notifications.Twilio",          // missing GranitDiagnosticsModule
+        "Granit.Notifications.Zulip",           // missing GranitDiagnosticsModule
+    };
+}

--- a/tests/Granit.Http.Resilience.Tests/GranitHttpResponseMessageExtensionsTests.cs
+++ b/tests/Granit.Http.Resilience.Tests/GranitHttpResponseMessageExtensionsTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Text;
+using Granit.Http.Resilience.Extensions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Resilience.Tests;
+
+public sealed class GranitHttpResponseMessageExtensionsTests
+{
+    private readonly ILogger _logger = Substitute.For<ILogger>();
+
+    [Fact]
+    public async Task SuccessResponse_DoesNothing()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.OK);
+
+        await Should.NotThrowAsync(() => response.EnsureGranitSuccessAsync(
+            _logger, "SendGrid", cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ErrorResponse_ThrowsWithStatusAndProvider_ButNeverTheBody()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("""{"error":"invalid recipient john.doe@example.com"}""", Encoding.UTF8),
+        };
+
+        HttpRequestException ex = await Should.ThrowAsync<HttpRequestException>(
+            () => response.EnsureGranitSuccessAsync(
+                _logger, "SendGrid", "/v3/mail/send", TestContext.Current.CancellationToken));
+
+        ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        ex.Message.ShouldContain("SendGrid API error 400 on /v3/mail/send");
+        // The body may echo the recipient — it must never travel in the exception message
+        // (exception messages end up in delivery audit rows and upstream logs).
+        ex.Message.ShouldNotContain("john.doe@example.com");
+        ex.Message.ShouldNotContain("invalid recipient");
+    }
+
+    [Fact]
+    public async Task ErrorResponse_LogsScrubbedBodyAtWarning()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.UnprocessableEntity)
+        {
+            Content = new StringContent("""{"to":"jane.doe@customer.org","detail":"blocked"}""", Encoding.UTF8),
+        };
+
+        RecordingLogger recorder = new();
+
+        await Should.ThrowAsync<HttpRequestException>(
+            () => response.EnsureGranitSuccessAsync(
+                recorder, "Brevo", cancellationToken: TestContext.Current.CancellationToken));
+
+        (LogLevel level, string message) = recorder.Entries.ShouldHaveSingleItem();
+        level.ShouldBe(LogLevel.Warning);
+        message.ShouldNotContain("jane.doe@customer.org"); // scrubbed
+        message.ShouldContain("@customer.org");            // domain kept for debugging
+        message.ShouldContain("blocked");                  // diagnostic content preserved
+    }
+
+    /// <summary>[LoggerMessage] guards on IsEnabled, so a plain substitute records nothing.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    [Fact]
+    public async Task ErrorResponse_WithoutEndpoint_OmitsEndpointFromMessage()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.InternalServerError);
+
+        HttpRequestException ex = await Should.ThrowAsync<HttpRequestException>(
+            () => response.EnsureGranitSuccessAsync(
+                _logger, "Zulip", cancellationToken: TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldBe("Zulip API error 500");
+    }
+}

--- a/tests/Granit.Tests/Diagnostics/LogRedactionTests.cs
+++ b/tests/Granit.Tests/Diagnostics/LogRedactionTests.cs
@@ -212,6 +212,54 @@ public sealed class LogRedactionTests
     }
 
     // -------------------------------------------------------------------------
+    // Scrub — free-form provider error bodies
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Scrub_MasksEmailAddressesInText()
+    {
+        string scrubbed = LogRedaction.Scrub("""{"error":"invalid recipient john.doe@example.com"}""");
+
+        scrubbed.ShouldNotContain("john.doe@example.com");
+        scrubbed.ShouldContain("@example.com"); // domain preserved for debugging
+    }
+
+    [Fact]
+    public void Scrub_MasksPhoneNumbersInText()
+    {
+        string scrubbed = LogRedaction.Scrub("""{"message":"The 'To' number +33612345678 is not valid"}""");
+
+        scrubbed.ShouldNotContain("+33612345678");
+        scrubbed.ShouldContain("*****78");
+    }
+
+    [Fact]
+    public void Scrub_MasksFormattedPhoneNumbers()
+    {
+        string scrubbed = LogRedaction.Scrub("call (206) 555-01 99 back");
+
+        scrubbed.ShouldNotContain("555-01 99");
+    }
+
+    [Fact]
+    public void Scrub_LeavesShortNumericIdsIntact()
+    {
+        // Status codes, short ids and error numbers are diagnostic value — not PII.
+        string scrubbed = LogRedaction.Scrub("""{"code":21211,"status":400}""");
+
+        scrubbed.ShouldBe("""{"code":21211,"status":400}""");
+    }
+
+    [Fact]
+    public void Scrub_TruncatesOversizedPayloads()
+    {
+        string scrubbed = LogRedaction.Scrub(new string('x', 5000));
+
+        scrubbed.Length.ShouldBeLessThan(2100);
+        scrubbed.ShouldContain("[truncated");
+    }
+
+    // -------------------------------------------------------------------------
     // Cross-method — multiple sensitive values
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Tests/Extensions/GranitProviderOptionsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Tests/Extensions/GranitProviderOptionsServiceCollectionExtensionsTests.cs
@@ -1,0 +1,130 @@
+using System.ComponentModel.DataAnnotations;
+using Granit.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Tests.Extensions;
+
+public sealed class GranitProviderOptionsServiceCollectionExtensionsTests
+{
+    private sealed class SampleProviderOptions
+    {
+        public const string SectionName = "Sample:Provider";
+
+        [Required]
+        public string ApiKey { get; set; } = string.Empty;
+
+        [Range(1, 300)]
+        public int TimeoutSeconds { get; set; } = 30;
+    }
+
+    private sealed class SampleCrossFieldValidator : IValidateOptions<SampleProviderOptions>
+    {
+        public ValidateOptionsResult Validate(string? name, SampleProviderOptions options) =>
+            options.ApiKey.StartsWith("sk-", StringComparison.Ordinal)
+                ? ValidateOptionsResult.Success
+                : ValidateOptionsResult.Fail("ApiKey must start with 'sk-'.");
+    }
+
+    private static ServiceProvider Build(Dictionary<string, string?> config, bool withValidator = false)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(config).Build());
+
+        if (withValidator)
+        {
+            services.AddGranitProviderOptions<SampleProviderOptions, SampleCrossFieldValidator>(SampleProviderOptions.SectionName);
+        }
+        else
+        {
+            services.AddGranitProviderOptions<SampleProviderOptions>(SampleProviderOptions.SectionName);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void BindsFromTheGivenSection()
+    {
+        using ServiceProvider sp = Build(new()
+        {
+            ["Sample:Provider:ApiKey"] = "sk-abc",
+            ["Sample:Provider:TimeoutSeconds"] = "60",
+        });
+
+        SampleProviderOptions opts = sp.GetRequiredService<IOptions<SampleProviderOptions>>().Value;
+
+        opts.ApiKey.ShouldBe("sk-abc");
+        opts.TimeoutSeconds.ShouldBe(60);
+    }
+
+    [Fact]
+    public void DataAnnotations_AreEffective_MissingRequiredThrows()
+    {
+        using ServiceProvider sp = Build([]);
+
+        Should.Throw<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<SampleProviderOptions>>().Value);
+    }
+
+    [Fact]
+    public void DataAnnotations_AreEffective_OutOfRangeThrows()
+    {
+        using ServiceProvider sp = Build(new()
+        {
+            ["Sample:Provider:ApiKey"] = "sk-abc",
+            ["Sample:Provider:TimeoutSeconds"] = "0",
+        });
+
+        Should.Throw<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<SampleProviderOptions>>().Value);
+    }
+
+    [Fact]
+    public void CrossFieldValidator_IsRegisteredAndEnforced()
+    {
+        using ServiceProvider sp = Build(new()
+        {
+            ["Sample:Provider:ApiKey"] = "wrong-prefix",
+        }, withValidator: true);
+
+        OptionsValidationException ex = Should.Throw<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<SampleProviderOptions>>().Value);
+        ex.Failures.ShouldContain(f => f.Contains("sk-"));
+    }
+
+    [Fact]
+    public void RegistersValidateOnStart()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddGranitProviderOptions<SampleProviderOptions>(SampleProviderOptions.SectionName);
+
+        // ValidateOnStart materializes as an IStartupValidator registration.
+        services.ShouldContain(d => d.ServiceType == typeof(IStartupValidator));
+    }
+
+    [Fact]
+    public void ReturnsOptionsBuilderForChaining()
+    {
+        ServiceCollection services = new();
+
+        OptionsBuilder<SampleProviderOptions> builder =
+            services.AddGranitProviderOptions<SampleProviderOptions>(SampleProviderOptions.SectionName);
+
+        builder.ShouldNotBeNull();
+        Should.NotThrow(() => builder.Configure(o => o.TimeoutSeconds = 10));
+    }
+
+    [Fact]
+    public void EmptySectionName_Throws()
+    {
+        ServiceCollection services = new();
+
+        Should.Throw<ArgumentException>(
+            () => services.AddGranitProviderOptions<SampleProviderOptions>(" "));
+    }
+}


### PR DESCRIPTION
Closes #2959 (part of epic #2957 — notifications family overhaul, phase 1a of 8). Follows #2966 (phase 0); independent branches, no merge dependency.

## What

Extracts the canonical provider template (reference: `Granit.Notifications.MobilePush.AwsSns`) into shared tooling, and locks it with an architecture test so the drift that produced 16 divergent providers cannot recur.

### Shared tooling

- **`AddGranitProviderOptions<TOptions>[, TValidator]`** ([Granit.Extensions](src/Granit/Extensions/GranitProviderOptionsServiceCollectionExtensions.cs)) — one helper chaining `BindConfiguration + ValidateDataAnnotations + ValidateOnStart`, optionally registering an `IValidateOptions` for cross-field rules. Zero new dependencies (ASP.NET shared framework). Replaces the three coexisting validation styles; per-provider adoption lands in phase 1b (#2961).
- **`EnsureGranitSuccessAsync`** ([Granit.Http.Resilience](src/Granit.Http.Resilience/Extensions/GranitHttpResponseMessageExtensions.cs)) — shared success-guard for HTTP senders: error body read best-effort, logged **scrubbed** at Warning, `HttpRequestException` carries status **but never the body** (exception messages reach delivery audit rows and upstream logs). Collapses the 5 near-identical `EnsureSuccessAsync` duplicates (Twilio, Brevo, SendGrid, Scaleway, Zulip) — call-site adoption in phase 1b.
- **`LogRedaction.Scrub`** — masks emails and phone-like sequences in free-form text (vendor error payloads echo recipients back on the error path), truncates to a bounded length; `[GeneratedRegex]` with match timeouts.

### ProviderConventionTests (architecture shard)

Discovers provider packages by reflection (any `Granit.Notifications.*` assembly implementing a channel `I*Sender`) — 13 today — and asserts per provider: options with `SectionName`, effective validation, `SectionName` test, ActivitySource, health check, self-registering module, `[DependsOn]` covering direct module references, and the top-level placement rule (a provider never nests under a channel).

Current violations are grandfathered in [ProviderExemptions.cs](tests/Granit.ArchitectureTests/ProviderExemptions.cs) — one justification + removal issue per entry — and a **stale-exemption fact** fails as soon as an entry stops being necessary, so the backlog can only shrink (phase 2 empties `PlacementPending`, phase 1b empties the rest).

The seeded exemptions cross-validate the audit and sharpen it: Twilio and Zulip also lack an ActivitySource, GoogleFcm's module does not self-register, and MobilePush.AwsSns has no SectionName test.

## Verification

- `dotnet test architecture.slnf` — 274/274 green (incl. the 11 new facts)
- `dotnet test tests/Granit.Tests` — 608/608 (incl. 7 helper + 5 Scrub tests); `tests/Granit.Http.Resilience.Tests` — 22/22
- `dotnet format --verify-no-changes` on all five touched projects ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)