### PR TITLE
feat(notifications): phase 3 — fail-at-startup configuration validation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -38555,7 +38555,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email",
       "file": "src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitNotificationsEmail",
@@ -38678,7 +38678,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Endpoints",
       "file": "src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitNotifications",
@@ -38694,7 +38694,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Endpoints",
       "file": "src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs",
-      "line": 29,
+      "line": 31,
       "members": [
         {
           "name": "ConfigureServices",
@@ -39131,7 +39131,7 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush.Endpoints",
       "file": "src/Granit.Notifications.MobilePush.Endpoints/Extensions/MobilePushTokenEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitMobilePushTokens",
@@ -39147,8 +39147,15 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush.Endpoints",
       "file": "src/Granit.Notifications.MobilePush.Endpoints/GranitNotificationsMobilePushEndpointsModule.cs",
-      "line": 19,
-      "members": []
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "MobilePushEndpointsOptions",
@@ -39219,7 +39226,7 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush",
       "file": "src/Granit.Notifications.MobilePush/Extensions/MobilePushNotificationsServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitNotificationsMobilePush",
@@ -39833,7 +39840,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Sms",
       "file": "src/Granit.Notifications.Sms/Extensions/SmsNotificationsServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitNotificationsSms",
@@ -40249,7 +40256,7 @@
       "kind": "class",
       "project": "Granit.Notifications.WebPush.Endpoints",
       "file": "src/Granit.Notifications.WebPush.Endpoints/Extensions/WebPushSubscriptionEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitWebPushSubscriptions",
@@ -40265,8 +40272,15 @@
       "kind": "class",
       "project": "Granit.Notifications.WebPush.Endpoints",
       "file": "src/Granit.Notifications.WebPush.Endpoints/GranitNotificationsWebPushEndpointsModule.cs",
-      "line": 19,
-      "members": []
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "WebPushEndpointsOptions",
@@ -40453,7 +40467,7 @@
       "kind": "class",
       "project": "Granit.Notifications.WhatsApp",
       "file": "src/Granit.Notifications.WhatsApp/Extensions/WhatsAppNotificationsServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 11,
       "members": [
         {
           "name": "AddGranitNotificationsWhatsApp",

--- a/src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Notifications.Email.Internal;
 using Granit.Notifications.Email.Options;
 using Granit.Templating.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.Email.Extensions;
 
@@ -18,6 +20,7 @@ public static class EmailNotificationsServiceCollectionExtensions
         services.AddOptions<EmailChannelOptions>()
             .BindConfiguration(EmailChannelOptions.SectionName)
             .ValidateOnStart();
+        services.TryAddSingleton<IValidateOptions<EmailChannelOptions>, EmailChannelOptionsValidator>();
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.Email/Options/EmailChannelOptionsValidator.cs
+++ b/src/Granit.Notifications.Email/Options/EmailChannelOptionsValidator.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Notifications.Email.Options;
+
+/// <summary>
+/// Fails startup when <see cref="EmailChannelOptions.Provider"/> does not resolve to a registered keyed
+/// <see cref="IEmailSender"/> — misconfiguration surfaces at boot with an explicit message
+/// instead of a <c>GetRequiredKeyedService</c> throw at the first send.
+/// </summary>
+internal sealed class EmailChannelOptionsValidator(IServiceProviderIsKeyedService keyedServices) : IValidateOptions<EmailChannelOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, EmailChannelOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                "EmailChannelOptions.Provider is required (Notifications:Email:Provider): set it to the key of a registered IEmailSender provider.");
+        }
+
+        if (!keyedServices.IsKeyedService(typeof(IEmailSender), options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                $"No IEmailSender is registered for provider key '{options.Provider}' " +
+                "(Notifications:Email:Provider). Reference the matching provider package (its module " +
+                "self-registers) or fix the configured key.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.Endpoints.Extensions;
 
@@ -28,7 +30,12 @@ public static class NotificationEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         Action<NotificationEndpointsOptions>? configure = null)
     {
-        NotificationEndpointsOptions options = new();
+        // Configuration-bound values first (NotificationEndpointsOptions.SectionName), then the delegate
+        // override. IOptionsFactory creates a fresh instance — the shared IOptions singleton
+        // is never mutated.
+        NotificationEndpointsOptions options = endpoints.ServiceProvider
+            .GetService<IOptionsFactory<NotificationEndpointsOptions>>()?
+            .Create(Microsoft.Extensions.Options.Options.DefaultName) ?? new();
         configure?.Invoke(options);
 
         RouteGroupBuilder group = endpoints.MapGranitGroup(options.RoutePrefix)

--- a/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
+++ b/src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs
@@ -4,10 +4,12 @@ using Granit.Http.ApiDocumentation;
 using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.Notifications.Endpoints.Internal;
+using Granit.Notifications.Endpoints.Options;
 using Granit.Notifications.Endpoints.Workspaces;
 using Granit.Validation;
 using Granit.Workspaces;
 using Granit.Workspaces.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Notifications.Endpoints;
 
@@ -32,6 +34,9 @@ public sealed class GranitNotificationsEndpointsModule : GranitModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddLocalizationResource<NotificationsEndpointsLocalizationResource>();
+        context.Services.AddOptions<NotificationEndpointsOptions>()
+            .BindConfiguration(NotificationEndpointsOptions.SectionName)
+            .ValidateOnStart();
         context.Services.AddFeatureProvider<NotificationsFeatureProvider>();
     }
 }

--- a/src/Granit.Notifications.MobilePush.Endpoints/Extensions/MobilePushTokenEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Notifications.MobilePush.Endpoints/Extensions/MobilePushTokenEndpointRouteBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.MobilePush.Endpoints.Extensions;
 
@@ -24,7 +26,12 @@ public static class MobilePushTokenEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         Action<MobilePushEndpointsOptions>? configure = null)
     {
-        MobilePushEndpointsOptions options = new();
+        // Configuration-bound values first (MobilePushEndpointsOptions.SectionName), then the delegate
+        // override. IOptionsFactory creates a fresh instance — the shared IOptions singleton
+        // is never mutated.
+        MobilePushEndpointsOptions options = endpoints.ServiceProvider
+            .GetService<IOptionsFactory<MobilePushEndpointsOptions>>()?
+            .Create(Microsoft.Extensions.Options.Options.DefaultName) ?? new();
         configure?.Invoke(options);
 
         endpoints.MapGranitGroup(options.RoutePrefix)

--- a/src/Granit.Notifications.MobilePush.Endpoints/GranitNotificationsMobilePushEndpointsModule.cs
+++ b/src/Granit.Notifications.MobilePush.Endpoints/GranitNotificationsMobilePushEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Modularity;
 using Granit.Notifications.Endpoints;
+using Granit.Notifications.MobilePush.Endpoints.Options;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Notifications.MobilePush.Endpoints;
 
@@ -16,4 +18,10 @@ namespace Granit.Notifications.MobilePush.Endpoints;
     typeof(GranitNotificationsEndpointsModule),
     typeof(GranitNotificationsMobilePushModule),
     typeof(GranitValidationModule))]
