### PR TITLE
feat(notifications): phase 1b — every provider conforms to the canonical template

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -37997,7 +37997,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AwsSes",
       "file": "src/Granit.Notifications.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitNotificationsAwsSes",
@@ -38067,7 +38067,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AwsSns",
       "file": "src/Granit.Notifications.AwsSns/MobilePush/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitNotificationsAwsSnsMobilePush",
@@ -38111,7 +38111,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AwsSns",
       "file": "src/Granit.Notifications.AwsSns/Sms/Extensions/SnsSmsServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitNotificationsAwsSnsSms",
@@ -38155,7 +38155,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AzureCommunicationServices",
       "file": "src/Granit.Notifications.AzureCommunicationServices/Email/Extensions/AcsEmailServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitNotificationsAcsEmail",
@@ -38209,7 +38209,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AzureCommunicationServices",
       "file": "src/Granit.Notifications.AzureCommunicationServices/Sms/Extensions/AcsSmsServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitNotificationsAcsSms",
@@ -38247,7 +38247,7 @@
       "kind": "class",
       "project": "Granit.Notifications.AzureNotificationHubs",
       "file": "src/Granit.Notifications.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitNotificationsAzureNotificationHubs",
@@ -38307,7 +38307,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Brevo",
       "file": "src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitNotificationsBrevo",
@@ -38323,8 +38323,15 @@
       "kind": "class",
       "project": "Granit.Notifications.Brevo",
       "file": "src/Granit.Notifications.Brevo/GranitNotificationsBrevoModule.cs",
-      "line": 21,
-      "members": []
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "BrevoOptions",
@@ -38687,7 +38694,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Endpoints",
       "file": "src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs",
-      "line": 27,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -38893,7 +38900,7 @@
       "kind": "class",
       "project": "Granit.Notifications.GoogleFcm",
       "file": "src/Granit.Notifications.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitNotificationsGoogleFcm",
@@ -38909,8 +38916,15 @@
       "kind": "class",
       "project": "Granit.Notifications.GoogleFcm",
       "file": "src/Granit.Notifications.GoogleFcm/GranitNotificationsGoogleFcmModule.cs",
-      "line": 19,
-      "members": []
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "GoogleFcmOptions",
@@ -38961,7 +38975,7 @@
       "kind": "class",
       "project": "Granit.Notifications",
       "file": "src/Granit.Notifications/GranitNotificationsModule.cs",
