### PR TITLE
feat(http): fail loud on non-distributed stores outside Development

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -15740,6 +15740,12 @@
       "line": 29,
       "members": [
         {
+          "name": "IsDistributed",
+          "kind": "property",
+          "signature": "bool IsDistributed",
+          "returnType": "bool"
+        },
+        {
           "name": "DeleteAsync",
           "kind": "method",
           "signature": "DeleteAsync(string key, CancellationToken cancellationToken)",
@@ -25489,7 +25495,7 @@
       "kind": "class",
       "project": "Granit.Http.Cors",
       "file": "src/Granit.Http.Cors/Extensions/CorsHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitCors",
@@ -25794,10 +25800,10 @@
       "line": 9,
       "members": [
         {
-          "name": "HeaderName",
+          "name": "AllowInMemoryStore",
           "kind": "property",
-          "signature": "string HeaderName",
-          "returnType": "string"
+          "signature": "bool AllowInMemoryStore",
+          "returnType": "bool"
         },
         {
           "name": "KeyPrefix",
@@ -52711,7 +52717,7 @@
       "kind": "class",
       "project": "Granit.Testing",
       "file": "src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "CreateAuthenticatedClient",

--- a/src/Granit.Caching.StackExchangeRedis/Internal/RedisConditionalCache.cs
+++ b/src/Granit.Caching.StackExchangeRedis/Internal/RedisConditionalCache.cs
@@ -28,6 +28,9 @@ internal sealed class RedisConditionalCache(
     private readonly CachingOptions _options = cachingOptions.Value;
 
     /// <inheritdoc/>
+    public bool IsDistributed => true;
+
+    /// <inheritdoc/>
     public async Task<bool> SetIfAbsentAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken)
     {
         RedisValue payload = Serialize(value);

--- a/src/Granit.Caching/IConditionalCache.cs
+++ b/src/Granit.Caching/IConditionalCache.cs
@@ -29,6 +29,15 @@ namespace Granit.Caching;
 public interface IConditionalCache
 {
     /// <summary>
+    /// <see langword="true"/> when entries are visible to every replica of the
+    /// application (shared backend such as Redis); <see langword="false"/> for
+    /// per-process implementations. Consumers whose correctness depends on
+    /// cluster-wide atomicity (idempotency, distributed locks) use this to
+    /// refuse silent single-instance operation outside Development.
+    /// </summary>
+    bool IsDistributed { get; }
+
+    /// <summary>
     /// Atomically sets the value only if the key does <b>not</b> already exist (SET NX).
     /// </summary>
     /// <typeparam name="T">Value type (must be JSON-serializable for the Redis implementation).</typeparam>

--- a/src/Granit.Caching/Internal/InMemoryConditionalCache.cs
+++ b/src/Granit.Caching/Internal/InMemoryConditionalCache.cs
@@ -20,6 +20,9 @@ internal sealed class InMemoryConditionalCache(
     private readonly Lock _lock = new();
 
     /// <inheritdoc/>
+    public bool IsDistributed => false;
+
+    /// <inheritdoc/>
     public Task<bool> SetIfAbsentAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken)
     {
         key = keyComposer.Compose(key);

--- a/src/Granit.Http.Cors/Extensions/CorsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Http.Cors/Extensions/CorsHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Http.Cors.Internal;
 using Granit.Http.Cors.Options;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -16,8 +17,10 @@ public static class CorsHostApplicationBuilderExtensions
     /// Adds standardized CORS configuration for Granit applications.
     /// </summary>
     /// <remarks>
-    /// Reads <see cref="GranitCorsOptions"/> from the <c>"Cors"</c> configuration section
-    /// and configures ASP.NET Core CORS middleware with a default policy.
+    /// Reads <see cref="GranitCorsOptions"/> from the <c>"Http:Cors"</c> configuration section
+    /// and configures ASP.NET Core CORS middleware with a default policy. The middleware is
+    /// auto-applied at the head of the pipeline (opt out via
+    /// <see cref="GranitCorsOptions.AutoRegisterMiddleware"/>).
     /// <para>
     /// The default policy applies <see cref="CorsPolicyBuilder.AllowAnyHeader"/> and
     /// <see cref="CorsPolicyBuilder.AllowAnyMethod"/> (standard for REST APIs).
@@ -46,6 +49,10 @@ public static class CorsHostApplicationBuilderExtensions
             ConfigureCorsPolicyOptions>();
 
         builder.Services.AddCors();
+
+        // Module owns the middleware: auto-applied at pipeline head unless the host
+        // opts out (Http:Cors:AutoRegisterMiddleware=false) to control ordering.
+        builder.Services.AddTransient<IStartupFilter, CorsStartupFilter>();
 
         return builder;
     }

--- a/src/Granit.Http.Cors/Internal/CorsStartupFilter.cs
+++ b/src/Granit.Http.Cors/Internal/CorsStartupFilter.cs
@@ -1,0 +1,50 @@
+using Granit.Http.Cors.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Http.Cors.Internal;
+
+/// <summary>
+/// Applies the CORS middleware (default policy) at the head of the pipeline so that
+/// registering the module is sufficient — before this filter existed, a host that
+/// forgot <c>app.UseCors()</c> got a silent no-op: policies were configured and
+/// validated but never enforced.
+/// </summary>
+/// <remarks>
+/// The default policy carries no endpoint-specific metadata, so running before
+/// routing is safe: the middleware answers preflights and stamps response headers
+/// from the configured policy alone. Hosts that need custom ordering (e.g. between
+/// <c>UseRouting</c> and <c>UseAuthorization</c> with per-endpoint policies) opt out
+/// via <see cref="GranitCorsOptions.AutoRegisterMiddleware"/> and call
+/// <c>UseCors()</c> themselves.
+/// </remarks>
+internal sealed partial class CorsStartupFilter(
+    IOptions<GranitCorsOptions> options,
+    ILogger<CorsStartupFilter> logger) : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        if (!options.Value.AutoRegisterMiddleware)
+        {
+            LogManualWiring(logger);
+            return next;
+        }
+
+        return app =>
+        {
+            LogAutoWired(logger);
+            app.UseCors();
+            next(app);
+        };
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "CORS middleware auto-registered at the head of the pipeline (default policy).")]
+    private static partial void LogAutoWired(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "CORS middleware auto-registration is disabled (Http:Cors:AutoRegisterMiddleware=false) — call app.UseCors() manually or no CORS headers will be emitted.")]
+    private static partial void LogManualWiring(ILogger logger);
+}

--- a/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
+++ b/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
@@ -34,6 +34,15 @@ public sealed class GranitCorsOptions
     public bool AllowCredentials { get; set; }
 
     /// <summary>
+    /// Automatically applies the CORS middleware (default policy) at the start of the
+    /// pipeline via an <c>IStartupFilter</c>. Default: <see langword="true"/> — the module
+    /// owns CORS end to end; forgetting <c>UseCors()</c> previously produced a silent no-op.
+    /// Set to <see langword="false"/> to control middleware ordering manually and call
+    /// <c>app.UseCors()</c> yourself.
+    /// </summary>
+    public bool AutoRegisterMiddleware { get; set; } = true;
+
+    /// <summary>
     /// Returns <see cref="AllowedOrigins"/> with any trailing slash trimmed.
     /// The CORS spec defines an origin as a <c>scheme + host + port</c> tuple
     /// with no path, so an entry like <c>"https://app.x.com/"</c> would silently

--- a/src/Granit.Http.Idempotency/Extensions/IdempotencyServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Idempotency/Extensions/IdempotencyServiceCollectionExtensions.cs
@@ -69,6 +69,9 @@ public static class IdempotencyServiceCollectionExtensions
         // are resolved from the request scope via IMiddlewareFactory.
         services.AddTransient<IdempotencyMiddleware>();
 
+        // Fail loud at startup when the resolved store is per-process outside Development.
+        services.AddHostedService<IdempotencyStartupGuard>();
+
         return services;
     }
 }