-public sealed class GranitNotificationsMobilePushEndpointsModule : GranitModule;
+public sealed class GranitNotificationsMobilePushEndpointsModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddOptions<MobilePushEndpointsOptions>()
+            .BindConfiguration(MobilePushEndpointsOptions.SectionName)
+            .ValidateOnStart();
+}

--- a/src/Granit.Notifications.MobilePush/Extensions/MobilePushNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.MobilePush/Extensions/MobilePushNotificationsServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Granit.Notifications.MobilePush.Internal;
 using Granit.Notifications.MobilePush.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.MobilePush.Extensions;
 
@@ -17,6 +18,7 @@ public static class MobilePushNotificationsServiceCollectionExtensions
         services.AddOptions<MobilePushChannelOptions>()
             .BindConfiguration(MobilePushChannelOptions.SectionName)
             .ValidateOnStart();
+        services.TryAddSingleton<IValidateOptions<MobilePushChannelOptions>, MobilePushChannelOptionsValidator>();
 
         services.AddOptions<MobilePushTokenHasherOptions>()
             .BindConfiguration(MobilePushTokenHasherOptions.SectionName);

--- a/src/Granit.Notifications.MobilePush/Options/MobilePushChannelOptionsValidator.cs
+++ b/src/Granit.Notifications.MobilePush/Options/MobilePushChannelOptionsValidator.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Notifications.MobilePush.Options;
+
+/// <summary>
+/// Fails startup when <see cref="MobilePushChannelOptions.Provider"/> does not resolve to a registered keyed
+/// <see cref="IMobilePushSender"/> — misconfiguration surfaces at boot with an explicit message
+/// instead of a <c>GetRequiredKeyedService</c> throw at the first send.
+/// </summary>
+internal sealed class MobilePushChannelOptionsValidator(IServiceProviderIsKeyedService keyedServices) : IValidateOptions<MobilePushChannelOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, MobilePushChannelOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                "MobilePushChannelOptions.Provider is required (Notifications:MobilePush:Provider): set it to the key of a registered IMobilePushSender provider.");
+        }
+
+        if (!keyedServices.IsKeyedService(typeof(IMobilePushSender), options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                $"No IMobilePushSender is registered for provider key '{options.Provider}' " +
+                "(Notifications:MobilePush:Provider). Reference the matching provider package (its module " +
+                "self-registers) or fix the configured key.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.Notifications.Sms/Extensions/SmsNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Sms/Extensions/SmsNotificationsServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@ using Granit.Notifications.Abstractions;
 using Granit.Notifications.Sms.Internal;
 using Granit.Notifications.Sms.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.Sms.Extensions;
 
@@ -16,6 +18,7 @@ public static class SmsNotificationsServiceCollectionExtensions
         services.AddOptions<SmsChannelOptions>()
             .BindConfiguration(SmsChannelOptions.SectionName)
             .ValidateOnStart();
+        services.TryAddSingleton<IValidateOptions<SmsChannelOptions>, SmsChannelOptionsValidator>();
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.Sms/Options/SmsChannelOptionsValidator.cs
+++ b/src/Granit.Notifications.Sms/Options/SmsChannelOptionsValidator.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Notifications.Sms.Options;
+
+/// <summary>
+/// Fails startup when <see cref="SmsChannelOptions.Provider"/> does not resolve to a registered keyed
+/// <see cref="ISmsSender"/> — misconfiguration surfaces at boot with an explicit message
+/// instead of a <c>GetRequiredKeyedService</c> throw at the first send.
+/// </summary>
+internal sealed class SmsChannelOptionsValidator(IServiceProviderIsKeyedService keyedServices) : IValidateOptions<SmsChannelOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, SmsChannelOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                "SmsChannelOptions.Provider is required (Notifications:Sms:Provider): set it to the key of a registered ISmsSender provider.");
+        }
+
+        if (!keyedServices.IsKeyedService(typeof(ISmsSender), options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                $"No ISmsSender is registered for provider key '{options.Provider}' " +
+                "(Notifications:Sms:Provider). Reference the matching provider package (its module " +
+                "self-registers) or fix the configured key.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.Notifications.WebPush.Endpoints/Extensions/WebPushSubscriptionEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Notifications.WebPush.Endpoints/Extensions/WebPushSubscriptionEndpointRouteBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.WebPush.Endpoints.Extensions;
 
@@ -24,7 +26,12 @@ public static class WebPushSubscriptionEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         Action<WebPushEndpointsOptions>? configure = null)
     {
-        WebPushEndpointsOptions options = new();
+        // Configuration-bound values first (WebPushEndpointsOptions.SectionName), then the delegate
+        // override. IOptionsFactory creates a fresh instance — the shared IOptions singleton
+        // is never mutated.
+        WebPushEndpointsOptions options = endpoints.ServiceProvider
+            .GetService<IOptionsFactory<WebPushEndpointsOptions>>()?
+            .Create(Microsoft.Extensions.Options.Options.DefaultName) ?? new();
         configure?.Invoke(options);
 
         endpoints.MapGranitGroup(options.RoutePrefix)

--- a/src/Granit.Notifications.WebPush.Endpoints/GranitNotificationsWebPushEndpointsModule.cs
+++ b/src/Granit.Notifications.WebPush.Endpoints/GranitNotificationsWebPushEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Modularity;
 using Granit.Notifications.Endpoints;
+using Granit.Notifications.WebPush.Endpoints.Options;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Notifications.WebPush.Endpoints;
 
@@ -16,4 +18,10 @@ namespace Granit.Notifications.WebPush.Endpoints;
     typeof(GranitNotificationsEndpointsModule),
     typeof(GranitNotificationsWebPushModule),
     typeof(GranitValidationModule))]
