### PR TITLE
test(architecture): wiring-convention ratchet tests

### DIFF
--- a/scripts/find-unreferenced-public-api.py
+++ b/scripts/find-unreferenced-public-api.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Informational sweep: public types under src/ whose name never appears outside
+their own project. Candidates for dead framework surface (the 2026-07 audit found
+one: MinimumResponseTimeGuard shipped with zero consumers).
+
+Heuristic (textual, not semantic): a type consumed only via reflection, DI
+open-generics, or from consuming apps outside this repo will show up as a false
+positive — this script REPORTS, it never gates CI. For live analysis prefer
+roslyn-lens `find_isolated_symbols`.
+
+Usage: python3 scripts/find-unreferenced-public-api.py [--json]
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+
+PUBLIC_TYPE = re.compile(
+    r"^\s*public\s+(?:sealed\s+|abstract\s+|static\s+|partial\s+|readonly\s+)*"
+    r"(?:class|record|interface|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)",
+    re.MULTILINE,
+)
+
+# Names conventionally never referenced by type name: modules (assembly-scanned),
+# attributes (used via [Name]), extension classes (invoked as methods), options
+# (resolved via IOptions<T> inside their own project is fine), localization markers.
+IGNORED_SUFFIXES = (
+    "Module",
+    "Attribute",
+    "Extensions",
+    "LocalizationResource",
+    "Migration",
+)
+
+
+def source_files() -> list[Path]:
+    return [
+        f
+        for f in SRC.rglob("*.cs")
+        if "/bin/" not in f.as_posix() and "/obj/" not in f.as_posix()
+    ]
+
+
+def main() -> int:
+    files = source_files()
+    contents = {f: f.read_text(encoding="utf-8", errors="replace") for f in files}
+
+    declarations: dict[str, Path] = {}
+    for f, text in contents.items():
+        for match in PUBLIC_TYPE.finditer(text):
+            name = match.group(1)
+            if not name.endswith(IGNORED_SUFFIXES):
+                declarations.setdefault(name, f)
+
+    references: dict[str, set[str]] = defaultdict(set)
+    for f, text in contents.items():
+        project = f.relative_to(SRC).parts[0]
+        for name in declarations:
+            if name in text:
+                references[name].add(project)
+
+    orphans = []
+    for name, decl_file in sorted(declarations.items()):
+        home = decl_file.relative_to(SRC).parts[0]
+        if references[name] <= {home}:
+            orphans.append(
+                {"type": name, "file": str(decl_file.relative_to(REPO_ROOT)), "project": home}
+            )
+
+    try:
+        if "--json" in sys.argv:
+            print(json.dumps(orphans, indent=2))
+        else:
+            print(f"{len(orphans)} public type(s) referenced only inside their own project:")
+            for o in orphans:
+                print(f"  {o['type']}  ({o['file']})")
+            print("\nHeuristic report — verify with roslyn-lens find_isolated_symbols before deleting.")
+    except BrokenPipeError:  # piped through head — not an error
+        pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/Granit.ArchitectureTests/ArchitectureTestHelpers.cs
+++ b/tests/Granit.ArchitectureTests/ArchitectureTestHelpers.cs
@@ -1,0 +1,42 @@
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Shared filesystem helpers for the source-scan convention tests introduced by the
+/// wiring-conventions suite (#2995). Pre-existing test classes keep their private
+/// copies; new source-scan tests should use these.
+/// </summary>
+internal static class ArchitectureTestHelpers
+{
+    /// <summary>Walks up from the test assembly to the directory containing <c>.git</c>.</summary>
+    public static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(ArchitectureTestHelpers).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    /// <summary>Enumerates non-generated C# sources under <paramref name="dir"/> (skips bin/obj).</summary>
+    public static IEnumerable<string> EnumerateSourceFiles(string dir) =>
+        Directory.GetFiles(dir, "*.cs", SearchOption.AllDirectories)
+            .Where(static f =>
+                !f.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                && !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.Ordinal));
+
+    /// <summary>Returns the <c>src/&lt;Project&gt;</c> directory that contains <paramref name="file"/>.</summary>
+    public static string ProjectDirOf(string srcDir, string file)
+    {
+        string relative = Path.GetRelativePath(srcDir, file);
+        string projectName = relative.Split(Path.DirectorySeparatorChar)[0];
+        return Path.Join(srcDir, projectName);
+    }
+}