--- a/src/Granit.Http.Idempotency/Internal/ConditionalCacheIdempotencyStore.cs
+++ b/src/Granit.Http.Idempotency/Internal/ConditionalCacheIdempotencyStore.cs
@@ -13,6 +13,12 @@ internal sealed partial class ConditionalCacheIdempotencyStore(
     IConditionalCache cache,
     ILogger<ConditionalCacheIdempotencyStore> logger) : IIdempotencyStore
 {
+    /// <summary>Whether the underlying cache is shared across replicas — see <see cref="IConditionalCache.IsDistributed"/>.</summary>
+    internal bool IsDistributed => cache.IsDistributed;
+
+    /// <summary>Backend implementation name, for the startup log.</summary>
+    internal string BackendName => cache.GetType().Name;
+
     /// <inheritdoc/>
     public Task<bool> TryAcquireAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken) =>
         cache.SetIfAbsentAsync(key, entry, ttl, cancellationToken);

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyStartupGuard.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyStartupGuard.cs
@@ -1,0 +1,67 @@
+using Granit.Http.Idempotency.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Http.Idempotency.Internal;
+
+/// <summary>
+/// Fails the host at startup when idempotency would run on a non-distributed store
+/// outside Development — a per-pod store silently breaks the at-most-once guarantee
+/// under multiple replicas (the same key routed to two pods executes twice).
+/// Always logs which backend is active so operators can verify the wiring.
+/// </summary>
+internal sealed partial class IdempotencyStartupGuard(
+    IServiceProvider serviceProvider,
+    IOptions<IdempotencyOptions> options,
+    IHostEnvironment environment,
+    ILogger<IdempotencyStartupGuard> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        using IServiceScope scope = serviceProvider.CreateScope();
+        Abstractions.IIdempotencyStore store = scope.ServiceProvider.GetRequiredService<Abstractions.IIdempotencyStore>();
+
+        if (store is not ConditionalCacheIdempotencyStore conditionalStore)
+        {
+            // Custom store — the host made a deliberate choice; log it and trust it.
+            LogCustomStore(logger, store.GetType().Name);
+            return Task.CompletedTask;
+        }
+
+        if (conditionalStore.IsDistributed)
+        {
+            LogDistributedStore(logger, conditionalStore.BackendName);
+            return Task.CompletedTask;
+        }
+
+        if (environment.IsDevelopment() || options.Value.AllowInMemoryStore)
+        {
+            LogInMemoryStore(logger, conditionalStore.BackendName, environment.EnvironmentName);
+            return Task.CompletedTask;
+        }
+
+        throw new InvalidOperationException(
+            $"Granit idempotency is backed by the non-distributed '{conditionalStore.BackendName}' in the " +
+            $"'{environment.EnvironmentName}' environment. Under multiple replicas the same Idempotency-Key " +
+            "can execute twice (double payment, double email). Register a distributed IConditionalCache " +
+            "(Granit.Caching.StackExchangeRedis) or, for a genuinely single-instance deployment, set " +
+            $"'{IdempotencyOptions.SectionName}:{nameof(IdempotencyOptions.AllowInMemoryStore)}' to true.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Idempotency store: custom implementation {StoreType} — distributed-store guard skipped.")]
+    private static partial void LogCustomStore(ILogger logger, string storeType);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Idempotency store: {Backend} (distributed).")]
+    private static partial void LogDistributedStore(ILogger logger, string backend);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Idempotency store: {Backend} (NOT distributed) in environment {Environment}. " +
+                  "The at-most-once guarantee only holds for a single replica.")]
+    private static partial void LogInMemoryStore(ILogger logger, string backend, string environment);
+}

