### PR TITLE
refactor(privacy): async-first ILegalDocumentRegistry

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -47708,19 +47708,19 @@
       "kind": "interface",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/LegalAgreements/ILegalDocumentRegistry.cs",
-      "line": 6,
+      "line": 11,
       "members": [
         {
-          "name": "GetDefinition",
+          "name": "GetDefinitionAsync",
           "kind": "method",
-          "signature": "GetDefinition(string documentId)",
-          "returnType": "LegalDocumentDefinition?"
+          "signature": "GetDefinitionAsync(string documentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<LegalDocumentDefinition?>"
         },
         {
-          "name": "GetAll",
+          "name": "GetAllAsync",
           "kind": "method",
-          "signature": "GetAll()",
-          "returnType": "IReadOnlyList<LegalDocumentDefinition>"
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<LegalDocumentDefinition>>"
         }
       ]
     },

--- a/src/Granit.Privacy.Endpoints/Endpoints/PrivacyAgreementEndpoints.cs
+++ b/src/Granit.Privacy.Endpoints/Endpoints/PrivacyAgreementEndpoints.cs
@@ -17,7 +17,7 @@ internal static class PrivacyAgreementEndpoints
 {
     internal static RouteGroupBuilder MapPrivacyAgreementEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/agreements/documents", HandleGetDocuments)
+        group.MapGet("/agreements/documents", HandleGetDocumentsAsync)
              .RequireAuthorization(PrivacyPermissions.Agreements.Read)
              .WithName("ListPrivacyLegalDocuments")
              .WithSummary("Returns all registered legal documents.")
@@ -68,11 +68,14 @@ internal static class PrivacyAgreementEndpoints
         return group;
     }
 
-    private static Ok<IReadOnlyList<PrivacyLegalDocumentResponse>> HandleGetDocuments(
-        [FromServices] ILegalDocumentRegistry registry)
+    private static async Task<Ok<IReadOnlyList<PrivacyLegalDocumentResponse>>> HandleGetDocumentsAsync(
+        [FromServices] ILegalDocumentRegistry registry,
+        CancellationToken cancellationToken)
     {
-        IReadOnlyList<PrivacyLegalDocumentResponse> result = registry
-            .GetAll()
+        IReadOnlyList<LegalDocumentDefinition> documents = await registry
+            .GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<PrivacyLegalDocumentResponse> result = documents
             .Select(d => new PrivacyLegalDocumentResponse(d.DocumentId, d.CurrentVersion, d.DisplayName))
             .ToList();
 
@@ -91,7 +94,8 @@ internal static class PrivacyAgreementEndpoints
             return PrivacyResponseMapper.UserNotAuthenticated();
         }
 
-        IReadOnlyList<LegalDocumentDefinition> documents = registry.GetAll();
+        IReadOnlyList<LegalDocumentDefinition> documents = await registry
+            .GetAllAsync(cancellationToken).ConfigureAwait(false);
         List<PrivacyConsentStatusResponse> result = new(documents.Count);
 
         foreach (LegalDocumentDefinition doc in documents)
@@ -129,13 +133,17 @@ internal static class PrivacyAgreementEndpoints
             .GetUserAgreementsAsync(userId, cancellationToken)
             .ConfigureAwait(false);
 
+        // One registry snapshot for the whole history instead of a lookup per row.
+        var currentVersions = (await registry.GetAllAsync(cancellationToken).ConfigureAwait(false))
+            .ToDictionary(d => d.DocumentId, d => d.CurrentVersion, StringComparer.OrdinalIgnoreCase);
+
         IReadOnlyList<PrivacyUserAgreementResponse> result = agreements
             .Select(a => new PrivacyUserAgreementResponse(
                 a.Id,
                 a.DocumentId,
                 a.Version,
                 a.AcceptedAt,
-                registry.GetDefinition(a.DocumentId)?.CurrentVersion == a.Version))
+                currentVersions.TryGetValue(a.DocumentId, out string? current) && current == a.Version))
             .ToList();
 
         return TypedResults.Ok(result);
@@ -157,7 +165,8 @@ internal static class PrivacyAgreementEndpoints
             return PrivacyResponseMapper.UserNotAuthenticated();
         }
 