-      "line": 27,
+      "line": 35,
       "members": [
         {
           "name": "ConfigureServices",
@@ -39597,7 +39611,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Scaleway",
       "file": "src/Granit.Notifications.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitNotificationsScaleway",
@@ -39613,7 +39627,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Scaleway",
       "file": "src/Granit.Notifications.Scaleway/GranitNotificationsScalewayModule.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -39681,7 +39695,7 @@
       "kind": "class",
       "project": "Granit.Notifications.SendGrid",
       "file": "src/Granit.Notifications.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitNotificationsSendGrid",
@@ -39697,7 +39711,7 @@
       "kind": "class",
       "project": "Granit.Notifications.SendGrid",
       "file": "src/Granit.Notifications.SendGrid/GranitNotificationsSendGridModule.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -39885,7 +39899,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Smtp",
       "file": "src/Granit.Notifications.Smtp/Extensions/SmtpEmailServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitNotificationsSmtp",
@@ -39901,8 +39915,15 @@
       "kind": "class",
       "project": "Granit.Notifications.Smtp",
       "file": "src/Granit.Notifications.Smtp/GranitNotificationsSmtpModule.cs",
-      "line": 14,
-      "members": []
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "SmtpOptions",
@@ -40095,7 +40116,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Twilio",
       "file": "src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitNotificationsTwilio",
@@ -40111,8 +40132,15 @@
       "kind": "class",
       "project": "Granit.Notifications.Twilio",
       "file": "src/Granit.Notifications.Twilio/GranitNotificationsTwilioModule.cs",
-      "line": 19,
-      "members": []
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "TwilioOptions",
@@ -40498,7 +40526,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Wolverine",
       "file": "src/Granit.Notifications.Wolverine/GranitNotificationsWolverineModule.cs",
-      "line": 34,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",
@@ -40514,7 +40542,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Zulip",
       "file": "src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitNotificationsZulip",
@@ -40530,8 +40558,15 @@
       "kind": "class",
       "project": "Granit.Notifications.Zulip",
       "file": "src/Granit.Notifications.Zulip/GranitNotificationsZulipModule.cs",
-      "line": 16,
-      "members": []
+      "line": 19,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IZulipSender",

--- a/src/Granit.Notifications.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleEmailV2;
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Notifications.AwsSes.Diagnostics;
 using Granit.Notifications.AwsSes.HealthChecks;
 using Granit.Notifications.AwsSes.Internal;
@@ -21,11 +22,7 @@ public static class SesEmailServiceCollectionExtensions
         this IServiceCollection services,
         Action<AwsSesOptions>? configure = null)
     {
-        services.AddOptions<AwsSesOptions>()
-            .BindConfiguration(AwsSesOptions.SectionName)
-            .ValidateOnStart();
-
-        services.AddSingleton<IValidateOptions<AwsSesOptions>, AwsSesOptionsValidator>();
+        services.AddGranitProviderOptions<AwsSesOptions, AwsSesOptionsValidator>(AwsSesOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.AwsSes/Options/AwsSesOptions.cs
+++ b/src/Granit.Notifications.AwsSes/Options/AwsSesOptions.cs
@@ -24,11 +24,13 @@ public sealed class AwsSesOptions
     /// <summary>
     /// AWS access key ID. When <c>null</c>, the SDK uses the default credential chain
     /// (IAM roles on ECS/EKS, environment variables, or shared credentials file).
+    /// Credential material — source from Vault, never from plaintext appsettings.
     /// </summary>
     public string? AccessKeyId { get; set; }
 
     /// <summary>
     /// AWS secret access key. When <c>null</c>, the SDK uses the default credential chain.
+    /// Secret material — source from Vault, never from plaintext appsettings.
     /// </summary>
     public string? SecretAccessKey { get; set; }
 

--- a/src/Granit.Notifications.AwsSns/MobilePush/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.AwsSns/MobilePush/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Notifications.AwsSns.MobilePush.Diagnostics;
 using Granit.Notifications.AwsSns.MobilePush.HealthChecks;
 using Granit.Notifications.AwsSns.MobilePush.Internal;
@@ -21,11 +22,7 @@ public static class AwsSnsMobilePushServiceCollectionExtensions
         this IServiceCollection services,
         Action<AwsSnsMobilePushOptions>? configure = null)
     {
-        services.AddOptions<AwsSnsMobilePushOptions>()
-            .BindConfiguration(AwsSnsMobilePushOptions.SectionName)
-            .ValidateOnStart();
-
-        services.AddSingleton<IValidateOptions<AwsSnsMobilePushOptions>, AwsSnsMobilePushOptionsValidator>();
+        services.AddGranitProviderOptions<AwsSnsMobilePushOptions, AwsSnsMobilePushOptionsValidator>(AwsSnsMobilePushOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.AwsSns/MobilePush/Options/AwsSnsMobilePushOptions.cs
+++ b/src/Granit.Notifications.AwsSns/MobilePush/Options/AwsSnsMobilePushOptions.cs
@@ -22,7 +22,7 @@ public sealed class AwsSnsMobilePushOptions
     /// <summary>Optional AWS access key. When null, default credential chain is used.</summary>
     public string? AccessKeyId { get; set; }
 
-    /// <summary>Optional AWS secret key. Required when <see cref="AccessKeyId"/> is set.</summary>
+    /// <summary>Optional AWS secret key. Required when <see cref="AccessKeyId"/> is set. Source from Vault, never from plaintext appsettings.</summary>
     public string? SecretAccessKey { get; set; }
 
     /// <summary>API call timeout in seconds. Default: 30.</summary>

--- a/src/Granit.Notifications.AwsSns/Sms/Extensions/SnsSmsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.AwsSns/Sms/Extensions/SnsSmsServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Notifications.AwsSns.Sms.Diagnostics;
 using Granit.Notifications.AwsSns.Sms.HealthChecks;
 using Granit.Notifications.AwsSns.Sms.Internal;
@@ -21,11 +22,7 @@ public static class SnsSmsServiceCollectionExtensions
         this IServiceCollection services,
         Action<AwsSnsSmsOptions>? configure = null)
     {
-        services.AddOptions<AwsSnsSmsOptions>()
-            .BindConfiguration(AwsSnsSmsOptions.SectionName)
-            .ValidateOnStart();
-
-        services.AddSingleton<IValidateOptions<AwsSnsSmsOptions>, AwsSnsSmsOptionsValidator>();
+        services.AddGranitProviderOptions<AwsSnsSmsOptions, AwsSnsSmsOptionsValidator>(AwsSnsSmsOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.AwsSns/Sms/Options/AwsSnsSmsOptions.cs
+++ b/src/Granit.Notifications.AwsSns/Sms/Options/AwsSnsSmsOptions.cs
@@ -29,7 +29,7 @@ public sealed class AwsSnsSmsOptions
     /// <summary>Optional AWS access key. When null, default credential chain is used.</summary>
     public string? AccessKeyId { get; set; }
 
-    /// <summary>Optional AWS secret key. Required when <see cref="AccessKeyId"/> is set.</summary>
+    /// <summary>Optional AWS secret key. Required when <see cref="AccessKeyId"/> is set. Source from Vault, never from plaintext appsettings.</summary>
     public string? SecretAccessKey { get; set; }
 
     /// <summary>API call timeout in seconds. Default: 30.</summary>

--- a/src/Granit.Notifications.AzureCommunicationServices/Email/Extensions/AcsEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.AzureCommunicationServices/Email/Extensions/AcsEmailServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Azure.Communication.Email;
 using Azure.Identity;
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Notifications.AzureCommunicationServices.Email.Diagnostics;
 using Granit.Notifications.AzureCommunicationServices.Email.HealthChecks;
 using Granit.Notifications.AzureCommunicationServices.Email.Internal;
@@ -23,11 +24,7 @@ public static class AcsEmailServiceCollectionExtensions
         this IServiceCollection services,
         Action<AcsEmailOptions>? configure = null)
     {
-        services.AddOptions<AcsEmailOptions>()
-            .BindConfiguration(AcsEmailOptions.SectionName)
-            .ValidateOnStart();
-
-        services.AddSingleton<IValidateOptions<AcsEmailOptions>, AcsEmailOptionsValidator>();
+        services.AddGranitProviderOptions<AcsEmailOptions, AcsEmailOptionsValidator>(AcsEmailOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.AzureCommunicationServices/Email/Options/AcsEmailOptions.cs
+++ b/src/Granit.Notifications.AzureCommunicationServices/Email/Options/AcsEmailOptions.cs
@@ -11,6 +11,7 @@ public sealed class AcsEmailOptions
     /// <summary>
     /// ACS connection string. When provided, takes precedence over <see cref="Endpoint"/>.
     /// Either <see cref="ConnectionString"/> or <see cref="Endpoint"/> must be set.
+    /// Contains the access key — source from Vault, never from plaintext appsettings.
     /// </summary>
     public string? ConnectionString { get; set; }
 

--- a/src/Granit.Notifications.AzureCommunicationServices/Sms/Extensions/AcsSmsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.AzureCommunicationServices/Sms/Extensions/AcsSmsServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Azure.Communication.Sms;
 using Azure.Identity;
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Notifications.AzureCommunicationServices.Sms.Diagnostics;
 using Granit.Notifications.AzureCommunicationServices.Sms.HealthChecks;
 using Granit.Notifications.AzureCommunicationServices.Sms.Internal;
@@ -20,11 +21,7 @@ public static class AcsSmsServiceCollectionExtensions
         this IServiceCollection services,
         Action<AcsSmsOptions>? configure = null)
     {
-        services.AddOptions<AcsSmsOptions>()
-            .BindConfiguration(AcsSmsOptions.SectionName)
-            .ValidateOnStart();
-
-        services.AddSingleton<IValidateOptions<AcsSmsOptions>, AcsSmsOptionsValidator>();
+        services.AddGranitProviderOptions<AcsSmsOptions, AcsSmsOptionsValidator>(AcsSmsOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.AzureCommunicationServices/Sms/Options/AcsSmsOptions.cs
+++ b/src/Granit.Notifications.AzureCommunicationServices/Sms/Options/AcsSmsOptions.cs
@@ -11,6 +11,7 @@ public sealed class AcsSmsOptions
     /// <summary>
     /// ACS connection string. When provided, takes precedence over <see cref="Endpoint"/>.
     /// Either <see cref="ConnectionString"/> or <see cref="Endpoint"/> must be set.
+    /// Contains the access key — source from Vault, never from plaintext appsettings.
     /// </summary>
     public string? ConnectionString { get; set; }
 

--- a/src/Granit.Notifications.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Notifications.AzureNotificationHubs.Diagnostics;
 using Granit.Notifications.AzureNotificationHubs.HealthChecks;
 using Granit.Notifications.AzureNotificationHubs.Internal;
@@ -20,12 +21,7 @@ public static class AzureNotificationHubsServiceCollectionExtensions
         this IServiceCollection services,
         Action<AzureNotificationHubsOptions>? configure = null)
     {
-        services.AddOptions<AzureNotificationHubsOptions>()
-            .BindConfiguration(AzureNotificationHubsOptions.SectionName)
-            .ValidateOnStart();
-
-        services.AddSingleton<IValidateOptions<AzureNotificationHubsOptions>,
-            AzureNotificationHubsOptionsValidator>();
+        services.AddGranitProviderOptions<AzureNotificationHubsOptions, AzureNotificationHubsOptionsValidator>(AzureNotificationHubsOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.Brevo/Diagnostics/NotificationsBrevoActivitySource.cs
+++ b/src/Granit.Notifications.Brevo/Diagnostics/NotificationsBrevoActivitySource.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+
+namespace Granit.Notifications.Brevo.Diagnostics;
+
+/// <summary>OpenTelemetry activity source for the Brevo multi-channel provider.</summary>
+internal static class NotificationsBrevoActivitySource
+{
+    /// <summary>Activity source name.</summary>
+    public const string Name = "Granit.Notifications.Brevo";
+
+    /// <summary>Shared activity source instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    /// <summary>Operation names.</summary>
+    internal static class Operations
+    {
+        public const string SendEmail = "brevo.send-email";
+        public const string SendSms = "brevo.send-sms";
+        public const string SendWhatsApp = "brevo.send-whatsapp";
+    }
+}

--- a/src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
+using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Http.Resilience.Extensions;
+using Granit.Notifications.Brevo.Diagnostics;
 using Granit.Notifications.Brevo.HealthChecks;
 using Granit.Notifications.Brevo.Internal;
 using Granit.Notifications.Brevo.Options;
@@ -22,10 +25,7 @@ public static class BrevoNotificationsServiceCollectionExtensions
         this IServiceCollection services,
         Action<BrevoOptions>? configure = null)
     {
-        services.AddOptions<BrevoOptions>()
-            .BindConfiguration(BrevoOptions.SectionName)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<BrevoOptions>(BrevoOptions.SectionName);
 
         if (configure is not null)
         {
@@ -49,11 +49,13 @@ public static class BrevoNotificationsServiceCollectionExtensions
         services.AddKeyedSingleton<IWhatsAppSender>(
             ProviderKey, (sp, _) => sp.GetRequiredService<BrevoNotificationProvider>());
 
+        GranitActivitySourceRegistry.Register(NotificationsBrevoActivitySource.Name);
+
         return services;
     }
 
     /// <summary>
-    /// Adds the Brevo API health check (tags: <c>readiness</c>).
+    /// Adds the Brevo API health check (tags: <c>readiness</c>, <c>startup</c>).
     /// </summary>
     /// <param name="builder">The health checks builder.</param>
     /// <param name="name">Optional check name (default: <c>"brevo"</c>).</param>
@@ -69,6 +71,6 @@ public static class BrevoNotificationsServiceCollectionExtensions
             name,
             sp => new BrevoHealthCheck(sp.GetRequiredService<IHttpClientFactory>()),
             failureStatus,
-            ["readiness"],
+            ["readiness", "startup"],
             timeout));
 }

--- a/src/Granit.Notifications.Brevo/GranitNotificationsBrevoModule.cs
+++ b/src/Granit.Notifications.Brevo/GranitNotificationsBrevoModule.cs
@@ -1,5 +1,7 @@
+using Granit.Diagnostics;
 using Granit.Http.Resilience;
 using Granit.Modularity;
+using Granit.Notifications.Brevo.Extensions;
 using Granit.Notifications.Email;
 using Granit.Notifications.Sms;
 using Granit.Notifications.WhatsApp;
@@ -14,8 +16,13 @@ namespace Granit.Notifications.Brevo;
 /// Registers <c>BrevoNotificationProvider</c> as a keyed service for email, SMS and WhatsApp channels.
 /// </remarks>
 [DependsOn(
+    typeof(GranitDiagnosticsModule),
     typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsEmailModule),
     typeof(GranitNotificationsSmsModule),
     typeof(GranitNotificationsWhatsAppModule))]
-public sealed class GranitNotificationsBrevoModule : GranitModule;
+public sealed class GranitNotificationsBrevoModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitNotificationsBrevo();
+}

--- a/src/Granit.Notifications.Brevo/Internal/BrevoNotificationProvider.cs
+++ b/src/Granit.Notifications.Brevo/Internal/BrevoNotificationProvider.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Granit.Diagnostics;
+using Granit.Http.Resilience.Extensions;
+using Granit.Notifications.Brevo.Diagnostics;
 using Granit.Notifications.Brevo.Options;
 using Granit.Notifications.Email;
 using Granit.Notifications.Sms;
@@ -30,6 +33,7 @@ internal sealed partial class BrevoNotificationProvider(
     /// <inheritdoc />
     async Task IEmailSender.SendAsync(EmailMessage message, CancellationToken cancellationToken)
     {
+        using Activity? activity = NotificationsBrevoActivitySource.Source.StartActivity(NotificationsBrevoActivitySource.Operations.SendEmail);
         BrevoOptions opts = options.CurrentValue;
         HttpClient client = httpClientFactory.CreateClient("Brevo");
 
@@ -51,7 +55,7 @@ internal sealed partial class BrevoNotificationProvider(
 
         using HttpResponseMessage response = await client.PostAsJsonAsync(
             "smtp/email", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync("smtp/email", response, cancellationToken).ConfigureAwait(false);
+        await response.EnsureGranitSuccessAsync(logger, "Brevo", "smtp/email", cancellationToken).ConfigureAwait(false);
 
         LogEmailSent(LogRedaction.Email(message.To));
     }
@@ -59,6 +63,7 @@ internal sealed partial class BrevoNotificationProvider(
     /// <inheritdoc />
     async Task ISmsSender.SendAsync(SmsMessage message, CancellationToken cancellationToken)
     {
+        using Activity? activity = NotificationsBrevoActivitySource.Source.StartActivity(NotificationsBrevoActivitySource.Operations.SendSms);
         BrevoOptions opts = options.CurrentValue;
         HttpClient client = httpClientFactory.CreateClient("Brevo");
 
@@ -72,7 +77,7 @@ internal sealed partial class BrevoNotificationProvider(
 
         using HttpResponseMessage response = await client.PostAsJsonAsync(
             "transactionalSMS/sms", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync("transactionalSMS/sms", response, cancellationToken).ConfigureAwait(false);
+        await response.EnsureGranitSuccessAsync(logger, "Brevo", "transactionalSMS/sms", cancellationToken).ConfigureAwait(false);
 
         LogSmsSent(LogRedaction.Phone(message.To));
     }
@@ -80,6 +85,7 @@ internal sealed partial class BrevoNotificationProvider(
     /// <inheritdoc />
     async Task IWhatsAppSender.SendAsync(WhatsAppMessage message, CancellationToken cancellationToken)
     {
+        using Activity? activity = NotificationsBrevoActivitySource.Source.StartActivity(NotificationsBrevoActivitySource.Operations.SendWhatsApp);
         HttpClient client = httpClientFactory.CreateClient("Brevo");
 
         object payload = new
@@ -93,38 +99,11 @@ internal sealed partial class BrevoNotificationProvider(
 
         using HttpResponseMessage response = await client.PostAsJsonAsync(
             "whatsapp/sendTemplate", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync("whatsapp/sendTemplate", response, cancellationToken).ConfigureAwait(false);
+        await response.EnsureGranitSuccessAsync(logger, "Brevo", "whatsapp/sendTemplate", cancellationToken).ConfigureAwait(false);
 
         LogWhatsAppSent(LogRedaction.Phone(message.To), message.TemplateName);
     }
 
-    /// <summary>
-    /// Reads the Brevo error body before throwing, so the caller (and logs) get a meaningful message.
-    /// </summary>
-    private async Task EnsureSuccessAsync(string endpoint, HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        string? errorBody = null;
-        try
-        {
-            errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            // Best-effort — do not mask the original HTTP error.
-        }
-
-        LogBrevoError(endpoint, (int)response.StatusCode, errorBody);
-
-        throw new HttpRequestException(
-            $"Brevo API error {(int)response.StatusCode} on {endpoint}: {errorBody ?? "(no body)"}",
-            inner: null,
-            response.StatusCode);
-    }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Brevo email sent to {RedactedRecipient}")]
     private partial void LogEmailSent(string redactedRecipient);
@@ -135,6 +114,4 @@ internal sealed partial class BrevoNotificationProvider(
     [LoggerMessage(Level = LogLevel.Information, Message = "Brevo WhatsApp sent to {RedactedRecipient} template {TemplateName}")]
     private partial void LogWhatsAppSent(string redactedRecipient, string templateName);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Brevo API error on {Endpoint}: HTTP {StatusCode} — {ErrorBody}")]
-    private partial void LogBrevoError(string endpoint, int statusCode, string? errorBody);
 }

--- a/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
+++ b/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
@@ -1,4 +1,5 @@
 using Granit.Authorization;
+using Granit.Guids;
 using Granit.Http.ApiDocumentation;
 using Granit.Localization.Extensions;
 using Granit.Modularity;
@@ -20,6 +21,7 @@ namespace Granit.Notifications.Endpoints;
 /// </remarks>
 [DependsOn(
     typeof(GranitAuthorizationModule),
+    typeof(GranitGuidsModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitNotificationsModule),
     typeof(GranitValidationModule),

--- a/src/Granit.Notifications.GoogleFcm/Diagnostics/NotificationsGoogleFcmActivitySource.cs
+++ b/src/Granit.Notifications.GoogleFcm/Diagnostics/NotificationsGoogleFcmActivitySource.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Granit.Notifications.GoogleFcm.Diagnostics;
+
+/// <summary>OpenTelemetry activity source for the FCM mobile push provider.</summary>
+internal static class NotificationsGoogleFcmActivitySource
+{
+    /// <summary>Activity source name.</summary>
+    public const string Name = "Granit.Notifications.GoogleFcm";
+
+    /// <summary>Shared activity source instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    /// <summary>Operation names.</summary>
+    internal static class Operations
+    {
+        public const string SendPush = "fcm.send-push";
+    }
+}

--- a/src/Granit.Notifications.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs
@@ -1,9 +1,14 @@
+using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Http.Resilience.Extensions;
+using Granit.Notifications.GoogleFcm.Diagnostics;
+using Granit.Notifications.GoogleFcm.HealthChecks;
 using Granit.Notifications.GoogleFcm.Internal;
 using Granit.Notifications.GoogleFcm.Options;
 using Granit.Notifications.MobilePush;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Granit.Notifications.GoogleFcm.Extensions;
 
@@ -18,10 +23,7 @@ public static class GoogleFcmMobilePushServiceCollectionExtensions
         this IServiceCollection services,
         Action<GoogleFcmOptions>? configure = null)
     {
-        services.AddOptions<GoogleFcmOptions>()
-            .BindConfiguration(GoogleFcmOptions.SectionName)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<GoogleFcmOptions, GoogleFcmOptionsValidator>(GoogleFcmOptions.SectionName);
 
         if (configure is not null)
         {
@@ -42,6 +44,27 @@ public static class GoogleFcmMobilePushServiceCollectionExtensions
         }).AddHttpMessageHandler<GoogleFcmAuthenticationHandler>();
 
         services.AddKeyedSingleton<IMobilePushSender, GoogleFcmMobilePushSender>(ProviderKey);
+        GranitActivitySourceRegistry.Register(NotificationsGoogleFcmActivitySource.Name);
+
         return services;
+    }
+
+    /// <summary>
+    /// Adds the FCM configuration health check (tags: <c>readiness</c>, <c>startup</c>).
+    /// </summary>
+    public static IHealthChecksBuilder AddGranitGoogleFcmHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "google-fcm-push",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        builder.Services.AddSingleton<GoogleFcmHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<GoogleFcmHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout));
     }
 }

--- a/src/Granit.Notifications.GoogleFcm/GranitNotificationsGoogleFcmModule.cs
+++ b/src/Granit.Notifications.GoogleFcm/GranitNotificationsGoogleFcmModule.cs
@@ -1,5 +1,6 @@
 using Granit.Http.Resilience;
 using Granit.Modularity;
+using Granit.Notifications.GoogleFcm.Extensions;
 using Granit.Notifications.MobilePush;
 using Granit.Timing;
 
@@ -16,4 +17,8 @@ namespace Granit.Notifications.GoogleFcm;
     typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsMobilePushModule),
     typeof(GranitTimingModule))]
-public sealed class GranitNotificationsGoogleFcmModule : GranitModule;
+public sealed class GranitNotificationsGoogleFcmModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitNotificationsGoogleFcm();
+}

--- a/src/Granit.Notifications.GoogleFcm/HealthChecks/GoogleFcmHealthCheck.cs
+++ b/src/Granit.Notifications.GoogleFcm/HealthChecks/GoogleFcmHealthCheck.cs
@@ -1,0 +1,43 @@
+using Granit.Notifications.GoogleFcm.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Notifications.GoogleFcm.HealthChecks;
+
+/// <summary>
+/// Health check that verifies the FCM configuration is present and coherent.
+/// Config-only probe — no network call, no message sent (mirrors the AwsSns /
+/// AzureNotificationHubs config probes; a real FCM send would cost quota and
+/// deliver to a device).
+/// </summary>
+internal sealed class GoogleFcmHealthCheck(
+    IOptions<GoogleFcmOptions> options) : IHealthCheck
+{
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            GoogleFcmOptions opts = options.Value;
+
+            if (string.IsNullOrWhiteSpace(opts.ProjectId))
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy("FCM ProjectId is not configured."));
+            }
+
+            if (string.IsNullOrWhiteSpace(opts.ServiceAccountJson))
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy("FCM ServiceAccountJson is not configured."));
+            }
+
+            return Task.FromResult(HealthCheckResult.Healthy());
+        }
+        catch (Exception ex)
+        {
+            // Sanitize: never expose the service-account key material.
+            return Task.FromResult(HealthCheckResult.Unhealthy($"FCM health check failed: {ex.GetType().Name}"));
+        }
+    }
+}

