### PR TITLE
fix(privacy): convention batch — validation key, OpenAPI metadata, deps hygiene

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2322,8 +2322,7 @@
       "name": "Granit.Privacy.Auditing",
       "deps": [
         "Granit.Auditing",
-        "Granit.Privacy",
-        "Granit.Timing"
+        "Granit.Privacy"
       ],
       "framework": "net10.0"
     },
@@ -48834,7 +48833,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Vault",
       "file": "src/Granit.Privacy.Vault/GranitPrivacyVaultModule.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Privacy.Auditing/Granit.Privacy.Auditing.csproj
+++ b/src/Granit.Privacy.Auditing/Granit.Privacy.Auditing.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\Granit.Privacy\Granit.Privacy.csproj" />
-    <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyAgreementEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyAgreementEndpoints.cs
@@ -35,7 +35,8 @@ internal static class PrivacyAgreementEndpoints
                  "For each registered legal document, returns whether the current user has accepted "
                  + "the latest version and when the last acceptance occurred. "
                  + "Documents where HasAcceptedLatest is false require re-consent.")
-             .Produces<IReadOnlyList<PrivacyConsentStatusResponse>>();
+             .Produces<IReadOnlyList<PrivacyConsentStatusResponse>>()
+             .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapGet("/agreements/history", HandleGetAgreementHistoryAsync)
              .RequireAuthorization(PrivacyPermissions.Agreements.Read)
@@ -45,7 +46,8 @@ internal static class PrivacyAgreementEndpoints
                  "Returns all consent records for the current user, ordered by most recent first. "
                  + "Each record includes the document ID, accepted version, timestamp, and whether "
                  + "it matches the current document version.")
-             .Produces<IReadOnlyList<PrivacyUserAgreementResponse>>();
+             .Produces<IReadOnlyList<PrivacyUserAgreementResponse>>()
+             .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapPost("/agreements/accept", HandleAcceptAgreementAsync)
              .RequireAuthorization(PrivacyPermissions.Agreements.Create)
@@ -58,9 +60,9 @@ internal static class PrivacyAgreementEndpoints
                  + "The client IP address is captured and pseudonymized for the audit trail. "
                  + "Ensure ForwardedHeadersMiddleware is enabled when running behind a reverse proxy.")
              .Produces(StatusCodes.Status201Created)
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
              .ProducesProblem(StatusCodes.Status404NotFound)
              .ProducesProblem(StatusCodes.Status409Conflict)
-             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
              .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
         return group;

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyDeletionEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyDeletionEndpoints.cs
@@ -35,6 +35,7 @@ internal static class PrivacyDeletionEndpoints
                  + "A confirmation email is sent in both cases after deletion is executed. "
                  + "Do not include personally identifiable information in the Reason field.")
              .Produces<PrivacyDeletionRequestResponse>(StatusCodes.Status202Accepted)
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
              .ProducesProblem(StatusCodes.Status409Conflict)
              .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
@@ -46,6 +47,7 @@ internal static class PrivacyDeletionEndpoints
                  "Cancels a deferred deletion request. Only requests in Deferred state can be "
                  + "cancelled. Returns 404 if the request is not found, 409 if already executed or cancelled.")
              .Produces(StatusCodes.Status200OK)
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
              .ProducesProblem(StatusCodes.Status404NotFound)
              .ProducesProblem(StatusCodes.Status409Conflict);
 
@@ -58,6 +60,7 @@ internal static class PrivacyDeletionEndpoints
                  + "Returns the current state (Deferred, Executed, Cancelled), scheduled deletion date, "
                  + "and timestamps. Returns 404 if the request is not found or belongs to another user.")
              .Produces<PrivacyDeletionStatusResponse>()
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
              .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapGet("/deletions", HandleGetMyDeletionsAsync)
@@ -66,7 +69,8 @@ internal static class PrivacyDeletionEndpoints
              .WithDescription(
                  "Returns all deferred deletion requests submitted by the current user, "
                  + "ordered by most recent first. Immediate deletions are not tracked.")
