### PR TITLE
refactor(privacy): extract deletion/export request orchestration into domain services

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2304,6 +2304,7 @@
       "deps": [
         "Granit",
         "Granit.DataExchange.Abstractions",
+        "Granit.Guids",
         "Granit.QueryEngine.Abstractions",
         "Granit.Settings",
         "Granit.Workflow"
@@ -45855,6 +45856,24 @@
       ]
     },
     {
+      "name": "CancelDeletionOutcome",
+      "fqn": "Granit.Privacy.DataDeletion.CancelDeletionOutcome",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs",
+      "line": 74,
+      "members": []
+    },
+    {
+      "name": "CancelDeletionResult",
+      "fqn": "Granit.Privacy.DataDeletion.CancelDeletionResult",
+      "kind": "enum",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs",
+      "line": 59,
+      "members": []
+    },
+    {
       "name": "DeletionAction",
       "fqn": "Granit.Privacy.DataDeletion.DeletionAction",
       "kind": "enum",
@@ -46037,6 +46056,28 @@
       ]
     },
     {
+      "name": "IPrivacyDeletionRequestService",
+      "fqn": "Granit.Privacy.DataDeletion.IPrivacyDeletionRequestService",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "RequestDeletionAsync",
+          "kind": "method",
+          "signature": "RequestDeletionAsync(RequestDeletionCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RequestDeletionOutcome>"
+        },
+        {
+          "name": "CancelDeletionAsync",
+          "kind": "method",
+          "signature": "CancelDeletionAsync(Guid requestId, Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<CancelDeletionOutcome>"
+        }
+      ]
+    },
+    {
       "name": "PersonalDataDeletionSaga",
       "fqn": "Granit.Privacy.DataDeletion.PersonalDataDeletionSaga",
       "kind": "class",
@@ -46075,6 +46116,33 @@
           "returnType": "int ExpectedProviderCount { get; set; } public DateTimeOffset? DeletionStartedAt { get; set; } public Task"
         }
       ]