--- a/tests/Granit.ArchitectureTests/MetricsWiringConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/MetricsWiringConventionTests.cs
@@ -1,0 +1,89 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Every <c>{Module}Metrics</c> class must be consumed — constructor-injected or resolved —
+/// by at least one type in <c>src/</c>. The 2026-07 Http* audit found a metrics class that
+/// was DI-registered, fully unit-tested, and never injected: its counters never emitted a
+/// single data point while dashboards assumed they existed.
+/// </summary>
+public sealed partial class MetricsWiringConventionTests
+{
+    private static readonly string RepoRoot = ArchitectureTestHelpers.FindRepoRoot();
+
+    /// <summary>
+    /// Ratchet list — nothing may be added without a linked issue. Key: metrics type name.
+    /// </summary>
+    private static readonly Dictionary<string, string> Exemptions = new(StringComparer.Ordinal)
+    {
+        // Pre-existing repo-wide debt, enumerated at introduction — tracked by #3010.
+        ["ApiKeysMetrics"] = "#3010 — registered singleton, counters never recorded",
+        ["TemplatingMetrics"] = "#3010 — registered singleton, counters never recorded",
+    };
+
+    [Fact]
+    public void Every_metrics_class_is_consumed_somewhere_in_src()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        List<string> violations = [];
+
+        List<(string File, string TypeName)> metricsClasses = [];
+        foreach (string csFile in ArchitectureTestHelpers.EnumerateSourceFiles(srcDir))
+        {
+            Match match = MetricsClassDeclaration().Match(File.ReadAllText(csFile));
+            if (match.Success)
+            {
+                metricsClasses.Add((csFile, match.Groups[1].Value));
+            }
+        }
+
+        string allSources = string.Join('\n', ArchitectureTestHelpers.EnumerateSourceFiles(srcDir)
+            .Select(File.ReadAllText));
+
+        foreach ((string file, string typeName) in metricsClasses)
+        {
+            if (Exemptions.ContainsKey(typeName))
+            {
+                continue;
+            }
+
+            // Consumption = the type name appears somewhere OTHER than its declaration,
+            // registration, or a typeof() reference: constructor parameter
+            // "(XxxMetrics metrics" / "XxxMetrics metrics," or service resolution.
+            bool consumed =
+                ConsumptionSites(typeName).Any(pattern => allSources.Contains(pattern, StringComparison.Ordinal));
+
+            if (!consumed)
+            {
+                violations.Add($"{Path.GetRelativePath(RepoRoot, file)} ({typeName})");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every {Module}Metrics class must be constructor-injected (or resolved) by at "
+            + "least one production type — a registered-but-never-injected metrics class "
+            + "emits nothing while dashboards assume it does. Wire it or add a justified "
+            + "exemption. Violators: " + string.Join("; ", violations));
+    }
+
+    private static IEnumerable<string> ConsumptionSites(string typeName)
+    {
+        // Constructor / method parameter (primary ctor or classic, required or
+        // optional-nullable), field initialization, or explicit resolution.
+        yield return $"({typeName} ";
+        yield return $"({typeName}? ";
+        yield return $" {typeName} metrics";
+        yield return $" {typeName}? metrics";
+        yield return $", {typeName} ";
+        yield return $", {typeName}? ";
+        yield return $"GetRequiredService<{typeName}>";
+        yield return $"GetService<{typeName}>";
+    }
+
+    /// <summary>Matches <c>class XxxMetrics</c> declarations under a <c>Diagnostics</c> namespace or folder.</summary>
+    [GeneratedRegex(@"(?:public|internal)\s+sealed\s+(?:partial\s+)?class\s+([A-Za-z0-9_]+Metrics)\b")]
+    private static partial Regex MetricsClassDeclaration();
+}