--- a/src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs
@@ -4,12 +4,23 @@ namespace Granit.Http.Idempotency.Models;
 
 /// <summary>
 /// Configuration options for <see cref="Internal.IdempotencyMiddleware"/>.
-/// Bound from <c>appsettings.json</c> section <c>"Idempotency"</c>.
+/// Bound from <c>appsettings.json</c> section <c>"Http:Idempotency"</c>.
 /// </summary>
 public sealed class IdempotencyOptions
 {
     /// <summary>Configuration section name.</summary>
     public const string SectionName = "Http:Idempotency";
+
+    /// <summary>
+    /// Allows the middleware to run on a non-distributed (per-process) store outside
+    /// Development. Default: <see langword="false"/> — the host fails at startup instead.
+    /// <para>
+    /// A per-pod store silently breaks the at-most-once guarantee under multiple
+    /// replicas: the same <c>Idempotency-Key</c> routed to two pods executes the
+    /// handler twice. Only opt in for genuinely single-instance deployments.
+    /// </para>
+    /// </summary>
+    public bool AllowInMemoryStore { get; set; }
 
     /// <summary>Name of the HTTP header carrying the idempotency key. Default: <c>Idempotency-Key</c>.</summary>
     [Required]

--- a/src/Granit.RateLimiting/Extensions/RateLimitingServiceCollectionExtensions.cs
+++ b/src/Granit.RateLimiting/Extensions/RateLimitingServiceCollectionExtensions.cs
@@ -120,6 +120,9 @@ public static class RateLimitingServiceCollectionExtensions
         // ActivitySource registration
         GranitActivitySourceRegistry.Register(RateLimitingActivitySource.Name);
 
+        // Fail loud at startup when the counter store is per-process outside Development.
+        services.AddHostedService<RateLimitingStartupGuard>();
+
         return services;
     }
 }