--- a/src/Granit.Notifications.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
+++ b/src/Granit.Notifications.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Granit.Diagnostics;
+using Granit.Notifications.GoogleFcm.Diagnostics;
 using Granit.Notifications.GoogleFcm.Options;
 using Granit.Notifications.MobilePush;
 using Microsoft.Extensions.Logging;
@@ -28,6 +30,7 @@ internal sealed partial class GoogleFcmMobilePushSender(
     /// <inheritdoc />
     public async Task SendAsync(MobilePushMessage message, CancellationToken cancellationToken = default)
     {
+        using Activity? activity = NotificationsGoogleFcmActivitySource.Source.StartActivity(NotificationsGoogleFcmActivitySource.Operations.SendPush);
         HttpClient client = httpClientFactory.CreateClient(FcmHttpClientName);
 
         List<Exception>? failures = null;

--- a/src/Granit.Notifications.GoogleFcm/Options/GoogleFcmOptionsValidator.cs
+++ b/src/Granit.Notifications.GoogleFcm/Options/GoogleFcmOptionsValidator.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Notifications.GoogleFcm.Options;
+
+/// <summary>
+/// Validates <see cref="GoogleFcmOptions"/> cross-field rules that DataAnnotations cannot
+/// express: the service-account key must be a JSON object of type "service_account", so a
+/// mis-pasted secret fails at startup instead of at the first token mint.
+/// </summary>
+internal sealed class GoogleFcmOptionsValidator : IValidateOptions<GoogleFcmOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, GoogleFcmOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ServiceAccountJson))
+        {
+            // [Required] already reports the missing value.
+            return ValidateOptionsResult.Skip;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(options.ServiceAccountJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("type", out JsonElement type)
+                || type.GetString() != "service_account")
+            {
+                return ValidateOptionsResult.Fail(
+                    "GoogleFcmOptions.ServiceAccountJson must be a Google service-account key (JSON object with \"type\": \"service_account\").");
+            }
+        }
+        catch (JsonException)
+        {
+            return ValidateOptionsResult.Fail("GoogleFcmOptions.ServiceAccountJson is not valid JSON.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.Notifications.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Email;
 using Granit.Notifications.Scaleway.Diagnostics;
@@ -20,10 +21,7 @@ public static class ScalewayEmailServiceCollectionExtensions
         this IServiceCollection services,
         Action<ScalewayEmailOptions>? configure = null)
     {
-        services.AddOptions<ScalewayEmailOptions>()
-            .BindConfiguration(ScalewayEmailOptions.SectionName)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<ScalewayEmailOptions>(ScalewayEmailOptions.SectionName);
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.Scaleway/GranitNotificationsScalewayModule.cs
+++ b/src/Granit.Notifications.Scaleway/GranitNotificationsScalewayModule.cs
@@ -1,3 +1,4 @@
+using Granit.Diagnostics;
 using Granit.Http.Resilience;
 using Granit.Modularity;
 using Granit.Notifications.Email;
@@ -7,6 +8,7 @@ namespace Granit.Notifications.Scaleway;
 
 /// <summary>Module for Scaleway Transactional Email provider.</summary>
 [DependsOn(
+    typeof(GranitDiagnosticsModule),
     typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsEmailModule))]
 public sealed class GranitNotificationsScalewayModule : GranitModule

--- a/src/Granit.Notifications.Scaleway/Internal/ScalewayEmailSender.cs
+++ b/src/Granit.Notifications.Scaleway/Internal/ScalewayEmailSender.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Granit.Diagnostics;
+using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Email;
 using Granit.Notifications.Scaleway.Diagnostics;
 using Granit.Notifications.Scaleway.Options;
@@ -56,42 +57,13 @@ internal sealed partial class ScalewayEmailSender(
 
         using HttpResponseMessage response = await client.PostAsJsonAsync(
             "emails", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        await response.EnsureGranitSuccessAsync(logger, "Scaleway", "emails", cancellationToken).ConfigureAwait(false);
 
         LogEmailSent(LogRedaction.Email(message.To));
     }
 
-    /// <summary>
-    /// Reads the Scaleway error body before throwing, so the caller (and logs) get a meaningful message.
-    /// </summary>
-    private async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        string? errorBody = null;
-        try
-        {
-            errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            // Best-effort — do not mask the original HTTP error.
-        }
-
-        LogScalewayError((int)response.StatusCode, errorBody);
-
-        throw new HttpRequestException(
-            $"Scaleway API error {(int)response.StatusCode} on emails: {errorBody ?? "(no body)"}",
-            inner: null,
-            response.StatusCode);
-    }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Scaleway email sent to {RedactedRecipient}")]
     private partial void LogEmailSent(string redactedRecipient);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Scaleway API error: HTTP {StatusCode} — {ErrorBody}")]
-    private partial void LogScalewayError(int statusCode, string? errorBody);
 }