--- a/tests/Granit.ArchitectureTests/OptionsBindingConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/OptionsBindingConventionTests.cs
@@ -1,0 +1,140 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Every options class that declares a <c>const string SectionName</c> must actually be
+/// bound to that section somewhere in <c>src/</c> (<c>BindConfiguration(...)</c> or an
+/// equivalent <c>GetSection(...)</c> binding). The 2026-07 Http* audit found four
+/// "decorative" SectionNames — declared, unit-tested, and never bound — meaning
+/// <c>appsettings.json</c> configuration was silently ignored.
+/// </summary>
+public sealed partial class OptionsBindingConventionTests
+{
+    private static readonly string RepoRoot = ArchitectureTestHelpers.FindRepoRoot();
+
+    /// <summary>
+    /// Pre-existing violations outside the Http* family, enumerated when this test was
+    /// introduced (ratchet: nothing may be added here without a linked issue explaining
+    /// why the section is deliberately delegate-configured or bound by the host).
+    /// Key: options type name. Value: rationale.
+    /// </summary>
+    private static readonly Dictionary<string, string> Exemptions = new(StringComparer.Ordinal)
+    {
+        // Pre-existing repo-wide debt, enumerated at introduction — tracked by #3010.
+        // Fixed-by-design elsewhere:
+        ["SecurityHeadersEndpointsOptions"] = "#3000 — bound when the package folds into Granit.Http.SecurityHeaders",
+        ["AIEndpointsOptions"] = "#3010 — pre-existing unbound section 'AI:Endpoints'",
+        ["AIQuotaOptions"] = "#3010 — pre-existing unbound section 'AI:Quota'",
+        ["ApiKeysEndpointsOptions"] = "#3010 — pre-existing unbound section 'Authentication:ApiKeys:Endpoints'",
+        ["AuthorizationEndpointsOptions"] = "#3010 — pre-existing unbound section 'Authorization:Endpoints'",
+        ["AwsSesOptions"] = "#3010 — pre-existing unbound section 'Notifications:AwsSes'",
+        ["AzureNotificationHubsOptions"] = "#3010 — pre-existing unbound section 'Notifications:AzureNotificationHubs'",
+        ["BrevoOptions"] = "#3010 — pre-existing unbound section 'Notifications:Brevo'",
+        ["DPoPValidationOptions"] = "#3010 — pre-existing unbound section 'Authentication:DPoP'",
+        ["DataExchangeEndpointsOptions"] = "#3010 — pre-existing unbound section 'DataExchange:Endpoints'",
+        ["DataLookupEndpointsOptions"] = "#3010 — pre-existing unbound section 'DataLookup:Endpoints'",
+        ["DiagnosticsEndpointsOptions"] = "#3010 — pre-existing unbound section 'Diagnostics:Endpoints'",
+        ["FeaturesEndpointsOptions"] = "#3010 — pre-existing unbound section 'Features:Endpoints'",
+        ["GeocodingEndpointsOptions"] = "#3010 — pre-existing unbound section 'Geocoding:Endpoints'",
+        ["GoogleFcmOptions"] = "#3010 — pre-existing unbound section 'Notifications:GoogleFcm'",
+        ["HostnamesEndpointsOptions"] = "#3010 — pre-existing unbound section 'Hostnames:Endpoints'",
+        ["IdentityEndpointsOptions"] = "#3010 — pre-existing unbound section 'Identity:Endpoints'",
+        ["IdentityNotificationOptions"] = "#3010 — pre-existing unbound section 'Identity:Local:Notifications'",
+        ["IdentityProviderEndpointsOptions"] = "#3010 — pre-existing unbound section 'Identity:Endpoints:Provider'",
+        ["IdentityUserSessionNotificationOptions"] = "#3010 — pre-existing unbound section 'Identity:Notifications:UserSessions'",
+        ["LocalizationEndpointsOptions"] = "#3010 — pre-existing unbound section 'Localization:Endpoints'",
+        ["MultiTenancyEndpointsOptions"] = "#3010 — pre-existing unbound section 'MultiTenancy:Endpoints'",
+        ["OpenIddictEndpointsOptions"] = "#3010 — pre-existing unbound section 'OpenIddict:Endpoints'",
+        ["OpenIddictServerEndpointsOptions"] = "#3010 — pre-existing unbound section 'OpenIddict:Server:Endpoints'",
+        ["PresenceEndpointsOptions"] = "#3010 — pre-existing unbound section 'Presence:Endpoints'",
+        ["PrivacyEndpointsOptions"] = "#3010 — pre-existing unbound section 'Privacy:Endpoints'",
+        ["QueryEndpointOptions"] = "#3010 — pre-existing unbound section 'QueryEngine:Endpoint'",
+        ["ReEncryptionOptions"] = "#3010 — pre-existing unbound section 'Vault:ReEncryption'",
+        ["RoleEndpointsOptions"] = "#3010 — pre-existing unbound section 'Identity:Local:Endpoints:Role'",
+        ["ScalewayEmailOptions"] = "#3010 — pre-existing unbound section 'Notifications:Scaleway'",
+        ["SchedulingEndpointsOptions"] = "#3010 — pre-existing unbound section 'Scheduling:Endpoints'",
+        ["SendGridEmailOptions"] = "#3010 — pre-existing unbound section 'Notifications:SendGrid'",
+        ["SettingsEndpointsOptions"] = "#3010 — pre-existing unbound section 'Settings:Endpoints'",
+        ["SettingsOptions"] = "#3010 — pre-existing unbound section 'Settings'",
+        ["SmtpOptions"] = "#3010 — pre-existing unbound section 'Notifications:Smtp'",
+        ["SseRedisBackplaneOptions"] = "#3010 — pre-existing unbound section 'Notifications:Sse:StackExchangeRedis'",
+        ["TemplatingEndpointsOptions"] = "#3010 — pre-existing unbound section 'Templating:Endpoints'",
+        ["TenantSchemaOptions"] = "#3010 — pre-existing unbound section 'MultiTenancy:TenantSchema'",
+        ["TimelineEndpointsOptions"] = "#3010 — pre-existing unbound section 'Timeline:Endpoints'",
+        ["TokenManagementOptions"] = "#3010 — pre-existing unbound section 'Oidc:TokenManagement'",
+        ["TwilioOptions"] = "#3010 — pre-existing unbound section 'Notifications:Twilio'",
+        ["UserSessionsEndpointsOptions"] = "#3010 — pre-existing unbound section 'Identity:Endpoints:UserSessions'",
+        ["ValidationEndpointsOptions"] = "#3010 — pre-existing unbound section 'Validation:Endpoints'",
+        ["WebhooksEndpointsOptions"] = "#3010 — pre-existing unbound section 'Webhooks:Endpoints'",
+        ["WorkflowEndpointsOptions"] = "#3010 — pre-existing unbound section 'Workflow:Endpoints'",
+        ["ZulipBotOptions"] = "#3010 — pre-existing unbound section 'Notifications:Zulip:Bot'",
+        ["ZulipChannelOptions"] = "#3010 — pre-existing unbound section 'Notifications:Zulip'",
+    };
+
+    [Fact]
+    public void Every_SectionName_is_bound_somewhere_in_src()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        List<string> violations = [];
+
+        // Pass 1 — collect (file, typeName, sectionValue) for every SectionName const.
+        List<(string File, string TypeName, string Value)> declarations = [];
+        foreach (string csFile in ArchitectureTestHelpers.EnumerateSourceFiles(srcDir))
+        {
+            string content = File.ReadAllText(csFile);
+            Match constMatch = SectionNameConstant().Match(content);
+            if (!constMatch.Success)
+            {
+                continue;
+            }
+
+            Match typeMatch = TypeDeclaration().Match(content);
+            string typeName = typeMatch.Success ? typeMatch.Groups[1].Value : Path.GetFileNameWithoutExtension(csFile);
+            declarations.Add((csFile, typeName, constMatch.Groups[1].Value));
+        }
+
+        // Pass 2 — for each declaration, look for a binding site anywhere in src.
+        // Accepted shapes: BindConfiguration(<Type>.SectionName), BindConfiguration("literal"),
+        // GetSection(<Type>.SectionName), GetSection("literal"), GetRequiredSection(...).
+        string allSources = string.Join('\n',
+            ArchitectureTestHelpers.EnumerateSourceFiles(srcDir).Select(File.ReadAllText));
+
+        foreach ((string file, string typeName, string value) in declarations)
+        {
+            if (Exemptions.ContainsKey(typeName))
+            {
+                continue;
+            }
+
+            bool bound =
+                allSources.Contains($"BindConfiguration({typeName}.SectionName", StringComparison.Ordinal)
+                || allSources.Contains($"BindConfiguration(\"{value}\"", StringComparison.Ordinal)
+                || allSources.Contains($"BindConfiguration($\"{{{typeName}.SectionName}}", StringComparison.Ordinal)
+                || allSources.Contains($"GetSection({typeName}.SectionName", StringComparison.Ordinal)
+                || allSources.Contains($"GetSection(\"{value}\"", StringComparison.Ordinal)
+                || allSources.Contains($"GetSection($\"{{{typeName}.SectionName}}", StringComparison.Ordinal)
+                || allSources.Contains($"GetRequiredSection({typeName}.SectionName", StringComparison.Ordinal)
+                || allSources.Contains($"GetRequiredSection(\"{value}\"", StringComparison.Ordinal);
+
+            if (!bound)
+            {
+                violations.Add($"{Path.GetRelativePath(RepoRoot, file)} ({typeName}, \"{value}\")");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every 'const string SectionName' must be bound via BindConfiguration/GetSection "
+            + "somewhere in src/ — a declared-but-never-bound section silently ignores "
+            + "appsettings.json. Bind it (see AuditingEndpointsOptions for the pattern) or add "
+            + "a justified exemption. Violators: " + string.Join("; ", violations));
+    }
+
+    [GeneratedRegex(@"public\s+const\s+string\s+SectionName\s*=\s*""([^""]+)""")]
+    private static partial Regex SectionNameConstant();
+
+    [GeneratedRegex(@"(?:class|record)\s+([A-Za-z0-9_]+Options)\b")]
+    private static partial Regex TypeDeclaration();
+}