-             .Produces<IReadOnlyList<PrivacyDeletionStatusResponse>>();
+             .Produces<IReadOnlyList<PrivacyDeletionStatusResponse>>()
+             .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         return group;
     }

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportDownloadEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportDownloadEndpoints.cs
@@ -45,6 +45,7 @@ internal static class PrivacyExportDownloadEndpoints
                 + "GET /exports/{requestId}/download/manifest to discover the shard count. "
                 + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
             .Produces(StatusCodes.Status200OK, contentType: "application/octet-stream")
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
@@ -57,6 +58,7 @@ internal static class PrivacyExportDownloadEndpoints
                 + "the shard count and per-shard sha256/integrity tag before pulling each ZIP. "
                 + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
             .Produces(StatusCodes.Status200OK, contentType: "application/json")
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
@@ -69,6 +71,7 @@ internal static class PrivacyExportDownloadEndpoints
                 + "Shard indices outside the manifest's bounds return 404. "
                 + "Step-up authentication required when DownloadStepUpRequired is enabled (default).")
             .Produces(StatusCodes.Status200OK, contentType: "application/zip")
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportEndpoints.cs
@@ -34,7 +34,8 @@ internal static class PrivacyExportEndpoints
                  + "\"if you never used it, it doesn't appear\"), and the host IPrivacyScopeVisibilityPolicy. "
                  + "Use the returned ProviderName values to populate the POST /privacy/exports `Scopes` field; "
                  + "unknown / hidden scopes in that POST are silently skipped.")
-             .Produces<IReadOnlyList<PrivacyExportScopeResponse>>();
+             .Produces<IReadOnlyList<PrivacyExportScopeResponse>>()
+             .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapPost("/exports/on-behalf-of", HandleRequestExportOnBehalfOfAsync)
              .RequireAuthorization(PrivacyPermissions.Exports.ExecuteOnBehalfOf)
@@ -54,7 +55,9 @@ internal static class PrivacyExportEndpoints
                  + "IPrivacySubjectValidator — a subject absent from the tenant returns 404 (same "
                  + "status as a non-existent request id, so cross-tenant existence cannot be probed).")
              .Produces<PrivacyExportRequestResponse>(StatusCodes.Status202Accepted)
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
              .ProducesProblem(StatusCodes.Status404NotFound)
+             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
              .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/exports", HandleRequestExportAsync)
@@ -75,6 +78,8 @@ internal static class PrivacyExportEndpoints
                  + "Honours an optional `Idempotency-Key` header (Granit.Http.Idempotency) so accidental "
                  + "double-clicks don't spawn two scatter-gather sagas.")
              .Produces<PrivacyExportRequestResponse>(StatusCodes.Status202Accepted)
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
+             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
              .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapGet("/exports/{requestId:guid}", HandleGetExportStatusAsync)
@@ -87,6 +92,7 @@ internal static class PrivacyExportEndpoints
                  + "the archive blob reference when available, and any missing providers. "
                  + "Returns 404 if the request ID is not found or belongs to another user.")
              .Produces<PrivacyExportStatusResponse>()
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
              .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapGet("/exports", HandleGetMyExportsAsync)
@@ -95,7 +101,8 @@ internal static class PrivacyExportEndpoints
              .WithDescription(
                  "Returns all export requests submitted by the current user, ordered by most recent first. "
                  + "Each entry includes the request state, timestamps, and archive reference when available.")