--- a/src/Granit.Notifications.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Email;
 using Granit.Notifications.SendGrid.Diagnostics;
@@ -20,10 +21,7 @@ public static class SendGridEmailServiceCollectionExtensions
         this IServiceCollection services,
         Action<SendGridEmailOptions>? configure = null)
     {
-        services.AddOptions<SendGridEmailOptions>()
-            .BindConfiguration(SendGridEmailOptions.SectionName)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<SendGridEmailOptions>(SendGridEmailOptions.SectionName);
 
         if (configure is not null)
         {
@@ -50,7 +48,7 @@ public static class SendGridEmailServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds the SendGrid health check (tags: <c>readiness</c>).
+    /// Adds the SendGrid health check (tags: <c>readiness</c>, <c>startup</c>).
     /// </summary>
     /// <param name="builder">The health checks builder.</param>
     /// <param name="name">Optional check name (default: <c>"sendgrid"</c>).</param>
@@ -66,6 +64,6 @@ public static class SendGridEmailServiceCollectionExtensions
             name,
             sp => new SendGridHealthCheck(sp.GetRequiredService<IHttpClientFactory>()),
             failureStatus,
-            ["readiness"],
+            ["readiness", "startup"],
             timeout));
 }

--- a/src/Granit.Notifications.SendGrid/GranitNotificationsSendGridModule.cs
+++ b/src/Granit.Notifications.SendGrid/GranitNotificationsSendGridModule.cs
@@ -1,3 +1,4 @@
+using Granit.Diagnostics;
 using Granit.Http.Resilience;
 using Granit.Modularity;
 using Granit.Notifications.Email;
@@ -7,6 +8,7 @@ namespace Granit.Notifications.SendGrid;
 
 /// <summary>Module for SendGrid email provider.</summary>
 [DependsOn(
+    typeof(GranitDiagnosticsModule),
     typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsEmailModule))]
 public sealed class GranitNotificationsSendGridModule : GranitModule