-public sealed class GranitNotificationsWebPushEndpointsModule : GranitModule;
+public sealed class GranitNotificationsWebPushEndpointsModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddOptions<WebPushEndpointsOptions>()
+            .BindConfiguration(WebPushEndpointsOptions.SectionName)
+            .ValidateOnStart();
+}

--- a/src/Granit.Notifications.WhatsApp/Extensions/WhatsAppNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.WhatsApp/Extensions/WhatsAppNotificationsServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@ using Granit.Notifications.Abstractions;
 using Granit.Notifications.WhatsApp.Internal;
 using Granit.Notifications.WhatsApp.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Notifications.WhatsApp.Extensions;
 
@@ -16,6 +18,7 @@ public static class WhatsAppNotificationsServiceCollectionExtensions
         services.AddOptions<WhatsAppChannelOptions>()
             .BindConfiguration(WhatsAppChannelOptions.SectionName)
             .ValidateOnStart();
+        services.TryAddSingleton<IValidateOptions<WhatsAppChannelOptions>, WhatsAppChannelOptionsValidator>();
 
         if (configure is not null)
         {

--- a/src/Granit.Notifications.WhatsApp/Options/WhatsAppChannelOptionsValidator.cs
+++ b/src/Granit.Notifications.WhatsApp/Options/WhatsAppChannelOptionsValidator.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Notifications.WhatsApp.Options;
+
+/// <summary>
+/// Fails startup when <see cref="WhatsAppChannelOptions.Provider"/> does not resolve to a registered keyed
+/// <see cref="IWhatsAppSender"/> — misconfiguration surfaces at boot with an explicit message
+/// instead of a <c>GetRequiredKeyedService</c> throw at the first send.
+/// </summary>
+internal sealed class WhatsAppChannelOptionsValidator(IServiceProviderIsKeyedService keyedServices) : IValidateOptions<WhatsAppChannelOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, WhatsAppChannelOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                "WhatsAppChannelOptions.Provider is required (Notifications:WhatsApp:Provider): set it to the key of a registered IWhatsAppSender provider.");
+        }
+
+        if (!keyedServices.IsKeyedService(typeof(IWhatsAppSender), options.Provider))
+        {
+            return ValidateOptionsResult.Fail(
+                $"No IWhatsAppSender is registered for provider key '{options.Provider}' " +
+                "(Notifications:WhatsApp:Provider). Reference the matching provider package (its module " +
+                "self-registers) or fix the configured key.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/tests/Granit.Notifications.AI.Tests/NotificationsAIOptionsTests.cs
+++ b/tests/Granit.Notifications.AI.Tests/NotificationsAIOptionsTests.cs
@@ -1,0 +1,21 @@
+using Granit.Notifications.AI.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.AI.Tests;
+
+public sealed class NotificationsAIOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        NotificationsAIOptions.SectionName.ShouldBe("Notifications:AI");
+
+    [Fact]
+    public void TimeoutSeconds_Default_IsPositive() =>
+        new NotificationsAIOptions().TimeoutSeconds.ShouldBeGreaterThan(0);
+
+    [Fact]
+    public void AllowPersonalDataInPrompts_Default_IsFalse() =>
+        new NotificationsAIOptions().AllowPersonalDataInPrompts.ShouldBeFalse();
+}

--- a/tests/Granit.Notifications.Email.Tests/EmailChannelOptionsValidatorTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailChannelOptionsValidatorTests.cs
@@ -1,0 +1,67 @@
+using Granit.Notifications.Email.Extensions;
+using Granit.Notifications.Email.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.Email.Tests;
+
+public sealed class EmailChannelOptionsValidatorTests
+{
+    private static EmailChannelOptionsValidator BuildValidator(bool keyIsRegistered)
+    {
+        IServiceProviderIsKeyedService keyed = Substitute.For<IServiceProviderIsKeyedService>();
+        keyed.IsKeyedService(typeof(IEmailSender), Arg.Any<object?>()).Returns(keyIsRegistered);
+        return new EmailChannelOptionsValidator(keyed);
+    }
+
+    [Fact]
+    public void EmptyProvider_Fails()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: true)
+            .Validate(null, new EmailChannelOptions { Provider = "" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("Provider is required");
+    }
+
+    [Fact]
+    public void UnknownProviderKey_FailsWithExplicitMessage()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: false)
+            .Validate(null, new EmailChannelOptions { Provider = "DoesNotExist" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("DoesNotExist");
+        result.FailureMessage.ShouldContain("provider package");
+    }
+
+    [Fact]
+    public void RegisteredProviderKey_Succeeds() =>
+        BuildValidator(keyIsRegistered: true)
+            .Validate(null, new EmailChannelOptions { Provider = "SomeProvider" })
+            .Succeeded.ShouldBeTrue();
+
+    /// <summary>
+    /// End-to-end: a misconfigured provider key fails at options resolution (ValidateOnStart
+    /// surfaces this at boot) instead of GetRequiredKeyedService throwing at the first send.
+    /// </summary>
+    [Fact]
+    public void MisconfiguredHost_FailsOptionsValidation_NotFirstSend()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Notifications:Email:Provider"] = "NotARealProvider",
+        }).Build());
+        services.AddGranitNotificationsEmail();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Should.Throw<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<EmailChannelOptions>>().Value);
+    }
+}

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsAdditionalTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsAdditionalTests.cs
@@ -3,6 +3,7 @@ using Granit.Notifications.Email.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -17,6 +18,8 @@ public sealed class EmailNotificationsServiceCollectionExtensionsAdditionalTests
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddGranitNotificationsEmail();
 