--- a/src/Granit.RateLimiting/Internal/RateLimitingStartupGuard.cs
+++ b/src/Granit.RateLimiting/Internal/RateLimitingStartupGuard.cs
@@ -1,0 +1,68 @@
+using Granit.RateLimiting.Abstractions;
+using Granit.RateLimiting.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.RateLimiting.Internal;
+
+/// <summary>
+/// Fails the host at startup when rate limiting would run on the per-process counter
+/// store outside Development — per-pod counters multiply every limit by the replica
+/// count, so a "100 req/s" policy silently becomes N×100 cluster-wide.
+/// Always logs which counter store is active so operators can verify the wiring.
+/// </summary>
+internal sealed partial class RateLimitingStartupGuard(
+    IServiceProvider serviceProvider,
+    IOptions<GranitRateLimitingOptions> options,
+    IHostEnvironment environment,
+    ILogger<RateLimitingStartupGuard> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        GranitRateLimitingOptions opts = options.Value;
+        if (!opts.Enabled)
+        {
+            LogDisabled(logger);
+            return Task.CompletedTask;
+        }
+
+        using IServiceScope scope = serviceProvider.CreateScope();
+        IRateLimitCounterStore store = scope.ServiceProvider.GetRequiredService<IRateLimitCounterStore>();
+
+        if (store is not InMemoryRateLimitCounterStore)
+        {
+            LogDistributedStore(logger, store.GetType().Name);
+            return Task.CompletedTask;
+        }
+
+        if (environment.IsDevelopment() || opts.AllowInMemoryCounterStore)
+        {
+            LogInMemoryStore(logger, environment.EnvironmentName);
+            return Task.CompletedTask;
+        }
+
+        throw new InvalidOperationException(
+            "Granit rate limiting is backed by the per-process in-memory counter store in the " +
+            $"'{environment.EnvironmentName}' environment. Under multiple replicas every limit is " +
+            "multiplied by the replica count. Register a Redis IConnectionMultiplexer for " +
+            "cluster-wide counters or, for a genuinely single-instance deployment, set " +
+            $"'{GranitRateLimitingOptions.SectionName}:{nameof(GranitRateLimitingOptions.AllowInMemoryCounterStore)}' to true.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Rate limiting is disabled — counter-store guard skipped.")]
+    private static partial void LogDisabled(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Rate limiting counter store: {StoreType} (distributed).")]
+    private static partial void LogDistributedStore(ILogger logger, string storeType);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Rate limiting counter store: InMemoryRateLimitCounterStore (NOT distributed) in environment {Environment}. " +
+                  "Limits are enforced per replica, not cluster-wide.")]
+    private static partial void LogInMemoryStore(ILogger logger, string environment);
+}