--- a/src/Granit.Notifications.SendGrid/Internal/SendGridEmailSender.cs
+++ b/src/Granit.Notifications.SendGrid/Internal/SendGridEmailSender.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Granit.Diagnostics;
+using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Email;
 using Granit.Notifications.SendGrid.Diagnostics;
 using Granit.Notifications.SendGrid.Options;
@@ -59,42 +60,13 @@ internal sealed partial class SendGridEmailSender(
 
         using HttpResponseMessage response = await client.PostAsJsonAsync(
             "mail/send", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        await response.EnsureGranitSuccessAsync(logger, "SendGrid", "v3/mail/send", cancellationToken).ConfigureAwait(false);
 
         LogEmailSent(LogRedaction.Email(message.To));
     }
 
-    /// <summary>
-    /// Reads the SendGrid error body before throwing, so the caller (and logs) get a meaningful message.
-    /// </summary>
-    private async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        string? errorBody = null;
-        try
-        {
-            errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            // Best-effort — do not mask the original HTTP error.
-        }
-
-        LogSendGridError((int)response.StatusCode, errorBody);
-
-        throw new HttpRequestException(
-            $"SendGrid API error {(int)response.StatusCode} on mail/send: {errorBody ?? "(no body)"}",
-            inner: null,
-            response.StatusCode);
-    }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "SendGrid email sent to {RedactedRecipient}")]
     private partial void LogEmailSent(string redactedRecipient);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "SendGrid API error: HTTP {StatusCode} — {ErrorBody}")]
-    private partial void LogSendGridError(int statusCode, string? errorBody);
 }

--- a/src/Granit.Notifications.Smtp/Diagnostics/NotificationsSmtpActivitySource.cs
+++ b/src/Granit.Notifications.Smtp/Diagnostics/NotificationsSmtpActivitySource.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Granit.Notifications.Smtp.Diagnostics;
+
+/// <summary>OpenTelemetry activity source for the SMTP email provider.</summary>
+internal static class NotificationsSmtpActivitySource
+{
+    /// <summary>Activity source name.</summary>
+    public const string Name = "Granit.Notifications.Smtp";
+
+    /// <summary>Shared activity source instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    /// <summary>Operation names.</summary>
+    internal static class Operations
+    {
+        public const string SendEmail = "smtp.send-email";
+    }
+}

--- a/src/Granit.Notifications.Smtp/Extensions/SmtpEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Smtp/Extensions/SmtpEmailServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
+using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Notifications.Email;
+using Granit.Notifications.Smtp.Diagnostics;
 using Granit.Notifications.Smtp.HealthChecks;
 using Granit.Notifications.Smtp.Internal;
 using Granit.Notifications.Smtp.Options;
@@ -15,9 +18,7 @@ public static class SmtpEmailServiceCollectionExtensions
         this IServiceCollection services,
         Action<SmtpOptions>? configure = null)
     {
-        services.AddOptions<SmtpOptions>()
-            .BindConfiguration(SmtpOptions.SectionName)
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<SmtpOptions>(SmtpOptions.SectionName);
 
         if (configure is not null)
         {
@@ -25,6 +26,8 @@ public static class SmtpEmailServiceCollectionExtensions
         }
 
         services.AddKeyedSingleton<IEmailSender, MailKitEmailSender>("Smtp");
+        GranitActivitySourceRegistry.Register(NotificationsSmtpActivitySource.Name);
+
         return services;
     }
 
@@ -48,7 +51,7 @@ public static class SmtpEmailServiceCollectionExtensions
             name,
             sp => sp.GetRequiredService<SmtpHealthCheck>(),
             failureStatus,
-            ["readiness"],
+            ["readiness", "startup"],
             timeout ?? TimeSpan.FromSeconds(10)));
     }
 }

--- a/src/Granit.Notifications.Smtp/GranitNotificationsSmtpModule.cs
+++ b/src/Granit.Notifications.Smtp/GranitNotificationsSmtpModule.cs
@@ -1,5 +1,6 @@
 using Granit.Modularity;
 using Granit.Notifications.Email;
+using Granit.Notifications.Smtp.Extensions;
 
 namespace Granit.Notifications.Smtp;
 
@@ -7,8 +8,13 @@ namespace Granit.Notifications.Smtp;
 /// Granit module for the SMTP email provider.
 /// </summary>
 /// <remarks>
-/// Registration is done via <c>AddGranitNotificationsSmtp()</c>.
+/// Self-registers the SMTP sender (EmailChannelOptions.Provider defaults to "Smtp", so the
+/// out-of-box path must work when this module is referenced).
 /// Registers <c>SmtpEmailSender</c> as a keyed <c>IEmailSender</c> implementation.
 /// </remarks>
 [DependsOn(typeof(GranitNotificationsEmailModule))]
-public sealed class GranitNotificationsSmtpModule : GranitModule;
+public sealed class GranitNotificationsSmtpModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitNotificationsSmtp();
+}

--- a/src/Granit.Notifications.Smtp/Internal/MailKitEmailSender.cs
+++ b/src/Granit.Notifications.Smtp/Internal/MailKitEmailSender.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using Granit.Diagnostics;
 using Granit.Notifications.Email;
+using Granit.Notifications.Smtp.Diagnostics;
 using Granit.Notifications.Smtp.Options;
 using MailKit.Security;
 using Microsoft.Extensions.Logging;
@@ -22,6 +24,7 @@ internal sealed partial class MailKitEmailSender(
     /// <inheritdoc />
     public async Task SendAsync(EmailMessage message, CancellationToken cancellationToken = default)
     {
+        using Activity? activity = NotificationsSmtpActivitySource.Source.StartActivity(NotificationsSmtpActivitySource.Operations.SendEmail);
         SmtpOptions smtp = options.CurrentValue;
         int timeoutMs = smtp.TimeoutSeconds * 1000;
 

--- a/src/Granit.Notifications.Twilio/Diagnostics/NotificationsTwilioActivitySource.cs
+++ b/src/Granit.Notifications.Twilio/Diagnostics/NotificationsTwilioActivitySource.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+
+namespace Granit.Notifications.Twilio.Diagnostics;
+
+/// <summary>OpenTelemetry activity source for the Twilio SMS/WhatsApp provider.</summary>
+internal static class NotificationsTwilioActivitySource
+{
+    /// <summary>Activity source name.</summary>
+    public const string Name = "Granit.Notifications.Twilio";
+
+    /// <summary>Shared activity source instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    /// <summary>Operation names.</summary>
+    internal static class Operations
+    {
+        public const string SendSms = "twilio.send-sms";
+        public const string SendWhatsApp = "twilio.send-whatsapp";
+    }
+}

--- a/src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
 using System.Net.Http.Headers;
 using System.Text;
+using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Sms;
+using Granit.Notifications.Twilio.Diagnostics;
 using Granit.Notifications.Twilio.HealthChecks;
 using Granit.Notifications.Twilio.Internal;
 using Granit.Notifications.Twilio.Options;
@@ -23,10 +26,7 @@ public static class TwilioNotificationsServiceCollectionExtensions
         this IServiceCollection services,
         Action<TwilioOptions>? configure = null)
     {
-        services.AddOptions<TwilioOptions>()
-            .BindConfiguration(TwilioOptions.SectionName)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<TwilioOptions>(TwilioOptions.SectionName);
 
         if (configure is not null)
         {
@@ -49,11 +49,13 @@ public static class TwilioNotificationsServiceCollectionExtensions
         services.AddKeyedSingleton<IWhatsAppSender>(
             ProviderKey, (sp, _) => sp.GetRequiredService<TwilioNotificationProvider>());
 
+        GranitActivitySourceRegistry.Register(NotificationsTwilioActivitySource.Name);
+
         return services;
     }
 
     /// <summary>
-    /// Adds the Twilio API health check (tags: <c>readiness</c>).
+    /// Adds the Twilio API health check (tags: <c>readiness</c>, <c>startup</c>).
     /// </summary>
     /// <param name="builder">The health checks builder.</param>
     /// <param name="name">Optional check name (default: <c>"twilio"</c>).</param>
@@ -75,6 +77,6 @@ public static class TwilioNotificationsServiceCollectionExtensions
                 return new TwilioHealthCheck(factory, opts);
             },
             failureStatus,
-            ["readiness"],
+            ["readiness", "startup"],
             timeout));
 }

--- a/src/Granit.Notifications.Twilio/GranitNotificationsTwilioModule.cs
+++ b/src/Granit.Notifications.Twilio/GranitNotificationsTwilioModule.cs
@@ -1,6 +1,8 @@
+using Granit.Diagnostics;
 using Granit.Http.Resilience;
 using Granit.Modularity;
 using Granit.Notifications.Sms;