+        // Satisfies the keyed-provider startup validator — these tests assert options mechanics.
+        services.AddKeyedSingleton("Smtp", (_, _) => Substitute.For<IEmailSender>());
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<EmailChannelOptions> options = sp.GetRequiredService<IOptions<EmailChannelOptions>>();
 
@@ -35,6 +38,8 @@ public sealed class EmailNotificationsServiceCollectionExtensionsAdditionalTests
             opts.DefaultSenderName = "Test App";
         });
 
+        // Satisfies the keyed-provider startup validator — these tests assert options mechanics.
+        services.AddKeyedSingleton("Brevo", (_, _) => Substitute.For<IEmailSender>());
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<EmailChannelOptions> options = sp.GetRequiredService<IOptions<EmailChannelOptions>>();
 
@@ -50,6 +55,8 @@ public sealed class EmailNotificationsServiceCollectionExtensionsAdditionalTests
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddGranitNotificationsEmail();
 
+        // Satisfies the keyed-provider startup validator — these tests assert options mechanics.
+        services.AddKeyedSingleton("Smtp", (_, _) => Substitute.For<IEmailSender>());
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<EmailChannelOptions> options = sp.GetRequiredService<IOptions<EmailChannelOptions>>();
 

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsTests.cs
@@ -14,6 +14,7 @@ using Granit.Templating.Pipeline;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -55,6 +56,8 @@ public sealed class EmailNotificationsServiceCollectionExtensionsTests
             opts.DefaultSenderName = "Test App";
         });
 