--- a/src/Granit.RateLimiting/Options/GranitRateLimitingOptions.cs
+++ b/src/Granit.RateLimiting/Options/GranitRateLimitingOptions.cs
@@ -32,4 +32,15 @@ public sealed class GranitRateLimitingOptions
 
     /// <summary>Whether to use <c>Granit.Features</c> for plan-based quota resolution.</summary>
     public bool UseFeatureBasedQuotas { get; set; }
+
+    /// <summary>
+    /// Allows the in-memory counter store outside Development. Default: <see langword="false"/> —
+    /// the host fails at startup instead.
+    /// <para>
+    /// Per-pod counters multiply every limit by the replica count (a 100 req/s policy becomes
+    /// N×100 cluster-wide). Register a Redis <c>IConnectionMultiplexer</c> for cluster-wide
+    /// enforcement, or opt in for genuinely single-instance deployments.
+    /// </para>
+    /// </summary>
+    public bool AllowInMemoryCounterStore { get; set; }
 }

--- a/src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs
+++ b/src/Granit.Testing/Endpoints/GranitEndpointTestHost.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Testing.Endpoints;
@@ -34,7 +35,11 @@ public sealed class GranitEndpointTestHost : IAsyncDisposable
         Action<WebApplication>? configureEndpoints = null,
         CancellationToken cancellationToken = default)
     {
-        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        // Tests run as Development: an in-process TestServer is a single-instance
+        // scenario by construction, and the framework's multi-replica startup guards
+        // (idempotency / rate-limiting in-memory stores) must not trip on it.
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = Environments.Development });
         builder.WebHost.UseTestServer();
         builder.Logging.ClearProviders();
         builder.Services.AddRouting();

--- a/tests/Granit.Caching.Tests/ConditionalCacheKeyComposerTests.cs
+++ b/tests/Granit.Caching.Tests/ConditionalCacheKeyComposerTests.cs
@@ -55,6 +55,10 @@ public sealed class ConditionalCacheKeyComposerTests
     }
 
     [Fact]
+    public void InMemoryConditionalCache_IsNotDistributed() =>
+        new InMemoryConditionalCache(TimeProvider.System, CreateSut()).IsDistributed.ShouldBeFalse();
+
+    [Fact]
     public async Task InMemoryConditionalCache_IsolatesTenants_OnSameLogicalKey()
     {
         var cache = new InMemoryConditionalCache(TimeProvider.System, CreateSut());

--- a/tests/Granit.Http.Cors.Tests/CorsStartupFilterTests.cs
+++ b/tests/Granit.Http.Cors.Tests/CorsStartupFilterTests.cs
@@ -1,0 +1,51 @@
+using Granit.Http.Cors.Internal;
+using Granit.Http.Cors.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Cors.Tests;
+
+public sealed class CorsStartupFilterTests
+{
+    private static CorsStartupFilter CreateFilter(bool autoRegister) =>
+        new(
+            Microsoft.Extensions.Options.Options.Create(new GranitCorsOptions
+            {
+                AllowedOrigins = ["https://app.example.com"],
+                AutoRegisterMiddleware = autoRegister,
+            }),
+            NullLogger<CorsStartupFilter>.Instance);
+
+    [Fact]
+    public void Configure_WhenAutoRegisterDisabled_ReturnsNextUnchanged()
+    {
+        static void Next(IApplicationBuilder _)
+        {
+        }
+
+        Action<IApplicationBuilder> result = CreateFilter(autoRegister: false).Configure(Next);
+
+        result.ShouldBeSameAs((Action<IApplicationBuilder>)Next);
+    }
+
+    [Fact]
+    public void Configure_WhenAutoRegisterEnabled_AppliesCorsMiddlewareAndCallsNext()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddCors();
+        using ServiceProvider sp = services.BuildServiceProvider();
+        ApplicationBuilder app = new(sp);
+
+        bool nextCalled = false;
+        CreateFilter(autoRegister: true).Configure(_ => nextCalled = true)(app);
+
+        nextCalled.ShouldBeTrue();
+        // Building succeeds only if the CORS middleware resolved its services —
+        // i.e. UseCors() was genuinely applied to the pipeline.
+        app.Build().ShouldNotBeNull();
+    }
+}

