### PR TITLE
refactor(privacy): typed legal-document exceptions replace string-matched control flow

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -47507,6 +47507,24 @@
       "members": []
     },
     {
+      "name": "LegalDocumentNotFoundException",
+      "fqn": "Granit.Privacy.LegalAgreements.Exceptions.LegalDocumentNotFoundException",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Exceptions/LegalDocumentNotFoundException.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "LegalDocumentNotPublishableException",
+      "fqn": "Granit.Privacy.LegalAgreements.Exceptions.LegalDocumentNotPublishableException",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Exceptions/LegalDocumentNotPublishableException.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "ILegalAgreementChecker",
       "fqn": "Granit.Privacy.LegalAgreements.ILegalAgreementChecker",
       "kind": "interface",

--- a/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/LegalDocumentAdminEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Privacy.Endpoints.Dtos;
 using Granit.Privacy.Endpoints.Permissions;
 using Granit.Privacy.LegalAgreements;
 using Granit.Privacy.LegalAgreements.Domain;
+using Granit.Privacy.LegalAgreements.Exceptions;
 using Granit.QueryEngine.Endpoints.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -156,11 +157,11 @@ internal static class LegalDocumentAdminEndpoints
 
             return TypedResults.Ok(ToResponse(published));
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+        catch (LegalDocumentNotFoundException)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
-        catch (InvalidOperationException ex)
+        catch (LegalDocumentNotPublishableException ex)
         {
             return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
         }

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentPublicationService.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentPublicationService.cs
@@ -4,6 +4,7 @@ using Granit.Events;
 using Granit.Privacy.LegalAgreements;
 using Granit.Privacy.LegalAgreements.Domain;
 using Granit.Privacy.LegalAgreements.Events;
+using Granit.Privacy.LegalAgreements.Exceptions;
 using Granit.Workflow.Domain;
 using Microsoft.EntityFrameworkCore;
 
@@ -30,12 +31,11 @@ internal sealed class LegalDocumentPublicationService(
         LegalDocument draft = await db.LegalDocuments
             .FirstOrDefaultAsync(d => d.Id == documentId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Legal document '{documentId}' not found.");
+            ?? throw new LegalDocumentNotFoundException(documentId);
 
         if (draft.LifecycleStatus != WorkflowLifecycleStatus.Draft)
         {
-            throw new InvalidOperationException(
-                $"Legal document '{documentId}' is in '{draft.LifecycleStatus}' status. Only drafts can be published.");
+            throw new LegalDocumentNotPublishableException(documentId, draft.LifecycleStatus);
         }
 
         // Find the currently published version for the same DocumentId.

--- a/src/Granit.Privacy/LegalAgreements/Exceptions/LegalDocumentNotFoundException.cs
+++ b/src/Granit.Privacy/LegalAgreements/Exceptions/LegalDocumentNotFoundException.cs
@@ -1,0 +1,16 @@
+namespace Granit.Privacy.LegalAgreements.Exceptions;
+
+/// <summary>
+/// Thrown when a legal-document operation targets a document id that has no matching
+/// row (across drafts and published versions).
+/// </summary>
+/// <remarks>
+/// The endpoint surface maps this to <c>404 Not Found</c>. A typed exception replaces the
+/// former brittle <c>InvalidOperationException.Message.Contains("not found")</c> disambiguation.
+/// </remarks>
+public sealed class LegalDocumentNotFoundException(Guid documentId)
+    : Exception($"Legal document '{documentId}' not found.")
+{
+    /// <summary>Identifier of the legal document that could not be found.</summary>
+    public Guid DocumentId { get; } = documentId;
+}

--- a/src/Granit.Privacy/LegalAgreements/Exceptions/LegalDocumentNotPublishableException.cs
+++ b/src/Granit.Privacy/LegalAgreements/Exceptions/LegalDocumentNotPublishableException.cs
@@ -1,0 +1,21 @@
+using Granit.Workflow.Domain;
+
+namespace Granit.Privacy.LegalAgreements.Exceptions;
+
+/// <summary>
+/// Thrown when publication is requested for a legal document that is not in
+/// <see cref="WorkflowLifecycleStatus.Draft"/> — only drafts can be published.
+/// </summary>
+/// <remarks>
+/// Distinct from a 404 — the document exists, it just isn't in a publishable state. The
+/// endpoint surface maps this to <c>400 Bad Request</c>.
+/// </remarks>
+public sealed class LegalDocumentNotPublishableException(Guid documentId, WorkflowLifecycleStatus status)
+    : Exception($"Legal document '{documentId}' is in '{status}' status. Only drafts can be published.")
+{
+    /// <summary>Identifier of the legal document that could not be published.</summary>
+    public Guid DocumentId { get; } = documentId;
+
+    /// <summary>The document's current lifecycle status that blocked publication.</summary>
+    public WorkflowLifecycleStatus Status { get; } = status;
+}

--- a/tests/Granit.Privacy.EntityFrameworkCore.Tests/LegalDocumentPublicationServiceTests.cs
+++ b/tests/Granit.Privacy.EntityFrameworkCore.Tests/LegalDocumentPublicationServiceTests.cs
@@ -1,4 +1,13 @@
+using Granit.Encryption;
+using Granit.Events;
+using Granit.MultiTenancy;
+using Granit.Privacy.EntityFrameworkCore.Internal;
 using Granit.Privacy.LegalAgreements.Domain;
+using Granit.Privacy.LegalAgreements.Exceptions;
+using Granit.Testing.Fakes;
+using Granit.Workflow.Domain;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -6,6 +15,37 @@ namespace Granit.Privacy.EntityFrameworkCore.Tests;
 
 public sealed class LegalDocumentPublicationServiceTests
 {
+    [Fact]
+    public async Task PublishAsync_UnknownDocument_ThrowsLegalDocumentNotFound()
+    {
+        await using var h = Harness.Create();
+        var service = new LegalDocumentPublicationService(h.Factory, Substitute.For<IDistributedEventBus>());
+
+        var unknownId = Guid.NewGuid();
+        LegalDocumentNotFoundException ex = await Should.ThrowAsync<LegalDocumentNotFoundException>(
+            () => service.PublishAsync(unknownId, TestContext.Current.CancellationToken));
+
+        ex.DocumentId.ShouldBe(unknownId);
+    }
+
+    [Fact]
+    public async Task PublishAsync_AlreadyPublishedDocument_ThrowsLegalDocumentNotPublishable()
+    {
+        await using var h = Harness.Create();
+
+        var doc = LegalDocument.Create(Guid.NewGuid(), "tos", "Terms", null, null);
+        doc.Publish();
+        await h.SeedAsync(doc, TestContext.Current.CancellationToken);
+
+        var service = new LegalDocumentPublicationService(h.Factory, Substitute.For<IDistributedEventBus>());
+
+        LegalDocumentNotPublishableException ex = await Should.ThrowAsync<LegalDocumentNotPublishableException>(
+            () => service.PublishAsync(doc.Id, TestContext.Current.CancellationToken));
+
+        ex.DocumentId.ShouldBe(doc.Id);
+        ex.Status.ShouldBe(WorkflowLifecycleStatus.Published);
+    }
+
     [Fact]
     public void LegalDocument_Create_should_set_properties()
     {
@@ -42,5 +82,56 @@ public sealed class LegalDocumentPublicationServiceTests
         doc.AttachDocument(blobId);
 
         doc.DocumentBlobId.ShouldBe(blobId);
+    }
+
+    /// <summary>
+    /// In-memory <see cref="PrivacyDbContext"/> harness. The publish exception paths query by
+    /// primary key and check lifecycle state before touching any tenant/publishable filter, so
+    /// the EF InMemory provider (which ignores query filters) is sufficient here.
+    /// </summary>
+    private sealed class Harness : IAsyncDisposable
+    {
+        private static readonly IStringEncryptionService Encryption = new PassthroughEncryption();
+        private static readonly ICurrentTenant Tenant = new FakeCurrentTenant();
+
+        private Harness(TestFactory factory) => Factory = factory;
+
+        public TestFactory Factory { get; }
+
+        public static Harness Create()
+        {
+            DbContextOptions<PrivacyDbContext> options = new DbContextOptionsBuilder<PrivacyDbContext>()
+                .UseInMemoryDatabase($"privacy-legaldoc-{Guid.NewGuid()}")
+                .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+                .Options;
+            return new Harness(new TestFactory(options));
+        }
+
+        public async Task SeedAsync(LegalDocument document, CancellationToken ct)
+        {
+            await using PrivacyDbContext db = await Factory.CreateDbContextAsync(ct);
+            db.LegalDocuments.Add(document);
+            await db.SaveChangesAsync(ct);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await using PrivacyDbContext db = await Factory.CreateDbContextAsync();
+            await db.Database.EnsureDeletedAsync();
+        }
+
+        public sealed class TestFactory(DbContextOptions<PrivacyDbContext> options)
+            : IDbContextFactory<PrivacyDbContext>
+        {
+            public PrivacyDbContext CreateDbContext() => new(options, Encryption, Tenant);
+            public Task<PrivacyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+                Task.FromResult(new PrivacyDbContext(options, Encryption, Tenant));
+        }
+
+        private sealed class PassthroughEncryption : IStringEncryptionService
+        {
+            public string Encrypt(string plainText) => plainText;
+            public string? Decrypt(string cipherText) => cipherText;
+        }
     }
 }


### PR DESCRIPTION
## Context

From the `Granit.Privacy*` framework audit. `LegalDocumentAdminEndpoints.PublishAsync` disambiguated not-found (404) from wrong-lifecycle (400) with `catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))` — fragile control flow that breaks on any message wording or locale change.

## Changes

- New `LegalDocumentNotFoundException` and `LegalDocumentNotPublishableException` in `Granit.Privacy/LegalAgreements/Exceptions/` (base module — visible to both `.EntityFrameworkCore` and `.Endpoints`).
- `LegalDocumentPublicationService.PublishAsync` throws the typed exceptions instead of generic `InvalidOperationException`.
- The endpoint catches the types → 404 / 400. The HTTP contract is unchanged; the string match is gone.
- Two new `PublishAsync` tests assert the typed throws + their payloads (`DocumentId`, `Status`).

## Tests

`Granit.Privacy.EntityFrameworkCore.Tests` (35, incl. 2 new) + `Granit.Privacy.Endpoints.Tests` (136) green; `dotnet format` clean on all touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)