-             .Produces<IReadOnlyList<PrivacyExportStatusResponse>>();
+             .Produces<IReadOnlyList<PrivacyExportStatusResponse>>()
+             .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapPrivacyExportDownloadEndpoints();
 

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
@@ -1,7 +1,7 @@
 {
   "culture": "cs",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "V jednom exportu bylo požádáno o příliš mnoho oborů (limit: 64).",
+    "Privacy:Validation:TooManyScopes": "V jednom exportu bylo požádáno o příliš mnoho oborů (limit: 64).",
     "Permission:Privacy.Agreements.Create": "Přijmout právní smlouvu",
     "Permission:Privacy.Agreements.Read": "Zobrazit právní dokumenty a stav souhlasu",
     "Permission:Privacy.Deletions.Execute": "Požádat o smazání osobních údajů",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
@@ -1,7 +1,7 @@
 {
   "culture": "de",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Zu viele Scopes in einem einzigen Export angefordert. Das Limit liegt bei 64.",
+    "Privacy:Validation:TooManyScopes": "Zu viele Scopes in einem einzigen Export angefordert. Das Limit liegt bei 64.",
     "Permission:Privacy.Agreements.Create": "Einer rechtlichen Vereinbarung zustimmen",
     "Permission:Privacy.Agreements.Read": "Rechtliche Dokumente und Einwilligungsstatus anzeigen",
     "Permission:Privacy.Deletions.Execute": "Löschung personenbezogener Daten anfordern",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en-GB.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en-GB.json
@@ -1,7 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Too many scopes requested in a single export. The limit is 64.",
+    "Privacy:Validation:TooManyScopes": "Too many scopes requested in a single export. The limit is 64.",
     "Permission:Privacy.Exports.ExecuteOnBehalfOf": "Request personal data export on behalf of another data subject (admin DSR)",
     "PrivacyEndpoints:Workspace.Agreements": "Agreements",
     "PrivacyEndpoints:Workspace.Purposes": "Purposes",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
@@ -1,7 +1,7 @@
 {
   "culture": "en",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Too many scopes requested in a single export. The limit is 64.",
+    "Privacy:Validation:TooManyScopes": "Too many scopes requested in a single export. The limit is 64.",
     "Permission:Privacy.Agreements.Create": "Accept a legal agreement",
     "Permission:Privacy.Agreements.Read": "View legal documents and consent status",
     "Permission:Privacy.Deletions.Execute": "Request personal data deletion",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
@@ -1,7 +1,7 @@
 {
   "culture": "es",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Se han solicitado demasiados ámbitos en una sola exportación. El límite es 64.",
+    "Privacy:Validation:TooManyScopes": "Se han solicitado demasiados ámbitos en una sola exportación. El límite es 64.",
     "Permission:Privacy.Agreements.Create": "Aceptar un acuerdo legal",
     "Permission:Privacy.Agreements.Read": "Ver documentos legales y estado de consentimiento",
     "Permission:Privacy.Deletions.Execute": "Solicitar eliminación de datos personales",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr-CA.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr-CA.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Trop de portées demandées dans un même export (limite : 64).",
+    "Privacy:Validation:TooManyScopes": "Trop de portées demandées dans un même export (limite : 64).",
     "Permission:Privacy.Exports.ExecuteOnBehalfOf": "Demander l'export des données personnelles d'un autre sujet (DSR administrateur)",
     "PrivacyEndpoints:Workspace.Agreements": "Consentements",
     "PrivacyEndpoints:Workspace.Purposes": "Finalités",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
@@ -1,7 +1,7 @@
 {
   "culture": "fr",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Trop de portées demandées dans un même export (limite : 64).",
+    "Privacy:Validation:TooManyScopes": "Trop de portées demandées dans un même export (limite : 64).",
     "Permission:Privacy.Agreements.Create": "Accepter un accord légal",
     "Permission:Privacy.Agreements.Read": "Consulter les documents légaux et le statut de consentement",
     "Permission:Privacy.Deletions.Execute": "Demander la suppression des données personnelles",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/hi.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/hi.json
@@ -1,7 +1,7 @@
 {
   "culture": "hi",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "एक ही एक्सपोर्ट में बहुत अधिक स्कोप मांगे गए हैं (सीमा: 64)।",
+    "Privacy:Validation:TooManyScopes": "एक ही एक्सपोर्ट में बहुत अधिक स्कोप मांगे गए हैं (सीमा: 64)।",
     "Permission:Privacy.Agreements.Create": "कानूनी समझौता स्वीकार करें",
     "Permission:Privacy.Agreements.Read": "कानूनी दस्तावेज़ और सहमति स्थिति देखें",
     "Permission:Privacy.Deletions.Execute": "व्यक्तिगत डेटा हटाने का अनुरोध करें",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
@@ -1,7 +1,7 @@
 {
   "culture": "it",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Sono stati richiesti troppi scope in una singola esportazione. Il limite è 64.",
+    "Privacy:Validation:TooManyScopes": "Sono stati richiesti troppi scope in una singola esportazione. Il limite è 64.",
     "Permission:Privacy.Agreements.Create": "Accettare un accordo legale",
     "Permission:Privacy.Agreements.Read": "Visualizzare documenti legali e stato del consenso",
     "Permission:Privacy.Deletions.Execute": "Richiedere la cancellazione dei dati personali",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
@@ -1,7 +1,7 @@
 {
   "culture": "ja",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "1 回のエクスポートで要求されたスコープが多すぎます (上限は 64 です)。",
+    "Privacy:Validation:TooManyScopes": "1 回のエクスポートで要求されたスコープが多すぎます (上限は 64 です)。",
     "Permission:Privacy.Agreements.Create": "法的合意に同意",
     "Permission:Privacy.Agreements.Read": "法的文書と同意ステータスを表示",
     "Permission:Privacy.Deletions.Execute": "個人データの削除を要求",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
@@ -1,7 +1,7 @@
 {
   "culture": "ko",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "단일 내보내기 요청에 너무 많은 스코프가 포함되어 있습니다 (최대 64개).",
+    "Privacy:Validation:TooManyScopes": "단일 내보내기 요청에 너무 많은 스코프가 포함되어 있습니다 (최대 64개).",
     "Permission:Privacy.Agreements.Create": "법적 계약 수락",
     "Permission:Privacy.Agreements.Read": "법적 문서 및 동의 상태 조회",
     "Permission:Privacy.Deletions.Execute": "개인 데이터 삭제 요청",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
@@ -1,7 +1,7 @@
 {
   "culture": "nl",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Te veel scopes opgevraagd in één export. De limiet is 64.",
+    "Privacy:Validation:TooManyScopes": "Te veel scopes opgevraagd in één export. De limiet is 64.",
     "Permission:Privacy.Agreements.Create": "Een juridische overeenkomst accepteren",
     "Permission:Privacy.Agreements.Read": "Juridische documenten en toestemmingsstatus bekijken",
     "Permission:Privacy.Deletions.Execute": "Verwijdering van persoonsgegevens aanvragen",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
@@ -1,7 +1,7 @@
 {
   "culture": "pl",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Zbyt wiele zakresów w jednym żądaniu eksportu (limit: 64).",
+    "Privacy:Validation:TooManyScopes": "Zbyt wiele zakresów w jednym żądaniu eksportu (limit: 64).",
     "Permission:Privacy.Agreements.Create": "Zaakceptowanie umowy prawnej",
     "Permission:Privacy.Agreements.Read": "Wyświetlanie dokumentów prawnych i statusu zgody",
     "Permission:Privacy.Deletions.Execute": "Żądanie usunięcia danych osobowych",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt-BR.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt-BR.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Muitos escopos solicitados em uma única exportação. O limite é 64.",
+    "Privacy:Validation:TooManyScopes": "Muitos escopos solicitados em uma única exportação. O limite é 64.",
     "Permission:Privacy.Exports.ExecuteOnBehalfOf": "Solicitar exportação de dados pessoais em nome de outro titular (DSR de administrador)",
     "PrivacyEndpoints:Workspace.Agreements": "Agreements",
     "PrivacyEndpoints:Workspace.Purposes": "Purposes",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
@@ -1,7 +1,7 @@
 {
   "culture": "pt",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Demasiados âmbitos pedidos numa única exportação. O limite é 64.",
+    "Privacy:Validation:TooManyScopes": "Demasiados âmbitos pedidos numa única exportação. O limite é 64.",
     "Permission:Privacy.Agreements.Create": "Aceitar um acordo legal",
     "Permission:Privacy.Agreements.Read": "Ver documentos legais e estado de consentimento",
     "Permission:Privacy.Deletions.Execute": "Solicitar eliminação de dados pessoais",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
@@ -1,7 +1,7 @@
 {
   "culture": "sv",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "För många scopes begärda i en enskild export. Gränsen är 64.",
+    "Privacy:Validation:TooManyScopes": "För många scopes begärda i en enskild export. Gränsen är 64.",
     "Permission:Privacy.Agreements.Create": "Acceptera ett juridiskt avtal",
     "Permission:Privacy.Agreements.Read": "Visa juridiska dokument och samtycksstatus",
     "Permission:Privacy.Deletions.Execute": "Begär radering av personuppgifter",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
@@ -1,7 +1,7 @@
 {
   "culture": "tr",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "Tek bir dışa aktarmada çok fazla kapsam istendi (sınır: 64).",
+    "Privacy:Validation:TooManyScopes": "Tek bir dışa aktarmada çok fazla kapsam istendi (sınır: 64).",
     "Permission:Privacy.Agreements.Create": "Yasal sözleşmeyi kabul et",
     "Permission:Privacy.Agreements.Read": "Yasal belgeleri ve onay durumunu görüntüle",
     "Permission:Privacy.Deletions.Execute": "Kişisel veri silme talep et",

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
@@ -1,7 +1,7 @@
 {
   "culture": "zh",
   "texts": {
-    "Granit:Validation:PrivacyExportTooManyScopes": "单次导出请求的范围过多,上限为 64。",
+    "Privacy:Validation:TooManyScopes": "单次导出请求的范围过多,上限为 64。",
     "Permission:Privacy.Agreements.Create": "接受法律协议",
     "Permission:Privacy.Agreements.Read": "查看法律文件和同意状态",
     "Permission:Privacy.Deletions.Execute": "请求删除个人数据",

--- a/src/Granit.Privacy.Endpoints/Validators/PrivacyExportOnBehalfOfRequestValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Validators/PrivacyExportOnBehalfOfRequestValidator.cs
@@ -24,7 +24,7 @@ internal sealed class PrivacyExportOnBehalfOfRequestValidator : GranitValidator<
 
         RuleFor(x => x.Scopes)
             .Must(s => s is null || s.Count <= MaxScopes)
-                .WithErrorCodeAndMessage("Granit:Validation:PrivacyExportTooManyScopes");
+                .WithErrorCodeAndMessage("Privacy:Validation:TooManyScopes");
 
         RuleForEach(x => x.Scopes!)
             .NotEmpty()

--- a/src/Granit.Privacy.Endpoints/Validators/PrivacyExportRequestValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Validators/PrivacyExportRequestValidator.cs
@@ -21,7 +21,7 @@ internal sealed class PrivacyExportRequestValidator : GranitValidator<PrivacyExp
     {
         RuleFor(x => x.Scopes)
             .Must(s => s is null || s.Count <= MaxScopes)
-                .WithErrorCodeAndMessage("Granit:Validation:PrivacyExportTooManyScopes");
+                .WithErrorCodeAndMessage("Privacy:Validation:TooManyScopes");
 
         RuleForEach(x => x.Scopes!)
             .NotEmpty()

--- a/src/Granit.Privacy.Vault/GranitPrivacyVaultModule.cs
+++ b/src/Granit.Privacy.Vault/GranitPrivacyVaultModule.cs
@@ -12,8 +12,9 @@ namespace Granit.Privacy.Vault;
 /// <c>GranitVaultGoogleCloudModule</c> / <c>GranitVaultAzureModule</c>, or the
 /// portable <c>SecretBackedMacService</c>.
 /// </summary>
-[DependsOn(typeof(GranitVaultModule))]
 [DependsOn(typeof(GranitPrivacyBlobStorageModule))]
+[DependsOn(typeof(GranitPrivacyModule))]
+[DependsOn(typeof(GranitVaultModule))]
 public sealed class GranitPrivacyVaultModule : GranitModule
 {
     /// <inheritdoc />


### PR DESCRIPTION
## Context

Convention findings from the `Granit.Privacy*` framework audit, batched into one low-risk PR. No behaviour change.

## Changes

**Validation key (ADR-066).** Renamed the module-owned key `Granit:Validation:PrivacyExportTooManyScopes` → `Privacy:Validation:TooManyScopes` — it was masquerading in the framework `Granit:Validation:` namespace and risked remapping by `GranitErrorCodeLanguageManager`. New name follows the `{Module}:Validation:{Rule}` house style (cf. `AIChat:Validation:TooManyAttachments`). Updated both export validators + all 18 culture files.

**OpenAPI error-path metadata.** Error-path coverage was ~37%. Added the missing declarations across the export / download / deletion / agreement routes:
- `ProducesProblem(401)` on the 15 handlers with a handler-level `UserNotAuthenticated` path (also covers the 3 download routes' step-up 401 challenge).
- `ProducesValidationProblem(422)` on the two export POSTs (their validators return 422 via the FluentValidation auto-filter).
- Dropped the duplicate bare `ProducesProblem(422)` on `AcceptPrivacyAgreement` — `ProducesValidationProblem` is the mandated variant when a validator exists.

**Dependency hygiene.**
- Removed the unused `Granit.Timing` ProjectReference from `Granit.Privacy.Auditing`.
- Ordered `Granit.Privacy.Vault` `[DependsOn]` alphabetically and declared the missing `GranitPrivacyModule` (direct project ref → must be declared, matching `GranitPrivacyBlobStorageModule`).

## Not included

The immediate-deletion body-less `202` is intentionally left undocumented — OpenAPI cannot express two different body shapes for one status code without a conflicting entry.

## Tests

`Granit.Privacy.Endpoints.Tests` (136) + `Auditing` (7) + `Vault` (6) green; relevant `Granit.ArchitectureTests` (validation-key, validation-status-code, project-dependency, module-convention, localization — 22) green; `dotnet format` clean on all three projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)