### PR TITLE
feat(notifications): phase 4b — text/markdown templates, non-email channels on the shared renderer

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -38902,7 +38902,7 @@
       "kind": "class",
       "project": "Granit.Notifications",
       "file": "src/Granit.Notifications/Extensions/NotificationsRenderingServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitNotificationContentRenderer",
@@ -51848,7 +51848,7 @@
       "kind": "record",
       "project": "Granit.Templating",
       "file": "src/Granit.Templating/Keys/TemplateKey.cs",
-      "line": 22,
+      "line": 28,
       "members": []
     },
     {

--- a/src/Granit.Notifications.MobilePush/Internal/MobilePushNotificationChannel.cs
+++ b/src/Granit.Notifications.MobilePush/Internal/MobilePushNotificationChannel.cs
@@ -1,6 +1,7 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.MobilePush.Domain;
 using Granit.Notifications.MobilePush.Options;
+using Granit.Notifications.Rendering;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -15,7 +16,8 @@ internal sealed partial class MobilePushNotificationChannel(
     IServiceProvider serviceProvider,
     IOptions<MobilePushChannelOptions> options,
     IMobilePushTokenReader tokenReader,
-    ILogger<MobilePushNotificationChannel> logger) : INotificationChannel
+    ILogger<MobilePushNotificationChannel> logger,
+    INotificationContentRenderer? contentRenderer = null) : INotificationChannel
 {
     /// <inheritdoc />
     public string Name => NotificationChannels.MobilePush;
@@ -36,11 +38,22 @@ internal sealed partial class MobilePushNotificationChannel(
         IMobilePushSender sender = serviceProvider
             .GetRequiredKeyedService<IMobilePushSender>(options.Value.Provider);
 
+        // Localized title/body from templates. The push payload must NOT contain PII
+        // (wake-up signal only — content is fetched from the API), so the template renders
+        // WITHOUT the notification data: type-specific templates get metadata only.
+        RenderedNotificationContent? rendered = contentRenderer is null
+            ? null
+            : await contentRenderer.RenderAsync(
+                context with { Data = default },
+                recipient: null,
+                NotificationContentFormat.TitleBody,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
         await sender.SendAsync(new MobilePushMessage
         {
             DeviceTokens = tokens.Select(t => t.DeviceToken).ToList(),
-            Title = context.NotificationTypeName,
-            Body = $"Notification: {context.NotificationTypeName}",
+            Title = rendered?.Title ?? context.NotificationTypeName,
+            Body = rendered?.Body ?? $"Notification: {context.NotificationTypeName}",
             Data = context.Data,
         }, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Granit.Notifications.Sms/Internal/SmsNotificationChannel.cs
+++ b/src/Granit.Notifications.Sms/Internal/SmsNotificationChannel.cs
@@ -1,4 +1,5 @@
 using Granit.Notifications.Abstractions;
+using Granit.Notifications.Rendering;
 using Granit.Notifications.Sms.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -11,7 +12,8 @@ namespace Granit.Notifications.Sms.Internal;
 internal sealed class SmsNotificationChannel(
     IServiceProvider serviceProvider,
     IOptions<SmsChannelOptions> options,
-    IRecipientResolver recipientResolver) : INotificationChannel
+    IRecipientResolver recipientResolver,
+    INotificationContentRenderer? contentRenderer = null) : INotificationChannel
 {
     /// <inheritdoc />
     public string Name => NotificationChannels.Sms;
@@ -27,7 +29,14 @@ internal sealed class SmsNotificationChannel(
             return;
         }
 
-        string body = $"Notification: {context.NotificationTypeName}";
+        // Localized template (type-specific or Notifications.Default .txt), minimal fallback
+        // when templating is not configured.
+        RenderedNotificationContent? rendered = contentRenderer is null
+            ? null
+            : await contentRenderer.RenderAsync(
+                context, recipient, NotificationContentFormat.PlainText, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        string body = rendered?.Body ?? $"Notification: {context.NotificationTypeName}";
 
         await sender.SendAsync(new SmsMessage
         {

--- a/src/Granit.Notifications.Zulip/Internal/ZulipNotificationChannel.cs
+++ b/src/Granit.Notifications.Zulip/Internal/ZulipNotificationChannel.cs
@@ -1,4 +1,5 @@
 using Granit.Notifications.Abstractions;
+using Granit.Notifications.Rendering;
 using Granit.Notifications.Zulip.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -9,7 +10,8 @@ namespace Granit.Notifications.Zulip.Internal;
 internal sealed partial class ZulipNotificationChannel(
     IZulipSender sender,
     IOptions<ZulipChannelOptions> options,
-    ILogger<ZulipNotificationChannel> logger) : INotificationChannel
+    ILogger<ZulipNotificationChannel> logger,
+    INotificationContentRenderer? contentRenderer = null) : INotificationChannel
 {
     /// <inheritdoc />
     public string Name => NotificationChannels.Zulip;
@@ -19,7 +21,14 @@ internal sealed partial class ZulipNotificationChannel(
     {
         ZulipChannelOptions channelOptions = options.Value;
 
-        string content = $"**{context.NotificationTypeName}** ({context.Severity})\n\nNotification: {context.NotificationTypeName}";
+        RenderedNotificationContent? rendered = contentRenderer is null
+            ? null
+            : await contentRenderer.RenderAsync(
+                context, recipient: null, NotificationContentFormat.Markdown, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        string content = rendered is not null
+            ? $"**{rendered.Title ?? context.NotificationTypeName}**\n\n{rendered.Body}"
+            : $"**{context.NotificationTypeName}** ({context.Severity})\n\nNotification: {context.NotificationTypeName}";
 
         await sender.SendAsync(new ZulipMessage
         {

--- a/src/Granit.Notifications/Extensions/NotificationsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications/Extensions/NotificationsRenderingServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Notifications.Internal;
 using Granit.Notifications.Rendering;
+using Granit.Templating.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -17,6 +18,11 @@ public static class NotificationsRenderingServiceCollectionExtensions
     public static IServiceCollection AddGranitNotificationContentRenderer(this IServiceCollection services)
     {
         services.TryAddSingleton<INotificationContentRenderer, TemplateNotificationContentRenderer>();
+
+        // Channel-agnostic text/markdown fallback templates (Notifications.Default.{txt,md},
+        // EN + FR baseline — other cultures via scripts/translate-templates.py).
+        services.AddEmbeddedTemplates(typeof(TemplateNotificationContentRenderer).Assembly);
+
         return services;
     }
 }

--- a/src/Granit.Notifications/Granit.Notifications.csproj
+++ b/src/Granit.Notifications/Granit.Notifications.csproj
@@ -32,4 +32,10 @@
   <ItemGroup>
     <EmbeddedResource Include="Localization\**\*.json" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- WithCulture="false": MSBuild would otherwise treat *.fr.txt as satellite resources. -->
+    <EmbeddedResource Include="Templates\**\*.txt" WithCulture="false" />
+    <EmbeddedResource Include="Templates\**\*.md" WithCulture="false" />
+  </ItemGroup>
+
 </Project>

--- a/src/Granit.Notifications/Internal/TemplateNotificationContentRenderer.cs
+++ b/src/Granit.Notifications/Internal/TemplateNotificationContentRenderer.cs
@@ -41,15 +41,13 @@ internal sealed partial class TemplateNotificationContentRenderer(
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (format != NotificationContentFormat.Html)
-        {
-            // Text/markdown templates need text-template support in Granit.Templating —
-            // lands in the #2963 follow-up. Channels keep their fallback until then.
-            return null;
-        }
-
         // Effective culture: explicit trigger override wins, then the recipient's preference.
         context = context with { Culture = context.Culture ?? recipient?.PreferredCulture };
+
+        if (format != NotificationContentFormat.Html)
+        {
+            return await RenderTextAsync(context, recipient, format, extraModelData, cancellationToken).ConfigureAwait(false);
+        }
 
         RenderedNotificationContent? content =
             await TryRenderTemplateAsync(context.NotificationTypeName, context, recipient, extraModelData, cancellationToken).ConfigureAwait(false)
@@ -62,6 +60,77 @@ internal sealed partial class TemplateNotificationContentRenderer(
 
         return await TryApplyLayoutAsync(context.NotificationTypeName, content, context, recipient, extraModelData, cancellationToken).ConfigureAwait(false)
             ?? content;
+    }
+
+    /// <summary>
+    /// Text/markdown path: resolves <c>.txt</c>/<c>.md</c> template variants (via the
+    /// <see cref="TemplateKey.MimeType"/> hint), no layout. Convention: the first non-empty
+    /// line is the title (mirrors <c>&lt;title&gt;</c> for HTML), the remainder is the body.
+    /// </summary>
+    private async Task<RenderedNotificationContent?> RenderTextAsync(
+        NotificationDeliveryContext context,
+        RecipientInfo? recipient,
+        NotificationContentFormat format,
+        IReadOnlyDictionary<string, object?>? extraModelData,
+        CancellationToken cancellationToken)
+    {
+        IEnumerable<ITemplateResolver>? resolvers = serviceProvider.GetService<IEnumerable<ITemplateResolver>>();
+        if (resolvers?.Any() != true)
+        {
+            return null;
+        }
+
+        string mimeType = format == NotificationContentFormat.Markdown ? "text/markdown" : "text/plain";
+
+        TemplateDescriptor? descriptor =
+            await ResolveAsync(resolvers, new TemplateKey(context.NotificationTypeName, context.Culture, mimeType), cancellationToken).ConfigureAwait(false)
+            ?? await ResolveAsync(resolvers, new TemplateKey(FallbackTemplateName, context.Culture, mimeType), cancellationToken).ConfigureAwait(false);
+
+        if (descriptor is null)
+        {
+            return null;
+        }
+
+        ITemplateEngine? engine = FindEngine(descriptor, context.NotificationTypeName);
+        if (engine is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            RenderedContent rendered = await engine
+                .RenderAsync(descriptor, BuildModel(context, recipient, extraModelData), DocumentFormat.Html, ResolveGlobalContexts(), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (rendered is TextRenderedContent textResult)
+            {
+                Log.TemplateRendered(logger, context.NotificationTypeName, context.Culture);
+                (string? title, string body) = SplitFirstLineTitle(textResult.Html);
+                return new RenderedNotificationContent(title, body);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.TemplateRenderFailed(logger, context.NotificationTypeName, ex);
+        }
+
+        return null;
+    }
+
+    /// <summary>First non-empty line = title, remainder = body (trimmed).</summary>
+    internal static (string? Title, string Body) SplitFirstLineTitle(string text)
+    {
+        string trimmed = text.Trim();
+        int newline = trimmed.IndexOf('\n');
+        if (newline < 0)
+        {
+            return (null, trimmed);
+        }
+
+        string title = trimmed[..newline].TrimEnd('\r').Trim();
+        string body = trimmed[(newline + 1)..].Trim();
+        return (title.Length == 0 ? null : title, body.Length == 0 ? trimmed : body);
     }
 
     /// <summary>
@@ -255,6 +324,7 @@ internal sealed partial class TemplateNotificationContentRenderer(
             .GetService<INotificationDefinitionStore>()?.Get(context.NotificationTypeName);
 
         dataDict.TryAdd("notification_type", context.NotificationTypeName);
+        dataDict.TryAdd("severity", context.Severity.ToString());
         dataDict.TryAdd("notification_group", definition?.GroupName ?? "");
         dataDict.TryAdd("allow_opt_out", definition?.AllowUserOptOut ?? true);
         dataDict.TryAdd("unsubscribe_url", "");

--- a/src/Granit.Notifications/Templates/Notifications.Default.fr.md
+++ b/src/Granit.Notifications/Templates/Notifications.Default.fr.md
@@ -1,0 +1,2 @@
+Vous avez une nouvelle notification
+Vous avez reçu une nouvelle notification de type **{{ model.notification_type }}**{{ if model.severity }} ({{ model.severity }}){{ end }}.

--- a/src/Granit.Notifications/Templates/Notifications.Default.fr.txt
+++ b/src/Granit.Notifications/Templates/Notifications.Default.fr.txt
@@ -1,0 +1,2 @@
+Vous avez une nouvelle notification
+Vous avez reçu une nouvelle notification de type {{ model.notification_type }}.

--- a/src/Granit.Notifications/Templates/Notifications.Default.md
+++ b/src/Granit.Notifications/Templates/Notifications.Default.md
@@ -1,0 +1,2 @@
+You have a new notification
+You have received a new notification of type **{{ model.notification_type }}**{{ if model.severity }} ({{ model.severity }}){{ end }}.

--- a/src/Granit.Notifications/Templates/Notifications.Default.txt
+++ b/src/Granit.Notifications/Templates/Notifications.Default.txt
@@ -1,0 +1,2 @@
+You have a new notification
+You have received a new notification of type {{ model.notification_type }}.

--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -51,7 +51,8 @@ internal sealed class ScribanTemplateEngine(
     /// <inheritdoc/>
     public bool CanRender(TemplateDescriptor descriptor) =>
         string.Equals(descriptor.MimeType, "text/html", StringComparison.OrdinalIgnoreCase)
-        || string.Equals(descriptor.MimeType, "text/plain", StringComparison.OrdinalIgnoreCase);
+        || string.Equals(descriptor.MimeType, "text/plain", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(descriptor.MimeType, "text/markdown", StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public async Task<RenderedContent> RenderAsync<TData>(

--- a/src/Granit.Templating/Keys/TemplateKey.cs
+++ b/src/Granit.Templating/Keys/TemplateKey.cs
@@ -19,4 +19,10 @@ namespace Granit.Templating.Keys;
 /// </list>
 /// Tenant scoping is handled inside each <see cref="Pipeline.ITemplateResolver"/> implementation.
 /// </remarks>
-public sealed record TemplateKey(string Name, string? Culture = null);
+/// <param name="MimeType">
+/// Optional MIME-type hint (<c>"text/html"</c>, <c>"text/plain"</c>, <c>"text/markdown"</c>).
+/// <c>null</c> means the resolver's default (HTML for embedded resources). Lets one logical
+/// template name ship per-channel variants (<c>.html</c> for email, <c>.txt</c> for SMS/push,
+/// <c>.md</c> for chat).
+/// </param>
+public sealed record TemplateKey(string Name, string? Culture = null, string? MimeType = null);

--- a/src/Granit.Templating/Resolvers/EmbeddedTemplateResolver.cs
+++ b/src/Granit.Templating/Resolvers/EmbeddedTemplateResolver.cs
@@ -71,7 +71,8 @@ internal sealed class EmbeddedTemplateResolver(IReadOnlyList<Assembly> assemblie
     private TemplateDescriptor? TryLoadFromAssembly(Assembly assembly, TemplateKey key)
     {
         string assemblyName = assembly.GetName().Name ?? string.Empty;
-        string neutralResource = $"{assemblyName}.Templates.{key.Name}.html";
+        (string extension, string mimeType) = ExtensionFor(key.MimeType);
+        string neutralResource = $"{assemblyName}.Templates.{key.Name}.{extension}";
 
         // Walk requested culture → parent → neutral. Mirrors the JSON locale fallback so
         // regional template files (pt-BR, en-GB...) can omit keys identical to their parent.
@@ -80,7 +81,7 @@ internal sealed class EmbeddedTemplateResolver(IReadOnlyList<Assembly> assemblie
         {
             foreach (string culture in EnumerateCultureChain(key.Culture))
             {
-                resourceName = FindResource(assembly, $"{assemblyName}.Templates.{key.Name}.{culture}.html");
+                resourceName = FindResource(assembly, $"{assemblyName}.Templates.{key.Name}.{culture}.{extension}");
                 if (resourceName is not null)
                 {
                     break;
@@ -102,10 +103,18 @@ internal sealed class EmbeddedTemplateResolver(IReadOnlyList<Assembly> assemblie
         return new TemplateDescriptor
         {
             Content = content,
-            MimeType = "text/html",
+            MimeType = mimeType,
             RevisionId = null,
         };
     }
+
+    /// <summary>Maps the requested MIME type to the embedded-resource file extension.</summary>
+    private static (string Extension, string MimeType) ExtensionFor(string? mimeType) => mimeType switch
+    {
+        "text/plain" => ("txt", "text/plain"),
+        "text/markdown" => ("md", "text/markdown"),
+        _ => ("html", "text/html"),
+    };
 
     private static IEnumerable<string> EnumerateCultureChain(string culture)
     {

--- a/tests/Granit.Notifications.Tests/Granit.Notifications.Tests.csproj
+++ b/tests/Granit.Notifications.Tests/Granit.Notifications.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Notifications\Granit.Notifications.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Templating.Scriban\Granit.Templating.Scriban.csproj" />
     <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Granit.Notifications.Tests/Internal/TemplateNotificationContentRendererTests.cs
+++ b/tests/Granit.Notifications.Tests/Internal/TemplateNotificationContentRendererTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Granit.Notifications.Internal;
 using Granit.Notifications.Rendering;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shouldly;
@@ -29,9 +30,102 @@ public sealed class TemplateNotificationContentRendererTests
     [InlineData(NotificationContentFormat.PlainText)]
     [InlineData(NotificationContentFormat.TitleBody)]
     [InlineData(NotificationContentFormat.Markdown)]
-    public async Task TextFormats_ReturnNull_UntilTextTemplateSupportLands(NotificationContentFormat format) =>
+    public async Task TextFormats_WithoutTemplating_ReturnNull_SoChannelsKeepTheirFallback(NotificationContentFormat format) =>
         (await CreateSut().RenderAsync(BuildContext(), recipient: null, format, cancellationToken: TestContext.Current.CancellationToken))
             .ShouldBeNull();
+
+    // ──── Text formats with the real Scriban engine + embedded fallback templates ────
+
+    private static ServiceProvider BuildTemplatingHost()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
+        services.AddSingleton(Substitute.For<Granit.Templating.Store.IDocumentTemplateStoreReader>());
+        services.AddSingleton(Substitute.For<Granit.Timing.IClock>());
+        services.AddLogging(b => b.AddProvider(new XunitLogProvider()));
+        Granit.Templating.Scriban.Extensions.ServiceCollectionExtensions.AddGranitTemplatingWithScriban(services);
+        Granit.Notifications.Extensions.NotificationsRenderingServiceCollectionExtensions.AddGranitNotificationContentRenderer(services);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PlainText_FallbackTemplate_RendersLocalizedTitleAndBody()
+    {
+        await using ServiceProvider sp = BuildTemplatingHost();
+        INotificationContentRenderer renderer = sp.GetRequiredService<INotificationContentRenderer>();
+
+        RenderedNotificationContent? rendered = await renderer.RenderAsync(
+            BuildContext(), recipient: null, NotificationContentFormat.PlainText,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        rendered.ShouldNotBeNull();
+        rendered.Title.ShouldBe("You have a new notification");
+        rendered.Body.ShouldBe("You have received a new notification of type test.notification.");
+    }
+
+    [Fact]
+    public async Task PlainText_FrenchRecipient_RendersFrenchVariant()
+    {
+        await using ServiceProvider sp = BuildTemplatingHost();
+        INotificationContentRenderer renderer = sp.GetRequiredService<INotificationContentRenderer>();
+
+        RenderedNotificationContent? rendered = await renderer.RenderAsync(
+            BuildContext(),
+            new RecipientInfo { UserId = "user-1", PreferredCulture = "fr" },
+            NotificationContentFormat.PlainText,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        rendered.ShouldNotBeNull();
+        rendered.Title.ShouldBe("Vous avez une nouvelle notification");
+        rendered.Body.ShouldContain("test.notification");
+    }
+
+    [Fact]
+    public async Task Markdown_FallbackTemplate_RendersBoldTypeAndSeverity()
+    {
+        await using ServiceProvider sp = BuildTemplatingHost();
+        INotificationContentRenderer renderer = sp.GetRequiredService<INotificationContentRenderer>();
+
+        RenderedNotificationContent? rendered = await renderer.RenderAsync(
+            BuildContext(), recipient: null, NotificationContentFormat.Markdown,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        rendered.ShouldNotBeNull();
+        rendered.Body.ShouldContain("**test.notification**");
+        rendered.Body.ShouldContain("(Info)");
+    }
+
+    private sealed class XunitLogProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new XunitLog();
+        public void Dispose() { }
+        private sealed class XunitLog : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+                TestContext.Current.TestOutputHelper?.WriteLine($"[{logLevel}] {formatter(state, exception)} {exception?.Message}");
+        }
+    }
+
+    [Fact]
+    public void SplitFirstLineTitle_SplitsTitleFromBody()
+    {
+        (string? title, string body) = TemplateNotificationContentRenderer.SplitFirstLineTitle("Title line\nBody line one\nBody line two");
+
+        title.ShouldBe("Title line");
+        body.ShouldBe("Body line one\nBody line two");
+    }
+
+    [Fact]
+    public void SplitFirstLineTitle_SingleLine_IsBodyOnly()
+    {
+        (string? title, string body) = TemplateNotificationContentRenderer.SplitFirstLineTitle("Just a body");
+
+        title.ShouldBeNull();
+        body.ShouldBe("Just a body");
+    }
 
     [Fact]
     public async Task Html_WithoutTemplating_ReturnsNull_SoChannelsKeepTheirFallback() =>

--- a/tests/Granit.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Tests/packages.lock.json
@@ -617,6 +617,14 @@
           "Granit.Workflow": "[0.1.0-dev, )"
         }
       },
+      "granit.templating.scriban": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Templating": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "Scriban": "[7.*, )"
+        }
+      },
       "granit.testing": {
         "type": "Project",
         "dependencies": {
@@ -774,6 +782,12 @@
           "Microsoft.Extensions.Options": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
+      },
+      "Scriban": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.2.5",
+        "contentHash": "6HDyv0P6PVdx/prWM3Aw0QHAT/DCpkBxOovZ2iPIH4L4ZvJ13JNYJgyUI+xJ5K2agXreYTBe23AL5ZQNTqJQvA=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Part 2 of 2 for #2963 — closes #2963 (epic #2957, phase 4 of 8). Builds on merged #2975.

## What

The non-email channels stop hand-building notification strings (`$"Notification: {type}"`, hardcoded severity interpolation) and consume the shared `INotificationContentRenderer` from 4a.

### Granit.Templating (additive, 149 existing tests unmodified)

- `TemplateKey` gains an optional **`MimeType` hint** — one logical template name can now ship per-channel variants: `.html` (email), `.txt` (SMS/push), `.md` (chat).
- `EmbeddedTemplateResolver` maps `text/plain` → `.txt`, `text/markdown` → `.md`, same culture-chain fallback as HTML.
- Scriban engine accepts `text/markdown`.

### Renderer text path

Two-tier `.txt`/`.md` resolution (type-specific → `Notifications.Default`), no layout, **first-non-empty-line-is-title** convention (mirrors `<title>` for HTML). `severity` joins the generic template model. Fallback templates `Notifications.Default.{txt,md}` embedded in the base module — EN + FR baseline per framework rule, other cultures via `scripts/translate-templates.py`.

### Channels

| Channel | Format | Note |
|---|---|---|
| SMS | `PlainText` | body only |
| Zulip | `Markdown` | bold title composed from rendered parts |
| MobilePush | `TitleBody` | **`Data` stripped before rendering** — the push payload stays a PII-free wake-up signal per the channel's own contract |

Every channel keeps its minimal hardcoded fallback when templating is not configured (renderer returns `null`).

## Verification

- Renderer integration tests over the real Scriban engine + embedded templates (EN, FR, markdown) — base suite 260/260
- Email golden master **3/3 byte-identical** (the sentinel for the whole phase)
- notifications shard 0W/0E, 0 failed; architecture 255/255; `dotnet format` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)