--- a/tests/Granit.Http.Idempotency.Tests/IdempotencyStartupGuardTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotencyStartupGuardTests.cs
@@ -1,0 +1,84 @@
+// =============================================================================
+// Tests - IdempotencyStartupGuard
+// =============================================================================
+// Environment × store × opt-in matrix for the fail-loud distributed-store guard.
+// =============================================================================
+
+using Granit.Caching;
+using Granit.Http.Idempotency.Abstractions;
+using Granit.Http.Idempotency.Internal;
+using Granit.Http.Idempotency.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Idempotency.Tests;
+
+public sealed class IdempotencyStartupGuardTests
+{
+    private static IdempotencyStartupGuard CreateGuard(
+        IIdempotencyStore store,
+        string environmentName,
+        bool allowInMemoryStore = false)
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => store);
+        ServiceProvider sp = services.BuildServiceProvider();
+
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+
+        return new IdempotencyStartupGuard(
+            sp,
+            Options.Create(new IdempotencyOptions { AllowInMemoryStore = allowInMemoryStore }),
+            environment,
+            NullLogger<IdempotencyStartupGuard>.Instance);
+    }
+
+    private static ConditionalCacheIdempotencyStore CreateConditionalStore(bool isDistributed)
+    {
+        IConditionalCache cache = Substitute.For<IConditionalCache>();
+        cache.IsDistributed.Returns(isDistributed);
+        return new ConditionalCacheIdempotencyStore(
+            cache, NullLogger<ConditionalCacheIdempotencyStore>.Instance);
+    }
+
+    [Fact]
+    public async Task InMemoryStore_InProduction_Throws()
+    {
+        IdempotencyStartupGuard guard = CreateGuard(CreateConditionalStore(isDistributed: false), Environments.Production);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => guard.StartAsync(CancellationToken.None));
+
+        ex.Message.ShouldContain("AllowInMemoryStore");
+    }
+
+    [Fact]
+    public async Task InMemoryStore_InDevelopment_Starts() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(CreateConditionalStore(isDistributed: false), Environments.Development)
+                .StartAsync(CancellationToken.None));
+
+    [Fact]
+    public async Task InMemoryStore_InProduction_WithOptIn_Starts() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(CreateConditionalStore(isDistributed: false), Environments.Production, allowInMemoryStore: true)
+                .StartAsync(CancellationToken.None));
+
+    [Fact]
+    public async Task DistributedStore_InProduction_Starts() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(CreateConditionalStore(isDistributed: true), Environments.Production)
+                .StartAsync(CancellationToken.None));
+
+    [Fact]
+    public async Task CustomStore_InProduction_SkipsEnforcement() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(Substitute.For<IIdempotencyStore>(), Environments.Production)
+                .StartAsync(CancellationToken.None));
+}

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Http.ODataExposure.Tests.Integration;
@@ -66,7 +67,10 @@ internal sealed class ODataTestApp : IAsyncDisposable
         Action<ODataEntitySetBuilder<Invoice>>? configureEntitySet,
         int? rateLimitPermitLimit)
     {
-        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        // Development: single-instance TestServer — the rate-limiting in-memory
+        // counter-store startup guard must not trip on it.
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = Environments.Development });
         builder.WebHost.UseTestServer();
 
         SqlCaptureSink sqlCapture = new();