+        // Satisfies the keyed-provider startup validator — these tests assert options mechanics.
+        services.AddKeyedSingleton("Brevo", (_, _) => Substitute.For<IEmailSender>());
         ServiceProvider sp = services.BuildServiceProvider();
         EmailChannelOptions options = sp.GetRequiredService<IOptions<EmailChannelOptions>>().Value;
 

--- a/tests/Granit.Notifications.Endpoints.Tests/NotificationEndpointsOptionsTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/NotificationEndpointsOptionsTests.cs
@@ -6,11 +6,12 @@ namespace Granit.Notifications.Endpoints.Tests;
 
 public sealed class NotificationEndpointsOptionsTests
 {
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
     [Fact]
-    public void RoutePrefix_Default_ShouldBeNotifications() =>
-        new NotificationEndpointsOptions().RoutePrefix.ShouldBe("notifications");
+    public void SectionName_IsPinned() =>
+        NotificationEndpointsOptions.SectionName.ShouldBe("Notifications:Endpoints");
 
     [Fact]
-    public void TagName_Default_ShouldBeNotifications() =>
-        new NotificationEndpointsOptions().TagName.ShouldBe("Notifications");
+    public void RoutePrefix_Default_IsNotifications() =>
+        new NotificationEndpointsOptions().RoutePrefix.ShouldBe("notifications");
 }