+    },
+    {
+      "name": "RequestDeletionCommand",
+      "fqn": "Granit.Privacy.DataDeletion.RequestDeletionCommand",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "RequestDeletionOutcome",
+      "fqn": "Granit.Privacy.DataDeletion.RequestDeletionOutcome",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs",
+      "line": 53,
+      "members": []
+    },
+    {
+      "name": "RequestDeletionResult",
+      "fqn": "Granit.Privacy.DataDeletion.RequestDeletionResult",
+      "kind": "enum",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs",
+      "line": 37,
+      "members": []
     },
     {
       "name": "IPrivacyExportAuditWriter",
@@ -46268,6 +46336,15 @@
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/IExportAssemblyCheckpointStore.cs",
       "line": 67,
+      "members": []
+    },
+    {
+      "name": "ExportRequestAuditMetadata",
+      "fqn": "Granit.Privacy.DataExport.ExportRequestAuditMetadata",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportRequestService.cs",
+      "line": 39,
       "members": []
     },
     {
@@ -46495,6 +46572,22 @@
       ]
     },
     {
+      "name": "IPrivacyExportRequestService",
+      "fqn": "Granit.Privacy.DataExport.IPrivacyExportRequestService",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportRequestService.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RequestExportAsync",
+          "kind": "method",
+          "signature": "RequestExportAsync(RequestExportCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RequestExportOutcome>"
+        }
+      ]
+    },
+    {
       "name": "IPrivacyScopeResolver",
       "fqn": "Granit.Privacy.DataExport.IPrivacyScopeResolver",
       "kind": "interface",
@@ -46651,6 +46744,33 @@
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/ReceivedFragment.cs",
       "line": 23,
+      "members": []
+    },
+    {
+      "name": "RequestExportCommand",
+      "fqn": "Granit.Privacy.DataExport.RequestExportCommand",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportRequestService.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "RequestExportOutcome",
+      "fqn": "Granit.Privacy.DataExport.RequestExportOutcome",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportRequestService.cs",
+      "line": 58,
+      "members": []
+    },
+    {
+      "name": "RequestExportResult",
+      "fqn": "Granit.Privacy.DataExport.RequestExportResult",
+      "kind": "enum",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IPrivacyExportRequestService.cs",
+      "line": 45,
       "members": []
     },
     {
@@ -47381,7 +47501,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs",
-      "line": 24,
+      "line": 26,
       "members": [
         {
           "name": "AddGranitPrivacy",
@@ -47419,7 +47539,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/GranitPrivacyModule.cs",
-      "line": 13,
+      "line": 15,
       "members": []
     },
     {

--- a/src/Granit.AI.Chat.Privacy/packages.lock.json
+++ b/src/Granit.AI.Chat.Privacy/packages.lock.json
@@ -522,6 +522,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.AI.Prompts.Privacy/packages.lock.json
+++ b/src/Granit.AI.Prompts.Privacy/packages.lock.json
@@ -441,6 +441,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Auditing.Privacy/packages.lock.json
+++ b/src/Granit.Auditing.Privacy/packages.lock.json
@@ -451,6 +451,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Federated.Privacy/packages.lock.json
@@ -496,6 +496,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Local.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Local.Privacy/packages.lock.json
@@ -509,6 +509,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Indexing.Privacy/packages.lock.json
+++ b/src/Granit.Indexing.Privacy/packages.lock.json
@@ -363,6 +363,14 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.indexing": {
         "type": "Project",
         "dependencies": {
@@ -381,6 +389,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Notifications.MobilePush.Privacy/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.Privacy/packages.lock.json
@@ -449,6 +449,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Notifications.Privacy/packages.lock.json
+++ b/src/Granit.Notifications.Privacy/packages.lock.json
@@ -456,6 +456,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Notifications.WebPush.Privacy/packages.lock.json
+++ b/src/Granit.Notifications.WebPush.Privacy/packages.lock.json
@@ -454,6 +454,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.AI/packages.lock.json
+++ b/src/Granit.Privacy.AI/packages.lock.json
@@ -432,6 +432,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.Auditing/packages.lock.json
+++ b/src/Granit.Privacy.Auditing/packages.lock.json
@@ -395,6 +395,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.BackgroundJobs.Wolverine/packages.lock.json
+++ b/src/Granit.Privacy.BackgroundJobs.Wolverine/packages.lock.json
@@ -582,6 +582,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Privacy.BackgroundJobs/packages.lock.json
@@ -390,6 +390,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.BlobStorage/packages.lock.json
+++ b/src/Granit.Privacy.BlobStorage/packages.lock.json
@@ -170,6 +170,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyDeletionEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyDeletionEndpoints.cs
@@ -1,13 +1,7 @@
-using Granit.Events;
-using Granit.Guids;
-using Granit.MultiTenancy;
 using Granit.Privacy.DataDeletion;
-using Granit.Privacy.DataDeletion.Events;
-using Granit.Privacy.Diagnostics;
 using Granit.Privacy.Endpoints.Dtos;
 using Granit.Privacy.Endpoints.Internal;
 using Granit.Privacy.Endpoints.Permissions;
-using Granit.Privacy.Options;
 using Granit.Privacy.Regulations;
 using Granit.Users;
 using Microsoft.AspNetCore.Builder;
@@ -15,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Options;
 
 namespace Granit.Privacy.Endpoints.Endpoints;
 
@@ -78,14 +71,7 @@ internal static class PrivacyDeletionEndpoints
     private static async Task<Results<Accepted<PrivacyDeletionRequestResponse>, Accepted, ProblemHttpResult>> HandleRequestDeletionAsync(
         PrivacyDeletionRequest body,
         [FromServices] ICurrentUserService currentUser,
-        [FromServices] IDistributedEventBus eventBus,
-        [FromServices] IDeletionRequestTrackerReader deletionTracker,
-        [FromServices] IDeletionRequestTrackerWriter? deletionTrackerWriter,
-        [FromServices] PrivacyMetrics metrics,
-        [FromServices] TimeProvider timeProvider,
-        [FromServices] ICurrentTenant currentTenant,
-        [FromServices] IOptions<GranitPrivacyOptions> privacyOptions,
-        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IPrivacyDeletionRequestService deletionService,
         [FromServices] IPrivacyRegulationResolver? regulationResolver,
         CancellationToken cancellationToken)
     {
@@ -94,73 +80,31 @@ internal static class PrivacyDeletionEndpoints
             return PrivacyResponseMapper.UserNotAuthenticated();
         }
 
-        IReadOnlyList<DeletionRequestStatus> existing = await deletionTracker
-            .GetByUserAsync(userId, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (existing.Any(r => r.State == DeletionRequestState.Deferred))
-        {
-            return TypedResults.Problem(
-                detail: "A deferred deletion request is already in progress. Cancel it before submitting a new one.",
-                statusCode: StatusCodes.Status409Conflict);
-        }
-
-        Guid requestId = guidGenerator.Create();
-        DateTimeOffset now = timeProvider.GetUtcNow();
-        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
-        string requestedBy = currentUser.Email ?? "unknown";
         string regulation = await PrivacyResponseMapper.ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
+        string requestedBy = currentUser.Email ?? "unknown";
 
-        if (body.Defer)
-        {
-            int graceDays = privacyOptions.Value.DefaultGracePeriodDays;
-            DateTimeOffset scheduledDeletionAt = now.AddDays(graceDays);
-
-            await eventBus
-                .PublishAsync(
-                    new DeletionDeferredEto(requestId, userId, requestedBy, now, body.Reason, scheduledDeletionAt, regulation, tenantId),
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            metrics.RecordDeletionDeferred(tenantId, regulation);
-
-            return TypedResults.Accepted(
-                $"/privacy/deletion/{requestId}",
-                new PrivacyDeletionRequestResponse(requestId, scheduledDeletionAt));
-        }
-
-        // Immediate deletion + confirmation event + audit trail (GDPR Art. 5(2))
-        if (deletionTrackerWriter is not null)
-        {
-            await deletionTrackerWriter
-                .RecordImmediateDeletionAsync(requestId, userId, body.Reason, now, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        await eventBus
-            .PublishAsync(
-                new PersonalDataDeletionRequestedEto(requestId, userId, requestedBy, now, body.Reason, regulation, tenantId),
+        RequestDeletionOutcome outcome = await deletionService
+            .RequestDeletionAsync(
+                new RequestDeletionCommand(userId, requestedBy, body.Defer, body.Reason, regulation),
                 cancellationToken)
             .ConfigureAwait(false);
 
-        await eventBus
-            .PublishAsync(
-                new DeletionExecutedEto(requestId, userId, now),
-                cancellationToken)
-            .ConfigureAwait(false);
-
-        metrics.RecordDeletionRequested(tenantId, regulation);
-        metrics.RecordDeletionExecuted(tenantId, regulation);
-
-        return TypedResults.Accepted((string?)null);
+        return outcome.Result switch
+        {
+            RequestDeletionResult.DuplicatePending => TypedResults.Problem(
+                detail: "A deferred deletion request is already in progress. Cancel it before submitting a new one.",
+                statusCode: StatusCodes.Status409Conflict),
+            RequestDeletionResult.Deferred => TypedResults.Accepted(
+                $"/privacy/deletion/{outcome.RequestId}",
+                new PrivacyDeletionRequestResponse(outcome.RequestId, outcome.ScheduledDeletionAt!.Value)),
+            _ => TypedResults.Accepted((string?)null),
+        };
     }
 
     private static async Task<Results<Ok, ProblemHttpResult>> HandleCancelDeletionAsync(
         Guid requestId,
         [FromServices] ICurrentUserService currentUser,
-        [FromServices] IDeletionRequestTrackerReader tracker,
-        [FromServices] IDistributedEventBus eventBus,
-        [FromServices] TimeProvider timeProvider,
+        [FromServices] IPrivacyDeletionRequestService deletionService,
         CancellationToken cancellationToken)
     {
         if (!PrivacyResponseMapper.TryGetUserId(currentUser, out Guid userId))
@@ -168,40 +112,20 @@ internal static class PrivacyDeletionEndpoints
             return PrivacyResponseMapper.UserNotAuthenticated();
         }
 
-        DeletionRequestStatus? status = await tracker
-            .GetStatusAsync(requestId, cancellationToken)
+        CancelDeletionOutcome outcome = await deletionService
+            .CancelDeletionAsync(requestId, userId, cancellationToken)
             .ConfigureAwait(false);
 
-        if (status is null)
+        return outcome.Result switch
         {
-            return TypedResults.Problem(
+            CancelDeletionResult.NotFound => TypedResults.Problem(
                 detail: $"Deletion request '{requestId}' not found.",
-                statusCode: StatusCodes.Status404NotFound);
-        }
-
-        if (status.UserId != userId)
-        {
-            return TypedResults.Problem(
-                detail: $"Deletion request '{requestId}' not found.",
-                statusCode: StatusCodes.Status404NotFound);
-        }
-
-        if (status.State != DeletionRequestState.Deferred)
-        {
-            return TypedResults.Problem(
-                detail: $"Deletion request '{requestId}' is already {status.State} and cannot be cancelled.",
-                statusCode: StatusCodes.Status409Conflict);
-        }
-
-        DateTimeOffset now = timeProvider.GetUtcNow();
-
-        await eventBus
-            .PublishAsync(
-                new DeletionCancelledEto(requestId, userId, now),
-                cancellationToken)
-            .ConfigureAwait(false);
-
-        return TypedResults.Ok();
+                statusCode: StatusCodes.Status404NotFound),
+            CancelDeletionResult.NotCancellable => TypedResults.Problem(
+                detail: $"Deletion request '{requestId}' is already {outcome.CurrentState} and cannot be cancelled.",
+                statusCode: StatusCodes.Status409Conflict),
+            _ => TypedResults.Ok(),
+        };
     }
 
     private static async Task<Results<Ok<PrivacyDeletionStatusResponse>, ProblemHttpResult>> HandleGetDeletionStatusAsync(

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyExportEndpoints.cs
@@ -1,12 +1,8 @@
-using Granit.Events;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Http.RateLimiting.AspNetCore;
 using Granit.MultiTenancy;
 using Granit.Privacy.DataExport;
-using Granit.Privacy.DataExport.Audit;
-using Granit.Privacy.DataExport.Events;
-using Granit.Privacy.Diagnostics;
 using Granit.Privacy.Endpoints.Dtos;
 using Granit.Privacy.Endpoints.Internal;
 using Granit.Privacy.Endpoints.Permissions;
@@ -113,13 +109,7 @@ internal static class PrivacyExportEndpoints
         [FromBody] PrivacyExportRequest? body,
         HttpContext httpContext,
         [FromServices] ICurrentUserService currentUser,
-        [FromServices] IDistributedEventBus eventBus,
-        [FromServices] IExportRequestTrackerWriter tracker,
-        [FromServices] IPrivacyExportAuditWriter auditWriter,
-        [FromServices] PrivacyMetrics metrics,
-        [FromServices] TimeProvider timeProvider,
-        [FromServices] ICurrentTenant currentTenant,
-        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IPrivacyExportRequestService exportService,
         [FromServices] IPrivacyRegulationResolver? regulationResolver,
         CancellationToken cancellationToken)
     {
@@ -128,67 +118,32 @@ internal static class PrivacyExportEndpoints
             return PrivacyResponseMapper.UserNotAuthenticated();
         }
 
-        Guid requestId = guidGenerator.Create();
-        DateTimeOffset now = timeProvider.GetUtcNow();
-        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
         string regulation = await PrivacyResponseMapper.ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
 
-        // Null / empty Scopes → "everything visible" (Takeout default). Unknown / hidden
-        // entries are silently dropped by the saga via the visibility resolver.
-        IReadOnlyList<string>? requestedScopes = body?.Scopes is { Count: > 0 } scopes ? scopes : null;
-
-        // Self-service: caller == subject. The tracker collapses equal pair to a null
-        // CallerUserId so the row is indistinguishable from pre-CallerUserId rows.
-        await tracker
-            .RecordRequestAsync(requestId, userId, userId, now, cancellationToken)
-            .ConfigureAwait(false);
-
-        await eventBus
-            .PublishAsync(
-                new PersonalDataRequestedEto(
-                    RequestId: requestId,
-                    UserId: userId,
-                    RequestedAt: now,
+        // Self-service: caller == subject, no subject validation.
+        RequestExportOutcome outcome = await exportService
+            .RequestExportAsync(
+                new RequestExportCommand(
+                    SubjectUserId: userId,
+                    CallerUserId: userId,
+                    Scopes: body?.Scopes,
                     Regulation: regulation,
-                    TenantId: tenantId,
-                    RequestedScopes: requestedScopes),
+                    ValidateSubject: false,
+                    Audit: PrivacyResponseMapper.ToExportAuditMetadata(httpContext)),
                 cancellationToken)
             .ConfigureAwait(false);
 
-        metrics.RecordExportRequested(tenantId, regulation);
-
-        await auditWriter.WriteExportRequestedAsync(
-            new PrivacyExportRequestedAudit(
-                RequestId: requestId,
-                CallerUserId: userId,
-                SubjectUserId: userId,
-                TenantId: tenantId,
-                Regulation: regulation,
-                ResolvedScopes: requestedScopes ?? [],
-                ClientIp: PrivacyResponseMapper.PseudonymizeIpAddress(httpContext.Connection.RemoteIpAddress?.ToString()),
-                UserAgent: httpContext.Request.Headers.UserAgent.ToString(),
-                CorrelationId: httpContext.TraceIdentifier,
-                Timestamp: now),
-            cancellationToken).ConfigureAwait(false);
-
         return TypedResults.Accepted(
-            $"/privacy/export/{requestId}",
-            new PrivacyExportRequestResponse(requestId, now));
+            $"/privacy/export/{outcome.RequestId}",
+            new PrivacyExportRequestResponse(outcome.RequestId, outcome.RequestedAt));
     }
 
     private static async Task<Results<Accepted<PrivacyExportRequestResponse>, ProblemHttpResult>> HandleRequestExportOnBehalfOfAsync(
         [FromBody] PrivacyExportOnBehalfOfRequest body,
         HttpContext httpContext,
         [FromServices] ICurrentUserService currentUser,
-        [FromServices] IDistributedEventBus eventBus,
-        [FromServices] IExportRequestTrackerWriter tracker,
-        [FromServices] IPrivacyExportAuditWriter auditWriter,
-        [FromServices] PrivacyMetrics metrics,
-        [FromServices] TimeProvider timeProvider,
-        [FromServices] ICurrentTenant currentTenant,
-        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IPrivacyExportRequestService exportService,
         [FromServices] IPrivacyRegulationResolver? regulationResolver,
-        [FromServices] IPrivacySubjectValidator subjectValidator,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(body);
@@ -200,67 +155,32 @@ internal static class PrivacyExportEndpoints
 
         // SubjectUserId non-empty + scope bounds are enforced by
         // PrivacyExportOnBehalfOfRequestValidator at the FluentValidation auto-filter
-        // pass — the handler is only reached on a clean body.
-
-        // Tenant-bound subject existence check. A subject the caller cannot see in
-        // its current tenant returns 404 (NOT 403) — same status as a non-existent
-        // request id, so cross-tenant subject probing yields no signal.
-        bool subjectExists = await subjectValidator
-            .SubjectExistsInCurrentTenantAsync(body.SubjectUserId, cancellationToken)
-            .ConfigureAwait(false);
-        if (!subjectExists)
-        {
-            return TypedResults.Problem(
-                detail: $"Subject '{body.SubjectUserId}' not found.",
-                statusCode: StatusCodes.Status404NotFound);
-        }
-
-        Guid requestId = guidGenerator.Create();
-        DateTimeOffset now = timeProvider.GetUtcNow();
-        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        // pass — the handler is only reached on a clean body. The tenant-bound subject
+        // existence check (404 on a subject absent from the caller's tenant) is performed
+        // by the export service via ValidateSubject.
         string regulation = await PrivacyResponseMapper.ResolveRegulationAsync(regulationResolver, cancellationToken).ConfigureAwait(false);
 
-        IReadOnlyList<string>? requestedScopes = body.Scopes is { Count: > 0 } scopes ? scopes : null;
-
-        // The saga's PersonalDataRequestedEto.UserId names the data subject — providers
-        // and the visibility resolver key off it for HasData probes etc. The caller's
-        // identity is persisted both on the tracker row (so the admin sees the export
-        // on their listing) and on the audit row (Art. 30 ROPA).
-        await tracker
-            .RecordRequestAsync(requestId, body.SubjectUserId, callerUserId, now, cancellationToken)
-            .ConfigureAwait(false);
-
-        await eventBus
-            .PublishAsync(
-                new PersonalDataRequestedEto(
-                    RequestId: requestId,
-                    UserId: body.SubjectUserId,
-                    RequestedAt: now,
+        RequestExportOutcome outcome = await exportService
+            .RequestExportAsync(
+                new RequestExportCommand(
+                    SubjectUserId: body.SubjectUserId,
+                    CallerUserId: callerUserId,
+                    Scopes: body.Scopes,
                     Regulation: regulation,
-                    TenantId: tenantId,
-                    RequestedScopes: requestedScopes),
+                    ValidateSubject: true,
+                    Audit: PrivacyResponseMapper.ToExportAuditMetadata(httpContext)),
                 cancellationToken)
             .ConfigureAwait(false);
 
-        metrics.RecordExportRequested(tenantId, regulation);
-
-        await auditWriter.WriteExportRequestedAsync(
-            new PrivacyExportRequestedAudit(
-                RequestId: requestId,
-                CallerUserId: callerUserId,
-                SubjectUserId: body.SubjectUserId,
-                TenantId: tenantId,
-                Regulation: regulation,
-                ResolvedScopes: requestedScopes ?? [],
-                ClientIp: PrivacyResponseMapper.PseudonymizeIpAddress(httpContext.Connection.RemoteIpAddress?.ToString()),
-                UserAgent: httpContext.Request.Headers.UserAgent.ToString(),
-                CorrelationId: httpContext.TraceIdentifier,
-                Timestamp: now),
-            cancellationToken).ConfigureAwait(false);
-
-        return TypedResults.Accepted(
-            $"/privacy/export/{requestId}",
-            new PrivacyExportRequestResponse(requestId, now));
+        return outcome.Result switch
+        {
+            RequestExportResult.SubjectNotFound => TypedResults.Problem(
+                detail: $"Subject '{body.SubjectUserId}' not found.",
+                statusCode: StatusCodes.Status404NotFound),
+            _ => TypedResults.Accepted(
+                $"/privacy/export/{outcome.RequestId}",
+                new PrivacyExportRequestResponse(outcome.RequestId, outcome.RequestedAt)),
+        };
     }
 
     private static async Task<Results<Ok<IReadOnlyList<PrivacyExportScopeResponse>>, ProblemHttpResult>> HandleListExportScopesAsync(

--- a/src/Granit.Privacy.Endpoints/Internal/PrivacyResponseMapper.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/PrivacyResponseMapper.cs
@@ -133,4 +133,14 @@ internal static class PrivacyResponseMapper
 
         return null;
     }
+
+    /// <summary>
+    /// Captures the HTTP-layer audit metadata for an export request — the pseudonymized client
+    /// IP, user-agent, and trace correlation id — so the domain service stays HTTP-agnostic.
+    /// </summary>
+    internal static ExportRequestAuditMetadata ToExportAuditMetadata(HttpContext httpContext) =>
+        new(
+            ClientIp: PseudonymizeIpAddress(httpContext.Connection.RemoteIpAddress?.ToString()),
+            UserAgent: httpContext.Request.Headers.UserAgent.ToString(),
+            CorrelationId: httpContext.TraceIdentifier);
 }

--- a/src/Granit.Privacy.Endpoints/packages.lock.json
+++ b/src/Granit.Privacy.Endpoints/packages.lock.json
@@ -231,6 +231,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Privacy.EntityFrameworkCore/packages.lock.json
@@ -447,6 +447,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.Notifications/packages.lock.json
+++ b/src/Granit.Privacy.Notifications/packages.lock.json
@@ -363,6 +363,14 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -375,6 +383,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy.Vault/packages.lock.json
+++ b/src/Granit.Privacy.Vault/packages.lock.json
@@ -470,6 +470,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs
+++ b/src/Granit.Privacy/DataDeletion/IPrivacyDeletionRequestService.cs
@@ -1,0 +1,76 @@
+namespace Granit.Privacy.DataDeletion;
+
+/// <summary>
+/// Application service that orchestrates personal-data deletion requests (GDPR Art. 17):
+/// the duplicate-request guard, grace-period arithmetic, deferred-vs-immediate branching,
+/// the distributed-event sequencing, and the tracker / metrics writes. Extracted from the
+/// HTTP handler so the workflow lives in the domain layer and is unit-testable in isolation.
+/// </summary>
+public interface IPrivacyDeletionRequestService
+{
+    /// <summary>
+    /// Requests deletion for a data subject. When <see cref="RequestDeletionCommand.Defer"/> is
+    /// set a cooling-off period is started; otherwise deletion executes immediately.
+    /// </summary>
+    Task<RequestDeletionOutcome> RequestDeletionAsync(
+        RequestDeletionCommand command, CancellationToken cancellationToken = default);
+
+    /// <summary>Cancels a deferred deletion request during its grace period.</summary>
+    Task<CancelDeletionOutcome> CancelDeletionAsync(
+        Guid requestId, Guid userId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Input for <see cref="IPrivacyDeletionRequestService.RequestDeletionAsync"/>.</summary>
+/// <param name="UserId">Data subject whose data is scheduled for deletion.</param>
+/// <param name="RequestedBy">Human-readable actor label recorded on the event (typically the user's email).</param>
+/// <param name="Defer">When <c>true</c>, start a grace period instead of deleting immediately.</param>
+/// <param name="Reason">Free-text justification (may contain personal data — never logged).</param>
+/// <param name="Regulation">Resolved regulation code (e.g. <c>EU_GDPR</c>), resolved at the call site.</param>
+public sealed record RequestDeletionCommand(
+    Guid UserId,
+    string RequestedBy,
+    bool Defer,
+    string Reason,
+    string Regulation);
+
+/// <summary>Discriminates the outcome of a deletion request.</summary>
+public enum RequestDeletionResult
+{
+    /// <summary>A cooling-off period was started; erasure is scheduled for later.</summary>
+    Deferred,
+
+    /// <summary>Deletion executed immediately.</summary>
+    ExecutedImmediately,
+
+    /// <summary>A deferred request is already pending for this subject — the new request was rejected.</summary>
+    DuplicatePending,
+}
+
+/// <summary>Result of <see cref="IPrivacyDeletionRequestService.RequestDeletionAsync"/>.</summary>
+/// <param name="Result">What happened.</param>
+/// <param name="RequestId">Correlation id of the created request (unset / ignored for <see cref="RequestDeletionResult.DuplicatePending"/>).</param>
+/// <param name="ScheduledDeletionAt">Scheduled erasure timestamp for a deferred request; <c>null</c> otherwise.</param>
+public sealed record RequestDeletionOutcome(
+    RequestDeletionResult Result,
+    Guid RequestId,
+    DateTimeOffset? ScheduledDeletionAt);
+
+/// <summary>Discriminates the outcome of a deletion-cancellation request.</summary>
+public enum CancelDeletionResult
+{
+    /// <summary>The deferred request was cancelled.</summary>
+    Cancelled,
+
+    /// <summary>No request with that id belongs to the caller.</summary>
+    NotFound,
+
+    /// <summary>The request exists but is no longer in a cancellable (deferred) state.</summary>
+    NotCancellable,
+}
+
+/// <summary>Result of <see cref="IPrivacyDeletionRequestService.CancelDeletionAsync"/>.</summary>
+/// <param name="Result">What happened.</param>
+/// <param name="CurrentState">The request's current state — set only for <see cref="CancelDeletionResult.NotCancellable"/>.</param>
+public sealed record CancelDeletionOutcome(
+    CancelDeletionResult Result,
+    DeletionRequestState? CurrentState = null);

--- a/src/Granit.Privacy/DataDeletion/Internal/PrivacyDeletionRequestService.cs
+++ b/src/Granit.Privacy/DataDeletion/Internal/PrivacyDeletionRequestService.cs
@@ -1,0 +1,118 @@
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion.Events;
+using Granit.Privacy.Diagnostics;
+using Granit.Privacy.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Privacy.DataDeletion.Internal;
+
+/// <summary>
+/// Default <see cref="IPrivacyDeletionRequestService"/> orchestrating the deletion workflow.
+/// The trackers are optional: a host that maps the deletion endpoints wires them via
+/// <c>UseDeletionRequestTracker</c>, but a host that only references the module must still be
+/// able to construct this service, so the reader/writer default to <c>null</c> and the
+/// duplicate guard / immediate-record steps degrade gracefully when absent.
+/// </summary>
+internal sealed class PrivacyDeletionRequestService(
+    IDistributedEventBus eventBus,
+    PrivacyMetrics metrics,
+    TimeProvider timeProvider,
+    ICurrentTenant currentTenant,
+    IOptions<GranitPrivacyOptions> options,
+    IGuidGenerator guidGenerator,
+    IDeletionRequestTrackerReader? deletionTracker = null,
+    IDeletionRequestTrackerWriter? deletionTrackerWriter = null) : IPrivacyDeletionRequestService
+{
+    public async Task<RequestDeletionOutcome> RequestDeletionAsync(
+        RequestDeletionCommand command, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (deletionTracker is not null)
+        {
+            IReadOnlyList<DeletionRequestStatus> existing = await deletionTracker
+                .GetByUserAsync(command.UserId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing.Any(r => r.State == DeletionRequestState.Deferred))
+            {
+                return new RequestDeletionOutcome(RequestDeletionResult.DuplicatePending, Guid.Empty, null);
+            }
+        }
+
+        Guid requestId = guidGenerator.Create();
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+
+        if (command.Defer)
+        {
+            int graceDays = options.Value.DefaultGracePeriodDays;
+            DateTimeOffset scheduledDeletionAt = now.AddDays(graceDays);
+
+            await eventBus
+                .PublishAsync(
+                    new DeletionDeferredEto(requestId, command.UserId, command.RequestedBy, now, command.Reason, scheduledDeletionAt, command.Regulation, tenantId),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            metrics.RecordDeletionDeferred(tenantId, command.Regulation);
+
+            return new RequestDeletionOutcome(RequestDeletionResult.Deferred, requestId, scheduledDeletionAt);
+        }
+
+        // Immediate deletion + confirmation event + audit trail (GDPR Art. 5(2)).
+        if (deletionTrackerWriter is not null)
+        {
+            await deletionTrackerWriter
+                .RecordImmediateDeletionAsync(requestId, command.UserId, command.Reason, now, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await eventBus
+            .PublishAsync(
+                new PersonalDataDeletionRequestedEto(requestId, command.UserId, command.RequestedBy, now, command.Reason, command.Regulation, tenantId),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        await eventBus
+            .PublishAsync(
+                new DeletionExecutedEto(requestId, command.UserId, now),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        metrics.RecordDeletionRequested(tenantId, command.Regulation);
+        metrics.RecordDeletionExecuted(tenantId, command.Regulation);
+
+        return new RequestDeletionOutcome(RequestDeletionResult.ExecutedImmediately, requestId, null);
+    }
+
+    public async Task<CancelDeletionOutcome> CancelDeletionAsync(
+        Guid requestId, Guid userId, CancellationToken cancellationToken = default)
+    {
+        DeletionRequestStatus? status = deletionTracker is null
+            ? null
+            : await deletionTracker.GetStatusAsync(requestId, cancellationToken).ConfigureAwait(false);
+
+        // Unknown request, or one owned by a different user — same 404 shape either way so a
+        // caller cannot probe for other users' request ids.
+        if (status is null || status.UserId != userId)
+        {
+            return new CancelDeletionOutcome(CancelDeletionResult.NotFound);
+        }
+
+        if (status.State != DeletionRequestState.Deferred)
+        {
+            return new CancelDeletionOutcome(CancelDeletionResult.NotCancellable, status.State);
+        }
+
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        await eventBus
+            .PublishAsync(new DeletionCancelledEto(requestId, userId, now), cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CancelDeletionOutcome(CancelDeletionResult.Cancelled);
+    }
+}

--- a/src/Granit.Privacy/DataExport/IPrivacyExportRequestService.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyExportRequestService.cs
@@ -1,0 +1,61 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Application service that orchestrates personal-data export requests (GDPR Art. 15/20):
+/// optional tenant-bound subject validation, scope normalization, the tracker write, the
+/// distributed-event dispatch, metrics, and the ROPA audit entry. Collapses the near-identical
+/// self-service and admin "on behalf of" HTTP handlers into one call and keeps the workflow in
+/// the domain layer, unit-testable in isolation.
+/// </summary>
+public interface IPrivacyExportRequestService
+{
+    /// <summary>Files an export request and returns its correlation id and acceptance timestamp.</summary>
+    Task<RequestExportOutcome> RequestExportAsync(
+        RequestExportCommand command, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Input for <see cref="IPrivacyExportRequestService.RequestExportAsync"/>.</summary>
+/// <param name="SubjectUserId">Data subject the export targets.</param>
+/// <param name="CallerUserId">User who filed the request — equal to <paramref name="SubjectUserId"/>
+/// for self-service, distinct for an admin DSR.</param>
+/// <param name="Scopes">Requested provider scopes, or <c>null</c> / empty for "everything visible".</param>
+/// <param name="Regulation">Resolved regulation code, resolved at the call site.</param>
+/// <param name="ValidateSubject">When <c>true</c> the subject is checked against the caller's
+/// tenant before the request is accepted (admin DSR path); a missing subject yields
+/// <see cref="RequestExportResult.SubjectNotFound"/>.</param>
+/// <param name="Audit">HTTP-layer audit metadata (already-pseudonymized IP, user-agent, correlation id).</param>
+public sealed record RequestExportCommand(
+    Guid SubjectUserId,
+    Guid CallerUserId,
+    IReadOnlyList<string>? Scopes,
+    string Regulation,
+    bool ValidateSubject,
+    ExportRequestAuditMetadata Audit);
+
+/// <summary>HTTP-layer metadata captured for the ROPA audit row; the call site masks the IP.</summary>
+/// <param name="ClientIp">Pseudonymized client IP.</param>
+/// <param name="UserAgent">Client user-agent string.</param>
+/// <param name="CorrelationId">Distributed-tracing correlation id.</param>
+public sealed record ExportRequestAuditMetadata(
+    string? ClientIp,
+    string? UserAgent,
+    string? CorrelationId);
+
+/// <summary>Discriminates the outcome of an export request.</summary>
+public enum RequestExportResult
+{
+    /// <summary>The request was accepted and the saga was triggered.</summary>
+    Accepted,
+
+    /// <summary>Subject validation was requested but the subject is not visible in the caller's tenant.</summary>
+    SubjectNotFound,
+}
+
+/// <summary>Result of <see cref="IPrivacyExportRequestService.RequestExportAsync"/>.</summary>
+/// <param name="Result">What happened.</param>
+/// <param name="RequestId">Correlation id of the created request (unset for <see cref="RequestExportResult.SubjectNotFound"/>).</param>
+/// <param name="RequestedAt">Acceptance timestamp (UTC).</param>
+public sealed record RequestExportOutcome(
+    RequestExportResult Result,
+    Guid RequestId,
+    DateTimeOffset RequestedAt);

--- a/src/Granit.Privacy/DataExport/Internal/PrivacyExportRequestService.cs
+++ b/src/Granit.Privacy/DataExport/Internal/PrivacyExportRequestService.cs
@@ -1,0 +1,93 @@
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Privacy.DataExport.Audit;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.Diagnostics;
+
+namespace Granit.Privacy.DataExport.Internal;
+
+/// <summary>
+/// Default <see cref="IPrivacyExportRequestService"/> orchestrating the export workflow. The
+/// tracker is optional so a host that only references the module can still construct the service;
+/// hosts that map the export endpoints wire it via <c>UseExportRequestTracker</c>. The audit
+/// writer and subject validator always have framework defaults registered.
+/// </summary>
+internal sealed class PrivacyExportRequestService(
+    IDistributedEventBus eventBus,
+    IPrivacyExportAuditWriter auditWriter,
+    IPrivacySubjectValidator subjectValidator,
+    PrivacyMetrics metrics,
+    TimeProvider timeProvider,
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator,
+    IExportRequestTrackerWriter? tracker = null) : IPrivacyExportRequestService
+{
+    public async Task<RequestExportOutcome> RequestExportAsync(
+        RequestExportCommand command, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // Tenant-bound subject existence check (admin DSR only). A subject the caller cannot see
+        // in its current tenant is reported as not-found (NOT forbidden) — same shape as a
+        // non-existent request id, so cross-tenant subject probing yields no signal.
+        if (command.ValidateSubject)
+        {
+            bool subjectExists = await subjectValidator
+                .SubjectExistsInCurrentTenantAsync(command.SubjectUserId, cancellationToken)
+                .ConfigureAwait(false);
+            if (!subjectExists)
+            {
+                return new RequestExportOutcome(RequestExportResult.SubjectNotFound, Guid.Empty, default);
+            }
+        }
+
+        Guid requestId = guidGenerator.Create();
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+
+        // Null / empty scopes → "everything visible" (Takeout default). Unknown / hidden entries
+        // are dropped by the saga via the visibility resolver.
+        IReadOnlyList<string>? requestedScopes = command.Scopes is { Count: > 0 } scopes ? scopes : null;
+
+        // Self-service collapses caller == subject to a null CallerUserId on the tracker row.
+        if (tracker is not null)
+        {
+            await tracker
+                .RecordRequestAsync(requestId, command.SubjectUserId, command.CallerUserId, now, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // The saga's PersonalDataRequestedEto.UserId names the data subject — providers and the
+        // visibility resolver key off it for HasData probes etc.
+        await eventBus
+            .PublishAsync(
+                new PersonalDataRequestedEto(
+                    RequestId: requestId,
+                    UserId: command.SubjectUserId,
+                    RequestedAt: now,
+                    Regulation: command.Regulation,
+                    TenantId: tenantId,
+                    RequestedScopes: requestedScopes),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        metrics.RecordExportRequested(tenantId, command.Regulation);
+
+        await auditWriter.WriteExportRequestedAsync(
+            new PrivacyExportRequestedAudit(
+                RequestId: requestId,
+                CallerUserId: command.CallerUserId,
+                SubjectUserId: command.SubjectUserId,
+                TenantId: tenantId,
+                Regulation: command.Regulation,
+                ResolvedScopes: requestedScopes ?? [],
+                ClientIp: command.Audit.ClientIp,
+                UserAgent: command.Audit.UserAgent,
+                CorrelationId: command.Audit.CorrelationId,
+                Timestamp: now),
+            cancellationToken).ConfigureAwait(false);
+
+        return new RequestExportOutcome(RequestExportResult.Accepted, requestId, now);
+    }
+}

--- a/src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs
+++ b/src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
+using Granit.Privacy.DataDeletion;
+using Granit.Privacy.DataDeletion.Internal;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Audit;
 using Granit.Privacy.DataExport.Internal;
@@ -75,6 +77,13 @@ public static class PrivacyServiceCollectionExtensions
         // has data stays visible) — hosts override via services.AddSingleton<IPrivacyScopeVisibilityPolicy, ...>.
         services.TryAddSingleton<IPrivacyScopeVisibilityPolicy, AllowAllPrivacyScopeVisibilityPolicy>();
         services.TryAddScoped<IPrivacyScopeResolver, PrivacyScopeResolver>();
+
+        // Domain orchestration services for the deletion / export request workflows. Registered
+        // here (not in .Endpoints) so the workflow lives in the base module; the HTTP handlers
+        // delegate to these. Their optional trackers keep DI construction valid for hosts that
+        // reference the module without wiring a tracker.
+        services.TryAddScoped<IPrivacyDeletionRequestService, PrivacyDeletionRequestService>();
+        services.TryAddScoped<IPrivacyExportRequestService, PrivacyExportRequestService>();
 
         // ROPA / ISO 27001 audit trail — hosts that wire Granit.Privacy.Auditing replace this
         // with the IAuditingWriter-backed adapter via DI overrides.

--- a/src/Granit.Privacy/Granit.Privacy.csproj
+++ b/src/Granit.Privacy/Granit.Privacy.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Privacy.BlobStorage" />
+    <InternalsVisibleTo Include="Granit.Privacy.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Privacy.Tests" />
   </ItemGroup>
 
@@ -37,6 +38,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />
     <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />

--- a/src/Granit.Privacy/GranitPrivacyModule.cs
+++ b/src/Granit.Privacy/GranitPrivacyModule.cs
@@ -1,3 +1,4 @@
+using Granit.Guids;
 using Granit.Modularity;
 using Granit.Settings;
 
@@ -9,5 +10,6 @@ namespace Granit.Privacy;
 /// an <see cref="System.Action{GranitPrivacyBuilder}"/> for data provider
 /// and legal document declarations.
 /// </summary>
+[DependsOn(typeof(GranitGuidsModule))]
 [DependsOn(typeof(GranitSettingsModule))]
 public sealed class GranitPrivacyModule : GranitModule;

--- a/src/Granit.Privacy/packages.lock.json
+++ b/src/Granit.Privacy/packages.lock.json
@@ -384,6 +384,14 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3691,6 +3691,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsTestServer.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsTestServer.cs
@@ -245,6 +245,13 @@ internal sealed class PrivacyEndpointsTestServer : IAsyncDisposable
         builder.Services.AddMetrics();
         builder.Services.AddSingleton<PrivacyMetrics>();
 
+        // Real domain orchestration services (composed from the mocks above) so the endpoint
+        // handlers exercise the full handler -> service -> dependency path in integration tests.
+        builder.Services.AddScoped<Granit.Privacy.DataDeletion.IPrivacyDeletionRequestService,
+            Granit.Privacy.DataDeletion.Internal.PrivacyDeletionRequestService>();
+        builder.Services.AddScoped<Granit.Privacy.DataExport.IPrivacyExportRequestService,
+            Granit.Privacy.DataExport.Internal.PrivacyExportRequestService>();
+
         // Validators from the Privacy.Endpoints assembly
         builder.Services.AddValidatorsFromAssemblyContaining<PrivacyEndpointsOptions>(
             ServiceLifetime.Singleton, includeInternalTypes: true);

--- a/tests/Granit.Privacy.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Endpoints.Tests/packages.lock.json
@@ -736,6 +736,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Privacy.Tests/DataDeletion/Internal/PrivacyDeletionRequestServiceTests.cs
+++ b/tests/Granit.Privacy.Tests/DataDeletion/Internal/PrivacyDeletionRequestServiceTests.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics.Metrics;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Privacy.DataDeletion;
+using Granit.Privacy.DataDeletion.Events;
+using Granit.Privacy.DataDeletion.Internal;
+using Granit.Privacy.Diagnostics;
+using Granit.Privacy.Options;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Tests.DataDeletion.Internal;
+
+public sealed class PrivacyDeletionRequestServiceTests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid RequestId = new("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid UserId = new("22222222-2222-2222-2222-222222222222");
+
+    private readonly ServiceProvider _sp;
+    private readonly PrivacyMetrics _metrics;
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly IDeletionRequestTrackerReader _reader = Substitute.For<IDeletionRequestTrackerReader>();
+    private readonly IDeletionRequestTrackerWriter _writer = Substitute.For<IDeletionRequestTrackerWriter>();
+    private readonly IGuidGenerator _guids = Substitute.For<IGuidGenerator>();
+    private readonly TimeProvider _time = Substitute.For<TimeProvider>();
+
+    public PrivacyDeletionRequestServiceTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _metrics = new PrivacyMetrics(_sp.GetRequiredService<IMeterFactory>());
+        _guids.Create().Returns(RequestId);
+        _time.GetUtcNow().Returns(Now);
+        _reader.GetByUserAsync(UserId, Arg.Any<CancellationToken>()).Returns([]);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private PrivacyDeletionRequestService CreateSut(int graceDays = 30) =>
+        new(_eventBus, _metrics, _time, NullTenantContext.Instance,
+            Microsoft.Extensions.Options.Options.Create(new GranitPrivacyOptions { DefaultGracePeriodDays = graceDays }),
+            _guids, _reader, _writer);
+
+    [Fact]
+    public async Task RequestDeletionAsync_Deferred_SchedulesAndPublishesDeferredEto()
+    {
+        PrivacyDeletionRequestService sut = CreateSut(graceDays: 30);
+
+        RequestDeletionOutcome outcome = await sut.RequestDeletionAsync(
+            new RequestDeletionCommand(UserId, "user@example.com", Defer: true, "no longer needed", "EU_GDPR"),
+            TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(RequestDeletionResult.Deferred);
+        outcome.RequestId.ShouldBe(RequestId);
+        outcome.ScheduledDeletionAt.ShouldBe(Now.AddDays(30));
+        await _eventBus.Received(1).PublishAsync(Arg.Any<DeletionDeferredEto>(), Arg.Any<CancellationToken>());
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DeletionExecutedEto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RequestDeletionAsync_Immediate_RecordsAndPublishesRequestedThenExecuted()
+    {
+        PrivacyDeletionRequestService sut = CreateSut();
+
+        RequestDeletionOutcome outcome = await sut.RequestDeletionAsync(
+            new RequestDeletionCommand(UserId, "user@example.com", Defer: false, "erase now", "EU_GDPR"),
+            TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(RequestDeletionResult.ExecutedImmediately);
+        outcome.RequestId.ShouldBe(RequestId);
+        outcome.ScheduledDeletionAt.ShouldBeNull();
+        await _writer.Received(1).RecordImmediateDeletionAsync(RequestId, UserId, "erase now", Now, Arg.Any<CancellationToken>());
+        await _eventBus.Received(1).PublishAsync(Arg.Any<PersonalDataDeletionRequestedEto>(), Arg.Any<CancellationToken>());
+        await _eventBus.Received(1).PublishAsync(Arg.Any<DeletionExecutedEto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RequestDeletionAsync_WithExistingDeferredRequest_ReturnsDuplicateAndPublishesNothing()
+    {
+        _reader.GetByUserAsync(UserId, Arg.Any<CancellationToken>()).Returns([
+            new DeletionRequestStatus(Guid.NewGuid(), UserId, DeletionRequestState.Deferred, "prior", Now, Now.AddDays(30), null, null)
+        ]);
+        PrivacyDeletionRequestService sut = CreateSut();
+
+        RequestDeletionOutcome outcome = await sut.RequestDeletionAsync(
+            new RequestDeletionCommand(UserId, "user@example.com", Defer: true, "again", "EU_GDPR"),
+            TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(RequestDeletionResult.DuplicatePending);
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DeletionDeferredEto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelDeletionAsync_UnknownRequest_ReturnsNotFound()
+    {
+        _reader.GetStatusAsync(RequestId, Arg.Any<CancellationToken>()).Returns((DeletionRequestStatus?)null);
+        PrivacyDeletionRequestService sut = CreateSut();
+
+        CancelDeletionOutcome outcome = await sut.CancelDeletionAsync(RequestId, UserId, TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(CancelDeletionResult.NotFound);
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DeletionCancelledEto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelDeletionAsync_OtherUsersRequest_ReturnsNotFound()
+    {
+        _reader.GetStatusAsync(RequestId, Arg.Any<CancellationToken>()).Returns(
+            new DeletionRequestStatus(RequestId, Guid.NewGuid(), DeletionRequestState.Deferred, "r", Now, Now.AddDays(30), null, null));
+        PrivacyDeletionRequestService sut = CreateSut();
+
+        CancelDeletionOutcome outcome = await sut.CancelDeletionAsync(RequestId, UserId, TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(CancelDeletionResult.NotFound);
+    }
+
+    [Fact]
+    public async Task CancelDeletionAsync_AlreadyExecuted_ReturnsNotCancellableWithState()
+    {
+        _reader.GetStatusAsync(RequestId, Arg.Any<CancellationToken>()).Returns(
+            new DeletionRequestStatus(RequestId, UserId, DeletionRequestState.Executed, "r", Now, Now.AddDays(30), null, Now));
+        PrivacyDeletionRequestService sut = CreateSut();
+
+        CancelDeletionOutcome outcome = await sut.CancelDeletionAsync(RequestId, UserId, TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(CancelDeletionResult.NotCancellable);
+        outcome.CurrentState.ShouldBe(DeletionRequestState.Executed);
+    }
+
+    [Fact]
+    public async Task CancelDeletionAsync_DeferredAndOwned_CancelsAndPublishesEto()
+    {
+        _reader.GetStatusAsync(RequestId, Arg.Any<CancellationToken>()).Returns(
+            new DeletionRequestStatus(RequestId, UserId, DeletionRequestState.Deferred, "r", Now, Now.AddDays(30), null, null));
+        PrivacyDeletionRequestService sut = CreateSut();
+
+        CancelDeletionOutcome outcome = await sut.CancelDeletionAsync(RequestId, UserId, TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(CancelDeletionResult.Cancelled);
+        await _eventBus.Received(1).PublishAsync(Arg.Any<DeletionCancelledEto>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Privacy.Tests/DataExport/Internal/PrivacyExportRequestServiceTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/Internal/PrivacyExportRequestServiceTests.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics.Metrics;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Audit;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.DataExport.Internal;
+using Granit.Privacy.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Tests.DataExport.Internal;
+
+public sealed class PrivacyExportRequestServiceTests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid RequestId = new("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Subject = new("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Caller = new("33333333-3333-3333-3333-333333333333");
+
+    private readonly ServiceProvider _sp;
+    private readonly PrivacyMetrics _metrics;
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly IPrivacyExportAuditWriter _audit = Substitute.For<IPrivacyExportAuditWriter>();
+    private readonly IPrivacySubjectValidator _subjectValidator = Substitute.For<IPrivacySubjectValidator>();
+    private readonly IExportRequestTrackerWriter _tracker = Substitute.For<IExportRequestTrackerWriter>();
+    private readonly IGuidGenerator _guids = Substitute.For<IGuidGenerator>();
+    private readonly TimeProvider _time = Substitute.For<TimeProvider>();
+
+    private static readonly ExportRequestAuditMetadata Audit = new("203.0.113.0", "agent", "corr-1");
+
+    public PrivacyExportRequestServiceTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _metrics = new PrivacyMetrics(_sp.GetRequiredService<IMeterFactory>());
+        _guids.Create().Returns(RequestId);
+        _time.GetUtcNow().Returns(Now);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private PrivacyExportRequestService CreateSut() =>
+        new(_eventBus, _audit, _subjectValidator, _metrics, _time, NullTenantContext.Instance, _guids, _tracker);
+
+    [Fact]
+    public async Task RequestExportAsync_SelfService_RecordsPublishesAndAudits()
+    {
+        PrivacyExportRequestService sut = CreateSut();
+
+        RequestExportOutcome outcome = await sut.RequestExportAsync(
+            new RequestExportCommand(Subject, Subject, Scopes: null, "EU_GDPR", ValidateSubject: false, Audit),
+            TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(RequestExportResult.Accepted);
+        outcome.RequestId.ShouldBe(RequestId);
+        outcome.RequestedAt.ShouldBe(Now);
+        await _tracker.Received(1).RecordRequestAsync(RequestId, Subject, Subject, Now, Arg.Any<CancellationToken>());
+        await _eventBus.Received(1).PublishAsync(Arg.Any<PersonalDataRequestedEto>(), Arg.Any<CancellationToken>());
+        await _audit.Received(1).WriteExportRequestedAsync(
+            Arg.Is<PrivacyExportRequestedAudit>(a => a.RequestId == RequestId && a.ClientIp == "203.0.113.0"),
+            Arg.Any<CancellationToken>());
+        await _subjectValidator.DidNotReceive().SubjectExistsInCurrentTenantAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RequestExportAsync_OnBehalfOf_MissingSubject_ReturnsNotFoundAndDoesNothing()
+    {
+        _subjectValidator.SubjectExistsInCurrentTenantAsync(Subject, Arg.Any<CancellationToken>()).Returns(false);
+        PrivacyExportRequestService sut = CreateSut();
+
+        RequestExportOutcome outcome = await sut.RequestExportAsync(
+            new RequestExportCommand(Subject, Caller, Scopes: ["profile"], "EU_GDPR", ValidateSubject: true, Audit),
+            TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(RequestExportResult.SubjectNotFound);
+        await _tracker.DidNotReceive().RecordRequestAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<PersonalDataRequestedEto>(), Arg.Any<CancellationToken>());
+        await _audit.DidNotReceive().WriteExportRequestedAsync(Arg.Any<PrivacyExportRequestedAudit>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RequestExportAsync_OnBehalfOf_ExistingSubject_RecordsCallerDistinctFromSubject()
+    {
+        _subjectValidator.SubjectExistsInCurrentTenantAsync(Subject, Arg.Any<CancellationToken>()).Returns(true);
+        PrivacyExportRequestService sut = CreateSut();
+
+        RequestExportOutcome outcome = await sut.RequestExportAsync(
+            new RequestExportCommand(Subject, Caller, Scopes: null, "EU_GDPR", ValidateSubject: true, Audit),
+            TestContext.Current.CancellationToken);
+
+        outcome.Result.ShouldBe(RequestExportResult.Accepted);
+        await _tracker.Received(1).RecordRequestAsync(RequestId, Subject, Caller, Now, Arg.Any<CancellationToken>());
+        await _audit.Received(1).WriteExportRequestedAsync(
+            Arg.Is<PrivacyExportRequestedAudit>(a => a.SubjectUserId == Subject && a.CallerUserId == Caller),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Tests/packages.lock.json
@@ -818,6 +818,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",


### PR DESCRIPTION
## Context

From the `Granit.Privacy*` framework audit — the finding with the most architectural weight. The `POST /privacy/deletions`, `/deletions/{id}/cancel`, `/exports` and `/exports/on-behalf-of` handlers carried the domain workflow inline (~160 lines): duplicate-deferred guard, grace-period arithmetic, deferred-vs-immediate branching, dual-Eto publish sequencing, tracker + audit writes, metrics — with the two export handlers ~90% duplicated. CLAUDE.md places domain orchestration in the base module.

## Changes

**New application services in base `Granit.Privacy`:**
- `IPrivacyDeletionRequestService` / `PrivacyDeletionRequestService` (`DataDeletion/`) — `RequestDeletionAsync` + `CancelDeletionAsync`, returning small outcome records (`Deferred` / `ExecutedImmediately` / `DuplicatePending`; `Cancelled` / `NotFound` / `NotCancellable`) that the handler maps to 202/409/404.
- `IPrivacyExportRequestService` / `PrivacyExportRequestService` (`DataExport/`) — a single `RequestExportAsync` collapsing the self-service and on-behalf-of paths; the tenant-bound subject check moves in via `ValidateSubject` (404-not-403 semantics preserved).

**HTTP concerns stay at the edge:** auth resolution, regulation resolution, and IP pseudonymization — captured via the new `PrivacyResponseMapper.ToExportAuditMetadata` into an audit-metadata DTO so the services stay HTTP-agnostic.

**Wiring:** both services registered in `AddGranitPrivacy` (TryAddScoped). Trackers are optional ctor params so hosts that reference the module without wiring a tracker still construct the services. Base module gains a `Granit.Guids` reference + `[DependsOn(GranitGuidsModule)]` for `IGuidGenerator`.

**Tests:** the endpoints test server registers the real services over its existing mocks, so the 136 integration tests now exercise the full handler → service → dependency path (mock assertions on event bus / trackers / audit unchanged). Adds 10 unit tests covering both services' outcome matrix.

## HTTP contract

Unchanged — same status codes, same problem details, same response bodies.

## Verification

`Granit.Privacy.Tests` 260/260 · `Granit.Privacy.Endpoints.Tests` 136/136 · relevant `Granit.ArchitectureTests` (project-dependency, module-convention, layer) 25/25 · `dotnet format` clean on all touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)