-        LegalDocumentDefinition? document = registry.GetDefinition(body.DocumentId);
+        LegalDocumentDefinition? document = await registry
+            .GetDefinitionAsync(body.DocumentId, cancellationToken).ConfigureAwait(false);
         if (document is null)
         {
             return TypedResults.Problem(

--- a/src/Granit.Privacy.Notifications/Handlers/LegalDocumentObsoleteHandler.cs
+++ b/src/Granit.Privacy.Notifications/Handlers/LegalDocumentObsoleteHandler.cs
@@ -25,7 +25,8 @@ public class LegalDocumentObsoleteHandler
         INotificationPublisher publisher,
         CancellationToken cancellationToken)
     {
-        LegalDocumentDefinition? definition = documentRegistry.GetDefinition(evt.DocumentId);
+        LegalDocumentDefinition? definition = await documentRegistry
+            .GetDefinitionAsync(evt.DocumentId, cancellationToken).ConfigureAwait(false);
         string displayName = definition?.DisplayName ?? evt.DocumentId;
 
         var data = new PrivacyLegalDocumentObsoleteNotificationData(

--- a/src/Granit.Privacy/LegalAgreements/ILegalDocumentRegistry.cs
+++ b/src/Granit.Privacy/LegalAgreements/ILegalDocumentRegistry.cs
@@ -3,11 +3,16 @@ namespace Granit.Privacy.LegalAgreements;
 /// <summary>
 /// Registry of legal documents declared at startup.
 /// </summary>
+/// <remarks>
+/// Async-first: the composite implementation lazily hydrates its cache from the database on
+/// first access, so a synchronous contract would force a thread-blocking
+/// <c>GetAwaiter().GetResult()</c> on that cold path.
+/// </remarks>
 public interface ILegalDocumentRegistry
 {
     /// <summary>Returns the definition for the given document ID, or <c>null</c> if not registered.</summary>
-    LegalDocumentDefinition? GetDefinition(string documentId);
+    Task<LegalDocumentDefinition?> GetDefinitionAsync(string documentId, CancellationToken cancellationToken = default);
 
     /// <summary>Returns all registered document definitions.</summary>
-    IReadOnlyList<LegalDocumentDefinition> GetAll();
+    Task<IReadOnlyList<LegalDocumentDefinition>> GetAllAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Privacy/LegalAgreements/Internal/CompositeLegalDocumentRegistry.cs
+++ b/src/Granit.Privacy/LegalAgreements/Internal/CompositeLegalDocumentRegistry.cs
@@ -25,21 +25,23 @@ internal sealed class CompositeLegalDocumentRegistry(
     private volatile bool _initialized;
 
     /// <inheritdoc/>
-    public LegalDocumentDefinition? GetDefinition(string documentId)
+    public async Task<LegalDocumentDefinition?> GetDefinitionAsync(
+        string documentId, CancellationToken cancellationToken = default)
     {
-        EnsureInitialized();
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         return _cache.GetValueOrDefault(documentId)
-            ?? staticRegistry.GetDefinition(documentId);
+            ?? await staticRegistry.GetDefinitionAsync(documentId, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<LegalDocumentDefinition> GetAll()
+    public async Task<IReadOnlyList<LegalDocumentDefinition>> GetAllAsync(
+        CancellationToken cancellationToken = default)
     {
-        EnsureInitialized();
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         // Merge: DB definitions take precedence over static ones.
         Dictionary<string, LegalDocumentDefinition> merged = new(StringComparer.OrdinalIgnoreCase);
-        foreach (LegalDocumentDefinition def in staticRegistry.GetAll())
+        foreach (LegalDocumentDefinition def in await staticRegistry.GetAllAsync(cancellationToken).ConfigureAwait(false))
         {
             merged[def.DocumentId] = def;
         }
@@ -54,7 +56,8 @@ internal sealed class CompositeLegalDocumentRegistry(
 
     /// <summary>
     /// Refreshes the in-memory cache from the database. Called by the
-    /// <see cref="Events.LegalDocumentCacheInvalidatedEto"/> handler.
+    /// <see cref="Events.LegalDocumentCacheInvalidatedEto"/> handler and by the lazy
+    /// first-access initialization.
     /// </summary>
     internal async Task RefreshAsync(CancellationToken cancellationToken = default)
     {
@@ -76,15 +79,9 @@ internal sealed class CompositeLegalDocumentRegistry(
         _initialized = true;
     }
 
-    private void EnsureInitialized()
-    {
-        if (_initialized)
-        {
-            return;
-        }
-
-        // Synchronous initialization on first access — blocks once per pod lifetime.
-        // Subsequent refreshes are async via the Wolverine handler.
-        RefreshAsync().GetAwaiter().GetResult();
-    }
+    private Task EnsureInitializedAsync(CancellationToken cancellationToken) =>
+        // Cold-path hydration on first access; subsequent refreshes come from the
+        // Wolverine invalidation handler. Concurrent first calls may refresh twice —
+        // harmless (idempotent snapshot), cheaper than a lock on every hot-path read.
+        _initialized ? Task.CompletedTask : RefreshAsync(cancellationToken);
 }

--- a/src/Granit.Privacy/LegalAgreements/Internal/LegalAgreementChecker.cs
+++ b/src/Granit.Privacy/LegalAgreements/Internal/LegalAgreementChecker.cs
@@ -12,7 +12,8 @@ internal sealed class LegalAgreementChecker(
     /// <inheritdoc/>
     public async Task<bool> HasAcceptedLatestAsync(Guid userId, string documentId, CancellationToken cancellationToken = default)
     {
-        LegalDocumentDefinition? definition = documentRegistry.GetDefinition(documentId);
+        LegalDocumentDefinition? definition = await documentRegistry
+            .GetDefinitionAsync(documentId, cancellationToken).ConfigureAwait(false);
         if (definition is null)
         {
             return false;

--- a/src/Granit.Privacy/LegalAgreements/Internal/LegalDocumentRegistry.cs
+++ b/src/Granit.Privacy/LegalAgreements/Internal/LegalDocumentRegistry.cs
@@ -21,10 +21,12 @@ internal sealed class LegalDocumentRegistry : ILegalDocumentRegistry
     }
 
     /// <inheritdoc/>
-    public LegalDocumentDefinition? GetDefinition(string documentId) =>
-        _documents.GetValueOrDefault(documentId);
+    public Task<LegalDocumentDefinition?> GetDefinitionAsync(
+        string documentId, CancellationToken cancellationToken = default) =>
+        Task.FromResult(_documents.GetValueOrDefault(documentId));
 
     /// <inheritdoc/>
-    public IReadOnlyList<LegalDocumentDefinition> GetAll() =>
-        _documents.Values.ToList();
+    public Task<IReadOnlyList<LegalDocumentDefinition>> GetAllAsync(
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<LegalDocumentDefinition>>(_documents.Values.ToList());
 }

--- a/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsIntegrationTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Integration/PrivacyEndpointsIntegrationTests.cs
@@ -445,7 +445,7 @@ public sealed class PrivacyEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetDocuments_ReturnsDocumentList()
     {
-        _server.DocumentRegistry.GetAll().Returns(
+        _server.DocumentRegistry.GetAllAsync(Arg.Any<CancellationToken>()).Returns(
         [
             new LegalDocumentDefinition("privacy-policy", "2.1.0", "Privacy Policy"),
             new LegalDocumentDefinition("terms-of-service", "1.0.0", "Terms of Service"),
@@ -469,7 +469,7 @@ public sealed class PrivacyEndpointsIntegrationTests : IAsyncLifetime
     public async Task AcceptAgreement_ValidRequest_Returns201()
     {
         LegalDocumentDefinition document = new("privacy-policy", "2.1.0", "Privacy Policy");
-        _server.DocumentRegistry.GetDefinition("privacy-policy").Returns(document);
+        _server.DocumentRegistry.GetDefinitionAsync("privacy-policy", Arg.Any<CancellationToken>()).Returns(document);
         _server.AgreementChecker
             .HasAcceptedLatestAsync(PrivacyEndpointsTestServer.TestUserId, "privacy-policy", Arg.Any<CancellationToken>())
             .Returns(false);
@@ -493,7 +493,7 @@ public sealed class PrivacyEndpointsIntegrationTests : IAsyncLifetime
     public async Task AcceptAgreement_AlreadyAccepted_Returns409()
     {
         LegalDocumentDefinition document = new("privacy-policy", "2.1.0", "Privacy Policy");
-        _server.DocumentRegistry.GetDefinition("privacy-policy").Returns(document);
+        _server.DocumentRegistry.GetDefinitionAsync("privacy-policy", Arg.Any<CancellationToken>()).Returns(document);
         _server.AgreementChecker
             .HasAcceptedLatestAsync(PrivacyEndpointsTestServer.TestUserId, "privacy-policy", Arg.Any<CancellationToken>())
             .Returns(true);
@@ -510,7 +510,7 @@ public sealed class PrivacyEndpointsIntegrationTests : IAsyncLifetime
     public async Task AcceptAgreement_VersionMismatch_Returns422()
     {
         LegalDocumentDefinition document = new("privacy-policy", "2.1.0", "Privacy Policy");
-        _server.DocumentRegistry.GetDefinition("privacy-policy").Returns(document);
+        _server.DocumentRegistry.GetDefinitionAsync("privacy-policy", Arg.Any<CancellationToken>()).Returns(document);
 
         HttpResponseMessage response = await _server.AuthenticatedClient.PostAsJsonAsync(
             "/privacy/agreements/accept",
@@ -523,7 +523,7 @@ public sealed class PrivacyEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task AcceptAgreement_UnknownDocument_Returns404()
     {
-        _server.DocumentRegistry.GetDefinition("unknown-doc").Returns((LegalDocumentDefinition?)null);
+        _server.DocumentRegistry.GetDefinitionAsync("unknown-doc", Arg.Any<CancellationToken>()).Returns((LegalDocumentDefinition?)null);
 
         HttpResponseMessage response = await _server.AuthenticatedClient.PostAsJsonAsync(
             "/privacy/agreements/accept",
@@ -548,7 +548,7 @@ public sealed class PrivacyEndpointsIntegrationTests : IAsyncLifetime
     public async Task GetConsentStatus_ReturnsStatusPerDocument()
     {
         LegalDocumentDefinition document = new("privacy-policy", "2.1.0", "Privacy Policy");
-        _server.DocumentRegistry.GetAll().Returns(new[] { document });
+        _server.DocumentRegistry.GetAllAsync(Arg.Any<CancellationToken>()).Returns(new[] { document });
         _server.AgreementChecker
             .HasAcceptedLatestAsync(PrivacyEndpointsTestServer.TestUserId, "privacy-policy", Arg.Any<CancellationToken>())
             .Returns(true);
@@ -584,7 +584,8 @@ public sealed class PrivacyEndpointsIntegrationTests : IAsyncLifetime
     public async Task GetAgreementHistory_ReturnsHistoryList()
     {
         LegalDocumentDefinition document = new("privacy-policy", "2.1.0", "Privacy Policy");
-        _server.DocumentRegistry.GetDefinition("privacy-policy").Returns(document);
+        // The history handler resolves IsLatest from one GetAllAsync registry snapshot.
+        _server.DocumentRegistry.GetAllAsync(Arg.Any<CancellationToken>()).Returns([document]);
 
         TestLegalAgreement agreement = new()
         {

--- a/tests/Granit.Privacy.Notifications.Tests/Handlers/LegalDocumentObsoleteHandlerTests.cs
+++ b/tests/Granit.Privacy.Notifications.Tests/Handlers/LegalDocumentObsoleteHandlerTests.cs
@@ -23,7 +23,7 @@ public sealed class LegalDocumentObsoleteHandlerTests
         Guid[] userIds = [Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()];
         storeReader.StreamUsersByDocumentVersionAsync("privacy-policy", "1.0", Arg.Any<CancellationToken>())
             .Returns(ci => AsAsync(userIds));
-        documentRegistry.GetDefinition("privacy-policy")
+        documentRegistry.GetDefinitionAsync("privacy-policy", Arg.Any<CancellationToken>())
             .Returns(new LegalDocumentDefinition("privacy-policy", "2.0", "Privacy Policy"));
 
         LegalAgreementObsoleteEto evt = new(
@@ -75,7 +75,7 @@ public sealed class LegalDocumentObsoleteHandlerTests
         Guid[] userIds = [.. Enumerable.Range(0, 1000).Select(_ => Guid.NewGuid())];
         storeReader.StreamUsersByDocumentVersionAsync("privacy-policy", "1.0", Arg.Any<CancellationToken>())
             .Returns(ci => AsAsync(userIds));
-        documentRegistry.GetDefinition("privacy-policy")
+        documentRegistry.GetDefinitionAsync("privacy-policy", Arg.Any<CancellationToken>())
             .Returns(new LegalDocumentDefinition("privacy-policy", "2.0", "Privacy Policy"));
 
         LegalAgreementObsoleteEto evt = new(
@@ -120,7 +120,7 @@ public sealed class LegalDocumentObsoleteHandlerTests
         Guid[] userIds = [.. Enumerable.Range(0, 1001).Select(_ => Guid.NewGuid())];
         storeReader.StreamUsersByDocumentVersionAsync("privacy-policy", "1.0", Arg.Any<CancellationToken>())
             .Returns(ci => AsAsync(userIds));
-        documentRegistry.GetDefinition("privacy-policy")
+        documentRegistry.GetDefinitionAsync("privacy-policy", Arg.Any<CancellationToken>())
             .Returns(new LegalDocumentDefinition("privacy-policy", "2.0", "Privacy Policy"));
 
         LegalAgreementObsoleteEto evt = new(
@@ -151,7 +151,7 @@ public sealed class LegalDocumentObsoleteHandlerTests
         Guid[] userIds = [Guid.NewGuid()];
         storeReader.StreamUsersByDocumentVersionAsync("unknown-doc", "1.0", Arg.Any<CancellationToken>())
             .Returns(ci => AsAsync(userIds));
-        documentRegistry.GetDefinition("unknown-doc").Returns((LegalDocumentDefinition?)null);
+        documentRegistry.GetDefinitionAsync("unknown-doc", Arg.Any<CancellationToken>()).Returns((LegalDocumentDefinition?)null);
 
         LegalAgreementObsoleteEto evt = new(
             DocumentId: "unknown-doc",

--- a/tests/Granit.Privacy.Tests/LegalDocumentRegistryTests.cs
+++ b/tests/Granit.Privacy.Tests/LegalDocumentRegistryTests.cs
@@ -10,11 +10,11 @@ public sealed class LegalDocumentRegistryTests
     private readonly LegalDocumentRegistry _sut = new();
 
     [Fact]
-    public void Register_AddsDocument()
+    public async Task Register_AddsDocument()
     {
         _sut.Register(new LegalDocumentDefinition("privacy-policy", "1.0.0", "Privacy Policy"));
 
-        _sut.GetDefinition("privacy-policy").ShouldNotBeNull();
+        (await _sut.GetDefinitionAsync("privacy-policy", TestContext.Current.CancellationToken)).ShouldNotBeNull();
     }
 
     [Fact]
@@ -28,24 +28,24 @@ public sealed class LegalDocumentRegistryTests
     }
 
     [Fact]
-    public void GetDefinition_UnknownDocument_ReturnsNull() =>
-        _sut.GetDefinition("unknown").ShouldBeNull();
+    public async Task GetDefinitionAsync_UnknownDocument_ReturnsNull() =>
+        (await _sut.GetDefinitionAsync("unknown", TestContext.Current.CancellationToken)).ShouldBeNull();
 
     [Fact]
-    public void GetDefinition_IsCaseInsensitive()
+    public async Task GetDefinitionAsync_IsCaseInsensitive()
     {
         _sut.Register(new LegalDocumentDefinition("Privacy-Policy", "1.0.0", "Privacy Policy"));
 
-        _sut.GetDefinition("privacy-policy").ShouldNotBeNull();
+        (await _sut.GetDefinitionAsync("privacy-policy", TestContext.Current.CancellationToken)).ShouldNotBeNull();
     }
 
     [Fact]
-    public void GetAll_ReturnsAllRegistered()
+    public async Task GetAllAsync_ReturnsAllRegistered()
     {
         _sut.Register(new LegalDocumentDefinition("privacy-policy", "1.0.0", "Privacy Policy"));
         _sut.Register(new LegalDocumentDefinition("terms", "1.0.0", "Terms of Service"));
 
-        _sut.GetAll().Count.ShouldBe(2);
+        (await _sut.GetAllAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(2);
     }
 
     [Fact]
@@ -57,20 +57,20 @@ public sealed class LegalDocumentRegistryTests
     }
 
     [Fact]
-    public void GetAll_Empty_ReturnsEmptyList()
+    public async Task GetAllAsync_Empty_ReturnsEmptyList()
     {
-        IReadOnlyList<LegalDocumentDefinition> result = _sut.GetAll();
+        IReadOnlyList<LegalDocumentDefinition> result = await _sut.GetAllAsync(TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void GetDefinition_ReturnsCorrectDefinition()
+    public async Task GetDefinitionAsync_ReturnsCorrectDefinition()
     {
         LegalDocumentDefinition definition = new("privacy-policy", "2.1.0", "Privacy Policy v2.1");
         _sut.Register(definition);
 
-        LegalDocumentDefinition? result = _sut.GetDefinition("privacy-policy");
+        LegalDocumentDefinition? result = await _sut.GetDefinitionAsync("privacy-policy", TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.CurrentVersion.ShouldBe("2.1.0");

--- a/tests/Granit.Privacy.Tests/PrivacyServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Privacy.Tests/PrivacyServiceCollectionExtensionsTests.cs
@@ -48,7 +48,7 @@ public sealed class PrivacyServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddGranitPrivacy_RegistersLegalDocuments()
+    public async Task AddGranitPrivacy_RegistersLegalDocuments()
     {
         ServiceCollection services = new();
         services.AddGranitPrivacy(privacy =>
@@ -61,8 +61,8 @@ public sealed class PrivacyServiceCollectionExtensionsTests
         ILegalDocumentRegistry? registry = provider.GetService<ILegalDocumentRegistry>();
 
         registry.ShouldNotBeNull();
-        registry!.GetAll().Count.ShouldBe(2);
-        registry.GetDefinition("privacy-policy")!.CurrentVersion.ShouldBe("2.0.0");
+        (await registry!.GetAllAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(2);
+        (await registry.GetDefinitionAsync("privacy-policy", TestContext.Current.CancellationToken))!.CurrentVersion.ShouldBe("2.0.0");
     }
 
     [Fact]


### PR DESCRIPTION
## Context

From the `Granit.Privacy*` framework audit: `CompositeLegalDocumentRegistry` lazily hydrates its cache from the database on first access, but the sync `ILegalDocumentRegistry` contract forced that cold path through `RefreshAsync().GetAwaiter().GetResult()` — the base module's only sync-over-async, blocking a (potentially request) thread once per pod lifetime.

## Changes

- `ILegalDocumentRegistry.GetDefinition/GetAll` → `GetDefinitionAsync/GetAllAsync` (CancellationToken last, per convention).
- `CompositeLegalDocumentRegistry`: lazy init awaits `RefreshAsync` directly — the blocking call is gone. Concurrent first calls may refresh twice: harmless idempotent snapshot, cheaper than locking every hot-path read (documented inline).
- `LegalDocumentRegistry` (static, in-memory): `Task.FromResult` passthrough.
- Callers updated (blast radius as scoped in the audit — all already async): `LegalAgreementChecker`, `LegalDocumentObsoleteHandler` (Notifications), `PrivacyAgreementEndpoints` (4 handlers). The agreement-history handler now resolves `IsLatest` from **one** `GetAllAsync` snapshot instead of a per-row `GetDefinition` lookup.

## HTTP contract

Unchanged.

## Verification

`Granit.Privacy.Tests` 216 · `Notifications.Tests` 278 · `Endpoints.Tests` 136 · `Wolverine.Tests` 44 (cache-invalidation handler unaffected) — all green; `dotnet format` clean on all six touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)