+using Granit.Notifications.Twilio.Extensions;
 using Granit.Notifications.WhatsApp;
 
 namespace Granit.Notifications.Twilio;
@@ -13,7 +15,12 @@ namespace Granit.Notifications.Twilio;
 /// Registers <c>TwilioNotificationProvider</c> as a keyed service for SMS and WhatsApp channels.
 /// </remarks>
 [DependsOn(
+    typeof(GranitDiagnosticsModule),
     typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsSmsModule),
     typeof(GranitNotificationsWhatsAppModule))]
-public sealed class GranitNotificationsTwilioModule : GranitModule;
+public sealed class GranitNotificationsTwilioModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitNotificationsTwilio();
+}

--- a/src/Granit.Notifications.Twilio/Internal/TwilioNotificationProvider.cs
+++ b/src/Granit.Notifications.Twilio/Internal/TwilioNotificationProvider.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using Granit.Diagnostics;
+using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Sms;
+using Granit.Notifications.Twilio.Diagnostics;
 using Granit.Notifications.Twilio.Options;
 using Granit.Notifications.WhatsApp;
 using Microsoft.Extensions.Logging;
@@ -20,6 +23,7 @@ internal sealed partial class TwilioNotificationProvider(
     /// <inheritdoc />
     async Task ISmsSender.SendAsync(SmsMessage message, CancellationToken cancellationToken)
     {
+        using Activity? activity = NotificationsTwilioActivitySource.Source.StartActivity(NotificationsTwilioActivitySource.Operations.SendSms);
         TwilioOptions opts = options.CurrentValue;
         HttpClient client = httpClientFactory.CreateClient("Twilio");
 
@@ -35,7 +39,7 @@ internal sealed partial class TwilioNotificationProvider(
 
         using HttpResponseMessage response = await client.PostAsync(
             endpoint, content, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(endpoint, response, cancellationToken).ConfigureAwait(false);
+        await response.EnsureGranitSuccessAsync(logger, "Twilio", endpoint, cancellationToken).ConfigureAwait(false);
 
         LogSmsSent(LogRedaction.Phone(message.To));
     }
@@ -43,6 +47,7 @@ internal sealed partial class TwilioNotificationProvider(
     /// <inheritdoc />
     async Task IWhatsAppSender.SendAsync(WhatsAppMessage message, CancellationToken cancellationToken)
     {
+        using Activity? activity = NotificationsTwilioActivitySource.Source.StartActivity(NotificationsTwilioActivitySource.Operations.SendWhatsApp);
         TwilioOptions opts = options.CurrentValue;
         HttpClient client = httpClientFactory.CreateClient("Twilio");
 
@@ -60,7 +65,7 @@ internal sealed partial class TwilioNotificationProvider(
 
         using HttpResponseMessage response = await client.PostAsync(
             endpoint, content, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(endpoint, response, cancellationToken).ConfigureAwait(false);
+        await response.EnsureGranitSuccessAsync(logger, "Twilio", endpoint, cancellationToken).ConfigureAwait(false);
 
         LogWhatsAppSent(LogRedaction.Phone(message.To), message.TemplateName);
     }
@@ -79,33 +84,6 @@ internal sealed partial class TwilioNotificationProvider(
         return string.Join(", ", message.TemplateParameters.Prepend(message.TemplateName));
     }
 
-    /// <summary>
-    /// Reads the Twilio error body before throwing, so the caller (and logs) get a meaningful message.
-    /// </summary>
-    private async Task EnsureSuccessAsync(string endpoint, HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        string? errorBody = null;
-        try
-        {
-            errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // Best-effort -- do not mask the original HTTP error.
-        }
-
-        LogTwilioError(endpoint, (int)response.StatusCode, errorBody);
-
-        throw new HttpRequestException(
-            $"Twilio API error {(int)response.StatusCode} on {endpoint}: {errorBody ?? "(no body)"}",
-            inner: null,
-            response.StatusCode);
-    }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Twilio SMS sent to {RedactedRecipient}")]
     private partial void LogSmsSent(string redactedRecipient);
@@ -113,6 +91,4 @@ internal sealed partial class TwilioNotificationProvider(
     [LoggerMessage(Level = LogLevel.Information, Message = "Twilio WhatsApp sent to {RedactedRecipient} template {TemplateName}")]
     private partial void LogWhatsAppSent(string redactedRecipient, string templateName);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Twilio API error on {Endpoint}: HTTP {StatusCode} — {ErrorBody}")]
-    private partial void LogTwilioError(string endpoint, int statusCode, string? errorBody);
 }

--- a/src/Granit.Notifications.Wolverine/GranitNotificationsWolverineModule.cs
+++ b/src/Granit.Notifications.Wolverine/GranitNotificationsWolverineModule.cs
@@ -1,3 +1,4 @@
+using Granit.Encryption;
 using Granit.Modularity;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Exceptions;
@@ -29,6 +30,7 @@ namespace Granit.Notifications.Wolverine;
 /// </para>
 /// </remarks>
 [DependsOn(
+    typeof(GranitEncryptionModule),
     typeof(GranitNotificationsModule),
     typeof(GranitWolverineModule))]
 public sealed class GranitNotificationsWolverineModule : GranitModule

--- a/src/Granit.Notifications.Zulip/Diagnostics/NotificationsZulipActivitySource.cs
+++ b/src/Granit.Notifications.Zulip/Diagnostics/NotificationsZulipActivitySource.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Granit.Notifications.Zulip.Diagnostics;
+
+/// <summary>OpenTelemetry activity source for the Zulip chat provider.</summary>
+internal static class NotificationsZulipActivitySource
+{
+    /// <summary>Activity source name.</summary>
+    public const string Name = "Granit.Notifications.Zulip";
+
+    /// <summary>Shared activity source instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    /// <summary>Operation names.</summary>
+    internal static class Operations
+    {
+        public const string SendMessage = "zulip.send-message";
+    }
+}

--- a/src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
+using Granit.Diagnostics;
+using Granit.Extensions;
 using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Abstractions;
+using Granit.Notifications.Zulip.Diagnostics;
 using Granit.Notifications.Zulip.HealthChecks;
 using Granit.Notifications.Zulip.Internal;
 using Granit.Notifications.Zulip.Options;
@@ -18,14 +21,9 @@ public static class ZulipNotificationsServiceCollectionExtensions
         Action<ZulipChannelOptions>? configureChannel = null,
         Action<ZulipBotOptions>? configureBot = null)
     {
-        services.AddOptions<ZulipChannelOptions>()
-            .BindConfiguration(ZulipChannelOptions.SectionName)
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<ZulipChannelOptions>(ZulipChannelOptions.SectionName);
 
-        services.AddOptions<ZulipBotOptions>()
-            .BindConfiguration(ZulipBotOptions.SectionName)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        services.AddGranitProviderOptions<ZulipBotOptions>(ZulipBotOptions.SectionName);
 
         if (configureChannel is not null)
         {
@@ -46,6 +44,8 @@ public static class ZulipNotificationsServiceCollectionExtensions
 
         services.AddSingleton<IZulipSender, ZulipBotSender>();
         services.AddScoped<INotificationChannel, ZulipNotificationChannel>();
+        GranitActivitySourceRegistry.Register(NotificationsZulipActivitySource.Name);
+
         return services;
     }
 
@@ -59,5 +59,5 @@ public static class ZulipNotificationsServiceCollectionExtensions
                 sp.GetRequiredService<IHttpClientFactory>(),
                 sp.GetRequiredService<IOptions<ZulipBotOptions>>()),
             failureStatus: null,
-            tags: ["readiness"]));
+            tags: ["readiness", "startup"]));
 }

--- a/src/Granit.Notifications.Zulip/GranitNotificationsZulipModule.cs
+++ b/src/Granit.Notifications.Zulip/GranitNotificationsZulipModule.cs
@@ -1,5 +1,7 @@
+using Granit.Diagnostics;
 using Granit.Http.Resilience;
 using Granit.Modularity;
+using Granit.Notifications.Zulip.Extensions;
 
 namespace Granit.Notifications.Zulip;
 
@@ -11,6 +13,11 @@ namespace Granit.Notifications.Zulip;
 /// Includes its own <c>ZulipBotSender</c> implementation.
 /// </remarks>
 [DependsOn(
+    typeof(GranitDiagnosticsModule),
     typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsAbstractionsModule))]
-public sealed class GranitNotificationsZulipModule : GranitModule;
+public sealed class GranitNotificationsZulipModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitNotificationsZulip();
+}