--- a/tests/Granit.Notifications.MobilePush.Endpoints.Tests/MobilePushEndpointsOptionsTests.cs
+++ b/tests/Granit.Notifications.MobilePush.Endpoints.Tests/MobilePushEndpointsOptionsTests.cs
@@ -1,0 +1,17 @@
+using Granit.Notifications.MobilePush.Endpoints.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.MobilePush.Endpoints.Tests;
+
+public sealed class MobilePushEndpointsOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        MobilePushEndpointsOptions.SectionName.ShouldBe("Notifications:MobilePush:Endpoints");
+
+    [Fact]
+    public void RoutePrefix_Default_IsPinned() =>
+        new MobilePushEndpointsOptions().RoutePrefix.ShouldBe("notifications/mobile-push");
+}

--- a/tests/Granit.Notifications.MobilePush.Tests/MobilePushChannelOptionsValidatorTests.cs
+++ b/tests/Granit.Notifications.MobilePush.Tests/MobilePushChannelOptionsValidatorTests.cs
@@ -1,0 +1,67 @@
+using Granit.Notifications.MobilePush.Extensions;
+using Granit.Notifications.MobilePush.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.MobilePush.Tests;
+
+public sealed class MobilePushChannelOptionsValidatorTests
+{
+    private static MobilePushChannelOptionsValidator BuildValidator(bool keyIsRegistered)
+    {
+        IServiceProviderIsKeyedService keyed = Substitute.For<IServiceProviderIsKeyedService>();
+        keyed.IsKeyedService(typeof(IMobilePushSender), Arg.Any<object?>()).Returns(keyIsRegistered);
+        return new MobilePushChannelOptionsValidator(keyed);
+    }
+
+    [Fact]
+    public void EmptyProvider_Fails()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: true)
+            .Validate(null, new MobilePushChannelOptions { Provider = "" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("Provider is required");
+    }
+
+    [Fact]
+    public void UnknownProviderKey_FailsWithExplicitMessage()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: false)
+            .Validate(null, new MobilePushChannelOptions { Provider = "DoesNotExist" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("DoesNotExist");
+        result.FailureMessage.ShouldContain("provider package");
+    }
+
+    [Fact]
+    public void RegisteredProviderKey_Succeeds() =>
+        BuildValidator(keyIsRegistered: true)
+            .Validate(null, new MobilePushChannelOptions { Provider = "SomeProvider" })
+            .Succeeded.ShouldBeTrue();
+
+    /// <summary>
+    /// End-to-end: a misconfigured provider key fails at options resolution (ValidateOnStart
+    /// surfaces this at boot) instead of GetRequiredKeyedService throwing at the first send.
+    /// </summary>
+    [Fact]
+    public void MisconfiguredHost_FailsOptionsValidation_NotFirstSend()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Notifications:MobilePush:Provider"] = "NotARealProvider",
+        }).Build());
+        services.AddGranitNotificationsMobilePush();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Should.Throw<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<MobilePushChannelOptions>>().Value);
+    }
+}