--- a/tests/Granit.RateLimiting.Tests/RateLimitingStartupGuardTests.cs
+++ b/tests/Granit.RateLimiting.Tests/RateLimitingStartupGuardTests.cs
@@ -1,0 +1,81 @@
+// =============================================================================
+// Tests - RateLimitingStartupGuard
+// =============================================================================
+// Environment × store × opt-in matrix for the fail-loud counter-store guard.
+// =============================================================================
+
+using Granit.RateLimiting.Abstractions;
+using Granit.RateLimiting.Internal;
+using Granit.RateLimiting.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.RateLimiting.Tests;
+
+public sealed class RateLimitingStartupGuardTests
+{
+    private static RateLimitingStartupGuard CreateGuard(
+        IRateLimitCounterStore store,
+        string environmentName,
+        bool allowInMemoryCounterStore = false,
+        bool enabled = true)
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => store);
+        ServiceProvider sp = services.BuildServiceProvider();
+
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+
+        return new RateLimitingStartupGuard(
+            sp,
+            Microsoft.Extensions.Options.Options.Create(new GranitRateLimitingOptions
+            {
+                Enabled = enabled,
+                AllowInMemoryCounterStore = allowInMemoryCounterStore,
+            }),
+            environment,
+            NullLogger<RateLimitingStartupGuard>.Instance);
+    }
+
+    private static InMemoryRateLimitCounterStore CreateInMemoryStore() => new(TimeProvider.System);
+
+    [Fact]
+    public async Task InMemoryStore_InProduction_Throws()
+    {
+        RateLimitingStartupGuard guard = CreateGuard(CreateInMemoryStore(), Environments.Production);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => guard.StartAsync(CancellationToken.None));
+
+        ex.Message.ShouldContain("AllowInMemoryCounterStore");
+    }
+
+    [Fact]
+    public async Task InMemoryStore_InDevelopment_Starts() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(CreateInMemoryStore(), Environments.Development)
+                .StartAsync(CancellationToken.None));
+
+    [Fact]
+    public async Task InMemoryStore_InProduction_WithOptIn_Starts() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(CreateInMemoryStore(), Environments.Production, allowInMemoryCounterStore: true)
+                .StartAsync(CancellationToken.None));
+
+    [Fact]
+    public async Task DistributedStore_InProduction_Starts() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(Substitute.For<IRateLimitCounterStore>(), Environments.Production)
+                .StartAsync(CancellationToken.None));
+
+    [Fact]
+    public async Task Disabled_InProduction_WithInMemoryStore_Starts() =>
+        await Should.NotThrowAsync(() =>
+            CreateGuard(CreateInMemoryStore(), Environments.Production, enabled: false)
+                .StartAsync(CancellationToken.None));
+}


### PR DESCRIPTION
## Summary

Second PR of the [Http* redesign epic](https://github.com/granit-fx/granit-dotnet/issues/2986) — **stacked on #3008** (retarget to `develop` happens automatically when #3008 merges).

Idempotency and rate limiting are multi-replica correctness modules; running them on per-pod in-memory stores silently breaks their guarantees (duplicate execution of the same `Idempotency-Key`; every rate limit multiplied by the replica count). They now refuse to start that way outside Development:

- `IConditionalCache.IsDistributed` capability (in-memory `false`, Redis `true`) — type-checking across package boundaries was not possible (both implementations are `internal`).
- `IdempotencyStartupGuard` / `RateLimitingStartupGuard` (`IHostedService`): throw at startup with an actionable message unless `AllowInMemoryStore` / `AllowInMemoryCounterStore` is explicitly set; the active backend is always logged at Information (Warning when non-distributed). A custom `IIdempotencyStore` skips enforcement (deliberate host choice).
- CORS: `CorsStartupFilter` auto-applies the middleware at the head of the pipeline — previously, forgetting `app.UseCors()` produced a fully configured, validated, never-enforced policy. Opt-out for manual ordering via `Http:Cors:AutoRegisterMiddleware=false`.
- Test harnesses (`GranitEndpointTestHost`, `ODataTestApp`) now run as **Development** — an in-process TestServer is single-instance by construction, and the implicit `Production` default was exactly the misconfiguration the guards are designed to catch (they caught it: 44 test failures before the harness fix).

## Verification

- Guard matrices unit-tested (env × store × opt-in × enabled): Idempotency 106, RateLimiting 135, Cors 33, Caching 83 — all green.
- Full `api-data` shard green (no failing assembly); previously-affected suites (BlobStorage.Endpoints 50, AI.Chat.Endpoints 48) green.
- `dotnet format` clean on `api-data.slnf`.

Closes #2994 · Feature #2987 · Epic #2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)