--- a/tests/Granit.ArchitectureTests/SchemaExampleProviderRegistrationTests.cs
+++ b/tests/Granit.ArchitectureTests/SchemaExampleProviderRegistrationTests.cs
@@ -1,0 +1,83 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Every <c>ISchemaExampleProvider</c> implementation must be DI-registered by its own
+/// project. The 2026-07 Http* audit found a provider that was implemented and unit-tested
+/// but never registered — its OpenAPI examples never surfaced, and the green test hid it.
+/// </summary>
+public sealed partial class SchemaExampleProviderRegistrationTests
+{
+    private static readonly string RepoRoot = ArchitectureTestHelpers.FindRepoRoot();
+
+    /// <summary>Ratchet list — nothing may be added without a linked issue.</summary>
+    private static readonly Dictionary<string, string> Exemptions = new(StringComparer.Ordinal)
+    {
+        // Pre-existing repo-wide debt, enumerated at introduction — tracked by #3010.
+        ["LocalizationSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["ApiKeysSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["NotificationsSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["WebhooksSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["IdentitySchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["AuthorizationSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["DataExchangeSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["SettingsSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["PrivacySchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["TemplatingSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["WorkflowSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["TimelineSchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+        ["AISchemaExampleProvider"] = "#3010 — implemented but never DI-registered",
+    };
+
+    [Fact]
+    public void Every_schema_example_provider_is_registered_in_its_project()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        List<string> violations = [];
+
+        foreach (string csFile in ArchitectureTestHelpers.EnumerateSourceFiles(srcDir))
+        {
+            string content = File.ReadAllText(csFile);
+            Match match = ProviderImplementation().Match(content);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            string typeName = match.Groups[1].Value;
+            if (Exemptions.ContainsKey(typeName))
+            {
+                continue;
+            }
+
+            string projectDir = ArchitectureTestHelpers.ProjectDirOf(srcDir, csFile);
+            bool registered = ArchitectureTestHelpers.EnumerateSourceFiles(projectDir)
+                .Select(File.ReadAllText)
+                .Any(source =>
+                    source.Contains($"ISchemaExampleProvider, {typeName}>", StringComparison.Ordinal));
+
+            if (!registered)
+            {
+                violations.Add($"{Path.GetRelativePath(RepoRoot, csFile)} ({typeName})");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every ISchemaExampleProvider implementation must be registered in its own module "
+            + "(TryAddEnumerable(ServiceDescriptor.Singleton<ISchemaExampleProvider, X>()) — see "
+            + "GranitAuditingEndpointsModule). An unregistered provider never surfaces its "
+            + "OpenAPI examples. Violators: " + string.Join("; ", violations));
+    }
+
+    /// <summary>
+    /// Matches <c>class Xxx : ... ISchemaExampleProvider</c> implementations — the interface
+    /// must appear in the base list (after <c>:</c>, outside any parameter list), so a type
+    /// merely injecting <c>IEnumerable&lt;ISchemaExampleProvider&gt;</c> through a primary
+    /// constructor does not match.
+    /// </summary>
+    [GeneratedRegex(@"class\s+([A-Za-z0-9_]+)(?:\s*\([^)]*\))?\s*:\s*[^{(]*\bISchemaExampleProvider\b")]
+    private static partial Regex ProviderImplementation();
+}


### PR DESCRIPTION
## Summary

Third PR of the [Http* redesign epic](https://github.com/granit-fx/granit-dotnet/issues/2986) — **stacked on #3009** (which stacks on #3008).

Makes the audit's systemic finding — code that is written, unit-tested green, and never wired — a CI failure, via three source-scan convention tests in `Granit.ArchitectureTests` (same style as `SectionNameConventionTests`):

| Test | Rule | First-scan harvest |
|---|---|---|
| `OptionsBindingConventionTests` | every `const string SectionName` is bound somewhere in `src/` | **46 unbound sections** (mostly the `new()` + delegate `*EndpointsOptions` pattern, plus notification providers) |
| `MetricsWiringConventionTests` | every `{Module}Metrics` class is constructor-injected or resolved | **2 unwired** (`ApiKeysMetrics`, `TemplatingMetrics`) |
| `SchemaExampleProviderRegistrationTests` | every `ISchemaExampleProvider` implementation is DI-registered by its project | **13 unregistered** (nearly every `.Endpoints` module) |

The pre-existing violations are **ratcheted**: enumerated in per-test exemption dictionaries tracked by #3010, with an explicit rule that nothing may be added without a linked issue. The Http* family (fixed in #3008) passes clean; `SecurityHeadersEndpointsOptions` is exempted with a pointer to #3000 (bound when the package folds).

Also ships `scripts/find-unreferenced-public-api.py` — an informational orphan-surface report (extension/module/attribute classes excluded); never gates CI.

## Verification

- Architecture shard: 260/260 green (including the 3 new tests against the ratcheted baseline).
- Scan false positives eliminated and pinned: interpolated `BindConfiguration($"{X.SectionName}:{name}")` (Http.Resilience), nullable-optional metrics injection (`QueryEngineMetrics?`), primary-ctor `IEnumerable<ISchemaExampleProvider>` (SchemaExampleSchemaTransformer).
- `dotnet format` clean.

Closes #2995 · Feature #2987 · Epic #2986 · Debt tracked by #3010

🤖 Generated with [Claude Code](https://claude.com/claude-code)