--- a/tests/Granit.Notifications.Sms.Tests/SmsChannelOptionsValidatorTests.cs
+++ b/tests/Granit.Notifications.Sms.Tests/SmsChannelOptionsValidatorTests.cs
@@ -1,0 +1,67 @@
+using Granit.Notifications.Sms.Extensions;
+using Granit.Notifications.Sms.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.Sms.Tests;
+
+public sealed class SmsChannelOptionsValidatorTests
+{
+    private static SmsChannelOptionsValidator BuildValidator(bool keyIsRegistered)
+    {
+        IServiceProviderIsKeyedService keyed = Substitute.For<IServiceProviderIsKeyedService>();
+        keyed.IsKeyedService(typeof(ISmsSender), Arg.Any<object?>()).Returns(keyIsRegistered);
+        return new SmsChannelOptionsValidator(keyed);
+    }
+
+    [Fact]
+    public void EmptyProvider_Fails()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: true)
+            .Validate(null, new SmsChannelOptions { Provider = "" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("Provider is required");
+    }
+
+    [Fact]
+    public void UnknownProviderKey_FailsWithExplicitMessage()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: false)
+            .Validate(null, new SmsChannelOptions { Provider = "DoesNotExist" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("DoesNotExist");
+        result.FailureMessage.ShouldContain("provider package");
+    }
+
+    [Fact]
+    public void RegisteredProviderKey_Succeeds() =>
+        BuildValidator(keyIsRegistered: true)
+            .Validate(null, new SmsChannelOptions { Provider = "SomeProvider" })
+            .Succeeded.ShouldBeTrue();
+
+    /// <summary>
+    /// End-to-end: a misconfigured provider key fails at options resolution (ValidateOnStart
+    /// surfaces this at boot) instead of GetRequiredKeyedService throwing at the first send.
+    /// </summary>
+    [Fact]
+    public void MisconfiguredHost_FailsOptionsValidation_NotFirstSend()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Notifications:Sms:Provider"] = "NotARealProvider",
+        }).Build());
+        services.AddGranitNotificationsSms();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Should.Throw<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<SmsChannelOptions>>().Value);
+    }
+}

--- a/tests/Granit.Notifications.Sms.Tests/SmsNotificationsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.Sms.Tests/SmsNotificationsServiceCollectionExtensionsTests.cs
@@ -4,6 +4,7 @@ using Granit.Notifications.Sms.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -26,9 +27,14 @@ public sealed class SmsNotificationsServiceCollectionExtensionsTests
     public void AddGranitNotificationsSms_RegistersOptions()
     {
         ServiceCollection services = new();
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Notifications:Sms:Provider"] = "Twilio",
+        }).Build());
         services.AddGranitNotificationsSms();
 
+        // Satisfies the keyed-provider startup validator — these tests assert options mechanics.
+        services.AddKeyedSingleton("Twilio", (_, _) => Substitute.For<ISmsSender>());
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<SmsChannelOptions> options = sp.GetRequiredService<IOptions<SmsChannelOptions>>();
 
@@ -46,6 +52,8 @@ public sealed class SmsNotificationsServiceCollectionExtensionsTests
             opts.SenderId = "CustomSender";
         });
 
+        // Satisfies the keyed-provider startup validator — these tests assert options mechanics.
+        services.AddKeyedSingleton("Twilio", (_, _) => Substitute.For<ISmsSender>());
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<SmsChannelOptions> options = sp.GetRequiredService<IOptions<SmsChannelOptions>>();
 

--- a/tests/Granit.Notifications.WebPush.Endpoints.Tests/WebPushEndpointsOptionsTests.cs
+++ b/tests/Granit.Notifications.WebPush.Endpoints.Tests/WebPushEndpointsOptionsTests.cs
@@ -1,0 +1,17 @@
+using Granit.Notifications.WebPush.Endpoints.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.WebPush.Endpoints.Tests;
+
+public sealed class WebPushEndpointsOptionsTests
+{
+    /// <summary>Pins the configuration section path so a rename surfaces in CI (checklist §1d).</summary>
+    [Fact]
+    public void SectionName_IsPinned() =>
+        WebPushEndpointsOptions.SectionName.ShouldBe("Notifications:WebPush:Endpoints");
+
+    [Fact]
+    public void RoutePrefix_Default_IsPinned() =>
+        new WebPushEndpointsOptions().RoutePrefix.ShouldBe("notifications/web-push");
+}