--- a/src/Granit.Notifications.Zulip/Internal/ZulipBotSender.cs
+++ b/src/Granit.Notifications.Zulip/Internal/ZulipBotSender.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Granit.Http.Resilience.Extensions;
+using Granit.Notifications.Zulip.Diagnostics;
 using Granit.Notifications.Zulip.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -21,6 +24,7 @@ internal sealed partial class ZulipBotSender(
     /// <inheritdoc />
     public async Task SendAsync(ZulipMessage message, CancellationToken cancellationToken = default)
     {
+        using Activity? activity = NotificationsZulipActivitySource.Source.StartActivity(NotificationsZulipActivitySource.Operations.SendMessage);
         HttpClient client = httpClientFactory.CreateClient(HttpClientName);
         ZulipBotOptions botOptions = options.CurrentValue;
 
@@ -46,12 +50,7 @@ internal sealed partial class ZulipBotSender(
         using var content = new FormUrlEncodedContent(formData);
         using HttpResponseMessage response = await client.PostAsync("api/v1/messages", content, cancellationToken).ConfigureAwait(false);
 
-        if (!response.IsSuccessStatusCode)
-        {
-            string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            LogSendFailed(response.StatusCode.ToString(), body);
-            response.EnsureSuccessStatusCode();
-        }
+        await response.EnsureGranitSuccessAsync(logger, "Zulip", "api/v1/messages", cancellationToken).ConfigureAwait(false);
 
         LogMessageSent(message.Type, message.Stream ?? "direct");
     }
@@ -59,6 +58,4 @@ internal sealed partial class ZulipBotSender(
     [LoggerMessage(Level = LogLevel.Information, Message = "Zulip message sent (type={Type}, target={Target})")]
     private partial void LogMessageSent(string type, string target);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Zulip API error: {StatusCode} — {Body}")]
-    private partial void LogSendFailed(string statusCode, string body);
 }

--- a/src/Granit.Notifications/GranitNotificationsModule.cs
+++ b/src/Granit.Notifications/GranitNotificationsModule.cs
@@ -1,9 +1,13 @@
+using Granit.DataExchange;
+using Granit.Encryption;
 using Granit.Guids;
+using Granit.Localization;
 using Granit.Modularity;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Diagnostics;
 using Granit.Notifications.Extensions;
 using Granit.Notifications.Internal;
+using Granit.QueryEngine;
 using Granit.Timing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -21,8 +25,12 @@ namespace Granit.Notifications;
 /// <c>AddGranitNotificationsEntityFrameworkCore()</c> for persistent stores.
 /// </remarks>
 [DependsOn(
+    typeof(GranitDataExchangeAbstractionsModule),
+    typeof(GranitEncryptionModule),
     typeof(GranitGuidsModule),
+    typeof(GranitLocalizationModule),
     typeof(GranitNotificationsAbstractionsModule),
+    typeof(GranitQueryEngineAbstractionsModule),
     typeof(GranitTimingModule))]
 public sealed class GranitNotificationsModule : GranitModule
 {

--- a/tests/Granit.ArchitectureTests/ProviderExemptions.cs
+++ b/tests/Granit.ArchitectureTests/ProviderExemptions.cs
@@ -6,61 +6,31 @@ namespace Granit.ArchitectureTests;
 /// and its removal issue. A companion fact fails when an entry stops being necessary, so
 /// this list can only shrink (honest-backlog pattern, cf. ValidationKeyConventionTests).
 /// </summary>
+/// <remarks>
+/// All lists were emptied by phases 1b/2 (#2960, #2961): every notification provider now
+/// conforms to the canonical template. A new provider that violates a rule must be fixed,
+/// not exempted — add an entry only for a documented, time-boxed exception.
+/// </remarks>
 internal static class ProviderExemptions
 {
-    /// <summary>Provider modules not yet self-registering in <c>ConfigureServices</c> — phase 1b (#2961).</summary>
-    public static readonly HashSet<string> SelfRegistrationPending = new(StringComparer.Ordinal)
-    {
-        "Granit.Notifications.Brevo",      // empty-bodied module; manual AddGranitNotificationsBrevo() required
-        "Granit.Notifications.GoogleFcm",  // empty-bodied module; manual AddGranitNotificationsGoogleFcm() required
-        "Granit.Notifications.Smtp",       // empty-bodied module — trap: EmailChannelOptions.Provider defaults to "Smtp"
-        "Granit.Notifications.Twilio",     // empty-bodied module
-        "Granit.Notifications.Zulip",      // empty-bodied module
-    };
+    /// <summary>Provider modules not yet self-registering in <c>ConfigureServices</c>.</summary>
+    public static readonly HashSet<string> SelfRegistrationPending = new(StringComparer.Ordinal);
 
-    /// <summary>Providers without a registered ActivitySource — phase 1b (#2961).</summary>
-    public static readonly HashSet<string> ActivitySourcePending = new(StringComparer.Ordinal)
-    {
-        "Granit.Notifications.Brevo",      // no OTel spans on send
-        "Granit.Notifications.GoogleFcm",  // no OTel spans on send
-        "Granit.Notifications.Smtp",       // no OTel spans on send
-        "Granit.Notifications.Twilio",     // no OTel spans on send
-        "Granit.Notifications.Zulip",      // no OTel spans on send
-    };
+    /// <summary>Providers without a registered ActivitySource.</summary>
+    public static readonly HashSet<string> ActivitySourcePending = new(StringComparer.Ordinal);
 
-    /// <summary>Providers without a health check — phase 1b (#2961).</summary>
-    public static readonly HashSet<string> HealthCheckPending = new(StringComparer.Ordinal)
-    {
-        "Granit.Notifications.GoogleFcm",  // only mobile-push provider without one (AwsSns/AzureNotificationHubs have config probes)
-    };
+    /// <summary>Providers without a health check.</summary>
+    public static readonly HashSet<string> HealthCheckPending = new(StringComparer.Ordinal);
 
-    /// <summary>
-    /// Providers nested under a channel package. Emptied by phase 2 (#2960) — the placement
-    /// rule is now fully enforced; new providers must be top-level from day one.
-    /// </summary>
+    /// <summary>Providers nested under a channel package.</summary>
     public static readonly HashSet<string> PlacementPending = new(StringComparer.Ordinal);
 
-    /// <summary>Providers whose options validation is a no-op — phase 1b (#2961).</summary>
-    public static readonly HashSet<string> ValidationPending = new(StringComparer.Ordinal)
-    {
-        "Granit.Notifications.Smtp",  // ValidateOnStart() without ValidateDataAnnotations() and no IValidateOptions
-    };
+    /// <summary>Providers whose options validation is a no-op.</summary>
+    public static readonly HashSet<string> ValidationPending = new(StringComparer.Ordinal);
 
-    /// <summary>Providers without a SectionName assertion test — phase 1b (#2961).</summary>
-    public static readonly HashSet<string> SectionNameTestPending = new(StringComparer.Ordinal)
-    {
-        "Granit.Notifications.AwsSes",                      // only *OptionsValidatorTests exist
-        "Granit.Notifications.AwsSns",                      // merged test project has no SectionName assertions yet
-        "Granit.Notifications.AzureCommunicationServices",  // merged test project has no SectionName assertions yet
-    };
+    /// <summary>Providers without a SectionName assertion test.</summary>
+    public static readonly HashSet<string> SectionNameTestPending = new(StringComparer.Ordinal);
 
-    /// <summary>Providers whose module [DependsOn] omits direct module references — phase 1b (#2961).</summary>
-    public static readonly HashSet<string> DependsOnPending = new(StringComparer.Ordinal)
-    {
-        "Granit.Notifications.Brevo",     // missing GranitDiagnosticsModule (direct ref via HttpServiceHealthCheckBase)
-        "Granit.Notifications.Scaleway",  // missing GranitDiagnosticsModule
-        "Granit.Notifications.SendGrid",  // missing GranitDiagnosticsModule
-        "Granit.Notifications.Twilio",    // missing GranitDiagnosticsModule
-        "Granit.Notifications.Zulip",     // missing GranitDiagnosticsModule
-    };
+    /// <summary>Providers whose module [DependsOn] omits direct module references.</summary>
+    public static readonly HashSet<string> DependsOnPending = new(StringComparer.Ordinal);
 }

--- a/tests/Granit.Notifications.AwsSes.Tests/AwsSesOptionsTests.cs
+++ b/tests/Granit.Notifications.AwsSes.Tests/AwsSesOptionsTests.cs
@@ -1,0 +1,17 @@
+using Granit.Notifications.AwsSes.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.AwsSes.Tests;
+
+public sealed class AwsSesOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        AwsSesOptions.SectionName.ShouldBe("Notifications:AwsSes");
+
+    [Fact]
+    public void TimeoutSeconds_Default_IsPositive() =>
+        new AwsSesOptions().TimeoutSeconds.ShouldBeGreaterThan(0);
+}

--- a/tests/Granit.Notifications.AwsSns.Tests/MobilePush/AwsSnsMobilePushOptionsTests.cs
+++ b/tests/Granit.Notifications.AwsSns.Tests/MobilePush/AwsSnsMobilePushOptionsTests.cs
@@ -1,0 +1,17 @@
+using Granit.Notifications.AwsSns.MobilePush.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.AwsSns.MobilePush.Tests;
+
+public sealed class AwsSnsMobilePushOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        AwsSnsMobilePushOptions.SectionName.ShouldBe("Notifications:AwsSns:MobilePush");
+
+    [Fact]
+    public void TimeoutSeconds_Default_IsPositive() =>
+        new AwsSnsMobilePushOptions().TimeoutSeconds.ShouldBeGreaterThan(0);
+}

--- a/tests/Granit.Notifications.AwsSns.Tests/Sms/AwsSnsSmsOptionsTests.cs
+++ b/tests/Granit.Notifications.AwsSns.Tests/Sms/AwsSnsSmsOptionsTests.cs
@@ -1,0 +1,17 @@
+using Granit.Notifications.AwsSns.Sms.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.AwsSns.Sms.Tests;
+
+public sealed class AwsSnsSmsOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        AwsSnsSmsOptions.SectionName.ShouldBe("Notifications:AwsSns:Sms");
+
+    [Fact]
+    public void TimeoutSeconds_Default_IsPositive() =>
+        new AwsSnsSmsOptions().TimeoutSeconds.ShouldBeGreaterThan(0);
+}