--- a/tests/Granit.Notifications.WhatsApp.Tests/WhatsAppChannelOptionsValidatorTests.cs
+++ b/tests/Granit.Notifications.WhatsApp.Tests/WhatsAppChannelOptionsValidatorTests.cs
@@ -1,0 +1,67 @@
+using Granit.Notifications.WhatsApp.Extensions;
+using Granit.Notifications.WhatsApp.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Notifications.WhatsApp.Tests;
+
+public sealed class WhatsAppChannelOptionsValidatorTests
+{
+    private static WhatsAppChannelOptionsValidator BuildValidator(bool keyIsRegistered)
+    {
+        IServiceProviderIsKeyedService keyed = Substitute.For<IServiceProviderIsKeyedService>();
+        keyed.IsKeyedService(typeof(IWhatsAppSender), Arg.Any<object?>()).Returns(keyIsRegistered);
+        return new WhatsAppChannelOptionsValidator(keyed);
+    }
+
+    [Fact]
+    public void EmptyProvider_Fails()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: true)
+            .Validate(null, new WhatsAppChannelOptions { Provider = "" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("Provider is required");
+    }
+
+    [Fact]
+    public void UnknownProviderKey_FailsWithExplicitMessage()
+    {
+        ValidateOptionsResult result = BuildValidator(keyIsRegistered: false)
+            .Validate(null, new WhatsAppChannelOptions { Provider = "DoesNotExist" });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("DoesNotExist");
+        result.FailureMessage.ShouldContain("provider package");
+    }
+
+    [Fact]
+    public void RegisteredProviderKey_Succeeds() =>
+        BuildValidator(keyIsRegistered: true)
+            .Validate(null, new WhatsAppChannelOptions { Provider = "SomeProvider" })
+            .Succeeded.ShouldBeTrue();
+
+    /// <summary>
+    /// End-to-end: a misconfigured provider key fails at options resolution (ValidateOnStart
+    /// surfaces this at boot) instead of GetRequiredKeyedService throwing at the first send.
+    /// </summary>
+    [Fact]
+    public void MisconfiguredHost_FailsOptionsValidation_NotFirstSend()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Notifications:WhatsApp:Provider"] = "NotARealProvider",
+        }).Build());
+        services.AddGranitNotificationsWhatsApp();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Should.Throw<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<WhatsAppChannelOptions>>().Value);
+    }
+}


### PR DESCRIPTION
Closes #2962 (part of epic #2957 — notifications family overhaul, phase 3 of 8). Builds on merged #2966/#2967/#2972/#2973.

## What

Both BREAKING findings of the original audit shared one disease: **the default configuration path was verified nowhere before the first lost message**. This phase makes misconfiguration a boot-time failure.

### Keyed-provider startup validation (net-new infrastructure)

Each channel package (Email, Sms, MobilePush, WhatsApp) ships an `IValidateOptions<{Channel}ChannelOptions>` injecting **`IServiceProviderIsKeyedService`**: the configured `Provider` key must resolve to a registered keyed `I*Sender` — checked **without instantiating** anything, wired into the existing `ValidateOnStart` chain. A bad or missing key now fails the host at startup with an actionable message:

> No IEmailSender is registered for provider key 'X' (Notifications:Email:Provider). Reference the matching provider package (its module self-registers) or fix the configured key.

Combined with phase 1b's self-registering provider modules, the out-of-box path is now: reference a provider package ⇒ it works; misconfigure it ⇒ the host refuses to start. Never a runtime surprise at first send.

### Endpoint options actually bound

`Notifications:Endpoints`, `Notifications:MobilePush:Endpoints`, `Notifications:WebPush:Endpoints` were declared (`SectionName` consts) but never bound — `RoutePrefix`/`TagName` were silently unconfigurable (audit CONVENTION cluster #3). Now bound in the endpoints modules; the `Map*` extensions consume a fresh `IOptionsFactory` instance (no shared-singleton mutation), with the `configure` delegate keeping precedence.

### Tests

16 new validator tests (incl. end-to-end "misconfigured host fails options resolution, not first send"), 4 SectionName pinning tests (AI + 3 endpoints options), 7 existing tests updated to register a stub keyed sender — resolving channel options without any provider is exactly what this phase forbids.

## Verification

- notifications shard: build 0W/0E, 29/29 test projects green
- architecture shard: 274/274
- `dotnet format --verify-no-changes` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)