--- a/tests/Granit.Notifications.AzureCommunicationServices.Tests/Email/AcsEmailOptionsTests.cs
+++ b/tests/Granit.Notifications.AzureCommunicationServices.Tests/Email/AcsEmailOptionsTests.cs
@@ -1,0 +1,17 @@
+using Granit.Notifications.AzureCommunicationServices.Email.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.AzureCommunicationServices.Email.Tests;
+
+public sealed class AcsEmailOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        AcsEmailOptions.SectionName.ShouldBe("Notifications:AzureCommunicationServices:Email");
+
+    [Fact]
+    public void TimeoutSeconds_Default_IsPositive() =>
+        new AcsEmailOptions().TimeoutSeconds.ShouldBeGreaterThan(0);
+}

--- a/tests/Granit.Notifications.AzureCommunicationServices.Tests/Sms/AcsSmsOptionsTests.cs
+++ b/tests/Granit.Notifications.AzureCommunicationServices.Tests/Sms/AcsSmsOptionsTests.cs
@@ -1,0 +1,17 @@
+using Granit.Notifications.AzureCommunicationServices.Sms.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.AzureCommunicationServices.Sms.Tests;
+
+public sealed class AcsSmsOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        AcsSmsOptions.SectionName.ShouldBe("Notifications:AzureCommunicationServices:Sms");
+
+    [Fact]
+    public void TimeoutSeconds_Default_IsPositive() =>
+        new AcsSmsOptions().TimeoutSeconds.ShouldBeGreaterThan(0);
+}

--- a/tests/Granit.Notifications.Brevo.Tests/BrevoNotificationProviderTests.cs
+++ b/tests/Granit.Notifications.Brevo.Tests/BrevoNotificationProviderTests.cs
@@ -222,7 +222,9 @@ public sealed class BrevoNotificationProviderTests : IDisposable
             },
             TestContext.Current.CancellationToken));
 
-        ex.Message.ShouldContain("Invalid email address");
+        // The vendor error body may echo the recipient — logged scrubbed, never thrown.
+        ex.Message.ShouldNotContain("Invalid email address");
+        ex.Message.ShouldContain("Brevo API error 400");
         ex.Message.ShouldContain("smtp/email");
         ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
@@ -320,7 +322,7 @@ public sealed class BrevoNotificationProviderTests : IDisposable
             },
             TestContext.Current.CancellationToken));
 
-        ex.Message.ShouldContain("Not enough SMS credits");
+        ex.Message.ShouldNotContain("Not enough SMS credits");
         ex.StatusCode.ShouldBe(HttpStatusCode.PaymentRequired);
     }
 
@@ -419,7 +421,9 @@ public sealed class BrevoNotificationProviderTests : IDisposable
             },
             TestContext.Current.CancellationToken));
 
-        ex.Message.ShouldContain("Access denied");
+        // Vendor error body is logged scrubbed, never thrown (PII posture).
+        ex.Message.ShouldNotContain("Access denied");
+        ex.Message.ShouldContain("Brevo API error");
         ex.Message.ShouldContain("whatsapp/sendTemplate");
         ex.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }
@@ -550,7 +554,7 @@ public sealed class BrevoNotificationProviderTests : IDisposable
             },
             TestContext.Current.CancellationToken));
 
-        ex.Message.ShouldContain("Invalid API key");
+        ex.Message.ShouldNotContain("Invalid API key");
         ex.Message.ShouldContain("whatsapp/sendTemplate");
         ex.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }

--- a/tests/Granit.Notifications.Twilio.Tests/TwilioNotificationProviderTests.cs
+++ b/tests/Granit.Notifications.Twilio.Tests/TwilioNotificationProviderTests.cs
@@ -166,7 +166,10 @@ public sealed class TwilioNotificationProviderTests : IDisposable
             },
             TestContext.Current.CancellationToken));
 
-        ex.Message.ShouldContain("Invalid 'To' Phone Number");
+        // The vendor error body may echo the recipient — it must never reach the
+        // exception message (it is logged scrubbed instead).
+        ex.Message.ShouldNotContain("Invalid 'To' Phone Number");
+        ex.Message.ShouldContain("Twilio API error 400");
         ex.Message.ShouldContain("Messages.json");
         ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
@@ -321,7 +324,8 @@ public sealed class TwilioNotificationProviderTests : IDisposable
             },
             TestContext.Current.CancellationToken));
 
-        ex.Message.ShouldContain("Access denied");
+        ex.Message.ShouldNotContain("Access denied");
+        ex.Message.ShouldContain("Twilio API error");
         ex.Message.ShouldContain("Messages.json");
         ex.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }


### PR DESCRIPTION
Closes #2961 (part of epic #2957 — notifications family overhaul, phase 1b of 8). Builds on merged #2966/#2967/#2972.

## What

**Every `ProviderExemptions` list is now empty** — the 13 notification providers all satisfy the 11 `ProviderConventionTests` facts with zero grandfathered violations, and the stale-exemption fact guarantees it stays that way.

| Template rule | Fixed here |
|---|---|
| `[DependsOn]` covers direct module refs | +`GranitDiagnosticsModule` ×5 (Brevo, Scaleway, SendGrid, Twilio, Zulip); core +4 (Encryption, Localization, DataExchange.Abstractions, QueryEngine.Abstractions); Endpoints +Guids; Wolverine +Encryption |
| Self-registering module | Smtp, Brevo, Twilio, Zulip, GoogleFcm — referencing the module is enough; kills the `Provider="Smtp"`-default-but-nothing-registered trap |
| Effective options validation | `AddGranitProviderOptions` at all 14 sites — SMTP no-op fixed; dead `[Range]`/`[Required]` on AwsSes/ACS/AwsSns/ANH finally enforced (checked: `[Required]` never targets optional credentials, ambient-credential AWS configs keep booting) |
| Shared HTTP success-guard | `EnsureGranitSuccessAsync` in the 5 HTTP senders; ~90 duplicated lines removed. **Vendor error bodies are logged scrubbed and never travel in exception messages** (they reach delivery audit rows) — 7 tests updated to pin this PII posture |
| ActivitySource per provider | 5 new (Smtp, Brevo, Twilio, Zulip, GoogleFcm) with spans on every send path |
| Health check per provider | GoogleFcm config-only probe + `IValidateOptions` (service-account key must be `"type":"service_account"` JSON — mis-pasted secrets fail at boot, not at first token mint) |
| Harmonized HC tags | `["readiness","startup"]` on the 5 readiness-only providers |
| SectionName pinned in tests | +5 (AwsSes, AwsSns ×2, ACS ×2) |

Plus: "source from Vault" guidance on the 6 secret-bearing option properties (BrevoOptions pattern).

## Verification

- architecture shard: **274/274 with all exemption lists empty**
- notifications shard: build 0W/0E, 29/29 test projects green
- `dotnet format --verify-no-changes` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)